### PR TITLE
fix(deps): migrate from serde_yml to serde_norway

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ bip39 = { version = "2" }
 keyring = { version = "3" }
 
 # SOPS decryption deps
-serde_yml = { version = "0.0" }
+serde_norway = { version = "0.9" }
 aes-gcm = { version = "0.10" }
 base64 = { version = "0.22" }
 

--- a/crates/tcfs-secrets/Cargo.toml
+++ b/crates/tcfs-secrets/Cargo.toml
@@ -12,7 +12,7 @@ age = { workspace = true }
 keepass = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yml = { workspace = true }
+serde_norway = { workspace = true }
 aes-gcm = { workspace = true }
 base64 = { workspace = true }
 toml = { workspace = true }

--- a/crates/tcfs-secrets/src/rotate.rs
+++ b/crates/tcfs-secrets/src/rotate.rs
@@ -123,27 +123,27 @@ fn build_rotated_yaml(
     new_secret_key: &str,
 ) -> Result<String> {
     // Parse the current YAML (may be SOPS-encrypted, but we only need the structure)
-    let mut doc: serde_yml::Value =
-        serde_yml::from_str(current_content).context("parsing current credential YAML")?;
+    let mut doc: serde_norway::Value =
+        serde_norway::from_str(current_content).context("parsing current credential YAML")?;
 
     // Strip the sops metadata block (we'll re-encrypt from plaintext)
-    if let serde_yml::Value::Mapping(ref mut map) = doc {
-        map.remove(serde_yml::Value::String("sops".into()));
+    if let serde_norway::Value::Mapping(ref mut map) = doc {
+        map.remove(serde_norway::Value::String("sops".into()));
     }
 
     // Update the credential fields
-    if let serde_yml::Value::Mapping(ref mut map) = doc {
+    if let serde_norway::Value::Mapping(ref mut map) = doc {
         map.insert(
-            serde_yml::Value::String("access_key_id".into()),
-            serde_yml::Value::String(new_access_key.into()),
+            serde_norway::Value::String("access_key_id".into()),
+            serde_norway::Value::String(new_access_key.into()),
         );
         map.insert(
-            serde_yml::Value::String("secret_access_key".into()),
-            serde_yml::Value::String(new_secret_key.into()),
+            serde_norway::Value::String("secret_access_key".into()),
+            serde_norway::Value::String(new_secret_key.into()),
         );
     }
 
-    serde_yml::to_string(&doc).context("serializing updated YAML")
+    serde_norway::to_string(&doc).context("serializing updated YAML")
 }
 
 /// Encrypt a plaintext YAML string using the `sops` CLI.

--- a/crates/tcfs-secrets/src/sops.rs
+++ b/crates/tcfs-secrets/src/sops.rs
@@ -42,14 +42,14 @@ pub struct SopsCredentials {
 #[derive(Debug)]
 pub struct SopsFile {
     /// Raw YAML parsed structure
-    data: serde_yml::Value,
+    data: serde_norway::Value,
     /// The encrypted data key for age recipients
     age_enc: String,
 }
 
 impl SopsFile {
     pub fn parse(yaml_str: &str) -> Result<Self> {
-        let data: serde_yml::Value = serde_yml::from_str(yaml_str).context("parsing SOPS YAML")?;
+        let data: serde_norway::Value = serde_norway::from_str(yaml_str).context("parsing SOPS YAML")?;
 
         let age_enc = extract_age_enc(&data)?;
 
@@ -85,7 +85,7 @@ pub async fn decrypt_sops_file(
 }
 
 /// Extract the age-encrypted data key from the sops block
-fn extract_age_enc(data: &serde_yml::Value) -> Result<String> {
+fn extract_age_enc(data: &serde_norway::Value) -> Result<String> {
     let sops = data
         .get("sops")
         .ok_or_else(|| anyhow::anyhow!("no 'sops' block in file (is this a SOPS file?)"))?;
@@ -109,13 +109,13 @@ fn extract_age_enc(data: &serde_yml::Value) -> Result<String> {
 
 /// Walk the YAML value tree, decrypting ENC[...] strings and populating creds
 fn decrypt_yaml_value(
-    value: &serde_yml::Value,
+    value: &serde_norway::Value,
     data_key: &[u8; 32],
     creds: &mut SopsCredentials,
     key_path: &str,
 ) -> Result<()> {
     match value {
-        serde_yml::Value::Mapping(map) => {
+        serde_norway::Value::Mapping(map) => {
             for (k, v) in map {
                 let key = k.as_str().unwrap_or("");
                 // Skip the sops metadata block
@@ -130,7 +130,7 @@ fn decrypt_yaml_value(
                 decrypt_yaml_value(v, data_key, creds, &path)?;
             }
         }
-        serde_yml::Value::String(s) => {
+        serde_norway::Value::String(s) => {
             let decrypted = if s.starts_with("ENC[AES256_GCM,") {
                 decrypt_enc_value(s, data_key)
                     .with_context(|| format!("decrypting field '{key_path}'"))?


### PR DESCRIPTION
## Summary
Replace unmaintained and unsound `serde_yml` with maintained fork `serde_norway`.

## Security Advisories Fixed
- **RUSTSEC-2025-0068**: `serde_yml` crate is unsound and unmaintained
- **RUSTSEC-2025-0067**: `libyml` is unsound and unmaintained (transitive dependency)

## Changes
- Update workspace dependency: `serde_yml 0.0` → `serde_norway 0.9`
- Update `tcfs-secrets/Cargo.toml` to use `serde_norway`
- Replace all `serde_yml::` usages in `rotate.rs` and `sops.rs` with `serde_norway::`
- API is fully compatible, no functional changes

## Migration Path
`serde_norway` is a maintained fork of `serde_yaml` that uses `unsafe-libyaml-norway` (maintained fork of `unsafe-libyaml`). It provides the same API surface as `serde_yml`.

## Testing
- All existing tests should pass without modification
- YAML parsing and serialization behavior unchanged