### PR TITLE
docs: Mermaid diagrams, link checking, PDF pipeline, reality check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,9 @@ name: Docs
 on:
   push:
     branches: [main]
-    paths: ["docs/**"]
+    paths: ["docs/**", "README.md", ".lychee.toml"]
+  pull_request:
+    paths: ["docs/**", "README.md", ".lychee.toml"]
   workflow_dispatch:
 
 permissions:
@@ -17,9 +19,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-links:
+    name: Check Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for broken links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config .lychee.toml "docs/**/*.md" "README.md"
+          fail: true
+
+  build-pdf:
+    name: Build PDFs
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+
+      - name: Build PDF docs
+        run: nix develop --command task docs:pdf
+
+      - name: Upload PDF artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tcfs-docs-pdf
+          path: dist/docs/*.pdf
+
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    needs: [check-links]
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ dist
 .yarn/install-state.gz
 .pnp.*
 notes/
+
+# Generated docs
+dist/docs/

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,12 @@
+exclude = [
+  "^https://github.com/tinyland-inc/tummycrypt/compare",
+  "^https://nix-cache.fuzzy-dev.tinyland.dev",
+  "localhost",
+  "127\\.0\\.0\\.1",
+  "192\\.168\\.",
+  "dees-appu-bearts",
+  "seaweedfs.tcfs.svc",
+]
+include_fragments = true
+max_concurrency = 8
+timeout = 30

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,11 +1,20 @@
 exclude = [
   "^https://github.com/tinyland-inc/tummycrypt/compare",
   "^https://nix-cache.fuzzy-dev.tinyland.dev",
+  "^https://docs.tummycrypt.io",
+  "your-org",
   "localhost",
   "127\\.0\\.0\\.1",
   "192\\.168\\.",
   "dees-appu-bearts",
   "seaweedfs.tcfs.svc",
+  "seaweedfs.example.com",
+  "nats.example.com",
+  "filer.example.com",
+  "example.com",
+]
+exclude_path = [
+  "docs/archive/",
 ]
 include_fragments = true
 max_concurrency = 8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/lycheeverse/lychee
+    rev: lychee-v0.16.1
+    hooks:
+      - id: lychee
+        args: ["--config", ".lychee.toml"]
+        types_or: [markdown]

--- a/README.md
+++ b/README.md
@@ -64,15 +64,18 @@ tummycrypt/
 ├── .sops.yaml              # SOPS encryption rules
 ├── crates/                 # Rust workspace members
 │   ├── tcfs-core/          # Shared types, config, proto
+│   ├── tcfs-crypto/        # XChaCha20-Poly1305 encryption
 │   ├── tcfs-secrets/       # SOPS/age/KDBX integration
 │   ├── tcfs-storage/       # OpenDAL + SeaweedFS
 │   ├── tcfs-chunks/        # FastCDC, BLAKE3, zstd
 │   ├── tcfs-sync/          # Sync engine + NATS
 │   ├── tcfs-fuse/          # FUSE driver (Linux)
 │   ├── tcfs-cloudfilter/   # Windows CFAPI (skeleton)
+│   ├── tcfs-sops/          # SOPS+age fleet propagation
 │   ├── tcfsd/              # Daemon binary
 │   ├── tcfs-cli/           # CLI binary (tcfs)
-│   └── tcfs-tui/           # TUI binary
+│   ├── tcfs-tui/           # TUI binary
+│   └── tcfs-mcp/           # MCP server binary
 ├── credentials/            # SOPS-encrypted credentials
 ├── infra/
 │   ├── ansible/            # SeaweedFS Ansible deployment
@@ -85,6 +88,9 @@ tummycrypt/
 └── docs/
     ├── ARCHITECTURE.md     # System design
     ├── PROTOCOL.md         # .tc/.tcf stub file format spec
+    ├── SECURITY.md         # Threat model, encryption details
+    ├── CONTRIBUTING.md     # Development setup, PR workflow
+    ├── BENCHMARKS.md       # Performance characteristics
     └── archive/            # Previous design documents
 ```
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -176,3 +176,23 @@ tasks:
       - task: lint
       - task: test
       - task: deny
+
+  # ── Documentation ──────────────────────────────────────────────────────────
+
+  docs:links:
+    desc: Check for broken links in documentation
+    cmds:
+      - lychee --config .lychee.toml "docs/**/*.md" "README.md"
+
+  docs:pdf:
+    desc: Build PDF versions of technical design docs
+    cmds:
+      - mkdir -p dist/docs
+      - pandoc docs/ARCHITECTURE.md -o dist/docs/ARCHITECTURE.pdf --template docs/templates/tcfs.latex --lua-filter docs/filters/mermaid.lua --pdf-engine=tectonic --toc
+      - pandoc docs/PROTOCOL.md -o dist/docs/PROTOCOL.pdf --template docs/templates/tcfs.latex --lua-filter docs/filters/mermaid.lua --pdf-engine=tectonic --toc
+      - pandoc docs/SECURITY.md -o dist/docs/SECURITY.pdf --template docs/templates/tcfs.latex --lua-filter docs/filters/mermaid.lua --pdf-engine=tectonic --toc
+
+  docs:serve:
+    desc: Serve docs site locally with Jekyll
+    cmds:
+      - cd docs && bundle exec jekyll serve

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,33 +6,31 @@ that transparently hydrates files on demand.
 
 ## System Overview
 
