### PR TITLE
feat(ios): scaffold iOS FileProvider project (Phase 7b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,22 @@ jobs:
           grep -q "tcfs_provider_delete" "$HEADER"
           echo "header: $HEADER"
 
+  ios-typecheck:
+    name: iOS FileProvider typecheck
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios-sim
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build iOS staticlib + type-check Swift
+        run: bash swift/ios/Scripts/build-ios.sh --simulator
+
   deny:
     name: cargo-deny
     runs-on: ubuntu-latest

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -475,18 +475,13 @@ impl TcfsProviderHandle {
 
     /// Get sync status (connected check + file count from index).
     pub fn get_sync_status(&self) -> Result<SyncStatus, ProviderError> {
-        let index_prefix = format!(
-            "{}/index/",
-            self.remote_prefix.trim_end_matches('/')
-        );
+        let index_prefix = format!("{}/index/", self.remote_prefix.trim_end_matches('/'));
 
         self.runtime.block_on(async {
             match self.operator.list(&index_prefix).await {
                 Ok(entries) => {
-                    let file_count = entries
-                        .iter()
-                        .filter(|e| !e.path().ends_with('/'))
-                        .count() as u64;
+                    let file_count =
+                        entries.iter().filter(|e| !e.path().ends_with('/')).count() as u64;
                     Ok(SyncStatus {
                         connected: true,
                         files_synced: file_count,

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -178,11 +178,17 @@ impl TcfsProviderHandle {
             let is_dir = name.ends_with('/');
             let display_name = name.trim_end_matches('/');
 
+            let modified_ts = entry
+                .metadata()
+                .last_modified()
+                .map(|t| t.into_inner().as_second())
+                .unwrap_or(0);
+
             items.push(FileItem {
                 item_id: entry_path.to_string(),
                 filename: display_name.to_string(),
                 file_size: entry.metadata().content_length(),
-                modified_timestamp: 0,
+                modified_timestamp: modified_ts,
                 is_directory: is_dir,
                 content_hash: String::new(),
             });
@@ -467,18 +473,34 @@ impl TcfsProviderHandle {
             .map_err(ProviderError::from)
     }
 
-    /// Get sync status (connected check via health probe).
+    /// Get sync status (connected check + file count from index).
     pub fn get_sync_status(&self) -> Result<SyncStatus, ProviderError> {
-        let connected = self.runtime.block_on(async {
-            let prefix = format!("{}/", self.remote_prefix.trim_end_matches('/'));
-            self.operator.list(&prefix).await.is_ok()
-        });
+        let index_prefix = format!(
+            "{}/index/",
+            self.remote_prefix.trim_end_matches('/')
+        );
 
-        Ok(SyncStatus {
-            connected,
-            files_synced: 0,
-            files_pending: 0,
-            last_error: None,
+        self.runtime.block_on(async {
+            match self.operator.list(&index_prefix).await {
+                Ok(entries) => {
+                    let file_count = entries
+                        .iter()
+                        .filter(|e| !e.path().ends_with('/'))
+                        .count() as u64;
+                    Ok(SyncStatus {
+                        connected: true,
+                        files_synced: file_count,
+                        files_pending: 0,
+                        last_error: None,
+                    })
+                }
+                Err(e) => Ok(SyncStatus {
+                    connected: false,
+                    files_synced: 0,
+                    files_pending: 0,
+                    last_error: Some(e.to_string()),
+                }),
+            }
         })
     }
 }

--- a/docs/rfc/0003-ios-file-provider.md
+++ b/docs/rfc/0003-ios-file-provider.md
@@ -1,9 +1,9 @@
 # RFC 0003: iOS File Provider Extension
 
-**Status**: Phase 7a Complete (UniFFI bindings)
+**Status**: Phase 7b In Progress (iOS project scaffold)
 **Author**: xoxd
 **Date**: 2026-02-22 (updated 2026-03-07)
-**Tracking**: Phase 7b next (iOS Xcode project)
+**Tracking**: Phase 7b — Swift sources + build script ready, needs Xcode project
 
 ---
 
@@ -188,12 +188,18 @@ enum ProviderError {
 - Uses `direct` backend (no gRPC — iOS sandbox blocks UDS)
 - Compiles for host target; iOS cross-compilation next phase
 
-### Phase 7b: Basic Hydration
+### Phase 7b: iOS Project Scaffold (IN PROGRESS)
 
-- Implement UniFFI bindings for `list_items` and `hydrate_file`
-- Swift FileProviderExtension with read-only enumeration
-- Xcode project with Rust build integration (cargo-xcode or manual)
-- Test on iOS Simulator
+- [x] `FileProviderExtension.swift` — full CRUD via UniFFI (item, fetchContents, createItem, modifyItem, deleteItem)
+- [x] `FileProviderEnumerator.swift` — directory listing via `provider.listItems(path:)`
+- [x] `FileProviderItem.swift` — NSFileProviderItem with placeholder support
+- [x] `HostApp.swift` — SwiftUI app with credential config + domain registration
+- [x] iOS plists (Extension-Info.plist, HostApp-Info.plist) targeting iOS 17+
+- [x] Entitlements (shared Keychain access group `group.io.tinyland.tcfs`)
+- [x] `build-ios.sh` — cargo cross-compile + UniFFI bindgen + xcodebuild
+- [x] Verified: Rust staticlib builds for `aarch64-apple-ios-sim`
+- [ ] Xcode project (.xcodeproj) — requires Xcode GUI to create
+- [ ] Test on iOS Simulator
 
 ### Phase 7c: E2E Encryption
 

--- a/docs/rfc/0003-ios-file-provider.md
+++ b/docs/rfc/0003-ios-file-provider.md
@@ -198,14 +198,17 @@ enum ProviderError {
 - [x] Entitlements (shared Keychain access group `group.io.tinyland.tcfs`)
 - [x] `build-ios.sh` — cargo cross-compile + UniFFI bindgen + xcodebuild
 - [x] Verified: Rust staticlib builds for `aarch64-apple-ios-sim`
-- [ ] Xcode project (.xcodeproj) — requires Xcode GUI to create
-- [ ] Test on iOS Simulator
+- [x] `project.yml` — xcodegen spec for programmatic project generation
+- [x] CI job: `ios-typecheck` validates Swift against iOS SDK on every push
+- [ ] Xcode project (.xcodeproj) — generate via `xcodegen` or create in Xcode
+- [ ] Test on iOS Simulator (needs runtime download)
 
-### Phase 7c: E2E Encryption
+### Phase 7c: E2E Encryption (COMPLETE — shipped with 7a/7b)
 
-- Wire tcfs-crypto through UniFFI
-- Keychain credential storage (replacing env vars)
-- Encrypted hydration flow
+- [x] tcfs-crypto wired through UniFFI (XChaCha20-Poly1305 + Argon2id KDF)
+- [x] Keychain credential storage (encryption_passphrase + encryption_salt)
+- [x] Encrypted hydration flow (file key unwrap → chunk decrypt → decompress)
+- [x] Encrypted upload flow (chunk compress → encrypt → file key wrap)
 
 ### Phase 7d: Sync Engine
 

--- a/swift/ios/Extension/FileProviderEnumerator.swift
+++ b/swift/ios/Extension/FileProviderEnumerator.swift
@@ -55,6 +55,7 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
                         filename: item.filename,
                         isDirectory: item.isDirectory,
                         fileSize: item.fileSize,
+                        modifiedTimestamp: item.modifiedTimestamp,
                         downloaded: false,
                         uploaded: true,
                         versionTag: item.contentHash
@@ -94,6 +95,7 @@ class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
                         filename: item.filename,
                         isDirectory: item.isDirectory,
                         fileSize: item.fileSize,
+                        modifiedTimestamp: item.modifiedTimestamp,
                         downloaded: false,
                         uploaded: true,
                         versionTag: item.contentHash

--- a/swift/ios/Extension/FileProviderEnumerator.swift
+++ b/swift/ios/Extension/FileProviderEnumerator.swift
@@ -1,0 +1,124 @@
+import FileProvider
+import Foundation
+import os.log
+
+private let enumLogger = Logger(subsystem: "io.tinyland.tcfs.fileprovider.ios", category: "enumerator")
+
+/// Enumerates TCFS directory contents via UniFFI bindings.
+///
+/// Uses `TcfsProviderHandle.listItems(path:)` instead of the macOS C FFI.
+/// Items are returned as placeholders (`isDownloaded = false`) so that
+/// iOS shows them in Files without downloading content.
+class TCFSFileProviderEnumerator: NSObject, NSFileProviderEnumerator {
+
+    private let providerAccessor: () -> TcfsProviderHandle?
+    private let containerIdentifier: NSFileProviderItemIdentifier
+
+    init(
+        providerAccessor: @escaping () -> TcfsProviderHandle?,
+        containerIdentifier: NSFileProviderItemIdentifier
+    ) {
+        self.providerAccessor = providerAccessor
+        self.containerIdentifier = containerIdentifier
+        super.init()
+    }
+
+    func invalidate() {
+        // No cleanup needed — provider lifetime managed by extension
+    }
+
+    func enumerateItems(
+        for observer: NSFileProviderEnumerationObserver,
+        startingAt page: NSFileProviderPage
+    ) {
+        let containerId = containerIdentifier
+        let accessor = providerAccessor
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            enumLogger.info("enumerateItems: container=\(containerId.rawValue)")
+            guard let prov = accessor() else {
+                enumLogger.error("enumerateItems: provider is nil")
+                observer.finishEnumeratingWithError(NSFileProviderError(.serverUnreachable))
+                return
+            }
+
+            let path = containerId == .rootContainer ? "" : containerId.rawValue
+
+            do {
+                let items = try prov.listItems(path: path)
+                enumLogger.info("enumerateItems: got \(items.count) items")
+
+                let providerItems: [NSFileProviderItem] = items.map { item in
+                    TCFSFileProviderItem(
+                        identifier: NSFileProviderItemIdentifier(item.itemId),
+                        parentIdentifier: containerId,
+                        filename: item.filename,
+                        isDirectory: item.isDirectory,
+                        fileSize: item.fileSize,
+                        downloaded: false,
+                        uploaded: true,
+                        versionTag: item.contentHash
+                    )
+                }
+
+                observer.didEnumerate(providerItems)
+                observer.finishEnumerating(upTo: nil)
+            } catch {
+                enumLogger.error("enumerateItems failed: \(error.localizedDescription)")
+                observer.finishEnumerating(upTo: nil)
+            }
+        }
+    }
+
+    func enumerateChanges(
+        for observer: NSFileProviderChangeObserver,
+        from anchor: NSFileProviderSyncAnchor
+    ) {
+        let accessor = providerAccessor
+        let containerId = containerIdentifier
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let prov = accessor() else {
+                observer.finishEnumeratingWithError(NSFileProviderError(.serverUnreachable))
+                return
+            }
+
+            let path = containerId == .rootContainer ? "" : containerId.rawValue
+
+            do {
+                let items = try prov.listItems(path: path)
+                let providerItems: [NSFileProviderItem] = items.map { item in
+                    TCFSFileProviderItem(
+                        identifier: NSFileProviderItemIdentifier(item.itemId),
+                        parentIdentifier: containerId,
+                        filename: item.filename,
+                        isDirectory: item.isDirectory,
+                        fileSize: item.fileSize,
+                        downloaded: false,
+                        uploaded: true,
+                        versionTag: item.contentHash
+                    )
+                }
+
+                if !providerItems.isEmpty {
+                    observer.didUpdate(providerItems)
+                }
+            } catch {
+                enumLogger.error("enumerateChanges failed: \(error.localizedDescription)")
+            }
+
+            let newAnchor = Self.makeAnchor()
+            observer.finishEnumeratingChanges(upTo: newAnchor, moreComing: false)
+        }
+    }
+
+    func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
+        completionHandler(Self.makeAnchor())
+    }
+
+    private static func makeAnchor() -> NSFileProviderSyncAnchor {
+        var timestamp = UInt64(Date().timeIntervalSince1970 * 1000)
+        let data = Data(bytes: &timestamp, count: MemoryLayout<UInt64>.size)
+        return NSFileProviderSyncAnchor(data)
+    }
+}

--- a/swift/ios/Extension/FileProviderExtension.swift
+++ b/swift/ios/Extension/FileProviderExtension.swift
@@ -1,0 +1,361 @@
+import FileProvider
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "io.tinyland.tcfs.fileprovider.ios", category: "extension")
+
+/// iOS TCFS FileProvider extension — bridges to Rust via UniFFI.
+///
+/// Uses the auto-generated `TcfsProviderHandle` from UniFFI instead of
+/// the macOS cbindgen C FFI. Config comes from iOS Keychain only.
+class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
+
+    let domain: NSFileProviderDomain
+    private lazy var provider: TcfsProviderHandle? = Self.createProvider()
+    private lazy var manager: NSFileProviderManager? = NSFileProviderManager(for: domain)
+
+    required init(domain: NSFileProviderDomain) {
+        self.domain = domain
+        super.init()
+    }
+
+    func invalidate() {
+        // TcfsProviderHandle is ARC-managed by UniFFI — just nil out
+        provider = nil
+    }
+
+    // MARK: - Item lookup
+
+    func item(
+        for identifier: NSFileProviderItemIdentifier,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 1)
+
+        if identifier == .rootContainer {
+            completionHandler(TCFSFileProviderItem.rootItem(), nil)
+            progress.completedUnitCount = 1
+            return progress
+        }
+
+        if identifier == .trashContainer {
+            completionHandler(nil, NSFileProviderError(.noSuchItem))
+            progress.completedUnitCount = 1
+            return progress
+        }
+
+        completionHandler(
+            TCFSFileProviderItem(
+                identifier: identifier,
+                parentIdentifier: .rootContainer,
+                filename: identifier.rawValue.components(separatedBy: "/").last ?? identifier.rawValue,
+                isDirectory: false,
+                fileSize: 0
+            ),
+            nil
+        )
+        progress.completedUnitCount = 1
+        return progress
+    }
+
+    // MARK: - Content fetching (hydration)
+
+    func fetchContents(
+        for itemIdentifier: NSFileProviderItemIdentifier,
+        version requestedVersion: NSFileProviderItemVersion?,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 100)
+
+        guard let prov = provider else {
+            completionHandler(nil, nil, NSFileProviderError(.serverUnreachable))
+            return progress
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let tempDir = FileManager.default.temporaryDirectory
+            let tempFile = tempDir.appendingPathComponent(UUID().uuidString)
+            let itemId = itemIdentifier.rawValue
+
+            do {
+                try prov.hydrateFile(itemId: itemId, destinationPath: tempFile.path)
+                let attrs = try? FileManager.default.attributesOfItem(atPath: tempFile.path)
+                let fileSize = (attrs?[.size] as? UInt64) ?? 0
+
+                let item = TCFSFileProviderItem(
+                    identifier: itemIdentifier,
+                    parentIdentifier: .rootContainer,
+                    filename: itemId.components(separatedBy: "/").last ?? itemId,
+                    isDirectory: false,
+                    fileSize: fileSize,
+                    downloaded: true,
+                    uploaded: true
+                )
+                progress.completedUnitCount = 100
+                self.signalEnumeratorUpdate(for: .rootContainer)
+                completionHandler(tempFile, item, nil)
+            } catch {
+                logger.error("fetchContents failed: \(error.localizedDescription)")
+                progress.completedUnitCount = 100
+                completionHandler(nil, nil, NSFileProviderError(.serverUnreachable))
+            }
+        }
+
+        return progress
+    }
+
+    // MARK: - Enumeration
+
+    func enumerator(
+        for containerItemIdentifier: NSFileProviderItemIdentifier,
+        request: NSFileProviderRequest
+    ) throws -> NSFileProviderEnumerator {
+        return TCFSFileProviderEnumerator(
+            providerAccessor: { [weak self] in self?.provider },
+            containerIdentifier: containerItemIdentifier
+        )
+    }
+
+    // MARK: - Write operations
+
+    func createItem(
+        basedOn itemTemplate: NSFileProviderItem,
+        fields: NSFileProviderItemFields,
+        contents url: URL?,
+        options: NSFileProviderCreateItemOptions,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 100)
+
+        guard let prov = provider else {
+            completionHandler(nil, [], false, NSFileProviderError(.serverUnreachable))
+            return progress
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let parentPath = itemTemplate.parentItemIdentifier == .rootContainer
+                ? "" : itemTemplate.parentItemIdentifier.rawValue
+            let filename = itemTemplate.filename
+
+            if itemTemplate.contentType == .folder {
+                do {
+                    try prov.createDirectory(parentPath: parentPath, dirName: filename)
+                    let dirPath = parentPath.isEmpty ? filename : "\(parentPath)/\(filename)"
+                    let item = TCFSFileProviderItem(
+                        identifier: NSFileProviderItemIdentifier(dirPath),
+                        parentIdentifier: itemTemplate.parentItemIdentifier,
+                        filename: filename,
+                        isDirectory: true,
+                        fileSize: 0
+                    )
+                    progress.completedUnitCount = 100
+                    self.signalEnumeratorUpdate(for: itemTemplate.parentItemIdentifier)
+                    completionHandler(item, [], false, nil)
+                } catch {
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(error))
+                }
+            } else if let contentsURL = url {
+                let accessed = contentsURL.startAccessingSecurityScopedResource()
+                defer { if accessed { contentsURL.stopAccessingSecurityScopedResource() } }
+
+                let remotePath = parentPath.isEmpty ? filename : "\(parentPath)/\(filename)"
+                do {
+                    try prov.uploadFile(localPath: contentsURL.path, remotePath: remotePath)
+                    let fileSize = (try? FileManager.default.attributesOfItem(atPath: contentsURL.path)[.size] as? UInt64) ?? 0
+                    let item = TCFSFileProviderItem(
+                        identifier: NSFileProviderItemIdentifier(remotePath),
+                        parentIdentifier: itemTemplate.parentItemIdentifier,
+                        filename: filename,
+                        isDirectory: false,
+                        fileSize: fileSize,
+                        downloaded: true,
+                        uploaded: true
+                    )
+                    progress.completedUnitCount = 100
+                    self.signalEnumeratorUpdate(for: itemTemplate.parentItemIdentifier)
+                    completionHandler(item, [], false, nil)
+                } catch {
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(error))
+                }
+            } else {
+                completionHandler(nil, [], false, NSFileProviderError(.noSuchItem))
+            }
+        }
+
+        return progress
+    }
+
+    func modifyItem(
+        _ item: NSFileProviderItem,
+        baseVersion version: NSFileProviderItemVersion,
+        changedFields: NSFileProviderItemFields,
+        contents newContents: URL?,
+        options: NSFileProviderModifyItemOptions,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 100)
+
+        guard let prov = provider else {
+            completionHandler(nil, [], false, NSFileProviderError(.serverUnreachable))
+            return progress
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            if changedFields.contains(.contents), let contentsURL = newContents {
+                let accessed = contentsURL.startAccessingSecurityScopedResource()
+                defer { if accessed { contentsURL.stopAccessingSecurityScopedResource() } }
+
+                let remotePath = item.itemIdentifier.rawValue
+                do {
+                    try prov.uploadFile(localPath: contentsURL.path, remotePath: remotePath)
+                    let fileSize = (try? FileManager.default.attributesOfItem(atPath: contentsURL.path)[.size] as? UInt64) ?? 0
+                    let updatedItem = TCFSFileProviderItem(
+                        identifier: item.itemIdentifier,
+                        parentIdentifier: item.parentItemIdentifier,
+                        filename: item.filename,
+                        isDirectory: false,
+                        fileSize: fileSize,
+                        downloaded: true,
+                        uploaded: true
+                    )
+                    progress.completedUnitCount = 100
+                    self.signalEnumeratorUpdate(for: item.parentItemIdentifier)
+                    completionHandler(updatedItem, [], false, nil)
+                } catch {
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(error))
+                }
+            } else {
+                progress.completedUnitCount = 100
+                completionHandler(item, [], false, nil)
+            }
+        }
+
+        return progress
+    }
+
+    func deleteItem(
+        identifier: NSFileProviderItemIdentifier,
+        baseVersion version: NSFileProviderItemVersion,
+        options: NSFileProviderDeleteItemOptions,
+        request: NSFileProviderRequest,
+        completionHandler: @escaping (Error?) -> Void
+    ) -> Progress {
+        let progress = Progress(totalUnitCount: 1)
+
+        guard let prov = provider else {
+            completionHandler(NSFileProviderError(.serverUnreachable))
+            return progress
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try prov.deleteItem(itemId: identifier.rawValue)
+                progress.completedUnitCount = 1
+                self.signalEnumeratorUpdate(for: .rootContainer)
+                completionHandler(nil)
+            } catch {
+                progress.completedUnitCount = 1
+                completionHandler(Self.mapError(error))
+            }
+        }
+
+        return progress
+    }
+
+    // MARK: - Helpers
+
+    private func signalEnumeratorUpdate(for containerIdentifier: NSFileProviderItemIdentifier) {
+        manager?.signalEnumerator(for: containerIdentifier) { error in
+            if let error = error {
+                logger.warning("signalEnumerator failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private static func mapError(_ error: Error) -> NSError {
+        if let providerError = error as? ProviderError {
+            switch providerError {
+            case .NotFound:
+                return NSFileProviderError(.noSuchItem) as NSError
+            case .Conflict:
+                // newerExtensionVersionFound is unavailable on iOS; use serverUnreachable
+                return NSFileProviderError(.serverUnreachable) as NSError
+            default:
+                return NSFileProviderError(.serverUnreachable) as NSError
+            }
+        }
+        return NSFileProviderError(.serverUnreachable) as NSError
+    }
+
+    // MARK: - Provider setup
+
+    private static func createProvider() -> TcfsProviderHandle? {
+        logger.error("createProvider: loading config from Keychain...")
+        guard let config = loadConfigFromKeychain() else {
+            logger.error("createProvider: Keychain config not found")
+            return nil
+        }
+
+        do {
+            let provider = try TcfsProviderHandle(config: config)
+            logger.error("createProvider: provider created successfully")
+            return provider
+        } catch {
+            logger.error("createProvider: failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Load TCFS config from iOS Keychain.
+    ///
+    /// The host app writes credentials to the shared Keychain access group
+    /// during initial setup. The extension reads them here.
+    private static func loadConfigFromKeychain() -> ProviderConfig? {
+        let fields = ["s3_endpoint", "s3_bucket", "access_key", "s3_secret",
+                      "remote_prefix", "device_id", "encryption_passphrase", "encryption_salt"]
+
+        var values: [String: String] = [:]
+        for field in fields {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: "io.tinyland.tcfs.config",
+                kSecAttrAccount as String: field,
+                kSecAttrAccessGroup as String: "group.io.tinyland.tcfs",
+                kSecReturnData as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne,
+            ]
+
+            var item: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+            if status == errSecSuccess,
+               let data = item as? Data,
+               let value = String(data: data, encoding: .utf8) {
+                values[field] = value
+            } else if field == "encryption_passphrase" || field == "encryption_salt" {
+                values[field] = ""  // Optional fields default to empty
+            } else {
+                logger.error("loadConfigFromKeychain: missing required field '\(field)' (status: \(status))")
+                return nil
+            }
+        }
+
+        return ProviderConfig(
+            s3Endpoint: values["s3_endpoint"]!,
+            s3Bucket: values["s3_bucket"]!,
+            accessKey: values["access_key"]!,
+            s3Secret: values["s3_secret"]!,
+            remotePrefix: values["remote_prefix"]!,
+            deviceId: values["device_id"]!,
+            encryptionPassphrase: values["encryption_passphrase"]!,
+            encryptionSalt: values["encryption_salt"]!
+        )
+    }
+}

--- a/swift/ios/Extension/FileProviderItem.swift
+++ b/swift/ios/Extension/FileProviderItem.swift
@@ -1,0 +1,71 @@
+import FileProvider
+import UniformTypeIdentifiers
+
+/// NSFileProviderItem implementation for TCFS files.
+///
+/// Shared protocol between macOS and iOS — maps UniFFI `FileItem` records
+/// to the NSFileProviderItem protocol that the Files app expects.
+///
+/// Supports placeholder (dataless) files: items with `isDownloaded = false`
+/// appear in Files but content is only fetched on demand via `fetchContents`.
+class TCFSFileProviderItem: NSObject, NSFileProviderItem {
+
+    let itemIdentifier: NSFileProviderItemIdentifier
+    let parentItemIdentifier: NSFileProviderItemIdentifier
+    let filename: String
+    let contentType: UTType
+    let documentSize: NSNumber?
+    let itemVersion: NSFileProviderItemVersion
+
+    var isDownloaded: Bool
+    var isUploaded: Bool
+    var isMostRecentVersionDownloaded: Bool
+
+    init(
+        identifier: NSFileProviderItemIdentifier,
+        parentIdentifier: NSFileProviderItemIdentifier,
+        filename: String,
+        isDirectory: Bool,
+        fileSize: UInt64,
+        downloaded: Bool = true,
+        uploaded: Bool = true,
+        versionTag: String = "1"
+    ) {
+        self.itemIdentifier = identifier
+        self.parentItemIdentifier = parentIdentifier
+        self.filename = filename
+        self.contentType = isDirectory ? .folder : (UTType(filenameExtension: (filename as NSString).pathExtension) ?? .data)
+        self.documentSize = isDirectory ? nil : NSNumber(value: fileSize)
+        self.itemVersion = NSFileProviderItemVersion(
+            contentVersion: versionTag.data(using: .utf8)!,
+            metadataVersion: versionTag.data(using: .utf8)!
+        )
+        self.isDownloaded = isDirectory ? true : downloaded
+        self.isUploaded = uploaded
+        self.isMostRecentVersionDownloaded = isDirectory ? true : downloaded
+    }
+
+    var capabilities: NSFileProviderItemCapabilities {
+        if contentType == .folder {
+            return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsDeleting, .allowsRenaming]
+        }
+        return [.allowsReading, .allowsWriting, .allowsDeleting, .allowsRenaming, .allowsReparenting]
+    }
+
+    var contentPolicy: NSFileProviderContentPolicy {
+        if contentType == .folder {
+            return .inherited
+        }
+        return .downloadLazilyAndEvictOnRemoteUpdate
+    }
+
+    static func rootItem() -> TCFSFileProviderItem {
+        return TCFSFileProviderItem(
+            identifier: .rootContainer,
+            parentIdentifier: .rootContainer,
+            filename: "TCFS",
+            isDirectory: true,
+            fileSize: 0
+        )
+    }
+}

--- a/swift/ios/Extension/FileProviderItem.swift
+++ b/swift/ios/Extension/FileProviderItem.swift
@@ -15,6 +15,7 @@ class TCFSFileProviderItem: NSObject, NSFileProviderItem {
     let filename: String
     let contentType: UTType
     let documentSize: NSNumber?
+    let contentModificationDate: Date?
     let itemVersion: NSFileProviderItemVersion
 
     var isDownloaded: Bool
@@ -27,6 +28,7 @@ class TCFSFileProviderItem: NSObject, NSFileProviderItem {
         filename: String,
         isDirectory: Bool,
         fileSize: UInt64,
+        modifiedTimestamp: Int64 = 0,
         downloaded: Bool = true,
         uploaded: Bool = true,
         versionTag: String = "1"
@@ -36,6 +38,9 @@ class TCFSFileProviderItem: NSObject, NSFileProviderItem {
         self.filename = filename
         self.contentType = isDirectory ? .folder : (UTType(filenameExtension: (filename as NSString).pathExtension) ?? .data)
         self.documentSize = isDirectory ? nil : NSNumber(value: fileSize)
+        self.contentModificationDate = modifiedTimestamp > 0
+            ? Date(timeIntervalSince1970: TimeInterval(modifiedTimestamp))
+            : nil
         self.itemVersion = NSFileProviderItemVersion(
             contentVersion: versionTag.data(using: .utf8)!,
             metadataVersion: versionTag.data(using: .utf8)!

--- a/swift/ios/HostApp/HostApp.swift
+++ b/swift/ios/HostApp/HostApp.swift
@@ -1,0 +1,210 @@
+import SwiftUI
+import FileProvider
+import Security
+import os.log
+
+private let hostLogger = Logger(subsystem: "io.tinyland.tcfs.ios", category: "host")
+
+@main
+struct TCFSApp: App {
+    @StateObject private var viewModel = TCFSViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(viewModel: viewModel)
+        }
+    }
+}
+
+class TCFSViewModel: ObservableObject {
+    @Published var status: String = "Not configured"
+    @Published var isConfigured: Bool = false
+
+    private let domain = NSFileProviderDomain(
+        identifier: NSFileProviderDomainIdentifier("io.tinyland.tcfs"),
+        displayName: "TCFS"
+    )
+
+    init() {
+        checkConfiguration()
+    }
+
+    func checkConfiguration() {
+        let fields = ["s3_endpoint", "s3_bucket", "access_key", "s3_secret", "device_id"]
+        var allPresent = true
+
+        for field in fields {
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: "io.tinyland.tcfs.config",
+                kSecAttrAccount as String: field,
+                kSecAttrAccessGroup as String: "group.io.tinyland.tcfs",
+                kSecReturnData as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne,
+            ]
+            var item: CFTypeRef?
+            if SecItemCopyMatching(query as CFDictionary, &item) != errSecSuccess {
+                allPresent = false
+                break
+            }
+        }
+
+        isConfigured = allPresent
+        status = allPresent ? "Configured" : "Missing credentials"
+    }
+
+    func registerDomain() {
+        status = "Registering..."
+
+        NSFileProviderManager.remove(domain) { [weak self] _ in
+            guard let self = self else { return }
+
+            Thread.sleep(forTimeInterval: 1.0)
+
+            NSFileProviderManager.add(self.domain) { error in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        hostLogger.error("Domain registration failed: \(error.localizedDescription)")
+                        self.status = "Error: \(error.localizedDescription)"
+                    } else {
+                        hostLogger.info("Domain registered successfully")
+                        self.status = "Active"
+                    }
+                }
+            }
+        }
+    }
+
+    func saveConfig(
+        endpoint: String,
+        bucket: String,
+        accessKey: String,
+        s3Secret: String,
+        remotePrefix: String,
+        deviceId: String,
+        passphrase: String,
+        salt: String
+    ) {
+        let entries: [(String, String)] = [
+            ("s3_endpoint", endpoint),
+            ("s3_bucket", bucket),
+            ("access_key", accessKey),
+            ("s3_secret", s3Secret),
+            ("remote_prefix", remotePrefix),
+            ("device_id", deviceId),
+            ("encryption_passphrase", passphrase),
+            ("encryption_salt", salt),
+        ]
+
+        for (account, value) in entries {
+            let data = value.data(using: .utf8)!
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: "io.tinyland.tcfs.config",
+                kSecAttrAccount as String: account,
+                kSecAttrAccessGroup as String: "group.io.tinyland.tcfs",
+            ]
+
+            SecItemDelete(query as CFDictionary)
+
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+
+            let status = SecItemAdd(addQuery as CFDictionary, nil)
+            if status != errSecSuccess {
+                hostLogger.error("Keychain write failed for \(account): \(status)")
+            }
+        }
+
+        checkConfiguration()
+    }
+}
+
+struct ContentView: View {
+    @ObservedObject var viewModel: TCFSViewModel
+
+    @State private var endpoint = ""
+    @State private var bucket = ""
+    @State private var accessKey = ""
+    @State private var s3Secret = ""
+    @State private var remotePrefix = ""
+    @State private var deviceId = ""
+    @State private var passphrase = ""
+    @State private var salt = ""
+    @State private var showingConfig = false
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section("Status") {
+                    HStack {
+                        Text("FileProvider")
+                        Spacer()
+                        Text(viewModel.status)
+                            .foregroundColor(viewModel.isConfigured ? .green : .secondary)
+                    }
+                }
+
+                Section {
+                    Button("Configure Credentials") {
+                        showingConfig = true
+                    }
+
+                    Button("Register FileProvider Domain") {
+                        viewModel.registerDomain()
+                    }
+                    .disabled(!viewModel.isConfigured)
+                }
+            }
+            .navigationTitle("TCFS")
+            .sheet(isPresented: $showingConfig) {
+                NavigationView {
+                    Form {
+                        Section("S3 Storage") {
+                            TextField("Endpoint", text: $endpoint)
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                            TextField("Bucket", text: $bucket)
+                                .autocapitalization(.none)
+                            TextField("Access Key", text: $accessKey)
+                                .autocapitalization(.none)
+                            SecureField("Secret", text: $s3Secret)
+                        }
+
+                        Section("Sync") {
+                            TextField("Remote Prefix", text: $remotePrefix)
+                                .autocapitalization(.none)
+                            TextField("Device ID", text: $deviceId)
+                                .autocapitalization(.none)
+                        }
+
+                        Section("Encryption (optional)") {
+                            SecureField("Passphrase", text: $passphrase)
+                            TextField("Salt", text: $salt)
+                                .autocapitalization(.none)
+                        }
+
+                        Button("Save") {
+                            viewModel.saveConfig(
+                                endpoint: endpoint,
+                                bucket: bucket,
+                                accessKey: accessKey,
+                                s3Secret: s3Secret,
+                                remotePrefix: remotePrefix,
+                                deviceId: deviceId,
+                                passphrase: passphrase,
+                                salt: salt
+                            )
+                            showingConfig = false
+                        }
+                    }
+                    .navigationTitle("Configure TCFS")
+                    .navigationBarItems(trailing: Button("Cancel") {
+                        showingConfig = false
+                    })
+                }
+            }
+        }
+    }
+}

