### PR TITLE
fix: add imagePullSecrets for private GHCR registry

### DIFF
--- a/infra/k8s/charts/tcfs-backend/templates/deployment.yaml
+++ b/infra/k8s/charts/tcfs-backend/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "tcfs-backend.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 60
       containers:
         - name: worker

--- a/infra/k8s/charts/tcfs-backend/values.yaml
+++ b/infra/k8s/charts/tcfs-backend/values.yaml
@@ -6,6 +6,9 @@ image:
   tag: latest
   pullPolicy: Always
 
+imagePullSecrets:
+  - name: ghcr-pull-secret
+
 replicaCount: 1
 
 nameOverride: ""


### PR DESCRIPTION
## Summary
- Add `imagePullSecrets` to the Helm chart deployment template
- Default to `ghcr-pull-secret` in values.yaml
- K8s secret `ghcr-pull-secret` already created in tcfs namespace on Civo

## Context
v0.2.3 deploy-civo failed with `ImagePullBackOff` — GHCR returned 401 because the repo is private.

## Test plan
- [ ] CI passes
- [ ] Next release deploys successfully to Civo