-```
-User Machine                              Cloud / Self-hosted
-┌─────────────────────────────────┐      ┌───────────────────────────────────┐
-│                                 │      │                                   │
-│  /mnt/tcfs/                     │      │  SeaweedFS Cluster                │
-│  ├── project/                   │      │  ┌──────────┐ ┌──────────────┐   │
-│  │   ├── main.rs.tc  (stub)     │◄────►│  │ Masters  │ │ Volume Svrs  │   │
-│  │   ├── lib.rs      (hydrated) │      │  │ (3x raft)│ │ (Drobo 5C)   │   │
-│  │   └── docs.tcf    (dir stub) │      │  └──────────┘ └──────────────┘   │
-│  └── photos/                    │      │         ↑                         │
-│      └── 2024-01-01.jpg.tc      │      │  ┌──────────────────────────┐    │
-│                    │            │      │  │ Filer + S3 Gateway        │    │
-│  ┌─────────────┐   │            │      │  │ dees-appu-bearts:8333     │    │
-│  │  FUSE VFS   │   │ open()     │      │  └──────────────────────────┘    │
-│  │  (tcfs-fuse)│───┘            │      │                                   │
-│  └──────┬──────┘                │      │  NATS JetStream                   │
-│         │ gRPC Hydrate          │      │  ┌──────────────────────────┐    │
-│  ┌──────▼──────┐                │      │  │ SYNC_TASKS stream        │    │
-│  │   tcfsd     │                │      │  │ HYDRATION_EVENTS stream   │    │
-│  │  (daemon)   │────────────────┼─────►│  └──────────────────────────┘    │
-│  └──────┬──────┘                │      │         │                         │
-│         │                       │      │  ┌───────▼────────────────────┐   │
-│  ┌──────▼──────┐                │      │  │ Sync Workers (K8s pods)    │   │
-│  │   RocksDB   │                │      │  │ HPA: 1–100 via KEDA        │   │
-│  │ (state cache│                │      │  └────────────────────────────┘   │
-│  └─────────────┘                │      │                                   │
-└─────────────────────────────────┘      └───────────────────────────────────┘
+```mermaid
+flowchart LR
+    subgraph client["User Machine"]
+        direction TB
+        mount["/mnt/tcfs/\n.tc stubs + hydrated files"]
+        fuse["FUSE VFS\n(tcfs-fuse)"]
+        daemon["tcfsd\n(daemon)"]
+        state["State Cache\n(JSON / RocksDB)"]
+        mount --> fuse
+        fuse -->|"gRPC Hydrate"| daemon
+        daemon --> state
+    end
+
+    subgraph cloud["Cloud / Self-hosted"]
+        direction TB
+        seaweed["SeaweedFS Cluster\nMasters (3x Raft)\nVolume Servers"]
+        s3gw["Filer + S3 Gateway"]
+        nats["NATS JetStream\nSYNC_TASKS\nHYDRATION_EVENTS"]
+        workers["Sync Workers\n(K8s pods, KEDA-scaled)"]
+        seaweed --> s3gw
+        nats --> workers
+    end
+
+    daemon <-->|"S3 API"| s3gw
+    daemon -->|"NATS publish"| nats
 ```
 
 ## Components
@@ -41,15 +39,19 @@ User Machine                              Cloud / Self-hosted
 
 | Component | Binary | Purpose |
 |-----------|--------|---------|
-| `tcfs-fuse` | (library) | FUSE driver: stubs, hydration, negative cache |
+| `tcfs-core` | (library) | Shared types, config schema, proto defs |
+| `tcfs-crypto` | (library) | XChaCha20-Poly1305 encryption, key derivation |
+| `tcfs-secrets` | (library) | SOPS/age/KDBX credential chain |
+| `tcfs-storage` | (library) | OpenDAL abstraction, SeaweedFS native API |
+| `tcfs-chunks` | (library) | FastCDC chunking, BLAKE3 hashing, zstd |
+| `tcfs-sync` | (library) | Sync engine: state cache, NATS workers |
+| `tcfs-fuse` | (library) | Linux FUSE driver (fuse3 crate) |
+| `tcfs-cloudfilter` | (library) | Windows Cloud Files API (skeleton) |
+| `tcfs-sops` | (library) | SOPS+age fleet secret propagation |
 | `tcfsd` | `tcfsd` | Daemon: gRPC server, FUSE mount mgr, cred loader |
 | `tcfs-cli` | `tcfs` | CLI: mount, push, pull, sync, status, unsync |
-| `tcfs-tui` | `tcfs-tui` | TUI: dashboard, file browser, progress bars |
-| `tcfs-sync` | (library) | Sync engine: RocksDB state, NATS workers |
-| `tcfs-chunks` | (library) | FastCDC chunking, BLAKE3 hashing, zstd |
-| `tcfs-storage` | (library) | OpenDAL abstraction, SeaweedFS native API |
-| `tcfs-secrets` | (library) | SOPS/age/KDBX credential chain |
-| `tcfs-core` | (library) | Shared types, config schema, proto defs |
+| `tcfs-tui` | `tcfs-tui` | TUI: dashboard, config viewer, mounts, secrets |
+| `tcfs-mcp` | `tcfs-mcp` | MCP server: 6 tools for AI agent integration |
 
 ### Server-side (K8s)
 
@@ -63,16 +65,21 @@ User Machine                              Cloud / Self-hosted
 
 ## Stub File Format
 
-Files not yet downloaded appear as `.tc` stubs (zero bytes in POSIX, metadata in stub content):
+Files not yet downloaded appear as `.tc` stubs. The stub is a JSON file containing
+metadata needed to reconstruct the original file:
 
-```
-version https://tummycrypt.io/tcfs/v1
-chunks 23
-compressed 0
-fetched 0
-oid blake3:4d7a2146...e239
-origin seaweedfs://filer.example.com/bucket/path/to/file
-size 94371840
+```json
+{
+  "version": 1,
+  "file_id": "<BLAKE3 hash of original file, hex>",
+  "original_name": "photo.jpg",
+  "original_size": 4194304,
+  "mime_type": "image/jpeg",
+  "modified_at": "2026-02-20T12:00:00Z",
+  "chunk_count": 3,
+  "manifest_key": "chunks/manifests/<file_id>",
+  "remote_prefix": "tcfs/default"
+}
 ```
 
 Directory stubs use the `.tcf` extension and list child entries.
