### PR TITLE
fix(ios): add version + ATS to xcodegen properties

### DIFF
--- a/swift/ios/project.yml
+++ b/swift/ios/project.yml
@@ -28,7 +28,12 @@ targets:
       properties:
         CFBundleDisplayName: TCFS
         CFBundleIconName: AppIcon
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         UILaunchScreen: {}
+        NSAppTransportSecurity:
+          NSAllowsLocalNetworking: true
+          NSAllowsArbitraryLoads: true
         CFBundleURLTypes:
           - CFBundleURLName: "io.tinyland.tcfs"
             CFBundleURLSchemes:
@@ -72,6 +77,11 @@ targets:
       path: Resources/Extension-Info.plist
       properties:
         CFBundleDisplayName: TCFS FileProvider
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        NSAppTransportSecurity:
+          NSAllowsLocalNetworking: true
+          NSAllowsArbitraryLoads: true
         NSExtension:
           NSExtensionFileProviderDocumentGroup: group.io.tinyland.tcfs
           NSExtensionFileProviderSupportsDatalessFolders: true


### PR DESCRIPTION
## Summary
- Add `CFBundleVersion`, `CFBundleShortVersionString`, `NSAppTransportSecurity` to xcodegen `info.properties` sections
- xcodegen regenerates plists from project.yml, overwriting manual edits to the plist files
- This ensures version variables and ATS exception survive xcodegen runs

## Test plan
- [ ] `xcodegen generate` produces plist with `$(CURRENT_PROJECT_VERSION)` not `1`
- [ ] IPA contains correct version after full pipeline