### PR TITLE
chore(ios): bump build number to 5

### DIFF
--- a/swift/ios/project.yml
+++ b/swift/ios/project.yml
@@ -13,7 +13,7 @@ settings:
     CODE_SIGN_IDENTITY: "Apple Distribution: John Sullivan (QP994XQKNH)"
     SWIFT_VERSION: "5.10"
     MARKETING_VERSION: "0.9.3"
-    CURRENT_PROJECT_VERSION: "2"
+    CURRENT_PROJECT_VERSION: "5"
 
 targets:
   TCFS:


### PR DESCRIPTION
TestFlight build 5 with QR fix, encryption, URL scheme, and BLAKE3 signing.