### PR TITLE
fix(flake): remove stale fuse-t feature flag for Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,8 +83,7 @@
         tcfsd = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
           pname = "tcfsd";
-          cargoExtraArgs = "-p tcfsd"
-            + pkgs.lib.optionalString pkgs.stdenv.isDarwin " --features fuse-t";
+          cargoExtraArgs = "-p tcfsd";
           meta.mainProgram = "tcfsd";
         });
 


### PR DESCRIPTION
## Problem

Darwin builds failing with:
```
error: the package 'tcfsd' does not contain this feature: fuse-t
```

## Root Cause

The `fuse-t` feature was removed from `crates/tcfsd/Cargo.toml` during FSkit transition (native macOS FUSE support), but `flake.nix` line 87 still tried to enable it for Darwin builds.

## Fix

Remove the stale feature flag:
```diff
- cargoExtraArgs = "-p tcfsd"
-   + pkgs.lib.optionalString pkgs.stdenv.isDarwin " --features fuse-t";
+ cargoExtraArgs = "-p tcfsd";
```

## Impact

**Before**: All Darwin hosts blocked (petting-zoo-mini, xoxd-bates, macbook-neo)
**After**: Darwin builds work, can deploy TCFS 0.9.1 + PRs #113/#114

## Testing

- [ ] Nix build on Darwin succeeds
- [ ] Deploy to petting-zoo-mini confirms TCFS 0.9.1