### PR TITLE
fix(fileprovider): use NSExtensionMain for XPC hosting

### DIFF
--- a/swift/fileprovider/Sources/Extension/main.swift
+++ b/swift/fileprovider/Sources/Extension/main.swift
@@ -1,9 +1,19 @@
 import Foundation
-import FileProvider
 
-// FileProvider extension entry point.
-// The system discovers TCFSFileProviderExtension via NSPrincipalClass in Info.plist.
+// NSExtensionMain is a C function exported by Foundation that sets up
+// the full extension hosting infrastructure:
+//   1. Parses -LaunchArguments from ExtensionKit
+//   2. Registers XPC listener for fileproviderd communication
+//   3. Discovers NSExtensionPrincipalClass from Info.plist
+//   4. Instantiates the principal class on first XPC connection
+//   5. Runs the main dispatch loop (never returns)
+//
+// dispatchMain() alone does NOT set up XPC — it just blocks the main
+// thread.  Without NSExtensionMain the extension process starts but
+// fileproviderd gets Cocoa 4099 "connection … was invalidated".
+@_silgen_name("NSExtensionMain")
+func NSExtensionMain(_ argc: Int32, _ argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>) -> Int32
+
 autoreleasepool {
-    // Keep the XPC service alive to handle FileProvider callbacks
-    dispatchMain()
+    _ = NSExtensionMain(CommandLine.argc, CommandLine.unsafeArgv)
 }


### PR DESCRIPTION
## Summary
- Replace `dispatchMain()` with `NSExtensionMain()` in extension entry point
- `dispatchMain()` keeps the process alive but doesn't register the XPC listener
- `NSExtensionMain` (Foundation C API) handles ExtensionKit launch args, XPC listener setup, principal class discovery, and main loop

## Root cause
fileproviderd launches the extension process via ExtensionKit/RunningBoard. The process starts and enters `dispatchMain()`, but nothing registers an XPC listener. fileproviderd gets `Cocoa 4099 "connection was invalidated"` with `pid -1 named (null)` and `db_is_bound` stays 0.

## Verification
- `otool -tV -p _main` confirms `_NSExtensionMain` is called instead of `_dispatch_main`
- Build tested locally (compiles clean with swiftc + staticlib)
- Needs notarized CI build to verify XPC binding on macOS