### PR TITLE
fix(ios): wrap conditional body in Group for sheet modifier

### DIFF
--- a/swift/ios/HostApp/HostApp.swift
+++ b/swift/ios/HostApp/HostApp.swift
@@ -203,6 +203,7 @@ struct ContentView: View {
 
     var body: some View {
         NavigationView {
+            Group {
             if !viewModel.isConfigured {
                 // --- Onboarding: unconfigured device ---
                 VStack(spacing: 24) {
@@ -300,6 +301,7 @@ struct ContentView: View {
                 }
                 .navigationTitle("TCFS")
             }
+            } // Group
             .sheet(isPresented: $showingConfig) {
                 NavigationView {
                     Form {


### PR DESCRIPTION
Swift 6 requires concrete type for .sheet modifier - wrapped if/else in Group