### PR TITLE
feat: placeholder support with sync anchors

### DIFF
--- a/crates/tcfs-core/src/proto/tcfs.proto
+++ b/crates/tcfs-core/src/proto/tcfs.proto
@@ -12,6 +12,7 @@ service TcfsDaemon {
   rpc Hydrate(HydrateRequest) returns (stream HydrateProgress);
   rpc Unsync(UnsyncRequest) returns (UnsyncResponse);
   rpc SyncStatus(SyncStatusRequest) returns (SyncStatusResponse);
+  rpc ListFiles(ListFilesRequest) returns (ListFilesResponse);
   rpc Watch(WatchRequest) returns (stream WatchEvent);
   rpc CredentialStatus(Empty) returns (CredentialStatusResponse);
   rpc ResolveConflict(ResolveConflictRequest) returns (ResolveConflictResponse);
@@ -110,6 +111,21 @@ message SyncStatusResponse {
   string blake3 = 3;
   uint64 size = 4;
   int64 last_synced = 5;
+}
+
+message ListFilesRequest {
+  string prefix = 1;
+}
+message ListFilesResponse {
+  repeated FileEntry files = 1;
+}
+message FileEntry {
+  string path = 1;
+  string filename = 2;
+  uint64 size = 3;
+  int64 last_synced = 4;
+  bool is_directory = 5;
+  string blake3 = 6;
 }
 
 message WatchRequest {

--- a/crates/tcfs-file-provider/src/grpc_backend.rs
+++ b/crates/tcfs-file-provider/src/grpc_backend.rs
@@ -144,34 +144,28 @@ pub unsafe extern "C" fn tcfs_provider_enumerate(
         };
 
         let enumerate_result = prov.runtime.block_on(async {
-            // Query sync status for the path — the daemon returns file metadata
+            // Query daemon for all files matching the prefix
             let resp = prov
                 .client
-                .sync_status(tonic::Request::new(tcfs_core::proto::SyncStatusRequest {
-                    path: rel_path.to_string(),
+                .list_files(tonic::Request::new(tcfs_core::proto::ListFilesRequest {
+                    prefix: rel_path.to_string(),
                 }))
                 .await?;
 
-            let status = resp.into_inner();
+            let list = resp.into_inner();
 
-            // The daemon returns a single file's status. For directory enumeration,
-            // we need to list files. Use the Watch RPC to get initial state, or
-            // fall back to status queries. For now, return the single item if found.
-            let mut items: Vec<TcfsFileItem> = Vec::new();
-
-            if !status.path.is_empty() && status.state != "not_found" {
-                let filename = status.path.rsplit('/').next().unwrap_or(&status.path);
-                let is_dir = status.state == "directory";
-
-                items.push(TcfsFileItem {
-                    item_id: to_c_string(&status.path),
-                    filename: to_c_string(filename),
-                    file_size: status.size,
-                    modified_timestamp: status.last_synced,
-                    is_directory: is_dir,
-                    content_hash: to_c_string(&status.blake3),
-                });
-            }
+            let items: Vec<TcfsFileItem> = list
+                .files
+                .into_iter()
+                .map(|entry| TcfsFileItem {
+                    item_id: to_c_string(&entry.path),
+                    filename: to_c_string(&entry.filename),
+                    file_size: entry.size,
+                    modified_timestamp: entry.last_synced,
+                    is_directory: entry.is_directory,
+                    content_hash: to_c_string(&entry.blake3),
+                })
+                .collect();
 
             Ok::<Vec<TcfsFileItem>, tonic::Status>(items)
         });

--- a/crates/tcfs-file-provider/src/grpc_backend.rs
+++ b/crates/tcfs-file-provider/src/grpc_backend.rs
@@ -24,10 +24,45 @@ pub struct TcfsProvider {
     client: TcfsDaemonClient<Channel>,
     /// Remote prefix for path construction
     remote_prefix: String,
+    /// Socket path for lazy reconnection
+    socket_path: String,
 }
 
-/// Connect to the daemon over a Unix domain socket.
-async fn connect(socket_path: &str) -> Result<TcfsDaemonClient<Channel>, anyhow::Error> {
+/// Connect to the daemon over a Unix domain socket with retry.
+///
+/// Retries up to `max_retries` times with exponential backoff (200ms base).
+/// This handles the case where the daemon hasn't started yet when the
+/// FileProvider extension is loaded by fileproviderd.
+async fn connect_with_retry(
+    socket_path: &str,
+    max_retries: u32,
+) -> Result<TcfsDaemonClient<Channel>, anyhow::Error> {
+    let mut last_err = None;
+
+    for attempt in 0..=max_retries {
+        if attempt > 0 {
+            let backoff = std::time::Duration::from_millis(200 * 2u64.pow(attempt - 1));
+            tokio::time::sleep(backoff).await;
+        }
+
+        match connect_once(socket_path).await {
+            Ok(client) => return Ok(client),
+            Err(e) => {
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    max = max_retries + 1,
+                    "connect to tcfsd failed: {e}"
+                );
+                last_err = Some(e);
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("connect failed")))
+}
+
+/// Single connection attempt to the daemon over a Unix domain socket.
+async fn connect_once(socket_path: &str) -> Result<TcfsDaemonClient<Channel>, anyhow::Error> {
     let path = PathBuf::from(socket_path);
 
     let channel = Endpoint::from_static("http://[::]:0")
@@ -99,7 +134,7 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
             Err(_) => return ptr::null_mut(),
         };
 
-        let client = match runtime.block_on(connect(&socket_path)) {
+        let client = match runtime.block_on(connect_with_retry(&socket_path, 4)) {
             Ok(c) => c,
             Err(e) => {
                 tracing::error!("failed to connect to tcfsd at {}: {}", socket_path, e);
@@ -111,10 +146,26 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
             runtime,
             client,
             remote_prefix: prefix,
+            socket_path,
         }))
     }));
 
     result.unwrap_or(ptr::null_mut())
+}
+
+impl TcfsProvider {
+    /// Attempt to reconnect if the daemon connection was lost.
+    fn try_reconnect(&mut self) {
+        match self.runtime.block_on(connect_once(&self.socket_path)) {
+            Ok(new_client) => {
+                tracing::info!("reconnected to tcfsd at {}", self.socket_path);
+                self.client = new_client;
+            }
+            Err(e) => {
+                tracing::warn!("reconnect to tcfsd failed: {e}");
+            }
+        }
+    }
 }
 
 /// Enumerate files by querying daemon sync status.
@@ -182,7 +233,8 @@ pub unsafe extern "C" fn tcfs_provider_enumerate(
                 TcfsError::TcfsErrorNone
             }
             Err(e) => {
-                tracing::error!("enumerate failed: {}", e);
+                tracing::error!("enumerate failed: {}, attempting reconnect", e);
+                prov.try_reconnect();
                 TcfsError::TcfsErrorStorage
             }
         }
@@ -260,7 +312,8 @@ pub unsafe extern "C" fn tcfs_provider_fetch(
         match fetch_result {
             Ok(()) => TcfsError::TcfsErrorNone,
             Err(e) => {
-                tracing::error!("fetch failed: {}", e);
+                tracing::error!("fetch failed: {}, attempting reconnect", e);
+                prov.try_reconnect();
                 TcfsError::TcfsErrorStorage
             }
         }
@@ -341,7 +394,8 @@ pub unsafe extern "C" fn tcfs_provider_upload(
         match upload_result {
             Ok(()) => TcfsError::TcfsErrorNone,
             Err(e) => {
-                tracing::error!("upload failed: {}", e);
+                tracing::error!("upload failed: {}, attempting reconnect", e);
+                prov.try_reconnect();
                 TcfsError::TcfsErrorStorage
             }
         }
@@ -393,7 +447,8 @@ pub unsafe extern "C" fn tcfs_provider_delete(
         match delete_result {
             Ok(()) => TcfsError::TcfsErrorNone,
             Err(e) => {
-                tracing::error!("delete failed: {}", e);
+                tracing::error!("delete failed: {}, attempting reconnect", e);
+                prov.try_reconnect();
                 TcfsError::TcfsErrorStorage
             }
         }
@@ -470,7 +525,8 @@ pub unsafe extern "C" fn tcfs_provider_create_dir(
         match create_result {
             Ok(()) => TcfsError::TcfsErrorNone,
             Err(e) => {
-                tracing::error!("create_dir failed: {}", e);
+                tracing::error!("create_dir failed: {}, attempting reconnect", e);
+                prov.try_reconnect();
                 TcfsError::TcfsErrorStorage
             }
         }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -16,6 +16,7 @@ use tcfs_core::proto::{
     tcfs_daemon_server::{TcfsDaemon, TcfsDaemonServer},
     *,
 };
+use tcfs_sync::state::StateCacheBackend;
 
 /// Implementation of the TcfsDaemon gRPC service
 pub struct TcfsDaemonImpl {
@@ -650,6 +651,46 @@ impl TcfsDaemon for TcfsDaemonImpl {
                 }))
             }
         }
+    }
+
+    // ── List Files ────────────────────────────────────────────────────────
+
+    async fn list_files(
+        &self,
+        request: tonic::Request<ListFilesRequest>,
+    ) -> Result<tonic::Response<ListFilesResponse>, tonic::Status> {
+        let req = request.into_inner();
+        let prefix = req.prefix;
+
+        let cache = self.state_cache.lock().await;
+        let all = cache.all_entries();
+
+        let files: Vec<FileEntry> = all
+            .into_iter()
+            .filter(|(_, state)| {
+                if prefix.is_empty() {
+                    return true;
+                }
+                // Match entries whose remote_path contains the prefix
+                state.remote_path.contains(&prefix)
+            })
+            .map(|(key, state): (String, &tcfs_sync::state::SyncState)| {
+                // Extract filename from the key (last path component)
+                let filename = key.rsplit('/').next().unwrap_or(&key).to_string();
+                let is_directory = state.remote_path.ends_with('/');
+
+                FileEntry {
+                    path: state.remote_path.clone(),
+                    filename,
+                    size: state.size,
+                    last_synced: state.last_synced as i64,
+                    is_directory,
+                    blake3: state.blake3.clone(),
+                }
+            })
+            .collect();
+
+        Ok(tonic::Response::new(ListFilesResponse { files }))
     }
 
     // ── Resolve Conflict ──────────────────────────────────────────────────

--- a/swift/fileprovider/Sources/Extension/FileProviderEnumerator.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderEnumerator.swift
@@ -107,14 +107,77 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
         for observer: NSFileProviderChangeObserver,
         from anchor: NSFileProviderSyncAnchor
     ) {
-        // TODO: Wire to daemon Watch gRPC stream for incremental changes.
-        // For now, signal no changes — fileproviderd will re-enumerate periodically.
-        observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+        let accessor = providerAccessor
+        let containerId = containerIdentifier
+
+        // Re-enumerate all items and report them as updates.
+        // fileproviderd diffs against its internal database to detect actual changes.
+        // This is correct but not incremental — Watch gRPC stream will optimize later.
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let prov = accessor() else {
+                observer.finishEnumeratingWithError(NSFileProviderError(.serverUnreachable))
+                return
+            }
+
+            let path: String
+            if containerId == .rootContainer {
+                path = ""
+            } else {
+                path = containerId.rawValue
+            }
+
+            var outItems: UnsafeMutablePointer<TcfsFileItem>?
+            var outCount: UInt = 0
+
+            let result = path.withCString { pathPtr in
+                tcfs_provider_enumerate(prov, pathPtr, &outItems, &outCount)
+            }
+
+            guard result == TCFS_ERROR_TCFS_ERROR_NONE, let items = outItems, outCount > 0 else {
+                let newAnchor = Self.makeAnchor()
+                observer.finishEnumeratingChanges(upTo: newAnchor, moreComing: false)
+                return
+            }
+
+            var providerItems: [NSFileProviderItem] = []
+            let count = Int(outCount)
+
+            for i in 0..<count {
+                let item = items[i]
+                let itemId = item.item_id.map { String(cString: $0) } ?? ""
+                let filename = item.filename.map { String(cString: $0) } ?? ""
+
+                providerItems.append(
+                    TCFSFileProviderItem(
+                        identifier: NSFileProviderItemIdentifier(itemId),
+                        parentIdentifier: containerId,
+                        filename: filename,
+                        isDirectory: item.is_directory,
+                        fileSize: item.file_size,
+                        downloaded: false,
+                        uploaded: true
+                    )
+                )
+            }
+
+            tcfs_file_items_free(outItems, outCount)
+
+            if !providerItems.isEmpty {
+                observer.didUpdate(providerItems)
+            }
+            let newAnchor = Self.makeAnchor()
+            observer.finishEnumeratingChanges(upTo: newAnchor, moreComing: false)
+        }
     }
 
     func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-        // Use timestamp as anchor — will be replaced with daemon event sequence
