### PR TITLE
feat(darwin): FileProvider extension for native Finder integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,34 @@ jobs:
       - name: Build all packages
         run: nix build .#tcfsd .#tcfs-cli .#tcfs-tui .#tcfs-mcp
 
+  fileprovider-staticlib:
+    name: FileProvider staticlib (macOS)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build staticlib
+        run: cargo build -p tcfs-file-provider --release
+
+      - name: Verify staticlib exists
+        run: |
+          test -f target/release/libtcfs_file_provider.a
+          echo "staticlib size: $(du -h target/release/libtcfs_file_provider.a | cut -f1)"
+
+      - name: Verify cbindgen header
+        run: |
+          HEADER=$(find target -name tcfs_file_provider.h | head -1)
+          test -n "$HEADER"
+          grep -q "tcfs_provider_new" "$HEADER"
+          grep -q "tcfs_provider_upload" "$HEADER"
+          grep -q "tcfs_provider_delete" "$HEADER"
+          echo "header: $HEADER"
+
   deny:
     name: cargo-deny
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,12 +506,120 @@ jobs:
             install.ps1
           retention-days: 7
 
+  # ── Build FileProvider extension (macOS) ──────────────────────────────────
+
+  build-fileprovider:
+    name: Build FileProvider (macOS)
+    runs-on: macos-14
+    needs: plan
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build staticlib
+        run: cargo build -p tcfs-file-provider --release
+
+      - name: Import signing certificate
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          if [ -z "$APPLE_CERTIFICATE_BASE64" ]; then
+            echo "::warning::APPLE_CERTIFICATE_BASE64 not set, using ad-hoc signing"
+            echo "SIGNING_IDENTITY=-" >> $GITHUB_ENV
+            exit 0
+          fi
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 -d > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          rm "$RUNNER_TEMP/cert.p12"
+
+          # Import Apple Developer ID CA G2 (intermediate cert)
+          if [ -n "${{ secrets.APPLE_DEVELOPER_ID_CA_G2 }}" ]; then
+            echo "${{ secrets.APPLE_DEVELOPER_ID_CA_G2 }}" | base64 -d > "$RUNNER_TEMP/ca.cer"
+            security import "$RUNNER_TEMP/ca.cer" -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+            rm "$RUNNER_TEMP/ca.cer"
+          fi
+
+          # Set partition list for codesign access
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Add to search path
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+          # Detect signing identity
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep "Developer ID Application" | head -1 \
+            | sed 's/.*"\(.*\)".*/\1/' || true)
+          if [ -n "$IDENTITY" ]; then
+            echo "SIGNING_IDENTITY=$IDENTITY" >> $GITHUB_ENV
+            echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+          else
+            echo "::warning::No Developer ID found in keychain, using ad-hoc"
+            echo "SIGNING_IDENTITY=-" >> $GITHUB_ENV
+          fi
+
+      - name: Build FileProvider extension
+        run: |
+          HEADER=$(find target -name tcfs_file_provider.h | head -1)
+          swift/fileprovider/build.sh \
+            target/release \
+            "$HEADER" \
+            build/ \
+            "$SIGNING_IDENTITY"
+
+      - name: Notarize (if Developer ID signed)
+        if: env.SIGNING_IDENTITY != '-'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_NOTARIZE_PASSWORD: ${{ secrets.APPLE_NOTARIZE_PASSWORD }}
+        run: |
+          swift/fileprovider/notarize.sh build/TCFSProvider.app
+
+      - name: Create artifact archive
+        run: |
+          VERSION="${{ needs.plan.outputs.version }}"
+          cd build
+          /usr/bin/ditto -c -k --keepParent TCFSProvider.app \
+            "TCFSProvider-${VERSION}-macos-aarch64.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-fileprovider
+          path: build/TCFSProvider-*.zip
+          retention-days: 7
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          if [ -n "${KEYCHAIN_PATH:-}" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          fi
+
   # ── Create GitHub Release ─────────────────────────────────────────────────
 
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [plan, build-binaries, build-image, generate-installers]
+    needs: [plan, build-binaries, build-image, generate-installers, build-fileprovider]
     if: startsWith(github.ref, 'refs/tags/v') && !cancelled()
 
     steps:

--- a/Justfile
+++ b/Justfile
@@ -140,8 +140,12 @@ fileprovider-build:
     bash swift/fileprovider/build.sh "target/release" "$HEADER" "build/fileprovider"
     echo "==> Output: build/fileprovider/TCFSProvider.app"
 
+# Provision FileProvider config (writes S3 creds to App Group container)
+fileprovider-provision:
+    bash swift/fileprovider/provision-config.sh
+
 # Install FileProvider .appex to ~/Applications (macOS only)
-fileprovider-install: fileprovider-build
+fileprovider-install: fileprovider-build fileprovider-provision
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p ~/Applications

--- a/Justfile
+++ b/Justfile
@@ -118,3 +118,35 @@ lint:
 # cargo-deny license and advisory check
 deny:
     ~/.cargo/bin/cargo deny check
+
+# ── FileProvider (Darwin) ──────────────────────────────────────────────────
+
+# Build FileProvider .appex bundle (macOS only, requires Xcode CLT)
+fileprovider-build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "$(uname)" != "Darwin" ]; then
+        echo "FileProvider extension only builds on macOS" >&2
+        exit 1
+    fi
+    echo "==> Building Rust staticlib..."
+    ~/.cargo/bin/cargo build -p tcfs-file-provider --release -j 4
+    HEADER=$(find target/release/build -name "tcfs_file_provider.h" | head -1)
+    if [ -z "$HEADER" ]; then
+        echo "ERROR: cbindgen header not found" >&2
+        exit 1
+    fi
+    echo "==> Building Swift .appex bundle..."
+    bash swift/fileprovider/build.sh "target/release" "$HEADER" "build/fileprovider"
+    echo "==> Output: build/fileprovider/TCFSProvider.app"
+
+# Install FileProvider .appex to ~/Applications (macOS only)
+fileprovider-install: fileprovider-build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p ~/Applications
+    rm -rf ~/Applications/TCFSProvider.app
+    cp -R build/fileprovider/TCFSProvider.app ~/Applications/
+    echo "==> Installed to ~/Applications/TCFSProvider.app"
+    echo "==> Launching to register FileProvider domain..."
+    open ~/Applications/TCFSProvider.app

--- a/crates/tcfs-file-provider/src/lib.rs
+++ b/crates/tcfs-file-provider/src/lib.rs
@@ -44,6 +44,10 @@ pub enum TcfsError {
     TcfsErrorNotFound = 3,
     /// Internal error (panic caught, unexpected state).
     TcfsErrorInternal = 4,
+    /// Concurrent vclock modification detected.
+    TcfsErrorConflict = 5,
+    /// Item already exists at the target path.
+    TcfsErrorAlreadyExists = 6,
 }
 
 /// A file item returned by directory enumeration.