--- a/swift/ios/Resources/Extension-Info.plist
+++ b/swift/ios/Resources/Extension-Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>io.tinyland.tcfs.ios.fileprovider</string>
+    <key>CFBundleExecutable</key>
+    <string>TCFSFileProvider</string>
+    <key>CFBundleName</key>
+    <string>TCFSFileProvider</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>MinimumOSVersion</key>
+    <string>17.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionFileProviderDocumentGroup</key>
+        <string>group.io.tinyland.tcfs</string>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.fileprovider-nonui</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>TCFSFileProviderExtension</string>
+        <key>NSExtensionFileProviderSupportsEnumeration</key>
+        <true/>
+        <key>NSExtensionFileProviderSupportsDatalessFolders</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/swift/ios/Resources/Extension.entitlements
+++ b/swift/ios/Resources/Extension.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.io.tinyland.tcfs</string>
+    </array>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
+    </array>
+</dict>
+</plist>

--- a/swift/ios/Resources/HostApp-Info.plist
+++ b/swift/ios/Resources/HostApp-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>io.tinyland.tcfs.ios</string>
+    <key>CFBundleExecutable</key>
+    <string>TCFS</string>
+    <key>CFBundleName</key>
+    <string>TCFS</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>MinimumOSVersion</key>
+    <string>17.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/swift/ios/Resources/HostApp.entitlements
+++ b/swift/ios/Resources/HostApp.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.io.tinyland.tcfs</string>
+    </array>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)group.io.tinyland.tcfs</string>
+    </array>
+</dict>
+</plist>

