### PR TITLE
feat: MCP server for AI agent integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: nix flake check
 
       - name: Build all packages
-        run: nix build .#tcfsd .#tcfs-cli .#tcfs-tui
+        run: nix build .#tcfsd .#tcfs-cli .#tcfs-tui .#tcfs-mcp
 
   deny:
     name: cargo-deny

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -72,10 +72,13 @@ jobs:
       - name: Build tcfs-tui
         run: nix build .#tcfs-tui
 
+      - name: Build tcfs-mcp
+        run: nix build .#tcfs-mcp
+
       - name: Push to Attic
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
-          for pkg in tcfsd tcfs-cli tcfs-tui; do
+          for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
             nix build .#${pkg} -o result-${pkg}
             attic push ${{ env.ATTIC_CACHE }} result-${pkg} || echo "::warning::Failed to push ${pkg} to Attic"
           done
@@ -112,10 +115,13 @@ jobs:
       - name: Build tcfs-tui
         run: nix build .#tcfs-tui
 
+      - name: Build tcfs-mcp
+        run: nix build .#tcfs-mcp
+
       - name: Push to Attic
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
-          for pkg in tcfs-cli tcfs-tui; do
+          for pkg in tcfs-cli tcfs-tui tcfs-mcp; do
             nix build .#${pkg} -o result-${pkg}
             attic push ${{ env.ATTIC_CACHE }} result-${pkg} || echo "::warning::Failed to push ${pkg} to Attic"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,16 @@ jobs:
             --target ${{ matrix.target }} \
             -p tcfs-tui
 
+      # ── Build tcfs-mcp ──────────────────────────────────────────────────
+
+      - name: Build tcfs-mcp
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          cargo build --release \
+            --target ${{ matrix.target }} \
+            -p tcfs-mcp
+
       # ── Package archive ──────────────────────────────────────────────────
 
       - name: Package archive (Unix)
@@ -210,6 +220,7 @@ jobs:
           cp target/${{ matrix.target }}/release/tcfs   "${DIST}/"
           cp target/${{ matrix.target }}/release/tcfsd  "${DIST}/" 2>/dev/null || true
           cp target/${{ matrix.target }}/release/tcfs-tui "${DIST}/"
+          cp target/${{ matrix.target }}/release/tcfs-mcp "${DIST}/" 2>/dev/null || true
           cp README.md LICENSE* "${DIST}/" 2>/dev/null || true
           tar czf "${DIST}.tar.gz" "${DIST}"
 
@@ -355,7 +366,7 @@ jobs:
 
       - name: Build all Nix packages
         run: |
-          for pkg in tcfsd tcfs-cli tcfs-tui; do
+          for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
             echo "Building ${pkg}..."
             nix build .#${pkg} -o result-${pkg}
           done
@@ -363,7 +374,7 @@ jobs:
       - name: Push to Attic cache
         if: env.ATTIC_CONFIGURED == 'true'
         run: |
-          for pkg in tcfsd tcfs-cli tcfs-tui; do
+          for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
             attic push main result-${pkg} || echo "::warning::Failed to push ${pkg}"
           done
 
@@ -416,19 +427,23 @@ jobs:
             cp "${TMPDIR}/tcfs-${VERSION}-${PLATFORM}/tcfs" "${INSTALL_DIR}/"
             cp "${TMPDIR}/tcfs-${VERSION}-${PLATFORM}/tcfsd" "${INSTALL_DIR}/"
             cp "${TMPDIR}/tcfs-${VERSION}-${PLATFORM}/tcfs-tui" "${INSTALL_DIR}/"
+            cp "${TMPDIR}/tcfs-${VERSION}-${PLATFORM}/tcfs-mcp" "${INSTALL_DIR}/" 2>/dev/null || true
           else
             sudo cp "${TMPDIR}/tcfs-${VERSION}-${PLATFORM}/tcfs" "${INSTALL_DIR}/"
             sudo cp "${TMPDIR}/tcfs-${VERSION}-${PLATFORM}/tcfsd" "${INSTALL_DIR}/"
             sudo cp "${TMPDIR}/tcfs-${VERSION}-${PLATFORM}/tcfs-tui" "${INSTALL_DIR}/"
