### PR TITLE
fix(fileprovider): remove com.apple.application-identifier entitlement

### DIFF
--- a/swift/fileprovider/resources/Extension.entitlements
+++ b/swift/fileprovider/resources/Extension.entitlements
@@ -11,8 +11,6 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
-    <key>com.apple.application-identifier</key>
-    <string>$(AppIdentifierPrefix)io.tinyland.tcfs.fileprovider</string>
     <key>keychain-access-groups</key>
     <array>
         <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>

--- a/swift/fileprovider/resources/HostApp.entitlements
+++ b/swift/fileprovider/resources/HostApp.entitlements
@@ -9,8 +9,6 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
-    <key>com.apple.application-identifier</key>
-    <string>$(AppIdentifierPrefix)io.tinyland.tcfs</string>
     <key>keychain-access-groups</key>
     <array>
         <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>


### PR DESCRIPTION
## Problem
`com.apple.application-identifier` requires a provisioning profile. Developer ID signed apps don't have one, so amfid kills the process with SIGKILL (error -413: No matching profile found).

## Fix
Remove `com.apple.application-identifier` from both Extension and HostApp entitlements. Keep `keychain-access-groups` with TeamID expansion for shared Keychain access.