### PR TITLE
fix(fileprovider): lazy-init provider to avoid XPC bringup timeout

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1116,11 +1116,7 @@ async fn cmd_mount(
 
         match resp {
             Ok(r) if r.get_ref().success => {
-                println!(
-                    "Mounted via daemon: {} → {}",
-                    remote,
-                    mountpoint.display()
-                );
+                println!("Mounted via daemon: {} → {}", remote, mountpoint.display());
                 return Ok(());
             }
             Ok(r) => {

--- a/crates/tcfs-storage/src/lib.rs
+++ b/crates/tcfs-storage/src/lib.rs
@@ -15,9 +15,9 @@ pub use operator::{build_operator, StorageConfig};
 /// - bucket: first path component
 /// - prefix: remaining path (may be empty)
 pub fn parse_remote_spec(spec: &str) -> anyhow::Result<(String, String, String)> {
-    let rest = spec
-        .strip_prefix("seaweedfs://")
-        .ok_or_else(|| anyhow::anyhow!("remote spec must start with seaweedfs:// — got: {}", spec))?;
+    let rest = spec.strip_prefix("seaweedfs://").ok_or_else(|| {
+        anyhow::anyhow!("remote spec must start with seaweedfs:// — got: {}", spec)
+    })?;
 
     // Split host:port from /bucket[/prefix]
     let slash = rest
@@ -60,15 +60,13 @@ mod tests {
 
     #[test]
     fn test_parse_remote_spec_nested_prefix() {
-        let (_, _, prefix) =
-            parse_remote_spec("seaweedfs://host:8333/bucket/a/b/c").unwrap();
+        let (_, _, prefix) = parse_remote_spec("seaweedfs://host:8333/bucket/a/b/c").unwrap();
         assert_eq!(prefix, "a/b/c");
     }
 
     #[test]
     fn test_parse_remote_spec_trailing_slash() {
-        let (_, _, prefix) =
-            parse_remote_spec("seaweedfs://host:8333/bucket/data/").unwrap();
+        let (_, _, prefix) = parse_remote_spec("seaweedfs://host:8333/bucket/data/").unwrap();
         assert_eq!(prefix, "data");
     }
 

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -8,12 +8,14 @@ import Foundation
 class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     let domain: NSFileProviderDomain
-    private var provider: OpaquePointer?
+    /// Provider is created lazily on first use to avoid blocking the XPC bringup.
+    /// `tcfs_provider_new()` creates a tokio runtime and S3 operator, which can
+    /// take seconds — long enough to exceed fileproviderd's initial handshake timeout.
+    private lazy var provider: OpaquePointer? = Self.createProvider()
 
     required init(domain: NSFileProviderDomain) {
         self.domain = domain
         super.init()
-        self.provider = Self.createProvider()
     }
 
     func invalidate() {

--- a/swift/fileprovider/resources/Extension-Info.plist
+++ b/swift/fileprovider/resources/Extension-Info.plist
@@ -27,6 +27,8 @@
         <string>com.apple.fileprovider-nonui</string>
         <key>NSExtensionPrincipalClass</key>
         <string>TCFSFileProviderExtension</string>
+        <key>NSExtensionFileProviderSupportsEnumeration</key>
+        <true/>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- `tcfs_provider_new()` creates a tokio runtime + OpenDAL S3 operator synchronously
- When called in `init(domain:)`, this blocks the XPC bringup thread
- fileproviderd times out with "failed to send initial bringup message" (Cocoa 4099)
- `supports enumeration: 0` — extension never completes initialization

Changed `provider` from eager init to `lazy var`, created on first actual use (enumeration/fetch).

## Test plan
- [ ] `fileproviderctl dump io.tinyland.tcfs.fileprovider` shows `supports enumeration: 1`
- [ ] Finder sidebar shows TCFS domain
- [ ] Files enumerate from SeaweedFS
- [ ] No "Cocoa 4099" errors in fileproviderd logs