### PR TITLE
fix(fileprovider): use legacy macOS keychain without restricted entitlements

### DIFF
--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -410,19 +410,18 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         return nil
     }
 
-    /// Read config JSON from the shared Keychain access group.
+    /// Read config JSON from the macOS login keychain.
     /// Keychain access uses securityd XPC — no filesystem I/O, immune to
     /// fileproviderd's file coordination locks.
     ///
-    /// Uses the data protection keychain (kSecUseDataProtectionKeychain)
-    /// which works with App Group names directly — no TeamID prefix needed.
+    /// Uses the legacy macOS keychain (NOT data protection keychain) to avoid
+    /// restricted entitlement requirements. Both host app and extension are
+    /// signed with the same Developer ID, so they share keychain access.
     private static func readConfigFromKeychain() -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: "io.tinyland.tcfs.config",
             kSecAttrAccount as String: "configJSON",
-            kSecAttrAccessGroup as String: "group.io.tinyland.tcfs",
-            kSecUseDataProtectionKeychain as String: true,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -87,19 +87,17 @@ struct TCFSProviderApp {
             return
         }
 
-        // Write to shared Keychain via data protection keychain (securityd XPC).
-        // Uses App Group access group directly — no TeamID prefix needed.
+        // Write to macOS login keychain via securityd XPC (no file I/O).
+        // Both host app and extension share the same Developer ID signing,
+        // so they can access each other's keychain items.
         let service = "io.tinyland.tcfs.config"
         let account = "configJSON"
-        let accessGroup = "group.io.tinyland.tcfs"
 
         // Try to update existing item first.
         let updateQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
-            kSecAttrAccessGroup as String: accessGroup,
-            kSecUseDataProtectionKeychain as String: true,
         ]
         let updateAttrs: [String: Any] = [
             kSecValueData as String: data,

--- a/swift/fileprovider/resources/Extension.entitlements
+++ b/swift/fileprovider/resources/Extension.entitlements
@@ -11,9 +11,5 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
-    <key>keychain-access-groups</key>
-    <array>
-        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
-    </array>
 </dict>
 </plist>

--- a/swift/fileprovider/resources/HostApp.entitlements
+++ b/swift/fileprovider/resources/HostApp.entitlements
@@ -9,9 +9,5 @@
     <array>
         <string>group.io.tinyland.tcfs</string>
     </array>
-    <key>keychain-access-groups</key>
-    <array>
-        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
-    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem
Both `keychain-access-groups` and `com.apple.application-identifier` are restricted entitlements requiring provisioning profiles. Developer ID apps don't have these, so amfid kills the process (SIGKILL, error -413).

## Fix
Use the legacy macOS login keychain instead of the data protection keychain:
- Remove `keychain-access-groups` entitlement from both host and extension
- Remove `kSecUseDataProtectionKeychain` and `kSecAttrAccessGroup` from code
- Both apps share the same Developer ID signing (TeamID QP994XQKNH), granting shared keychain access

This is the simplest approach that avoids both:
1. File coordination deadlocks (Group Container)
2. Restricted entitlement requirements (provisioning profiles)