### PR TITLE
feat(daemon): master key loading + real age enrollment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,7 @@ name = "tcfs-cli"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "blake3",
  "clap",
  "fuse3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4833,6 +4833,7 @@ dependencies = [
 name = "tcfsd"
 version = "0.5.0"
 dependencies = [
+ "age",
  "anyhow",
  "async-nats",
  "axum",
@@ -4846,6 +4847,7 @@ dependencies = [
  "serde",
  "service-manager",
  "tcfs-core",
+ "tcfs-crypto",
  "tcfs-fuse",
  "tcfs-secrets",
  "tcfs-storage",

--- a/crates/tcfs-cli/Cargo.toml
+++ b/crates/tcfs-cli/Cargo.toml
@@ -20,6 +20,7 @@ tcfs-fuse = { path = "../tcfs-fuse" }
 tcfs-crypto = { path = "../tcfs-crypto" }
 secrecy = { workspace = true }
 rand = { workspace = true }
+base64 = { workspace = true }
 blake3 = { workspace = true }
 fuse3 = { workspace = true, optional = true }
 opendal = { workspace = true }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1332,69 +1332,111 @@ async fn cmd_init(
 ) -> Result<()> {
     let device_name = device_name.unwrap_or_else(tcfs_secrets::device::default_device_name);
 
-    // Check if already initialized
-    let registry_path = tcfs_secrets::device::default_registry_path();
-    let registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path)?;
-    if registry.find(&device_name).is_some() {
+    // Step 1: Check if already initialized (master key file exists)
+    let config_dir = std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+            PathBuf::from(home).join(".config")
+        })
+        .join("tcfs");
+    let master_key_path = config_dir.join("master.key");
+
+    if master_key_path.exists() {
         anyhow::bail!(
-            "Device '{}' is already enrolled. Use 'tcfs device list' to see devices.",
-            device_name
+            "Already initialized: {} exists. Remove it to re-initialize.",
+            master_key_path.display()
         );
     }
 
-    // Get master passphrase
-    let passphrase = if non_interactive {
-        password.context("--password is required in non-interactive mode")?
-    } else {
-        let p = rpassword::prompt_password("Master passphrase: ")
-            .context("failed to read passphrase")?;
-        let confirm = rpassword::prompt_password("Confirm passphrase: ")
-            .context("failed to read confirmation")?;
-        if p != confirm {
-            anyhow::bail!("Passphrases do not match");
+    // Step 2-4: Derive or generate master key
+    let master_key = if let Some(ref pw) = password {
+        // Password provided: derive master key from passphrase via Argon2id
+        println!("Deriving master key from passphrase...");
+        let salt: [u8; 16] = rand_salt();
+        tcfs_crypto::derive_master_key(
+            &secrecy::SecretString::from(pw.clone()),
+            &salt,
+            &tcfs_crypto::kdf::KdfParams::default(),
+        )?
+    } else if non_interactive {
+        // Non-interactive, no password: generate mnemonic, print it, no prompt
+        println!("Generating BIP-39 recovery mnemonic...");
+        let (mnemonic, master_key) = tcfs_crypto::generate_mnemonic()?;
+        println!();
+        println!("RECOVERY MNEMONIC (store this securely):");
+        println!();
+        let words: Vec<&str> = mnemonic.split_whitespace().collect();
+        for (i, chunk) in words.chunks(4).enumerate() {
+            println!("  {:2}. {}", i * 4 + 1, chunk.join("  "));
         }
-        p
+        println!();
+        master_key
+    } else {
+        // Interactive, no password: generate mnemonic, display prominently, confirm
+        println!("Generating BIP-39 recovery mnemonic...");
+        let (mnemonic, master_key) = tcfs_crypto::generate_mnemonic()?;
+        println!();
+        println!("╔══════════════════════════════════════════════════════════════╗");
+        println!("║  RECOVERY MNEMONIC — WRITE THIS DOWN AND STORE IT SAFELY   ║");
+        println!("╠══════════════════════════════════════════════════════════════╣");
+        println!("║                                                              ║");
+        let words: Vec<&str> = mnemonic.split_whitespace().collect();
+        for (i, chunk) in words.chunks(4).enumerate() {
+            let line = format!("  {:2}. {}", i * 4 + 1, chunk.join("  "));
+            println!("║ {:<60} ║", line);
+        }
+        println!("║                                                              ║");
+        println!("╚══════════════════════════════════════════════════════════════╝");
+        println!();
+        println!("This mnemonic is the ONLY way to recover your master key.");
+        println!("It will NOT be shown again.");
+        println!();
+
+        // Ask user to confirm they wrote it down
+        let confirmation = rpassword::prompt_password(
+            "Type 'yes' to confirm you have written down the mnemonic: ",
+        )
+        .context("failed to read confirmation")?;
+        if confirmation.trim().to_lowercase() != "yes" {
+            anyhow::bail!("Initialization aborted. Please run 'tcfs init' again when ready.");
+        }
+        master_key
     };
 
-    // Generate recovery mnemonic
-    println!("Creating tcfs identity...");
-    let (mnemonic, _master_key) = tcfs_crypto::generate_mnemonic()?;
+    // Step 5: Write master key to ~/.config/tcfs/master.key (raw 32 bytes)
+    std::fs::create_dir_all(&config_dir)
+        .with_context(|| format!("creating config dir: {}", config_dir.display()))?;
+    std::fs::write(&master_key_path, master_key.as_bytes())
+        .with_context(|| format!("writing master key: {}", master_key_path.display()))?;
 
-    // Derive master key from passphrase
-    let salt: [u8; 16] = rand_salt();
-    let master_key = tcfs_crypto::derive_master_key(
-        &secrecy::SecretString::from(passphrase),
-        &salt,
-        &tcfs_crypto::kdf::KdfParams::default(),
-    )?;
+    // Restrict permissions to owner-only (Unix)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&master_key_path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("setting permissions on: {}", master_key_path.display()))?;
+    }
 
-    // Generate a device file key and store it
-    let file_key = tcfs_crypto::generate_file_key();
-    let _wrapped = tcfs_crypto::wrap_key(&master_key, &file_key)?;
-
-    // Register device
+    // Step 6: Create device registry and enroll this device
+    let registry_path = tcfs_secrets::device::default_registry_path();
     let mut registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path)?;
     let public_key = format!("age1-device-{}", &blake3_short(&device_name));
     let device_id = registry.enroll(&device_name, &public_key, None);
     registry.save(&registry_path)?;
 
+    // Step 7: Print success message
     println!();
-    println!("Your recovery phrase (WRITE THIS DOWN):");
+    println!("tcfs initialized successfully.");
     println!();
-    // Display mnemonic in groups of 4 words
-    let words: Vec<&str> = mnemonic.split_whitespace().collect();
-    for (i, chunk) in words.chunks(4).enumerate() {
-        println!("  {:2}. {}", i * 4 + 1, chunk.join("  "));
-    }
-    println!();
-    println!("Device name:     {}", device_name);
-    println!("Device ID:       {}", device_id);
-    println!("Registry:        {}", registry_path.display());
+    println!("  Device name:  {}", device_name);
+    println!("  Device ID:    {}", device_id);
+    println!("  Master key:   {}", master_key_path.display());
+    println!("  Registry:     {}", registry_path.display());
     println!();
     println!("Next steps:");
-    println!("  1. Store your recovery phrase in a safe place");
-    println!("  2. Configure storage: tcfs config show");
-    println!("  3. Push files: tcfs push /path/to/files");
+    println!("  1. Configure storage: tcfs config show");
+    println!("  2. Push files: tcfs push /path/to/files");
 
     Ok(())
 }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -11,8 +11,10 @@
 //!   sync-status [<path>]         - show local sync state for a file/dir
 
 use anyhow::{Context, Result};