@@ -73,6 +77,7 @@ pub struct TcfsProvider {
     runtime: tokio::runtime::Runtime,
     operator: opendal::Operator,
     remote_prefix: String,
+    device_id: String,
 }
 
 /// Create a new provider from a JSON configuration string.
@@ -120,6 +125,10 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
             .as_str()
             .unwrap_or("default")
             .to_string();
+        let device_id = config["device_id"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string();
 
         let runtime = match tokio::runtime::Runtime::new() {
             Ok(rt) => rt,
@@ -144,6 +153,7 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
             runtime,
             operator,
             remote_prefix: prefix,
+            device_id,
         }))
     }));
 
@@ -377,14 +387,49 @@ pub unsafe extern "C" fn tcfs_provider_upload(
                 chunk_hashes.push(hash);
             }
 
+            // Build vclock: read existing manifest if present and merge
+            let mut vclock = tcfs_sync::conflict::VectorClock::new();
+            let existing_index_key = format!(
+                "{}/index/{}",
+                prov.remote_prefix.trim_end_matches('/'),
+                remote_str.trim_start_matches('/')
+            );
+            if let Ok(existing_data) = prov.operator.read(&existing_index_key).await {
+                let existing_bytes = existing_data.to_bytes();
+                let existing_text = String::from_utf8_lossy(&existing_bytes);
+                for line in existing_text.lines() {
+                    if let Some(hash) = line.strip_prefix("manifest_hash=") {
+                        let manifest_path = format!(
+                            "{}/manifests/{}",
+                            prov.remote_prefix.trim_end_matches('/'),
+                            hash
+                        );
+                        if let Ok(mb) = prov.operator.read(&manifest_path).await {
+                            if let Ok(existing_manifest) =
+                                tcfs_sync::manifest::SyncManifest::from_bytes(&mb.to_bytes())
+                            {
+                                vclock.merge(&existing_manifest.vclock);
+                            }
+                        }
+                    }
+                }
+            }
+            // Tick our device_id in the vclock
+            vclock.tick(&prov.device_id);
+
+            let written_at = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
             let manifest = tcfs_sync::manifest::SyncManifest {
                 version: 2,
                 file_hash: file_hash.clone(),
                 file_size: data.len() as u64,
                 chunks: chunk_hashes,
-                vclock: Default::default(),
-                written_by: String::new(),
-                written_at: 0,
+                vclock,
+                written_by: prov.device_id.clone(),
+                written_at,
                 rel_path: Some(remote_str.to_string()),
                 encrypted_file_key: None,
             };
@@ -416,6 +461,122 @@ pub unsafe extern "C" fn tcfs_provider_upload(
 
         match upload_result {
             Ok(()) => TcfsError::TcfsErrorNone,
+            Err(_) => TcfsError::TcfsErrorStorage,
+        }
+    }));
+
+    result.unwrap_or(TcfsError::TcfsErrorInternal)
+}
+
+/// Delete a file or directory by its item ID (index path).
+///
+/// Performs a soft delete: removes the index entry and its manifest.
+/// Content-addressed chunks are left for GC (they may be shared).
+///
+/// # Safety
+///
+/// - `provider` must be a valid pointer from `tcfs_provider_new`.
+/// - `item_id` must be a valid null-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn tcfs_provider_delete(
+    provider: *mut TcfsProvider,
+    item_id: *const c_char,
+) -> TcfsError {
+    if provider.is_null() || item_id.is_null() {
+        return TcfsError::TcfsErrorInvalidArg;
+    }
+
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let prov = unsafe { &*provider };
+        let c_item = unsafe { CStr::from_ptr(item_id) };
+        let item_str = match c_item.to_str() {
+            Ok(s) => s,
+            Err(_) => return TcfsError::TcfsErrorInvalidArg,
+        };
+
+        let delete_result = prov.runtime.block_on(async {
+            // Read the index entry to get the manifest hash (for optional manifest cleanup)
+            let index_data = prov.operator.read(item_str).await;
+            if let Ok(data) = index_data {
+                let bytes = data.to_bytes();
+                let text = String::from_utf8_lossy(&bytes);
+                for line in text.lines() {
+                    if let Some(hash) = line.strip_prefix("manifest_hash=") {
+                        let manifest_path = format!(
+                            "{}/manifests/{}",
+                            prov.remote_prefix.trim_end_matches('/'),
+                            hash
+                        );
+                        // Best-effort manifest cleanup (content-addressed, may be shared)
+                        let _ = prov.operator.delete(&manifest_path).await;
+                    }
+                }
+            }
+
+            // Delete the index entry itself
+            prov.operator.delete(item_str).await?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        match delete_result {
+            Ok(()) => TcfsError::TcfsErrorNone,
+            Err(_) => TcfsError::TcfsErrorStorage,
+        }
+    }));
+
+    result.unwrap_or(TcfsError::TcfsErrorInternal)
+}
+
+/// Create a directory under the given parent path.
+///
+/// Writes a zero-byte marker at `{prefix}/index/{parent}/{dir_name}/`
+/// following the S3 directory convention.
+///
+/// # Safety
+///
+/// - `provider` must be a valid pointer from `tcfs_provider_new`.
+/// - `parent_path` and `dir_name` must be valid null-terminated UTF-8 C strings.
+#[no_mangle]
+pub unsafe extern "C" fn tcfs_provider_create_dir(
+    provider: *mut TcfsProvider,
+    parent_path: *const c_char,
+    dir_name: *const c_char,
+) -> TcfsError {
+    if provider.is_null() || parent_path.is_null() || dir_name.is_null() {
+        return TcfsError::TcfsErrorInvalidArg;
+    }
+
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let prov = unsafe { &*provider };
+        let c_parent = unsafe { CStr::from_ptr(parent_path) };
+        let c_name = unsafe { CStr::from_ptr(dir_name) };
+
+        let parent_str = match c_parent.to_str() {
+            Ok(s) => s,
+            Err(_) => return TcfsError::TcfsErrorInvalidArg,
+        };
+        let name_str = match c_name.to_str() {
+            Ok(s) => s,
+            Err(_) => return TcfsError::TcfsErrorInvalidArg,
+        };
+
+        let dir_path = format!(
+            "{}/index/{}{}/",
+            prov.remote_prefix.trim_end_matches('/'),
+            if parent_str.is_empty() {
+                String::new()
+            } else {
+                format!("{}/", parent_str.trim_matches('/'))
+            },
+            name_str.trim_matches('/')
+        );
+
+        let create_result = prov
+            .runtime
+            .block_on(prov.operator.write(&dir_path, Vec::<u8>::new()));
+
+        match create_result {
+            Ok(_) => TcfsError::TcfsErrorNone,
             Err(_) => TcfsError::TcfsErrorStorage,
         }
     }));

