### PR TITLE
fix: add missing serde_json to Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5494,6 +5494,7 @@ dependencies = [
  "libc",
  "opendal",
  "serde",
+ "serde_json",
  "tcfs-core",
  "tcfs-storage",
  "tempfile",


### PR DESCRIPTION
PR #101 added serde_json to tcfs-vfs/Cargo.toml but Cargo.lock wasn't regenerated. Breaks --locked builds.