### PR TITLE
fix(fileprovider): add TcfsChangeEvent to cbindgen exports

### DIFF
--- a/crates/tcfs-file-provider/cbindgen.toml
+++ b/crates/tcfs-file-provider/cbindgen.toml
@@ -11,6 +11,7 @@ cpp_compat = true
 [export]
 include = [
     "TcfsFileItem",
+    "TcfsChangeEvent",
     "TcfsError",
 ]
 


### PR DESCRIPTION
## Summary
- Add `TcfsChangeEvent` to cbindgen `[export] include` list
- Fixes undefined symbol `_tcfs_provider_enumerate_changes` linker error on aarch64-darwin
- The Rust staticlib already contains the symbol; this is purely a header generation fix

## Test plan
- [x] `nix build .#tcfs-file-provider-staticlib` succeeds
- [x] Generated header contains `tcfs_provider_enumerate_changes` declaration (5 references)
- [ ] FileProvider .appex builds successfully on xoxd-bates after merge