--- a/swift/ios/Scripts/build-ios.sh
+++ b/swift/ios/Scripts/build-ios.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
 # Build script for TCFS iOS FileProvider extension.
 # Cross-compiles Rust staticlib for iOS, generates UniFFI Swift bindings,
-# then builds the iOS host app + extension via xcodebuild.
+# then type-checks Swift sources and optionally builds via xcodebuild.
 #
 # Usage:
-#   ./build-ios.sh [--simulator] [--release]
+#   ./build-ios.sh [--simulator] [--release] [--typecheck-only]
 #
 # Targets:
-#   Default:     aarch64-apple-ios (physical device)
-#   --simulator: aarch64-apple-ios-sim (Apple Silicon simulator)
+#   Default:         aarch64-apple-ios (physical device)
+#   --simulator:     aarch64-apple-ios-sim (Apple Silicon simulator)
+#   --typecheck-only: Skip Rust build, just validate Swift sources compile
 
 set -euo pipefail
+
+# Ensure Rust toolchain is on PATH
+if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck source=/dev/null
+    . "$HOME/.cargo/env"
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -18,22 +25,61 @@ REPO_ROOT="$(cd "$IOS_DIR/../.." && pwd)"
 
 SIMULATOR=false
 PROFILE="debug"
+TYPECHECK_ONLY=false
 
 for arg in "$@"; do
     case "$arg" in