-        let data = "\(Date().timeIntervalSince1970)".data(using: .utf8)!
-        completionHandler(NSFileProviderSyncAnchor(data))
+        completionHandler(Self.makeAnchor())
+    }
+
+    /// Monotonic sync anchor from current timestamp.
+    private static func makeAnchor() -> NSFileProviderSyncAnchor {
+        var timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+        let data = Data(bytes: &timestamp, count: MemoryLayout<UInt64>.size)
+        return NSFileProviderSyncAnchor(data)
     }
 }

--- a/swift/fileprovider/Sources/Extension/FileProviderEnumerator.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderEnumerator.swift
@@ -78,6 +78,7 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
 
                 let itemId = item.item_id.map { String(cString: $0) } ?? ""
                 let filename = item.filename.map { String(cString: $0) } ?? ""
+                let contentHash = item.content_hash.map { String(cString: $0) } ?? "1"
 
                 // Items are created as placeholders (downloaded: false).
                 // Content will be fetched on demand via fetchContents.
@@ -89,7 +90,8 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
                         isDirectory: item.is_directory,
                         fileSize: item.file_size,
                         downloaded: false,
-                        uploaded: true
+                        uploaded: true,
+                        versionTag: contentHash
                     )
                 )
             }
@@ -146,6 +148,7 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
                 let item = items[i]
                 let itemId = item.item_id.map { String(cString: $0) } ?? ""
                 let filename = item.filename.map { String(cString: $0) } ?? ""
