### PR TITLE
fix(daemon): update state cache on NATS auto-pull events

### DIFF
--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -1044,16 +1044,52 @@ async fn do_auto_download(
         }
     };
 
-    match op.stat(manifest_path).await {
-        Ok(_) => {
-            info!(
-                path = %local_path.display(),
-                manifest = %manifest_path,
-                "auto-pull: S3 data verified (FUSE mount will serve on demand)"
-            );
-            // Update state cache with the remote's state
-            let mut cache = state_cache.lock().await;
-            let _ = cache.flush();
+    match op.read(manifest_path).await {
+        Ok(manifest_data) => {
+            // Parse manifest to extract file hash and vclock for state cache
+            let manifest_bytes = manifest_data.to_bytes();
+            match tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes) {
+                Ok(manifest) => {
+                    info!(
+                        path = %local_path.display(),
+                        manifest = %manifest_path,
+                        hash = %manifest.file_hash,
+                        written_by = %manifest.written_by,
+                        "auto-pull: S3 data verified, updating state cache"
+                    );
+                    // Update state cache with the remote's metadata so
+                    // vector clocks stay in sync for future conflict detection.
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    let mut cache = state_cache.lock().await;
+                    cache.set(
+                        local_path,
+                        tcfs_sync::state::SyncState {
+                            blake3: manifest.file_hash.clone(),
+                            size: manifest.file_size,
+                            mtime: manifest.written_at,
+                            chunk_count: manifest.chunks.len(),
+                            remote_path: manifest_path.to_string(),
+                            last_synced: now,
+                            vclock: manifest.vclock.clone(),
+                            device_id: manifest.written_by.clone(),
+                            conflict: None,
+                        },
+                    );
+                    let _ = cache.flush();
+                }
+                Err(e) => {
+                    warn!(
+                        manifest = %manifest_path,
+                        "auto-pull: failed to parse manifest: {e}"
+                    );
+                    // Still mark as verified even if parse fails
+                    let mut cache = state_cache.lock().await;
+                    let _ = cache.flush();
+                }
+            }
         }
         Err(e) => {
             warn!(


### PR DESCRIPTION
## Summary

`do_auto_download` previously only called `stat()` on the manifest and logged "S3 data verified" without updating the state cache. Vector clocks diverged and the state cache had no record of remote files.

Now reads the full manifest, parses it, and updates the state cache with blake3 hash, file size, vclock, device_id, and manifest path.

## Note on FUSE cache invalidation

The VFS queries S3 directly for readdir (no in-memory cache), so new files appear within ATTR_TTL (5s). The negative cache (30s) remains a potential issue for files looked up before the push — a follow-up could add a callback to clear negative cache entries on NATS events.

Closes #127 (state cache portion)