### PR TITLE
fix: gate CRD resources for fresh cluster deploys

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -52,11 +52,17 @@ dns-status:
     @dig +short nats.tcfs.tummycrypt.dev
 
 # Full deploy: infra + DNS (may need two runs for Tailscale IP)
-# First run installs operators + CRDs, second creates DNS after IP is assigned.
+# Fresh cluster (no CRDs installed yet):
+#   just deploy-fresh   # Installs operators without CRD consumers
+#   just deploy         # Second run creates ServiceMonitors + ScaledObject
 # Import existing DNS record first if needed:
 #   cd infra/tofu/environments/civo && tofu import 'module.nats_dns[0].porkbun_dns_record.this' 'tummycrypt.dev:RECORD_ID'
 deploy env="civo":
     cd infra/tofu/environments/{{env}} && tofu apply
+
+# First-apply on fresh cluster: skip CRD consumers (ServiceMonitor, ScaledObject)
+deploy-fresh env="civo":
+    cd infra/tofu/environments/{{env}} && tofu apply -var='enable_crds=false'
 
 # ── NATS ────────────────────────────────────────────────────────────────────
 

--- a/infra/tofu/environments/civo/main.tf
+++ b/infra/tofu/environments/civo/main.tf
@@ -45,11 +45,12 @@ module "nats" {
   source     = "../../modules/nats"
   depends_on = [module.observability]  # CRD: ServiceMonitor
 
-  namespace      = var.namespace
-  cluster_size   = 3
-  storage_type   = "file"
-  storage_size_gi = 20
-  storage_class  = "civo-volume"
+  namespace         = var.namespace
+  cluster_size      = 3
+  storage_type      = "file"
+  storage_size_gi   = 20
+  storage_class     = "civo-volume"
+  enable_monitoring = var.enable_crds
 }
 
 # ── Tailscale NATS exposure (tailnet only, no public IP) ──────────────────────
@@ -78,12 +79,13 @@ module "keda" {
   source     = "../../modules/keda"
   depends_on = [module.observability]  # CRD: ScaledObject + ServiceMonitor
 
-  namespace         = var.namespace
-  nats_url          = module.nats.nats_url
-  target_deployment = module.tcfs_backend.worker_deployment_name
-  min_replicas      = 1
-  max_replicas      = 50
-  lag_threshold     = 100
+  namespace          = var.namespace
+  nats_url           = module.nats.nats_url
+  target_deployment  = module.tcfs_backend.worker_deployment_name
+  min_replicas       = 1
+  max_replicas       = 50
+  lag_threshold      = 100
+  enable_autoscaling = var.enable_crds
 }
 
 # ── tcfs-backend (sync workers) ───────────────────────────────────────────────
@@ -108,6 +110,7 @@ module "tcfs_backend" {
   worker_memory_request = "512Mi"
   worker_cpu_limit      = "2"
   worker_memory_limit   = "2Gi"
+  enable_monitoring     = var.enable_crds
 }
 
 # ── Observability ─────────────────────────────────────────────────────────────

--- a/infra/tofu/environments/civo/variables.tf
+++ b/infra/tofu/environments/civo/variables.tf
@@ -29,3 +29,9 @@ variable "dns_domain" {
   type        = string
   default     = "tummycrypt.dev"
 }
+
+variable "enable_crds" {
+  description = "Create CRD-based resources (ServiceMonitor, ScaledObject). Set false on first apply before operators install CRDs."
+  type        = bool
+  default     = true
+}

--- a/infra/tofu/modules/keda/main.tf
+++ b/infra/tofu/modules/keda/main.tf
@@ -47,6 +47,7 @@ resource "helm_release" "keda" {
 # ── ScaledObject for sync-worker ──────────────────────────────────────────────
 
 resource "kubernetes_manifest" "sync_worker_scaled_object" {
+  count      = var.enable_autoscaling ? 1 : 0
   depends_on = [helm_release.keda]
 
   manifest = {

--- a/infra/tofu/modules/keda/variables.tf
+++ b/infra/tofu/modules/keda/variables.tf
@@ -62,3 +62,9 @@ variable "nats_stream_name" {
   type        = string
   default     = "SYNC_TASKS"
 }
+
+variable "enable_autoscaling" {
+  description = "Create ScaledObject (requires KEDA CRDs — set false on first apply)"
+  type        = bool
+  default     = true
+}

--- a/infra/tofu/modules/nats/main.tf
+++ b/infra/tofu/modules/nats/main.tf
@@ -72,6 +72,8 @@ resource "helm_release" "nats" {
 
 # ServiceMonitor for Prometheus scraping (if kube-prometheus-stack is installed)
 resource "kubernetes_manifest" "nats_service_monitor" {
+  count = var.enable_monitoring ? 1 : 0
+
   manifest = {
     apiVersion = "monitoring.coreos.com/v1"
     kind       = "ServiceMonitor"

--- a/infra/tofu/modules/nats/variables.tf
+++ b/infra/tofu/modules/nats/variables.tf
@@ -33,3 +33,9 @@ variable "chart_version" {
   type        = string
   default     = "1.2.6"
 }
+
+variable "enable_monitoring" {
+  description = "Create ServiceMonitor (requires kube-prometheus-stack CRDs)"
+  type        = bool
+  default     = true
+}

--- a/infra/tofu/modules/tcfs-backend/main.tf
+++ b/infra/tofu/modules/tcfs-backend/main.tf
@@ -249,6 +249,8 @@ resource "kubernetes_service" "sync_worker_metrics" {
 # ── ServiceMonitor for Prometheus ─────────────────────────────────────────────
 
 resource "kubernetes_manifest" "worker_service_monitor" {
+  count = var.enable_monitoring ? 1 : 0
+
   manifest = {
     apiVersion = "monitoring.coreos.com/v1"
     kind       = "ServiceMonitor"

--- a/infra/tofu/modules/tcfs-backend/variables.tf
+++ b/infra/tofu/modules/tcfs-backend/variables.tf
@@ -73,3 +73,9 @@ variable "worker_concurrency" {
   type        = number
   default     = 4
 }
+
+variable "enable_monitoring" {
+  description = "Create ServiceMonitor (requires kube-prometheus-stack CRDs)"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- `kubernetes_manifest` validates CRDs at **plan time**, not just apply time. On a fresh cluster, `tofu plan` fails with "API did not recognize GroupVersionKind" even with `depends_on` ordering.
- Added `count` gates on all CRD-consuming resources: ServiceMonitor (nats, tcfs-backend) and ScaledObject (keda)
- Wired through a single `enable_crds` root variable so first-apply can skip CRD consumers: `tofu apply -var='enable_crds=false'`
- Added `just deploy-fresh` recipe for the two-stage workflow

## Deploy workflow (fresh cluster)
```bash
just deploy-fresh   # Stage 1: installs operators + CRDs (skips ServiceMonitor/ScaledObject)
just deploy         # Stage 2: creates CRD consumers (enable_crds defaults to true)
```

## Test plan
- [x] `tofu validate` passes
- [ ] CI passes (fmt, clippy, test, gitleaks, nix)
- [ ] `tofu plan -var='enable_crds=false'` shows no CRD resources
- [ ] `tofu plan` (default) shows CRD resources included

🤖 Generated with [Claude Code](https://claude.com/claude-code)