### PR TITLE
fix(crypto): enable crypto feature flag + wire EncryptionContext into all push paths

### DIFF
--- a/crates/tcfs-cli/Cargo.toml
+++ b/crates/tcfs-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 tcfs-core = { path = "../tcfs-core" }
 tcfs-secrets = { path = "../tcfs-secrets" }
 tcfs-storage = { path = "../tcfs-storage" }
-tcfs-sync = { path = "../tcfs-sync" }
+tcfs-sync = { path = "../tcfs-sync", features = ["crypto"] }
 tcfs-chunks = { path = "../tcfs-chunks" }
 tcfs-vfs = { path = "../tcfs-vfs" }
 tcfs-nfs = { path = "../tcfs-nfs" }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -672,6 +672,19 @@ async fn cmd_push(
         let sync_root = config.sync.sync_root.as_deref();
         let rel = tcfs_sync::engine::normalize_rel_path(local, sync_root);
 
+        // Load master key for E2E encryption if configured
+        let master_key = config.crypto.master_key_file.as_ref()
+            .and_then(|p| std::fs::read(p).ok())
+            .filter(|k| k.len() == 32)
+            .map(|bytes| {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&bytes);
+                tcfs_crypto::MasterKey::from_bytes(arr)
+            });
+        let enc_ctx = master_key.as_ref().map(|mk| tcfs_sync::engine::EncryptionContext {
+            master_key: mk.clone(),
+        });
+
         let result = tcfs_sync::engine::upload_file_with_device(
             &op,
             local,
@@ -680,7 +693,7 @@ async fn cmd_push(
             Some(&progress),
             &device_id,
             Some(&rel),
-            None,
+            enc_ctx.as_ref(),
         )
         .await
         .with_context(|| format!("uploading {}", local.display()))?;

--- a/crates/tcfs-vfs/Cargo.toml
+++ b/crates/tcfs-vfs/Cargo.toml
@@ -9,13 +9,15 @@ description = "tcfs virtual filesystem trait, disk cache, stub formats, and hydr
 [dependencies]
 tcfs-core = { path = "../tcfs-core" }
 tcfs-storage = { path = "../tcfs-storage" }
-tcfs-sync = { path = "../tcfs-sync", default-features = false }
+tcfs-sync = { path = "../tcfs-sync", features = ["crypto"] }
 opendal = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 blake3 = { workspace = true }
 tcfs-chunks = { path = "../tcfs-chunks" }
+tcfs-crypto = { path = "../tcfs-crypto" }
+base64 = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tcfs-vfs/src/driver.rs
+++ b/crates/tcfs-vfs/src/driver.rs
@@ -84,6 +84,8 @@ pub struct TcfsVfs {
     device_id: String,
     /// Per-file vector clocks for conflict detection
     vclocks: Arc<Mutex<HashMap<String, VectorClock>>>,
+    /// Master key for E2E chunk encryption (None = plaintext mode)
+    master_key: Option<tcfs_crypto::MasterKey>,
 }
 
 impl TcfsVfs {
@@ -119,6 +121,7 @@ impl TcfsVfs {
             on_flush: None,
             device_id,
             vclocks: Arc::new(Mutex::new(HashMap::new())),
+            master_key: None,
         }
     }
 
@@ -126,6 +129,12 @@ impl TcfsVfs {
     /// Used by the daemon to publish NATS FileSynced events.
     pub fn set_on_flush(&mut self, callback: OnFlushCallback) {
         self.on_flush = Some(callback);
+    }
+
+    /// Set the master key for E2E chunk encryption.
+    /// When set, flush_to_remote encrypts chunks with XChaCha20-Poly1305.
+    pub fn set_master_key(&mut self, key: tcfs_crypto::MasterKey) {
+        self.master_key = Some(key);
     }
 
     /// Access the underlying disk cache (for stats, inspection).
@@ -148,20 +157,46 @@ impl TcfsVfs {
         let chunks = tcfs_chunks::chunk_data(data, sizes);
         let file_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(data));
 
-        // 2. Upload each chunk (dedup: same content hash = same chunk)
+        // 2. Generate per-file encryption key if master key is available
+        let file_key = self.master_key.as_ref().map(|_| tcfs_crypto::generate_file_key());
+        let file_id_bytes: [u8; 32] = {
+            let h = tcfs_chunks::hash_bytes(data);
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(h.as_bytes());
+            arr
+        };
+
+        // 3. Upload each chunk (encrypt if master key available)
         let mut chunk_hashes = Vec::with_capacity(chunks.len());
-        for chunk in &chunks {
+        for (idx, chunk) in chunks.iter().enumerate() {
             let chunk_data = &data[chunk.offset as usize..chunk.offset as usize + chunk.length];
-            let chunk_hex = tcfs_chunks::hash_to_hex(&chunk.hash);
+
+            let upload_data = if let Some(ref fk) = file_key {
+                tcfs_crypto::encrypt_chunk(fk, idx as u64, &file_id_bytes, chunk_data)
+                    .context("encrypting chunk")?
+            } else {
+                chunk_data.to_vec()
+            };
+
+            let chunk_hex = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&upload_data));
             let chunk_key = format!("{}/chunks/{}", prefix, chunk_hex);
             self.op
-                .write(&chunk_key, chunk_data.to_vec())
+                .write(&chunk_key, upload_data)
                 .await
                 .with_context(|| format!("uploading chunk {}", chunk_hex))?;
             chunk_hashes.push(chunk_hex);
         }
 
-        // 3. Build vector clock and create v2 manifest with conflict metadata
+        // 4. Wrap file key with master key for manifest storage
+        let encrypted_file_key = match (&self.master_key, &file_key) {
+            (Some(mk), Some(fk)) => {
+                let wrapped = tcfs_crypto::wrap_key(mk, fk).context("wrapping file key")?;
+                Some(base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wrapped))
+            }
+            _ => None,
+        };
+
+        // 5. Build vector clock and create v2 manifest with conflict metadata
         let mut vclock = {
             let vclocks = self.vclocks.lock().await;
             vclocks.get(vpath).cloned().unwrap_or_default()
@@ -182,7 +217,7 @@ impl TcfsVfs {
             written_by: self.device_id.clone(),
             written_at: now,
             rel_path: Some(vpath.to_string()),
-            encrypted_file_key: None,
+            encrypted_file_key,
         };
         let manifest_key = format!("{}/manifests/{}", prefix, file_hash);
         self.op

--- a/crates/tcfsd/Cargo.toml
+++ b/crates/tcfsd/Cargo.toml
@@ -15,7 +15,7 @@ tcfs-core = { path = "../tcfs-core" }
 tcfs-crypto = { path = "../tcfs-crypto" }
 tcfs-secrets = { path = "../tcfs-secrets" }
 tcfs-storage = { path = "../tcfs-storage" }
-tcfs-sync = { path = "../tcfs-sync", features = ["nats"] }
+tcfs-sync = { path = "../tcfs-sync", features = ["nats", "crypto"] }
 tcfs-vfs = { path = "../tcfs-vfs" }
 tcfs-nfs = { path = "../tcfs-nfs" }
 tcfs-fuse = { path = "../tcfs-fuse", features = ["fuse"] }

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -292,6 +292,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                     let sched_status_tx = status_tx.clone();
                     let sched_nats = shared_nats.clone();
                     let sched_metrics = daemon_metrics.clone();
+                    let sched_master_key = master_key.clone();
 
                     tokio::spawn({
                         let scheduler = scheduler.clone();
@@ -306,6 +307,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                     let status_tx = sched_status_tx.clone();
                                     let nats = sched_nats.clone();
                                     let metrics = sched_metrics.clone();
+                                    let mk = sched_master_key.clone();
 
                                     Box::pin(async move {
                                         match task.op {
@@ -326,6 +328,9 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                                     .to_string_lossy()
                                                     .to_string();
                                                 let mut cache = state.lock().await;
+                                                let enc_ctx = mk.as_ref().map(|k| tcfs_sync::engine::EncryptionContext {
+                                                    master_key: k.clone(),
+                                                });
                                                 let upload_result =
                                                     tcfs_sync::engine::upload_file_with_device(
                                                         op_ref,
@@ -335,7 +340,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                                         None,
                                                         &device,
                                                         Some(&rel_path),
-                                                        None,
+                                                        enc_ctx.as_ref(),
                                                     )
                                                     .await?;
 

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -594,6 +594,10 @@ impl TcfsDaemon for TcfsDaemonImpl {
 
         let result = {
             let mut cache = state_cache.lock().await;
+            let mk_guard = self.master_key.lock().await;
+            let enc_ctx = mk_guard.as_ref().map(|mk| tcfs_sync::engine::EncryptionContext {
+                master_key: mk.clone(),
+            });
             tcfs_sync::engine::upload_file_with_device(
                 &op,
                 &local_path,
@@ -602,7 +606,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                 None,
                 &device_id,
                 Some(&normalized_rel),
-                None,
+                enc_ctx.as_ref(),
             )
             .await
         };


### PR DESCRIPTION
## Summary

**CRITICAL SECURITY FIX**: All chunk encryption code in `tcfs-sync` is behind `#[cfg(feature = "crypto")]`, but no consumer (CLI, daemon, VFS) enables the feature. Every push path uploads plaintext chunks to S3 despite `[crypto] enabled = true` in config.toml.

## Root Cause

`tcfs-sync/Cargo.toml` defines `crypto` as an optional feature, but:
- `tcfs-cli/Cargo.toml`: `tcfs-sync = { path = "../tcfs-sync" }` — no features
- `tcfsd/Cargo.toml`: `features = ["nats"]` — nats only, not crypto  
- `tcfs-vfs/Cargo.toml`: `default-features = false` — explicitly disabled

The `EncryptionContext` struct, `encrypt_chunk` calls, and file key wrapping are all compiled out. The `#[cfg(not(feature = "crypto"))]` fallback passes through plaintext.

## Changes

1. **Enable `crypto` feature** in tcfs-cli, tcfsd, tcfs-vfs Cargo.toml
2. **CLI push**: Load master key from `config.crypto.master_key_file`, construct `EncryptionContext`
3. **Daemon gRPC push**: Lock `self.master_key`, construct `EncryptionContext`
4. **Daemon scheduler push**: Clone master key into scheduler closure for file watcher auto-push

## Test plan

- [ ] `cargo check -p tcfs-cli -p tcfsd -p tcfs-vfs` passes
- [ ] Push a test file, download raw chunk from S3, verify content is NOT plaintext
- [ ] Push with no master key configured — should still work (plaintext fallback)

Closes #125