### PR TITLE
feat(vfs): wire vector clock conflict detection into FUSE writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5499,6 +5499,7 @@ dependencies = [
  "tcfs-chunks",
  "tcfs-core",
  "tcfs-storage",
+ "tcfs-sync",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1353,6 +1353,8 @@ async fn cmd_mount(
             read_only: read_only,
             allow_other: false,
             on_flush: None,
+            device_id: std::env::var("HOSTNAME")
+                .unwrap_or_else(|_| "cli".to_string()),
         })
         .await
         .context("FUSE mount failed")

--- a/crates/tcfs-fuse/src/driver.rs
+++ b/crates/tcfs-fuse/src/driver.rs
@@ -502,6 +502,8 @@ pub struct MountConfig {
     pub allow_other: bool,
     /// Optional callback after file flush (e.g., NATS publish)
     pub on_flush: Option<tcfs_vfs::OnFlushCallback>,
+    /// Device identifier for vector clock tracking (e.g., hostname)
+    pub device_id: String,
 }
 
 /// Mount the FUSE filesystem and block until unmounted.
@@ -515,6 +517,7 @@ pub async fn mount(cfg: MountConfig) -> std::io::Result<()> {
         cfg.cache_dir,
         cfg.cache_max_bytes,
         Duration::from_secs(cfg.negative_ttl_secs),
+        cfg.device_id,
     );
     if let Some(cb) = cfg.on_flush {
         vfs.set_on_flush(cb);

--- a/crates/tcfs-nfs/src/server.rs
+++ b/crates/tcfs-nfs/src/server.rs
@@ -87,6 +87,7 @@ pub async fn serve_and_mount(cfg: NfsMountConfig) -> Result<()> {
         cfg.cache_dir,
         cfg.cache_max_bytes,
         Duration::from_secs(cfg.negative_ttl_secs),
+        String::new(), // NFS adapter: no vclock tracking yet
     ));
 
     let adapter = NfsAdapter::new(vfs);
@@ -137,6 +138,7 @@ pub async fn serve_only(cfg: NfsMountConfig) -> Result<u16> {
         cfg.cache_dir,
         cfg.cache_max_bytes,
         Duration::from_secs(cfg.negative_ttl_secs),
+        String::new(), // NFS adapter: no vclock tracking yet
     ));
 
     let adapter = NfsAdapter::new(vfs);

--- a/crates/tcfs-vfs/Cargo.toml
+++ b/crates/tcfs-vfs/Cargo.toml
@@ -9,6 +9,7 @@ description = "tcfs virtual filesystem trait, disk cache, stub formats, and hydr
 [dependencies]
 tcfs-core = { path = "../tcfs-core" }
 tcfs-storage = { path = "../tcfs-storage" }
+tcfs-sync = { path = "../tcfs-sync", default-features = false }
 opendal = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/tcfs-vfs/src/driver.rs
+++ b/crates/tcfs-vfs/src/driver.rs
@@ -29,6 +29,9 @@ use opendal::Operator;
 use tokio::sync::Mutex;
 use tracing::debug;
 
+use tcfs_sync::conflict::VectorClock;
+use tcfs_sync::manifest::SyncManifest;
+
 use crate::cache::DiskCache;
 use crate::hydrate::fetch_cached;
 use crate::negative_cache::NegativeCache;
@@ -54,8 +57,9 @@ struct FileHandle {
 }
 
 /// Callback invoked after a file is flushed to remote storage.
-/// Parameters: (virtual_path, file_hash, size_bytes, chunk_count)
-pub type OnFlushCallback = Arc<dyn Fn(&str, &str, u64, usize) + Send + Sync + 'static>;
+/// Parameters: (virtual_path, file_hash, size_bytes, chunk_count, vclock)
+pub type OnFlushCallback =
+    Arc<dyn Fn(&str, &str, u64, usize, &VectorClock) + Send + Sync + 'static>;
 
 /// The tcfs virtual filesystem driver.
 ///