@@ -81,18 +88,24 @@ See `docs/PROTOCOL.md` for the full specification.
 
 ## Hydration Sequence
 
-```
-User process         FUSE VFS         tcfsd           SeaweedFS
-     │                  │               │                 │
-     │── open("x.tc") ─►│               │                 │
-     │                  │── Hydrate ───►│                 │
-     │                  │               │── S3 GetObject ►│
-     │                  │               │◄── stream ──────│
-     │                  │               │ (chunk assembly) │
-     │                  │◄──── fd ──────│                 │
-     │◄── fd ───────────│               │                 │
-     │── read() ────────►│               │                 │
-     │◄── data ──────────│               │                 │
+```mermaid
+sequenceDiagram
+    participant User as User Process
+    participant FUSE as FUSE VFS
+    participant Daemon as tcfsd
+    participant S3 as SeaweedFS
+
+    User->>FUSE: open("x.tc")
+    FUSE->>Daemon: Hydrate(file_id)
+    Daemon->>S3: S3 GetObject (manifest)
+    S3-->>Daemon: manifest JSON
+    Daemon->>S3: S3 GetObject (chunks, parallel)
+    S3-->>Daemon: chunk stream
+    Note over Daemon: decompress + reassemble
+    Daemon-->>FUSE: fd (hydrated file)
+    FUSE-->>User: fd
+    User->>FUSE: read()
+    FUSE-->>User: data
 ```
 
 After hydration, `x.tc` is atomically replaced with `x` (the real file).
@@ -100,31 +113,37 @@ After hydration, `x.tc` is atomically replaced with `x` (the real file).
 
 ## Credential Chain
 
-```
-tcfsd startup:
-  1. $CREDENTIALS_DIRECTORY/age-identity   (systemd LoadCredentialEncrypted)
-  2. $SOPS_AGE_KEY_FILE                    (env var path)
-  3. $SOPS_AGE_KEY                         (env var literal)
-  4. ~/.config/sops/age/keys.txt           (fallback)
-  → age identity loaded → SOPS decrypt credentials/*.yaml
-  → S3 credentials available to OpenDAL operator
-  → mtime watcher: auto-reload on credential file change
+```mermaid
+flowchart TD
+    A["tcfsd startup"] --> B{"$CREDENTIALS_DIRECTORY\n/age-identity?"}
+    B -->|found| G["age identity loaded"]
+    B -->|not found| C{"$SOPS_AGE_KEY_FILE?"}
+    C -->|found| G
+    C -->|not found| D{"$SOPS_AGE_KEY?"}
+    D -->|found| G
+    D -->|not found| E["~/.config/sops/age/keys.txt"]
+    E --> G
+    G --> H["SOPS decrypt credentials/*.yaml"]
+    H --> I["S3 credentials available\nto OpenDAL operator"]
+    I --> J["mtime watcher:\nauto-reload on change"]
 ```
 
 ## Phase Roadmap
 
 | Phase | Scope | Status |
 |-------|-------|--------|
-| 0 | Repo foundation, SOPS migration, Rust workspace stubs | In Progress |
-| 1 | Core daemon + secrets + gRPC | Pending |
-| 2 | Sync engine + chunking + NATS | Pending |
-| 3 | FUSE driver + .tc stubs + hydration | Pending |
-| 4 | K8s backend + HPA + full Tofu deploy | Pending |
-| 5 | RemoteJuggler KDBX integration | Pending |
-| 6 | Nix packaging + RPM + Homebrew | Pending |
+| 0 | Repo foundation, SOPS migration, Rust workspace stubs | Complete |
+| 1 | Core daemon + secrets + gRPC | Complete |
+| 2 | Sync engine + chunking + NATS | Complete |
+| 3 | FUSE driver + .tc stubs + hydration | Complete |
+| 4 | K8s backend + HPA + full Tofu deploy | Complete |
+| 5 | Release pipeline + packaging + docs site | Complete |
+| 6 | macOS FUSE-T + Windows CFAPI skeleton + GitLab mirror | Complete |
 | 7 | Production hardening + chaos tests | Pending |
 
-## Real Infrastructure (Local Network)
+## Real Infrastructure
+
+### Local Network (bare-metal)
 
 | Role | Address |
 |------|---------|
@@ -132,5 +151,14 @@ tcfsd startup:
 | SeaweedFS master-2 | 192.168.101.184:9333 |
 | SeaweedFS master-3 | 192.168.101.248:9333 |
 | Volume server (Drobo 5C) | 192.168.101.171:8080 |
-| Filer / S3 gateway | 192.168.101.146:8333 (dees-appu-bearts) |
-| Civo K8s cluster | bitter-darkness-16657317 (namespace: fuzzy-dev) |
+| Filer / S3 gateway | 192.168.101.146:8333 |
+
+### Civo Kubernetes
+
+| Property | Value |
+|----------|-------|
+| Cluster | bitter-darkness-16657317 |
+| Namespace | tcfs |
+| In-cluster SeaweedFS | seaweedfs.tcfs.svc.cluster.local:8333 |
+| In-cluster NATS | nats.tcfs.svc.cluster.local:4222 |
+| Container image | ghcr.io/tinyland-inc/tcfsd |

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,3 +1,81 @@
-# BENCHMARKS
+# Benchmarks
 
-Phase 0 stub. Full documentation pending Phase 7 (Production Hardening).
+Performance characteristics of tcfs operations. All measurements are preliminary
+and will be updated as the benchmark harness matures.
+
+## Chunking Throughput
+
+FastCDC content-defined chunking with BLAKE3 hashing:
+
+| Operation | Throughput | Notes |
+|-----------|-----------|-------|
+| FastCDC split (8 KiB avg) | TBD | Single-threaded, in-memory |
+| BLAKE3 hash | TBD | Single-threaded |
+| zstd compress (level 3) | TBD | Single-threaded |
+| Full pipeline (chunk + hash + compress) | TBD | Single-threaded |
+
+## Push / Pull Latency
+
+End-to-end latency for push and pull operations against local SeaweedFS:
+
+| File Size | Push (chunk + upload) | Pull (download + reassemble) | Notes |
+|-----------|----------------------|------------------------------|-------|
+| 1 KiB | TBD | TBD | Single chunk |
+| 1 MiB | TBD | TBD | ~128 chunks |
+| 100 MiB | TBD | TBD | ~12,800 chunks |
+| 1 GiB | TBD | TBD | ~128,000 chunks |
+
+Measured on: localhost SeaweedFS (single master, single volume).
+
+## Compression Ratios
+
+zstd level 3 compression ratios by file type:
+
+| File Type | Avg Ratio | Notes |
+|-----------|-----------|-------|
+| Source code (.rs, .go, .py) | TBD | High compressibility |
+| JSON / YAML | TBD | High compressibility |
+| JPEG / PNG images | TBD | Already compressed, ~1.0x |
+| Binary executables | TBD | Moderate compressibility |
+| Random data | TBD | ~1.0x (incompressible) |
+
+## FUSE Read Latency
+
+On-demand hydration latency (cold cache, local SeaweedFS):
+
+| Operation | Latency | Notes |
+|-----------|---------|-------|
+| Stub metadata read | TBD | JSON parse only |
+| First-byte (small file, 1 chunk) | TBD | Manifest fetch + chunk fetch |
+| First-byte (large file, many chunks) | TBD | Manifest fetch + first chunk |
+| Full hydration (1 MiB file) | TBD | All chunks fetched in parallel |
+| Cached read (after hydration) | TBD | Direct filesystem read |
+
+## Deduplication Efficiency
+
+Content-addressed storage deduplication across common workloads:
+
+| Workload | Files | Raw Size | Deduplicated | Savings |
+|----------|-------|----------|--------------|---------|
+| Git repo (10 commits) | TBD | TBD | TBD | TBD |
+| Photo library (RAW+JPEG) | TBD | TBD | TBD | TBD |
+| Node.js project (with node_modules) | TBD | TBD | TBD | TBD |
+
+## Test Environment
+
+Benchmarks will be run on:
+- **Hardware**: TBD
+- **OS**: Rocky Linux 10 / NixOS
+- **SeaweedFS**: 3-master Raft cluster, Drobo 5C volume server
+- **Network**: Gigabit Ethernet (local) / Civo K8s (remote)
+
+## Running Benchmarks
+
+```bash
+# Automated benchmark suite (future)
+task bench
+
+# Manual timing
+time cargo run -p tcfs-cli -- push /path/to/testfile
+time cargo run -p tcfs-cli -- pull testfile -o /tmp/output
+```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,20 +55,23 @@ integration tests (S3 access key, secret key, endpoint, bucket name).
 
 ## Project Structure
 
-The workspace is split into 10 crates under `crates/`:
+The workspace is split into 13 crates under `crates/`:
 
 | Crate | Type | Description |
 |-------|------|-------------|
 | `tcfs-core` | lib | Shared types, config parsing, protobuf definitions |
+| `tcfs-crypto` | lib | XChaCha20-Poly1305 encryption, key derivation, BIP-39 |
 | `tcfs-secrets` | lib | SOPS decryption, age identity, KeePassXC integration |
 | `tcfs-storage` | lib | OpenDAL-based S3/SeaweedFS operator |
 | `tcfs-chunks` | lib | FastCDC chunking, BLAKE3 hashing, zstd compression |
 | `tcfs-sync` | lib | Sync engine, state cache, NATS JetStream |
 | `tcfs-fuse` | lib | Linux FUSE driver (fuse3 crate) |
 | `tcfs-cloudfilter` | lib | Windows Cloud Files API (skeleton) |
+| `tcfs-sops` | lib | SOPS+age fleet secret propagation |
 | `tcfsd` | bin | Daemon: gRPC, FUSE, metrics, systemd notify |
 | `tcfs-cli` | bin | CLI: push, pull, mount, unmount, status |
 | `tcfs-tui` | bin | Interactive terminal UI (ratatui) |
+| `tcfs-mcp` | bin | MCP server for AI agent integration |
 
 ## Development Workflow
 
@@ -113,7 +116,7 @@ cargo run -p tcfs-cli -- mount seaweedfs://localhost:8333/tcfs /tmp/tcfs-mount
 
 ## Pull Request Guidelines
 
-1. **Branch from** `1-build-proxmox-mvp` (current development branch)
+1. **Branch from** `main`
 2. **Run checks locally** before pushing: `task check` (fmt + clippy + test + build)
 3. **Keep PRs focused** - one feature or fix per PR
 4. **Add tests** for new functionality

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,4 @@
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'default' });
+</script>

--- a/docs/filters/mermaid.lua
+++ b/docs/filters/mermaid.lua
@@ -1,0 +1,68 @@
+-- mermaid.lua — Pandoc Lua filter to render Mermaid diagrams as SVG
+-- Requires mmdc (mermaid-cli) on PATH. Falls back to code block if unavailable.
+
+local system = require("pandoc.system")
+
+local function file_exists(name)
+  local f = io.open(name, "r")
+  if f then
+    f:close()
+    return true
+  end
+  return false
+end
+
+local mmdc_available = nil
+
+local function check_mmdc()
+  if mmdc_available == nil then
+    local ok = os.execute("mmdc --version >/dev/null 2>&1")
+    mmdc_available = (ok == true or ok == 0)
+    if not mmdc_available then
+      io.stderr:write("mermaid.lua: mmdc not found, rendering diagrams as code blocks\n")
+    end
+  end
+  return mmdc_available
+end
+
+local img_counter = 0
+
+function CodeBlock(block)
+  if block.classes[1] ~= "mermaid" then
+    return nil
+  end
+
+  if not check_mmdc() then
+    return nil
+  end
+
+  img_counter = img_counter + 1
+
+  return system.with_temporary_directory("mermaid", function(tmpdir)
+    local input_file = tmpdir .. "/input.mmd"
+    local output_file = tmpdir .. "/output.svg"
+
+    local f = io.open(input_file, "w")
+    f:write(block.text)
+    f:close()
+
+    local cmd = string.format(
+      "mmdc -i %s -o %s -b transparent --quiet 2>/dev/null",
+      input_file, output_file
+    )
+    os.execute(cmd)
+
+    if file_exists(output_file) then
+      local img_f = io.open(output_file, "r")
+      local svg_data = img_f:read("*a")
+      img_f:close()
+      return pandoc.RawBlock("latex",
+        "\\begin{center}\n" ..
+        "\\includegraphics[width=\\textwidth]{" .. output_file .. "}\n" ..
+        "\\end{center}"
+      )
+    else
+      return nil
+    end
+  end)
+end

--- a/docs/templates/tcfs.latex
+++ b/docs/templates/tcfs.latex
@@ -1,0 +1,68 @@
+% tcfs.latex — Pandoc LaTeX template for tcfs technical documentation
+% Usage: pandoc doc.md -o doc.pdf --template docs/templates/tcfs.latex --pdf-engine=tectonic --toc
+\documentclass[11pt,a4paper]{article}
+
+% Encoding and fonts
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{textcomp}
+
+% Page geometry
+\usepackage[margin=2.5cm]{geometry}
+
+% Colors and hyperlinks
+\usepackage[dvipsnames]{xcolor}
+\usepackage[colorlinks=true,linkcolor=NavyBlue,urlcolor=NavyBlue,citecolor=NavyBlue]{hyperref}
+
+% Code listings
+\usepackage{listings}
+\usepackage{fancyvrb}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\},fontsize=\small}
+
+% Tables
+\usepackage{longtable}
+\usepackage{booktabs}
+\usepackage{array}
+
+% Graphics
+\usepackage{graphicx}
+\usepackage{float}
+
+% Better lists
+\usepackage{enumitem}
+
+% Header/footer
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[L]{\small\textsc{tcfs}}
+\fancyhead[R]{\small $title$}
+\fancyfoot[C]{\thepage}
+\renewcommand{\headrulewidth}{0.4pt}
+
+% Title metadata
+\title{$title$}
+\author{$if(author)$$author$$else$tcfs / TummyCrypt$endif$}
+\date{$if(date)$$date$$else$\today$endif$}
+
+% Tighter spacing
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt}
+
+% Pandoc tightlist support
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
+\begin{document}
+
+\maketitle
+
+$if(toc)$
+\tableofcontents
+\newpage
+$endif$
+
+$body$
+
+\end{document}

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,12 @@
             # NATS
             natscli
 
+            # Docs tooling
+            lychee
+            pandoc
+            tectonic
+            mermaid-cli
+
             # Dev tools
             git
             yq-go


### PR DESCRIPTION
## Summary

- Convert 6 ASCII diagrams to Mermaid (`flowchart`, `sequenceDiagram`) across ARCHITECTURE.md, SECURITY.md, index.md
- Reality-check all docs: update phase statuses (0-6 Complete), add 3 missing crates (tcfs-crypto, tcfs-sops, tcfs-mcp), fix stale `dees-appu-bearts` hostnames, update branch refs, expand BENCHMARKS.md stub
- Add docs tooling to `flake.nix` devShell: lychee, pandoc, tectonic, mermaid-cli
- Add CI jobs to `docs.yml`: `check-links` (lychee, gates deploy), `build-pdf` (pandoc+tectonic, uploads artifacts)
- Add Taskfile tasks: `docs:links`, `docs:pdf`, `docs:serve`
- Add Jekyll Mermaid CDN include, Pandoc Lua filter for Mermaid→SVG, LaTeX template for PDF output
- Add `.lychee.toml` config and `.pre-commit-config.yaml` for local link validation

## Test plan

- [ ] Verify Mermaid diagrams render on GitHub PR diff view
- [ ] CI `check-links` job passes (no broken links)
- [ ] CI `build-pdf` job produces PDF artifacts (on merge to main)
- [ ] `nix develop` includes lychee, pandoc, tectonic, mmdc
- [ ] `task docs:links` runs locally without errors
- [ ] GitHub Pages deploy still works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)