### PR TITLE
fix(nfs): add diagnostic logging for NFS server exit

### DIFF
--- a/crates/tcfs-nfs/src/server.rs
+++ b/crates/tcfs-nfs/src/server.rs
@@ -115,7 +115,16 @@ pub async fn serve_and_mount(cfg: NfsMountConfig) -> Result<()> {
     });
 
     // Block forever serving NFS requests
-    listener.handle_forever().await?;
+    info!("NFS server entering handle_forever loop");
+    match listener.handle_forever().await {
+        Ok(()) => {
+            warn!("NFS handle_forever returned Ok (unexpected — should loop forever)");
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "NFS handle_forever exited with error");
+            return Err(anyhow::anyhow!("NFS server loop exited: {}", e));
+        }
+    }
 
     Ok(())
 }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -349,7 +349,8 @@ impl TcfsDaemon for TcfsDaemonImpl {
         // loss, and the process dying before the wrapper can sudo-retry the
         // mount command.
         tokio::spawn(async move {
-            if let Err(e) = tcfs_nfs::serve_and_mount(tcfs_nfs::NfsMountConfig {
+            tracing::info!("NFS mount task starting (prefix={prefix})");
+            match tcfs_nfs::serve_and_mount(tcfs_nfs::NfsMountConfig {
                 op,
                 prefix,
                 mountpoint: mp,
@@ -360,11 +361,16 @@ impl TcfsDaemon for TcfsDaemonImpl {
             })
             .await
             {
-                tracing::error!(error = %e, "in-process NFS mount failed");
-                // Remove from active mounts on failure
-                let mut mounts = active_mounts.lock().await;
-                mounts.remove(&mountpoint_key);
+                Ok(()) => {
+                    tracing::warn!("NFS serve_and_mount returned Ok (server stopped)");
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, error_debug = ?e, "in-process NFS mount failed");
+                }
             }
+            // Remove from active mounts on exit
+            let mut mounts = active_mounts.lock().await;
+            mounts.remove(&mountpoint_key);
         });
 
         // Give the NFS server a moment to bind + mount


### PR DESCRIPTION
Adds tracing to diagnose why NFS handle_forever exits silently on Linux. serve_and_mount was returning without any log output.