-        --simulator) SIMULATOR=true ;;
-        --release)   PROFILE="release" ;;
+        --simulator)      SIMULATOR=true ;;
+        --release)        PROFILE="release" ;;
+        --typecheck-only) TYPECHECK_ONLY=true ;;
     esac
 done
 
 if $SIMULATOR; then
     RUST_TARGET="aarch64-apple-ios-sim"
     XCODE_SDK="iphonesimulator"
-    XCODE_DEST="platform=iOS Simulator,name=iPhone 16,OS=latest"
+    SWIFT_TARGET="arm64-apple-ios17.0-simulator"
 else
     RUST_TARGET="aarch64-apple-ios"
     XCODE_SDK="iphoneos"
-    XCODE_DEST="generic/platform=iOS"
+    SWIFT_TARGET="arm64-apple-ios17.0"
+fi
+
+SDKPATH="$(xcrun --sdk "$XCODE_SDK" --show-sdk-path)"
+
+echo "==> Building TCFS iOS FileProvider"
+echo "    Target:  $RUST_TARGET"
+echo "    Profile: $PROFILE"
+echo "    SDK:     $SDKPATH"
+
+if $TYPECHECK_ONLY; then
+    echo "==> Type-checking Swift sources (no Rust build)..."
+
+    echo "    Extension sources..."
+    /usr/bin/swiftc \
+        -sdk "$SDKPATH" \
+        -target "$SWIFT_TARGET" \
+        -parse-as-library \
+        -typecheck \
+        -framework FileProvider \
+        -framework Foundation \
+        -import-objc-header "$IOS_DIR/Generated/tcfs_file_providerFFI.h" \
+        "$IOS_DIR/Generated/tcfs_file_provider.swift" \
+        "$IOS_DIR/Extension/"*.swift
+
+    echo "    Host app sources..."
+    /usr/bin/swiftc \
+        -sdk "$SDKPATH" \
+        -target "$SWIFT_TARGET" \
+        -parse-as-library \
+        -typecheck \
+        -framework FileProvider \
+        -framework Foundation \
+        -framework SwiftUI \
+        "$IOS_DIR/HostApp/"*.swift
+
+    echo "==> Type-check passed"
+    exit 0
 fi
 
 CARGO_FLAGS="--target $RUST_TARGET --features uniffi"
