### PR TITLE
fix(tcfsd): skip directories in watcher push path

### DIFF
--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -310,6 +310,10 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                     Box::pin(async move {
                                         match task.op {
                                             tcfs_sync::scheduler::SyncOp::Push => {
+                                                // Skip directories — only push regular files
+                                                if task.path.is_dir() {
+                                                    return Ok(());
+                                                }
                                                 let op_guard = op.lock().await;
                                                 let op_ref =
                                                     op_guard.as_ref().ok_or_else(|| {


### PR DESCRIPTION
## Summary

The file watcher detected `~/tcfs/` itself as a change event and tried to Push the directory, failing with `chunking: /home/jess/tcfs`. Add `is_dir()` check at the top of `SyncOp::Push` to skip directories.

## Test plan

- [x] `cargo check -p tcfsd` passes
- [ ] Deploy to honey, verify no "chunking" errors on daemon restart