### PR TITLE
feat: Sprint 7 — benchmarks, fleet ops docs, iOS RFC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -774,6 +775,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
@@ -1131,6 +1138,31 @@ name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "divan"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3616,6 +3648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,6 +4524,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
+ "divan",
  "fastcdc",
  "proptest",
  "rayon",
@@ -4577,6 +4616,7 @@ dependencies = [
  "bip39",
  "blake3",
  "chacha20poly1305",
+ "divan",
  "hkdf",
  "proptest",
  "rand 0.8.5",
@@ -4588,6 +4628,20 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "tcfs-file-provider"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "tcfs-chunks",
+ "tcfs-core",
+ "tcfs-storage",
+ "tcfs-sync",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4784,6 +4838,16 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/tcfs-cli",
     "crates/tcfs-tui",
     "crates/tcfs-mcp",
+    "crates/tcfs-file-provider",
 ]
 
 [workspace.package]
@@ -131,6 +132,7 @@ glob = { version = "0.3" }
 proptest = { version = "1" }
 tempfile = { version = "3" }
 tokio-test = { version = "0.4" }
+divan = { version = "0.1" }
 
 [profile.release]
 opt-level = 3

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -49,6 +49,12 @@ tasks:
     cmds:
       - cargo clean
 
+  bench:
+    desc: Run all divan benchmarks
+    cmds:
+      - ~/.cargo/bin/cargo bench -p tcfs-chunks --bench chunks
+      - ~/.cargo/bin/cargo bench -p tcfs-crypto --bench crypto
+
   deny:
     desc: Check licenses and advisories (cargo-deny)
     cmds:

--- a/crates/tcfs-chunks/Cargo.toml
+++ b/crates/tcfs-chunks/Cargo.toml
@@ -20,3 +20,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+divan = { workspace = true }
+
+[[bench]]
+name = "chunks"
+harness = false

--- a/crates/tcfs-chunks/benches/chunks.rs
+++ b/crates/tcfs-chunks/benches/chunks.rs
@@ -1,0 +1,62 @@
+use tcfs_chunks::{chunk_data, compress, decompress_all, hash_bytes, ChunkSizes};
+
+fn make_data(size: usize) -> Vec<u8> {
+    // Semi-realistic data: repeating pattern with some entropy
+    (0..size)
+        .map(|i| (i.wrapping_mul(7) ^ (i >> 3)) as u8)
+        .collect()
+}
+
+#[divan::bench(args = [1024, 65536, 1048576, 10485760])]
+fn fastcdc_chunk(bencher: divan::Bencher, size: usize) {
+    let data = make_data(size);
+    bencher
+        .counter(divan::counter::BytesCount::new(size))
+        .bench(|| chunk_data(divan::black_box(&data), ChunkSizes::SMALL));
+}
+
+#[divan::bench(args = [1024, 65536, 1048576, 10485760])]
+fn blake3_hash(bencher: divan::Bencher, size: usize) {
+    let data = make_data(size);
+    bencher
+        .counter(divan::counter::BytesCount::new(size))
+        .bench(|| hash_bytes(divan::black_box(&data)));
+}
+
+#[divan::bench(args = [1024, 65536, 1048576, 10485760])]
+fn zstd_compress(bencher: divan::Bencher, size: usize) {
+    let data = make_data(size);
+    bencher
+        .counter(divan::counter::BytesCount::new(size))
+        .bench(|| compress(divan::black_box(&data), 1024 * 1024, 3).unwrap());
+}
+
+#[divan::bench(args = [1024, 65536, 1048576, 10485760])]
+fn zstd_decompress(bencher: divan::Bencher, size: usize) {
+    let data = make_data(size);
+    let blob = compress(&data, 1024 * 1024, 3).unwrap();
+    bencher
+        .counter(divan::counter::BytesCount::new(size))
+        .bench(|| decompress_all(divan::black_box(&blob)).unwrap());
+}
+
+#[divan::bench(args = [1024, 65536, 1048576, 10485760])]
+fn full_pipeline(bencher: divan::Bencher, size: usize) {
+    let data = make_data(size);
+    bencher
+        .counter(divan::counter::BytesCount::new(size))
+        .bench(|| {
+            let chunks = chunk_data(divan::black_box(&data), ChunkSizes::SMALL);
+            for chunk in &chunks {
+                let start = chunk.offset as usize;
+                let end = start + chunk.length;
+                let slice = &data[start..end];
+                let _hash = hash_bytes(slice);
+                let _compressed = compress(slice, 1024 * 1024, 3).unwrap();
+            }
+        });
+}
+
+fn main() {
+    divan::main();
+}

