### PR TITLE
fix: CRD dependency ordering + cert cleanup + TLS docs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -52,6 +52,9 @@ dns-status:
     @dig +short nats.tcfs.tummycrypt.dev
 
 # Full deploy: infra + DNS (may need two runs for Tailscale IP)
+# First run installs operators + CRDs, second creates DNS after IP is assigned.
+# Import existing DNS record first if needed:
+#   cd infra/tofu/environments/civo && tofu import 'module.nats_dns[0].porkbun_dns_record.this' 'tummycrypt.dev:RECORD_ID'
 deploy env="civo":
     cd infra/tofu/environments/{{env}} && tofu apply
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       -garbageThreshold=0.3
     volumes:
       - master_data_1:/data
-      - ./certs:/certs:ro
+
     networks:
       - tcfs-net
     healthcheck:
@@ -45,7 +45,7 @@ services:
       -garbageThreshold=0.3
     volumes:
       - master_data_2:/data
-      - ./certs:/certs:ro
+
     networks:
       - tcfs-net
     depends_on:
@@ -72,7 +72,7 @@ services:
       -garbageThreshold=0.3
     volumes:
       - master_data_3:/data
-      - ./certs:/certs:ro
+
     networks:
       - tcfs-net
     depends_on:
@@ -102,7 +102,7 @@ services:
       -ip.bind=0.0.0.0
     volumes:
       - volume_data:/data
-      - ./certs:/certs:ro
+
     networks:
       - tcfs-net
     depends_on:
@@ -134,7 +134,7 @@ services:
       - filer_data:/data
       - ./config/filer.toml:/etc/seaweedfs/filer.toml:ro
       - ./config/s3.json:/etc/seaweedfs/s3.json:ro
-      - ./certs:/certs:ro
+
     networks:
       - tcfs-net
     depends_on:

--- a/docs/ops/fleet-deployment.md
+++ b/docs/ops/fleet-deployment.md
@@ -317,3 +317,20 @@ just k8s-logs app=tcfsd
 ```
 
 The Justfile is at the project root. All recipes use the `civo` environment by default.
+
+---
+
+## 5. TLS Status
+
+SeaweedFS runs HTTP internally (trusted network, not internet-facing). mTLS is
+supported via `scripts/generate-certs.sh` but not currently enabled in any
+deployment (docker-compose, Ansible, or Civo K8s).
+
+The historical TLS private keys committed in the initial monorepo have been
+removed from tracking (`.gitignore`) and should be considered compromised.
+Regenerate with `./scripts/generate-certs.sh` before enabling mTLS.
+
+NATS and the tcfsd gRPC socket also run unencrypted. For production hardening:
+- Set `storage.enforce_tls = true` in tcfs config for HTTPS S3
+- Set `sync.nats_tls = true` for TLS NATS connections
+- Wire `security.toml` into SeaweedFS Ansible roles / Helm values for mTLS

--- a/infra/tofu/environments/civo/main.tf
+++ b/infra/tofu/environments/civo/main.tf
@@ -42,7 +42,8 @@ provider "porkbun" {
 # ── NATS JetStream ────────────────────────────────────────────────────────────
 
 module "nats" {
-  source = "../../modules/nats"
+  source     = "../../modules/nats"
+  depends_on = [module.observability]  # CRD: ServiceMonitor
 
   namespace      = var.namespace
   cluster_size   = 3
@@ -74,7 +75,8 @@ module "nats_dns" {
 # ── KEDA autoscaler ───────────────────────────────────────────────────────────
 
 module "keda" {
-  source = "../../modules/keda"
+  source     = "../../modules/keda"
+  depends_on = [module.observability]  # CRD: ScaledObject + ServiceMonitor
 
   namespace         = var.namespace
   nats_url          = module.nats.nats_url
@@ -87,7 +89,8 @@ module "keda" {
 # ── tcfs-backend (sync workers) ───────────────────────────────────────────────
 
 module "tcfs_backend" {
-  source = "../../modules/tcfs-backend"
+  source     = "../../modules/tcfs-backend"
+  depends_on = [module.observability]  # CRD: ServiceMonitor
 
   namespace  = var.namespace
   image      = "ghcr.io/tinyland-inc/tcfsd:${var.image_tag}"


### PR DESCRIPTION
## Summary
- Add `depends_on = [module.observability]` to `nats`, `tcfs_backend`, and `keda` modules in the Civo environment — ensures `kube-prometheus-stack` CRDs (ServiceMonitor) and KEDA CRDs are installed before resources that consume them. Fixes the chicken-and-egg failure on fresh `tofu apply`.
- Remove 5 unused `./certs:/certs:ro` volume mounts from `docker-compose.yml` — no SeaweedFS service actually references the mounted certs.
- Add TLS Status section to `docs/ops/fleet-deployment.md` documenting the current HTTP-only state and hardening path.
- Update Justfile `deploy` recipe with import and CRD ordering notes.
- Regenerated fresh SeaweedFS TLS certs locally (gitignored) to replace the compromised historical ones.

## Test plan
- [ ] CI passes (fmt, clippy, test, gitleaks, nix)
- [ ] `tofu validate` passes in `infra/tofu/environments/civo/`
- [ ] Post-merge: `tofu import` brings existing DNS record under state management
- [ ] Post-merge: `tofu apply` on fresh cluster creates resources in correct order (observability first)