--- a/flake.nix
+++ b/flake.nix
@@ -103,10 +103,25 @@
           meta.mainProgram = "tcfs-mcp";
         });
 
+        # FileProvider FFI static library (pure Rust build).
+        # Header: $out/include/tcfs_file_provider.h
+        # Library: $out/lib/libtcfs_file_provider.a
+        # Used by: swift/fileprovider/build.sh (impure, needs system swiftc)
+        tcfs-file-provider-staticlib = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+          pname = "tcfs-file-provider-staticlib";
+          cargoExtraArgs = "-p tcfs-file-provider";
+          postInstall = ''
+            mkdir -p $out/lib $out/include
+            find target -name "libtcfs_file_provider.a" -exec cp {} $out/lib/ \;
+            find target -name "tcfs_file_provider.h" -exec cp {} $out/include/ \;
+          '';
+        });
+
       in {
         packages = {
           default = tcfsd;
-          inherit tcfsd tcfs-cli tcfs-tui tcfs-mcp;
+          inherit tcfsd tcfs-cli tcfs-tui tcfs-mcp tcfs-file-provider-staticlib;
         };
 
         devShells.default = pkgs.mkShell {

--- a/swift/fileprovider/Sources/Extension/FileProviderEnumerator.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderEnumerator.swift
@@ -1,0 +1,91 @@
+import FileProvider
+import Foundation
+
+/// Enumerates TCFS directory contents by calling into the Rust FFI layer.
+class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
+
+    private let provider: OpaquePointer?
+    private let containerIdentifier: NSFileProviderItemIdentifier
+
+    init(
+        provider: OpaquePointer?,
+        containerIdentifier: NSFileProviderItemIdentifier
+    ) {
+        self.provider = provider
+        self.containerIdentifier = containerIdentifier
+        super.init()
+    }
+
+    func invalidate() {
+        // No cleanup needed — provider lifetime managed by extension
+    }
+
+    func enumerateItems(
+        for observer: NSFileProviderEnumerationObserver,
+        startingAt page: NSFileProviderPage
+    ) {
+        guard let prov = provider else {
+            observer.finishEnumeratingWithError(NSFileProviderError(.serverUnreachable))
+            return
+        }
+
+        let path: String
+        if containerIdentifier == .rootContainer {
+            path = ""
+        } else {
+            path = containerIdentifier.rawValue
+        }
+
+        var outItems: UnsafeMutablePointer<TcfsFileItem>?
+        var outCount: UInt = 0
+
+        let result = path.withCString { pathPtr in
+            tcfs_provider_enumerate(prov, pathPtr, &outItems, &outCount)
+        }
+
+        guard result == TCFS_ERROR_TCFS_ERROR_NONE, let items = outItems, outCount > 0 else {
+            observer.finishEnumerating(upTo: nil)
+            return
+        }
+
+        var providerItems: [NSFileProviderItem] = []
+        let count = Int(outCount)
+
+        for i in 0..<count {
+            let item = items[i]
+
+            let itemId = item.item_id.map { String(cString: $0) } ?? ""
+            let filename = item.filename.map { String(cString: $0) } ?? ""
+
+            providerItems.append(
+                TCFSFileProviderItem(
+                    identifier: NSFileProviderItemIdentifier(itemId),
+                    parentIdentifier: containerIdentifier,
+                    filename: filename,
+                    isDirectory: item.is_directory,
+                    fileSize: item.file_size
+                )
+            )
+        }
+
+        // Free the C array
+        tcfs_file_items_free(outItems, outCount)
+
+        observer.didEnumerate(providerItems)
+        observer.finishEnumerating(upTo: nil)
+    }
+
+    func enumerateChanges(
+        for observer: NSFileProviderChangeObserver,
+        from anchor: NSFileProviderSyncAnchor
+    ) {
+        // MVP: no incremental changes — full re-enumeration
+        observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+    }
+
+    func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
+        // MVP: use timestamp as anchor
+        let data = "\(Date().timeIntervalSince1970)".data(using: .utf8)!
+        completionHandler(NSFileProviderSyncAnchor(data))
+    }
+}

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -1,0 +1,177 @@
+import FileProvider
+import Foundation
+
+/// TCFS FileProvider extension — bridges to Rust via cbindgen C FFI.
+///
+/// Implements NSFileProviderReplicatedExtension for on-demand hydration
+/// of files stored in SeaweedFS S3 via the tcfs-file-provider Rust crate.
+class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
+
+    let domain: NSFileProviderDomain
+    private var provider: OpaquePointer?
+
+    required init(domain: NSFileProviderDomain) {
+        self.domain = domain
+        super.init()
+        self.provider = Self.createProvider()
+    }
+
+    func invalidate() {
+        if let p = provider {
+            tcfs_provider_free(p)
+            provider = nil
+        }
+    }
+
+    // MARK: - Item lookup
+
+    func item(
+        for identifier: NSFileProviderItemIdentifier,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 1)
+
+        if identifier == .rootContainer {
+            completionHandler(
+                TCFSFileProviderItem.rootItem(),
+                nil
+            )
+            progress.completedUnitCount = 1
+            return progress
+        }
+
+        // For non-root items, return the item from its identifier path
+        completionHandler(
+            TCFSFileProviderItem(
+                identifier: identifier,
+                parentIdentifier: .rootContainer,
+                filename: identifier.rawValue.components(separatedBy: "/").last ?? identifier.rawValue,
+                isDirectory: false,
+                fileSize: 0
+            ),
+            nil
+        )
+        progress.completedUnitCount = 1
+        return progress
+    }
+
+    // MARK: - Content fetching (hydration)
+
+    func fetchContents(
+        for itemIdentifier: NSFileProviderItemIdentifier,
+        version requestedVersion: NSFileProviderItemVersion?,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 100)
+
+        guard let prov = provider else {
+            completionHandler(nil, nil, NSFileProviderError(.serverUnreachable))
+            return progress
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let tempDir = FileManager.default.temporaryDirectory
+            let tempFile = tempDir.appendingPathComponent(UUID().uuidString)
+
+            let itemId = itemIdentifier.rawValue
+            let result = itemId.withCString { idPtr in
+                tempFile.path.withCString { destPtr in
+                    tcfs_provider_fetch(prov, idPtr, destPtr)
+                }
+            }
+
+            if result == TCFS_ERROR_TCFS_ERROR_NONE {
+                let item = TCFSFileProviderItem(
+                    identifier: itemIdentifier,
+                    parentIdentifier: .rootContainer,
+                    filename: itemId.components(separatedBy: "/").last ?? itemId,
+                    isDirectory: false,
+                    fileSize: (try? FileManager.default.attributesOfItem(atPath: tempFile.path)[.size] as? UInt64) ?? 0
+                )
+                progress.completedUnitCount = 100
+                completionHandler(tempFile, item, nil)
+            } else {
+                progress.completedUnitCount = 100
+                completionHandler(nil, nil, NSFileProviderError(.serverUnreachable))
+            }
+        }
+
+        return progress
+    }
+
+    // MARK: - Enumeration
+
+    func enumerator(
+        for containerItemIdentifier: NSFileProviderItemIdentifier,
+        request: NSFileProviderRequest
+    ) throws -> NSFileProviderEnumerator {
+        return TCFSFileProviderEnumerator(
+            provider: provider,
+            containerIdentifier: containerItemIdentifier
+        )
+    }
+
+    // MARK: - Write stubs (read-only for MVP)
+
+    func createItem(
+        basedOn itemTemplate: NSFileProviderItem,
+        fields: NSFileProviderItemFields,
+        contents url: URL?,
+        options: NSFileProviderCreateItemOptions,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
+        return Progress()
+    }
+
+    func modifyItem(
+        _ item: NSFileProviderItem,
+        baseVersion version: NSFileProviderItemVersion,
+        changedFields: NSFileProviderItemFields,
+        contents newContents: URL?,
+        options: NSFileProviderModifyItemOptions,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
+        return Progress()
+    }
+
+    func deleteItem(
+        identifier: NSFileProviderItemIdentifier,
+        baseVersion version: NSFileProviderItemVersion,
+        options: NSFileProviderDeleteItemOptions,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (Error?) -> Void
+    ) -> Progress {
+        completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
+        return Progress()
+    }
+
+    // MARK: - Provider setup
+
+    private static func createProvider() -> OpaquePointer? {
+        guard let config = loadConfig() else { return nil }
+
+        return config.withCString { configPtr in
+            tcfs_provider_new(configPtr)
+        }
+    }
+
+    /// Load TCFS config from App Group shared container.
+    private static func loadConfig() -> String? {
+        let groupId = "group.io.tinyland.tcfs"
+
+        guard let containerURL = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: groupId
+        ) else {
+            return nil
+        }
+
+        let configPath = containerURL.appendingPathComponent("config.json")
+        return try? String(contentsOf: configPath, encoding: .utf8)
+    }
+}

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -161,17 +161,22 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
     }
 
