### PR TITLE
chore(ios): auto-skip encryption compliance prompt

### DIFF
--- a/swift/ios/project.yml
+++ b/swift/ios/project.yml
@@ -31,6 +31,7 @@ targets:
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         UILaunchScreen: {}
+        ITSAppUsesNonExemptEncryption: false
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
           NSAllowsArbitraryLoads: true


### PR DESCRIPTION
Adds ITSAppUsesNonExemptEncryption=false to Info.plist properties so future builds don't require manual compliance confirmation.