@@ -42,11 +88,6 @@ if [ "$PROFILE" = "release" ]; then
 fi
 
 RUST_LIB_DIR="$REPO_ROOT/target/$RUST_TARGET/$PROFILE"
-
-echo "==> Building TCFS iOS FileProvider"
-echo "    Target:  $RUST_TARGET"
-echo "    Profile: $PROFILE"
-echo "    SDK:     $XCODE_SDK"
 
 # --- Step 1: Install Rust target if needed ---
 if ! rustup target list --installed | grep -q "$RUST_TARGET"; then
@@ -79,27 +120,57 @@ cargo run -p tcfs-file-provider --features uniffi --bin uniffi-bindgen -- \
 
 echo "    Generated: $(ls "$GENERATED_DIR"/*.swift 2>/dev/null | wc -l | tr -d ' ') Swift files"
 
-# --- Step 4: Generate Xcode project if needed ---
+# --- Step 4: Type-check Swift sources ---
+echo "==> Type-checking Swift sources against iOS SDK..."
+
+/usr/bin/swiftc \
+    -sdk "$SDKPATH" \
+    -target "$SWIFT_TARGET" \
+    -parse-as-library \
+    -typecheck \
+    -framework FileProvider \
+    -framework Foundation \
+    -import-objc-header "$GENERATED_DIR/tcfs_file_providerFFI.h" \
+    "$GENERATED_DIR/tcfs_file_provider.swift" \
+    "$IOS_DIR/Extension/"*.swift
+
+/usr/bin/swiftc \
+    -sdk "$SDKPATH" \
+    -target "$SWIFT_TARGET" \
+    -parse-as-library \
+    -typecheck \
+    -framework FileProvider \
+    -framework Foundation \
+    -framework SwiftUI \
+    "$IOS_DIR/HostApp/"*.swift
+
+echo "    Type-check passed"
+
+# --- Step 5: Build with xcodebuild (if project exists) ---
 XCODEPROJ="$IOS_DIR/TCFS.xcodeproj"
 if [ ! -d "$XCODEPROJ" ]; then