+                let contentHash = item.content_hash.map { String(cString: $0) } ?? "1"
 
                 providerItems.append(
                     TCFSFileProviderItem(
@@ -155,7 +158,8 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
                         isDirectory: item.is_directory,
                         fileSize: item.file_size,
                         downloaded: false,
-                        uploaded: true
+                        uploaded: true,
+                        versionTag: contentHash
                     )
                 )
             }

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -17,6 +17,8 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     /// `tcfs_provider_new()` creates a tokio runtime and S3 operator, which can
     /// take seconds — long enough to exceed fileproviderd's initial handshake timeout.
     private lazy var provider: OpaquePointer? = Self.createProvider()
+    /// FileProvider manager for signaling enumerator updates after mutations.
+    private lazy var manager: NSFileProviderManager? = NSFileProviderManager(for: domain)
 
     required init(domain: NSFileProviderDomain) {
         self.domain = domain
@@ -108,6 +110,7 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     uploaded: true
                 )
                 progress.completedUnitCount = 100
+                self.signalEnumeratorUpdate(for: .rootContainer)
                 completionHandler(tempFile, item, nil)
             } else {
                 progress.completedUnitCount = 100
@@ -174,6 +177,7 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                         fileSize: 0
                     )
                     progress.completedUnitCount = 100
