### PR TITLE
feat: v0.4.0 production hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-02-23
+
+### Added
+
+- **Benchmarks**: divan benchmark framework for chunking and encryption throughput (#22)
+  - FastCDC chunking, BLAKE3 hashing, zstd compress/decompress, XChaCha20-Poly1305 encrypt/decrypt
+  - `task bench` command for running all benchmarks
+  - `docs/BENCHMARKS.md` populated with real measurements (BLAKE3: 1.39 GB/s, zstd: 1.26 GB/s)
+- **Chunk integrity verification**: BLAKE3 hash verified per-chunk on download and against manifest file hash (#23)
+- **Graceful shutdown**: SIGTERM/SIGINT handler flushes state cache, publishes DeviceOffline, sends systemd STOPPING=1 (#23)
+- **Health endpoints**: `/healthz` (liveness) and `/readyz` (readiness with S3 check) on metrics HTTP server (#23)
+- **7 integration tests**: push/pull round-trip, dedup, integrity, tree push, device-aware sync using in-memory backend (#23)
+- **Fleet deployment guide**: `docs/ops/fleet-deployment.md` covering NATS access, credential distribution, daemon startup (#22)
+- **macOS launchd plist**: `dist/com.tummycrypt.tcfsd.plist` for automatic daemon startup (#22)
+- RFC 0002: Darwin File Integration Strategy — FileProvider as primary macOS/iOS path (#21)
+- RFC 0003: iOS File Provider with UniFFI bridge design (#22)
+- `tcfs-file-provider` crate skeleton for macOS/iOS FileProvider extension (#22)
+- `docs/tex/fileprovider.tex` LaTeX design document (#21)
+
+### Changed
+
+- Storage retry improved: 5 retries with jitter (was 3 without jitter) + OpenDAL logging layer (#23)
+- gRPC `serve()` now supports graceful shutdown via async signal (#23)
+- Metrics server operator handle shared with health endpoint for live readiness checks (#23)
+
+### Fixed
+
+- Resolved RFC 0001 open questions (NATS access path, credential distribution, daemon startup) (#22)
+
 ## [0.3.0] - 2026-02-22
 
 ### Added
@@ -98,6 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Homebrew formula, `.deb`/`.rpm` packages, install scripts
 - 77 tests, cargo-deny license/advisory checks, security audit CI
 
+[0.4.0]: https://github.com/tinyland-inc/tummycrypt/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/tinyland-inc/tummycrypt/compare/v0.2.5...v0.3.0
 [0.2.5]: https://github.com/tinyland-inc/tummycrypt/compare/v0.2.1...v0.2.5
 [0.2.1]: https://github.com/tinyland-inc/tummycrypt/compare/v0.1.0...v0.2.1

--- a/crates/tcfs-storage/src/operator.rs
+++ b/crates/tcfs-storage/src/operator.rs
@@ -30,7 +30,12 @@ pub fn build_operator(cfg: &StorageConfig) -> Result<Operator> {
 
     let op = Operator::new(builder)
         .context("creating OpenDAL S3 operator")?
-        .layer(opendal::layers::RetryLayer::new().with_max_times(3))
+        .layer(opendal::layers::LoggingLayer::default())
+        .layer(
+            opendal::layers::RetryLayer::new()
+                .with_max_times(5)
+                .with_jitter(),
+        )
         .finish();
 
     Ok(op)

--- a/crates/tcfs-sync/tests/push_pull_roundtrip.rs
+++ b/crates/tcfs-sync/tests/push_pull_roundtrip.rs
@@ -1,0 +1,276 @@
+//! Integration test: push → pull round-trip with in-memory storage
+//!
+//! Verifies the full content pipeline: chunk → hash → upload → download →
+//! verify integrity → reassemble → byte-equal output. Uses OpenDAL's
+//! in-memory backend so no live SeaweedFS is required.
+
+use opendal::Operator;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn memory_operator() -> Operator {
+    Operator::new(opendal::services::Memory::default())
+        .expect("memory operator")
+        .finish()
+}
+
+fn write_test_file(dir: &Path, name: &str, content: &[u8]) -> std::path::PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, content).expect("write test file");
+    path
+}
+
+#[tokio::test]
+async fn roundtrip_small_file() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/default";
+
+    let original = b"hello world, this is a small test file for tcfs round-trip";
+    let src = write_test_file(tmp.path(), "small.txt", original);
+    let dst = tmp.path().join("output/small.txt");
+
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    // Push
+    let upload = tcfs_sync::engine::upload_file(&op, &src, prefix, &mut state, None)
+        .await
+        .expect("upload should succeed");
+
+    assert!(!upload.skipped);
+    assert!(upload.chunks > 0);
+    assert_eq!(upload.bytes, original.len() as u64);
+
+    // Pull
+    let download = tcfs_sync::engine::download_file(&op, &upload.remote_path, &dst, prefix, None)
+        .await
+        .expect("download should succeed");
+
+    assert_eq!(download.bytes, original.len() as u64);
+
+    // Verify byte equality
+    let downloaded = std::fs::read(&dst).unwrap();
+    assert_eq!(downloaded, original, "downloaded file must match original");
+}
+
+#[tokio::test]
+async fn roundtrip_binary_data() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/binary";
+
+    // Generate 256 KiB of pseudo-random binary data
+    let original: Vec<u8> = (0u64..262144)
+        .map(|i| (i.wrapping_mul(7) ^ (i >> 3)) as u8)
+        .collect();
+    let src = write_test_file(tmp.path(), "binary.bin", &original);
+    let dst = tmp.path().join("output/binary.bin");
+
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    let upload = tcfs_sync::engine::upload_file(&op, &src, prefix, &mut state, None)
+        .await
+        .expect("upload binary");
+
+    assert!(!upload.skipped);
+    assert!(
+        upload.chunks >= 1,
+        "256 KiB should produce at least 1 chunk, got {}",
+        upload.chunks
+    );
+
+    tcfs_sync::engine::download_file(&op, &upload.remote_path, &dst, prefix, None)
+        .await
+        .expect("download binary");
+
+    let downloaded = std::fs::read(&dst).unwrap();
+    assert_eq!(downloaded.len(), original.len());
+    assert_eq!(downloaded, original, "binary round-trip must be exact");
+}
+
+#[tokio::test]
+async fn roundtrip_dedup_skips_rechunk() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/dedup";
+
+    let original = b"deduplicated content test";
+    let src = write_test_file(tmp.path(), "dedup.txt", original);
+
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    // First upload
+    let first = tcfs_sync::engine::upload_file(&op, &src, prefix, &mut state, None)
+        .await
+        .expect("first upload");
+    assert!(!first.skipped);
+
+    // Second upload of same file should be skipped (state cache hit)
+    let second = tcfs_sync::engine::upload_file(&op, &src, prefix, &mut state, None)
+        .await
+        .expect("second upload");
+    assert!(second.skipped, "unchanged file should be skipped");
+}
+
+#[tokio::test]
+async fn roundtrip_integrity_verification() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/integrity";
+
+    // Upload a file
+    let original = b"integrity verification test data";
+    let src = write_test_file(tmp.path(), "verify.txt", original);
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    let upload = tcfs_sync::engine::upload_file(&op, &src, prefix, &mut state, None)
+        .await
+        .expect("upload");
+
+    // Corrupt a chunk in storage
+    let manifest_bytes = op.read(&upload.remote_path).await.unwrap();
+    let manifest =
+        tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes()).unwrap();
+    let chunk_hashes = manifest.chunk_hashes();
+    let chunk_key = format!("{prefix}/chunks/{}", chunk_hashes[0]);
+
+    // Overwrite chunk with garbage
+    op.write(&chunk_key, vec![0xDE, 0xAD, 0xBE, 0xEF])
+        .await
+        .unwrap();
+
+    // Pull should fail integrity check
+    let dst = tmp.path().join("output/verify.txt");
+    let result =
+        tcfs_sync::engine::download_file(&op, &upload.remote_path, &dst, prefix, None).await;
+
+    assert!(
+        result.is_err(),
+        "corrupted chunk should fail integrity check"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("integrity check failed"),
+        "error should mention integrity: {err}"
+    );
+}
+
+#[tokio::test]
+async fn roundtrip_large_file_many_chunks() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/large";
+
+    // 1 MiB file — should produce many chunks with FastCDC
+    let original: Vec<u8> = (0u64..1048576)
+        .map(|i| (i.wrapping_mul(13) ^ (i >> 5)) as u8)
+        .collect();
+    let src = write_test_file(tmp.path(), "large.bin", &original);
+    let dst = tmp.path().join("output/large.bin");
+
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    let upload = tcfs_sync::engine::upload_file(&op, &src, prefix, &mut state, None)
+        .await
+        .expect("upload large");
+
+    assert!(
+        upload.chunks >= 4,
+        "1 MiB should produce at least 4 chunks, got {}",
+        upload.chunks
+    );
+
+    let _download = tcfs_sync::engine::download_file(&op, &upload.remote_path, &dst, prefix, None)
+        .await
+        .expect("download large");
+
+    let downloaded = std::fs::read(&dst).unwrap();
+    assert_eq!(downloaded.len(), original.len());
+    assert_eq!(downloaded, original, "1 MiB round-trip must be exact");
+}
+
+#[tokio::test]
+async fn roundtrip_push_tree() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/tree";
+
+    // Create a directory tree
+    let src_dir = tmp.path().join("src");
+    std::fs::create_dir_all(src_dir.join("subdir")).unwrap();
+    write_test_file(&src_dir, "a.txt", b"file a content");
+    write_test_file(&src_dir, "b.txt", b"file b content");
+    write_test_file(&src_dir.join("subdir"), "c.txt", b"file c in subdir");
+
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    let (uploaded, skipped, _bytes) =
+        tcfs_sync::engine::push_tree(&op, &src_dir, prefix, &mut state, None)
+            .await
+            .expect("push_tree");
+
+    assert_eq!(uploaded, 3, "should upload 3 files");
+    assert_eq!(skipped, 0);
+
+    // Push again — should skip all
+    let (uploaded2, skipped2, _) =
+        tcfs_sync::engine::push_tree(&op, &src_dir, prefix, &mut state, None)
+            .await
+            .expect("push_tree second");
+
+    assert_eq!(uploaded2, 0, "second push should upload nothing");
+    assert_eq!(skipped2, 3, "second push should skip all 3");
+}
+
+#[tokio::test]
+async fn roundtrip_with_device_identity() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/device";
+    let device_id = "test-device-001";
+
+    let original = b"device-aware upload test";
+    let src = write_test_file(tmp.path(), "device.txt", original);
+    let dst = tmp.path().join("output/device.txt");
+
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    // Upload with device identity
+    let upload = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        device_id,
+        Some("device.txt"),
+    )
+    .await
+    .expect("upload with device");
+
+    assert!(!upload.skipped);
+
+    // Download with device identity
+    let download = tcfs_sync::engine::download_file_with_device(
+        &op,
+        &upload.remote_path,
+        &dst,
+        prefix,
+        None,
+        device_id,
+        Some(&mut state),
+    )
+    .await
+    .expect("download with device");
+
+    let downloaded = std::fs::read(&dst).unwrap();
+    assert_eq!(downloaded, original);
+    assert_eq!(download.bytes, original.len() as u64);
+
+    // Verify state cache has vclock entry
+    let cached = state.get(&dst).expect("state cache should have entry");
+    assert!(
+        !cached.vclock.clocks.is_empty(),
+        "vclock should be non-empty after device-aware sync"
+    );
+}

--- a/crates/tcfsd/src/metrics.rs
+++ b/crates/tcfsd/src/metrics.rs
@@ -1,32 +1,47 @@
-//! Prometheus /metrics HTTP endpoint
+//! Prometheus /metrics + health check HTTP endpoints
+//!
+//! Endpoints:
+//!   GET /metrics  — Prometheus text format
+//!   GET /healthz  — Liveness probe (always 200 if process is running)
+//!   GET /readyz   — Readiness probe (200 if storage is reachable)
 
 use anyhow::Result;
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Router};
 use prometheus_client::{encoding::text::encode, registry::Registry as PRegistry};
 use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
 
 pub type Registry = PRegistry;
 
-/// Serve Prometheus metrics on `addr` (e.g. "127.0.0.1:9100")
-pub async fn serve(addr: String, registry: Arc<Registry>) -> Result<()> {
+/// Shared health state updated by the daemon
+#[derive(Clone)]
+pub struct HealthState {
+    pub registry: Arc<Registry>,
+    pub operator: Arc<TokioMutex<Option<opendal::Operator>>>,
+}
+
+/// Serve Prometheus metrics and health endpoints on `addr` (e.g. "127.0.0.1:9100")
+pub async fn serve(addr: String, state: HealthState) -> Result<()> {
     let app = Router::new()
         .route("/metrics", get(metrics_handler))
-        .with_state(registry);
+        .route("/healthz", get(healthz_handler))
+        .route("/readyz", get(readyz_handler))
+        .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .map_err(|e| anyhow::anyhow!("metrics bind {addr}: {e}"))?;
 
-    tracing::info!(addr = %addr, "metrics: listening on /metrics");
+    tracing::info!(addr = %addr, "metrics: listening on /metrics, /healthz, /readyz");
 
     axum::serve(listener, app)
         .await
         .map_err(|e| anyhow::anyhow!("metrics server: {e}"))
 }
 
-async fn metrics_handler(State(registry): State<Arc<Registry>>) -> impl IntoResponse {
+async fn metrics_handler(State(state): State<HealthState>) -> impl IntoResponse {
     let mut body = String::new();
-    match encode(&mut body, &registry) {
+    match encode(&mut body, &state.registry) {
         Ok(()) => (
             StatusCode::OK,
             [("content-type", "text/plain; version=0.0.4")],
@@ -40,5 +55,22 @@ async fn metrics_handler(State(registry): State<Arc<Registry>>) -> impl IntoResp
                 e.to_string(),
             )
         }
+    }
+}
+
+/// Liveness probe: returns 200 if the process is running.
+async fn healthz_handler() -> impl IntoResponse {
+    (StatusCode::OK, "ok")
+}
+
+/// Readiness probe: returns 200 if storage is reachable, 503 otherwise.
+async fn readyz_handler(State(state): State<HealthState>) -> impl IntoResponse {
+    let op = state.operator.lock().await;
+    match op.as_ref() {
+        Some(op) => match tcfs_storage::check_health(op).await {
+            Ok(()) => (StatusCode::OK, "ready"),
+            Err(_) => (StatusCode::SERVICE_UNAVAILABLE, "storage unreachable"),
+        },
+        None => (StatusCode::SERVICE_UNAVAILABLE, "no storage operator"),
     }
 }


### PR DESCRIPTION
## Summary

Production hardening for v0.4.0 release:

- **Chunk integrity verification** on download — BLAKE3 hash checked per-chunk and against manifest file hash. Corrupted or truncated data now fails fast with clear error
- **Graceful shutdown** — SIGTERM/SIGINT handler drains gRPC, flushes state cache, publishes DeviceOffline to NATS, sends systemd `STOPPING=1`, cleans up Unix socket
- **Health endpoints** — `/healthz` (liveness, always 200) and `/readyz` (readiness, checks S3 connectivity) added to metrics HTTP server for K8s probes
- **Improved retry** — Storage retry increased from 3 to 5 attempts with jitter; OpenDAL logging layer added
- **7 new integration tests** using in-memory OpenDAL backend (no live infrastructure required):
  - Small file round-trip
  - Binary data round-trip (256 KiB)
  - Dedup skip on unchanged files
  - Integrity verification (corrupted chunk detection)
  - Large file round-trip (1 MiB, multi-chunk)
  - Directory tree push
  - Device-aware sync with vector clocks

**Test count**: 133 → 140 (all pass, zero clippy errors in new code)

## Test plan

- [x] `cargo test --workspace` — 140 tests pass
- [x] `cargo clippy --workspace --all-targets` — no new warnings
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI passes (build, lint, test, deny, audit, nix, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)