### PR TITLE
fix(fileprovider): write generated Swift to output dir

### DIFF
--- a/swift/fileprovider/build.sh
+++ b/swift/fileprovider/build.sh
@@ -51,7 +51,8 @@ echo "    Output:     $OUTPUT_DIR"
 # The config only changes when credentials rotate, which triggers
 # a home-manager rebuild anyway.
 CONFIG_PATH="${TCFS_FP_CONFIG:-$HOME/.config/tcfs/fileprovider/config.json}"
-EMBEDDED_CONFIG_SWIFT="$SCRIPT_DIR/Sources/Extension/EmbeddedConfig.generated.swift"
+mkdir -p "$OUTPUT_DIR"
+EMBEDDED_CONFIG_SWIFT="$OUTPUT_DIR/EmbeddedConfig.generated.swift"
 
 if [ -f "$CONFIG_PATH" ]; then
     CONFIG_B64=$(base64 < "$CONFIG_PATH" | tr -d '\n')
@@ -100,6 +101,7 @@ echo "==> Compiling FileProvider extension..."
     -O \
     -o TCFSFileProvider \
     "$SCRIPT_DIR/Sources/Extension/"*.swift \
+    "$EMBEDDED_CONFIG_SWIFT" \
     extension_main.o
 
 # --- Compile host app binary ---


### PR DESCRIPTION
## Summary
- `build.sh` wrote `EmbeddedConfig.generated.swift` to `$SCRIPT_DIR/Sources/Extension/` which fails when the source tree is in the Nix store (read-only `/nix/store/...`)
- Moves the generated file to `$OUTPUT_DIR` and passes it as an explicit source file to `swiftc`
- Fixes FileProvider build failure during `home-manager switch` on xoxd-bates

## Test plan
- [ ] `build.sh` succeeds when `$SCRIPT_DIR` is in Nix store (read-only)
- [ ] `build.sh` succeeds when `$SCRIPT_DIR` is a writable local dir (backwards compat)
- [ ] FileProvider loads embedded config at runtime