+use base64::Engine;
 use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
+use secrecy::ExposeSecret;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -174,6 +176,20 @@ enum Commands {
         #[arg(long)]
         cred_file: Option<PathBuf>,
         /// Non-interactive mode (reads new credentials from environment)
+        #[arg(long)]
+        non_interactive: bool,
+    },
+
+    /// Rotate the master encryption key (re-wraps all file keys)
+    #[command(name = "rotate-key")]
+    RotateKey {
+        /// Path to old master key file (default: ~/.config/tcfs/master.key)
+        #[arg(long)]
+        old_key_file: Option<PathBuf>,
+        /// Use passphrase for the new key (instead of generating a mnemonic)
+        #[arg(long)]
+        password: bool,
+        /// Non-interactive mode (generate and print mnemonic without prompt)
         #[arg(long)]
         non_interactive: bool,
     },
@@ -343,6 +359,11 @@ async fn main() -> Result<()> {
             cred_file,
             non_interactive,
         } => cmd_rotate_credentials(&config, cred_file.as_deref(), non_interactive).await,
+        Commands::RotateKey {
+            old_key_file,
+            password,
+            non_interactive,
+        } => cmd_rotate_key(&config, old_key_file.as_deref(), password, non_interactive).await,
     }
 }
 
@@ -1651,6 +1672,206 @@ async fn cmd_auth_status(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
     } else {
         println!("Encryption: DISABLED (crypto.enabled = false in config)");
     }
