### PR TITLE
fix(sync): resolve pull 404 for files pushed with absolute paths (#122)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -669,10 +669,8 @@ async fn cmd_push(
             pb_clone.set_message(msg.to_string());
         });
 
-        let rel = local
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_default();
+        let sync_root = config.sync.sync_root.as_deref();
+        let rel = tcfs_sync::engine::normalize_rel_path(local, sync_root);
 
         let result = tcfs_sync::engine::upload_file_with_device(
             &op,
@@ -793,25 +791,49 @@ async fn cmd_pull(
     let op = build_operator_from_env(config)?;
     let device_id = load_device_id(config);
 
+    // Detect whether input looks like a file path vs a manifest path
+    let is_file_path = manifest_path.starts_with('/')
+        || manifest_path.starts_with('.')
+        || std::path::Path::new(manifest_path).exists();
+
     // Derive the remote prefix from the manifest path if not provided
     // e.g. "devices/A29247/manifests/abc123" → prefix = "devices/A29247"
     let remote_prefix = prefix
         .map(|s| s.trim_end_matches('/').to_string())
         .unwrap_or_else(|| {
-            manifest_path
-                .rsplit_once("/manifests/")
-                .map(|(pfx, _)| pfx.to_string())
-                .unwrap_or_else(|| {
-                    manifest_path
-                        .split('/')
-                        .next()
-                        .unwrap_or("tcfs")
-                        .to_string()
-                })
+            if is_file_path {
+                // Derive prefix the same way push does: from file_name()
+                std::path::Path::new(manifest_path)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "tcfs".to_string())
+            } else {
+                manifest_path
+                    .rsplit_once("/manifests/")
+                    .map(|(pfx, _)| pfx.to_string())
+                    .unwrap_or_else(|| {
+                        manifest_path
+                            .split('/')
+                            .next()
+                            .unwrap_or("tcfs")
+                            .to_string()
+                    })
+            }
         });
 
+    // Resolve file paths to manifest paths via the S3 index
+    let sync_root = config.sync.sync_root.as_deref();
+    let resolved_manifest = tcfs_sync::engine::resolve_manifest_path(
+        &op,
+        manifest_path,
+        &remote_prefix,
+        sync_root,
+    )
+    .await
+    .with_context(|| format!("resolving manifest for: {manifest_path}"))?;
+
     // Default local path: current dir + manifest hash (last path component)
-    let hash_basename = manifest_path.split('/').next_back().unwrap_or("downloaded");
+    let hash_basename = resolved_manifest.split('/').next_back().unwrap_or("downloaded");
     let local_path = local
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from(hash_basename));
@@ -835,7 +857,7 @@ async fn cmd_pull(
 
     let result = tcfs_sync::engine::download_file_with_device(
         &op,
-        manifest_path,
+        &resolved_manifest,
         &local_path,
         &remote_prefix,
         Some(&progress),

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -823,17 +823,16 @@ async fn cmd_pull(
 
     // Resolve file paths to manifest paths via the S3 index
     let sync_root = config.sync.sync_root.as_deref();
-    let resolved_manifest = tcfs_sync::engine::resolve_manifest_path(
-        &op,
-        manifest_path,
-        &remote_prefix,
-        sync_root,
-    )
-    .await
-    .with_context(|| format!("resolving manifest for: {manifest_path}"))?;
+    let resolved_manifest =
+        tcfs_sync::engine::resolve_manifest_path(&op, manifest_path, &remote_prefix, sync_root)
+            .await
+            .with_context(|| format!("resolving manifest for: {manifest_path}"))?;
 
     // Default local path: current dir + manifest hash (last path component)
-    let hash_basename = resolved_manifest.split('/').next_back().unwrap_or("downloaded");
+    let hash_basename = resolved_manifest
+        .split('/')
+        .next_back()
+        .unwrap_or("downloaded");
     let local_path = local
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from(hash_basename));

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -812,6 +812,70 @@ fn collect_files_inner(
     Ok(())
 }
 
+/// Normalize a filesystem path into a stable S3 index key component.
+///
+/// - If `sync_root` is provided and the path is under it, returns the relative path.
+/// - Otherwise strips the leading `/` from absolute paths, or returns relative paths as-is.
+/// - Replaces `\` with `/` for cross-platform consistency.
+pub fn normalize_rel_path(path: &Path, sync_root: Option<&Path>) -> String {
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+    let rel = if let Some(root) = sync_root {
+        let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+        canonical
+            .strip_prefix(&canonical_root)
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|_| {
+                let s = canonical.to_string_lossy();
+                PathBuf::from(s.trim_start_matches('/'))
+            })
+    } else if canonical.is_absolute() {
+        let s = canonical.to_string_lossy();
+        PathBuf::from(s.trim_start_matches('/'))
+    } else {
+        canonical
+    };
+
+    rel.to_string_lossy().replace('\\', "/")
+}
+
+/// Resolve a file path or manifest path to the actual S3 manifest path.
+///
+/// If the input contains `/manifests/`, it is returned as-is (assumed to be a manifest path).
+/// Otherwise, treat it as a file path: normalize it, look up the index entry,
+/// and construct the manifest path from the stored hash.
+pub async fn resolve_manifest_path(
+    op: &Operator,
+    input: &str,
+    remote_prefix: &str,
+    sync_root: Option<&Path>,
+) -> Result<String> {
+    // If it already looks like a manifest path, use it directly
+    if input.contains("/manifests/") {
+        return Ok(input.to_string());
+    }
+
+    let prefix = remote_prefix.trim_end_matches('/');
+
+    // Normalize the input path to derive the index key
+    let rel = normalize_rel_path(Path::new(input), sync_root);
+    let index_key = format!("{prefix}/index/{rel}");
+
+    let idx_bytes = op
+        .read(&index_key)
+        .await
+        .with_context(|| format!("reading index entry: {index_key}"))?;
+
+    let idx_raw = idx_bytes.to_bytes();
+    let idx_str = String::from_utf8_lossy(&idx_raw);
+    let manifest_hash = idx_str
+        .lines()
+        .find_map(|l| l.strip_prefix("manifest_hash="))
+        .ok_or_else(|| anyhow::anyhow!("index entry missing manifest_hash: {index_key}"))?;
+
+    Ok(format!("{prefix}/manifests/{manifest_hash}"))
+}
+
 /// Normalize a remote prefix: ensure it doesn't have trailing slash
 fn remote_path_prefix(prefix: &str) -> String {
     prefix.trim_end_matches('/').to_string()

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -710,14 +710,10 @@ impl TcfsDaemon for TcfsDaemonImpl {
 
         let sync_root = self.config.sync.sync_root.as_deref();
 
-        let resolved_manifest = tcfs_sync::engine::resolve_manifest_path(
-            &op,
-            &req.remote_path,
-            &prefix,
-            sync_root,
-        )
-        .await
-        .map_err(|e| tonic::Status::not_found(format!("resolve manifest: {e}")))?;
+        let resolved_manifest =
+            tcfs_sync::engine::resolve_manifest_path(&op, &req.remote_path, &prefix, sync_root)
+                .await
+                .map_err(|e| tonic::Status::not_found(format!("resolve manifest: {e}")))?;
 
         let result = {
             let mut cache = state_cache.lock().await;

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -708,11 +708,22 @@ impl TcfsDaemon for TcfsDaemonImpl {
         let local_path = std::path::PathBuf::from(&req.local_path);
         let state_cache = self.state_cache.clone();
 
+        let sync_root = self.config.sync.sync_root.as_deref();
+
+        let resolved_manifest = tcfs_sync::engine::resolve_manifest_path(
+            &op,
+            &req.remote_path,
+            &prefix,
+            sync_root,
+        )
+        .await
+        .map_err(|e| tonic::Status::not_found(format!("resolve manifest: {e}")))?;
+
         let result = {
             let mut cache = state_cache.lock().await;
             tcfs_sync::engine::download_file_with_device(
                 &op,
-                &req.remote_path,
+                &resolved_manifest,
                 &local_path,
                 &prefix,
                 None,


### PR DESCRIPTION
## Summary

Fixes #122. When `tcfs push /tmp/foo.txt` is followed by `tcfs pull /tmp/foo.txt`, pull returns 404 because it passes the raw file path as an S3 key instead of resolving it through the index.

## Changes

### `crates/tcfs-sync/src/engine.rs`
- **`normalize_rel_path(path, sync_root)`**: Shared path → S3 index key derivation. Strips sync_root prefix or leading `/`, normalizes separators.
- **`resolve_manifest_path(op, input, prefix, sync_root)`**: Resolves file paths to manifest paths via S3 index lookup. Manifest paths (containing `/manifests/`) pass through unchanged.

### `crates/tcfs-cli/src/main.rs`
- **Push**: Uses `normalize_rel_path` for `rel` derivation instead of `file_name()`, ensuring consistent index keys.
- **Pull**: Detects file paths (starts with `/` or `.`, or exists on disk), derives prefix the same way push does, then resolves to manifest path via index before download.

### `crates/tcfsd/src/grpc.rs`
- **Pull RPC**: Adds `resolve_manifest_path` before `download_file_with_device`, so daemon and MCP pull also accept file paths.

## Backward Compatibility

- Manifest-path pull (`tcfs pull mydata/manifests/abc123 out.txt`) short-circuits via the `/manifests/` check — identical behavior.
- No S3 object migration needed — existing index entries already contain `manifest_hash=`.
- Push index keys use the same `file_name()` derivation, just through `normalize_rel_path`.

## Test Plan

```bash
# Push with absolute path, pull by file path
echo "test-122" > /tmp/test-122.txt
tcfs push /tmp/test-122.txt
tcfs pull /tmp/test-122.txt /tmp/pulled-122.txt
diff /tmp/test-122.txt /tmp/pulled-122.txt  # should match

# Existing manifest-path pull still works
tcfs push /tmp/test-122b.txt  # note manifest path from output
tcfs pull <manifest_path> /tmp/pulled-122b.txt
```