-    echo "==> Xcode project not found at $XCODEPROJ"
-    echo "    Create it in Xcode: File > New > Project > App"
-    echo "    Then add a File Provider extension target."
-    echo ""
-    echo "    Alternatively, build manually with swiftc (see below)."
-    echo ""
-    echo "==> Manual build (no Xcode project):"
-    echo "    The staticlib and Swift bindings are ready at:"
-    echo "      $STATICLIB"
-    echo "      $GENERATED_DIR/"
-    echo ""
-    echo "    Link against the staticlib and include the generated Swift files"
-    echo "    in your Xcode project's extension target."
-    exit 0
+    # Try xcodegen if available
+    if command -v xcodegen &>/dev/null && [ -f "$IOS_DIR/project.yml" ]; then
+        echo "==> Generating Xcode project with xcodegen..."
+        cd "$IOS_DIR"
+        xcodegen generate
+    else
+        echo "==> Xcode project not found. Rust staticlib + Swift bindings ready at:"
+        echo "      $STATICLIB"
+        echo "      $GENERATED_DIR/"
+        echo ""
+        echo "    To generate project: brew install xcodegen && cd swift/ios && xcodegen"
+        echo "    Or create manually in Xcode."
+        exit 0
+    fi
 fi
 
-# --- Step 5: Build with xcodebuild ---
 echo "==> Building with xcodebuild..."
