### PR TITLE
fix: OpenTofu provider v3 compatibility + kubeconfig context

### DIFF
--- a/infra/tofu/environments/civo/main.tf
+++ b/infra/tofu/environments/civo/main.tf
@@ -1,4 +1,4 @@
-# Civo Kubernetes environment: bitter-darkness-16657317
+# Civo Kubernetes environment: tinyland-civo-dev
 #
 # Deploy the full tcfs stack to Civo K8s.
 # SeaweedFS and NATS run in-cluster in the tcfs namespace;
@@ -12,19 +12,26 @@
 
 terraform {
   required_version = ">= 1.6"
+
+  required_providers {
+    porkbun = {
+      source  = "marcfrederick/porkbun"
+      version = "~> 1.3"
+    }
+  }
 }
 
 # ── Providers ─────────────────────────────────────────────────────────────────
 
 provider "kubernetes" {
   config_path    = var.kubeconfig_path
-  config_context = "bitter-darkness-16657317"
+  config_context = "tinyland-civo-dev"
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path    = var.kubeconfig_path
-    config_context = "bitter-darkness-16657317"
+    config_context = "tinyland-civo-dev"
   }
 }
 

--- a/infra/tofu/modules/keda/main.tf
+++ b/infra/tofu/modules/keda/main.tf
@@ -36,10 +36,12 @@ resource "helm_release" "keda" {
   version    = var.chart_version
   namespace  = var.keda_namespace
 
-  set {
-    name  = "watchNamespace"
-    value = var.namespace
-  }
+  set = [
+    {
+      name  = "watchNamespace"
+      value = var.namespace
+    }
+  ]
 }
 
 # ── ScaledObject for sync-worker ──────────────────────────────────────────────
@@ -67,7 +69,7 @@ resource "kubernetes_manifest" "sync_worker_scaled_object" {
       triggers = [{
         type = "nats-jetstream"
         metadata = {
-          natsServerMonitoringEndpoint = replace(var.nats_url, "nats://", "http://") + ":8222"
+          natsServerMonitoringEndpoint = "${replace(var.nats_url, "nats://", "http://")}:8222"
           account                      = "$G"
           stream                       = var.nats_stream_name
           consumer                     = var.nats_consumer_name

--- a/infra/tofu/modules/observability/main.tf
+++ b/infra/tofu/modules/observability/main.tf
@@ -37,12 +37,14 @@ resource "helm_release" "kube_prometheus" {
   version    = var.prometheus_chart_version
   namespace  = var.namespace
 
-  # Grafana admin credential set via set_sensitive below to avoid
+  # Grafana admin credential set via set_sensitive to avoid
   # embedding the pattern in source (pre-commit credential scan).
-  set_sensitive {
-    name  = "grafana.adminPassword"
-    value = var.grafana_admin_pw
-  }
+  set_sensitive = [
+    {
+      name  = "grafana.adminPassword"
+      value = var.grafana_admin_pw
+    }
+  ]
 
   values = [
     yamlencode({


### PR DESCRIPTION
## Summary

- Fix Helm provider v3 breaking changes (`set`/`set_sensitive` block → list-of-objects, `kubernetes` block → assignment)
- Fix Kubernetes provider v3 string concat (`+` → interpolation) in keda module
- Add `required_providers` for porkbun in civo environment terraform block (required for `tofu init`)
- Update kubeconfig context name: `bitter-darkness-16657317` → `tinyland-civo-dev`

## Context

`tofu init -upgrade` pulled Helm v3.1.1 and Kubernetes v3.0.1 which have breaking syntax changes. These fixes are required for `just deploy` to work.

## Test plan

- [x] `tofu init` succeeds
- [x] `tofu plan` validates all resource configs (CRD-dependent resources fail at plan time on fresh clusters — pre-existing, separate issue)
- [ ] `tofu apply` on cluster with existing CRDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)