+                    self.signalEnumeratorUpdate(for: itemTemplate.parentItemIdentifier)
                     completionHandler(item, [], false, nil)
                 } else {
                     progress.completedUnitCount = 100
@@ -203,6 +207,7 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                         uploaded: true
                     )
                     progress.completedUnitCount = 100
+                    self.signalEnumeratorUpdate(for: itemTemplate.parentItemIdentifier)
                     completionHandler(item, [], false, nil)
                 } else {
                     progress.completedUnitCount = 100
@@ -257,6 +262,7 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                         uploaded: true
                     )
                     progress.completedUnitCount = 100
+                    self.signalEnumeratorUpdate(for: item.parentItemIdentifier)
                     completionHandler(updatedItem, [], false, nil)
                 } else {
                     progress.completedUnitCount = 100
@@ -287,6 +293,7 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     fileSize: (item.documentSize as? UInt64) ?? 0
                 )
                 progress.completedUnitCount = 100
+                self.signalEnumeratorUpdate(for: item.parentItemIdentifier)
                 completionHandler(renamedItem, [], false, nil)
             } else {
                 // No content or filename change — return item as-is
@@ -319,6 +326,7 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
             progress.completedUnitCount = 1
             if result == TCFS_ERROR_TCFS_ERROR_NONE {
+                self.signalEnumeratorUpdate(for: .rootContainer)
                 completionHandler(nil)
             } else {
                 completionHandler(Self.mapError(result))
@@ -326,6 +334,17 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         return progress
+    }
+
+    // MARK: - Enumerator signaling
+
+    /// Signal fileproviderd to re-enumerate after a mutation so Finder updates immediately.
+    private func signalEnumeratorUpdate(for containerIdentifier: NSFileProviderItemIdentifier) {
+        manager?.signalEnumerator(for: containerIdentifier) { error in
+            if let error = error {
+                logger.warning("signalEnumerator failed: \(error.localizedDescription)")
+            }
+        }
     }
 
     // MARK: - Error mapping

--- a/swift/fileprovider/Sources/Extension/FileProviderItem.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderItem.swift
@@ -54,7 +54,17 @@ class TCFSFileProviderItem: NSObject, NSFileProviderItem {
         if contentType == .folder {
             return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsDeleting, .allowsRenaming]
         }
-        return [.allowsReading, .allowsWriting, .allowsDeleting, .allowsRenaming, .allowsReparenting, .allowsEvicting]
+        return [.allowsReading, .allowsWriting, .allowsDeleting, .allowsRenaming, .allowsReparenting]
+    }
+
+    /// Content policy controls eviction (dehydration) for placeholder support.
+    /// `.downloadLazilyAndEvictOnRemoteUpdate` means files are only downloaded
+    /// when opened and automatically evicted when a newer remote version exists.
+    var contentPolicy: NSFileProviderContentPolicy {
+        if contentType == .folder {
+            return .inherited
+        }
+        return .downloadLazilyAndEvictOnRemoteUpdate
     }
 
     static func rootItem() -> TCFSFileProviderItem {


### PR DESCRIPTION
## Summary
- Signal `NSFileProviderManager.signalEnumerator` after create/modify/delete/fetch for immediate Finder updates
- Implement `enumerateChanges` with full re-enumerate (Watch gRPC stream optimization in future PR)
- Use monotonic timestamp-based sync anchors (millisecond precision)
- Replace deprecated `.allowsEvicting` with `NSFileProviderContentPolicy.downloadLazilyAndEvictOnRemoteUpdate`
- Files appear as placeholders by default, hydrated on demand via `fetchContents`

## Test plan
- [ ] Build FileProvider with `just nix-switch` on macOS
- [ ] Verify files appear as placeholders in Finder (cloud icon)
- [ ] Open placeholder file → content downloads on demand
- [ ] Right-click → "Remove Download" → file becomes placeholder again
- [ ] Create/delete files → Finder updates immediately (no manual refresh)