### PR TITLE
fix(fileprovider): fix EDEADLK hydration deadlock + CLI pull prefix

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -789,15 +789,20 @@ async fn cmd_pull(
     let device_id = load_device_id(config);
 
     // Derive the remote prefix from the manifest path if not provided
-    // e.g. "mydata/manifests/abc123" → prefix = "mydata"
+    // e.g. "devices/A29247/manifests/abc123" → prefix = "devices/A29247"
     let remote_prefix = prefix
         .map(|s| s.trim_end_matches('/').to_string())
         .unwrap_or_else(|| {
             manifest_path
-                .split('/')
-                .next()
-                .unwrap_or("tcfs")
-                .to_string()
+                .rsplit_once("/manifests/")
+                .map(|(pfx, _)| pfx.to_string())
+                .unwrap_or_else(|| {
+                    manifest_path
+                        .split('/')
+                        .next()
+                        .unwrap_or("tcfs")
+                        .to_string()
+                })
         });
 
     // Default local path: current dir + manifest hash (last path component)

--- a/crates/tcfs-file-provider/cbindgen.toml
+++ b/crates/tcfs-file-provider/cbindgen.toml
@@ -11,6 +11,7 @@ cpp_compat = true
 [export]
 include = [
     "TcfsFileItem",
+    "TcfsChangeEvent",
     "TcfsError",
 ]
 

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -58,14 +58,16 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return progress
         }
 
-        // For non-root items, return the item from its identifier path
+        // For non-root items, return the item as a placeholder (not downloaded).
+        // This tells fileproviderd the content needs to be fetched via fetchContents.
         completionHandler(
             TCFSFileProviderItem(
                 identifier: identifier,
                 parentIdentifier: .rootContainer,
                 filename: identifier.rawValue.components(separatedBy: "/").last ?? identifier.rawValue,
                 isDirectory: false,
-                fileSize: 0
+                fileSize: 0,
+                downloaded: false
             ),
             nil
         )


### PR DESCRIPTION
## Summary
- `item(for:)` was returning `downloaded: true` (default), telling fileproviderd content was already local. Finder read attempts got `EDEADLK` because no local content existed. Fix: return `downloaded: false` for non-root items.
- CLI `pull` prefix derivation used `split('/').next()` which only took the first segment. For multi-segment prefixes like `devices/A29247/manifests/<hash>`, this gave `devices` instead of `devices/A29247`. Fix: use `rsplit_once("/manifests/")`.

## Test plan
- [ ] Push file with `--prefix devices/<id>`, pull via CLI — chunks found correctly
- [ ] Open placeholder file in Finder CloudStorage — triggers `fetchContents` instead of EDEADLK
- [ ] Domain reset + enumerate shows files as placeholders with correct download state