### PR TITLE
feat(vfs): FastCDC chunking for FUSE writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,9 +4996,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -5491,6 +5491,7 @@ version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "blake3",
  "libc",
  "opendal",
  "serde",
@@ -6471,9 +6472,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5496,6 +5496,7 @@ dependencies = [
  "opendal",
  "serde",
  "serde_json",
+ "tcfs-chunks",
  "tcfs-core",
  "tcfs-storage",
  "tempfile",

--- a/crates/tcfs-vfs/Cargo.toml
+++ b/crates/tcfs-vfs/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 blake3 = { workspace = true }
+tcfs-chunks = { path = "../tcfs-chunks" }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tcfs-vfs/src/driver.rs
+++ b/crates/tcfs-vfs/src/driver.rs
@@ -104,33 +104,44 @@ impl TcfsVfs {
 
     /// Flush modified file content to SeaweedFS (index + manifest + chunks).
     ///
-    /// This is the reverse of hydration: takes in-memory bytes, chunks them,
-    /// uploads to S3, creates a JSON v2 manifest, and updates the index entry.
+    /// Uses FastCDC content-defined chunking for deduplication. Small files
+    /// (<4KB) produce a single chunk; larger files are split at content
+    /// boundaries for efficient cross-file dedup.
     async fn flush_to_remote(&self, vpath: &str, data: &[u8]) -> Result<()> {
         use tracing::info;
 
         let prefix = self.prefix.trim_end_matches('/');
 
-        // 1. Compute BLAKE3 content hash (matches sync engine)
-        let chunk_hash = blake3::hash(data).to_hex().to_string();
-        let chunk_key = format!("{}/chunks/{}", prefix, chunk_hash);
-        self.op
-            .write(&chunk_key, data.to_vec())
-            .await
-            .context("uploading chunk")?;
+        // 1. Chunk the data using FastCDC (content-defined boundaries)
+        let sizes = tcfs_chunks::ChunkSizes::for_path(std::path::Path::new(vpath));
+        let chunks = tcfs_chunks::chunk_data(data, sizes);
+        let file_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(data));
+
+        // 2. Upload each chunk (dedup: same content hash = same chunk)
+        let mut chunk_hashes = Vec::with_capacity(chunks.len());
+        for chunk in &chunks {
+            let chunk_data = &data[chunk.offset as usize..chunk.offset as usize + chunk.length];
+            let chunk_hex = tcfs_chunks::hash_to_hex(&chunk.hash);
+            let chunk_key = format!("{}/chunks/{}", prefix, chunk_hex);
+            self.op
+                .write(&chunk_key, chunk_data.to_vec())
+                .await
+                .with_context(|| format!("uploading chunk {}", chunk_hex))?;
+            chunk_hashes.push(chunk_hex);
+        }
 
         // 3. Create JSON v2 manifest
         let manifest = serde_json::json!({
             "version": 2,
-            "file_hash": chunk_hash,
+            "file_hash": file_hash,
             "file_size": data.len(),
-            "chunks": [chunk_hash],
+            "chunks": chunk_hashes,
             "written_at": std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
         });
-        let manifest_key = format!("{}/manifests/{}", prefix, chunk_hash);
+        let manifest_key = format!("{}/manifests/{}", prefix, file_hash);
         self.op
             .write(&manifest_key, manifest.to_string().into_bytes())
             .await
@@ -141,9 +152,10 @@ impl TcfsVfs {
             .index_key_for(vpath)
             .context("cannot compute index key")?;
         let index_content = format!(
-            "manifest_hash={}\nsize={}\nchunks=1\n",
-            chunk_hash,
-            data.len()
+            "manifest_hash={}\nsize={}\nchunks={}\n",
+            file_hash,
+            data.len(),
+            chunk_hashes.len()
         );
         self.op
             .write(&index_key, index_content.into_bytes())
@@ -153,6 +165,7 @@ impl TcfsVfs {
         info!(
             path = %vpath,
             bytes = data.len(),
+            chunks = chunk_hashes.len(),
             manifest = %manifest_key,
             "flushed to SeaweedFS"
         );


### PR DESCRIPTION
Replaces single-chunk upload with FastCDC content-defined chunking. Enables dedup for large files.