### PR TITLE
feat(ios): TestFlight pipeline + simulator fixes

### DIFF
--- a/swift/ios/Resources/Extension-Info.plist
+++ b/swift/ios/Resources/Extension-Info.plist
@@ -1,41 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleIdentifier</key>
-    <string>io.tinyland.tcfs.ios.fileprovider</string>
-    <key>CFBundleExecutable</key>
-    <string>TCFSFileProvider</string>
-    <key>CFBundleName</key>
-    <string>TCFSFileProvider</string>
-    <key>CFBundlePackageType</key>
-    <string>XPC!</string>
-    <key>CFBundleVersion</key>
-    <string>1</string>
-    <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>MinimumOSVersion</key>
-    <string>17.0</string>
-    <key>UIDeviceFamily</key>
-    <array>
-        <integer>1</integer>
-        <integer>2</integer>
-    </array>
-    <key>NSExtension</key>
-    <dict>
-        <key>NSExtensionFileProviderDocumentGroup</key>
-        <string>group.io.tinyland.tcfs</string>
-        <key>NSExtensionPointIdentifier</key>
-        <string>com.apple.fileprovider-nonui</string>
-        <key>NSExtensionPrincipalClass</key>
-        <string>TCFSFileProviderExtension</string>
-        <key>NSExtensionFileProviderSupportsEnumeration</key>
-        <true/>
-        <key>NSExtensionFileProviderSupportsDatalessFolders</key>
-        <true/>
-    </dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionFileProviderDocumentGroup</key>
+		<string>group.io.tinyland.tcfs</string>
+		<key>NSExtensionFileProviderSupportsDatalessFolders</key>
+		<true/>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.fileprovider-nonui</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).TCFSFileProviderExtension</string>
+	</dict>
 </dict>
 </plist>

--- a/swift/ios/Scripts/ExportOptions.plist
+++ b/swift/ios/Scripts/ExportOptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>teamID</key>
+	<string>QP994XQKNH</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>destination</key>
+	<string>upload</string>
+</dict>
+</plist>

--- a/swift/ios/Scripts/upload-testflight.sh
+++ b/swift/ios/Scripts/upload-testflight.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Upload TCFS iOS app to TestFlight.
+#
+# Prerequisites:
+#   1. Apple Developer Program membership (developer.apple.com)
+#   2. App IDs registered: io.tinyland.tcfs.ios + io.tinyland.tcfs.ios.fileprovider
+#   3. App Group: group.io.tinyland.tcfs
+#   4. Keychain Access Group configured in both App IDs
+#   5. Apple Distribution certificate in Keychain (or Xcode auto-manages)
+#   6. App created in App Store Connect (appstoreconnect.apple.com)
+#
+# Usage:
+#   ./upload-testflight.sh [--api-key <key_id> --api-issuer <issuer_id>]
+#
+# Authentication:
+#   Either pass --api-key/--api-issuer for App Store Connect API key,
+#   or ensure you're signed into Xcode with your Apple ID.
+
+set -euo pipefail
+
+if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck source=/dev/null
+    . "$HOME/.cargo/env"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$IOS_DIR/../.." && pwd)"
+
+API_KEY=""
+API_ISSUER=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --api-key)    shift; API_KEY="$1"; shift ;;
+        --api-issuer) shift; API_ISSUER="$1"; shift ;;
+    esac
+done
+
+RUST_TARGET="aarch64-apple-ios"
+PROFILE="release"
+RUST_LIB_DIR="$REPO_ROOT/target/$RUST_TARGET/$PROFILE"
+
+echo "==> Building TCFS for TestFlight"
+echo "    Target:  $RUST_TARGET"
+echo "    Profile: $PROFILE"
+
+# --- Step 1: Build Rust staticlib (release) ---
+echo "==> Building Rust staticlib (release)..."
+cd "$REPO_ROOT"
+if ! rustup target list --installed | grep -q "$RUST_TARGET"; then
+    rustup target add "$RUST_TARGET"
+fi
+cargo build -p tcfs-file-provider --target "$RUST_TARGET" --features uniffi --release
+
+STATICLIB="$RUST_LIB_DIR/libtcfs_file_provider.a"
+if [ ! -f "$STATICLIB" ]; then
+    echo "ERROR: staticlib not found at $STATICLIB" >&2
+    exit 1
+fi
+echo "    Staticlib: $STATICLIB ($(du -h "$STATICLIB" | cut -f1))"
+
+# --- Step 2: Generate UniFFI Swift bindings ---
+echo "==> Generating UniFFI Swift bindings..."
+GENERATED_DIR="$IOS_DIR/Generated"
+mkdir -p "$GENERATED_DIR"
+
+cargo run -p tcfs-file-provider --features uniffi --bin uniffi-bindgen -- \
+    generate --library "$STATICLIB" \
+    --language swift \
+    --out-dir "$GENERATED_DIR"
+
+# --- Step 3: Generate Xcode project ---
+echo "==> Generating Xcode project..."
+cd "$IOS_DIR"
+if command -v xcodegen &>/dev/null; then
+    xcodegen generate
+else
+    echo "ERROR: xcodegen not found. Install with: brew install xcodegen" >&2
+    exit 1
+fi
+
+# --- Step 4: Archive ---
+echo "==> Archiving..."
+ARCHIVE_PATH="$IOS_DIR/build/TCFS.xcarchive"
+
+xcodebuild archive \
+    -project "$IOS_DIR/TCFS.xcodeproj" \
+    -scheme "TCFS" \
+    -sdk iphoneos \
+    -configuration Release \
+    -archivePath "$ARCHIVE_PATH" \
+    LIBRARY_SEARCH_PATHS="$RUST_LIB_DIR" \
+    ONLY_ACTIVE_ARCH=NO \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+echo "    Archive: $ARCHIVE_PATH"
+
+# --- Step 5: Export IPA ---
+echo "==> Exporting IPA..."
+EXPORT_DIR="$IOS_DIR/build/export"
+EXPORT_OPTIONS="$IOS_DIR/Scripts/ExportOptions.plist"
+
+if [ ! -f "$EXPORT_OPTIONS" ]; then
+    echo "ERROR: ExportOptions.plist not found at $EXPORT_OPTIONS" >&2
+    echo "Create it with method=app-store and teamID=QP994XQKNH" >&2
+    exit 1
+fi
+
+xcodebuild -exportArchive \
+    -archivePath "$ARCHIVE_PATH" \
+    -exportPath "$EXPORT_DIR" \
+    -exportOptionsPlist "$EXPORT_OPTIONS"
+
+IPA_FILE="$EXPORT_DIR/TCFS.ipa"
+echo "    IPA: $IPA_FILE ($(du -h "$IPA_FILE" | cut -f1))"
+
+# --- Step 6: Upload to TestFlight ---
+echo "==> Uploading to TestFlight..."
+
+if [ -n "$API_KEY" ] && [ -n "$API_ISSUER" ]; then
+    xcrun altool --upload-app \
+        -f "$IPA_FILE" \
+        -t ios \
+        --apiKey "$API_KEY" \
+        --apiIssuer "$API_ISSUER"
+else
+    xcrun altool --upload-app \
+        -f "$IPA_FILE" \
+        -t ios \
+        -u "${APPLE_ID:-}" \
+        -p "${APPLE_APP_SPECIFIC_PASSWORD:-}"
+fi
+
+echo "==> Done! Check App Store Connect for TestFlight processing."
+echo "    https://appstoreconnect.apple.com"

