### PR TITLE
fix: bind metrics to 0.0.0.0 for K8s health probes

### DIFF
--- a/infra/k8s/charts/tcfs-backend/templates/configmap.yaml
+++ b/infra/k8s/charts/tcfs-backend/templates/configmap.yaml
@@ -8,9 +8,10 @@ metadata:
 data:
   config.toml: |
     [daemon]
-    socket     = "/run/tcfsd/tcfsd.sock"
-    log_level  = {{ .Values.config.logLevel | quote }}
-    log_format = {{ .Values.config.logFormat | quote }}
+    socket       = "/run/tcfsd/tcfsd.sock"
+    log_level    = {{ .Values.config.logLevel | quote }}
+    log_format   = {{ .Values.config.logFormat | quote }}
+    metrics_addr = "0.0.0.0:{{ .Values.metrics.port }}"
 
     [storage]
     endpoint = {{ .Values.config.s3Endpoint | quote }}


### PR DESCRIPTION
## Summary
- Add explicit `metrics_addr = "0.0.0.0:9100"` in the Helm chart configmap
- Default in code is `127.0.0.1:9100` which is inaccessible to kubelet health probes
- Pod was crash-looping because liveness checks failed (couldn't reach metrics endpoint)

## Test plan
- [ ] CI passes
- [ ] Next release: pod becomes ready and passes health checks