+    Ok(())
+}
+
+// ── `tcfs rotate-key` ─────────────────────────────────────────────────────
+
+async fn cmd_rotate_key(
+    config: &tcfs_core::config::TcfsConfig,
+    old_key_file: Option<&Path>,
+    use_password: bool,
+    non_interactive: bool,
+) -> Result<()> {
+    use tcfs_crypto::{MasterKey, KEY_SIZE};
+
+    // Step 1: Load old master key
+    let key_path = old_key_file
+        .map(|p| p.to_path_buf())
+        .or_else(|| config.crypto.master_key_file.clone())
+        .unwrap_or_else(|| {
+            tcfs_secrets::device::default_registry_path()
+                .parent()
+                .unwrap_or(Path::new("."))
+                .join("master.key")
+        });
+
+    let old_bytes = std::fs::read(&key_path)
+        .with_context(|| format!("reading old master key: {}", key_path.display()))?;
+    if old_bytes.len() != KEY_SIZE {
+        anyhow::bail!(
+            "old master key has wrong size: {} bytes (expected {})",
+            old_bytes.len(),
+            KEY_SIZE
+        );
+    }
+    let mut old_key_bytes = [0u8; KEY_SIZE];
+    old_key_bytes.copy_from_slice(&old_bytes);
+    let old_master = MasterKey::from_bytes(old_key_bytes);
+
+    println!("Old master key loaded from: {}", key_path.display());
+
+    // Step 2: Generate new master key
+    let new_master = if use_password {
+        let passphrase =
+            rpassword::prompt_password("New master passphrase: ").context("reading passphrase")?;
+        let confirm =
+            rpassword::prompt_password("Confirm passphrase: ").context("reading confirmation")?;
+        if passphrase != confirm {
+            anyhow::bail!("passphrases do not match");
+        }
+
+        println!("Deriving new master key from passphrase...");
+        let salt: [u8; 16] = rand::random();
+        tcfs_crypto::derive_master_key(
+            &secrecy::SecretString::from(passphrase),
+            &salt,
+            &tcfs_crypto::kdf::KdfParams::default(),
+        )?
+    } else {
+        let (mnemonic, master_key) = tcfs_crypto::generate_mnemonic()?;
+
+        if non_interactive {
+            println!("\nNew BIP-39 recovery mnemonic:");
+            println!("{mnemonic}");
+        } else {
+            println!("\n{}", "=".repeat(60));
+            println!("NEW RECOVERY MNEMONIC (write this down!):");
+            println!("{}", "=".repeat(60));
+            println!("\n  {mnemonic}\n");
+            println!("{}", "=".repeat(60));
+            println!("This mnemonic is the ONLY way to recover your new master key.");
+            println!("Store it securely and NEVER share it.\n");
+
+            let confirm = rpassword::prompt_password("Type 'ROTATE' to confirm key rotation: ")
+                .context("reading confirmation")?;
+            if confirm != "ROTATE" {
+                anyhow::bail!("key rotation cancelled");
+            }
+        }
+        master_key
+    };
+
+    // Step 3: Connect to storage and enumerate manifests
+    let cred_store = tcfs_secrets::CredStore::load(&config.secrets, &config.storage)
+        .await
+        .context("loading credentials for S3 access")?;
+
+    let s3 = cred_store
+        .s3
+        .as_ref()
+        .context("no S3 credentials available")?;
+
+    let op = tcfs_storage::operator::build_from_core_config(
+        &config.storage,
+        &s3.access_key_id,
+        s3.secret_access_key.expose_secret(),
+    )?;
+
+    let manifest_prefix = format!("{}/manifests/", config.storage.bucket);
+    println!("Scanning manifests at: {manifest_prefix}");
+
+    let entries = op
+        .list(&manifest_prefix)
+        .await
+        .context("listing manifests from S3")?;
+
+    let mut rotated = 0u64;
+    let mut skipped = 0u64;
+    let mut errors = 0u64;
+
+    for entry in entries {
+        let path = entry.path().to_string();
+        if entry.metadata().is_dir() {
+            continue;
+        }
+
+        // Read manifest
+        let data = match op.read(&path).await {
+            Ok(d) => d.to_bytes(),
+            Err(e) => {
+                eprintln!("  WARN: failed to read {path}: {e}");
+                errors += 1;
+                continue;
+            }
+        };
+
+        let mut manifest: tcfs_sync::manifest::SyncManifest =
+            match tcfs_sync::manifest::SyncManifest::from_bytes(&data) {
+                Ok(m) => m,
+                Err(e) => {
+                    eprintln!("  WARN: failed to parse {path}: {e}");
+                    errors += 1;
+                    continue;
+                }
+            };
+
+        // Only rotate manifests that have wrapped file keys
+        let wrapped_b64 = match &manifest.encrypted_file_key {
+            Some(k) => k.clone(),
+            None => {
+                skipped += 1;
+                continue;
+            }
+        };
+
+        // Unwrap with old key, re-wrap with new key
+        let wrapped_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&wrapped_b64)
+            .context("decoding wrapped file key")?;
+
+        let file_key = match tcfs_crypto::unwrap_key(&old_master, &wrapped_bytes) {
+            Ok(fk) => fk,
+            Err(e) => {
+                eprintln!("  WARN: unwrap failed for {path}: {e}");
+                errors += 1;
+                continue;
+            }
+        };
+
+        let new_wrapped = tcfs_crypto::wrap_key(&new_master, &file_key)?;
+        let new_wrapped_b64 = base64::engine::general_purpose::STANDARD.encode(&new_wrapped);
+
+        manifest.encrypted_file_key = Some(new_wrapped_b64);
+
+        // Write back
+        let new_data = serde_json::to_vec(&manifest).context("serializing rotated manifest")?;
+        op.write(&path, new_data)
+            .await
+            .with_context(|| format!("writing rotated manifest: {path}"))?;
+
+        rotated += 1;
+    }
+
+    // Step 4: Write new master key file
+    std::fs::write(&key_path, new_master.as_bytes())
+        .with_context(|| format!("writing new master key: {}", key_path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    println!("\nKey rotation complete:");
+    println!("  Manifests rotated: {rotated}");
+    println!("  Manifests skipped (plaintext): {skipped}");
+    if errors > 0 {
+        println!("  Errors: {errors}");
+    }
+    println!("  New master key: {}", key_path.display());
+
+    // Step 5: Notify daemon to reload if running
+    if let Ok(mut client) = connect_daemon(&config.daemon.socket).await {
+        let key_bytes = std::fs::read(&key_path)?;
+        let _ = client
+            .auth_unlock(tcfs_core::proto::AuthUnlockRequest {
+                master_key: key_bytes,
+            })
+            .await;
+        println!("  Daemon notified with new key.");
+    }
+
     Ok(())
 }
 

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -200,10 +200,16 @@ enum DeviceAction {
 
 #[derive(Subcommand, Debug)]
 enum AuthAction {
-    /// Unlock the encryption session (store master key in keychain)
-    Unlock,
-    /// Lock the encryption session (clear master key from keychain)
+    /// Unlock the encryption session (load master key into daemon)
+    Unlock {
+        /// Path to master key file (default: ~/.config/tcfs/master.key)
+        #[arg(long)]
+        key_file: Option<PathBuf>,
+    },
+    /// Lock the encryption session (clear master key from daemon memory)
     Lock,
+    /// Show encryption session status
+    Status,
 }
 
 #[derive(Subcommand, Debug)]
@@ -329,8 +335,9 @@ async fn main() -> Result<()> {
             DeviceAction::Status => cmd_device_status(),
         },
         Commands::Auth { action } => match action {
-            AuthAction::Unlock => cmd_auth_unlock(),
-            AuthAction::Lock => cmd_auth_lock(),
+            AuthAction::Unlock { key_file } => cmd_auth_unlock(&config, key_file.as_deref()).await,
+            AuthAction::Lock => cmd_auth_lock(&config).await,
+            AuthAction::Status => cmd_auth_status(&config).await,
         },
         Commands::RotateCredentials {
             cred_file,
@@ -1559,32 +1566,91 @@ fn cmd_device_status() -> Result<()> {
 
 // ── `tcfs auth unlock` / `tcfs auth lock` ────────────────────────────────────
 
-fn cmd_auth_unlock() -> Result<()> {
-    if !tcfs_secrets::keychain::is_available() {
+async fn cmd_auth_unlock(
+    config: &tcfs_core::config::TcfsConfig,
+    key_file: Option<&Path>,
+) -> Result<()> {
+    // Resolve master key file path
+    let key_path = key_file
+        .map(|p| p.to_path_buf())
+        .or_else(|| config.crypto.master_key_file.clone())
+        .unwrap_or_else(|| {
+            tcfs_secrets::device::default_registry_path()
+                .parent()
+                .unwrap_or(Path::new("."))
+                .join("master.key")
+        });
+
+    let key_bytes = std::fs::read(&key_path)
+        .with_context(|| format!("reading master key: {}", key_path.display()))?;
+
+    if key_bytes.len() != tcfs_crypto::KEY_SIZE {
         anyhow::bail!(
-            "Platform keychain not available. \
-             On Linux, ensure GNOME Keyring or KDE Wallet is running."
+            "master key file has wrong size: {} bytes (expected {})",
+            key_bytes.len(),
+            tcfs_crypto::KEY_SIZE
         );
     }
 
-    let passphrase =
-        rpassword::prompt_password("Master passphrase: ").context("failed to read passphrase")?;
+    // Send to daemon via gRPC
+    let mut client = connect_daemon(&config.daemon.socket).await?;
+    let resp = client
+        .auth_unlock(tcfs_core::proto::AuthUnlockRequest {
+            master_key: key_bytes,
+        })
+        .await
+        .context("auth_unlock RPC failed")?
+        .into_inner();
 
-    // Store in keychain for session use
-    tcfs_secrets::keychain::store_secret(
-        tcfs_secrets::keychain::keys::SESSION_TOKEN,
-        &secrecy::SecretString::from(passphrase),
-    )?;
+    if resp.success {
+        println!("Encryption unlocked. Master key loaded into daemon.");
+        println!("Run 'tcfs auth lock' to clear it from memory.");
+    } else {
+        anyhow::bail!("unlock failed: {}", resp.error);
+    }
 
-    println!("Session unlocked. Master key stored in platform keychain.");
-    println!("Run 'tcfs auth lock' to clear it.");
     Ok(())
 }
 
-fn cmd_auth_lock() -> Result<()> {
-    tcfs_secrets::keychain::delete_secret(tcfs_secrets::keychain::keys::SESSION_TOKEN)?;
-    tcfs_secrets::keychain::delete_secret(tcfs_secrets::keychain::keys::MASTER_KEY)?;
-    println!("Session locked. Master key cleared from keychain.");
+async fn cmd_auth_lock(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
+    // Clear from daemon
+    let mut client = connect_daemon(&config.daemon.socket).await?;
+    let resp = client
+        .auth_lock(tcfs_core::proto::Empty {})
+        .await
+        .context("auth_lock RPC failed")?
+        .into_inner();
+
+    if !resp.success {
+        anyhow::bail!("lock failed: {}", resp.error);
+    }
+
+    // Clear from platform keychain too
+    let _ = tcfs_secrets::keychain::delete_secret(tcfs_secrets::keychain::keys::SESSION_TOKEN);
+    let _ = tcfs_secrets::keychain::delete_secret(tcfs_secrets::keychain::keys::MASTER_KEY);
+
+    println!("Session locked. Master key cleared from daemon and keychain.");
+    Ok(())
+}
+
+async fn cmd_auth_status(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
+    let mut client = connect_daemon(&config.daemon.socket).await?;
+    let resp = client
+        .auth_status(tcfs_core::proto::Empty {})
+        .await
+        .context("auth_status RPC failed")?
+        .into_inner();
+
+    if resp.crypto_enabled {
+        if resp.unlocked {
+            println!("Encryption: ACTIVE (master key loaded in daemon)");
+        } else {
+            println!("Encryption: LOCKED (configured but key not loaded)");
+            println!("Run 'tcfs auth unlock' to load the master key.");
+        }
+    } else {
+        println!("Encryption: DISABLED (crypto.enabled = false in config)");
+    }
     Ok(())
 }
 

--- a/crates/tcfs-core/src/proto/tcfs.proto
+++ b/crates/tcfs-core/src/proto/tcfs.proto
@@ -15,6 +15,9 @@ service TcfsDaemon {
   rpc Watch(WatchRequest) returns (stream WatchEvent);
   rpc CredentialStatus(Empty) returns (CredentialStatusResponse);
   rpc ResolveConflict(ResolveConflictRequest) returns (ResolveConflictResponse);
+  rpc AuthUnlock(AuthUnlockRequest) returns (AuthUnlockResponse);
+  rpc AuthLock(Empty) returns (AuthLockResponse);
+  rpc AuthStatus(Empty) returns (AuthStatusResponse);
 }
 
 message Empty {}
@@ -133,4 +136,23 @@ message ResolveConflictResponse {
   bool success = 1;
   string resolved_path = 2;
   string error = 3;
+}
+
+message AuthUnlockRequest {
+  // Raw 32-byte master key (loaded from file by the CLI)
+  bytes master_key = 1;
+}
+message AuthUnlockResponse {
+  bool success = 1;
+  string error = 2;
+}
+
+message AuthLockResponse {
+  bool success = 1;
+  string error = 2;
+}
+
+message AuthStatusResponse {
+  bool unlocked = 1;
+  bool crypto_enabled = 2;
 }

--- a/crates/tcfsd/Cargo.toml
+++ b/crates/tcfsd/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 tcfs-core = { path = "../tcfs-core" }
+tcfs-crypto = { path = "../tcfs-crypto" }
 tcfs-secrets = { path = "../tcfs-secrets" }
 tcfs-storage = { path = "../tcfs-storage" }
 tcfs-sync = { path = "../tcfs-sync", features = ["nats"] }
@@ -37,6 +38,7 @@ notify = { workspace = true }
 secrecy = { workspace = true }
 tempfile = { workspace = true }
 blake3 = { workspace = true }
+age = { workspace = true }
 
 [features]
 default = ["fuse"]

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -7,6 +7,8 @@ use tcfs_core::config::TcfsConfig;
 use tcfs_sync::conflict::ConflictResolver;
 use tracing::{error, info, warn};
 
+use tcfs_crypto::MasterKey;
+
 use crate::cred_store::{new_shared as new_cred_store, SharedCredStore};
 use crate::grpc::TcfsDaemonImpl;
 
@@ -32,20 +34,40 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             tcfs_secrets::device::DeviceRegistry::default()
         });
 
-    // Auto-enroll this device on first run
+    // Auto-enroll this device on first run (with real age X25519 keypair)
     let device_id = if let Some(dev) = registry.find(&device_name) {
         info!(device = %device_name, id = %dev.device_id, "device identity loaded");
         dev.device_id.clone()
     } else {
-        let public_key = format!(
-            "age1-device-{}",
-            &blake3::hash(device_name.as_bytes()).to_hex().as_str()[..8]
-        );
+        let identity = age::x25519::Identity::generate();
+        let public_key = identity.to_public().to_string();
+        let secret_key = identity.to_string();
+
         let id = registry.enroll(&device_name, &public_key, None);
+
+        // Persist the device secret key alongside the registry
+        let secret_key_path = registry_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join(format!("device-{id}.age"));
+        if let Err(e) = std::fs::write(&secret_key_path, secret_key.expose_secret().as_bytes()) {
+            warn!("failed to write device secret key: {e}");
+        } else {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    &secret_key_path,
+                    std::fs::Permissions::from_mode(0o600),
+                );
+            }
+            info!(path = %secret_key_path.display(), "device secret key saved");
+        }
+
         if let Err(e) = registry.save(&registry_path) {
             warn!("failed to save device registry: {e}");
         }
-        info!(device = %device_name, id = %id, "device auto-enrolled");
+        info!(device = %device_name, id = %id, "device auto-enrolled with age keypair");
         id
     };
 
@@ -59,6 +81,47 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         Err(e) => {
             warn!("credential load failed: {e}  (daemon will start without creds)");
         }
+    }
+
+    // ── Load master key for E2E encryption ─────────────────────────────
+    let master_key: Option<MasterKey> = if config.crypto.enabled {
+        if let Some(ref key_path) = config.crypto.master_key_file {
+            match std::fs::read(key_path) {
+                Ok(bytes) if bytes.len() == tcfs_crypto::KEY_SIZE => {
+                    let mut key_bytes = [0u8; tcfs_crypto::KEY_SIZE];
+                    key_bytes.copy_from_slice(&bytes);
+                    info!(path = %key_path.display(), "master key loaded");
+                    Some(MasterKey::from_bytes(key_bytes))
+                }
+                Ok(bytes) => {
+                    warn!(
+                        path = %key_path.display(),
+                        size = bytes.len(),
+                        expected = tcfs_crypto::KEY_SIZE,
+                        "master key file has wrong size, encryption disabled"
+                    );
+                    None
+                }
+                Err(e) => {
+                    warn!(
+                        path = %key_path.display(),
+                        "failed to read master key file: {e} (encryption disabled)"
+                    );
+                    None
+                }
+            }
+        } else {
+            warn!("crypto.enabled = true but no master_key_file configured");
+            None
+        }
+    } else {
+        None
+    };
+
+    if config.crypto.enabled && master_key.is_some() {
+        info!("E2E encryption: active");
+    } else if config.crypto.enabled {
+        warn!("E2E encryption: configured but master key unavailable");
     }
 
     // Build storage operator and verify connectivity
@@ -163,6 +226,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         operator.clone(),
         device_id.clone(),
         device_name.clone(),
+        master_key,
     );
 
     // Connect to NATS for fleet state sync (non-blocking, best-effort)

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -28,8 +28,7 @@ pub struct TcfsDaemonImpl {
     operator: Arc<TokioMutex<Option<opendal::Operator>>>,
     device_id: String,
     device_name: String,
-    #[allow(dead_code)] // Will be used when sync engine gets encryption support
-    master_key: Option<tcfs_crypto::MasterKey>,
+    master_key: Arc<TokioMutex<Option<tcfs_crypto::MasterKey>>>,
     nats_ok: std::sync::atomic::AtomicBool,
     nats: Arc<TokioMutex<Option<tcfs_sync::NatsClient>>>,
     active_mounts: Arc<TokioMutex<std::collections::HashMap<String, tokio::process::Child>>>,
@@ -58,7 +57,7 @@ impl TcfsDaemonImpl {
             operator,
             device_id,
             device_name,
-            master_key,
+            master_key: Arc::new(TokioMutex::new(master_key)),
             nats_ok: std::sync::atomic::AtomicBool::new(false),
             nats: Arc::new(TokioMutex::new(None)),
             active_mounts: Arc::new(TokioMutex::new(std::collections::HashMap::new())),
@@ -989,6 +988,68 @@ impl TcfsDaemon for TcfsDaemonImpl {
 
         let stream = tokio_stream::wrappers::ReceiverStream::new(async_rx);
         Ok(tonic::Response::new(Box::pin(stream)))
+    }
+
+    // ── Auth (encryption key management) ────────────────────────────────
+
+    async fn auth_unlock(
+        &self,
+        request: tonic::Request<AuthUnlockRequest>,
+    ) -> Result<tonic::Response<AuthUnlockResponse>, tonic::Status> {
+        let req = request.into_inner();
+
+        if req.master_key.len() != tcfs_crypto::KEY_SIZE {
+            return Ok(tonic::Response::new(AuthUnlockResponse {
+                success: false,
+                error: format!(
+                    "master key must be {} bytes, got {}",
+                    tcfs_crypto::KEY_SIZE,
+                    req.master_key.len()
+                ),
+            }));
+        }
+
+        let mut key_bytes = [0u8; tcfs_crypto::KEY_SIZE];
+        key_bytes.copy_from_slice(&req.master_key);
+        let master_key = tcfs_crypto::MasterKey::from_bytes(key_bytes);
+
+        let mut guard = self.master_key.lock().await;
+        *guard = Some(master_key);
+
+        info!("encryption unlocked via gRPC");
+        Ok(tonic::Response::new(AuthUnlockResponse {
+            success: true,
+            error: String::new(),
+        }))
+    }
+
+    async fn auth_lock(
+        &self,
+        _request: tonic::Request<Empty>,
+    ) -> Result<tonic::Response<AuthLockResponse>, tonic::Status> {
+        let mut guard = self.master_key.lock().await;
+        let was_unlocked = guard.is_some();
+        *guard = None;
+
+        if was_unlocked {
+            info!("encryption locked via gRPC");
+        }
+
+        Ok(tonic::Response::new(AuthLockResponse {
+            success: true,
+            error: String::new(),
+        }))
+    }
+
+    async fn auth_status(
+        &self,
+        _request: tonic::Request<Empty>,
+    ) -> Result<tonic::Response<AuthStatusResponse>, tonic::Status> {
+        let guard = self.master_key.lock().await;
+        Ok(tonic::Response::new(AuthStatusResponse {
+            unlocked: guard.is_some(),
+            crypto_enabled: self.config.crypto.enabled,
+        }))
     }
 }
 

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -28,6 +28,8 @@ pub struct TcfsDaemonImpl {
     operator: Arc<TokioMutex<Option<opendal::Operator>>>,
     device_id: String,
     device_name: String,
+    #[allow(dead_code)] // Will be used when sync engine gets encryption support
+    master_key: Option<tcfs_crypto::MasterKey>,
     nats_ok: std::sync::atomic::AtomicBool,
     nats: Arc<TokioMutex<Option<tcfs_sync::NatsClient>>>,
     active_mounts: Arc<TokioMutex<std::collections::HashMap<String, tokio::process::Child>>>,
@@ -44,6 +46,7 @@ impl TcfsDaemonImpl {
         operator: Arc<TokioMutex<Option<opendal::Operator>>>,
         device_id: String,
         device_name: String,
+        master_key: Option<tcfs_crypto::MasterKey>,
     ) -> Self {
         Self {
             cred_store,
@@ -55,6 +58,7 @@ impl TcfsDaemonImpl {
             operator,
             device_id,
             device_name,
+            master_key,
             nats_ok: std::sync::atomic::AtomicBool::new(false),
             nats: Arc::new(TokioMutex::new(None)),
             active_mounts: Arc::new(TokioMutex::new(std::collections::HashMap::new())),


### PR DESCRIPTION
## Summary
- **Track 3b**: Thread encryption context through the daemon at startup
- Load raw 32-byte master key from `config.crypto.master_key_file` (written by `tcfs init`)
- Pass `Option<MasterKey>` to `TcfsDaemonImpl` for future sync engine encryption
- Replace stub `age1-device-{hash}` auto-enrollment with real age X25519 keypair generation
- Persist device secret key to `~/.config/tcfs/device-{id}.age` (mode 0600)

## Test plan
- [ ] `cargo check -p tcfsd` compiles cleanly
- [ ] `cargo test -p tcfsd` passes
- [ ] CI passes (cargo fmt, clippy, test)
- [ ] Start daemon with `crypto.enabled = true` + `master_key_file` set → logs "master key loaded" + "E2E encryption: active"
- [ ] Start daemon without master key file → logs warning, starts without encryption
- [ ] Start daemon with `crypto.enabled = false` → no encryption logs
- [ ] Auto-enrollment creates real age keypair (not stub hash)
- [ ] Device secret key file created with correct permissions