### PR TITLE
feat(auth): credential broker for zero-touch enrollment

### DIFF
--- a/crates/tcfs-auth/src/enrollment.rs
+++ b/crates/tcfs-auth/src/enrollment.rs
@@ -43,6 +43,18 @@ pub struct EnrollmentInvite {
     pub nats_url: Option<String>,
     /// Optional: S3/SeaweedFS endpoint for storage.
     pub storage_endpoint: Option<String>,
+    /// Optional: S3 bucket name.
+    pub storage_bucket: Option<String>,
+    /// Optional: S3 access key (credential brokering).
+    pub storage_access_key: Option<String>,
+    /// Optional: S3 secret key (credential brokering).
+    pub storage_secret_key: Option<String>,
+    /// Optional: remote prefix for file sync.
+    pub remote_prefix: Option<String>,
+    /// Optional: encryption passphrase for E2EE.
+    pub encryption_passphrase: Option<String>,
+    /// Optional: encryption salt for KDF.
+    pub encryption_salt: Option<String>,
     /// Optional: human-readable description of the invite.
     pub description: Option<String>,
 }
@@ -76,6 +88,12 @@ impl EnrollmentInvite {
             signature: String::new(),
             nats_url: None,
             storage_endpoint: None,
+            storage_bucket: None,
+            storage_access_key: None,
+            storage_secret_key: None,
+            remote_prefix: None,
+            encryption_passphrase: None,
+            encryption_salt: None,
             description: None,
         };
 