--- a/crates/tcfs-crypto/Cargo.toml
+++ b/crates/tcfs-crypto/Cargo.toml
@@ -27,3 +27,8 @@ tracing = { workspace = true }
 [dev-dependencies]
 proptest = { workspace = true }
 tempfile = { workspace = true }
+divan = { workspace = true }
+
+[[bench]]
+name = "crypto"
+harness = false

--- a/crates/tcfs-crypto/benches/crypto.rs
+++ b/crates/tcfs-crypto/benches/crypto.rs
@@ -1,0 +1,48 @@
+use tcfs_crypto::{decrypt_chunk, encrypt_chunk, generate_file_key};
+
+fn make_data(size: usize) -> Vec<u8> {
+    (0..size)
+        .map(|i| (i.wrapping_mul(7) ^ (i >> 3)) as u8)
+        .collect()
+}
+
+#[divan::bench(args = [1024, 65536, 1048576])]
+fn bench_encrypt_chunk(bencher: divan::Bencher, size: usize) {
+    let file_key = generate_file_key();
+    let file_id = [0xABu8; 32];
+    let data = make_data(size);
+    bencher
+        .counter(divan::counter::BytesCount::new(size))
+        .bench(|| {
+            encrypt_chunk(
+                divan::black_box(&file_key),
+                0,
+                divan::black_box(&file_id),
+                divan::black_box(&data),
+            )
+            .unwrap()
+        });
+}
+
+#[divan::bench(args = [1024, 65536, 1048576])]
+fn bench_decrypt_chunk(bencher: divan::Bencher, size: usize) {
+    let file_key = generate_file_key();
+    let file_id = [0xABu8; 32];
+    let data = make_data(size);
+    let encrypted = encrypt_chunk(&file_key, 0, &file_id, &data).unwrap();
+    bencher
+        .counter(divan::counter::BytesCount::new(size))
+        .bench(|| {
+            decrypt_chunk(
+                divan::black_box(&file_key),
+                0,
+                divan::black_box(&file_id),
+                divan::black_box(&encrypted),
+            )
+            .unwrap()
+        });
+}
+
+fn main() {
+    divan::main();
+}

--- a/crates/tcfs-file-provider/Cargo.toml
+++ b/crates/tcfs-file-provider/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tcfs-file-provider"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "tcfs UniFFI bridge for iOS/macOS File Provider extensions"
+
+[dependencies]
+tcfs-core = { path = "../tcfs-core" }
+tcfs-storage = { path = "../tcfs-storage" }
+tcfs-chunks = { path = "../tcfs-chunks" }
+tcfs-sync = { path = "../tcfs-sync" }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+# UniFFI will be enabled when implementation begins (Phase 7b)
+# uniffi = { workspace = true }
+
+# [build-dependencies]
+# uniffi = { workspace = true, features = ["build"] }

--- a/crates/tcfs-file-provider/src/lib.rs
+++ b/crates/tcfs-file-provider/src/lib.rs
@@ -1,0 +1,76 @@
+//! tcfs-file-provider: UniFFI bridge for iOS/macOS File Provider extensions
+//!
+//! This crate exposes tcfs storage, chunking, and sync operations
+//! as a C-compatible FFI layer via Mozilla UniFFI, enabling Swift
+//! and Kotlin consumers to build native file provider extensions.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! iOS Files App / macOS Finder
+//!       │
+//!       ├── NSFileProviderExtension (Swift)
+//!       │         │
+//!       │         └── UniFFI C bridge
+//!       │                   │
+//!       └── tcfs-file-provider (this crate)
+//!                   │
+//!                   ├── tcfs-storage  → S3/SeaweedFS access
+//!                   ├── tcfs-chunks   → FastCDC + BLAKE3 + zstd
+//!                   ├── tcfs-sync     → state cache, vector clocks
+//!                   └── tcfs-core     → config, proto types
+//! ```
+//!
+//! ## Status
+//!
+//! Skeleton — see [RFC 0003](../../docs/rfc/0003-ios-file-provider.md) for
+//! implementation roadmap.
+
+// UniFFI scaffolding will be generated here when implementation begins (Phase 7b)
+// uniffi::setup_scaffolding!();
+
+/// Provider configuration passed from the Swift layer.
+#[derive(Debug, Clone)]
+pub struct ProviderConfig {
+    pub s3_endpoint: String,
+    pub s3_bucket: String,
+    pub access_key: String,
+    pub secret_key: String,
+    pub remote_prefix: String,
+    pub encryption_key: Option<String>,
+}
+
+/// A file item returned by directory enumeration.
+#[derive(Debug, Clone)]
+pub struct FileItem {
+    pub item_id: String,
+    pub filename: String,
+    pub file_size: u64,
+    pub modified_timestamp: i64,
+    pub is_directory: bool,
+    pub content_hash: String,
+}
+
+/// Sync status reported to the Swift layer.
+#[derive(Debug, Clone)]
+pub struct SyncStatus {
+    pub connected: bool,
+    pub files_synced: u64,
+    pub files_pending: u64,
+    pub last_error: Option<String>,
+}
+
+/// Errors returned to the Swift layer via UniFFI.
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    #[error("storage error: {0}")]
+    Storage(String),
+    #[error("decryption error: {0}")]
+    Decryption(String),
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+}

