### PR TITLE
RFC 0002: Darwin File Integration Strategy

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -191,6 +191,7 @@ tasks:
       - cmd: 'cd docs/tex && tectonic architecture.tex -o ../../dist/docs'
       - cmd: 'cd docs/tex && tectonic protocol.tex -o ../../dist/docs'
       - cmd: 'cd docs/tex && tectonic security.tex -o ../../dist/docs'
+      - cmd: 'cd docs/tex && tectonic fileprovider.tex -o ../../dist/docs'
 
   docs:serve:
     desc: Serve docs site locally with Jekyll

--- a/docs/rfc/0002-darwin-fuse-strategy.md
+++ b/docs/rfc/0002-darwin-fuse-strategy.md
@@ -1,0 +1,572 @@
+# RFC 0002: Darwin FUSE Strategy — macFUSE Alternatives and Privilege Escalation
+
+**Status**: Draft
+**Author**: xoxd
+**Date**: 2026-02-22
+**Tracking**: Sprint 7
+**Signed-off-by**: xoxd
+
+---
+
+## Abstract
+
+This RFC addresses the macOS-specific challenges of mounting FUSE filesystems for
+tcfs on Darwin. The current dependency on macFUSE introduces friction: it requires
+a third-party kernel extension (or system extension on Apple Silicon), manual
+approval in System Settings, and elevated privileges for mount operations. On
+managed machines with ABR (Admin By Request), additional automation is needed.
+
+We evaluate three paths forward:
+
+1. **Status quo**: macFUSE with automated bootstrapping and extension approval
+2. **Native reimplementation**: Pure Rust (or Zig) FUSE userspace via macOS NFS
+   loopback or FSKit (macOS 15+)
+3. **Hybrid**: macFUSE for existing macOS versions, FSKit for macOS 15+
+
+## Motivation
+
+During the Sprint 6 fleet deployment, tcfsd successfully connected to SeaweedFS
+on all Darwin machines but failed to mount the FUSE filesystem:
+
+| Host | macOS Version | Error | Root Cause |
+|------|---------------|-------|------------|
+| xoxd-bates | Sequoia 15.3 | `Read-only file system (os error 30)` | macFUSE system extension not approved |
+| petting-zoo-mini | Sequoia 15.3 | `Permission denied (os error 13)` | macFUSE system extension not loaded |
+
+The daemon's non-FUSE functionality works perfectly: S3 storage, gRPC socket,
+metrics endpoint, device identity, and fleet sync all operate without FUSE. Only
+the local mount point (which provides transparent file access via Finder/CLI)
+requires FUSE.
+
+### Why This Is Non-Trivial on macOS
+
+1. **Sealed System Volume**: macOS 13+ enforces a read-only system volume. FUSE
+   mounts must target the data volume (`/System/Volumes/Data`) or user-writable
+   paths like `~/tcfs`.
+
+2. **System Extension Approval**: macFUSE 4.x uses a system extension instead of
+   a kernel extension. This requires:
+   - User navigates to System Settings > Privacy & Security
+   - Clicks "Allow" for the macFUSE extension
+   - Reboots the machine
+   - On Apple Silicon: may require reduced security in Recovery Mode
+
+3. **Gatekeeper & Notarization**: macFUSE is notarized by its developer
+   (Benjamin Fleischer), but custom FUSE implementations need their own Apple
+   Developer ID and notarization workflow.
+
+4. **Admin By Request (ABR)**: Managed machines in enterprise/education
+   environments use ABR to gate sudo access. FUSE mount operations that require
+   root (or the macFUSE helper) need ABR elevation, which is time-limited and
+   requires user approval via a native dialog.
+
+## Option 1: macFUSE with Automated Bootstrapping
+
+### Approach
+
+Keep macFUSE as the FUSE provider. Automate as much of the setup as possible via
+the Nix home-manager module and launchd agents.
+
+### Implementation
+
+#### 1.1 Installation Detection & Auto-Install
+
+```nix
+# In tummycrypt.nix Darwin activation
+home.activation.ensureMacFuse = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  if ! [ -d "/Library/Filesystems/macfuse.fs" ]; then
+    echo "macFUSE not installed. Installing via Homebrew..."
+    if command -v brew &>/dev/null; then
+      $DRY_RUN_CMD brew install --cask macfuse
+    else
+      echo "ERROR: Homebrew not available. Install macFUSE manually:"
+      echo "  brew install --cask macfuse"
+      exit 1
+    fi
+  fi
+'';
+```
+
+#### 1.2 System Extension Approval Automation
+
+macOS does not provide a programmatic API to approve system extensions. However:
+
+**Option A: MDM Profile (Recommended for managed fleets)**
+
+Deploy a configuration profile that pre-approves the macFUSE system extension:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "...">
+<plist version="1.0">
+<dict>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadType</key>
+            <string>com.apple.system-extension-policy</string>
+            <key>AllowedSystemExtensions</key>
+            <dict>
+                <key>9T634XKSRH</key>  <!-- macFUSE developer team ID -->
+                <array>
+                    <string>io.macfuse.filesystems.macfuse</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>
+```
+
+This requires an MDM server (Mosyle, Jamf, Fleet). For lab machines without MDM,
+this is not viable unless we self-host a minimal MDM.
+
+**Option B: osascript/AppleScript Guided Approval**
+
+Cannot auto-approve, but can guide the user:
+
+```bash
+osascript -e 'display dialog "macFUSE needs approval.\n\nSystem Settings > Privacy & Security > Allow" \
+  with title "tcfs Setup" buttons {"Open Settings", "Later"} default button 1'
+if [ "$?" = "0" ]; then
+  open "x-apple.systempreferences:com.apple.preference.security"
+fi
+```
+
+**Option C: Reduced Security Mode (Apple Silicon)**
+
+For headless machines (petting-zoo-mini), system extensions require booting into
+Recovery Mode and running:
+
+```bash
+csrutil enable --without kext  # Or: bputil -d  (Reduced Security)
+```
+
+This is a one-time manual step per machine.
+
+#### 1.3 ABR (Admin By Request) Integration
+
+ABR gates sudo access behind a native approval dialog. When tcfs needs elevated
+privileges (mount operations, extension loading), we need to detect and integrate
+with ABR.
+
+**Detection:**
+
+```bash
+# Check if ABR is installed
+abr_installed() {
+  [ -f "/Library/Application Support/AdminByRequest/AdminByRequest" ] || \
+  [ -d "/Applications/Admin By Request.app" ]
+}
+
+# Check if ABR elevation is active (user has temporary admin)
+abr_elevated() {
+  # ABR adds user to admin group temporarily
+  groups | grep -q admin
+}
+```
+
+**Elevation Flow:**
+
+```bash
+if abr_installed && ! abr_elevated; then
+  # Prompt user to request ABR elevation
+  osascript -e 'display dialog "tcfs needs administrator access for FUSE mount.\n\n\
+Please request Admin By Request elevation, then retry." \
+    with title "tcfs - Admin Required" \
+    buttons {"Request Admin", "Cancel"} default button 1'
+
+  if [ "$?" = "0" ]; then
+    # Open ABR elevation request
+    open -a "Admin By Request"
+    echo "Waiting for ABR elevation..."
+    # Poll for elevation (max 5 minutes)
+    for i in $(seq 1 30); do
+      if abr_elevated; then
+        echo "ABR elevation granted. Proceeding with mount."
+        break
+      fi
+      sleep 10
+    done
+  fi
+fi
+```
+
+**Launchd Integration:**
+
+The tcfsd launchd agent should detect ABR and defer mount operations until
+elevation is available:
+
+```nix
+# In daemon wrapper
+if [ "$(uname)" = "Darwin" ] && abr_installed && ! abr_elevated; then
+  echo "ABR detected, no elevation. Running in degraded mode (no FUSE mount)."
+  exec ${tcfsdBin} --config "${configPath}" --no-mount
+fi
+```
+
+### Pros
+
+- Mature, well-tested (macFUSE has been around since 2006 as MacFuse/OSXFUSE)
+- Supports all macOS versions back to 10.15
+- Large user base (Docker Desktop, Cryptomator, VeraCrypt all use macFUSE)
+- No additional code to maintain
+
+### Cons
+
+- Third-party dependency with unclear long-term maintenance
+- System extension approval is manual and per-machine
+- Apple Silicon requires reduced security mode for some configurations
+- Notarization tied to macFUSE developer, not our keys
+- ABR integration is polling-based, not event-driven
+- Each macOS major release risks breaking macFUSE
+
+## Option 2: Native FUSE Reimplementation in Rust
+
+### Approach
+
+Eliminate macFUSE entirely by implementing FUSE-like functionality using macOS
+native APIs. Two sub-options exist:
+
+#### 2A: NFS Loopback Mount
+
+Mount a local NFS server that translates filesystem operations to tcfs operations.
+No kernel extension needed.
+
+**Architecture:**
+
+```
+Finder / CLI
+    |
+    v
+NFS Client (built into macOS kernel)
+    |
+    v (localhost:2049)
+tcfs-nfsd (Rust userspace NFS server)
+    |
+    v
+tcfs storage layer (S3/SeaweedFS)
+```
+
+**Implementation:**
+
+```rust
+// Using nfs-server-rs or custom NFSv3/v4 implementation
+use nfs_server::{NfsServer, FileSystem};
+
+struct TcfsNfs {
+    storage: Arc<StorageOperator>,
+    cache: Arc<CacheManager>,
+}
+
+impl FileSystem for TcfsNfs {
+    fn read(&self, path: &Path, offset: u64, size: u32) -> Result<Vec<u8>> {
+        // Hydrate from SeaweedFS on demand
+        self.storage.hydrate_and_read(path, offset, size)
+    }
+
+    fn write(&self, path: &Path, offset: u64, data: &[u8]) -> Result<u32> {
+        // Write to local cache, queue sync
+        self.cache.write_through(path, offset, data)
+    }
+
+    fn readdir(&self, path: &Path) -> Result<Vec<DirEntry>> {
+        // Return .tc stubs + hydrated files
+        self.storage.list_with_stubs(path)
+    }
+}
+```
+
+**Mount via launchd:**
+
+```bash
+# No macFUSE needed — just mount NFS
+mkdir -p ~/tcfs
+mount -t nfs -o tcp,resvport,locallocks localhost:/tcfs ~/tcfs
+```
+
+**Pros:**
+
+- Zero third-party dependencies (NFS is built into macOS kernel)
+- No system extension approval needed
+- No reduced security mode needed
+- Works on all macOS versions (NFS is ancient and stable)
+- Can be notarized with our own Developer ID
+
+**Cons:**
+
+- NFS semantics differ from POSIX (stale caches, attribute caching)
+- NFSv3 has 4GB file size limits on some configurations
+- NFS loopback has overhead vs direct FUSE
+- Must implement full NFS server (complex protocol)
+- NFS port (2049) may require root or port >= 1024 workaround
+- File change notifications (FSEvents) don't work over NFS
+
+#### 2B: FSKit (macOS 15+ / Sequoia)
+
+Apple introduced FSKit in macOS 15 as the official replacement for kernel-based
+filesystems. It runs entirely in userspace with no kernel extension.
+
+**Architecture:**
+
+```
+Finder / CLI
+    |
+    v
+VFS Layer (macOS kernel)
+    |
+    v (XPC)
+tcfs-fskit (FSKit Extension, Rust + Swift bridge)
+    |
+    v
+tcfs storage layer (S3/SeaweedFS)
+```
+
+**Implementation:**
+
+FSKit requires a System Extension bundle (.systemextension) distributed inside an
+app bundle. The extension implements the `FSBlockDeviceFileSystem` or
+`FSUnaryFileSystem` protocol.
+
+```swift
+// Swift bridge (FSKit requires Objective-C/Swift entry points)
+import FSKit
+
+@objc class TcfsFileSystem: FSUnaryFileSystem {
+    let rustCore = TcfsRustBridge()
+
+    override func mount(options: FSMountOptions) async throws -> FSVolume {
+        try await rustCore.mount(options)
+    }
+
+    override func read(volume: FSVolume, node: FSNode,
+                       offset: UInt64, length: UInt32) async throws -> Data {
+        try await rustCore.read(node.path, offset, length)
+    }
+}
+```
+
+```rust
+// Rust core (called via C FFI from Swift)
+#[no_mangle]
+pub extern "C" fn tcfs_read(path: *const c_char, offset: u64, len: u32,
+                             buf: *mut u8) -> i32 {
+    // ... hydration logic
+}
+```
+
+**Code Signing & Notarization:**
+
+FSKit extensions require:
+
+1. **Apple Developer ID** ($99/year)
+   - Needed for: Developer ID Application certificate, notarization
+   - Entitlements: `com.apple.developer.fs-kit.user-space-driver`
+
+2. **Provisioning Profile**
+   - Must request `com.apple.developer.fs-kit.user-space-driver` entitlement
+     from Apple (may require justification)
+
+3. **Notarization**
+   - All code must be notarized via `notarytool`
+   - Includes the .systemextension bundle, the host app, and any helper tools
+
+4. **Distribution**
+   - Can be distributed outside App Store (Developer ID signed + notarized)
+   - App bundle structure required:
+     ```
+     TummyCrypt.app/
+       Contents/
+         Library/
+           SystemExtensions/
+             dev.tinyland.tcfs-fskit.systemextension/
+         MacOS/
+           tcfs-helper  # Host app that manages the extension lifecycle
+     ```
+
+**Pros:**
+
+- Apple-sanctioned API (future-proof)
+- No kernel extension, no reduced security mode
+- Full POSIX semantics (unlike NFS loopback)
+- FSEvents / Spotlight integration possible
+- Our own Developer ID (full control over signing)
+
+**Cons:**
+
+- macOS 15+ only (drops support for Ventura, Sonoma)
+- FSKit API is new and sparsely documented (as of 2026)
+- Requires Swift bridge layer (Rust cannot directly implement ObjC protocols)
+- Apple Developer ID enrollment ($99/year) + entitlement approval
+- .systemextension still requires user approval in System Settings (but lighter
+  than kernel extensions)
+- Test surface is small — few FSKit filesystems exist in the wild
+
+#### 2C: Zig FUSE Implementation
+
+Similar to 2A/2B but using Zig instead of Rust for the native layer.
+
+**Rationale for Zig:**
+
+- C ABI compatibility (no FFI overhead for calling macOS APIs)
+- Compiles to tiny binaries (important for system extension size limits)
+- `@cImport` directly imports macOS system headers
+- Zig's allocator model maps well to filesystem buffer management
+
+**Implementation would mirror 2A or 2B** but with Zig replacing Rust for the
+platform-specific layer. The core tcfs logic (storage, crypto, sync) would remain
+in Rust with a C FFI boundary.
+
+**Tradeoff:** Introduces a second systems language into the codebase. Only
+justified if the platform layer is small and well-bounded.
+
+## Option 3: Hybrid Strategy (Recommended)
+
+### Approach
+
+Use macFUSE for macOS 13-14 (Ventura/Sonoma) and FSKit for macOS 15+ (Sequoia).
+Runtime detection selects the backend.
+
+### Implementation
+
+```rust
+enum FuseBackend {
+    MacFuse,    // macOS 13-14
+    FSKit,      // macOS 15+
+    NfsLoopback, // Fallback (no FUSE/FSKit available)
+    None,       // Degraded mode (push/pull only, no mount)
+}
+
+fn detect_backend() -> FuseBackend {
+    let version = macos_version();
+    if version >= (15, 0) && fskit_entitlement_granted() {
+        FuseBackend::FSKit
+    } else if macfuse_installed() && macfuse_extension_approved() {
+        FuseBackend::MacFuse
+    } else if can_bind_nfs_port() {
+        FuseBackend::NfsLoopback
+    } else {
+        FuseBackend::None  // Graceful degradation
+    }
+}
+```
+
+### Graceful Degradation Levels
+
+| Level | Mount | Push/Pull | Sync | Status |
+|-------|-------|-----------|------|--------|
+| Full (FSKit/macFUSE) | Yes | Yes | Yes | Transparent file access |
+| NFS Loopback | Yes (limited) | Yes | Yes | Mount works, no FSEvents |
+| Degraded (no mount) | No | Yes | Yes | CLI-only file access |
+
+### ABR Integration (All Levels)
+
+```rust
+/// Detect ABR and adapt privilege escalation strategy
+fn escalation_strategy() -> EscalationStrategy {
+    if cfg!(target_os = "macos") {
+        if abr_detected() {
+            EscalationStrategy::ABR {
+                // Use osascript to prompt for ABR elevation
+                prompt: "tcfs needs temporary admin for FUSE mount",
+                // Poll for elevation with exponential backoff
+                poll_interval: Duration::from_secs(10),
+                max_wait: Duration::from_secs(300),
+            }
+        } else {
+            EscalationStrategy::Standard {
+                // Use AuthorizationServices for sudo-like elevation
+                right: "dev.tinyland.tcfs.mount",
+            }
+        }
+    } else {
+        EscalationStrategy::None // Linux: no elevation needed for FUSE3
+    }
+}
+```
+
+### Developer Key Strategy
+
+Regardless of which FUSE backend ships, we need Apple code signing for macOS
+distribution:
+
+1. **Enroll in Apple Developer Program** ($99/year, `developer.apple.com`)
+   - Organization: Tinyland Inc.
+   - Type: Developer ID (for distribution outside App Store)
+
+2. **Certificates needed:**
+   - `Developer ID Application` — signs the tcfs binaries and app bundle
+   - `Developer ID Installer` — signs .pkg installers
+
+3. **Entitlements to request:**
+   - `com.apple.developer.fs-kit.user-space-driver` (for FSKit path)
+   - `com.apple.security.cs.allow-unsigned-executable-memory` (if needed for
+     Rust runtime)
+
+4. **CI/CD Integration:**
+   ```yaml
+   # GitHub Actions: sign and notarize
+   - name: Sign tcfs binaries
+     run: |
+       codesign --sign "Developer ID Application: Tinyland Inc (TEAMID)" \
+         --options runtime \
+         --entitlements entitlements.plist \
+         target/release/tcfs
+
+   - name: Notarize
+     run: |
+       xcrun notarytool submit tcfs.zip \
+         --apple-id "$APPLE_ID" \
+         --team-id "$TEAM_ID" \
+         --password "$APP_SPECIFIC_PASSWORD" \
+         --wait
+   ```
+
+## Recommendation
+
+**Short-term (v0.4.x):** Option 1 — macFUSE with ABR detection and guided setup.
+Ship `--no-mount` degraded mode as the default on Darwin until FUSE is confirmed
+working. This unblocks the fleet immediately.
+
+**Medium-term (v0.5.x):** Option 2A — NFS loopback as a zero-dependency fallback.
+This gives us a mount point on every Mac without any third-party software or
+system extension approval.
+
+**Long-term (v1.0):** Option 2B — FSKit native filesystem. This is the
+Apple-sanctioned path and will be the most robust option as macOS evolves. Requires
+Apple Developer enrollment and entitlement approval.
+
+## Decision Matrix
+
+| Criteria | macFUSE (Opt 1) | NFS Loopback (2A) | FSKit (2B) | Hybrid (Opt 3) |
+|----------|-----------------|--------------------|-----------|----|
+| Time to ship | 1 week | 3-4 weeks | 8-12 weeks | 4-6 weeks |
+| macOS version support | 10.15+ | 10.15+ | 15+ only | All |
+| Third-party deps | macFUSE | None | None | macFUSE (old macOS) |
+| Kernel extension | Yes (sysext) | No | No | Varies |
+| Apple Developer ID | No | No | Yes ($99/yr) | Yes |
+| ABR compatible | With integration | Natively (no root for NFS?) | With sysext approval | Best coverage |
+| POSIX compliance | Full | Partial (NFS caching) | Full | Varies |
+| Spotlight/FSEvents | Yes | No | Yes | Varies |
+| Maintenance burden | Low (upstream) | Medium (NFS server) | High (new API, Swift) | Highest |
+
+## Open Questions
+
+1. **FSKit entitlement timeline**: How long does Apple take to approve
+   `com.apple.developer.fs-kit.user-space-driver`? Is it automatic or review-gated?
+
+2. **NFS loopback root requirement**: Does `mount -t nfs localhost:/path` require
+   root on modern macOS? If yes, this negates the zero-privilege advantage.
+
+3. **ABR API**: Does Admin By Request expose any programmatic API (beyond polling
+   group membership) for detecting elevation state?
+
+4. **Zig vs Rust for platform layer**: Is the C ABI advantage of Zig worth adding
+   a second language? Could use `objc2` Rust crate for ObjC bridging instead.
+
+5. **Apple Developer enrollment**: Is Tinyland Inc already enrolled? If not, who
+   initiates enrollment and manages the certificates?
+
+---
+
+Signed-off-by: xoxd

--- a/docs/tex/architecture.tex
+++ b/docs/tex/architecture.tex
@@ -30,7 +30,7 @@ with a FUSE-based mount that transparently hydrates files on demand.
         before upload; storage operator never sees plaintext.
   \item \textbf{Content-addressed deduplication} --- FastCDC chunking with BLAKE3
         hashing eliminates redundant storage.
-  \item \textbf{Cross-platform} --- Linux (FUSE3), macOS (FUSE-T), Windows (Cloud Files API).
+  \item \textbf{Cross-platform} --- Linux (FUSE3), macOS/iOS (FileProvider), Windows (Cloud Files API).
   \item \textbf{Kubernetes-native backend} --- stateless sync workers scaled by KEDA,
         NATS JetStream for reliable task dispatch.
 \end{enumerate}

--- a/docs/tex/fileprovider.tex
+++ b/docs/tex/fileprovider.tex
@@ -1,0 +1,489 @@
+\documentclass[11pt,a4paper]{article}
+\input{preamble}
+
+\fancyhead[L]{\small\textsc{tcfs}}
+\fancyhead[R]{\small FileProvider Design}
+
+\title{tcfs FileProvider Integration\\
+\large macOS \& iOS On-Demand Hydration via NSFileProviderReplicatedExtension}
+\author{tcfs / TummyCrypt}
+\date{February 2026}
+
+\begin{document}
+\maketitle
+\tableofcontents
+\newpage
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Overview}
+
+This document describes the design for integrating \tcfs{} with Apple's
+FileProvider framework on macOS and iOS. FileProvider is the official mechanism
+for cloud storage providers to present files in Finder (macOS) and the Files app
+(iOS) with on-demand hydration, cloud status icons, and native Spotlight
+integration.
+
+FileProvider replaces FUSE as the primary file integration point on Apple
+platforms. FUSE remains the correct approach for Linux via \code{tcfs-fuse}.
+
+\subsection{Design Goals}
+
+\begin{enumerate}
+  \item \textbf{Native Finder integration} --- files appear under Locations in
+        the Finder sidebar at \filepath{\textasciitilde/Library/CloudStorage/}.
+  \item \textbf{On-demand hydration} --- files exist as APFS dataless stubs
+        until opened; kernel calls FileProvider extension to fetch content.
+  \item \textbf{Reuse existing Rust crates} --- \code{tcfs-storage},
+        \code{tcfs-chunks}, \code{tcfs-crypto}, and \code{tcfs-sync} are
+        linked as a static library with a thin Swift shim.
+  \item \textbf{No kernel extensions} --- FileProvider runs entirely in
+        userspace as an application extension (.appex).
+  \item \textbf{No root privileges} --- no \code{sudo}, no system extension
+        approval, no Reduced Security mode on Apple Silicon.
+  \item \textbf{Cross-Apple platform} --- shared Rust crate serves both
+        macOS and iOS with platform-conditional compilation.
+\end{enumerate}
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Platform Integration Matrix}
+
+\begin{table}[H]
+\centering
+\begin{tabularx}{\textwidth}{lllXl}
+\toprule
+\textbf{Platform} & \textbf{Framework} & \textbf{Crate} & \textbf{Mechanism} & \textbf{Status} \\
+\midrule
+Linux   & FUSE3                & tcfs-fuse         & Kernel FUSE module           & Working (v0.3.0) \\
+Windows & Cloud Files API      & tcfs-cloudfilter  & CFAPI minifilter             & Skeleton \\
+macOS   & FileProvider         & tcfs-fileprovider & APFS dataless files          & This design \\
+iOS     & FileProvider         & tcfs-fileprovider & APFS dataless files          & RFC 0003 \\
+\bottomrule
+\end{tabularx}
+\caption{Per-platform file integration strategy}
+\end{table}
+
+All four platforms share the same hydration concept: a lightweight stub
+represents each remote file; content is fetched on demand from SeaweedFS via
+the CAS chunk store.
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Architecture}
+
+\subsection{Component Stack}
+
+\begin{lstlisting}[language={},title={FileProvider component stack}]
+[Finder / CLI / Any App]
+       |
+       v
+[macOS Kernel -- APFS dataless files]
+       |  (on-demand hydration callback)
+       v
+[FileProvider Extension (.appex)]     ~200 LOC Swift
+       |  extern "C" function calls
+       v
+[tcfs-fileprovider (Rust static lib)]
+       |  uses existing tcfs crates
+       +---> tcfs-storage  (OpenDAL S3)
+       +---> tcfs-chunks   (FastCDC + BLAKE3 + zstd)
+       +---> tcfs-crypto   (XChaCha20-Poly1305)
+       +---> tcfs-sync     (vector clocks, state cache)
+       |
+       v
+[SeaweedFS S3 / NATS JetStream]
+\end{lstlisting}
+
+\subsection{Extension Bundle Structure}
+
+FileProvider extensions are delivered inside a host application:
+
+\begin{lstlisting}[language={}]
+TummyCrypt.app/
+  Contents/
+    MacOS/
+      TummyCrypt            # Host app (manages extension lifecycle)
+    PlugIns/
+      TcfsFileProvider.appex/
+        Contents/
+          MacOS/
+            TcfsFileProvider   # Extension binary (Swift + Rust staticlib)
+          Info.plist           # NSExtension metadata
+          Resources/
+            tcfs_fileprovider.h  # C header (cbindgen output)
+    Frameworks/
+      libtcfs_fileprovider.a   # Rust static library
+\end{lstlisting}
+
+\subsection{Data Flow}
+
+\begin{enumerate}
+  \item \textbf{Enumeration}: Finder opens the tcfs location. The extension's
+        \code{enumerator(for:)} creates an enumerator that calls the Rust
+        backend's \code{tcfs\_fp\_enumerate\_dir()}, which lists manifests
+        from S3. Each manifest becomes an \code{NSFileProviderItem} with
+        metadata (name, size, hash, modified time).
+
+  \item \textbf{Hydration}: User opens a cloud-only file. The kernel detects
+        the APFS dataless flag and calls \code{fetchContents(for:version:)}.
+        The Swift shim calls \code{tcfs\_fp\_fetch\_contents()}, which:
+        \begin{enumerate}[label=\alph*)]
+          \item Fetches the manifest from \code{manifests/\{file\_hash\}}
+          \item Fetches chunks in parallel from \code{chunks/\{chunk\_hash\}}
+          \item Decrypts each chunk (XChaCha20-Poly1305 per-chunk encryption)
+          \item Decompresses each chunk (zstd)
+          \item Reassembles and writes to the provided temporary URL
+        \end{enumerate}
+        The kernel then delivers the content to the requesting application.
+
+  \item \textbf{Upload}: User saves a file. The extension's \code{createItem}
+        or \code{modifyItem} callback receives the new content. The Rust
+        backend chunks, compresses, encrypts, and pushes to S3.
+
+  \item \textbf{Eviction}: When disk space is low, macOS automatically evicts
+        hydrated files back to dataless stubs. The extension's
+        \code{materializedSetDidChange()} callback is notified.
+
+  \item \textbf{Sync}: Background sync is triggered by
+        \code{NSFileProviderManager.signalEnumerator(for:)}, which causes
+        the system to re-enumerate and detect remote changes.
+\end{enumerate}
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Swift Shim Design}
+
+The FileProvider extension entry point must be Swift or Objective-C.
+The shim implements three protocols with all logic delegated to Rust:
+
+\subsection{Extension Entry Point}
+
+\begin{lstlisting}[language={},title={TcfsFileProvider.swift (simplified)}]
+import FileProvider
+
+class TcfsFileProvider: NSObject,
+    NSFileProviderReplicatedExtension {
+
+    let domain: NSFileProviderDomain
+
+    required init(domain: NSFileProviderDomain) {
+        self.domain = domain
+        tcfs_fp_initialize()  // Rust: load config, connect S3
+    }
+
+    func invalidate() {
+        tcfs_fp_shutdown()
+    }
+
+    func item(for identifier: NSFileProviderItemIdentifier,
+              request: NSFileProviderRequest,
+              completionHandler: @escaping (NSFileProviderItem?,
+                  Error?) -> Void) -> Progress {
+        // Call Rust backend
+        var item = FPItem()
+        let rc = tcfs_fp_get_item_metadata(
+            identifier.rawValue, &item)
+        if rc == 0 {
+            completionHandler(TcfsItem(item), nil)
+        } else {
+            completionHandler(nil, mapError(rc))
+        }
+        return Progress()
+    }
+
+    func fetchContents(
+        for itemIdentifier: NSFileProviderItemIdentifier,
+        version: NSFileProviderItemVersion?,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (URL?,
+            NSFileProviderItem?, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 100)
+        DispatchQueue.global().async {
+            let tmpURL = /* temporary file URL */
+            let rc = tcfs_fp_fetch_contents(
+                itemIdentifier.rawValue,
+                tmpURL.path,
+                { pct in progress.completedUnitCount =
+                    Int64(pct * 100) }
+            )
+            if rc == 0 {
+                completionHandler(tmpURL, /*item*/, nil)
+            } else {
+                completionHandler(nil, nil, mapError(rc))
+            }
+        }
+        return progress
+    }
+
+    func enumerator(
+        for containerItemIdentifier:
+            NSFileProviderItemIdentifier,
+        request: NSFileProviderRequest
+    ) throws -> NSFileProviderEnumerator {
+        return TcfsEnumerator(containerItemIdentifier)
+    }
+}
+\end{lstlisting}
+
+\subsection{Item and Enumerator}
+
+The \code{TcfsItem} class wraps the C struct returned by Rust:
+
+\begin{lstlisting}[language={},title={C bridge types (cbindgen output)}]
+typedef struct {
+    const char *item_id;
+    const char *filename;
+    const char *parent_id;
+    uint64_t    file_size;
+    int64_t     modified_ts;
+    bool        is_directory;
+    const char *content_hash;
+} FPItem;
+\end{lstlisting}
+
+The enumerator calls \code{tcfs\_fp\_enumerate\_dir()} and wraps each
+\code{FPItem} in an \code{NSFileProviderItem}-conforming Swift object.
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Rust Static Library}
+
+\subsection{Crate Configuration}
+
+\begin{lstlisting}[language=toml,title={crates/tcfs-fileprovider/Cargo.toml (future)}]
+[package]
+name = "tcfs-fileprovider"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+tcfs-core    = { path = "../tcfs-core" }
+tcfs-storage = { path = "../tcfs-storage" }
+tcfs-chunks  = { path = "../tcfs-chunks" }
+tcfs-crypto  = { path = "../tcfs-crypto" }
+tcfs-sync    = { path = "../tcfs-sync" }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+
+[build-dependencies]
+cbindgen = "0.27"
+\end{lstlisting}
+
+\subsection{C API Surface}
+
+The Rust library exposes a minimal C API. All functions return \code{i32}
+error codes (0 = success, negative = error) and write output through
+pointer parameters.
+
+\begin{lstlisting}[language={},title={Exported C functions}]
+// Lifecycle
+int32_t tcfs_fp_initialize(void);
+int32_t tcfs_fp_shutdown(void);
+
+// Enumeration
+int32_t tcfs_fp_enumerate_dir(
+    const char *path,
+    FPItem    **out_items,
+    size_t     *out_count
+);
+void tcfs_fp_free_items(FPItem *items, size_t count);
+
+// Item metadata
+int32_t tcfs_fp_get_item_metadata(
+    const char *item_id,
+    FPItem     *out_item
+);
+
+// Hydration (download + decrypt + decompress)
+int32_t tcfs_fp_fetch_contents(
+    const char *item_id,
+    const char *dest_path,
+    void      (*progress_cb)(double)
+);
+
+// Upload (chunk + compress + encrypt + push)
+int32_t tcfs_fp_upload_file(
+    const char *local_path,
+    const char *remote_path,
+    void      (*progress_cb)(double)
+);
+
+// Sync status
+int32_t tcfs_fp_sync_status(FPSyncStatus *out);
+\end{lstlisting}
+
+\subsection{Async Bridge}
+
+The Rust library owns a \code{tokio::Runtime} for async operations. All
+C-exported functions block on the runtime:
+
+\begin{lstlisting}[language={},title={Async bridge pattern}]
+use std::sync::LazyLock;
+use tokio::runtime::Runtime;
+
+static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+    Runtime::new().expect("Failed to create tokio runtime")
+});
+
+#[no_mangle]
+pub extern "C" fn tcfs_fp_fetch_contents(
+    item_id: *const c_char,
+    dest: *const c_char,
+    progress: extern "C" fn(f64),
+) -> i32 {
+    RUNTIME.block_on(async {
+        // ... hydration using tcfs-storage, tcfs-chunks,
+        //     tcfs-crypto (all async)
+    })
+}
+\end{lstlisting}
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Credential Storage}
+
+FileProvider extensions run in a sandboxed process and cannot read environment
+variables or arbitrary config files. Credentials are stored via:
+
+\begin{description}
+  \item[Keychain] S3 access and secret credentials stored in a shared Keychain
+    access group (\code{group.com.tummycrypt.tcfs}). The host app writes
+    credentials during setup; the extension reads them at runtime.
+  \item[App Group UserDefaults] Configuration values (S3 endpoint, bucket,
+    prefix, NATS URL) stored in shared UserDefaults.
+  \item[App Group Container] Large config files or state caches stored in
+    the shared App Group container directory.
+\end{description}
+
+The credential flow:
+
+\begin{enumerate}
+  \item User launches TummyCrypt.app host application
+  \item Host app prompts for S3 endpoint, credentials, encryption passphrase
+  \item Credentials written to shared Keychain; config to shared UserDefaults
+  \item FileProvider extension reads credentials on first enumeration
+  \item Encryption key derived from passphrase via Argon2id (same as desktop)
+\end{enumerate}
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Build Pipeline}
+
+\subsection{Cross-Compilation}
+
+\begin{lstlisting}[language={},title={Build steps}]
+# 1. Build Rust static library for Apple targets
+cargo build --lib -p tcfs-fileprovider \
+    --target aarch64-apple-darwin    # macOS Apple Silicon
+cargo build --lib -p tcfs-fileprovider \
+    --target aarch64-apple-ios       # iOS
+
+# 2. Generate C header
+cbindgen --crate tcfs-fileprovider --lang c \
+    -o TcfsFileProvider.h
+
+# 3. Build Xcode project (extension + host app)
+xcodebuild -project TummyCrypt.xcodeproj \
+    -scheme TummyCrypt \
+    -configuration Release \
+    -archivePath build/TummyCrypt.xcarchive \
+    archive
+
+# 4. Sign and notarize
+codesign --sign "Developer ID Application: Tinyland Inc" \
+    --options runtime \
+    --entitlements entitlements.plist \
+    build/TummyCrypt.app
+
+xcrun notarytool submit build/TummyCrypt.zip \
+    --apple-id "$APPLE_ID" \
+    --team-id "$TEAM_ID" \
+    --password "$APP_SPECIFIC_PASSWORD" \
+    --wait
+\end{lstlisting}
+
+\subsection{CI Integration}
+
+The build runs on macOS GitHub Actions runners:
+
+\begin{enumerate}
+  \item Rust cross-compilation: \code{cargo build} with Apple targets
+  \item \code{cbindgen} header generation
+  \item \code{xcodebuild} for the extension bundle
+  \item Code signing with stored certificates (GitHub Secrets)
+  \item Notarization via \code{notarytool}
+  \item Archive as \code{.dmg} release asset
+\end{enumerate}
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Comparison with Other Platforms}
+
+\subsection{Hydration Trigger Comparison}
+
+\begin{table}[H]
+\centering
+\begin{tabularx}{\textwidth}{lXXX}
+\toprule
+\textbf{Concept} & \textbf{Linux (tcfs-fuse)} & \textbf{Windows (tcfs-cloudfilter)} & \textbf{macOS/iOS (tcfs-fileprovider)} \\
+\midrule
+Stub file        & \code{.tc} JSON file         & CFAPI placeholder         & APFS dataless file \\
+Hydration trigger & \code{read()} syscall        & \code{CF\_CALLBACK\_FETCH\_DATA} & \code{fetchContents(for:)} \\
+Dehydration      & \code{unsync} command         & \code{CfDehydratePlaceholder}    & System automatic eviction \\
+Directory listing & \code{readdir()}             & \code{CfGetPlaceholders}          & \code{enumerator(for:)} \\
+Status icons     & None (FUSE limitation)        & Explorer cloud icons              & Finder cloud icons \\
+Spotlight        & N/A                           & Windows Search integration        & Native APFS indexing \\
+\bottomrule
+\end{tabularx}
+\caption{Platform comparison for file integration}
+\end{table}
+
+\subsection{Reuse Matrix}
+
+\begin{table}[H]
+\centering
+\begin{tabular}{lcccc}
+\toprule
+\textbf{Crate} & \textbf{Linux} & \textbf{Windows} & \textbf{macOS} & \textbf{iOS} \\
+\midrule
+tcfs-core       & 100\% & 100\% & 100\% & 100\% \\
+tcfs-storage    & 100\% & 100\% & 100\% & 70\%  \\
+tcfs-chunks     & 100\% & 100\% & 100\% & 100\% \\
+tcfs-crypto     & 100\% & 100\% & 100\% & 100\% \\
+tcfs-sync       & 100\% & 100\% & 100\% & 80\%  \\
+\bottomrule
+\end{tabular}
+\caption{Crate reuse across platforms (iOS storage/sync need minor adaptation)}
+\end{table}
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Implementation Phases}
+
+\begin{description}
+  \item[Phase 1 (v0.4.x)] Transitional: macOS daemon with \code{--no-mount}
+    default. Push/pull/sync work without FUSE. macFUSE opt-in for existing users.
+  \item[Phase 2 (v0.5.x)] FileProvider MVP: read-only enumeration + on-demand
+    hydration. Rust staticlib + Swift shim. Keychain credentials. Apple
+    Developer ID enrollment.
+  \item[Phase 3 (v0.6.x)] Full FileProvider: write support, conflict resolution,
+    background sync, progress reporting, file pinning, E2E encryption through
+    the hydration path.
+  \item[Phase 4 (v1.0)] Polish: automatic eviction integration, thumbnails,
+    QuickLook, share extension. Deprecate macFUSE transitional path.
+\end{description}
+
+% ─────────────────────────────────────────────────────────────────────────────
+\section{Open Questions}
+
+\begin{enumerate}
+  \item \textbf{Apple Developer enrollment}: Is Tinyland Inc enrolled in the
+    Apple Developer Program (\$99/year)? If not, who initiates enrollment?
+  \item \textbf{App Group identifier}: Proposed
+    \code{group.com.tummycrypt.tcfs} for shared Keychain and container access.
+  \item \textbf{Distribution}: \code{.dmg} with drag-to-install? Homebrew cask?
+    Both?
+  \item \textbf{Minimum macOS}: \code{NSFileProviderReplicatedExtension}
+    matured in macOS 13+. Recommend targeting macOS 13 (Ventura) as minimum.
+  \item \textbf{iOS timeline}: Shared crate enables iOS but requires Xcode
+    project, TestFlight, and App Store submission. Defer to Phase 3+.
+\end{enumerate}
+
+\end{document}


### PR DESCRIPTION
## Summary

- Revised RFC 0002 from a FUSE-alternatives evaluation to a comprehensive Darwin file integration strategy
- **FileProvider (`NSFileProviderReplicatedExtension`)** identified as the correct framework for macOS/iOS — same mechanism used by iCloud Drive, Dropbox, and OneDrive
- FUSE remains correct for Linux; macFUSE available as transitional opt-in on macOS
- Added comprehensive LaTeX design document (`docs/tex/fileprovider.tex`)

## Key Findings

1. **FSKit** is for block-device filesystems only — not suitable for cloud storage
2. **FUSE-T** only supports libfuse2 (tcfs uses fuse3 crate) — incompatible
3. **NFS loopback** requires root on macOS (kernel restriction)
4. **FileProvider** provides native Finder integration, APFS dataless files, Spotlight, FSEvents, no kernel extension, no root

## Architecture

```
Rust staticlib (tcfs-fileprovider) -> cbindgen C header -> Swift shim (~200 LOC) -> .appex FileProvider extension
```

## Files Changed

- `docs/rfc/0002-darwin-fuse-strategy.md` — Complete RFC revision (FileProvider-first)
- `docs/tex/fileprovider.tex` — New LaTeX design document
- `docs/tex/architecture.tex` — Updated cross-platform reference
- `Taskfile.yaml` — Added fileprovider.tex to docs:pdf build