--- a/swift/ios/project.yml
+++ b/swift/ios/project.yml
@@ -8,8 +8,8 @@ options:
 
 settings:
   base:
-    DEVELOPMENT_TEAM: ""
-    CODE_SIGN_STYLE: Manual
+    DEVELOPMENT_TEAM: QP994XQKNH
+    CODE_SIGN_STYLE: Automatic
     SWIFT_VERSION: "5.10"
 
 targets:

--- a/swift/ios/project.yml
+++ b/swift/ios/project.yml
@@ -18,6 +18,7 @@ targets:
     platform: iOS
     sources:
       - path: HostApp
+      - path: Generated
     info:
       path: Resources/HostApp-Info.plist
     entitlements:
@@ -27,6 +28,9 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: io.tinyland.tcfs.ios
         INFOPLIST_FILE: Resources/HostApp-Info.plist
         CODE_SIGN_ENTITLEMENTS: Resources/HostApp.entitlements
+        SWIFT_OBJC_BRIDGING_HEADER: "$(SRCROOT)/Generated/tcfs_file_providerFFI.h"
+        LIBRARY_SEARCH_PATHS: "$(SRCROOT)/../../target/aarch64-apple-ios/release $(SRCROOT)/../../target/aarch64-apple-ios-sim/debug"
+        OTHER_LDFLAGS: "-ltcfs_file_provider -lc++"
     dependencies:
       - target: TCFSFileProvider
 
@@ -38,6 +42,12 @@ targets:
       - path: Generated
     info:
       path: Resources/Extension-Info.plist
+      properties:
+        NSExtension:
+          NSExtensionFileProviderDocumentGroup: group.io.tinyland.tcfs
+          NSExtensionFileProviderSupportsDatalessFolders: true
+          NSExtensionPointIdentifier: com.apple.fileprovider-nonui
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).TCFSFileProviderExtension"
     entitlements:
       path: Resources/Extension.entitlements
     settings:
@@ -47,4 +57,4 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Resources/Extension.entitlements
         LIBRARY_SEARCH_PATHS: "$(SRCROOT)/../../target/aarch64-apple-ios/release $(SRCROOT)/../../target/aarch64-apple-ios-sim/debug"
         OTHER_LDFLAGS: "-ltcfs_file_provider -lc++"
-        SWIFT_OBJC_BRIDGING_HEADER: Generated/tcfs_file_providerFFI.h
+        SWIFT_OBJC_BRIDGING_HEADER: "$(SRCROOT)/Generated/tcfs_file_providerFFI.h"


### PR DESCRIPTION
## Summary
- Fix NSExtension plist for FileProvider (was missing, causing simulator install failure)
- Add Generated sources + UniFFI bridging header to host app target
- Set Team ID (QP994XQKNH) and automatic code signing
- Add `upload-testflight.sh` pipeline: cargo release → archive → IPA → TestFlight upload
- Verified: app installs and runs on iPhone 17 Pro simulator (iOS 26.3.1)

## Screenshot
App launches on iOS Simulator showing TCFS config UI with status, credential config, and domain registration.

## Apple Developer Portal Setup Required
Before first TestFlight upload:
1. Register App IDs: `io.tinyland.tcfs.ios` + `io.tinyland.tcfs.ios.fileprovider`
2. Register App Group: `group.io.tinyland.tcfs`
3. Enable Keychain Sharing capability on both App IDs
4. Create app in App Store Connect
5. Xcode will auto-manage provisioning profiles with Automatic signing

## Test plan
- [x] App builds for iOS Simulator (`--simulator` flag)
- [x] App installs and launches on iPhone 17 Pro simulator
- [x] NSExtension plist properly embedded in .appex
- [ ] Archive builds for physical device (needs Apple Distribution cert)
- [ ] TestFlight upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)