### PR TITLE
fix: add Jekyll build for GitHub Pages docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,10 +29,14 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: docs/
+          destination: ./_site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+title: tcfs — TummyCrypt Filesystem
+description: FOSS self-hosted odrive replacement
+theme: jekyll-theme-cayman


### PR DESCRIPTION
## Summary
- Add `actions/jekyll-build-pages` step to render Markdown to HTML
- Add `docs/_config.yml` with Cayman theme
- Previously the workflow uploaded raw `.md` files, resulting in 404s

## Test plan
- [ ] CI passes
- [ ] After merge, trigger docs workflow and verify https://tinyland-inc.github.io/tummycrypt/ loads