### PR TITLE
fix: disable KEDA/ServiceMonitor CRDs in Civo deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -698,6 +698,8 @@ jobs:
             --set config.natsUrl=nats://nats.tcfs.svc.cluster.local:4222 \
             --set config.s3Endpoint=http://seaweedfs.tcfs.svc.cluster.local:8333 \
             --set config.s3Bucket=tcfs \
+            --set autoscaling.enabled=false \
+            --set metrics.serviceMonitor.enabled=false \
             --wait \
             --timeout=5m
 


### PR DESCRIPTION
## Summary
- Disable KEDA ScaledObject and Prometheus ServiceMonitor in the Helm deploy step
- KEDA and Prometheus Operator CRDs are not installed on the Civo cluster
- The chart templates already have conditional guards, just need to pass `--set` overrides

## Context
v0.2.2 release pipeline: deploy-civo failed with:
```
no matches for kind "ScaledObject" in version "keda.sh/v1alpha1"
no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
```

## Test plan
- [ ] CI passes
- [ ] Next release triggers successful Civo deployment