@@ -165,6 +183,18 @@ pub struct EnrollmentResult {
     pub nats_url: Option<String>,
     /// Storage endpoint URL.
     pub storage_endpoint: Option<String>,
+    /// S3 bucket name.
+    pub storage_bucket: Option<String>,
+    /// S3 access key (brokered from invite).
+    pub storage_access_key: Option<String>,
+    /// S3 secret key (brokered from invite).
+    pub storage_secret_key: Option<String>,
+    /// Remote prefix for file sync.
+    pub remote_prefix: Option<String>,
+    /// Encryption passphrase (if E2EE enabled).
+    pub encryption_passphrase: Option<String>,
+    /// Encryption salt (if E2EE enabled).
+    pub encryption_salt: Option<String>,
     /// Auth methods available (e.g., ["totp", "webauthn"]).
     pub available_auth_methods: Vec<String>,
 }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -2027,14 +2027,75 @@ async fn cmd_device_invite(
         .context("status RPC failed")?
         .into_inner();
 
-    // TODO: derive signing key from master key instead of placeholder
-    let signing_key = blake3::hash(b"tcfs-fleet-invite-key");
-    let invite = EnrollmentInvite::new(
+    // Load master key for signing
+    let key_path = config
+        .crypto
+        .master_key_file
+        .clone()
+        .unwrap_or_else(|| {
+            tcfs_secrets::device::default_registry_path()
+                .parent()
+                .unwrap_or(std::path::Path::new("."))
+                .join("master.key")
+        });
+
+    let signing_key = if key_path.exists() {
+        let key_bytes = std::fs::read(&key_path)
+            .with_context(|| format!("reading master key: {}", key_path.display()))?;
+        if key_bytes.len() != tcfs_crypto::KEY_SIZE {
+            anyhow::bail!(
+                "master key has wrong size: {} bytes (expected {})",
+                key_bytes.len(),
+                tcfs_crypto::KEY_SIZE,
+            );
+        }
+        *blake3::hash(&key_bytes).as_bytes()
+    } else {
+        eprintln!(
+            "Warning: master key not found at {}, using placeholder signing key",
+            key_path.display()
+        );
+        *blake3::hash(b"tcfs-fleet-invite-key").as_bytes()
+    };
+
+    let mut invite = EnrollmentInvite::new(
         &status.device_id,
-        signing_key.as_bytes(),
+        &signing_key,
         expiry_hours,
         DevicePermissions::default(),
     );
+
+    // Include storage credentials for credential brokering
+    invite.storage_endpoint = Some(config.storage.endpoint.clone());
+    invite.storage_bucket = Some(config.storage.bucket.clone());
+    invite.remote_prefix = Some(String::from("default"));
+
+    // Load S3 credentials from environment (sops-nix populates these)
+    if let Ok(access_key) = std::env::var("AWS_ACCESS_KEY_ID")
+        .or_else(|_| {
+            std::env::var("TCFS_S3_ACCESS_KEY_FILE")
+                .and_then(|f| std::fs::read_to_string(f).map_err(|_| std::env::VarError::NotPresent))
+        })
+    {
+        invite.storage_access_key = Some(access_key);
+    }
+    if let Ok(secret_key) = std::env::var("AWS_SECRET_ACCESS_KEY")
+        .or_else(|_| {
+            std::env::var("TCFS_S3_SECRET_KEY_FILE")
+                .and_then(|f| std::fs::read_to_string(f).map_err(|_| std::env::VarError::NotPresent))
+        })
+    {
+        invite.storage_secret_key = Some(secret_key);
+    }
+
+    // Include encryption config if enabled
+    if config.crypto.enabled {
+        if let Ok(passphrase) = std::env::var("TCFS_ENCRYPTION_KEY_FILE")
+            .and_then(|f| std::fs::read_to_string(f).map_err(|_| std::env::VarError::NotPresent))
+        {
+            invite.encryption_passphrase = Some(passphrase);
+        }
+    }
 
     let encoded = invite.encode().context("failed to encode invite")?;
     let deep_link = format!("tcfs://enroll?data={encoded}");
@@ -2042,6 +2103,12 @@ async fn cmd_device_invite(
     println!("Device enrollment invite created");
     println!();
     println!("Expires: {} hours from now", expiry_hours);
+    println!("Storage: {} (bucket: {})", config.storage.endpoint, config.storage.bucket);
+    if invite.storage_access_key.is_some() {
+        println!("Credentials: included (S3 access key brokered)");
+    } else {
+        println!("Credentials: NOT included (set AWS_ACCESS_KEY_ID or TCFS_S3_ACCESS_KEY_FILE)");
+    }
     println!();
     println!("Share this invite data with the new device:");
     println!("  {encoded}");

--- a/crates/tcfs-core/src/proto/tcfs.proto
+++ b/crates/tcfs-core/src/proto/tcfs.proto
@@ -265,4 +265,11 @@ message DeviceEnrollResponse {
   string storage_endpoint = 4;
   repeated string available_auth_methods = 5;
   string error = 6;
+  // Credential broker fields (populated from invite)
+  string storage_bucket = 7;
+  string storage_access_key = 8;
+  string storage_secret = 9;
+  string remote_prefix = 10;
+  string encryption_passphrase = 11;
+  string encryption_salt = 12;
 }

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -78,6 +78,24 @@ pub struct AuthResult {
     pub error_message: String,
 }
 
+/// Result of a device enrollment via invite.
+///
+/// Contains all credentials needed to configure the new device.
+#[derive(uniffi::Record)]
+pub struct EnrollmentResult {
+    pub success: bool,
+    pub error_message: String,
+    pub device_id: String,
+    pub storage_endpoint: String,
+    pub storage_bucket: String,
+    pub access_key: String,
+    pub s3_secret: String,
+    pub remote_prefix: String,
+    pub encryption_passphrase: String,
+    pub encryption_salt: String,
+    pub session_token: String,
+}
+
 /// Errors returned by provider operations.
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 pub enum ProviderError {
@@ -743,11 +761,13 @@ impl TcfsProviderHandle {
     }
 
     /// Process a device enrollment invite (from QR code or deep link).
+    ///
+    /// Returns credentials extracted from the invite for auto-configuration.
     #[cfg(feature = "uniffi")]
     pub fn process_enrollment_invite(
         &self,
         invite_data: &str,
-    ) -> Result<AuthResult, ProviderError> {
+    ) -> Result<EnrollmentResult, ProviderError> {
         let invite = tcfs_auth::enrollment::EnrollmentInvite::decode(invite_data).map_err(|e| {
             ProviderError::Auth {
                 message: format!("invalid invite: {e}"),
@@ -755,10 +775,18 @@ impl TcfsProviderHandle {
         })?;
 
         if invite.is_expired() {
-            return Ok(AuthResult {
+            return Ok(EnrollmentResult {
                 success: false,
-                session_token: String::new(),
                 error_message: "invite has expired".into(),
+                device_id: String::new(),
+                storage_endpoint: String::new(),
+                storage_bucket: String::new(),
+                access_key: String::new(),
+                s3_secret: String::new(),
+                remote_prefix: String::new(),
+                encryption_passphrase: String::new(),
+                encryption_salt: String::new(),
+                session_token: String::new(),
             });
         }
 
@@ -768,10 +796,18 @@ impl TcfsProviderHandle {
         let token = session.token.clone();
         self.runtime.block_on(self.session_store.insert(session));
 
-        Ok(AuthResult {
+        Ok(EnrollmentResult {
             success: true,
-            session_token: token,
             error_message: String::new(),
+            device_id: invite.created_by.clone(),
+            storage_endpoint: invite.storage_endpoint.unwrap_or_default(),
+            storage_bucket: invite.storage_bucket.unwrap_or_default(),
+            access_key: invite.storage_access_key.unwrap_or_default(),
+            s3_secret: invite.storage_secret_key.unwrap_or_default(),
+            remote_prefix: invite.remote_prefix.unwrap_or_else(|| "default".into()),
+            encryption_passphrase: invite.encryption_passphrase.unwrap_or_default(),
+            encryption_salt: invite.encryption_salt.unwrap_or_default(),
+            session_token: token,
         })
     }
 

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1780,6 +1780,12 @@ impl TcfsDaemon for TcfsDaemonImpl {
             storage_endpoint: invite.storage_endpoint.unwrap_or_default(),
             available_auth_methods: vec!["totp".into()],
             error: String::new(),
+            storage_bucket: invite.storage_bucket.unwrap_or_default(),
+            storage_access_key: invite.storage_access_key.unwrap_or_default(),
+            storage_secret: invite.storage_secret_key.unwrap_or_default(),
+            remote_prefix: invite.remote_prefix.unwrap_or_default(),
+            encryption_passphrase: invite.encryption_passphrase.unwrap_or_default(),
+            encryption_salt: invite.encryption_salt.unwrap_or_default(),
         }))
     }
 }

--- a/swift/ios/HostApp/AuthView.swift
+++ b/swift/ios/HostApp/AuthView.swift
@@ -150,22 +150,43 @@ class AuthViewModel: ObservableObject {
 
     // MARK: - QR Code Enrollment (device invite)
 
-    func processInviteData(_ data: String) {
+    func processInviteData(_ data: String, tcfsViewModel: TCFSViewModel? = nil) {
         isLoading = true
         errorMessage = nil
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
 
+            // Decode invite directly — no provider needed (credentials come FROM the invite)
+            let config = ProviderConfig(
+                s3Endpoint: "", s3Bucket: "", accessKey: "", s3Secret: "",
+                remotePrefix: "default", deviceId: "pending",
+                encryptionPassphrase: "", encryptionSalt: ""
+            )
+
             do {
-                guard let provider = self.loadProvider() else {
-                    throw NSError(domain: "tcfs", code: -1, userInfo: [NSLocalizedDescriptionKey: "Provider not configured"])
-                }
+                let provider = try TcfsProviderHandle(config: config)
                 let result = try provider.processEnrollmentInvite(inviteData: data)
 
                 DispatchQueue.main.async {
                     self.isLoading = false
                     if result.success {
+                        // Auto-configure: save brokered credentials to keychain
+                        if !result.storageEndpoint.isEmpty, let vm = tcfsViewModel {
+                            vm.saveConfig(
+                                endpoint: result.storageEndpoint,
+                                bucket: result.storageBucket,
+                                accessKey: result.accessKey,
+                                s3Secret: result.s3Secret,
+                                remotePrefix: result.remotePrefix.isEmpty ? "default" : result.remotePrefix,
+                                deviceId: result.deviceId.isEmpty
+                                    ? "ios-\(UIDevice.current.name.lowercased().replacingOccurrences(of: " ", with: "-"))"
+                                    : result.deviceId,
+                                passphrase: result.encryptionPassphrase,
+                                salt: result.encryptionSalt
+                            )
+                            authLogger.info("Credentials auto-configured from invite")
+                        }
                         self.saveKeychain("session_token", value: result.sessionToken)
                         self.authState = .authenticated
                         authLogger.info("Device enrolled via invite")

--- a/swift/ios/HostApp/HostApp.swift
+++ b/swift/ios/HostApp/HostApp.swift
@@ -69,7 +69,7 @@ struct TCFSApp: App {
             return
         }
 
-        authViewModel.processInviteData(dataParam)
+        authViewModel.processInviteData(dataParam, tcfsViewModel: viewModel)
         hostLogger.info("Enrollment invite processed via deep link")
     }
 }


### PR DESCRIPTION
## Summary
- Full-stack credential brokering: `tcfs device invite` embeds S3 credentials in the enrollment invite
- Admin's invite flows through daemon → UniFFI → iOS keychain automatically
- CLI loads real master key for HMAC signing (was hardcoded placeholder)
- New `EnrollmentResult` UniFFI record with all credential fields
- iOS auto-saves brokered credentials to keychain on invite scan

## Architecture
```
tcfs device invite → EnrollmentInvite(creds) → QR/deep link
  → iOS scan → UniFFI decode → EnrollmentResult(creds)
  → auto-save to keychain → FileProvider configured
```

## Files changed (7)
- `enrollment.rs`: S3 creds, bucket, prefix, encryption on EnrollmentInvite + EnrollmentResult
- `main.rs`: CLI loads master key, reads S3 creds from env/sops
- `tcfs.proto`: 6 new fields on DeviceEnrollResponse
- `grpc.rs`: handler passes invite credentials to response
- `uniffi_bridge.rs`: new EnrollmentResult record
- `AuthView.swift`: auto-save brokered creds to keychain
- `HostApp.swift`: pass viewModel through deep link handler

## Test plan
- [ ] `cargo check --workspace` passes (verified)
- [ ] `tcfs device invite` includes S3 credentials when env vars set
- [ ] iOS invite scan auto-populates keychain credentials
- [ ] FileProvider works after invite-based enrollment (no manual config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)