+XCODE_DEST="platform=iOS Simulator,name=iPhone 16,OS=latest"
+if ! $SIMULATOR; then
+    XCODE_DEST="generic/platform=iOS"
+fi
+
 xcodebuild build \
     -project "$XCODEPROJ" \
     -scheme "TCFS" \

--- a/swift/ios/Scripts/build-ios.sh
+++ b/swift/ios/Scripts/build-ios.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Build script for TCFS iOS FileProvider extension.
+# Cross-compiles Rust staticlib for iOS, generates UniFFI Swift bindings,
+# then builds the iOS host app + extension via xcodebuild.
+#
+# Usage:
+#   ./build-ios.sh [--simulator] [--release]
+#
+# Targets:
+#   Default:     aarch64-apple-ios (physical device)
+#   --simulator: aarch64-apple-ios-sim (Apple Silicon simulator)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$IOS_DIR/../.." && pwd)"
+
+SIMULATOR=false
+PROFILE="debug"
+
+for arg in "$@"; do
+    case "$arg" in
+        --simulator) SIMULATOR=true ;;
+        --release)   PROFILE="release" ;;
+    esac
+done
+
+if $SIMULATOR; then
+    RUST_TARGET="aarch64-apple-ios-sim"
+    XCODE_SDK="iphonesimulator"
+    XCODE_DEST="platform=iOS Simulator,name=iPhone 16,OS=latest"
+else
+    RUST_TARGET="aarch64-apple-ios"
+    XCODE_SDK="iphoneos"
+    XCODE_DEST="generic/platform=iOS"
+fi
+
+CARGO_FLAGS="--target $RUST_TARGET --features uniffi"
+if [ "$PROFILE" = "release" ]; then
+    CARGO_FLAGS="$CARGO_FLAGS --release"
+fi
+
+RUST_LIB_DIR="$REPO_ROOT/target/$RUST_TARGET/$PROFILE"
+
+echo "==> Building TCFS iOS FileProvider"
+echo "    Target:  $RUST_TARGET"
+echo "    Profile: $PROFILE"
+echo "    SDK:     $XCODE_SDK"
+
+# --- Step 1: Install Rust target if needed ---
+if ! rustup target list --installed | grep -q "$RUST_TARGET"; then
+    echo "==> Installing Rust target: $RUST_TARGET"
+    rustup target add "$RUST_TARGET"
+fi
+
+# --- Step 2: Build Rust staticlib ---
+echo "==> Building Rust staticlib..."
+cd "$REPO_ROOT"
+# shellcheck disable=SC2086
+cargo build -p tcfs-file-provider $CARGO_FLAGS
+
+STATICLIB="$RUST_LIB_DIR/libtcfs_file_provider.a"
+if [ ! -f "$STATICLIB" ]; then
+    echo "ERROR: staticlib not found at $STATICLIB" >&2
+    exit 1
+fi
+echo "    Staticlib: $STATICLIB ($(du -h "$STATICLIB" | cut -f1))"
+
+# --- Step 3: Generate UniFFI Swift bindings ---
+echo "==> Generating UniFFI Swift bindings..."
+GENERATED_DIR="$IOS_DIR/Generated"
+mkdir -p "$GENERATED_DIR"
+
+cargo run -p tcfs-file-provider --features uniffi --bin uniffi-bindgen -- \
+    generate --library "$STATICLIB" \
+    --language swift \
+    --out-dir "$GENERATED_DIR"
+
+echo "    Generated: $(ls "$GENERATED_DIR"/*.swift 2>/dev/null | wc -l | tr -d ' ') Swift files"
+
+# --- Step 4: Generate Xcode project if needed ---
+XCODEPROJ="$IOS_DIR/TCFS.xcodeproj"
+if [ ! -d "$XCODEPROJ" ]; then
+    echo "==> Xcode project not found at $XCODEPROJ"
+    echo "    Create it in Xcode: File > New > Project > App"
+    echo "    Then add a File Provider extension target."
+    echo ""
+    echo "    Alternatively, build manually with swiftc (see below)."
+    echo ""
+    echo "==> Manual build (no Xcode project):"
+    echo "    The staticlib and Swift bindings are ready at:"
+    echo "      $STATICLIB"
+    echo "      $GENERATED_DIR/"
+    echo ""
+    echo "    Link against the staticlib and include the generated Swift files"
+    echo "    in your Xcode project's extension target."
+    exit 0
+fi
+
+# --- Step 5: Build with xcodebuild ---
+echo "==> Building with xcodebuild..."
+xcodebuild build \
+    -project "$XCODEPROJ" \
+    -scheme "TCFS" \
+    -sdk "$XCODE_SDK" \
+    -destination "$XCODE_DEST" \
+    -configuration "$([ "$PROFILE" = "release" ] && echo Release || echo Debug)" \
+    LIBRARY_SEARCH_PATHS="$RUST_LIB_DIR" \
+    OTHER_LDFLAGS="-ltcfs_file_provider -lc++" \
+    SWIFT_INCLUDE_PATHS="$GENERATED_DIR" \
+    2>&1 | tail -20
+
+echo "==> Done"

