### PR TITLE
fix(fileprovider): module-qualify NSExtensionPrincipalClass

### DIFF
--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -43,6 +43,14 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return progress
         }
 
+        // Trash container not supported — tell fileproviderd so it doesn't
+        // create reconciliation entries that never resolve.
+        if identifier == .trashContainer {
+            completionHandler(nil, NSFileProviderError(.noSuchItem))
+            progress.completedUnitCount = 1
+            return progress
+        }
+
         // For non-root items, return the item from its identifier path
         completionHandler(
             TCFSFileProviderItem(

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -4,28 +4,60 @@ import Foundation
 @main
 struct TCFSProviderApp {
     static func main() {
-        // Register the FileProvider domain so macOS activates our extension.
         let domain = NSFileProviderDomain(
             identifier: NSFileProviderDomainIdentifier("io.tinyland.tcfs"),
             displayName: "TCFS"
         )
 
-        NSFileProviderManager.add(domain) { error in
-            if let error = error {
-                let nsError = error as NSError
-                // -1004 = domain already exists (not an error)
-                if nsError.domain == NSFileProviderErrorDomain && nsError.code == -1004 {
-                    print("TCFS domain already registered")
-                } else {
-                    print("Failed to add domain: \(error)")
+        let args = CommandLine.arguments
+        let shouldReset = args.contains("--reset")
+
+        // Run domain setup on a background thread so the main RunLoop
+        // can process XPC callbacks from fileproviderd.
+        DispatchQueue.global(qos: .userInitiated).async {
+            if shouldReset {
+                let sem = DispatchSemaphore(value: 0)
+                print("Removing domain...")
+                NSFileProviderManager.remove(domain) { error in
+                    if let error = error {
+                        print("Remove: \(error.localizedDescription)")
+                    } else {
+                        print("Domain removed")
+                    }
+                    sem.signal()
                 }
-            } else {
-                print("TCFS FileProvider domain registered")
+                sem.wait()
+                Thread.sleep(forTimeInterval: 3.0)
+            }
+
+            let addSem = DispatchSemaphore(value: 0)
+            NSFileProviderManager.add(domain) { error in
+                if let error = error {
+                    let nsError = error as NSError
+                    if nsError.domain == NSFileProviderErrorDomain && nsError.code == -1004 {
+                        print("TCFS domain already registered")
+                    } else {
+                        print("Failed to add domain: \(error)")
+                    }
+                } else {
+                    print("TCFS FileProvider domain registered")
+                }
+                addSem.signal()
+            }
+            addSem.wait()
+
+            // Signal re-enumeration after domain is ready
+            if let manager = NSFileProviderManager(for: domain) {
+                manager.signalEnumerator(for: .rootContainer) { error in
+                    print("Signal root: \(error?.localizedDescription ?? "OK")")
+                }
+                manager.reimportItems(below: .rootContainer) { error in
+                    print("Reimport: \(error?.localizedDescription ?? "OK")")
+                }
             }
         }
 
-        // Keep running so the extension stays available.
-        // LSUIElement = true in Info.plist prevents dock icon.
+        // Main RunLoop — processes XPC callbacks and keeps app alive.
         RunLoop.current.run()
     }
 }

--- a/swift/fileprovider/resources/Extension-Info.plist
+++ b/swift/fileprovider/resources/Extension-Info.plist
@@ -26,7 +26,7 @@
         <key>NSExtensionPointIdentifier</key>
         <string>com.apple.fileprovider-nonui</string>
         <key>NSExtensionPrincipalClass</key>
-        <string>TCFSFileProviderExtension</string>
+        <string>TCFSFileProvider.TCFSFileProviderExtension</string>
         <key>NSExtensionFileProviderSupportsEnumeration</key>
         <true/>
     </dict>


### PR DESCRIPTION
## Summary
- Fix `NSExtensionPrincipalClass` from `TCFSFileProviderExtension` to `TCFSFileProvider.TCFSFileProviderExtension`
- Swift classes use module-mangled ObjC names; without the module prefix, `NSClassFromString()` returns nil
- This caused XPC 4099 errors, reconciliation table throttling (retry_count=10), and EDEADLK on `ls`
- Also: handle `.trashContainer` in `item(for:)`, add `--reset` flag to host app

## Root Cause
`nm` shows the ObjC symbol is `_TtC16TCFSFileProvider25TCFSFileProviderExtension` — the runtime needs `TCFSFileProvider.TCFSFileProviderExtension` to resolve it.

## Test plan
- [ ] `fileproviderctl check io.tinyland.tcfs.fileprovider` passes FPCK
- [ ] `ls ~/Library/CloudStorage/TCFSProvider-TCFS/` returns file listing
- [ ] Extension logs show enumeration activity