### PR TITLE
docs: v0.3.0 documentation audit and update

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,81 @@
+# tcfs Development Context
+
+## Quick Start
+
+```bash
+# Enter Nix devShell (recommended)
+nix develop
+# Or with direnv:
+echo 'use flake' > .envrc && direnv allow
+
+# Build
+~/.cargo/bin/cargo build --workspace
+
+# Test
+~/.cargo/bin/cargo test --workspace
+
+# Lint
+~/.cargo/bin/cargo fmt --all -- --check
+~/.cargo/bin/cargo clippy --workspace --all-targets
+
+# Start dev infrastructure (SeaweedFS + NATS + Prometheus + Grafana)
+task dev
+```
+
+## Environment Notes
+
+- **Shell**: fish (does NOT support `export VAR=VALUE`; use `env VAR=VALUE command`)
+- **Cargo**: Not in PATH on Rocky Linux — always use `~/.cargo/bin/cargo`
+- **Linker**: mold is NOT installed outside Nix; do not add to `.cargo/config.toml`
+- **Docker**: Do not run docker-compose on yoga (resource-constrained)
+- **Rust edition**: 2021 (Rust >= 1.93 required for workspace)
+
+## Workspace Crates
+
+| Crate | Type | Description |
+|-------|------|-------------|
+| `tcfs-core` | lib | Shared types, config, protobuf (gRPC service definition) |
+| `tcfs-crypto` | lib | XChaCha20-Poly1305 encryption, Argon2id KDF, BIP-39 |
+| `tcfs-secrets` | lib | SOPS/age decryption, KeePassXC, device identity/registry |
+| `tcfs-storage` | lib | OpenDAL S3/SeaweedFS operator + health checks |
+| `tcfs-chunks` | lib | FastCDC chunking, BLAKE3 hashing, zstd compression |
+| `tcfs-sync` | lib | Sync engine, vector clocks, state cache, NATS JetStream |
+| `tcfs-fuse` | lib | Linux FUSE driver (fuse3) |
+| `tcfs-cloudfilter` | lib | Windows Cloud Files API (skeleton) |
+| `tcfs-sops` | lib | SOPS+age fleet secret propagation |
+| `tcfsd` | bin | Daemon: gRPC over Unix socket, FUSE, metrics, systemd |
+| `tcfs-cli` | bin | CLI: push, pull, mount, device, status |
+| `tcfs-tui` | bin | Terminal UI: ratatui 5-tab dashboard |
+| `tcfs-mcp` | bin | MCP server: 8 tools, rmcp 0.16, stdio transport |
+
+## Key Patterns
+
+- **Proto source of truth**: `crates/tcfs-core/src/proto/tcfs.proto` — all crates import via `tcfs_core::proto`
+- **Error handling**: `thiserror` for libraries, `anyhow` for binaries
+- **Async**: tokio full features, `tracing` for structured logging
+- **State cache**: JSON-backed at `{config.sync.state_db}.json`
+- **CAS layout**: chunks at `{prefix}/chunks/{hash}`, manifests at `{prefix}/manifests/{file_hash}`
+- **Feature gates**: `fuse` feature on tcfs-cli (default on), `nats` feature on tcfs-sync
+
+## Testing
+
+```bash
+# All tests
+~/.cargo/bin/cargo test --workspace
+
+# Specific crate
+~/.cargo/bin/cargo test -p tcfs-sync
+
+# Property-based tests
+~/.cargo/bin/cargo test -p tcfs-sync -- conflict
+~/.cargo/bin/cargo test -p tcfs-sync --test multi_machine_sim
+
+# With output
+~/.cargo/bin/cargo test -- --nocapture
+```
+
+## CI
+
+- GitHub Actions: fmt, clippy, test, build, cargo-deny, security audit, nix build
+- Docs CI: lychee link check + tectonic PDF build + Jekyll GitHub Pages
+- Release: 9 build targets (5 platforms + container + nix + installers + plan)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,105 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2026-02-22
+
+### Added
+
+- Multi-machine fleet sync with vector clocks and conflict resolution (#18, #19)
+- `VectorClock` implementation with `tick()`, `merge()`, `partial_cmp()`, `is_concurrent()`
+- `SyncManifest` v2 (JSON format with vector clocks, backward-compatible v1 text fallback)
+- Device identity system with auto-enrollment and S3-backed `DeviceRegistry`
+- CLI `device` subcommand: `enroll`, `list`, `revoke`, `status`
+- NATS JetStream real-time state sync (`StateEvent` enum with 6 event types)
+- Per-device durable NATS consumers with hierarchical subjects (`STATE.{device_id}.{type}`)
+- `ResolveConflict` gRPC RPC (11 total RPCs)
+- `.git` directory sync safety: lock detection, git bundle mode, cooperative locking
+- Config-driven file collection (`sync_git_dirs`, `exclude_patterns`, `sync_hidden_dirs`)
+- Interactive conflict resolver in CLI (`keep_local`, `keep_remote`, `keep_both`, `defer`)
+- TUI Conflicts tab for pending conflict review
+- MCP `resolve_conflict` and `device_status` tools (8 total tools)
+- NixOS and Home Manager module options for fleet sync
+- `examples/lab-fleet/` with per-machine config fragments
+- 18 proptest properties (8 vector clock, 2 crypto round-trip, 5 simulation, 3 integration)
+- RFC 0001: Fleet sync integration plan
+- LaTeX design documents (Architecture, Protocol, Security) with CI-built PDFs
+- Mermaid architecture diagrams in docs site
+- Link checking with lychee
+
+### Changed
+
+- CLI `push`/`pull` now use device-aware upload/download with vector clock tracking
+- Daemon publishes `DeviceOnline` event on NATS connect and `FileSynced` on push
+- `tcfs-sync` NATS feature is now always enabled in `tcfsd` (fleet sync is core)
+- Status RPC returns `device_id`, `device_name`, and `conflict_mode`
+- Manifest format upgraded from newline-delimited text to JSON (v2)
+
+## [0.2.5] - 2026-02-21
+
+### Fixed
+
+- Bind metrics server to `0.0.0.0` in K8s configmap for health probes (#14)
+- Add `imagePullSecrets` for private GHCR container registry (#13)
+- Disable KEDA `ScaledObject` and `ServiceMonitor` CRDs in Civo deploy (#12)
+- Update container image repo and S3 endpoint for in-cluster SeaweedFS (#11)
+
+### Added
+
+- MCP server (`tcfs-mcp`) for AI agent integration with 6 tools (#10)
+- Civo K8s deployment with NATS + SeaweedFS in `tcfs` namespace
+
+## [0.2.1] - 2026-02-21
+
+### Added
+
+- gRPC RPCs: `push` (client-streaming), `pull` (server-streaming), `sync_status` (#9)
+- TUI dashboard with 4 tabs: Dashboard, Config, Mounts, Secrets (#7)
+- `tcfs-sops` crate for SOPS+age fleet secret propagation (#7)
+
+### Fixed
+
+- macOS `fuse3` `FileAttr` missing `crtime`/`flags` fields
+- Darwin `apple_sdk` migration for nixpkgs-unstable 2026
+- Homebrew formula retry logic + container build amd64-only (#5)
+
+### Security
+
+- Removed committed TLS certificates and private keys from tracking (#8)
+
+## [0.2.0] - 2026-02-21
+
+### Changed
+
+- Version bump for release pipeline (no functional changes beyond v0.2.1 pre-releases)
+
+## [0.1.0] - 2026-02-21
+
+### Added
+
+- Rust monorepo with 13 workspace crates
+- Core daemon (`tcfsd`) with gRPC over Unix domain socket
+- CLI (`tcfs`): `status`, `config show`, `push`, `pull`, `sync-status`, `mount`, `unmount`, `unsync`
+- FUSE driver for Linux with on-demand hydration via `.tc` stubs
+- Windows Cloud Files API skeleton (`tcfs-cloudfilter`)
+- E2E encryption: XChaCha20-Poly1305, Argon2id key derivation, BIP-39 recovery
+- Content-defined chunking (FastCDC) with BLAKE3 hashing and zstd compression
+- Secrets management: SOPS/age decryption, KeePassXC integration
+- OpenDAL-based S3/SeaweedFS storage backend
+- Sync engine with JSON state cache and NATS JetStream messaging
+- K8s worker mode with KEDA auto-scaling
+- Prometheus metrics endpoint with systemd `sd_notify(READY=1)`
+- Cross-platform release pipeline: Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64
+- Container image: `ghcr.io/tinyland-inc/tcfsd` (multi-arch distroless)
+- Nix flake with NixOS module and Home Manager module
+- Homebrew formula, `.deb`/`.rpm` packages, install scripts
+- 77 tests, cargo-deny license/advisory checks, security audit CI
+
+[0.3.0]: https://github.com/tinyland-inc/tummycrypt/compare/v0.2.5...v0.3.0
+[0.2.5]: https://github.com/tinyland-inc/tummycrypt/compare/v0.2.1...v0.2.5
+[0.2.1]: https://github.com/tinyland-inc/tummycrypt/compare/v0.1.0...v0.2.1
+[0.2.0]: https://github.com/tinyland-inc/tummycrypt/releases/tag/v0.2.0
+[0.1.0]: https://github.com/tinyland-inc/tummycrypt/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -2193,9 +2193,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -2208,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2244,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2421,9 +2421,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3863,14 +3863,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-chunks"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cloudfilter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "opendal",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "prost",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-siv",
  "anyhow",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-fuse"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-secrets"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "age",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sops"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-storage"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "opendal",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sync"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-tui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "tcfsd"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -4782,7 +4782,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5574,9 +5574,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5587,9 +5587,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.60"
+version = "0.4.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5601,9 +5601,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5611,9 +5611,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5624,9 +5624,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]
@@ -5680,9 +5680,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.87"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ task infra:plan ENV=local    # Preview local k3s changes
 
 ## Peer Projects
 
-- **[remote-juggler](https://github.com/Jesssullivan/remote-juggler)**: Git identity management + KDBX credential resolution.
+- **[remote-juggler](https://github.com/tinyland-inc/remote-juggler)**: Git identity management + KDBX credential resolution.
   tcfs integrates with remote-juggler for credential fallback via KeePassXC.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ clients (odrive, Dropbox desktop, etc.). It mounts remote SeaweedFS storage as a
 directory, with files appearing as zero-byte `.tc` stubs until accessed — at which point they
 are transparently hydrated on demand.
 
-**Status**: Active development. Core sync (push/pull), FUSE mount, CLI, TUI, K8s worker mode, and cross-platform CI are functional. E2E encryption in progress.
+**Status**: Active development. Core sync, FUSE mount, CLI, TUI, MCP server, K8s worker mode, E2E encryption, and multi-machine fleet sync with vector clocks are functional. See [CHANGELOG](CHANGELOG.md) for release history.
 
 ## What it does
 
@@ -14,7 +14,30 @@ are transparently hydrated on demand.
 - Opening a `.tc` stub triggers on-demand download, replacing stub with real file
 - `tcfs unsync <path>` converts a hydrated file back to a stub (reclaims disk)
 - Sync is bidirectional, conflict-aware, git-friendly (BLAKE3 hashed, FastCDC chunked)
+- E2E encryption: XChaCha20-Poly1305 with Argon2id key derivation and BIP-39 recovery
+- Multi-machine fleet sync with vector clocks, NATS JetStream, and pluggable conflict resolution
 - Billions of small files, horizontal K8s backend, KEDA auto-scaling
+
+## Fleet Sync
+
+tcfs supports multi-machine sync across a device fleet:
+
+- **Device identity**: Each machine enrolls with a UUID and age keypair, stored in an S3-backed registry
+- **Vector clocks**: Distributed partial ordering detects concurrent edits without a central coordinator
+- **NATS JetStream**: Real-time state events (`FileSynced`, `DeviceOnline`, `ConflictResolved`, etc.) with per-device durable consumers
+- **Conflict resolution**: Pluggable modes — `auto` (lexicographic tie-break), `interactive` (CLI/TUI prompt), or `defer` (log and skip)
+- **Git-safe sync**: Optional `.git/` directory sync via atomic git bundles with lock detection
+
+```bash
+# Enroll this machine
+tcfs device enroll --name $(hostname)
+
+# Push a file (vector clock ticks, manifest v2 written)
+tcfs push ~/documents/report.pdf
+
+# On another machine: pull with conflict detection
+tcfs pull tcfs/default/report.pdf ~/documents/report.pdf
+```
 
 ## Architecture
 
@@ -26,7 +49,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for full system diagram and com
 # Enter devShell (requires Nix)
 nix develop
 
-# Or install tools manually (see scripts/setup-dev.sh)
+# Or install tools manually (see docs/CONTRIBUTING.md)
 
 # Generate TLS certs + start SeaweedFS + NATS + Prometheus + Grafana
 task dev
@@ -36,6 +59,28 @@ curl http://localhost:9333/cluster/status
 
 # Verify NATS is running
 nats server ping nats://localhost:4222
+```
+
+## Installation
+
+```bash
+# Linux (x86_64) — installer script
+curl -fsSL https://github.com/tinyland-inc/tummycrypt/releases/latest/download/install.sh | sh
+
+# macOS (Homebrew)
+brew install tinyland-inc/tap/tcfs
+
+# Debian/Ubuntu
+sudo dpkg -i tcfs-*.deb
+
+# RPM (Fedora/RHEL/Rocky)
+sudo rpm -i tcfsd-*.rpm
+
+# Container (K8s worker mode)
+podman pull ghcr.io/tinyland-inc/tcfsd:v0.3.0
+
+# Nix
+nix build github:tinyland-inc/tummycrypt
 ```
 
 ## Security: Credential Setup
@@ -58,47 +103,75 @@ task sops:decrypt FILE=credentials/seaweedfs-admin.yaml
 ```
 tummycrypt/
 ├── Cargo.toml              # Rust workspace root
+├── CHANGELOG.md            # Release history
 ├── flake.nix               # Nix devShell + packages
 ├── Taskfile.yaml           # Build tasks (task --list)
 ├── docker-compose.yml      # Local dev stack
 ├── .sops.yaml              # SOPS encryption rules
-├── crates/                 # Rust workspace members
-│   ├── tcfs-core/          # Shared types, config, proto
-│   ├── tcfs-crypto/        # XChaCha20-Poly1305 encryption
-│   ├── tcfs-secrets/       # SOPS/age/KDBX integration
-│   ├── tcfs-storage/       # OpenDAL + SeaweedFS
-│   ├── tcfs-chunks/        # FastCDC, BLAKE3, zstd
-│   ├── tcfs-sync/          # Sync engine + NATS
+├── crates/                 # Rust workspace members (13 crates)
+│   ├── tcfs-core/          # Shared types, config, protobuf definitions
+│   ├── tcfs-crypto/        # XChaCha20-Poly1305 encryption, key derivation
+│   ├── tcfs-secrets/       # SOPS/age/KDBX + device identity/registry
+│   ├── tcfs-storage/       # OpenDAL + SeaweedFS operator
+│   ├── tcfs-chunks/        # FastCDC chunking, BLAKE3, zstd compression
+│   ├── tcfs-sync/          # Sync engine, vector clocks, NATS JetStream
 │   ├── tcfs-fuse/          # FUSE driver (Linux)
 │   ├── tcfs-cloudfilter/   # Windows CFAPI (skeleton)
-│   ├── tcfs-sops/          # SOPS+age fleet propagation
-│   ├── tcfsd/              # Daemon binary
+│   ├── tcfs-sops/          # SOPS+age fleet secret propagation
+│   ├── tcfsd/              # Daemon binary (gRPC + metrics + systemd)
 │   ├── tcfs-cli/           # CLI binary (tcfs)
-│   ├── tcfs-tui/           # TUI binary
-│   └── tcfs-mcp/           # MCP server binary
+│   ├── tcfs-tui/           # TUI binary (ratatui dashboard)
+│   └── tcfs-mcp/           # MCP server binary (AI agent integration)
 ├── credentials/            # SOPS-encrypted credentials
 ├── infra/
 │   ├── ansible/            # SeaweedFS Ansible deployment
 │   ├── tofu/               # OpenTofu (K8s infrastructure)
 │   └── k8s/                # Helm charts + Kustomize
 ├── nix/                    # Nix modules (NixOS + Home Manager)
+├── examples/lab-fleet/     # Per-machine fleet config fragments
 ├── config/                 # Non-secret configs + examples
-├── certs/                  # TLS certificates
 ├── scripts/                # Dev + ops scripts
 └── docs/
-    ├── ARCHITECTURE.md     # System design
-    ├── PROTOCOL.md         # .tc/.tcf stub file format spec
-    ├── SECURITY.md         # Threat model, encryption details
+    ├── ARCHITECTURE.md     # System design (LaTeX → PDF)
+    ├── PROTOCOL.md         # Wire format, gRPC RPCs (LaTeX → PDF)
+    ├── SECURITY.md         # Threat model, encryption (LaTeX → PDF)
     ├── CONTRIBUTING.md     # Development setup, PR workflow
     ├── BENCHMARKS.md       # Performance characteristics
+    ├── rfc/                # Design RFCs
     └── archive/            # Previous design documents
 ```
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `tcfs status` | Show daemon status, device identity, NATS connection |
+| `tcfs config show` | Display active configuration |
+| `tcfs push <path>` | Upload files with chunking, encryption, vector clock tick |
+| `tcfs pull <remote> <local>` | Download files with conflict detection |
+| `tcfs sync-status <path>` | Check sync state of a file |
+| `tcfs mount <source> <target>` | FUSE mount with on-demand hydration |
+| `tcfs unmount <path>` | Unmount FUSE directory |
+| `tcfs unsync <path>` | Convert hydrated file back to `.tc` stub |
+| `tcfs device enroll` | Generate keypair and register in S3 |
+| `tcfs device list` | Show all enrolled devices |
+| `tcfs device revoke <name>` | Mark a device as revoked |
+| `tcfs device status` | Show this device's identity |
+
+## Binaries
+
+| Binary | Purpose |
+|--------|---------|
+| `tcfs` | CLI: push, pull, sync-status, mount, unmount, unsync, device management |
+| `tcfsd` | Daemon: 11 gRPC RPCs, FUSE mounts, NATS state sync, Prometheus metrics, systemd notify |
+| `tcfs-tui` | Terminal UI: 5-tab dashboard (Dashboard, Config, Mounts, Secrets, Conflicts) |
+| `tcfs-mcp` | MCP server: 8 tools for AI agent integration (stdio transport) |
 
 ## Development
 
 ```bash
 task build          # Build all Rust crates
-task test           # Run all tests
+task test           # Run all tests (133 tests + 18 proptest properties)
 task lint           # Clippy + rustfmt check
 task deny           # License + advisory check
 task check          # All of the above
@@ -114,8 +187,8 @@ task infra:plan ENV=local    # Preview local k3s changes
 
 ## Peer Projects
 
-- **remote-juggler** (`@tummycrypt/remote-juggler`): KDBX + git identity + MCP tools.
-  tcfs integrates with remote-juggler for credential management.
+- **[remote-juggler](https://github.com/Jesssullivan/remote-juggler)**: Git identity management + KDBX credential resolution.
+  tcfs integrates with remote-juggler for credential fallback via KeePassXC.
 
 ## License
 

--- a/crates/tcfs-core/src/lib.rs
+++ b/crates/tcfs-core/src/lib.rs
@@ -1,3 +1,5 @@
+//! tcfs-core: shared types, config parsing, and protobuf definitions for the tcfs workspace.
+
 pub mod config;
 pub mod error;
 pub mod types;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,10 @@ task docs:pdf
 # Output: dist/docs/architecture.pdf
 ```
 
+## Overview
+
+tcfs is a Rust monorepo of 13 workspace crates organized around a daemon (`tcfsd`) that exposes 11 gRPC RPCs over a Unix domain socket. The daemon manages FUSE mounts, coordinates with SeaweedFS via OpenDAL, and synchronizes state across a device fleet using NATS JetStream with vector clocks. Clients (CLI, TUI, MCP server) connect to the daemon via gRPC. Files are content-addressed using FastCDC chunking with BLAKE3 hashes, compressed with zstd, and encrypted with XChaCha20-Poly1305 before upload.
+
 ## Quick Reference
 
 See the [Architecture PDF](https://github.com/tinyland-inc/tummycrypt/actions/workflows/docs.yml) for full details including:

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,7 +1,8 @@
 # Benchmarks
 
-Performance characteristics of tcfs operations. All measurements are preliminary
-and will be updated as the benchmark harness matures.
+> **Note**: Benchmarks are planned for v0.4.0. The tables below define the measurement framework; all values are currently TBD.
+
+Performance characteristics of tcfs operations.
 
 ## Chunking Throughput
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,7 +16,7 @@
 # Clone and enter devShell
 git clone https://github.com/tinyland-inc/tummycrypt.git
 cd tummycrypt
-nix develop    # or: direnv allow
+nix develop    # or: echo 'use flake' > .envrc && direnv allow
 
 # Build everything
 task build
@@ -24,6 +24,8 @@ task build
 # Run tests
 task test
 ```
+
+> **Rocky Linux note**: `cargo` is not in `$PATH` by default. Use `~/.cargo/bin/cargo` for all cargo commands outside the Nix devShell.
 
 ### Quick Start without Nix
 
@@ -69,7 +71,7 @@ The workspace is split into 13 crates under `crates/`:
 | `tcfs-cloudfilter` | lib | Windows Cloud Files API (skeleton) |
 | `tcfs-sops` | lib | SOPS+age fleet secret propagation |
 | `tcfsd` | bin | Daemon: gRPC, FUSE, metrics, systemd notify |
-| `tcfs-cli` | bin | CLI: push, pull, mount, unmount, status |
+| `tcfs-cli` | bin | CLI: push, pull, mount, unmount, status, device management |
 | `tcfs-tui` | bin | Interactive terminal UI (ratatui) |
 | `tcfs-mcp` | bin | MCP server for AI agent integration |
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -24,4 +24,7 @@ See the [Protocol PDF](https://github.com/tinyland-inc/tummycrypt/actions/workfl
 - FastCDC chunking parameters
 - Hydration flow
 - State tracking schema
-- gRPC wire protocol (10 RPCs)
+- gRPC wire protocol (11 RPCs, including `ResolveConflict`)
+- NATS `StateEvent` types: `FileSynced`, `FileDeleted`, `FileRenamed`, `DeviceOnline`, `DeviceOffline`, `ConflictResolved`
+- NATS subject hierarchy: `STATE.{device_id}.{event_type}`
+- SyncManifest v2 JSON format (with v1 text fallback)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -13,6 +13,10 @@ task docs:pdf
 # Output: dist/docs/security.pdf
 ```
 
+## Overview
+
+tcfs encrypts all file content client-side before upload using XChaCha20-Poly1305 with per-file keys derived via HKDF from a master key. The master key is protected by Argon2id key derivation with BIP-39 mnemonic recovery. Credentials are managed through a layered chain: SOPS/age encrypted files, KeePassXC databases, or environment variables. Device identity uses age keypairs with BLAKE3 fingerprints, stored in an S3-backed registry. All chunk data is content-addressed (BLAKE3) ensuring integrity verification on every read.
+
 ## Quick Reference
 
 See the [Security PDF](https://github.com/tinyland-inc/tummycrypt/actions/workflows/docs.yml) for full details including:

--- a/docs/rfc/0001-fleet-sync-integration.md
+++ b/docs/rfc/0001-fleet-sync-integration.md
@@ -1,6 +1,6 @@
 # RFC 0001: Fleet Sync Integration for Lab Machines
 
-**Status**: Draft
+**Status**: Implemented (v0.3.0)
 **Author**: xoxd
 **Date**: 2026-02-22
 **Branch**: `fleet/multi-machine-sync` (PR #18)
@@ -224,6 +224,15 @@ tinyland.host.tummycrypt = {
    SeaweedFS creds to `nix/secrets/hosts/*.yaml` for each host.
 3. **Automatic daemon startup**: Should tcfsd start automatically via systemd/launchd?
    Or on-demand via CLI? Recommend: systemd on yoga, launchd on macOS machines.
+
+---
+
+## Implementation Notes
+
+- PR #18: Core implementation (vector clocks, device identity, NATS events, git safety, PBT, Nix modules)
+- PR #19: Stack wiring (device_id through CLI/daemon/gRPC/MCP, ResolveConflict RPC, NATS publishing)
+- Tagged as v0.3.0 on 2026-02-22, all CI green across 9 build targets
+- 133 tests passing, 18 proptest properties
 
 ---
 

--- a/scripts/setup_venv.sh
+++ b/scripts/setup_venv.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-echo "Setting up a local venv ..."
-python3 -m venv darwin_venv
-source darwin_venv/bin/activate
-pip3 install -r requirements.txt
-
-echo "All setup :)" && exit 0


### PR DESCRIPTION
## Summary

- Bump workspace version `0.2.0` → `0.3.0` to match tagged release
- Add `CHANGELOG.md` covering v0.1.0 through v0.3.0 (Keep a Changelog format)
- Overhaul `README.md`: fleet sync section, CLI commands table, container install, fixed peer projects link
- Update `docs/index.md`: Mermaid diagram with NATS + DeviceRegistry, 11 RPCs, 8 MCP tools, platform clarifications
- Update `docs/PROTOCOL.md`: 10 → 11 RPCs, NATS StateEvent + manifest v2 references
- Mark RFC 0001 as Implemented (was Draft)
- Add direnv tip and Rocky Linux note to `docs/CONTRIBUTING.md`
- Add v0.4.0 notice to `docs/BENCHMARKS.md` for TBD values
- Add inline overview paragraphs to `docs/ARCHITECTURE.md` and `docs/SECURITY.md`
- Add module doc comment to `tcfs-core/src/lib.rs`
- Remove legacy `scripts/setup_venv.sh` (no Python in workspace)
- Create repo-level `.claude/CLAUDE.md` with dev quick-start

## Test plan

- [ ] CI passes (no code changes, docs/metadata only)
- [ ] `grep '^version' Cargo.toml` shows `"0.3.0"`
- [ ] CHANGELOG.md renders correctly on GitHub
- [ ] docs/index.md Mermaid diagram shows NATS and DeviceRegistry nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)