### PR TITLE
fix: update image repo and S3 endpoints for in-cluster deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -696,7 +696,7 @@ jobs:
             --create-namespace \
             --set image.tag=${{ needs.plan.outputs.tag }} \
             --set config.natsUrl=nats://nats.tcfs.svc.cluster.local:4222 \
-            --set config.s3Endpoint=http://dees-appu-bearts:8333 \
+            --set config.s3Endpoint=http://seaweedfs.tcfs.svc.cluster.local:8333 \
             --set config.s3Bucket=tcfs \
             --wait \
             --timeout=5m

--- a/Containerfile
+++ b/Containerfile
@@ -5,12 +5,12 @@
 #   runtime  — distroless/cc for minimal attack surface
 #
 # Build:
-#   podman build -t ghcr.io/tummycrypt/tcfsd:latest -f Containerfile .
+#   podman build -t ghcr.io/tinyland-inc/tcfsd:latest -f Containerfile .
 #
 # Run:
 #   podman run --rm \
 #     --env-file /path/to/s3-credentials.env \
-#     ghcr.io/tummycrypt/tcfsd:latest \
+#     ghcr.io/tinyland-inc/tcfsd:latest \
 #     --mode=worker --config=/etc/tcfsd/config.toml
 
 # ── Stage 1: Rust builder ─────────────────────────────────────────────────────

--- a/infra/k8s/charts/tcfs-backend/values.yaml
+++ b/infra/k8s/charts/tcfs-backend/values.yaml
@@ -2,7 +2,7 @@
 # Override with: helm install tcfs-backend ./infra/k8s/charts/tcfs-backend -f my-values.yaml
 
 image:
-  repository: ghcr.io/tummycrypt/tcfsd
+  repository: ghcr.io/tinyland-inc/tcfsd
   tag: latest
   pullPolicy: Always
 
@@ -14,7 +14,7 @@ fullnameOverride: ""
 # tcfsd daemon configuration
 config:
   natsUrl: "nats://nats.tcfs.svc.cluster.local:4222"
-  s3Endpoint: "http://seaweedfs-s3.tcfs.svc.cluster.local:8333"
+  s3Endpoint: "http://seaweedfs.tcfs.svc.cluster.local:8333"
   s3Region: "us-east-1"
   s3Bucket: "tcfs"
   logLevel: "info"

--- a/infra/k8s/charts/tcfs-stack/values.yaml
+++ b/infra/k8s/charts/tcfs-stack/values.yaml
@@ -4,7 +4,7 @@ global:
   namespace: tcfs
 
   # -- SeaweedFS S3-compatible endpoint
-  seaweedfsEndpoint: "http://dees-appu-bearts:8333"
+  seaweedfsEndpoint: "http://seaweedfs.tcfs.svc.cluster.local:8333"
 
   # -- NATS server URL
   natsUrl: "nats://nats:4222"

--- a/infra/tofu/backend.tf
+++ b/infra/tofu/backend.tf
@@ -7,8 +7,8 @@ terraform {
     key    = "terraform.tfstate"
     region = "us-east-1"
 
-    # SeaweedFS S3 gateway endpoint
-    endpoint = "http://dees-appu-bearts:8333"
+    # SeaweedFS S3 gateway endpoint (in-cluster)
+    endpoint = "http://seaweedfs.tcfs.svc.cluster.local:8333"
 
     skip_credentials_validation = true
     skip_metadata_api_check     = true

--- a/infra/tofu/environments/civo/main.tf
+++ b/infra/tofu/environments/civo/main.tf
@@ -1,8 +1,8 @@
 # Civo Kubernetes environment: bitter-darkness-16657317
 #
 # Deploy the full tcfs stack to Civo K8s.
-# The existing bare-metal SeaweedFS (192.168.101.x) is used for storage;
-# only the sync workers + NATS + observability run in K8s.
+# SeaweedFS and NATS run in-cluster in the tcfs namespace;
+# sync workers + observability also run in K8s.
 #
 # To deploy:
 #   task infra:apply ENV=civo
@@ -59,11 +59,11 @@ module "tcfs_backend" {
   source = "../../modules/tcfs-backend"
 
   namespace  = var.namespace
-  image      = "ghcr.io/tummycrypt/tcfsd:${var.image_tag}"
+  image      = "ghcr.io/tinyland-inc/tcfsd:${var.image_tag}"
   nats_url   = module.nats.nats_url
 
-  # Point workers at the existing bare-metal SeaweedFS
-  s3_endpoint    = "http://dees-appu-bearts:8333"
+  # Point workers at the in-cluster SeaweedFS
+  s3_endpoint    = "http://seaweedfs.tcfs.svc.cluster.local:8333"
   s3_bucket      = "tcfs"
   s3_region      = "us-east-1"
   s3_secret_name = "seaweedfs-admin"

--- a/infra/tofu/environments/local/main.tf
+++ b/infra/tofu/environments/local/main.tf
@@ -56,7 +56,7 @@ module "tcfs_backend" {
   source = "../../modules/tcfs-backend"
 
   namespace  = var.namespace
-  image      = "ghcr.io/tummycrypt/tcfsd:${var.image_tag}"
+  image      = "ghcr.io/tinyland-inc/tcfsd:${var.image_tag}"
   nats_url   = module.nats.nats_url
 
   s3_endpoint    = "http://localhost:8333"

--- a/infra/tofu/modules/tcfs-backend/variables.tf
+++ b/infra/tofu/modules/tcfs-backend/variables.tf
@@ -7,7 +7,7 @@ variable "namespace" {
 variable "image" {
   description = "tcfsd container image (repository:tag)"
   type        = string
-  default     = "ghcr.io/tummycrypt/tcfsd:latest"
+  default     = "ghcr.io/tinyland-inc/tcfsd:latest"
 }
 
 variable "worker_replicas" {


### PR DESCRIPTION
## Summary
- Update container image registry from `ghcr.io/tummycrypt/tcfsd` to `ghcr.io/tinyland-inc/tcfsd` across all infra configs
- Update S3 endpoint from bare-metal hostname (`dees-appu-bearts:8333`) to in-cluster service DNS (`seaweedfs.tcfs.svc.cluster.local:8333`)
- SeaweedFS and NATS are already running in-cluster in the `tcfs` namespace on Civo, eliminating the bare-metal network bridge requirement

## Files changed
- `Containerfile` — image repo in build comments
- `.github/workflows/release.yml` — deploy-civo S3 endpoint
- `infra/k8s/charts/tcfs-backend/values.yaml` — image + S3 endpoint
- `infra/k8s/charts/tcfs-stack/values.yaml` — global S3 endpoint
- `infra/tofu/backend.tf` — Terraform state backend endpoint
- `infra/tofu/environments/civo/main.tf` — image + S3 endpoint
- `infra/tofu/environments/local/main.tf` — image
- `infra/tofu/modules/tcfs-backend/variables.tf` — image default

## Test plan
- [ ] CI passes (no Rust code changes)
- [ ] Helm template renders correctly with updated values
- [ ] Civo deploy job uses correct in-cluster endpoints