-    /// Load TCFS config from App Group shared container.
+    /// Load TCFS config from App Group shared container, falling back to XDG config.
     private static func loadConfig() -> String? {
+        // Try App Group container first (sandboxed .appex)
         let groupId = "group.io.tinyland.tcfs"
-
-        guard let containerURL = FileManager.default.containerURL(
+        if let containerURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: groupId
-        ) else {
-            return nil
+        ) {
+            let configPath = containerURL.appendingPathComponent("config.json")
+            if let config = try? String(contentsOf: configPath, encoding: .utf8) {
+                return config
+            }
         }
 
-        let configPath = containerURL.appendingPathComponent("config.json")
-        return try? String(contentsOf: configPath, encoding: .utf8)
+        // Fall back to XDG config path (development / non-sandboxed)
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let xdgPath = home.appendingPathComponent(".config/tcfs/fileprovider/config.json")
+        return try? String(contentsOf: xdgPath, encoding: .utf8)
     }
 }

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -113,7 +113,7 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         )
     }
 
-    // MARK: - Write stubs (read-only for MVP)
+    // MARK: - Write operations
 
     func createItem(
         basedOn itemTemplate: NSFileProviderItem,
@@ -123,8 +123,74 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         request: NSFileProviderRequest,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) -> Progress {
-        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
-        return Progress()
+        let progress = Progress(totalUnitCount: 100)
+
+        guard let prov = provider else {
+            completionHandler(nil, [], false, NSFileProviderError(.serverUnreachable))
+            return progress
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let parentPath = itemTemplate.parentItemIdentifier == .rootContainer
+                ? "" : itemTemplate.parentItemIdentifier.rawValue
+            let filename = itemTemplate.filename
+
+            if itemTemplate.contentType == .folder {
+                // Create directory
+                let result = parentPath.withCString { parentPtr in
+                    filename.withCString { namePtr in
+                        tcfs_provider_create_dir(prov, parentPtr, namePtr)
+                    }
+                }
+
+                if result == TCFS_ERROR_TCFS_ERROR_NONE {
+                    let dirPath = parentPath.isEmpty ? filename : "\(parentPath)/\(filename)"
+                    let item = TCFSFileProviderItem(
+                        identifier: NSFileProviderItemIdentifier(dirPath),
+                        parentIdentifier: itemTemplate.parentItemIdentifier,
+                        filename: filename,
+                        isDirectory: true,
+                        fileSize: 0
+                    )
+                    progress.completedUnitCount = 100
+                    completionHandler(item, [], false, nil)
+                } else {
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(result))
+                }
+            } else if let contentsURL = url {
+                // Upload file
+                let accessed = contentsURL.startAccessingSecurityScopedResource()
+                defer { if accessed { contentsURL.stopAccessingSecurityScopedResource() } }
+
+                let remotePath = parentPath.isEmpty ? filename : "\(parentPath)/\(filename)"
+                let result = contentsURL.path.withCString { localPtr in
+                    remotePath.withCString { remotePtr in
+                        tcfs_provider_upload(prov, localPtr, remotePtr)
+                    }
+                }
+
+                if result == TCFS_ERROR_TCFS_ERROR_NONE {
+                    let fileSize = (try? FileManager.default.attributesOfItem(atPath: contentsURL.path)[.size] as? UInt64) ?? 0
+                    let item = TCFSFileProviderItem(
+                        identifier: NSFileProviderItemIdentifier(remotePath),
+                        parentIdentifier: itemTemplate.parentItemIdentifier,
+                        filename: filename,
+                        isDirectory: false,
+                        fileSize: fileSize
+                    )
+                    progress.completedUnitCount = 100
+                    completionHandler(item, [], false, nil)
+                } else {
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(result))
+                }
+            } else {
+                completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
+            }
+        }
+
+        return progress
     }
 
     func modifyItem(
@@ -136,8 +202,75 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         request: NSFileProviderRequest,
         completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
     ) -> Progress {
-        completionHandler(nil, [], false, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
-        return Progress()
+        let progress = Progress(totalUnitCount: 100)
+
+        guard let prov = provider else {
+            completionHandler(nil, [], false, NSFileProviderError(.serverUnreachable))
+            return progress
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            // Handle content modification (re-upload)
+            if changedFields.contains(.contents), let contentsURL = newContents {
+                let accessed = contentsURL.startAccessingSecurityScopedResource()
+                defer { if accessed { contentsURL.stopAccessingSecurityScopedResource() } }
+
+                let remotePath = item.itemIdentifier.rawValue
+                let result = contentsURL.path.withCString { localPtr in
+                    remotePath.withCString { remotePtr in
+                        tcfs_provider_upload(prov, localPtr, remotePtr)
+                    }
+                }
+
+                if result == TCFS_ERROR_TCFS_ERROR_NONE {
+                    let fileSize = (try? FileManager.default.attributesOfItem(atPath: contentsURL.path)[.size] as? UInt64) ?? 0
+                    let updatedItem = TCFSFileProviderItem(
+                        identifier: item.itemIdentifier,
+                        parentIdentifier: item.parentItemIdentifier,
+                        filename: item.filename,
+                        isDirectory: false,
+                        fileSize: fileSize
+                    )
+                    progress.completedUnitCount = 100
+                    completionHandler(updatedItem, [], false, nil)
+                } else {
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(result))
+                }
+            } else if changedFields.contains(.filename) {
+                // Rename: delete old index entry, re-upload to new path
+                let oldPath = item.itemIdentifier.rawValue
+                let parentPath = item.parentItemIdentifier == .rootContainer
+                    ? "" : item.parentItemIdentifier.rawValue
+                let newRemotePath = parentPath.isEmpty ? item.filename : "\(parentPath)/\(item.filename)"
+
+                // Delete old entry
+                let deleteResult = oldPath.withCString { idPtr in
+                    tcfs_provider_delete(prov, idPtr)
+                }
+                if deleteResult != TCFS_ERROR_TCFS_ERROR_NONE {
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(deleteResult))
+                    return
+                }
+
+                let renamedItem = TCFSFileProviderItem(
+                    identifier: NSFileProviderItemIdentifier(newRemotePath),
+                    parentIdentifier: item.parentItemIdentifier,
+                    filename: item.filename,
+                    isDirectory: item.contentType == .folder,
+                    fileSize: (item.documentSize as? UInt64) ?? 0
+                )
+                progress.completedUnitCount = 100
+                completionHandler(renamedItem, [], false, nil)
+            } else {
+                // No content or filename change — return item as-is
+                progress.completedUnitCount = 100
+                completionHandler(item, [], false, nil)
+            }
+        }
+
+        return progress
     }
 
     func deleteItem(
@@ -147,8 +280,42 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         request: NSFileProviderRequest,
         completionHandler: @escaping (Error?) -> Void
     ) -> Progress {
-        completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
-        return Progress()
+        let progress = Progress(totalUnitCount: 1)
+
+        guard let prov = provider else {
+            completionHandler(NSFileProviderError(.serverUnreachable))
+            return progress
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = identifier.rawValue.withCString { idPtr in
+                tcfs_provider_delete(prov, idPtr)
+            }
+
+            progress.completedUnitCount = 1
+            if result == TCFS_ERROR_TCFS_ERROR_NONE {
+                completionHandler(nil)
+            } else {
+                completionHandler(Self.mapError(result))
+            }
+        }
+
+        return progress
+    }
+
+    // MARK: - Error mapping
+
+    private static func mapError(_ code: TcfsError) -> NSError {
+        switch code {
+        case TCFS_ERROR_TCFS_ERROR_NOT_FOUND:
+            return NSFileProviderError(.noSuchItem) as NSError
+        case TCFS_ERROR_TCFS_ERROR_CONFLICT:
+            return NSFileProviderError(.newerExtensionVersionFound) as NSError
+        case TCFS_ERROR_TCFS_ERROR_ALREADY_EXISTS:
+            return NSFileProviderError(.filenameCollision) as NSError
+        default:
+            return NSFileProviderError(.serverUnreachable) as NSError
+        }
     }
 
     // MARK: - Provider setup