@@ -76,6 +80,10 @@ pub struct TcfsVfs {
     mount_time: SystemTime,
     /// Optional callback after flush_to_remote (e.g., NATS publish)
     on_flush: Option<OnFlushCallback>,
+    /// Device identifier for vector clock tracking (e.g., hostname)
+    device_id: String,
+    /// Per-file vector clocks for conflict detection
+    vclocks: Arc<Mutex<HashMap<String, VectorClock>>>,
 }
 
 impl TcfsVfs {
@@ -92,6 +100,7 @@ impl TcfsVfs {
         cache_dir: std::path::PathBuf,
         cache_max_bytes: u64,
         negative_ttl: Duration,
+        device_id: String,
     ) -> Self {
         #[cfg(unix)]
         let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
@@ -108,6 +117,8 @@ impl TcfsVfs {
             next_fh: Arc::new(AtomicU64::new(1)),
             mount_time: SystemTime::now(),
             on_flush: None,
+            device_id,
+            vclocks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -150,22 +161,42 @@ impl TcfsVfs {
             chunk_hashes.push(chunk_hex);
         }
 
-        // 3. Create JSON v2 manifest
-        let manifest = serde_json::json!({
-            "version": 2,
-            "file_hash": file_hash,
-            "file_size": data.len(),
-            "chunks": chunk_hashes,
-            "written_at": std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-        });
+        // 3. Build vector clock and create v2 manifest with conflict metadata
+        let mut vclock = {
+            let vclocks = self.vclocks.lock().await;
+            vclocks.get(vpath).cloned().unwrap_or_default()
+        };
+        if !self.device_id.is_empty() {
+            vclock.tick(&self.device_id);
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let manifest = SyncManifest {
+            version: 2,
+            file_hash: file_hash.clone(),
+            file_size: data.len() as u64,
+            chunks: chunk_hashes.clone(),
+            vclock: vclock.clone(),
+            written_by: self.device_id.clone(),
+            written_at: now,
+            rel_path: Some(vpath.to_string()),
+            encrypted_file_key: None,
+        };
         let manifest_key = format!("{}/manifests/{}", prefix, file_hash);
         self.op
-            .write(&manifest_key, manifest.to_string().into_bytes())
+            .write(
+                &manifest_key,
+                manifest.to_bytes().context("serializing manifest")?,
+            )
             .await
             .context("uploading manifest")?;
+        // Store updated vclock for future writes to this path
+        {
+            let mut vclocks = self.vclocks.lock().await;
+            vclocks.insert(vpath.to_string(), vclock.clone());
+        }
 
         // 4. Update index entry
         let index_key = self
@@ -195,7 +226,7 @@ impl TcfsVfs {
 
         // 6. Notify listeners (e.g., NATS FileSynced publish)
         if let Some(ref cb) = self.on_flush {
-            cb(vpath, &file_hash, data.len() as u64, chunk_hashes.len());
+            cb(vpath, &file_hash, data.len() as u64, chunk_hashes.len(), &vclock);
         }
 
         Ok(())
@@ -733,6 +764,7 @@ mod tests {
             std::path::PathBuf::from("/tmp/tcfs-test-cache"),
             64 * 1024 * 1024,
             Duration::from_secs(30),
+            "test-host".to_string(),
         )
     }
 

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -376,21 +376,23 @@ impl TcfsDaemon for TcfsDaemonImpl {
             // FUSE write, notify other hosts so their FUSE mounts pick it up.
             let nats_handle = self.nats.clone();
             let flush_device_id = self.device_id.clone();
+            let mount_device_id = self.device_id.clone();
             let on_flush: Option<tcfs_vfs::OnFlushCallback> = Some(std::sync::Arc::new(
-                move |vpath: &str, hash: &str, size: u64, chunks: usize| {
+                move |vpath: &str, hash: &str, size: u64, _chunks: usize, vclock: &tcfs_sync::conflict::VectorClock| {
                     let nats = nats_handle.clone();
                     let device = flush_device_id.clone();
                     let path = vpath.to_string();
                     let hash = hash.to_string();
+                    let vclock = vclock.clone();
                     tokio::spawn(async move {
                         if let Some(ref client) = *nats.lock().await {
                             let event = tcfs_sync::StateEvent::FileSynced {
                                 device_id: device,
                                 rel_path: path.clone(),
-                                blake3: hash,
+                                blake3: hash.clone(),
                                 size,
-                                vclock: tcfs_sync::conflict::VectorClock::default(),
-                                manifest_path: String::new(),
+                                vclock,
+                                manifest_path: format!("manifests/{}", hash),
                                 timestamp: std::time::SystemTime::now()
                                     .duration_since(std::time::UNIX_EPOCH)
                                     .unwrap_or_default()
@@ -418,6 +420,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                     read_only: req.read_only,
                     allow_other: false,
                     on_flush,
+                    device_id: mount_device_id,
                 })
                 .await
                 {


### PR DESCRIPTION
## Summary
- Wire `VectorClock` from `tcfs-sync` into VFS FUSE write path
- Manifests now include `vclock`, `written_by`, `written_at`, and `rel_path` fields (SyncManifest v2)
- NATS `FileSynced` events propagate real vclocks instead of `Default::default()`
- Device ID threaded from daemon config through `MountConfig` → `TcfsVfs`

## Changes
| File | Change |
|------|--------|
| `tcfs-vfs/Cargo.toml` | Add `tcfs-sync` dep (default-features = false) |
| `tcfs-vfs/src/driver.rs` | Add `device_id` + `vclocks` to TcfsVfs, use SyncManifest in flush |
| `tcfs-fuse/src/driver.rs` | Add `device_id` to MountConfig, pass to VFS |
| `tcfsd/src/grpc.rs` | Forward real vclock + manifest_path in NATS events |
| `tcfs-cli/src/main.rs` | Pass hostname as device_id for standalone mounts |
| `tcfs-nfs/src/server.rs` | Pass empty device_id (NFS: no vclock yet) |

## Test plan
- [x] `cargo check` — compiles clean (0 errors, 0 warnings after fixes)
- [x] `cargo test -p tcfs-vfs` — 24 tests pass
- [x] `cargo test -p tcfs-sync` — all tests pass (manifest format compatible)
- [ ] Deploy to yoga, verify manifest JSON contains vclock fields
- [ ] Write file on yoga FUSE mount, check NATS event has non-empty vclock
- [ ] Write same file on honey, verify conflict detection in daemon logs