### PR TITLE
fix(sync): prevent orphaned index entries on skipped uploads

### DIFF
--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -702,20 +702,21 @@ pub async fn push_tree_with_device(
         .await
         {
             Ok(result) => {
-                // Write index entry: maps relative path → manifest hash + metadata.
-                // This allows the FUSE driver to list files by original name.
-                let index_key = format!("{}/index/{}", remote_path_prefix(remote_prefix), rel_str);
-                let index_entry = format!(
-                    "manifest_hash={}\nsize={}\nchunks={}\n",
-                    result.hash, result.bytes, result.chunks
-                );
-                if let Err(e) = op.write(&index_key, index_entry.into_bytes()).await {
-                    warn!(path = %path.display(), "failed to write index entry: {e}");
-                }
-
                 if result.skipped {
                     skipped += 1;
                 } else {
+                    // Write index entry only when the manifest was actually uploaded.
+                    // Skipped files (RemoteNewer, UpToDate, Conflict) already have
+                    // a valid index entry, and writing one with the local hash would
+                    // create an orphan pointing to a non-existent manifest.
+                    let index_key = format!("{}/index/{}", remote_path_prefix(remote_prefix), rel_str);
+                    let index_entry = format!(
+                        "manifest_hash={}\nsize={}\nchunks={}\n",
+                        result.hash, result.bytes, result.chunks
+                    );
+                    if let Err(e) = op.write(&index_key, index_entry.into_bytes()).await {
+                        warn!(path = %path.display(), "failed to write index entry: {e}");
+                    }
                     uploaded += 1;
                     bytes += result.bytes;
                 }


### PR DESCRIPTION
## Summary
- Only write index entries when the manifest was actually uploaded (`!result.skipped`)
- Fixes bug where RemoteNewer/UpToDate/Conflict results wrote index entries using the local file hash, but the manifest was never uploaded
- Prevents orphans that cause FUSE hydration failures (404 NotFound)

## Root Cause
When `upload_file_with_device` returns `RemoteNewer` (remote version is newer, skip upload):
1. Local file has hash A (different from remote hash B)
2. Function returns `Ok(UploadResult { hash: A, skipped: true })`
3. `push_tree_with_device` writes index entry with `manifest_hash=A`
4. But manifest `{prefix}/manifests/A` was never written (upload was skipped)
5. Result: orphaned index entry pointing to non-existent manifest

## Impact
- Current S3 state: 4,097 index entries vs 3,968 manifests (~129 orphans, 3.1%)
- Affected files fail FUSE hydration: `cat ~/tcfs/CLAUDE.md` → ENOENT
- All orphans from the initial bulk `push_tree` where some manifest uploads failed

## Fix
Move index write inside `!result.skipped` branch. Index entries now only written when:
- Manifest was successfully uploaded in this invocation
- NOT written for: RemoteNewer, UpToDate, Conflict (these already have correct index entries)

## Test Plan
- [x] `cargo check -p tcfs-sync` — compiles clean
- [ ] Deploy to fleet, re-push sync_root from yoga to regenerate missing manifests
- [ ] Verify all 4,097 files hydrate correctly after re-push
- [ ] Monitor future pushes to ensure no new orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)