+            sudo cp "${TMPDIR}/tcfs-${VERSION}-${PLATFORM}/tcfs-mcp" "${INSTALL_DIR}/" 2>/dev/null || true
           fi
 
           chmod +x "${INSTALL_DIR}/tcfs" "${INSTALL_DIR}/tcfsd" "${INSTALL_DIR}/tcfs-tui"
+          chmod +x "${INSTALL_DIR}/tcfs-mcp" 2>/dev/null || true
 
           echo ""
           echo "tcfs ${TAG} installed successfully!"
-          echo "  tcfs   → ${INSTALL_DIR}/tcfs"
-          echo "  tcfsd  → ${INSTALL_DIR}/tcfsd"
+          echo "  tcfs     → ${INSTALL_DIR}/tcfs"
+          echo "  tcfsd    → ${INSTALL_DIR}/tcfsd"
           echo "  tcfs-tui → ${INSTALL_DIR}/tcfs-tui"
+          echo "  tcfs-mcp → ${INSTALL_DIR}/tcfs-mcp"
           echo ""
           echo "Run 'tcfs status' to get started."
           INSTALLER
@@ -563,6 +578,7 @@ jobs:
             | `tcfs` | CLI: push, pull, sync-status, mount, unsync |
             | `tcfsd` | Daemon: gRPC socket, FUSE, Prometheus metrics |
             | `tcfs-tui` | Terminal UI for interactive management |
+            | `tcfs-mcp` | MCP server for AI agent integration |
 
   # ── Update Homebrew tap formula ──────────────────────────────────────────
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,6 +2804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,6 +3573,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,6 +3703,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3926,6 +3993,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.2.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4029,6 +4146,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4481,6 +4609,26 @@ dependencies = [
  "tokio-test",
  "tonic",
  "tracing",
+]
+
+[[package]]
+name = "tcfs-mcp"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "hyper-util",
+ "rmcp",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tcfs-core",
+ "tokio",
+ "tokio-stream",
+ "toml 0.8.23",
+ "tonic",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/tcfsd",
     "crates/tcfs-cli",
     "crates/tcfs-tui",
+    "crates/tcfs-mcp",
 ]
 
 [workspace.package]
@@ -92,6 +93,10 @@ clap = { version = "4", features = ["derive", "env"] }
 # TUI
 ratatui = { version = "0.30" }
 crossterm = { version = "0.29" }
+
+# MCP (Model Context Protocol)
+rmcp = { version = "0.16", features = ["server", "transport-io", "macros", "schemars"] }
+schemars = { version = "0.8" }
 
 # Progress display
 indicatif = { version = "0.18" }

--- a/crates/tcfs-mcp/Cargo.toml
+++ b/crates/tcfs-mcp/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "tcfs-mcp"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "tcfs MCP (Model Context Protocol) server for AI agent integration"
+
+[[bin]]
+name = "tcfs-mcp"
+path = "src/main.rs"
+
+[dependencies]
+tcfs-core = { path = "../tcfs-core" }
+rmcp = { workspace = true }
+schemars = { workspace = true }
+tonic = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tower = { workspace = true }
+hyper-util = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/tcfs-mcp/src/main.rs
+++ b/crates/tcfs-mcp/src/main.rs
@@ -1,0 +1,36 @@
+//! tcfs MCP server — exposes daemon capabilities as MCP tools for AI agents
+//!
+//! Communicates with tcfsd over Unix domain socket gRPC, then translates
+//! responses into MCP tool results. Runs over stdio for Claude Code integration.
+
+use anyhow::Result;
+use rmcp::{transport::stdio, ServiceExt};
+use tracing_subscriber::{self, EnvFilter};
+
+mod server;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Logging MUST go to stderr — stdout is reserved for JSON-RPC messages
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    tracing::info!("tcfs-mcp starting");
+
+    let socket_path =
+        std::env::var("TCFS_SOCKET").unwrap_or_else(|_| "/run/tcfsd/tcfsd.sock".to_string());
+
+    let config_path = std::env::var("TCFS_CONFIG").ok();
+
+    let server = server::TcfsMcp::new(socket_path.into(), config_path.map(|p| p.into()));
+
+    let service = server.serve(stdio()).await.inspect_err(|e| {
+        tracing::error!("MCP server error: {:?}", e);
+    })?;
+
+    service.waiting().await?;
+    Ok(())
+}

