### PR TITLE
fix(fileprovider): add keychain entitlements with TeamID expansion

### DIFF
--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -1,6 +1,9 @@
 import FileProvider
 import Foundation
 import Security
+import os.log
+
+private let hostLogger = Logger(subsystem: "io.tinyland.tcfs", category: "host")
 
 @main
 struct TCFSProviderApp {
@@ -113,9 +116,9 @@ struct TCFSProviderApp {
         }
 
         if status == errSecSuccess {
-            print("Config: provisioned \(config.count) bytes to shared Keychain")
+            hostLogger.info("provisionConfig: provisioned \(config.count) bytes to shared Keychain")
         } else {
-            print("Config: Keychain write failed with status \(status)")
+            hostLogger.error("provisionConfig: Keychain write failed with status \(status)")
         }
     }
 }

--- a/swift/fileprovider/build.sh
+++ b/swift/fileprovider/build.sh
@@ -101,27 +101,52 @@ cp "$SCRIPT_DIR/resources/HostApp-Info.plist" "$APP/Info.plist"
 cp TCFSFileProvider "$EXT/MacOS/"
 cp "$SCRIPT_DIR/resources/Extension-Info.plist" "$EXT/Info.plist"
 
+# --- Resolve entitlements (expand TeamID for keychain-access-groups) ---
+echo "==> Resolving entitlements..."
+EXT_ENTITLEMENTS="$SCRIPT_DIR/resources/Extension.entitlements"
+HOST_ENTITLEMENTS="$SCRIPT_DIR/resources/HostApp.entitlements"
+
+if [ "$SIGNING_IDENTITY" != "-" ]; then
+    # Extract TeamID from the signing certificate.
+    TEAM_ID=$(/usr/bin/security find-identity -v -p codesigning \
+        | grep "$SIGNING_IDENTITY" \
+        | head -1 \
+        | sed -E 's/.*\(([A-Z0-9]{10})\).*/\1/')
+    if [ -n "$TEAM_ID" ]; then
+        echo "    TeamID: $TEAM_ID"
+        # Generate entitlements with resolved keychain-access-groups
+        EXT_ENTITLEMENTS="/tmp/tcfs-ext-entitlements.$$.plist"
+        HOST_ENTITLEMENTS="/tmp/tcfs-host-entitlements.$$.plist"
+        sed "s/\$(AppIdentifierPrefix)/${TEAM_ID}./g" \
+            "$SCRIPT_DIR/resources/Extension.entitlements" > "$EXT_ENTITLEMENTS"
+        sed "s/\$(AppIdentifierPrefix)/${TEAM_ID}./g" \
+            "$SCRIPT_DIR/resources/HostApp.entitlements" > "$HOST_ENTITLEMENTS"
+    else
+        echo "    WARNING: Could not extract TeamID, using entitlements as-is"
+    fi
+fi
+
 # --- Code sign (inside-out: extension first, then host app) ---
 echo "==> Signing..."
 if [ "$SIGNING_IDENTITY" != "-" ]; then
     echo "    Identity: $SIGNING_IDENTITY (Developer ID)"
     /usr/bin/codesign -f -s "$SIGNING_IDENTITY" \
         --options runtime --timestamp \
-        --entitlements "$SCRIPT_DIR/resources/Extension.entitlements" \
+        --entitlements "$EXT_ENTITLEMENTS" \
         "$APP/Extensions/TCFSFileProvider.appex"
 
     /usr/bin/codesign -f -s "$SIGNING_IDENTITY" \
         --options runtime --timestamp \
-        --entitlements "$SCRIPT_DIR/resources/HostApp.entitlements" \
+        --entitlements "$HOST_ENTITLEMENTS" \
         "$OUTPUT_DIR/TCFSProvider.app"
 else
     echo "    Identity: ad-hoc (development)"
     /usr/bin/codesign -f -s - \
-        --entitlements "$SCRIPT_DIR/resources/Extension.entitlements" \
+        --entitlements "$EXT_ENTITLEMENTS" \
         "$APP/Extensions/TCFSFileProvider.appex"
 
     /usr/bin/codesign -f -s - \
-        --entitlements "$SCRIPT_DIR/resources/HostApp.entitlements" \
+        --entitlements "$HOST_ENTITLEMENTS" \
         "$OUTPUT_DIR/TCFSProvider.app"
 fi
 

--- a/swift/fileprovider/resources/Extension.entitlements
+++ b/swift/fileprovider/resources/Extension.entitlements
@@ -11,5 +11,11 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
+    <key>com.apple.application-identifier</key>
+    <string>$(AppIdentifierPrefix)io.tinyland.tcfs.fileprovider</string>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
+    </array>
 </dict>
 </plist>

--- a/swift/fileprovider/resources/HostApp.entitlements
+++ b/swift/fileprovider/resources/HostApp.entitlements
@@ -9,5 +9,11 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
+    <key>com.apple.application-identifier</key>
+    <string>$(AppIdentifierPrefix)io.tinyland.tcfs</string>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes errSecMissingEntitlement (-34018) when the FileProvider extension tries to read config from the shared Keychain.

## Root Cause
The data protection keychain on macOS requires:
1. `com.apple.application-identifier` entitlement (`TeamID.BundleID`)
2. `keychain-access-groups` entitlement (`TeamID.group.io.tinyland.tcfs`)

These use `$(AppIdentifierPrefix)` in the plist, which **Xcode** expands at build time but **raw codesign** (our build.sh) does not.

## Fix
- `build.sh`: Extracts TeamID from the signing certificate and sed-expands entitlement templates before codesigning
- Added `com.apple.application-identifier` to both Extension and HostApp entitlements
- Restored `keychain-access-groups` with `$(AppIdentifierPrefix)` macro
- Added `os_log` to host app for Keychain provisioning diagnostics

## Testing
- Extension was launched and produced logs showing `SecItemCopyMatching returned -34018`
- After this fix, the TeamID (`QP994XQKNH`) will be properly embedded in the signed entitlements