--- a/crates/tcfs-file-provider/uniffi/tcfs_file_provider.udl
+++ b/crates/tcfs-file-provider/uniffi/tcfs_file_provider.udl
@@ -1,0 +1,4 @@
+// tcfs File Provider — UniFFI interface definition
+// Status: Skeleton — will be populated in Phase 7b
+//
+// See RFC 0002 for the planned interface.

--- a/dist/com.tummycrypt.tcfsd.plist
+++ b/dist/com.tummycrypt.tcfsd.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tummycrypt.tcfsd</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/tcfsd</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/tcfsd.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/tcfsd.stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TCFS_CONFIG</key>
+        <string>~/.config/tcfs/config.toml</string>
+    </dict>
+</dict>
+</plist>

--- a/docs/ops/fleet-deployment.md
+++ b/docs/ops/fleet-deployment.md
@@ -1,0 +1,312 @@
+# Fleet Deployment Guide
+
+Operational guide for deploying tcfs across a multi-machine fleet.
+Companion to [RFC 0001: Fleet Sync Integration](../rfc/0001-fleet-sync-integration.md).
+
+## Prerequisites
+
+- tcfs v0.3.0+ installed on all machines
+- SeaweedFS S3 reachable from all machines (verified: `dees-appu-bearts:8333`)
+- Each machine enrolled: `tcfs device enroll --name $(hostname)`
+
+---
+
+## 1. NATS Access Path
+
+NATS JetStream runs in the Civo K8s cluster (`nats.tcfs.svc.cluster.local:4222`).
+Lab machines need external access. Three options:
+
+### Option A: NodePort / LoadBalancer (Simplest)
+
+Expose NATS via Civo LoadBalancer:
+
+```bash
+# Create NATS LoadBalancer service
+kubectl -n tcfs expose deployment nats \
+  --type=LoadBalancer \
+  --port=4222 \
+  --target-port=4222 \
+  --name=nats-external
+
+# Get external IP
+kubectl -n tcfs get svc nats-external -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+**Pros**: Simplest setup, no VPN needed.
+**Cons**: NATS port exposed to internet (add firewall rules), requires static IP, no offline resilience.
+
+Firewall rules (Civo):
+```bash
+# Allow only lab IPs
+civo firewall rule create tcfs-fw \
+  --protocol tcp --startport 4222 --endport 4222 \
+  --cidr "YOUR_LAB_PUBLIC_IP/32"
+```
+
+### Option B: WireGuard Tunnel (Secure)
+
+Route NATS over a WireGuard mesh:
+
+```bash
+# On each lab machine
+wg-quick up tcfs-mesh
+
+# NATS URL uses WireGuard IP
+natsUrl = "nats://10.0.0.1:4222"  # WireGuard peer address
+```
+
+**Pros**: Encrypted tunnel, works behind NAT, no exposed ports.
+**Cons**: Requires VPN setup on all machines, adds latency, single point of failure if relay goes down.
+
+### Option C: NATS Leaf Node (Recommended)
+
+Run a NATS leaf node on one lab machine that connects upstream to the Civo cluster:
+
+```bash
+# Install NATS server on yoga
+nix-env -iA nixpkgs.nats-server
+
+# /etc/nats/leaf.conf
+leafnodes {
+  remotes [
+    {
+      url: "nats-leaf://nats.tcfs.svc.cluster.local:7422"
+      credentials: "/etc/nats/tcfs.creds"
+    }
+  ]
+}
+
+listen: "0.0.0.0:4222"
+jetstream {
+  store_dir: "/var/lib/nats/jetstream"
+  max_mem: 256MB
+  max_file: 1GB
+}
+
+# Start
+nats-server -c /etc/nats/leaf.conf
+```
+
+All lab machines connect to `nats://yoga.local:4222` (or `nats://192.168.101.X:4222`).
+
+**Pros**: Lowest latency for LAN operations, offline resilience (leaf buffers messages), single upstream connection to cluster.
+**Cons**: Requires running NATS on one lab machine, leaf node is a dependency.
+
+### Connectivity Verification
+
+```bash
+# Test NATS connectivity
+nats pub test "hello" --server nats://NATS_HOST:4222
+nats sub test --server nats://NATS_HOST:4222
+
+# Check JetStream status
+nats stream ls --server nats://NATS_HOST:4222
+
+# tcfs daemon connectivity
+tcfs status  # Shows NATS connection state
+```
+
+### Fallback Behavior
+
+tcfs works without NATS. If NATS is unreachable:
+- Push/pull operations proceed normally (S3 only)
+- State events are not published (no real-time notification)
+- Other machines must manually `tcfs pull` to see updates
+- When NATS reconnects, the daemon automatically resumes event publishing
+
+---
+
+## 2. Credential Distribution
+
+### Credential Precedence
+
+tcfs resolves credentials in this order (first match wins):
+
+1. **Environment variables**: `TCFS_S3_ACCESS`, `TCFS_S3_SECRET` (or standard AWS S3 credential env vars)
+2. **SOPS-encrypted file**: `~/.config/tcfs/secrets.yaml` (decrypted at runtime)
+3. **RemoteJuggler KDBX**: KeePassXC database via `keyring` crate
+4. **Config file**: `~/.config/tcfs/config.toml` (plaintext, not recommended)
+
+### Creating Per-Host Age Keys
+
+```bash
+# On each machine (one-time setup)
+age-keygen -o ~/.config/sops/age/keys.txt
+
+# Show public key (needed for .sops.yaml)
+age-keygen -y ~/.config/sops/age/keys.txt
+# → age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+```
+
+### Encrypting Credentials with SOPS
+
+Create a SOPS-encrypted secrets file per host:
+
+```bash
+# .sops.yaml (in repo root)
+creation_rules:
+  - path_regex: secrets/hosts/yoga\.yaml$
+    age: >-
+      age1...yoga_public_key
+  - path_regex: secrets/hosts/xoxd-bates\.yaml$
+    age: >-
+      age1...xoxd_bates_public_key
+  - path_regex: secrets/hosts/petting-zoo-mini\.yaml$
+    age: >-
+      age1...petting_zoo_mini_public_key
+```
+
+```yaml
+# secrets/hosts/yoga.yaml (before encryption)
+s3_access: "<access-credential>"
+s3_secret: "<secret-credential>"
+s3_endpoint: "http://dees-appu-bearts:8333"
+nats_url: "nats://yoga.local:4222"
+```
+
+```bash
+# Encrypt with SOPS
+sops --encrypt --in-place secrets/hosts/yoga.yaml
+```
+
+### Deploying via sops-nix
+
+For NixOS/Home Manager machines:
+
+```nix
+# In crush-dots host config
+sops.secrets."tcfs/s3_access" = {
+  sopsFile = ./secrets/hosts/yoga.yaml;
+  key = "s3_access";
+};
+
+# tcfs reads from /run/secrets/tcfs/s3_access
+```
+
+### Deploying via Environment Variables
+
+For non-NixOS machines:
+
+```bash
+# ~/.config/tcfs/env (sourced by systemd/launchd)
+TCFS_S3_ACCESS=<your-access-credential>
+TCFS_S3_SECRET=<your-secret-credential>
+TCFS_S3_ENDPOINT=http://dees-appu-bearts:8333
+TCFS_NATS_URL=nats://yoga.local:4222
+```
+
+### Credential Rotation
+
+```bash
+# 1. Generate new S3 credentials in SeaweedFS
+curl -X POST http://dees-appu-bearts:8333/admin/keys \
+  -d '{"accessKey":"new-key","secretKey":"new-secret"}'
+
+# 2. Update SOPS secrets on each host
+sops secrets/hosts/yoga.yaml
+# Edit s3_access and s3_secret values
+
+# 3. Re-encrypt
+sops --encrypt --in-place secrets/hosts/yoga.yaml
+
+# 4. Deploy
+# NixOS: nixos-rebuild switch
+# Non-NixOS: copy env file, restart tcfsd
+```
+
+---
+
+## 3. Automatic Daemon Startup
+
+### Linux (NixOS)
+
+Already handled by the NixOS module:
+
+```nix
+# In host configuration
+services.tcfsd = {
+  enable = true;
+  deviceName = "yoga";
+  conflictMode = "interactive";
+  natsUrl = "nats://yoga.local:4222";
+};
+```
+
+This generates a systemd unit with `After=network-online.target` and restart-on-failure.
+
+### Linux (systemd, non-NixOS)
+
+The systemd unit is installed at `/etc/systemd/system/tcfsd.service` or `~/.config/systemd/user/tcfsd.service`:
+
+```bash
+# System-level (runs as dedicated user)
+sudo systemctl enable tcfsd
+sudo systemctl start tcfsd
+
+# User-level
+systemctl --user enable tcfsd
+systemctl --user start tcfsd
+```
+
+The unit file is at `crates/tcfsd/tcfsd.service` in the repo.
+
+### macOS (launchd)
+
+Install the launchd plist:
+
+```bash
+# Copy plist
+cp dist/com.tummycrypt.tcfsd.plist ~/Library/LaunchAgents/
+
+# Load (starts immediately and on login)
+launchctl load ~/Library/LaunchAgents/com.tummycrypt.tcfsd.plist
+
+# Verify running
+launchctl list | grep tcfs
+```
+
+To unload:
+```bash
+launchctl unload ~/Library/LaunchAgents/com.tummycrypt.tcfsd.plist
+```
+
+The plist file is at `dist/com.tummycrypt.tcfsd.plist` in the repo.
+
+### Startup Dependencies
+
+```
+network-online.target (Linux) / NetworkReady (macOS)
+       │
+       ▼
+   NATS (optional — daemon starts without it, reconnects later)
+       │
+       ▼
+     tcfsd
+       │
+       ├── gRPC socket: /run/tcfsd.sock (Linux) / /tmp/tcfsd.sock (macOS)
+       ├── Metrics: http://localhost:9100/metrics
+       └── FUSE mount (if configured)
+```
+
+### Troubleshooting
+
+```bash
+# Linux: check daemon logs
+journalctl -u tcfsd -f
+journalctl -u tcfsd --since "5 min ago"
+
+# macOS: check daemon logs
+tail -f /tmp/tcfsd.stdout.log
+tail -f /tmp/tcfsd.stderr.log
+
+# macOS: check launchd status
+launchctl list | grep tcfs
+# PID > 0 means running, "-" means not running
+# Status 0 = exited cleanly, non-zero = error
+
+# Check gRPC socket
+tcfs status
+
+# Check NATS connectivity
+tcfs sync-status
+```

