### PR TITLE
fix: macOS Nix build — use darwin.apple_sdk

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,9 +48,8 @@
           fuse3
           rocksdb
         ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-          # macOS: use apple_sdk_12_3 (apple_sdk_11_0 alias removed in nixpkgs-unstable)
-          darwin.apple_sdk_12_3.frameworks.Security
-          darwin.apple_sdk_12_3.frameworks.SystemConfiguration
+          darwin.apple_sdk.frameworks.Security
+          darwin.apple_sdk.frameworks.SystemConfiguration
         ];
 
         # Source filter: include .proto files alongside standard Cargo sources


### PR DESCRIPTION
## Summary
- `darwin.apple_sdk_12_3` was removed as a legacy compatibility stub in nixpkgs-unstable
- Use `darwin.apple_sdk.frameworks.Security` and `SystemConfiguration` directly
- Fixes macOS aarch64 Nix CI build failure