### PR TITLE
fix: Tailscale ingress IP index for multi-entry status

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -46,7 +46,7 @@ k8s-describe app="tcfsd" ns="tcfs":
 # Show current DNS records for tummycrypt.dev
 dns-status:
     @echo "NATS Tailscale IP:"
-    @kubectl get svc nats-tailscale -n tcfs -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    @kubectl get svc nats-tailscale -n tcfs -o jsonpath='{.status.loadBalancer.ingress[?(@.ip)].ip}'
     @echo ""
     @echo "DNS record:"
     @dig +short nats.tcfs.tummycrypt.dev

--- a/infra/tofu/modules/tailscale-nats/outputs.tf
+++ b/infra/tofu/modules/tailscale-nats/outputs.tf
@@ -6,7 +6,7 @@ output "tailscale_nats_url" {
 output "tailscale_ip" {
   description = "Tailscale CGNAT IP assigned to the NATS LoadBalancer (populated after operator reconciles)"
   value       = try(
-    kubernetes_service_v1.nats_tailscale.status[0].load_balancer[0].ingress[0].ip,
+    [for ingress in kubernetes_service_v1.nats_tailscale.status[0].load_balancer[0].ingress : ingress.ip if ingress.ip != ""][0],
     ""
   )
 }


### PR DESCRIPTION
## Summary

- Tailscale operator returns `[{hostname: ...}, {ip: ..., ipMode: VIP}]` in ingress status
- Justfile `dns-status` and tofu `tailscale_ip` output were using `ingress[0].ip` which got the hostname entry (no `.ip` field)
- Fix: JSONPath filter `ingress[?(@.ip)].ip` in Justfile, HCL for-expression in outputs.tf

## Test plan

- [x] `kubectl get svc nats-tailscale -n tcfs -o jsonpath='{.status.loadBalancer.ingress[?(@.ip)].ip}'` returns `100.71.19.127`

🤖 Generated with [Claude Code](https://claude.com/claude-code)