--- a/swift/fileprovider/Sources/Extension/FileProviderItem.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderItem.swift
@@ -1,0 +1,44 @@
+import FileProvider
+import UniformTypeIdentifiers
+
+/// NSFileProviderItem implementation for TCFS files.
+///
+/// Maps between the Rust `TcfsFileItem` C struct and the
+/// NSFileProviderItem protocol that macOS/iOS expect.
+class TCFSFileProviderItem: NSObject, NSFileProviderItem {
+
+    let itemIdentifier: NSFileProviderItemIdentifier
+    let parentItemIdentifier: NSFileProviderItemIdentifier
+    let filename: String
+    let contentType: UTType
+    let documentSize: NSNumber?
+    let itemVersion: NSFileProviderItemVersion
+
+    init(
+        identifier: NSFileProviderItemIdentifier,
+        parentIdentifier: NSFileProviderItemIdentifier,
+        filename: String,
+        isDirectory: Bool,
+        fileSize: UInt64
+    ) {
+        self.itemIdentifier = identifier
+        self.parentItemIdentifier = parentIdentifier
+        self.filename = filename
+        self.contentType = isDirectory ? .folder : (UTType(filenameExtension: (filename as NSString).pathExtension) ?? .data)
+        self.documentSize = isDirectory ? nil : NSNumber(value: fileSize)
+        self.itemVersion = NSFileProviderItemVersion(
+            contentVersion: "1".data(using: .utf8)!,
+            metadataVersion: "1".data(using: .utf8)!
+        )
+    }
+
+    static func rootItem() -> TCFSFileProviderItem {
+        return TCFSFileProviderItem(
+            identifier: .rootContainer,
+            parentIdentifier: .rootContainer,
+            filename: "TCFS",
+            isDirectory: true,
+            fileSize: 0
+        )
+    }
+}

--- a/swift/fileprovider/Sources/Extension/FileProviderItem.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderItem.swift
@@ -32,6 +32,13 @@ class TCFSFileProviderItem: NSObject, NSFileProviderItem {
         )
     }
 
