### PR TITLE
feat(mount): resurrect FUSE3 as default, NFS as fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/tcfs-crypto",
     "crates/tcfs-sync",
     "crates/tcfs-vfs",
+    "crates/tcfs-fuse",
     "crates/tcfs-nfs",
     "crates/tcfs-cloudfilter",
     "crates/tcfs-sops",

--- a/crates/tcfs-cli/Cargo.toml
+++ b/crates/tcfs-cli/Cargo.toml
@@ -18,6 +18,7 @@ tcfs-sync = { path = "../tcfs-sync" }
 tcfs-chunks = { path = "../tcfs-chunks" }
 tcfs-vfs = { path = "../tcfs-vfs" }
 tcfs-nfs = { path = "../tcfs-nfs" }
+tcfs-fuse = { path = "../tcfs-fuse", features = ["fuse"] }
 tcfs-crypto = { path = "../tcfs-crypto" }
 tcfs-auth = { path = "../tcfs-auth" }
 qrcode = "0.14"

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1329,7 +1329,7 @@ async fn cmd_mount(
     );
 
     if use_nfs {
-        // NFS loopback mount — no kernel modules required
+        // NFS loopback mount (fallback — use --nfs flag)
         tcfs_nfs::serve_and_mount(tcfs_nfs::NfsMountConfig {
             op,
             prefix,
@@ -1342,19 +1342,19 @@ async fn cmd_mount(
         .await
         .context("NFS mount failed")
     } else {
-        // FUSE has been retired — NFS is the only mount backend.
-        // Use NFS mount for all cases.
-        tcfs_nfs::serve_and_mount(tcfs_nfs::NfsMountConfig {
+        // FUSE3 mount (default — unprivileged via fusermount3)
+        tcfs_fuse::mount(tcfs_fuse::MountConfig {
             op,
             prefix,
             mountpoint: mountpoint.to_path_buf(),
             cache_dir,
             cache_max_bytes: cache_max,
             negative_ttl_secs: neg_ttl,
-            port: nfs_port,
+            read_only: read_only,
+            allow_other: false,
         })
         .await
-        .context("NFS mount failed")
+        .context("FUSE mount failed")
     }
 }
 

--- a/crates/tcfs-fuse/Cargo.toml
+++ b/crates/tcfs-fuse/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tcfs-fuse"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "tcfs FUSE filesystem driver (Linux)"
+
+[dependencies]
+tcfs-vfs = { path = "../tcfs-vfs" }
+opendal = { workspace = true }
+fuse3 = { version = "0.8", features = ["tokio-runtime", "unprivileged"], optional = true }
+libc = { version = "0.2", optional = true }
+bytes = { version = "1", optional = true }
+futures-util = { version = "0.3", optional = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+
+[features]
+default = []
+fuse = ["dep:fuse3", "dep:libc", "dep:bytes", "dep:futures-util"]

--- a/crates/tcfs-fuse/src/driver.rs
+++ b/crates/tcfs-fuse/src/driver.rs
@@ -1,0 +1,397 @@
+//! FUSE mount adapter: translates fuse3 `PathFilesystem` calls to
+//! `tcfs_vfs::VirtualFilesystem`.
+//!
+//! This is a thin protocol adapter. All filesystem logic lives in `tcfs-vfs`.
+//! VFS calls are wrapped with 10s timeouts to prevent mount hangs when the
+//! S3 backend is slow or unreachable.
+
+use std::ffi::OsStr;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use fuse3::path::prelude::*;
+use fuse3::{Errno, FileType, MountOptions};
+use futures_util::stream;
+use opendal::Operator;
+use tracing::{debug, info, warn};
+
+use tcfs_vfs::types::VfsFileType;
+use tcfs_vfs::{TcfsVfs, VfsAttr, VirtualFilesystem};
+
+// ── Configuration ─────────────────────────────────────────────────────────
+
+/// TTL for positive dentry/attr cache entries (FUSE kernel cache)
+const ATTR_TTL: Duration = Duration::from_secs(5);
+
+/// Timeout for VFS/S3 operations. Prevents mount from hanging when the
+/// S3 backend is slow or unreachable.
+const VFS_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ── TcfsFs ────────────────────────────────────────────────────────────────
+
+/// The FUSE filesystem driver — thin wrapper around `TcfsVfs`.
+pub struct TcfsFs {
+    vfs: Arc<TcfsVfs>,
+}
+
+impl TcfsFs {
+    pub fn new(vfs: Arc<TcfsVfs>) -> Self {
+        TcfsFs { vfs }
+    }
+}
+
+/// Convert VfsAttr to fuse3 FileAttr.
+fn to_fuse_attr(attr: &VfsAttr) -> FileAttr {
+    FileAttr {
+        size: attr.size,
+        blocks: attr.blocks,
+        atime: attr.atime,
+        mtime: attr.mtime,
+        ctime: attr.ctime,
+        kind: match attr.kind {
+            VfsFileType::RegularFile => FileType::RegularFile,
+            VfsFileType::Directory => FileType::Directory,
+        },
+        perm: attr.perm,
+        nlink: attr.nlink,
+        uid: attr.uid,
+        gid: attr.gid,
+        rdev: 0,
+        blksize: 4096,
+        #[cfg(target_os = "macos")]
+        crtime: attr.mtime,
+        #[cfg(target_os = "macos")]
+        flags: 0,
+    }
+}
+
+fn to_fuse_file_type(kind: VfsFileType) -> FileType {
+    match kind {
+        VfsFileType::RegularFile => FileType::RegularFile,
+        VfsFileType::Directory => FileType::Directory,
+    }
+}
+
+// ── PathFilesystem impl ────────────────────────────────────────────────────
+
+impl PathFilesystem for TcfsFs {
+    async fn init(&self, _req: Request) -> fuse3::Result<ReplyInit> {
+        debug!("tcfs-fuse init");
+        Ok(ReplyInit {
+            max_write: NonZeroU32::new(128 * 1024).unwrap(),
+        })
+    }
+
+    async fn destroy(&self, _req: Request) {
+        debug!("tcfs-fuse destroy");
+    }
+
+    async fn getattr(
+        &self,
+        _req: Request,
+        path: Option<&OsStr>,
+        _fh: Option<u64>,
+        _flags: u32,
+    ) -> fuse3::Result<ReplyAttr> {
+        let path_str = path.and_then(|p| p.to_str()).unwrap_or("/");
+
+        let attr = tokio::time::timeout(VFS_TIMEOUT, self.vfs.getattr(path_str))
+            .await
+            .map_err(|_| {
+                warn!(path = %path_str, "FUSE GETATTR timed out");
+                Errno::from(libc::EIO)
+            })?
+            .map_err(|_| Errno::from(libc::ENOENT))?;
+
+        Ok(ReplyAttr {
+            ttl: ATTR_TTL,
+            attr: to_fuse_attr(&attr),
+        })
+    }
+
+    async fn lookup(
+        &self,
+        _req: Request,
+        parent: &OsStr,
+        name: &OsStr,
+    ) -> fuse3::Result<ReplyEntry> {
+        let parent_str = parent.to_str().unwrap_or("/");
+        let child_attr = tokio::time::timeout(VFS_TIMEOUT, self.vfs.lookup(parent_str, name))
+            .await
+            .map_err(|_| {
+                warn!(parent = %parent_str, name = ?name, "FUSE LOOKUP timed out");
+                Errno::from(libc::EIO)
+            })?
+            .map_err(|_| Errno::from(libc::ENOENT))?;
+
+        Ok(ReplyEntry {
+            ttl: ATTR_TTL,
+            attr: to_fuse_attr(&child_attr),
+        })
+    }
+
+    type DirEntryStream<'a>
+        = futures_util::stream::Iter<std::vec::IntoIter<fuse3::Result<DirectoryEntry>>>
+    where
+        Self: 'a;
+
+    async fn readdir(
+        &self,
+        _req: Request,
+        path: &OsStr,
+        _fh: u64,
+        offset: i64,
+    ) -> fuse3::Result<ReplyDirectory<Self::DirEntryStream<'_>>> {
+        let path_str = path.to_str().unwrap_or("/");
+
+        let vfs_entries = tokio::time::timeout(VFS_TIMEOUT, self.vfs.readdir(path_str))
+            .await
+            .map_err(|_| {
+                warn!(path = %path_str, "FUSE READDIR timed out");
+                Errno::from(libc::EIO)
+            })?
+            .map_err(|_| Errno::from(libc::EIO))?;
+
+        let mut entries: Vec<fuse3::Result<DirectoryEntry>> = Vec::new();
+
+        if offset == 0 {
+            entries.push(Ok(DirectoryEntry {
+                kind: FileType::Directory,
+                name: ".".into(),
+                offset: 1,
+            }));
+        }
+        if offset <= 1 {
+            entries.push(Ok(DirectoryEntry {
+                kind: FileType::Directory,
+                name: "..".into(),
+                offset: 2,
+            }));
+        }
+
+        let mut next_offset = 3i64;
+        for vfs_entry in vfs_entries {
+            if next_offset > offset {
+                entries.push(Ok(DirectoryEntry {
+                    kind: to_fuse_file_type(vfs_entry.kind),
+                    name: vfs_entry.name.into(),
+                    offset: next_offset,
+                }));
+            }
+            next_offset += 1;
+        }
+
+        Ok(ReplyDirectory {
+            entries: stream::iter(entries),
+        })
+    }
+
+    type DirEntryPlusStream<'a>
+        = futures_util::stream::Iter<std::vec::IntoIter<fuse3::Result<DirectoryEntryPlus>>>
+    where
+        Self: 'a;
+
+    async fn readdirplus(
+        &self,
+        _req: Request,
+        parent: &OsStr,
+        _fh: u64,
+        offset: u64,
+        _lock_owner: u64,
+    ) -> fuse3::Result<ReplyDirectoryPlus<Self::DirEntryPlusStream<'_>>> {
+        let path_str = parent.to_str().unwrap_or("/");
+        let offset = offset as i64;
+
+        let vfs_entries = tokio::time::timeout(VFS_TIMEOUT, self.vfs.readdirplus(path_str))
+            .await
+            .map_err(|_| {
+                warn!(path = %path_str, "FUSE READDIRPLUS timed out");
+                Errno::from(libc::EIO)
+            })?
+            .map_err(|_| Errno::from(libc::EIO))?;
+
+        let dir_attr = self
+            .vfs
+            .getattr("/")
+            .await
+            .map(|a| to_fuse_attr(&a))
+            .unwrap_or_else(|_| to_fuse_attr(&VfsAttr::dir(0, 0, std::time::SystemTime::now())));
+
+        let mut entries: Vec<fuse3::Result<DirectoryEntryPlus>> = Vec::new();
+
+        if offset == 0 {
+            entries.push(Ok(DirectoryEntryPlus {
+                kind: FileType::Directory,
+                name: ".".into(),
+                offset: 1,
+                attr: dir_attr,
+                entry_ttl: ATTR_TTL,
+                attr_ttl: ATTR_TTL,
+            }));
+        }
+        if offset <= 1 {
+            entries.push(Ok(DirectoryEntryPlus {
+                kind: FileType::Directory,
+                name: "..".into(),
+                offset: 2,
+                attr: dir_attr,
+                entry_ttl: ATTR_TTL,
+                attr_ttl: ATTR_TTL,
+            }));
+        }
+
+        let mut next_offset = 3i64;
+        for vfs_entry in vfs_entries {
+            if next_offset > offset {
+                let attr = match vfs_entry.attr {
+                    Some(ref a) => to_fuse_attr(a),
+                    None => dir_attr,
+                };
+                entries.push(Ok(DirectoryEntryPlus {
+                    kind: to_fuse_file_type(vfs_entry.kind),
+                    name: vfs_entry.name.into(),
+                    offset: next_offset,
+                    attr,
+                    entry_ttl: ATTR_TTL,
+                    attr_ttl: ATTR_TTL,
+                }));
+            }
+            next_offset += 1;
+        }
+
+        Ok(ReplyDirectoryPlus {
+            entries: stream::iter(entries),
+        })
+    }
+
+    async fn opendir(&self, _req: Request, _path: &OsStr, _flags: u32) -> fuse3::Result<ReplyOpen> {
+        Ok(ReplyOpen { fh: 0, flags: 0 })
+    }
+
+    async fn open(&self, _req: Request, path: &OsStr, _flags: u32) -> fuse3::Result<ReplyOpen> {
+        let path_str = path.to_str().ok_or(Errno::from(libc::ENOENT))?;
+
+        let (fh, _data) = tokio::time::timeout(VFS_TIMEOUT, self.vfs.open(path_str))
+            .await
+            .map_err(|_| {
+                warn!(path = %path_str, "FUSE OPEN timed out");
+                Errno::from(libc::EIO)
+            })?
+            .map_err(|_| Errno::from(libc::ENOENT))?;
+
+        Ok(ReplyOpen { fh, flags: 0 })
+    }
+
+    async fn read(
+        &self,
+        _req: Request,
+        _path: Option<&OsStr>,
+        fh: u64,
+        offset: u64,
+        size: u32,
+    ) -> fuse3::Result<ReplyData> {
+        let data = self
+            .vfs
+            .read(fh, offset, size)
+            .await
+            .map_err(|_| Errno::from(libc::EBADF))?;
+
+        Ok(ReplyData {
+            data: Bytes::from(data),
+        })
+    }
+
+    async fn release(
+        &self,
+        _req: Request,
+        _path: Option<&OsStr>,
+        fh: u64,
+        _flags: u32,
+        _lock_owner: u64,
+        _flush: bool,
+    ) -> fuse3::Result<()> {
+        self.vfs
+            .release(fh)
+            .await
+            .map_err(|_| Errno::from(libc::EIO))
+    }
+
+    async fn flush(
+        &self,
+        _req: Request,
+        _path: Option<&OsStr>,
+        _fh: u64,
+        _lock_owner: u64,
+    ) -> fuse3::Result<()> {
+        Ok(())
+    }
+
+    async fn statfs(&self, _req: Request, _path: &OsStr) -> fuse3::Result<ReplyStatFs> {
+        let stats = tokio::time::timeout(VFS_TIMEOUT, self.vfs.statfs())
+            .await
+            .map_err(|_| {
+                warn!("FUSE STATFS timed out");
+                Errno::from(libc::EIO)
+            })?
+            .map_err(|_| Errno::from(libc::EIO))?;
+
+        Ok(ReplyStatFs {
+            blocks: stats.blocks,
+            bfree: stats.bfree,
+            bavail: stats.bavail,
+            files: stats.files,
+            ffree: stats.ffree,
+            bsize: stats.bsize,
+            namelen: stats.namelen,
+            frsize: stats.frsize,
+        })
+    }
+}
+
+// ── Public mount API ──────────────────────────────────────────────────────
+
+/// Mount configuration
+pub struct MountConfig {
+    pub op: Operator,
+    pub prefix: String,
+    pub mountpoint: std::path::PathBuf,
+    pub cache_dir: std::path::PathBuf,
+    pub cache_max_bytes: u64,
+    pub negative_ttl_secs: u64,
+    pub read_only: bool,
+    pub allow_other: bool,
+}
+
+/// Mount the FUSE filesystem and block until unmounted.
+///
+/// Creates a `TcfsVfs` and wraps it with the FUSE `PathFilesystem` adapter.
+/// Uses `mount_with_unprivileged` which invokes `fusermount3` — no root needed.
+pub async fn mount(cfg: MountConfig) -> std::io::Result<()> {
+    let vfs = Arc::new(TcfsVfs::new(
+        cfg.op,
+        cfg.prefix,
+        cfg.cache_dir,
+        cfg.cache_max_bytes,
+        Duration::from_secs(cfg.negative_ttl_secs),
+    ));
+
+    let fs = TcfsFs::new(vfs);
+
+    let mut opts = MountOptions::default();
+    opts.fs_name("tcfs");
+    opts.read_only(cfg.read_only);
+    opts.force_readdir_plus(true);
+    if cfg.allow_other {
+        opts.allow_other(true);
+    }
+
+    info!(mountpoint = %cfg.mountpoint.display(), "mounting tcfs via FUSE3 (unprivileged)");
+
+    let handle = Session::new(opts)
+        .mount_with_unprivileged(fs, &cfg.mountpoint)
+        .await?;
+
+    handle.await
+}

--- a/crates/tcfs-fuse/src/lib.rs
+++ b/crates/tcfs-fuse/src/lib.rs
@@ -1,0 +1,13 @@
+//! tcfs-fuse: FUSE3 mount adapter for `tcfs-vfs::VirtualFilesystem`.
+//!
+//! Presents SeaweedFS files as a local FUSE mount. All filesystem operations
+//! are delegated to `tcfs-vfs::TcfsVfs` via the `VirtualFilesystem` trait.
+//!
+//! Uses `fuse3` crate with `unprivileged` feature — mounts via `fusermount3`
+//! without needing root. No kernel modules beyond the built-in FUSE module.
+
+#[cfg(feature = "fuse")]
+pub mod driver;
+
+#[cfg(feature = "fuse")]
+pub use driver::{mount, MountConfig};

--- a/crates/tcfsd/Cargo.toml
+++ b/crates/tcfsd/Cargo.toml
@@ -18,6 +18,7 @@ tcfs-storage = { path = "../tcfs-storage" }
 tcfs-sync = { path = "../tcfs-sync", features = ["nats"] }
 tcfs-vfs = { path = "../tcfs-vfs" }
 tcfs-nfs = { path = "../tcfs-nfs" }
+tcfs-fuse = { path = "../tcfs-fuse", features = ["fuse"] }
 tcfs-auth = { path = "../tcfs-auth", features = ["totp", "webauthn"] }
 opendal = { workspace = true }
 async-nats = { workspace = true }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -342,68 +342,75 @@ impl TcfsDaemon for TcfsDaemonImpl {
         let cache_max = self.config.fuse.cache_max_mb as u64 * 1024 * 1024;
         let neg_ttl = self.config.fuse.negative_cache_ttl_secs;
         let mountpoint_key = req.mountpoint.clone();
-        let active_mounts = self.active_mounts.clone();
-
-        // Start NFS server in-process (tokio task) instead of spawning a
-        // subprocess.  This avoids the recursive gRPC mount call, credential
-        // loss, and the process dying before the wrapper can sudo-retry the
-        // mount command.
-        let nfs_handle = tokio::spawn(async move {
-            tracing::info!("NFS mount task starting (prefix={prefix})");
-            match tcfs_nfs::serve_and_mount(tcfs_nfs::NfsMountConfig {
-                op,
-                prefix,
-                mountpoint: mp,
-                port: 0, // auto-assign
-                cache_dir: std::path::PathBuf::from(&cache_dir),
-                cache_max_bytes: cache_max,
-                negative_ttl_secs: neg_ttl,
-            })
-            .await
-            {
-                Ok(()) => {
-                    tracing::warn!("NFS serve_and_mount returned Ok (server stopped)");
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, error_debug = ?e, "in-process NFS mount failed");
-                }
-            }
-        });
-
-        // Monitor the NFS task in a separate watcher so we detect panics
         let active_mounts_watcher = self.active_mounts.clone();
-        let mountpoint_key_watcher = req.mountpoint.clone();
-        tokio::spawn(async move {
-            match nfs_handle.await {
-                Ok(()) => {
-                    tracing::warn!("NFS task exited normally");
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "NFS task PANICKED: {e}");
-                }
-            }
-            let mut mounts = active_mounts_watcher.lock().await;
-            mounts.remove(&mountpoint_key_watcher);
-        });
 
-        // Give the NFS server a moment to bind + mount
+        if use_nfs {
+            // NFS loopback (fallback — use --nfs flag or "nfs" option)
+            let mount_handle = tokio::spawn(async move {
+                tracing::info!("NFS mount task starting (prefix={prefix})");
+                match tcfs_nfs::serve_and_mount(tcfs_nfs::NfsMountConfig {
+                    op,
+                    prefix,
+                    mountpoint: mp,
+                    port: 0,
+                    cache_dir: std::path::PathBuf::from(&cache_dir),
+                    cache_max_bytes: cache_max,
+                    negative_ttl_secs: neg_ttl,
+                })
+                .await
+                {
+                    Ok(()) => tracing::warn!("NFS serve_and_mount returned Ok"),
+                    Err(e) => tracing::error!(error = %e, "NFS mount failed"),
+                }
+            });
+
+            let mk = mountpoint_key.clone();
+            tokio::spawn(async move {
+                let _ = mount_handle.await;
+                active_mounts_watcher.lock().await.remove(&mk);
+            });
+        } else {
+            // FUSE3 (default — unprivileged mount via fusermount3)
+            let mount_handle = tokio::spawn(async move {
+                tracing::info!("FUSE mount task starting (prefix={prefix})");
+                match tcfs_fuse::mount(tcfs_fuse::MountConfig {
+                    op,
+                    prefix,
+                    mountpoint: mp,
+                    cache_dir: std::path::PathBuf::from(&cache_dir),
+                    cache_max_bytes: cache_max,
+                    negative_ttl_secs: neg_ttl,
+                    read_only: true,
+                    allow_other: false,
+                })
+                .await
+                {
+                    Ok(()) => tracing::info!("FUSE mount unmounted cleanly"),
+                    Err(e) => tracing::error!(error = %e, "FUSE mount failed"),
+                }
+            });
+
+            let mk = mountpoint_key.clone();
+            tokio::spawn(async move {
+                let _ = mount_handle.await;
+                active_mounts_watcher.lock().await.remove(&mk);
+            });
+        }
+
+        // Give the mount a moment to establish
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-        // Record as active (no Child to track — it's an in-process task)
+        // Record as active
         {
-            // Use a dummy Child (PID 0) since we're in-process now.
-            // The active_mounts map is only used for "already mounted" checks.
             let mut mounts = self.active_mounts.lock().await;
-            // Only insert if not already there (the spawned task may have failed fast)
             mounts.entry(req.mountpoint.clone()).or_insert_with(|| {
-                // Dummy process — `cat` exits immediately, we just need a Child value
                 tokio::process::Command::new("sleep")
                     .arg("infinity")
                     .stdin(std::process::Stdio::null())
                     .stdout(std::process::Stdio::null())
                     .stderr(std::process::Stdio::null())
                     .spawn()
-                    .expect("spawn sleep sentinel")
+                    .expect("spawn sentinel")
             });
         }
 


### PR DESCRIPTION
## Summary
- Resurrects `tcfs-fuse` crate from git history with VFS timeouts
- FUSE3 becomes default mount backend (no sudo, no ports, no S3 during mount)
- NFS loopback preserved as `--nfs` fallback
- Resolves the 4-layer NFS mount debugging saga (PRs #90-#94)

## Test plan
- [x] `cargo check -p tcfs-fuse -p tcfsd -p tcfs-cli` passes
- [ ] Deploy to honey, verify `mountpoint ~/tcfs`
- [ ] `ls ~/tcfs/` shows SeaweedFS content