### PR TITLE
chore: bump workspace version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-auth"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-chunks"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cloudfilter"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "prost",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-crypto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes-siv",
  "anyhow",
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-dbus"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -5276,7 +5276,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-file-provider"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-fuse"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-mcp"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5346,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-nfs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-secrets"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sops"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-storage"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sync"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5455,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-tui"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-vfs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5492,7 +5492,7 @@ dependencies = [
 
 [[package]]
 name = "tcfsd"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.8.0 → 0.9.0
- Prepares for v0.9.0 release tag (FUSE-free VFS + Enterprise Auth)

## Test plan
- [x] `cargo check` passes with new version
- [ ] CI green