--- a/docs/rfc/0001-fleet-sync-integration.md
+++ b/docs/rfc/0001-fleet-sync-integration.md
@@ -215,15 +215,21 @@ tinyland.host.tummycrypt = {
 | Git bundle fails (dirty worktree) | Medium | .git sync skipped | `git_is_safe()` pre-checks, warnings logged |
 | macOS FUSE unavailable | Low | Mount doesn't work | Push/pull/sync work without FUSE |
 
-## Open Questions
+## Open Questions (Resolved)
 
-1. **NATS access path**: NodePort, WireGuard, or leaf node? Leaf node recommended
-   for offline resilience but requires running NATS on one lab machine.
-2. **Credential distribution**: How to distribute SeaweedFS S3 credentials to all
-   machines? Currently via `TCFS_*` env vars from sops-nix secrets. Need to add
-   SeaweedFS creds to `nix/secrets/hosts/*.yaml` for each host.
-3. **Automatic daemon startup**: Should tcfsd start automatically via systemd/launchd?
-   Or on-demand via CLI? Recommend: systemd on yoga, launchd on macOS machines.
+All open questions have been resolved. See [Fleet Deployment Guide](../ops/fleet-deployment.md) for full details.
+
+1. **NATS access path**: Resolved — **NATS leaf node** on yoga (recommended). Provides lowest
+   latency for LAN operations and offline resilience. NodePort and WireGuard documented as
+   alternatives. See [Fleet Deployment Guide, Section 1](../ops/fleet-deployment.md#1-nats-access-path).
+
+2. **Credential distribution**: Resolved — **SOPS+age** per-host encrypted secrets with
+   sops-nix for NixOS hosts, env file for others. Credential precedence: env vars > SOPS >
+   KDBX > config file. Rotation procedure documented. See [Fleet Deployment Guide, Section 2](../ops/fleet-deployment.md#2-credential-distribution).
+
+3. **Automatic daemon startup**: Resolved — **systemd** on Linux (NixOS module or manual unit),
+   **launchd** on macOS (plist at `dist/com.tummycrypt.tcfsd.plist`). Both configured for
+   auto-start on boot with restart-on-failure. See [Fleet Deployment Guide, Section 3](../ops/fleet-deployment.md#3-automatic-daemon-startup).
 
 ---
 

--- a/docs/rfc/0003-ios-file-provider.md
+++ b/docs/rfc/0003-ios-file-provider.md
@@ -1,0 +1,290 @@
+# RFC 0003: iOS File Provider Extension
+
+**Status**: Draft
+**Author**: xoxd
+**Date**: 2026-02-22
+**Tracking**: Phase 7 (Future)
+
+---
+
+## Abstract
+
+This RFC describes the architecture for an iOS File Provider extension that exposes
+tcfs storage in the iOS Files app. The extension reuses existing Rust crates
+(tcfs-storage, tcfs-chunks, tcfs-crypto, tcfs-sync) via Mozilla UniFFI, bridging
+to Swift for the native FileProviderExtension API.
+
+## Motivation
+
+iOS is a first-class target for tcfs. Users should be able to:
+
+- Browse their tcfs files in the iOS Files app
+- Open files on-demand (hydration from SeaweedFS)
+- Share files between iOS and desktop machines via the same CAS backend
+- Benefit from E2E encryption on mobile
+
+The iOS File Provider framework provides the system integration point, similar to
+how tcfs-fuse provides Linux integration and tcfs-cloudfilter provides Windows
+integration.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────┐
+│                    iOS Files App                  │
+├──────────────────────────────────────────────────┤
+│           NSFileProviderExtension                │
+│  ┌────────────────────────────────────────────┐  │
+│  │              Swift Layer                    │  │
+│  │  - FileProviderExtension.swift             │  │
+│  │  - FileProviderItem.swift                  │  │
+│  │  - FileProviderEnumerator.swift            │  │
+│  │  - ContentKeychain.swift (~2000 LOC)       │  │
+│  └────────────────┬───────────────────────────┘  │
+│                   │ UniFFI (C ABI)               │
+│  ┌────────────────┴───────────────────────────┐  │
+│  │          tcfs-file-provider (Rust)          │  │
+│  │  - uniffi bindings (~1000 LOC)             │  │
+│  │  - async task bridge                       │  │
+│  │  - credential adapter (Keychain)           │  │
+│  └────────────────┬───────────────────────────┘  │
+│                   │                              │
+│  ┌────────────────┴───────────────────────────┐  │
+│  │           Reused tcfs Crates               │  │
+│  │  ┌─────────────┐  ┌──────────────┐        │  │
+│  │  │ tcfs-storage │  │  tcfs-chunks │        │  │
+│  │  │ (70% reuse)  │  │ (100% reuse) │        │  │
+│  │  └──────────────┘  └──────────────┘        │  │
+│  │  ┌─────────────┐  ┌──────────────┐        │  │
+│  │  │  tcfs-sync  │  │  tcfs-crypto │        │  │
+│  │  │ (80% reuse) │  │ (100% reuse) │        │  │
+│  │  └──────────────┘  └──────────────┘        │  │
+│  └────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────┘
+```
+
+### Reusable Code
+
+| Crate | Reuse % | Notes |
+|-------|---------|-------|
+| tcfs-chunks | 100% | Pure computation, no platform deps |
+| tcfs-crypto | 100% | Pure computation, no platform deps |
+| tcfs-storage | 70% | OpenDAL S3 works on iOS; health checks need adaptation |
+| tcfs-sync | 80% | State cache and vector clocks reusable; NATS client needs iOS networking adaptation |
+| tcfs-core | 100% | Proto types, config structs |
+
+### New Code
+
+| Component | LOC (est.) | Language |
+|-----------|-----------|----------|
+| UniFFI bindings | ~1000 | Rust |
+| Swift FileProviderExtension | ~2000 | Swift |
+| Xcode project / build scripts | ~500 | Various |
+
+## Hydration Pattern
+
+The hydration flow mirrors tcfs-fuse and tcfs-cloudfilter:
+
+```
+User taps file in Files app
+       │
+       ▼
+NSFileProviderExtension.startProvidingItem(at:completionHandler:)
+       │
+       ▼
+tcfs_file_provider::hydrate(item_id)
+       │
+       ├── 1. Fetch manifest from S3: manifests/{file_hash}
+       ├── 2. Parse SyncManifest v2 (JSON)
+       ├── 3. Fetch chunks in parallel: chunks/{chunk_hash}
+       ├── 4. Decrypt chunks (XChaCha20-Poly1305)
+       ├── 5. Decompress chunks (zstd)
+       └── 6. Reassemble and write to provided URL
+       │
+       ▼
+completionHandler(nil)  // success
+```
+
+### Platform Analogs
+
+| Concept | Linux (tcfs-fuse) | Windows (tcfs-cloudfilter) | iOS (tcfs-file-provider) |
+|---------|-------------------|---------------------------|--------------------------|
+| Integration point | FUSE kernel module | Cloud Files minifilter | NSFileProviderExtension |
+| Stub/placeholder | `.tc` file | CFAPI placeholder | NSFileProviderItem |
+| Hydration trigger | `read()` syscall | `CF_CALLBACK_FETCH_DATA` | `startProvidingItem()` |
+| Dehydration | `unsync` command | `CfDehydratePlaceholder` | `itemChanged(at:)` |
+| Directory listing | `readdir()` | `CfGetPlaceholders` | `enumerator(for:)` |
+
+## UniFFI Interface Definition
+
+```udl
+namespace tcfs_file_provider {
+    // Initialize the provider with S3 credentials
+    [Throws=ProviderError]
+    void initialize(ProviderConfig config);
+
+    // List files at a given path
+    [Throws=ProviderError]
+    sequence<FileItem> list_items(string path);
+
+    // Hydrate a file (download + decrypt + decompress)
+    [Throws=ProviderError]
+    void hydrate_file(string item_id, string destination_path);
+
+    // Upload a local file
+    [Throws=ProviderError]
+    void upload_file(string local_path, string remote_path);
+
+    // Get sync status
+    [Throws=ProviderError]
+    SyncStatus get_sync_status();
+};
+
+dictionary ProviderConfig {
+    string s3_endpoint;
+    string s3_bucket;
+    string access_key;
+    string secret_key;
+    string remote_prefix;
+    string? encryption_key;
+};
+
+dictionary FileItem {
+    string item_id;
+    string filename;
+    u64 file_size;
+    i64 modified_timestamp;
+    boolean is_directory;
+    string content_hash;
+};
+
+dictionary SyncStatus {
+    boolean connected;
+    u64 files_synced;
+    u64 files_pending;
+    string? last_error;
+};
+
+[Error]
+enum ProviderError {
+    "StorageError",
+    "DecryptionError",
+    "NetworkError",
+    "NotFound",
+    "PermissionDenied",
+};
+```
+
+## Phase Roadmap
+
+### Phase 7a: Skeleton (This Sprint)
+
+- RFC document (this file)
+- `tcfs-file-provider` crate with module stubs
+- UniFFI UDL file (minimal)
+- Added to workspace members
+
+### Phase 7b: Basic Hydration
+
+- Implement UniFFI bindings for `list_items` and `hydrate_file`
+- Swift FileProviderExtension with read-only enumeration
+- Xcode project with Rust build integration (cargo-xcode or manual)
+- Test on iOS Simulator
+
+### Phase 7c: E2E Encryption
+
+- Wire tcfs-crypto through UniFFI
+- Keychain credential storage (replacing env vars)
+- Encrypted hydration flow
+
+### Phase 7d: Sync Engine
+
+- Wire tcfs-sync state cache through UniFFI
+- Background refresh via `NSFileProviderManager.signalEnumerator`
+- Push notifications for real-time updates (APNs or polling)
+
+### Phase 7e: UI + Polish
+
+- Progress reporting during hydration
+- Conflict resolution UI
+- Share extension for uploading
+- TestFlight beta
+
+## Technical Challenges
+
+### Async FFI
+
+UniFFI supports async functions but the bridge between tokio (Rust) and
+Swift concurrency (async/await) requires careful lifetime management.
+The recommended pattern is to run a tokio runtime in the Rust layer and
+expose blocking or callback-based APIs to Swift.
+
+```rust
+// Rust side: run async in dedicated runtime
+static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().unwrap());
+
+#[uniffi::export]
+fn hydrate_file(item_id: String, dest: String) -> Result<(), ProviderError> {
+    RUNTIME.block_on(async {
+        // ... async hydration logic
+    })
+}
+```
+
+### Keychain Credentials
+
+iOS sandbox prevents reading env vars or config files from the host.
+Credentials must be stored in the iOS Keychain and accessed via
+`Security.framework`:
+
+```swift
+let query: [String: Any] = [
+    kSecClass: kSecClassGenericPassword,
+    kSecAttrService: "com.tummycrypt.tcfsd",
+    kSecAttrAccount: "s3_access_key",
+    kSecReturnData: true,
+]
+```
+
+### App Sandbox Restrictions
+
+- File Provider extensions run in a separate process with limited memory (~50 MB)
+- No direct filesystem access outside the extension's container
+- Network requests must use `URLSession` (not raw sockets)
+- OpenDAL's S3 backend uses `reqwest` which should work via iOS networking
+
+### OpenDAL iOS Compilation
+
+OpenDAL with `services-s3` feature needs:
+- Cross-compilation to `aarch64-apple-ios`
+- Ring (TLS dependency) compiles for iOS with proper SDK paths
+- Tested: OpenDAL 0.55 builds for iOS targets
+
+## Dependency Chain
+
+```
+tcfs-core (proto types, config)
+    │
+    ├── tcfs-storage (OpenDAL S3 operator)
+    │       │
+    │       └── tcfs-chunks (FastCDC + BLAKE3 + zstd)
+    │               │
+    │               └── tcfs-crypto (XChaCha20 + Argon2id)
+    │
+    └── tcfs-sync (state cache, vector clocks)
+            │
+            └── tcfs-file-provider (UniFFI bridge) ← NEW
+                    │
+                    └── Swift FileProviderExtension (Xcode project) ← FUTURE
+```
+
+## References
+
+- [Apple File Provider documentation](https://developer.apple.com/documentation/fileprovider)
+- [Mozilla UniFFI](https://mozilla.github.io/uniffi-rs/)
+- [tcfs-cloudfilter](../../crates/tcfs-cloudfilter/) — Windows analog
+- [tcfs-fuse](../../crates/tcfs-fuse/) — Linux analog
+
+---
+
+Signed-off-by: xoxd


### PR DESCRIPTION
## Summary

- **Phase A**: divan benchmark framework for tcfs-chunks and tcfs-crypto with real measurements from yoga
- **Phase B**: Fleet deployment guide (NATS access, credential distribution, daemon startup), macOS launchd plist, RFC 0001 open questions resolved
- **Phase C**: RFC 0003 iOS File Provider (UniFFI architecture, hydration pattern, 5-phase roadmap), tcfs-file-provider crate skeleton

## Benchmark Highlights (yoga: i7-8550U, NVMe)

| Operation | 1 MiB Median |
|-----------|-------------|
| BLAKE3 hash | 1.39 GB/s |
| zstd compress (level 3) | 1.26 GB/s |
| zstd decompress | 2.79 GB/s |
| XChaCha20 encrypt | 252 MB/s |
| Full pipeline (chunk+hash+compress) | 44.6 MB/s |

## Files Changed (15)

| File | Action |
|------|--------|
| `Cargo.toml` | Add divan dep, tcfs-file-provider member |
| `crates/tcfs-chunks/Cargo.toml` | Add divan dev-dep + bench |
| `crates/tcfs-crypto/Cargo.toml` | Add divan dev-dep + bench |
| `crates/tcfs-chunks/benches/chunks.rs` | New: 5 divan benchmarks |
| `crates/tcfs-crypto/benches/crypto.rs` | New: 2 divan benchmarks |
| `crates/tcfs-file-provider/` | New: crate skeleton |
| `Taskfile.yaml` | Add `task bench` |
| `docs/BENCHMARKS.md` | Populated with real values |
| `docs/ops/fleet-deployment.md` | New: deployment guide |
| `dist/com.tummycrypt.tcfsd.plist` | New: macOS launchd |
| `docs/rfc/0001-fleet-sync-integration.md` | Resolve open questions |
| `docs/rfc/0003-ios-file-provider.md` | New: iOS RFC |

## Test plan

- [x] `cargo test --workspace` — 133 tests pass
- [x] `cargo clippy --workspace --all-targets` — no new warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check -p tcfs-file-provider` — compiles
- [x] `cargo bench -p tcfs-chunks --bench chunks` — runs
- [x] `cargo bench -p tcfs-crypto --bench crypto` — runs