--- a/crates/tcfs-mcp/src/server.rs
+++ b/crates/tcfs-mcp/src/server.rs
@@ -1,0 +1,283 @@
+//! MCP server implementation with tool definitions
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler,
+};
+
+use tcfs_core::proto::{
+    tcfs_daemon_client::TcfsDaemonClient, Empty, PullRequest, StatusRequest, SyncStatusRequest,
+};
+use tonic::transport::Channel;
+
+// ── Input schemas ────────────────────────────────────────────────────────
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SyncStatusInput {
+    #[schemars(description = "File or directory path to check sync state for")]
+    pub path: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct PullInput {
+    #[schemars(description = "Remote path (S3 key) to download")]
+    pub remote_path: String,
+    #[schemars(description = "Local filesystem path to save the downloaded file")]
+    pub local_path: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct PushInput {
+    #[schemars(description = "Local file path to upload to remote storage")]
+    pub local_path: String,
+}
+
+// ── MCP Server ───────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct TcfsMcp {
+    socket_path: PathBuf,
+    config_path: Option<PathBuf>,
+    client: Arc<Mutex<Option<TcfsDaemonClient<Channel>>>>,
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router]
+impl TcfsMcp {
+    pub fn new(socket_path: PathBuf, config_path: Option<PathBuf>) -> Self {
+        Self {
+            socket_path,
+            config_path,
+            client: Arc::new(Mutex::new(None)),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Connect to the daemon, reusing existing connection if available
+    async fn connect(&self) -> Result<TcfsDaemonClient<Channel>, String> {
+        let mut guard = self.client.lock().await;
+        if let Some(ref client) = *guard {
+            return Ok(client.clone());
+        }
+
+        let path = self.socket_path.clone();
+        let channel = tonic::transport::Endpoint::from_static("http://[::]:0")
+            .connect_with_connector(tower::service_fn(move |_: tonic::transport::Uri| {
+                let path = path.clone();
+                async move {
+                    let stream = tokio::net::UnixStream::connect(&path).await?;
+                    Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+                }
+            }))
+            .await
+            .map_err(|e| {
+                format!(
+                    "failed to connect to daemon at {}: {e}",
+                    self.socket_path.display()
+                )
+            })?;
+
+        let client = TcfsDaemonClient::new(channel);
+        *guard = Some(client.clone());
+        Ok(client)
+    }
+
+    // ── Tools ────────────────────────────────────────────────────────────
+
+    #[tool(
+        description = "Get tcfs daemon status: version, storage connectivity, uptime, active mounts"
+    )]
+    async fn daemon_status(&self) -> String {
+        match self.connect().await {
+            Ok(mut client) => match client.status(StatusRequest {}).await {
+                Ok(resp) => {
+                    let s = resp.into_inner();
+                    serde_json::json!({
+                        "version": s.version,
+                        "storage_endpoint": s.storage_endpoint,
+                        "storage_ok": s.storage_ok,
+                        "nats_ok": s.nats_ok,
+                        "active_mounts": s.active_mounts,
+                        "uptime_secs": s.uptime_secs,
+                    })
+                    .to_string()
+                }
+                Err(e) => format!("{{\"error\": \"status RPC failed: {e}\"}}"),
+            },
+            Err(e) => format!("{{\"error\": \"{e}\"}}"),
+        }
+    }
+
+    #[tool(description = "Get credential status: whether S3/storage credentials are loaded")]
+    async fn credential_status(&self) -> String {
+        match self.connect().await {
+            Ok(mut client) => match client.credential_status(Empty {}).await {
+                Ok(resp) => {
+                    let c = resp.into_inner();
+                    serde_json::json!({
+                        "loaded": c.loaded,
+                        "source": c.source,
+                        "loaded_at": c.loaded_at,
+                        "needs_reload": c.needs_reload,
+                    })
+                    .to_string()
+                }
+                Err(e) => format!("{{\"error\": \"credential_status RPC failed: {e}\"}}"),
+            },
+            Err(e) => format!("{{\"error\": \"{e}\"}}"),
+        }
+    }
+
+    #[tool(description = "Show tcfs configuration (daemon, storage, sync, fuse, crypto sections)")]
+    async fn config_show(&self) -> String {
+        let path = self
+            .config_path
+            .clone()
+            .or_else(|| std::env::var("TCFS_CONFIG").ok().map(PathBuf::from))
+            .unwrap_or_else(|| PathBuf::from("/etc/tcfs/config.toml"));
+
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match toml::from_str::<tcfs_core::config::TcfsConfig>(&contents) {
+                Ok(config) => match serde_json::to_string_pretty(&config) {
+                    Ok(json) => json,
+                    Err(e) => format!("{{\"error\": \"serialize config: {e}\"}}"),
+                },
+                Err(e) => {
+                    format!("{{\"error\": \"parse config at {}: {e}\"}}", path.display())
+                }
+            },
+            Err(e) => format!("{{\"error\": \"read config at {}: {e}\"}}", path.display()),
+        }
+    }
+
+    #[tool(description = "Check sync status of a file: synced, pending, or unknown")]
+    async fn sync_status(&self, Parameters(input): Parameters<SyncStatusInput>) -> String {
+        match self.connect().await {
+            Ok(mut client) => {
+                match client
+                    .sync_status(SyncStatusRequest { path: input.path })
+                    .await
+                {
+                    Ok(resp) => {
+                        let s = resp.into_inner();
+                        serde_json::json!({
+                            "path": s.path,
+                            "state": s.state,
+                            "blake3": s.blake3,
+                            "size": s.size,
+                            "last_synced": s.last_synced,
+                        })
+                        .to_string()
+                    }
+                    Err(e) => format!("{{\"error\": \"sync_status RPC failed: {e}\"}}"),
+                }
+            }
+            Err(e) => format!("{{\"error\": \"{e}\"}}"),
+        }
+    }
+
+    #[tool(description = "Pull (download) a file from remote storage to a local path")]
+    async fn pull(&self, Parameters(input): Parameters<PullInput>) -> String {
+        match self.connect().await {
+            Ok(mut client) => {
+                match client
+                    .pull(PullRequest {
+                        remote_path: input.remote_path,
+                        local_path: input.local_path,
+                    })
+                    .await
+                {
+                    Ok(resp) => {
+                        use tokio_stream::StreamExt;
+                        let mut stream = resp.into_inner();
+                        let mut last_progress = None;
+                        while let Some(item) = stream.next().await {
+                            match item {
+                                Ok(p) => last_progress = Some(p),
+                                Err(e) => {
+                                    return format!("{{\"error\": \"pull stream error: {e}\"}}")
+                                }
+                            }
+                        }
+                        match last_progress {
+                            Some(p) => serde_json::json!({
+                                "bytes_received": p.bytes_received,
+                                "total_bytes": p.total_bytes,
+                                "done": p.done,
+                                "error": if p.error.is_empty() { None } else { Some(&p.error) },
+                            })
+                            .to_string(),
+                            None => "{\"error\": \"no progress received\"}".to_string(),
+                        }
+                    }
+                    Err(e) => format!("{{\"error\": \"pull RPC failed: {e}\"}}"),
+                }
+            }
+            Err(e) => format!("{{\"error\": \"{e}\"}}"),
+        }
+    }
+
+    #[tool(description = "Push (upload) a local file to remote storage")]
+    async fn push(&self, Parameters(input): Parameters<PushInput>) -> String {
+        let data = match std::fs::read(&input.local_path) {
+            Ok(d) => d,
+            Err(e) => return format!("{{\"error\": \"read file: {e}\"}}"),
+        };
+
+        let chunk = tcfs_core::proto::PushChunk {
+            path: input.local_path.clone(),
+            data,
+            offset: 0,
+            last: true,
+        };
+
+        match self.connect().await {
+            Ok(mut client) => match client.push(tokio_stream::once(chunk)).await {
+                Ok(resp) => {
+                    use tokio_stream::StreamExt;
+                    let mut stream = resp.into_inner();
+                    let mut last_progress = None;
+                    while let Some(item) = stream.next().await {
+                        match item {
+                            Ok(p) => last_progress = Some(p),
+                            Err(e) => return format!("{{\"error\": \"push stream error: {e}\"}}"),
+                        }
+                    }
+                    match last_progress {
+                        Some(p) => serde_json::json!({
+                            "bytes_sent": p.bytes_sent,
+                            "total_bytes": p.total_bytes,
+                            "chunk_hash": p.chunk_hash,
+                            "done": p.done,
+                            "error": if p.error.is_empty() { None } else { Some(&p.error) },
+                        })
+                        .to_string(),
+                        None => "{\"error\": \"no progress received\"}".to_string(),
+                    }
+                }
+                Err(e) => format!("{{\"error\": \"push RPC failed: {e}\"}}"),
+            },
+            Err(e) => format!("{{\"error\": \"{e}\"}}"),
+        }
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for TcfsMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some(
+                "tcfs daemon control — query status, push/pull files, check sync state. \
+                 Connects to tcfsd over Unix domain socket gRPC."
+                    .into(),
+            ),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -96,10 +96,17 @@
           meta.mainProgram = "tcfs-tui";
         });
 
