### PR TITLE
fix(nfs): use sudo for NFS mount on Linux

### DIFF
--- a/crates/tcfs-nfs/src/server.rs
+++ b/crates/tcfs-nfs/src/server.rs
@@ -167,8 +167,12 @@ async fn mount_nfs(port: u16, mountpoint: &Path) -> Result<()> {
             .await
             .context("executing mount_nfs")?
     } else {
-        // Linux: mount -t nfs
-        Command::new("mount")
+        // Linux: sudo mount -t nfs (requires sudoers rule for NFS loopback)
+        // Unprivileged users cannot call mount(2) directly; the sudoers rule
+        // in crush-dots/roles/common/tasks/system.yml grants NOPASSWD access
+        // for localhost NFS mounts only.
+        Command::new("sudo")
+            .arg("mount")
             .arg("-t")
             .arg("nfs")
             .arg("-o")
@@ -177,7 +181,7 @@ async fn mount_nfs(port: u16, mountpoint: &Path) -> Result<()> {
             .arg(mountpoint)
             .status()
             .await
-            .context("executing mount -t nfs")?
+            .context("executing sudo mount -t nfs")?
     };
 
     if !status.success() {

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -310,6 +310,10 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                     Box::pin(async move {
                                         match task.op {
                                             tcfs_sync::scheduler::SyncOp::Push => {
+                                                // Skip directories — only push regular files
+                                                if task.path.is_dir() {
+                                                    return Ok(());
+                                                }
                                                 let op_guard = op.lock().await;
                                                 let op_ref =
                                                     op_guard.as_ref().ok_or_else(|| {


### PR DESCRIPTION
## Summary
- Use `sudo mount -t nfs` on Linux instead of unprivileged `mount -t nfs`
- Unprivileged mount silently fails, leaving NFS server running but no actual mount
- macOS unaffected (uses mount_nfs which works without elevation)

## Requires
Sudoers rule deployed via crush-dots Ansible (roles/common/tasks/system.yml):
```
user ALL=(root) NOPASSWD: /usr/bin/mount -t nfs -o tcp,vers=3,noacl,nolock,port=* 127.0.0.1:/ *
```

## Test plan
- [ ] Deploy sudoers rule to honey/yoga via `just deploy <host> common`
- [ ] Update flake.lock + nix-switch to get new binary
- [ ] Verify `mountpoint -q ~/tcfs` returns true after daemon restart