### PR TITLE
fix(fileprovider): use Keychain instead of UserDefaults for config delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tfplan
 # Build outputs
 bin/
 out/
+/build/
 
 # Logs
 logs

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -1,5 +1,6 @@
 import FileProvider
 import Foundation
+import Security
 import os.log
 
 private let logger = Logger(subsystem: "io.tinyland.tcfs.fileprovider", category: "extension")
@@ -359,26 +360,22 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     /// Load TCFS config, trying multiple sources in order of safety.
     ///
     /// Sources (in priority order):
-    /// 1. Shared UserDefaults (App Group suite) — no file I/O, no deadlock risk
+    /// 1. Shared Keychain — provisioned by host app, accessed via securityd XPC
     /// 2. XDG config path — requires sandbox temp-exception entitlement
     /// 3. App Group container file — deadlock-prone, short timeout
     ///
-    /// IMPORTANT: The App Group container file is checked LAST because
-    /// fileproviderd holds file coordination locks on group container paths.
-    /// Reading from the group container during an enumeration callback can
-    /// deadlock the extension (open() blocks in the kernel waiting for the
-    /// lock that fileproviderd holds until enumeration completes).
+    /// IMPORTANT: Keychain is checked FIRST because it uses securityd XPC,
+    /// completely bypassing the filesystem. UserDefaults with an App Group
+    /// suite stores data in the Group Container, which is file-coordinated
+    /// by fileproviderd — reading it during enumeration deadlocks.
     private static func loadConfig() -> String? {
-        // 1. Shared UserDefaults — provisioned by the host app from XDG config.
-        //    No file I/O, no file coordination, no deadlock risk.
-        let groupId = "group.io.tinyland.tcfs"
-        if let defaults = UserDefaults(suiteName: groupId),
-           let config = defaults.string(forKey: "configJSON"),
-           !config.isEmpty {
-            logger.info("loadConfig: loaded from shared UserDefaults")
+        // 1. Shared Keychain — provisioned by the host app.
+        //    Uses securityd XPC, no file I/O, no file coordination, no deadlock.
+        if let config = readConfigFromKeychain() {
+            logger.info("loadConfig: loaded from shared Keychain")
             return config
         }
-        logger.warning("loadConfig: UserDefaults empty, trying XDG path")
+        logger.warning("loadConfig: Keychain empty, trying XDG path")
 
         // 2. XDG config path (sandbox temp-exception may or may not work for extensions).
         let home = FileManager.default.homeDirectoryForCurrentUser
@@ -390,13 +387,12 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         logger.warning("loadConfig: XDG path not accessible, trying App Group container file")
 
         // 3. App Group container file (last resort, deadlock-prone).
+        let groupId = "group.io.tinyland.tcfs"
         if let containerURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: groupId
         ) {
             let configPath = containerURL.appendingPathComponent("config.json")
 
-            // Use a background thread with timeout to avoid blocking forever
-            // if file coordination deadlocks.
             var result: String?
             let sem = DispatchSemaphore(value: 0)
             DispatchQueue.global(qos: .utility).async {
@@ -412,5 +408,30 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
         logger.error("loadConfig: no config found at any location")
         return nil
+    }
+
+    /// Read config JSON from the shared Keychain access group.
+    /// Keychain access uses securityd XPC — no filesystem I/O, immune to
+    /// fileproviderd's file coordination locks.
+    private static func readConfigFromKeychain() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "io.tinyland.tcfs.config",
+            kSecAttrAccount as String: "configJSON",
+            kSecAttrAccessGroup as String: "group.io.tinyland.tcfs",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let config = String(data: data, encoding: .utf8),
+              !config.isEmpty else {
+            return nil
+        }
+        return config
     }
 }

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -1,5 +1,6 @@
 import FileProvider
 import Foundation
