### PR TITLE
fix(ios): auto-unlock keychain in pipeline for SSH

### DIFF
--- a/swift/ios/Scripts/xcode-pipeline.sh
+++ b/swift/ios/Scripts/xcode-pipeline.sh
@@ -63,6 +63,16 @@ if ! $SKIP_ARCHIVE; then
     clean_exec /opt/homebrew/bin/xcodegen generate
 fi
 
+# ── Keychain: unlock tcfs-build for codesigning from SSH ─────────────────
+TCFS_KEYCHAIN="$HOME/Library/Keychains/tcfs-build.keychain-db"
+if [ -f "$TCFS_KEYCHAIN" ]; then
+    echo "==> Unlocking tcfs-build keychain..."
+    security unlock-keychain -p "tcfs-build" "$TCFS_KEYCHAIN"
+    security set-key-partition-list -S "apple-tool:,apple:,codesign:" -s -k "tcfs-build" "$TCFS_KEYCHAIN" >/dev/null 2>&1 || true
+    security list-keychains -d user -s "$TCFS_KEYCHAIN" "$HOME/Library/Keychains/login.keychain-db"
+    security set-keychain-settings "$TCFS_KEYCHAIN"  # disable auto-lock
+fi
+
 # ── Step 2: Archive ──────────────────────────────────────────────────────
 if $SKIP_ARCHIVE; then
     if [ ! -d "$ARCHIVE_PATH" ]; then


### PR DESCRIPTION
## Summary
- Auto-unlock `tcfs-build.keychain-db` in `xcode-pipeline.sh` before archiving
- Sets partition list, disables auto-lock, and puts it first in search list
- Fixes `errSecInternalComponent` when building via SSH

## Test plan
- [ ] Build via SSH on PZM succeeds without manual keychain unlock