### PR TITLE
fix(nats): include storage prefix in FUSE flush manifest_path

### DIFF
--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -377,6 +377,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
             let nats_handle = self.nats.clone();
             let flush_device_id = self.device_id.clone();
             let mount_device_id = self.device_id.clone();
+            let flush_prefix = prefix.clone();
             let on_flush: Option<tcfs_vfs::OnFlushCallback> = Some(std::sync::Arc::new(
                 move |vpath: &str, hash: &str, size: u64, _chunks: usize, vclock: &tcfs_sync::conflict::VectorClock| {
                     let nats = nats_handle.clone();
@@ -384,6 +385,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                     let path = vpath.to_string();
                     let hash = hash.to_string();
                     let vclock = vclock.clone();
+                    let pfx = flush_prefix.clone();
                     tokio::spawn(async move {
                         if let Some(ref client) = *nats.lock().await {
                             let event = tcfs_sync::StateEvent::FileSynced {
@@ -392,7 +394,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                                 blake3: hash.clone(),
                                 size,
                                 vclock,
-                                manifest_path: format!("manifests/{}", hash),
+                                manifest_path: format!("{}/manifests/{}", pfx, hash),
                                 timestamp: std::time::SystemTime::now()
                                     .duration_since(std::time::UNIX_EPOCH)
                                     .unwrap_or_default()


### PR DESCRIPTION
## Summary
The on_flush NATS callback sent `manifest_path: "manifests/{hash}"` but auto-pull looks up `"{prefix}/manifests/{hash}"` (e.g., `data/manifests/{hash}`). Result: 404 NotFound on every auto-pull triggered by FUSE writes.

## Evidence (honey daemon log)
```
INFO  new file from remote, pulling path=/conflict-e2e-193.txt
WARN  auto-pull: manifest not found in S3: NotFound ... path: manifests/5584066b...
```
Actual S3 key: `data/manifests/5584066b...`

## Fix
Clone the `prefix` variable into the on_flush closure, prepend to manifest_path:
```rust
manifest_path: format!("{}/manifests/{}", pfx, hash),
```

## Test plan
- [x] `cargo check -p tcfsd` — compiles
- [ ] Deploy to honey, write file, verify auto-pull finds manifest (no 404)