### PR TITLE
fix: release pipeline failures for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,9 @@ jobs:
             deb: true
             rpm: false  # cross-compiled RPM is complex
 
-          # macOS x86_64 — no FUSE, CLI + unsync only
+          # macOS x86_64 — no FUSE, CLI + unsync only (cross from aarch64)
           - name: macos-x86_64
-            os: macos-13
+            os: macos-14
             target: x86_64-apple-darwin
             features: "--no-default-features"
             cross: false
@@ -147,6 +147,9 @@ jobs:
             gcc-aarch64-linux-gnu \
             g++-aarch64-linux-gnu \
             libc6-dev-arm64-cross
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
 
       - name: Install Linux build deps
         if: runner.os == 'Linux'
@@ -171,6 +174,7 @@ jobs:
       # ── Build tcfs CLI ────────────────────────────────────────────────────
 
       - name: Build tcfs CLI
+        shell: bash
         run: |
           cargo build --release \
             --target ${{ matrix.target }} \
@@ -181,6 +185,7 @@ jobs:
 
       - name: Build tcfsd daemon
         if: runner.os != 'Windows'
+        shell: bash
         run: |
           cargo build --release \
             --target ${{ matrix.target }} \
@@ -189,6 +194,7 @@ jobs:
       # ── Build tcfs-tui ────────────────────────────────────────────────────
 
       - name: Build tcfs-tui
+        shell: bash
         run: |
           cargo build --release \
             --target ${{ matrix.target }} \

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+notes/

--- a/Containerfile
+++ b/Containerfile
@@ -30,6 +30,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
 # Cache dependency compilation: copy manifests first, then source
 COPY Cargo.toml Cargo.lock ./
 COPY crates/tcfs-core/Cargo.toml      crates/tcfs-core/
+COPY crates/tcfs-crypto/Cargo.toml    crates/tcfs-crypto/
 COPY crates/tcfs-secrets/Cargo.toml   crates/tcfs-secrets/
 COPY crates/tcfs-storage/Cargo.toml   crates/tcfs-storage/
 COPY crates/tcfs-chunks/Cargo.toml    crates/tcfs-chunks/
@@ -41,7 +42,7 @@ COPY crates/tcfs-cli/Cargo.toml       crates/tcfs-cli/
 COPY crates/tcfs-tui/Cargo.toml       crates/tcfs-tui/
 
 # Create stub lib/main files so cargo can compute the dependency graph
-RUN for d in tcfs-core tcfs-secrets tcfs-storage tcfs-chunks tcfs-sync tcfs-fuse tcfs-cloudfilter tcfs-tui; do \
+RUN for d in tcfs-core tcfs-crypto tcfs-secrets tcfs-storage tcfs-chunks tcfs-sync tcfs-fuse tcfs-cloudfilter tcfs-tui; do \
       mkdir -p crates/$d/src && echo "// stub" > crates/$d/src/lib.rs; \
     done && \
     mkdir -p crates/tcfsd/src crates/tcfs-cli/src && \


### PR DESCRIPTION
## Summary
- Containerfile: add missing tcfs-crypto crate to COPY and stub list
- release.yml: change macos-x86_64 runner from macos-13 (deprecated) to macos-14
- release.yml: add cross-compilation linker env vars for aarch64-linux
- release.yml: add shell: bash to all cargo build steps (fixes Windows PowerShell)
- .gitignore: add notes/ directory

Fixes all 4 release build failures from v0.1.0 attempt.