### PR TITLE
fix(ci): resolve release workflow build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,14 +144,18 @@ jobs:
       - name: Install Linux cross-compilation tools
         if: matrix.cross
         run: |
+          sudo dpkg --add-architecture arm64
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             gcc-aarch64-linux-gnu \
             g++-aarch64-linux-gnu \
-            libc6-dev-arm64-cross
+            libc6-dev-arm64-cross \
+            libfuse3-dev:arm64
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/" >> $GITHUB_ENV
 
       - name: Install Linux build deps
         if: runner.os == 'Linux'
@@ -168,10 +172,11 @@ jobs:
         run: |
           brew install protobuf
 
-      - name: Install Windows build deps
+      - name: Install protoc (Windows)
         if: runner.os == 'Windows'
-        run: |
-          choco install protoc -y
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # ── Build tcfs CLI ────────────────────────────────────────────────────
 
@@ -189,8 +194,13 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
+          FEATURES="${{ matrix.features }}"
+          if [[ "${{ matrix.fuse }}" == "true" ]]; then
+            FEATURES=""  # use default features (includes fuse)
+          fi
           cargo build --release \
             --target ${{ matrix.target }} \
+            ${FEATURES} \
             -p tcfsd
 
       # ── Build tcfs-tui ────────────────────────────────────────────────────
@@ -674,7 +684,13 @@ jobs:
 
       - name: Build FileProvider extension
         run: |
-          HEADER=$(find target -name tcfs_file_provider.h | head -1)
+          HEADER=$(find target -name tcfs_file_provider.h -path '*/tcfs-file-provider*/out/*' | head -1)
+          if [ -z "$HEADER" ]; then
+            echo "::error::cbindgen header not found — listing target/release/build/ for debugging:"
+            find target/release/build -name '*.h' 2>/dev/null || true
+            exit 1
+          fi
+          echo "Found header: $HEADER"
           swift/fileprovider/build.sh \
             target/release \
             "$HEADER" \


### PR DESCRIPTION
## Summary
- **tcfsd**: Pass `matrix.features` (`--no-default-features`) on non-FUSE platforms (macOS, Windows) — was building with default FUSE feature where no FUSE library exists
- **linux-aarch64**: Add `libfuse3-dev:arm64` multiarch package + pkg-config env vars for cross-compilation
- **windows**: Replace flaky `choco install protoc` with `arduino/setup-protoc` action
- **fileprovider**: Add error handling for cbindgen header discovery (fail with diagnostic output instead of silently passing empty path)

## Context
v0.9.0 release build had 4/8 platform jobs fail (linux-aarch64, macos-x86_64, windows-x86_64, fileprovider). This fixes all root causes.

## Test plan
- [ ] Re-tag v0.9.1 after merge to trigger release workflow
- [ ] Verify all platform jobs pass