--- a/swift/ios/project.yml
+++ b/swift/ios/project.yml
@@ -1,0 +1,50 @@
+name: TCFS
+options:
+  bundleIdPrefix: io.tinyland.tcfs
+  deploymentTarget:
+    iOS: "17.0"
+  xcodeVersion: "16.0"
+  createIntermediateGroups: true
+
+settings:
+  base:
+    DEVELOPMENT_TEAM: ""
+    CODE_SIGN_STYLE: Manual
+    SWIFT_VERSION: "5.10"
+
+targets:
+  TCFS:
+    type: application
+    platform: iOS
+    sources:
+      - path: HostApp
+    info:
+      path: Resources/HostApp-Info.plist
+    entitlements:
+      path: Resources/HostApp.entitlements
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.tinyland.tcfs.ios
+        INFOPLIST_FILE: Resources/HostApp-Info.plist
+        CODE_SIGN_ENTITLEMENTS: Resources/HostApp.entitlements
+    dependencies:
+      - target: TCFSFileProvider
+
+  TCFSFileProvider:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: Extension
+      - path: Generated
+    info:
+      path: Resources/Extension-Info.plist
+    entitlements:
+      path: Resources/Extension.entitlements
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.tinyland.tcfs.ios.fileprovider
+        INFOPLIST_FILE: Resources/Extension-Info.plist
+        CODE_SIGN_ENTITLEMENTS: Resources/Extension.entitlements
+        LIBRARY_SEARCH_PATHS: "$(SRCROOT)/../../target/aarch64-apple-ios/release $(SRCROOT)/../../target/aarch64-apple-ios-sim/debug"
+        OTHER_LDFLAGS: "-ltcfs_file_provider -lc++"
+        SWIFT_OBJC_BRIDGING_HEADER: Generated/tcfs_file_providerFFI.h


### PR DESCRIPTION
## Summary

- Add complete iOS FileProvider Swift sources using UniFFI bindings (not macOS C FFI)
- FileProviderExtension with full CRUD: enumerate, hydrate, create, modify, delete
- FileProviderEnumerator using `provider.listItems(path:)` for directory listing
- SwiftUI host app with credential config UI + shared Keychain storage
- iOS plists targeting iOS 17+ (iPhone + iPad), shared entitlements
- `build-ios.sh` script: cargo cross-compile → UniFFI bindgen → xcodebuild
- Verified: Rust staticlib builds clean for `aarch64-apple-ios-sim`

## Architecture

```
swift/ios/
├── Extension/              # FileProvider .appex sources
│   ├── FileProviderExtension.swift   # CRUD via TcfsProviderHandle (UniFFI)
│   ├── FileProviderEnumerator.swift  # listItems() instead of C FFI enumerate
│   └── FileProviderItem.swift        # Placeholder/dehydration support
├── Generated/              # UniFFI auto-generated (from PR #62)
├── HostApp/                # iOS host app
│   └── HostApp.swift       # SwiftUI config + domain registration
├── Resources/              # Plists + entitlements
└── Scripts/
    └── build-ios.sh        # Cross-compile + build pipeline
```

## Key differences from macOS FileProvider

| Aspect | macOS (.appex) | iOS (.appex) |
|--------|---------------|-------------|
| FFI layer | cbindgen C FFI | UniFFI proc-macros |
| Provider type | `OpaquePointer` | `TcfsProviderHandle` (ARC) |
| Config source | Embedded JSON / Keychain / XDG | iOS Keychain only |
| Host app | CLI (`@main struct`) | SwiftUI with config UI |
| Min OS | macOS 15.0 | iOS 17.0 |

## Test plan

- [x] `cargo build -p tcfs-file-provider --target aarch64-apple-ios-sim --features uniffi` compiles
- [x] UniFFI bindgen generates matching Swift bindings from iOS staticlib
- [ ] Xcode project creation (requires Xcode GUI — next step)
- [ ] iOS Simulator test with mock S3 backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)