### PR TITLE
feat: wire device_id, NATS events, and ResolveConflict RPC

### DIFF
--- a/crates/tcfs-core/src/proto/tcfs.proto
+++ b/crates/tcfs-core/src/proto/tcfs.proto
@@ -14,6 +14,7 @@ service TcfsDaemon {
   rpc SyncStatus(SyncStatusRequest) returns (SyncStatusResponse);
   rpc Watch(WatchRequest) returns (stream WatchEvent);
   rpc CredentialStatus(Empty) returns (CredentialStatusResponse);
+  rpc ResolveConflict(ResolveConflictRequest) returns (ResolveConflictResponse);
 }
 
 message Empty {}
@@ -26,6 +27,9 @@ message StatusResponse {
   bool nats_ok = 4;
   int32 active_mounts = 5;
   int64 uptime_secs = 6;
+  string device_id = 7;
+  string device_name = 8;
+  string conflict_mode = 9;
 }
 
 message MountRequest {
@@ -119,4 +123,14 @@ message CredentialStatusResponse {
   string source = 2;
   int64 loaded_at = 3;
   bool needs_reload = 4;
+}
+
+message ResolveConflictRequest {
+  string path = 1;
+  string resolution = 2;
+}
+message ResolveConflictResponse {
+  bool success = 1;
+  string resolved_path = 2;
+  string error = 3;
 }

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -8,3 +8,7 @@ pub mod nats;
 pub mod scheduler;
 pub mod state;
 pub mod watcher;
+
+// Re-export key NATS types for convenience
+#[cfg(feature = "nats")]
+pub use nats::{NatsClient, StateEvent};

--- a/crates/tcfsd/Cargo.toml
+++ b/crates/tcfsd/Cargo.toml
@@ -14,11 +14,11 @@ path = "src/main.rs"
 tcfs-core = { path = "../tcfs-core" }
 tcfs-secrets = { path = "../tcfs-secrets" }
 tcfs-storage = { path = "../tcfs-storage" }
-tcfs-sync = { path = "../tcfs-sync" }
+tcfs-sync = { path = "../tcfs-sync", features = ["nats"] }
 tcfs-fuse = { path = "../tcfs-fuse" }
 opendal = { workspace = true }
-async-nats = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
+async-nats = { workspace = true }
+futures = { workspace = true }
 service-manager = { workspace = true }
 tonic = { workspace = true }
 tokio-stream = { workspace = true }
@@ -41,7 +41,7 @@ blake3 = { workspace = true }
 [features]
 default = []
 # Enables NATS consumer worker mode (for K8s pods)
-k8s-worker = ["dep:async-nats", "dep:futures", "tcfs-sync/nats"]
+k8s-worker = []
 
 [package.metadata.deb]
 maintainer = "TummyCrypt Contributors <jess@sulliwood.org>"


### PR DESCRIPTION
## Summary

- Wire device_id through CLI push/pull and daemon gRPC for vector clock conflict detection
- Connect daemon to NATS on startup, publish DeviceOnline + FileSynced state events, spawn state_sync_loop consumer
- Add ResolveConflict RPC to proto and wire MCP resolve_conflict tool to actual gRPC call
- Add device_id, device_name, conflict_mode to StatusResponse (visible in `tcfs status` and MCP daemon_status)

## Changes

| File | Change |
|------|--------|
| `tcfs-cli/src/main.rs` | `cmd_push`/`cmd_pull` use `*_with_device()` variants, load device registry, report conflicts |
| `tcfs-core/src/proto/tcfs.proto` | `ResolveConflict` RPC, `ResolveConflictRequest/Response`, StatusResponse fields |
| `tcfs-mcp/src/server.rs` | `resolve_conflict` calls gRPC RPC, `daemon_status` shows device info |
| `tcfs-sync/src/lib.rs` | Re-export `NatsClient` and `StateEvent` |
| `tcfsd/Cargo.toml` | Always link `tcfs-sync` with `nats` feature (fleet sync is core) |
| `tcfsd/src/daemon.rs` | NATS connect + DeviceOnline + state_sync_loop |
| `tcfsd/src/grpc.rs` | device_id field, NATS publish on push, ResolveConflict impl |

## Test plan

- [x] 133 tests pass, 0 failures
- [x] cargo fmt clean
- [x] Full workspace builds
- [ ] CI: cargo fmt + clippy + test + build

Signed-off-by: xoxd