+import Security
 
 @main
 struct TCFSProviderApp {
@@ -66,9 +67,9 @@ struct TCFSProviderApp {
         RunLoop.current.run()
     }
 
-    /// Read config.json from XDG path and store it in the shared UserDefaults
-    /// suite so the extension can access it without file I/O into the Group
-    /// Container (which deadlocks with fileproviderd's file coordination).
+    /// Read config.json from XDG path and store it in the shared Keychain
+    /// so the extension can access it via securityd XPC without touching the
+    /// Group Container filesystem (which deadlocks with fileproviderd).
     private static func provisionConfig() {
         let home = FileManager.default.homeDirectoryForCurrentUser
         let xdgPath = home.appendingPathComponent(".config/tcfs/fileprovider/config.json")
@@ -78,13 +79,41 @@ struct TCFSProviderApp {
             return
         }
 
-        guard let defaults = UserDefaults(suiteName: "group.io.tinyland.tcfs") else {
-            print("Config: failed to open shared UserDefaults suite")
+        guard let data = config.data(using: .utf8) else {
+            print("Config: failed to encode config as UTF-8")
             return
         }
 
-        defaults.set(config, forKey: "configJSON")
-        defaults.synchronize()
-        print("Config: provisioned \(config.count) bytes to shared UserDefaults")
+        // Write to shared Keychain access group (securityd XPC, no file I/O).
+        let service = "io.tinyland.tcfs.config"
+        let account = "configJSON"
+        let accessGroup = "group.io.tinyland.tcfs"
+
+        // Try to update existing item first.
+        let updateQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessGroup as String: accessGroup,
+        ]
+        let updateAttrs: [String: Any] = [
+            kSecValueData as String: data,
+        ]
+
+        var status = SecItemUpdate(updateQuery as CFDictionary, updateAttrs as CFDictionary)
+
+        if status == errSecItemNotFound {
+            // Item doesn't exist yet — add it.
+            var addQuery = updateQuery
+            addQuery[kSecValueData as String] = data
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            status = SecItemAdd(addQuery as CFDictionary, nil)
+        }
+
+        if status == errSecSuccess {
+            print("Config: provisioned \(config.count) bytes to shared Keychain")
+        } else {
+            print("Config: Keychain write failed with status \(status)")
+        }
     }
 }

--- a/swift/fileprovider/resources/Extension.entitlements
+++ b/swift/fileprovider/resources/Extension.entitlements
@@ -11,9 +11,9 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
-    <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+    <key>keychain-access-groups</key>
     <array>
-        <string>/.config/tcfs/</string>
+        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
     </array>
 </dict>
 </plist>

--- a/swift/fileprovider/resources/HostApp.entitlements
+++ b/swift/fileprovider/resources/HostApp.entitlements
@@ -9,5 +9,9 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

UserDefaults with App Group suite (v0.7.8) stores data in the Group Container at ~/Library/Group Containers/group.io.tinyland.tcfs/. This path is file-coordinated by fileproviderd, creating the same deadlock as direct file reads:

1. fileproviderd holds file coordination lock on Group Container during enumeration
2. Extension tries to read UserDefaults (backed by a plist IN the Group Container)
3. open() blocks in kernel waiting for lock → deadlock

The deadlock persists at the kernel VFS level across process restarts and even across reboots (fileproviderd immediately re-acquires the lock on startup).

## Solution

Switch to macOS Keychain with shared access group (`group.io.tinyland.tcfs`). Keychain access uses securityd XPC, completely bypassing the Group Container filesystem.

- Host app reads XDG config and writes to Keychain via SecItemAdd/SecItemUpdate
- Extension reads from Keychain via SecItemCopyMatching as first priority
- Falls back to XDG path and App Group container file (with timeout)

## Changes

- `FileProviderExtension.swift`: loadConfig() now checks Keychain first via readConfigFromKeychain()
- `HostApp.swift`: provisionConfig() writes to Keychain instead of UserDefaults
- `Extension.entitlements`: Replace sandbox temp exception with keychain-access-groups
- `HostApp.entitlements`: Add keychain-access-groups

Tags: v0.7.9