### PR TITLE
fix(fileprovider): avoid Group Container deadlock in config loading

### DIFF
--- a/swift/fileprovider/Sources/Extension/FileProviderEnumerator.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderEnumerator.swift
@@ -1,5 +1,8 @@
 import FileProvider
 import Foundation
+import os.log
+
+private let enumLogger = Logger(subsystem: "io.tinyland.tcfs.fileprovider", category: "enumerator")
 
 /// Enumerates TCFS directory contents by calling into the Rust FFI layer.
 class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
@@ -30,7 +33,9 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
         // Dispatch off the file-coordination thread to avoid EDEADLK when the
         // lazy provider init (tokio runtime + S3 operator) blocks.
         DispatchQueue.global(qos: .userInitiated).async {
+            enumLogger.info("enumerateItems: resolving provider for container \(containerId.rawValue)")
             guard let prov = accessor() else {
+                enumLogger.error("enumerateItems: provider is nil — returning serverUnreachable")
                 observer.finishEnumeratingWithError(NSFileProviderError(.serverUnreachable))
                 return
             }
@@ -42,6 +47,8 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
                 path = containerId.rawValue
             }
 
+            enumLogger.info("enumerateItems: calling tcfs_provider_enumerate for path='\(path)'")
+
             var outItems: UnsafeMutablePointer<TcfsFileItem>?
             var outCount: UInt = 0
 
@@ -49,7 +56,12 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
                 tcfs_provider_enumerate(prov, pathPtr, &outItems, &outCount)
             }
 
+            enumLogger.info("enumerateItems: enumerate returned \(result.rawValue), count=\(outCount)")
+
             guard result == TCFS_ERROR_TCFS_ERROR_NONE, let items = outItems, outCount > 0 else {
+                if result != TCFS_ERROR_TCFS_ERROR_NONE {
+                    enumLogger.error("enumerateItems: enumerate failed with code \(result.rawValue)")
+                }
                 observer.finishEnumerating(upTo: nil)
                 return
             }
@@ -77,6 +89,7 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
             // Free the C array
             tcfs_file_items_free(outItems, outCount)
 
+            enumLogger.info("enumerateItems: returning \(providerItems.count) items")
             observer.didEnumerate(providerItems)
             observer.finishEnumerating(upTo: nil)
         }

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -1,5 +1,8 @@
 import FileProvider
 import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "io.tinyland.tcfs.fileprovider", category: "extension")
 
 /// TCFS FileProvider extension — bridges to Rust via cbindgen C FFI.
 ///
@@ -335,29 +338,69 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     // MARK: - Provider setup
 
     private static func createProvider() -> OpaquePointer? {
-        guard let config = loadConfig() else { return nil }
+        logger.info("createProvider: loading config...")
+        guard let config = loadConfig() else {
+            logger.error("createProvider: config load failed — provider will be nil")
+            return nil
+        }
+        logger.info("createProvider: config loaded (\(config.count) bytes), creating provider")
 
-        return config.withCString { configPtr in
+        let ptr = config.withCString { configPtr in
             tcfs_provider_new(configPtr)
         }
+        if ptr != nil {
+            logger.info("createProvider: provider created successfully")
+        } else {
+            logger.error("createProvider: tcfs_provider_new returned null")
+        }
+        return ptr
     }
 
-    /// Load TCFS config from App Group shared container, falling back to XDG config.
+    /// Load TCFS config, trying XDG path first (fast, no file coordination),
+    /// then App Group container as fallback.
+    ///
+    /// IMPORTANT: The App Group container is checked LAST because fileproviderd
+    /// holds file coordination locks on group container paths.  Reading from the
+    /// group container during an enumeration callback can deadlock the extension
+    /// (open() blocks in the kernel waiting for the lock that fileproviderd holds
+    /// until the enumeration completes — circular dependency).
     private static func loadConfig() -> String? {
-        // Try App Group container first (sandboxed .appex)
+        // 1. Try XDG config path first (requires sandbox temp-exception entitlement).
+        //    This uses a plain POSIX path that doesn't go through file coordination,
+        //    so it can never deadlock with fileproviderd.
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let xdgPath = home.appendingPathComponent(".config/tcfs/fileprovider/config.json")
+        if let config = try? String(contentsOf: xdgPath, encoding: .utf8) {
+            logger.info("loadConfig: loaded from XDG path")
+            return config
+        }
+        logger.warning("loadConfig: XDG path not accessible, trying App Group container")
+
+        // 2. App Group container (sandboxed fallback).
+        //    Only safe when NOT called from a fileproviderd callback path, but we
+        //    attempt it as last resort with a short timeout to avoid deadlock.
         let groupId = "group.io.tinyland.tcfs"
         if let containerURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: groupId
         ) {
             let configPath = containerURL.appendingPathComponent("config.json")
-            if let config = try? String(contentsOf: configPath, encoding: .utf8) {
+
+            // Use a background thread with timeout to avoid blocking forever
+            // if file coordination deadlocks.
+            var result: String?
+            let sem = DispatchSemaphore(value: 0)
+            DispatchQueue.global(qos: .utility).async {
+                result = try? String(contentsOf: configPath, encoding: .utf8)
+                sem.signal()
+            }
+            if sem.wait(timeout: .now() + 3.0) == .success, let config = result {
+                logger.info("loadConfig: loaded from App Group container")
                 return config
             }
+            logger.warning("loadConfig: App Group container read timed out or failed")
         }
 
-        // Fall back to XDG config path (development / non-sandboxed)
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let xdgPath = home.appendingPathComponent(".config/tcfs/fileprovider/config.json")
-        return try? String(contentsOf: xdgPath, encoding: .utf8)
+        logger.error("loadConfig: no config found at any location")
+        return nil
     }
 }

--- a/swift/fileprovider/resources/Extension.entitlements
+++ b/swift/fileprovider/resources/Extension.entitlements
@@ -11,5 +11,9 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
+    <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+    <array>
+        <string>.config/tcfs/</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Try XDG config path (`~/.config/tcfs/`) first with sandbox temp exception — no file coordination, no deadlock
- Fall back to App Group container with 3-second timeout to prevent indefinite blocking
- Add `os_log` throughout extension and enumerator for debugging

## Root Cause
The App Group container (`~/Library/Group Containers/group.io.tinyland.tcfs/`) is subject to file coordination locks held by `fileproviderd`. When the extension reads `config.json` from the group container during an enumeration callback, `open()` blocks in the kernel waiting for the lock that `fileproviderd` holds until the enumeration completes — creating a circular deadlock that manifests as EDEADLK on `ls ~/Library/CloudStorage/TCFSProvider-TCFS/`.

## Test plan
- [ ] Deploy v0.7.6 to petting-zoo-mini (after reboot to clear kernel deadlock)
- [ ] Verify `log stream --predicate 'subsystem == "io.tinyland.tcfs.fileprovider"'` shows config loaded from XDG
- [ ] Verify `ls ~/Library/CloudStorage/TCFSProvider-TCFS/` returns files
- [ ] Verify FPCK passes: `fileproviderctl check -v io.tinyland.tcfs.fileprovider`