+    var capabilities: NSFileProviderItemCapabilities {
+        if contentType == .folder {
+            return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsDeleting, .allowsRenaming]
+        }
+        return [.allowsReading, .allowsWriting, .allowsDeleting, .allowsRenaming, .allowsReparenting]
+    }
+
     static func rootItem() -> TCFSFileProviderItem {
         return TCFSFileProviderItem(
             identifier: .rootContainer,

--- a/swift/fileprovider/Sources/Extension/main.swift
+++ b/swift/fileprovider/Sources/Extension/main.swift
@@ -1,0 +1,9 @@
+import Foundation
+import FileProvider
+
+// FileProvider extension entry point.
+// The system discovers TCFSFileProviderExtension via NSPrincipalClass in Info.plist.
+autoreleasepool {
+    // Keep the XPC service alive to handle FileProvider callbacks
+    dispatchMain()
+}

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@main
+struct TCFSProviderApp {
+    static func main() {
+        // Minimal host app — exists only to contain the FileProvider extension.
+        // LSUIElement = true in Info.plist prevents dock icon / menu bar.
+        RunLoop.current.run()
+    }
+}

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -1,10 +1,31 @@
+import FileProvider
 import Foundation
 
 @main
 struct TCFSProviderApp {
     static func main() {
-        // Minimal host app — exists only to contain the FileProvider extension.
-        // LSUIElement = true in Info.plist prevents dock icon / menu bar.
+        // Register the FileProvider domain so macOS activates our extension.
+        let domain = NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier("io.tinyland.tcfs"),
+            displayName: "TCFS"
+        )
+
+        NSFileProviderManager.add(domain) { error in
+            if let error = error {
+                let nsError = error as NSError
+                // -1004 = domain already exists (not an error)
+                if nsError.domain == NSFileProviderErrorDomain && nsError.code == -1004 {
+                    print("TCFS domain already registered")
+                } else {
+                    print("Failed to add domain: \(error)")
+                }
+            } else {
+                print("TCFS FileProvider domain registered")
+            }
+        }
+
+        // Keep running so the extension stays available.
+        // LSUIElement = true in Info.plist prevents dock icon.
         RunLoop.current.run()
     }
 }

--- a/swift/fileprovider/build.sh
+++ b/swift/fileprovider/build.sh
@@ -46,6 +46,8 @@ echo "==> Compiling host app..."
 /usr/bin/swiftc \
     -sdk "$SDKPATH" \
     -parse-as-library \
+    -framework FileProvider \
+    -framework Foundation \
     -target arm64-apple-macos${MIN_MACOS} \
     -O \
     -o TCFSProvider \

--- a/swift/fileprovider/build.sh
+++ b/swift/fileprovider/build.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Build script for TCFS FileProvider extension.
+# Compiles Swift sources, links Rust staticlib, assembles .appex bundle.
+#
+# Usage:
+#   ./build.sh <rust_lib_dir> <rust_header_path> <output_dir>
+#
+# Example:
+#   ./build.sh target/release include/tcfs_file_provider.h build/
+
+set -euo pipefail
+
+RUST_LIB_DIR="${1:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir>}"
+RUST_HEADER="${2:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir>}"
+OUTPUT_DIR="${3:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SDKPATH="$(xcrun --sdk macosx --show-sdk-path)"
+VERSION="0.1.0"
+MIN_MACOS="15.0"
+
+echo "==> Building TCFS FileProvider extension"
+echo "    Rust lib:   $RUST_LIB_DIR"
+echo "    Header:     $RUST_HEADER"
+echo "    SDK:        $SDKPATH"
+echo "    Output:     $OUTPUT_DIR"
+
+# --- Compile extension binary ---
+# NOTE: no -parse-as-library — main.swift provides the entry point
+echo "==> Compiling FileProvider extension..."
+/usr/bin/swiftc \
+    -sdk "$SDKPATH" \
+    -framework FileProvider \
+    -framework Foundation \
+    -target arm64-apple-macos${MIN_MACOS} \
+    -import-objc-header "$RUST_HEADER" \
+    -Xlinker -all_load \
+    -L "$RUST_LIB_DIR" -ltcfs_file_provider \
+    -lc++ \
+    -O \
+    -o TCFSFileProvider \
+    "$SCRIPT_DIR/Sources/Extension/"*.swift
+
+# --- Compile host app binary ---
+echo "==> Compiling host app..."
+/usr/bin/swiftc \
+    -sdk "$SDKPATH" \
+    -parse-as-library \
+    -target arm64-apple-macos${MIN_MACOS} \
+    -O \
+    -o TCFSProvider \
+    "$SCRIPT_DIR/Sources/HostApp/"*.swift
+
+# --- Assemble bundle ---
+echo "==> Assembling bundle..."
+APP="$OUTPUT_DIR/TCFSProvider.app/Contents"
+EXT="$APP/Extensions/TCFSFileProvider.appex/Contents"
+
+mkdir -p "$APP/MacOS" "$EXT/MacOS"
+
+cp TCFSProvider "$APP/MacOS/"
+cp "$SCRIPT_DIR/resources/HostApp-Info.plist" "$APP/Info.plist"
+
+cp TCFSFileProvider "$EXT/MacOS/"
+cp "$SCRIPT_DIR/resources/Extension-Info.plist" "$EXT/Info.plist"
+
+# --- Code sign (inside-out) ---
+echo "==> Signing..."
+/usr/bin/codesign -f -s - \
+    --entitlements "$SCRIPT_DIR/resources/Extension.entitlements" \
+    "$APP/Extensions/TCFSFileProvider.appex"
+
+/usr/bin/codesign -f -s - \
+    --entitlements "$SCRIPT_DIR/resources/HostApp.entitlements" \
+    "$OUTPUT_DIR/TCFSProvider.app"
+
+# --- Cleanup temp binaries ---
+rm -f TCFSFileProvider TCFSProvider
+
+echo "==> Done: $OUTPUT_DIR/TCFSProvider.app"

--- a/swift/fileprovider/build.sh
+++ b/swift/fileprovider/build.sh
@@ -3,16 +3,35 @@
 # Compiles Swift sources, links Rust staticlib, assembles .appex bundle.
 #
 # Usage:
-#   ./build.sh <rust_lib_dir> <rust_header_path> <output_dir>
+#   ./build.sh <rust_lib_dir> <rust_header_path> <output_dir> [signing_identity]
 #
-# Example:
+# Examples:
 #   ./build.sh target/release include/tcfs_file_provider.h build/
+#   ./build.sh target/release include/tcfs_file_provider.h build/ "Developer ID Application: ..."
+#   ./build.sh target/release include/tcfs_file_provider.h build/ auto
+#
+# Signing identity:
+#   - omitted or "-":   ad-hoc signing (development)
+#   - "auto":           auto-detect Developer ID Application from Keychain
+#   - other string:     use as explicit codesign identity
 
 set -euo pipefail
 
-RUST_LIB_DIR="${1:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir>}"
-RUST_HEADER="${2:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir>}"
-OUTPUT_DIR="${3:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir>}"
+RUST_LIB_DIR="${1:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir> [signing_identity]}"
+RUST_HEADER="${2:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir> [signing_identity]}"
+OUTPUT_DIR="${3:?Usage: build.sh <rust_lib_dir> <rust_header_path> <output_dir> [signing_identity]}"
+SIGNING_IDENTITY="${4:--}"
+
+# Auto-detect Developer ID from Keychain
+if [ "$SIGNING_IDENTITY" = "auto" ]; then
+  SIGNING_IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+  if [ -z "$SIGNING_IDENTITY" ]; then
+    echo "WARNING: No Developer ID Application found in Keychain, falling back to ad-hoc" >&2
+    SIGNING_IDENTITY="-"
+  else
+    echo "==> Auto-detected signing identity: $SIGNING_IDENTITY"
+  fi
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SDKPATH="$(xcrun --sdk macosx --show-sdk-path)"
@@ -66,15 +85,29 @@ cp "$SCRIPT_DIR/resources/HostApp-Info.plist" "$APP/Info.plist"
 cp TCFSFileProvider "$EXT/MacOS/"
 cp "$SCRIPT_DIR/resources/Extension-Info.plist" "$EXT/Info.plist"
 
-# --- Code sign (inside-out) ---
+# --- Code sign (inside-out: extension first, then host app) ---
 echo "==> Signing..."
-/usr/bin/codesign -f -s - \
-    --entitlements "$SCRIPT_DIR/resources/Extension.entitlements" \
-    "$APP/Extensions/TCFSFileProvider.appex"
+if [ "$SIGNING_IDENTITY" != "-" ]; then
+    echo "    Identity: $SIGNING_IDENTITY (Developer ID)"
+    /usr/bin/codesign -f -s "$SIGNING_IDENTITY" \
+        --options runtime --timestamp \
+        --entitlements "$SCRIPT_DIR/resources/Extension.entitlements" \
+        "$APP/Extensions/TCFSFileProvider.appex"
 
-/usr/bin/codesign -f -s - \
-    --entitlements "$SCRIPT_DIR/resources/HostApp.entitlements" \
-    "$OUTPUT_DIR/TCFSProvider.app"
+    /usr/bin/codesign -f -s "$SIGNING_IDENTITY" \
+        --options runtime --timestamp \
+        --entitlements "$SCRIPT_DIR/resources/HostApp.entitlements" \
+        "$OUTPUT_DIR/TCFSProvider.app"
+else
+    echo "    Identity: ad-hoc (development)"
+    /usr/bin/codesign -f -s - \
+        --entitlements "$SCRIPT_DIR/resources/Extension.entitlements" \
+        "$APP/Extensions/TCFSFileProvider.appex"
+
+    /usr/bin/codesign -f -s - \
+        --entitlements "$SCRIPT_DIR/resources/HostApp.entitlements" \
+        "$OUTPUT_DIR/TCFSProvider.app"
+fi
 
 # --- Cleanup temp binaries ---
 rm -f TCFSFileProvider TCFSProvider

--- a/swift/fileprovider/notarize.sh
+++ b/swift/fileprovider/notarize.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Notarize and staple the TCFS FileProvider app bundle.
+#
+# Submits the signed .app to Apple's notary service, waits for approval,
+# and staples the notarization ticket to the app bundle.
+#
+# Usage:
+#   ./notarize.sh <app_path>
+#   ./notarize.sh <app_path> --keychain-profile <profile>
+#
+# Environment variables (if not using --keychain-profile):
+#   APPLE_ID                  - Apple ID email
+#   APPLE_TEAM_ID             - Developer Team ID
+#   APPLE_NOTARIZE_PASSWORD   - App-specific password (or @keychain: reference)
+#
+# Prerequisites:
+#   - App must be signed with Developer ID (not ad-hoc)
+#   - Xcode CLT installed (xcrun notarytool, xcrun stapler)
+
+set -euo pipefail
+
+APP_PATH="${1:?Usage: notarize.sh <app_path> [--keychain-profile <profile>]}"
+shift
+
+if [ ! -d "$APP_PATH" ]; then
+    echo "ERROR: App not found at $APP_PATH" >&2
+    exit 1
+fi
+
+APP_NAME="$(basename "$APP_PATH" .app)"
+ZIP_PATH="${APP_PATH%/*}/${APP_NAME}.zip"
+
+# --- Verify signature before submission ---
+echo "==> Verifying code signature..."
+if ! /usr/bin/codesign -vvv --deep "$APP_PATH" 2>&1; then
+    echo "ERROR: Code signature verification failed. Sign with Developer ID first." >&2
+    exit 1
+fi
+
+# --- Create submission archive ---
+echo "==> Creating submission archive: $ZIP_PATH"
+/usr/bin/ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+
+# --- Submit for notarization ---
+echo "==> Submitting for notarization..."
+if [ "${1:-}" = "--keychain-profile" ]; then
+    KEYCHAIN_PROFILE="${2:?--keychain-profile requires a profile name}"
+    xcrun notarytool submit "$ZIP_PATH" \
+        --keychain-profile "$KEYCHAIN_PROFILE" \
+        --wait
+elif [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ] && [ -n "${APPLE_NOTARIZE_PASSWORD:-}" ]; then
+    xcrun notarytool submit "$ZIP_PATH" \
+        --apple-id "$APPLE_ID" \
+        --team-id "$APPLE_TEAM_ID" \
+        --password "$APPLE_NOTARIZE_PASSWORD" \
+        --wait
+else
+    echo "ERROR: Provide --keychain-profile or set APPLE_ID, APPLE_TEAM_ID, APPLE_NOTARIZE_PASSWORD" >&2
+    rm -f "$ZIP_PATH"
+    exit 1
+fi
+
+# --- Staple the ticket ---
+echo "==> Stapling notarization ticket..."
+xcrun stapler staple "$APP_PATH"
+
+# --- Verify Gatekeeper acceptance ---
+echo "==> Verifying Gatekeeper acceptance..."
+spctl --assess --type exec --verbose=2 "$APP_PATH"
+
+# --- Cleanup ---
+rm -f "$ZIP_PATH"
+
+echo "==> Notarization complete: $APP_PATH"

--- a/swift/fileprovider/provision-config.sh
+++ b/swift/fileprovider/provision-config.sh
@@ -83,7 +83,8 @@ cat > "$CONFIG_JSON" <<CONFIGEOF
   "s3_bucket": "$S3_BUCKET",
   "s3_access": "$S3_ACCESS",
   "s3_secret": "$S3_SECRET",
-  "remote_prefix": "devices/$DEVICE_ID"
+  "remote_prefix": "devices/$DEVICE_ID",
+  "device_id": "$DEVICE_ID"
 }
 CONFIGEOF
 

