### PR TITLE
fix(fileprovider): use data protection keychain for shared config access

### DIFF
--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -413,18 +413,26 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     /// Read config JSON from the shared Keychain access group.
     /// Keychain access uses securityd XPC — no filesystem I/O, immune to
     /// fileproviderd's file coordination locks.
+    ///
+    /// Uses the data protection keychain (kSecUseDataProtectionKeychain)
+    /// which works with App Group names directly — no TeamID prefix needed.
     private static func readConfigFromKeychain() -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: "io.tinyland.tcfs.config",
             kSecAttrAccount as String: "configJSON",
             kSecAttrAccessGroup as String: "group.io.tinyland.tcfs",
+            kSecUseDataProtectionKeychain as String: true,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]
 
         var item: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        if status != errSecSuccess {
+            logger.warning("readConfigFromKeychain: SecItemCopyMatching returned \(status)")
+        }
 
         guard status == errSecSuccess,
               let data = item as? Data,

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -84,7 +84,8 @@ struct TCFSProviderApp {
             return
         }
 
-        // Write to shared Keychain access group (securityd XPC, no file I/O).
+        // Write to shared Keychain via data protection keychain (securityd XPC).
+        // Uses App Group access group directly — no TeamID prefix needed.
         let service = "io.tinyland.tcfs.config"
         let account = "configJSON"
         let accessGroup = "group.io.tinyland.tcfs"
@@ -95,6 +96,7 @@ struct TCFSProviderApp {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecAttrAccessGroup as String: accessGroup,
+            kSecUseDataProtectionKeychain as String: true,
         ]
         let updateAttrs: [String: Any] = [
             kSecValueData as String: data,

--- a/swift/fileprovider/resources/Extension.entitlements
+++ b/swift/fileprovider/resources/Extension.entitlements
@@ -11,9 +11,5 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
-    <key>keychain-access-groups</key>
-    <array>
-        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
-    </array>
 </dict>
 </plist>

--- a/swift/fileprovider/resources/HostApp.entitlements
+++ b/swift/fileprovider/resources/HostApp.entitlements
@@ -9,9 +9,5 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
-    <key>keychain-access-groups</key>
-    <array>
-        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
-    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Follow-up to #43.

## Problem
`keychain-access-groups` entitlement uses `$(AppIdentifierPrefix)` which is only expanded by Xcode. Our build.sh uses raw swiftc/codesign, so the literal string `$(AppIdentifierPrefix)group.io.tinyland.tcfs` was embedded in the entitlements, preventing actual Keychain access.

## Fix
- Remove `keychain-access-groups` entitlement from both host app and extension (`application-groups` already grants shared keychain access automatically per Apple docs)
- Add `kSecUseDataProtectionKeychain: true` to all `SecItem*` queries — the data protection keychain works with App Group names directly without requiring a TeamID prefix
- Add diagnostic logging (`SecItemCopyMatching` status code) for easier debugging