### PR TITLE
chore(ios): bump to v1.1.0 build 9

### DIFF
--- a/swift/ios/project.yml
+++ b/swift/ios/project.yml
@@ -12,8 +12,8 @@ settings:
     CODE_SIGN_STYLE: Manual
     CODE_SIGN_IDENTITY: "Apple Distribution: John Sullivan (QP994XQKNH)"
     SWIFT_VERSION: "5.10"
-    MARKETING_VERSION: "0.9.4"
-    CURRENT_PROJECT_VERSION: "8"
+    MARKETING_VERSION: "1.1.0"
+    CURRENT_PROJECT_VERSION: "9"
     GIT_COMMIT_SHA: "dev"
 
 targets:


### PR DESCRIPTION
## Summary
- Bump marketing version from 0.9.4 → 1.1.0 (> 1.0 so TestFlight shows it as latest)
- Bump build number to 9

TestFlight orders by semver — builds with version < 1.0 get listed as "Previous Builds" behind the 1.0 (5) build.