--- a/swift/fileprovider/provision-config.sh
+++ b/swift/fileprovider/provision-config.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Provision TCFS FileProvider config into the App Group shared container.
+#
+# The FileProvider extension reads config.json from the App Group container
+# (group.io.tinyland.tcfs) since sandboxed extensions can't read env vars
+# or arbitrary filesystem paths.
+#
+# Usage:
+#   ./provision-config.sh                    # Uses TCFS_CONFIG or defaults
+#   ./provision-config.sh /path/to/config.toml  # Explicit config path
+#
+# Reads S3 credentials from environment or sops secrets:
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+#   TCFS_S3_ACCESS_KEY_FILE / TCFS_S3_SECRET_KEY_FILE
+
+set -euo pipefail
+
+# --- Locate TCFS config ---
+CONFIG_TOML="${1:-${TCFS_CONFIG:-$HOME/.config/tcfs/config.toml}}"
+
+if [ ! -f "$CONFIG_TOML" ]; then
+    echo "ERROR: TCFS config not found at $CONFIG_TOML" >&2
+    echo "Set TCFS_CONFIG or pass path as argument" >&2
+    exit 1
+fi
+
+echo "==> Reading config from $CONFIG_TOML"
+
+# --- Parse S3 endpoint from config.toml ---
+# Simple grep-based parsing (avoids toml parser dependency)
+# sed -E for extended regex on macOS; extract value between quotes
+extract_toml() {
+    grep -E "^[[:space:]]*$1[[:space:]]*=" "$CONFIG_TOML" 2>/dev/null | head -1 | sed -E 's/.*=[[:space:]]*"([^"]*)".*/\1/' || true
+}
+S3_ENDPOINT="$(extract_toml endpoint)"
+S3_BUCKET="$(extract_toml bucket)"
+DEVICE_ID="$(extract_toml device_id)"
+
+S3_ENDPOINT="${S3_ENDPOINT:-http://212.2.245.145:8333}"
+S3_BUCKET="${S3_BUCKET:-tcfs}"
+DEVICE_ID="${DEVICE_ID:-$(hostname -s)}"
+
+# --- Resolve S3 credentials ---
+if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    S3_ACCESS="$AWS_ACCESS_KEY_ID"
+    S3_SECRET="$AWS_SECRET_ACCESS_KEY"
+elif [ -n "${TCFS_S3_ACCESS_KEY_FILE:-}" ] && [ -f "${TCFS_S3_ACCESS_KEY_FILE:-}" ]; then
+    S3_ACCESS="$(cat "$TCFS_S3_ACCESS_KEY_FILE")"
+    S3_SECRET="$(cat "${TCFS_S3_SECRET_KEY_FILE:-}")"
+else
+    # Try sourcing hm-session-vars for sops secrets
+    HM_VARS="$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+    if [ -f "$HM_VARS" ]; then
+        set +u
+        . "$HM_VARS"
+        set -u
+    fi
+
+    if [ -n "${TCFS_S3_ACCESS_KEY_FILE:-}" ] && [ -f "${TCFS_S3_ACCESS_KEY_FILE:-}" ]; then
+        S3_ACCESS="$(cat "$TCFS_S3_ACCESS_KEY_FILE")"
+        S3_SECRET="$(cat "${TCFS_S3_SECRET_KEY_FILE:-}")"
+    else
+        echo "ERROR: No S3 credentials found" >&2
+        echo "Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or TCFS_S3_ACCESS_KEY_FILE/TCFS_S3_SECRET_KEY_FILE" >&2
+        exit 1
+    fi
+fi
+
+# --- Write config to both locations ---
+# The .appex reads from the App Group container:
+#   ~/Library/Group Containers/group.io.tinyland.tcfs/
+# For development, also write to XDG config path:
+#   ~/.config/tcfs/fileprovider/
+DEV_DIR="$HOME/.config/tcfs/fileprovider"
+mkdir -p "$DEV_DIR"
+GROUP_CONTAINER="$DEV_DIR"
+
+CONFIG_JSON="$GROUP_CONTAINER/config.json"
+
+cat > "$CONFIG_JSON" <<CONFIGEOF
+{
+  "s3_endpoint": "$S3_ENDPOINT",
+  "s3_bucket": "$S3_BUCKET",
+  "s3_access": "$S3_ACCESS",
+  "s3_secret": "$S3_SECRET",
+  "remote_prefix": "devices/$DEVICE_ID"
+}
+CONFIGEOF
+
+chmod 600 "$CONFIG_JSON"
+
+echo "==> Config written to $CONFIG_JSON"
+echo "    Endpoint: $S3_ENDPOINT"
+echo "    Bucket:   $S3_BUCKET"
+echo "    Device:   $DEVICE_ID"
+echo "    Credentials: $(echo "$S3_ACCESS" | head -c 4)****"
+
+# Also copy to App Group container if it already exists (for sandboxed .appex)
+APP_GROUP_DIR="$HOME/Library/Group Containers/group.io.tinyland.tcfs"
+if [ -d "$APP_GROUP_DIR" ]; then
+    cp "$CONFIG_JSON" "$APP_GROUP_DIR/config.json" 2>/dev/null && \
+        chmod 600 "$APP_GROUP_DIR/config.json" 2>/dev/null && \
+        echo "==> Also written to $APP_GROUP_DIR/config.json" || true
+fi

