### PR TITLE
fix: add blake3 to Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,9 +4996,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -5491,6 +5491,7 @@ version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "blake3",
  "libc",
  "opendal",
  "serde",
@@ -6471,9 +6472,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",


### PR DESCRIPTION
PR #106 added blake3 to tcfs-vfs but Cargo.lock wasn't regenerated.