### PR TITLE
feat: Porkbun DNS automation for Tailscale NATS

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -8,6 +8,7 @@ exclude = [
   "192\\.168\\.",
   "dees-appu-bearts",
   "seaweedfs.tcfs.svc",
+  "nats.tcfs.tummycrypt.dev",
   "seaweedfs.example.com",
   "nats.example.com",
   "filer.example.com",

--- a/examples/lab-fleet/petting-zoo-mini.nix
+++ b/examples/lab-fleet/petting-zoo-mini.nix
@@ -10,7 +10,7 @@
     deviceName = "petting-zoo-mini";
     conflictMode = "auto";
     syncGitDirs = false;
-    natsUrl = "nats://nats-tcfs:4222";
+    natsUrl = "nats://nats.tcfs.tummycrypt.dev:4222";
     syncRoot = "~/tcfs";
     excludePatterns = [ "*.swp" "*.swo" ".direnv" "*.log" ];
 

--- a/examples/lab-fleet/xoxd-bates.nix
+++ b/examples/lab-fleet/xoxd-bates.nix
@@ -10,7 +10,7 @@
     deviceName = "xoxd-bates";
     conflictMode = "auto";
     syncGitDirs = false;
-    natsUrl = "nats://nats-tcfs:4222";
+    natsUrl = "nats://nats.tcfs.tummycrypt.dev:4222";
     syncRoot = "~/tcfs";
     excludePatterns = [ "*.swp" "*.swo" ".direnv" ];
 

--- a/examples/lab-fleet/yoga.nix
+++ b/examples/lab-fleet/yoga.nix
@@ -11,7 +11,7 @@
     conflictMode = "interactive";
     syncGitDirs = true;
     gitSyncMode = "bundle";
-    natsUrl = "nats://nats-tcfs:4222";
+    natsUrl = "nats://nats.tcfs.tummycrypt.dev:4222";
     syncRoot = "~/tcfs";
     excludePatterns = [ "*.swp" "*.swo" ".direnv" "*.pyc" ];
 

--- a/infra/tofu/environments/civo/variables.tf
+++ b/infra/tofu/environments/civo/variables.tf
@@ -23,3 +23,9 @@ variable "grafana_admin_pw" {
   default     = "tcfs-changeme"
   sensitive   = true
 }
+
+variable "dns_domain" {
+  description = "Base domain for DNS records"
+  type        = string
+  default     = "tummycrypt.dev"
+}

--- a/infra/tofu/modules/porkbun-dns/main.tf
+++ b/infra/tofu/modules/porkbun-dns/main.tf
@@ -1,0 +1,21 @@
+# Porkbun DNS record management
+#
+# Creates a DNS record via the Porkbun API.
+# Credentials: PORKBUN_API_KEY + PORKBUN_SECRET_API_KEY env vars.
+
+terraform {
+  required_providers {
+    porkbun = {
+      source  = "marcfrederick/porkbun"
+      version = "~> 1.3"
+    }
+  }
+}
+
+resource "porkbun_dns_record" "this" {
+  domain    = var.domain
+  subdomain = var.subdomain
+  type      = var.record_type
+  content   = var.content
+  ttl       = var.ttl
+}

--- a/infra/tofu/modules/porkbun-dns/outputs.tf
+++ b/infra/tofu/modules/porkbun-dns/outputs.tf
@@ -1,0 +1,9 @@
+output "fqdn" {
+  description = "Fully qualified domain name"
+  value       = "${var.subdomain}.${var.domain}"
+}
+
+output "record_id" {
+  description = "Porkbun DNS record ID"
+  value       = porkbun_dns_record.this.id
+}

--- a/infra/tofu/modules/porkbun-dns/variables.tf
+++ b/infra/tofu/modules/porkbun-dns/variables.tf
@@ -1,0 +1,26 @@
+variable "domain" {
+  description = "Base domain (e.g. tummycrypt.dev)"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "Subdomain to create (e.g. nats.tcfs)"
+  type        = string
+}
+
+variable "record_type" {
+  description = "DNS record type"
+  type        = string
+  default     = "A"
+}
+
+variable "content" {
+  description = "Record content (IP address or CNAME target)"
+  type        = string
+}
+
+variable "ttl" {
+  description = "TTL in seconds (Porkbun minimum is 600)"
+  type        = number
+  default     = 600
+}

--- a/infra/tofu/modules/tailscale-nats/main.tf
+++ b/infra/tofu/modules/tailscale-nats/main.tf
@@ -9,8 +9,8 @@
 #
 # Lab machines connect via MagicDNS:
 #   nats://nats-tcfs:4222
-# Or via DNS alias (if configured in Tailscale admin):
-#   nats://nats.tcfs.tinyland.dev:4222
+# Or via the IaC-managed FQDN (Porkbun A record → Tailscale CGNAT IP):
+#   nats://nats.tcfs.tummycrypt.dev:4222
 
 terraform {
   required_providers {

--- a/infra/tofu/modules/tailscale-nats/outputs.tf
+++ b/infra/tofu/modules/tailscale-nats/outputs.tf
@@ -2,3 +2,11 @@ output "tailscale_nats_url" {
   description = "NATS client URL via Tailscale MagicDNS"
   value       = "nats://${var.tailscale_hostname}:4222"
 }
+
+output "tailscale_ip" {
+  description = "Tailscale CGNAT IP assigned to the NATS LoadBalancer (populated after operator reconciles)"
+  value       = try(
+    kubernetes_service_v1.nats_tailscale.status[0].load_balancer[0].ingress[0].ip,
+    ""
+  )
+}

--- a/infra/tofu/versions.tf
+++ b/infra/tofu/versions.tf
@@ -14,5 +14,9 @@ terraform {
       source  = "civo/civo"
       version = "~> 1.0"
     }
+    porkbun = {
+      source  = "marcfrederick/porkbun"
+      version = "~> 1.3"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add IaC-managed `nats.tcfs.tummycrypt.dev` A record via Porkbun DNS provider, pointing at the Tailscale CGNAT IP assigned to the NATS LoadBalancer
- New `porkbun-dns` OpenTofu module (`marcfrederick/porkbun ~> 1.3`) with conditional creation (handles async Tailscale operator reconciliation via two-apply pattern)
- Update all fleet configs, Justfile recipes, and ops docs to use the FQDN (MagicDNS `nats-tcfs` remains as fallback)

## Changes

| Area | Files | What |
|------|-------|------|
| New module | `infra/tofu/modules/porkbun-dns/` | Reusable Porkbun DNS record module |
| Tailscale | `modules/tailscale-nats/outputs.tf` | Export `tailscale_ip` from LB status |
| Civo env | `environments/civo/main.tf`, `variables.tf` | Porkbun provider + `nats_dns` module (count-gated) |
| Providers | `versions.tf` | Add porkbun provider constraint |
| Justfile | `Justfile` | `dns-status` and `deploy` recipes, FQDN defaults |
| Fleet | `examples/lab-fleet/*.nix` | `natsUrl` → `nats://nats.tcfs.tummycrypt.dev:4222` |
| Docs | `docs/ops/fleet-deployment.md` | DNS section, two-apply pattern, FQDN URLs |
| CI | `.lychee.toml` | Exclude `nats.tcfs.tummycrypt.dev` from link checker |

## Credentials needed

- `PORKBUN_API_KEY` + `PORKBUN_SECRET_API_KEY` env vars (from KeePassXC)
- API access enabled for `tummycrypt.dev` in Porkbun dashboard

## Test plan

- [ ] `tofu validate` passes in civo environment
- [ ] First `just deploy` creates Tailscale LB (DNS skipped, IP empty)
- [ ] Second `just deploy` creates Porkbun A record
- [ ] `just dns-status` shows matching IP and DNS record
- [ ] `just nats-status` connects via FQDN
- [ ] Verify MagicDNS fallback still works (`nats://nats-tcfs:4222`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)