### PR TITLE
fix(ios): use build setting variables for version in Info.plist

### DIFF
--- a/swift/ios/Resources/Extension-Info.plist
+++ b/swift/ios/Resources/Extension-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/swift/ios/Resources/HostApp-Info.plist
+++ b/swift/ios/Resources/HostApp-Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/swift/ios/project.yml
+++ b/swift/ios/project.yml
@@ -13,7 +13,7 @@ settings:
     CODE_SIGN_IDENTITY: "Apple Distribution: John Sullivan (QP994XQKNH)"
     SWIFT_VERSION: "5.10"
     MARKETING_VERSION: "0.9.3"
-    CURRENT_PROJECT_VERSION: "6"
+    CURRENT_PROJECT_VERSION: "7"
 
 targets:
   TCFS:


### PR DESCRIPTION
## Summary
- Replace hardcoded `CFBundleVersion` ("1") and `CFBundleShortVersionString` ("1.0") with `$(CURRENT_PROJECT_VERSION)` and `$(MARKETING_VERSION)` build setting variables
- Bump build number to 7 for TestFlight upload
- Fixes: TestFlight upload fails with `ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE` because the IPA always contained version "1" regardless of project.yml setting

## Test plan
- [ ] xcodebuild archive produces IPA with CFBundleVersion=7
- [ ] TestFlight upload succeeds