### PR TITLE
chore: add SOPS-encrypted Porkbun DNS credentials

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -12,7 +12,7 @@ creation_rules:
 
   # Admin/shared credentials (JWT, rclone passwords, S3 admin)
   - path_regex: ^credentials/.*\.yaml$
-    encrypted_regex: ^(access_key_id|secret_access_key|jwt_signing_key|password|token|rclone_password.*)$
+    encrypted_regex: ^(access_key_id|secret_access_key|jwt_signing_key|password|token|rclone_password.*|api_key|secret_api_key)$
     age: age1wc2s9pfju7haufdw0at0pm2cxx9rs9qmj80nf0nzy82w0fr0gp3skzfgds
 
   # Tofu environment tfvars

--- a/credentials/porkbun.yaml
+++ b/credentials/porkbun.yaml
@@ -1,0 +1,20 @@
+# Porkbun DNS API credentials
+# Used by OpenTofu porkbun provider (marcfrederick/porkbun)
+# Env vars: PORKBUN_API_KEY + PORKBUN_SECRET_API_KEY
+api_key: ENC[AES256_GCM,data:zklmtfTh8uFBb1T2MlXWOciY0XFcuyXV5ve/jjr2N+3sEH2BMLbQaeJUdRA9SK6uy5uWWtzgjLN66lTJt+AJBbssDyA=,iv:ihZno4WQZhBXmjZGFXXSJtGHwHl6+b0doaJGr1123y8=,tag:ZSAzj27iuwcMpLUXMKNOew==,type:str]
+secret_api_key: ENC[AES256_GCM,data:FTEaF4iCPd4c7Csv/f4ePzNaKfzaLjsPK6/0nJIqs4V6F7kGP0oypzUAocbT95YanoQAIwQ27POgSuVCPWsjzAC2ftY=,iv:A35kNxlgRcru/XgEgOfgHQoXaaBUb/roLTfukZGG+Gc=,tag:pmGxUMJoVVUA9hOPg1wOoA==,type:str]
+sops:
+    age:
+        - recipient: age1wc2s9pfju7haufdw0at0pm2cxx9rs9qmj80nf0nzy82w0fr0gp3skzfgds
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5bGJmUFlhMU9CVzdtZURi
+            QXNVM09pWk9TV3hlWUxBNVZVMENUOGFNS1NvCkZJVWNaZVlqaGFEQU5OYytETDlS
+            Z09xdjlIYlY4dWZSVTV2NWs0UllIc3cKLS0tIDBhNEU3UHpiZldsckNDSnM3QWhp
+            TjQ5dVlxZElpd0NOTmtNblRZWkdYY3cKBct4NMD2tEyJRGKYw/OGJbinZ1pEoXRf
+            NU+dhV6ZWWS8qOr+Qxd9V6NQe0oCO38gbH6XV+woF3uGspkuqEWHWw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-02-23T16:01:57Z"
+    mac: ENC[AES256_GCM,data:GYyTquT08h4x6LmP3Pg48a4Pp7EY/NyXELnZrvY9WCqjPLqaos8x8XWfEsz0I1/2l9SXjBkNolOB+Sph/mLEtUByFS4ggQbOXuMpe0nVCvGoQsCkUBVgqr7EU1ie0lMb29Fnj856zSv4sGMZFtYpJCRJHYNrOP9vz9k9ZIWyTo0=,iv:VWQpmU0kaE9dGBctBDgFyiP5FcoIc+ucObWNCT55u2I=,tag:s5fQr/8yfkv3CywnXSCmkQ==,type:str]
+    encrypted_regex: ^(access_key_id|secret_access_key|jwt_signing_key|password|token|rclone_password.*|api_key|secret_api_key)$
+    version: 3.11.0


### PR DESCRIPTION
## Summary

- Add `credentials/porkbun.yaml` — SOPS+age encrypted Porkbun API credentials for `tummycrypt.dev` DNS management
- Extend `.sops.yaml` `encrypted_regex` to cover `api_key` / `secret_api_key` fields

## Usage

```bash
export PORKBUN_API_KEY=$(sops --decrypt --extract '["api_key"]' credentials/porkbun.yaml)
export PORKBUN_SECRET_API_KEY=$(sops --decrypt --extract '["secret_api_key"]' credentials/porkbun.yaml)
just deploy
```

## Test plan

- [x] `sops --decrypt credentials/porkbun.yaml` returns plaintext keys
- [x] Credentials match existing keys in `blahaj/.env` and `tinyland-platform/.env`
- [ ] `just deploy` with env vars creates the Porkbun A record

🤖 Generated with [Claude Code](https://claude.com/claude-code)