+        tcfs-mcp = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+          pname = "tcfs-mcp";
+          cargoExtraArgs = "-p tcfs-mcp";
+          meta.mainProgram = "tcfs-mcp";
+        });
+
       in {
         packages = {
           default = tcfsd;
-          inherit tcfsd tcfs-cli tcfs-tui;
+          inherit tcfsd tcfs-cli tcfs-tui tcfs-mcp;
         };
 
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
## Summary
- New `tcfs-mcp` crate: MCP (Model Context Protocol) server for AI agent integration
- 6 MCP tools exposing daemon capabilities: `daemon_status`, `credential_status`, `config_show`, `sync_status`, `push`, `pull`
- Uses `rmcp` 0.16 (official Rust MCP SDK) with stdio transport
- Connects to tcfsd daemon over Unix domain socket gRPC (same pattern as TUI)
- Updated CI, Nix flake, and release workflows to build/distribute `tcfs-mcp` binary

## MCP Tools
| Tool | Description |
|------|-------------|
| `daemon_status` | Get version, storage connectivity, uptime, active mounts |
| `credential_status` | Check if S3/storage credentials are loaded |
| `config_show` | Display current tcfs configuration |
| `sync_status` | Check file sync state (synced/pending/unknown) |
| `push` | Upload a local file to remote storage |
| `pull` | Download a remote file to local path |

## Claude Code Integration
After install, add to `.mcp.json`:
```json
{
  "mcpServers": {
    "tcfs": {
      "command": "tcfs-mcp",
      "env": { "TCFS_SOCKET": "/run/tcfsd/tcfsd.sock" }
    }
  }
}
```

## Test plan
- [x] `cargo build --workspace` - clean build
- [x] `cargo clippy --workspace -- -D warnings` - zero warnings  
- [x] `cargo fmt --check` - formatted
- [ ] CI passes (fmt, clippy, test, build, deny, audit, nix)
- [ ] Release workflow includes `tcfs-mcp` in archives

🤖 Generated with [Claude Code](https://claude.com/claude-code)