### PR TITLE
fix(nats): use create_or_update_stream to apply subject filter changes

### DIFF
--- a/crates/tcfs-sync/src/nats.rs
+++ b/crates/tcfs-sync/src/nats.rs
@@ -208,10 +208,15 @@ mod inner {
             Ok(NatsClient { js })
         }
 
-        /// Ensure all required JetStream streams exist (idempotent via CreateOrUpdate).
+        /// Ensure all required JetStream streams exist.
+        ///
+        /// Uses `create_or_update_stream` (not `get_or_create_stream`) so that
+        /// config changes — especially subject filter updates — are applied to
+        /// existing streams. Without this, a stream created by an older binary
+        /// with different subjects would never get its filter updated.
         pub async fn ensure_streams(&self) -> Result<()> {
             self.js
-                .get_or_create_stream(stream::Config {
+                .create_or_update_stream(stream::Config {
                     name: STREAM_SYNC_TASKS.to_string(),
                     subjects: vec![STREAM_SYNC_TASKS.to_string()],
                     max_messages: 1_000_000,
@@ -223,7 +228,7 @@ mod inner {
                 .map_err(|e| anyhow::anyhow!("ensuring SYNC_TASKS stream: {e}"))?;
 
             self.js
-                .get_or_create_stream(stream::Config {
+                .create_or_update_stream(stream::Config {
                     name: STREAM_HYDRATION.to_string(),
                     subjects: vec![STREAM_HYDRATION.to_string()],
                     max_messages: 100_000,
@@ -235,7 +240,7 @@ mod inner {
 
             // STATE_UPDATES: fan-out (Limits retention), hierarchical subjects, 7-day TTL
             self.js
-                .get_or_create_stream(stream::Config {
+                .create_or_update_stream(stream::Config {
                     name: STREAM_STATE.to_string(),
                     subjects: vec!["STATE.>".to_string()],
                     max_messages: 500_000,
@@ -247,6 +252,20 @@ mod inner {
                 .await
                 .map_err(|e| anyhow::anyhow!("ensuring STATE_UPDATES stream: {e}"))?;
 
+            // Verify STATE_UPDATES stream config by reading it back
+            match self.js.get_stream(STREAM_STATE).await {
+                Ok(mut stream) => {
+                    let info = stream.info().await;
+                    if let Ok(info) = info {
+                        info!(
+                            subjects = ?info.config.subjects,
+                            messages = info.state.messages,
+                            "NATS: STATE_UPDATES stream config"
+                        );
+                    }
+                }
+                Err(e) => warn!("NATS: could not read STATE_UPDATES config: {e}"),
+            }
             info!("NATS: streams verified (SYNC_TASKS, HYDRATION_EVENTS, STATE_UPDATES)");
             Ok(())
         }


### PR DESCRIPTION
## Summary
- Switch `get_or_create_stream` → `create_or_update_stream` for all 3 JetStream streams
- Add diagnostic logging showing actual STATE_UPDATES stream subject config after update

## Root Cause
Streams created by older binaries had stale subject filters (e.g., `["STATE_UPDATES"]` instead of `["STATE.>"]`). `get_or_create_stream` returns the existing config without updating, so `STATE.{device}.file_synced` publishes failed with "no stream found" even after `ensure_streams()` reported success.

## Evidence from honey daemon log
```
NATS: streams verified (SYNC_TASKS, HYDRATION_EVENTS, STATE_UPDATES)   ← appears OK
failed to publish DeviceOnline: ...no stream found for given subject   ← but publish fails
```

## Test plan
- [x] `cargo check -p tcfs-sync --features nats` — compiles clean
- [x] `cargo test -p tcfs-sync` — all tests pass
- [ ] Deploy to honey, verify daemon log shows correct subjects: `["STATE.>"]`
- [ ] Write file on honey FUSE mount, verify NATS publish succeeds (no WARN)
- [ ] Verify cross-host auto-pull triggers on yoga after honey FUSE write