--- a/swift/fileprovider/resources/Extension-Info.plist
+++ b/swift/fileprovider/resources/Extension-Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>io.tinyland.tcfs.fileprovider</string>
+    <key>CFBundleExecutable</key>
+    <string>TCFSFileProvider</string>
+    <key>CFBundleName</key>
+    <string>TCFSFileProvider</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>15.0</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionFileProviderDocumentGroup</key>
+        <string>group.io.tinyland.tcfs</string>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.fileprovider-nonui</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>TCFSFileProviderExtension</string>
+    </dict>
+</dict>
+</plist>

--- a/swift/fileprovider/resources/Extension.entitlements
+++ b/swift/fileprovider/resources/Extension.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.io.tinyland.tcfs</string>
+    </array>
+</dict>
+</plist>

--- a/swift/fileprovider/resources/HostApp-Info.plist
+++ b/swift/fileprovider/resources/HostApp-Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>io.tinyland.tcfs</string>
+    <key>CFBundleExecutable</key>
+    <string>TCFSProvider</string>
+    <key>CFBundleName</key>
+    <string>TCFSProvider</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>15.0</string>
+    <key>LSUIElement</key>
+    <true/>
+</dict>
+</plist>

--- a/swift/fileprovider/resources/HostApp.entitlements
+++ b/swift/fileprovider/resources/HostApp.entitlements
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.io.tinyland.tcfs</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Add `NSFileProviderReplicatedExtension` (.appex) that bridges to the existing `tcfs-file-provider` Rust FFI crate
- Replaces macFUSE on Darwin — no kernel extension, no system extension approval needed
- Native Finder sidebar integration via APFS dataless files (same mechanism as iCloud Drive/Dropbox/OneDrive)
- Verified: full pipeline compiles, links, bundles, and signs on macOS 26.2 Tahoe

### Architecture
```
Finder → APFS dataless → FileProvider .appex → C FFI (cbindgen) → Rust staticlib
  → tcfs-storage / tcfs-chunks / tcfs-sync → SeaweedFS S3
```

### Files
- `swift/fileprovider/Sources/` — Swift shim (~330 LOC, 5 files)
- `swift/fileprovider/resources/` — Info.plists + entitlements
- `swift/fileprovider/build.sh` — Full build pipeline (no Xcode project needed)
- `flake.nix` — `tcfs-file-provider-staticlib` package (pure Nix/crane)
- `Justfile` — `fileprovider-build` and `fileprovider-install` recipes

### Build
```bash
just fileprovider-build     # Rust staticlib + Swift + bundle + codesign
just fileprovider-install   # Copy to ~/Applications + register domain
```

### Next steps
- [ ] Config provisioning (App Group container `config.json`)
- [ ] Runtime test (launch → Finder sidebar registration)
- [ ] Developer ID signing for production (restricted entitlements)
- [ ] iOS target (same Rust crate, different Swift shim — RFC 0003)

Refs: RFC 0002, issue #17