### PR TITLE
feat(sync): Phase 3 per-folder sync policies + auto-unsync controller

### DIFF
--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -217,6 +217,13 @@ pub struct SyncConfig {
     pub exclude_patterns: Vec<String>,
     /// Local directory root for synced files (used by auto-pull)
     pub sync_root: Option<PathBuf>,
+    /// Maximum file age (seconds) before eligible for auto-unsync.
+    /// 0 = disabled. Default: 0 (disabled).
+    pub auto_unsync_max_age_secs: u64,
+    /// How often to run the auto-unsync sweep (seconds). Default: 3600 (hourly).
+    pub auto_unsync_interval_secs: u64,
+    /// If true, log auto-unsync candidates but don't actually remove them.
+    pub auto_unsync_dry_run: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -335,6 +342,9 @@ impl Default for SyncConfig {
             sync_hidden_dirs: false,
             exclude_patterns: Vec::new(),
             sync_root: None,
+            auto_unsync_max_age_secs: 0,
+            auto_unsync_interval_secs: 3600,
+            auto_unsync_dry_run: false,
         }
     }
 }

--- a/crates/tcfs-sync/src/auto_unsync.rs
+++ b/crates/tcfs-sync/src/auto_unsync.rs
@@ -1,0 +1,293 @@
+//! Auto-unsync controller — periodically scans the state cache for stale files
+//! and removes them from tracking to reclaim sync state.
+//!
+//! Files are considered stale when `last_synced` exceeds the configured max age.
+//! The sweep respects per-folder policy exemptions and skips files with unsynced
+//! local modifications (dirty-child safety).
+//!
+//! Auto-unsync removes entries from the state cache but does NOT delete local files.
+//! Untracked files will be re-synced if modified (caught by the file watcher).
+
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing::{debug, info};
+
+use crate::policy::PolicyStore;
+use crate::state::{StateCache, StateCacheBackend};
+
+/// Result of a single auto-unsync sweep.
+#[derive(Debug, Default)]
+pub struct SweepResult {
+    /// Total entries scanned.
+    pub scanned: usize,
+    /// Entries removed from state cache (unsynced).
+    pub unsynced: usize,
+    /// Entries skipped due to policy exemption.
+    pub skipped_exempt: usize,
+    /// Entries skipped because they have unsynced local changes.
+    pub skipped_dirty: usize,
+    /// Entries skipped because the file no longer exists on disk.
+    pub skipped_missing: usize,
+    /// Total bytes of state entries removed (from cached size field).
+    pub bytes_reclaimed: u64,
+}
+
+/// Run a single auto-unsync sweep over the state cache.
+///
+/// Finds files where `last_synced` is older than `max_age_secs`, respects
+/// `PolicyStore` exemptions, and removes eligible entries from the state cache.
+///
+/// Local files are NOT deleted — only their tracking state is removed.
+pub fn sweep(
+    state: &mut StateCache,
+    policy_store: &PolicyStore,
+    max_age_secs: u64,
+    dry_run: bool,
+) -> SweepResult {
+    let mut result = SweepResult::default();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    // Collect candidates (can't mutate state while iterating)
+    let entries: Vec<(String, u64, u64)> = state
+        .all_entries()
+        .iter()
+        .map(|(key, s)| (key.clone(), s.last_synced, s.size))
+        .collect();
+
+    let mut to_remove: Vec<(String, u64)> = Vec::new();
+
+    for (key, last_synced, size) in &entries {
+        result.scanned += 1;
+        let path = Path::new(key);
+
+        // Check age
+        let age = now.saturating_sub(*last_synced);
+        if age <= max_age_secs {
+            continue;
+        }
+
+        // Check policy exemption
+        if policy_store.is_auto_unsync_exempt(path) {
+            result.skipped_exempt += 1;
+            debug!(path = key, "auto-unsync: skipped (exempt)");
+            continue;
+        }
+
+        // Check if file still exists on disk
+        if !path.exists() {
+            result.skipped_missing += 1;
+            continue;
+        }
+
+        // Check for unsynced local changes (dirty-child safety)
+        match state.needs_sync(path) {
+            Ok(Some(_reason)) => {
+                result.skipped_dirty += 1;
+                debug!(path = key, "auto-unsync: skipped (dirty)");
+                continue;
+            }
+            Err(_) => {
+                // Can't stat file — skip rather than risk data loss
+                continue;
+            }
+            Ok(None) => {
+                // File is clean — eligible for unsync
+            }
+        }
+
+        to_remove.push((key.clone(), *size));
+    }
+
+    // Execute removals
+    for (key, size) in &to_remove {
+        let path = Path::new(key.as_str());
+        if dry_run {
+            info!(
+                path = key,
+                age_secs = now.saturating_sub(
+                    entries
+                        .iter()
+                        .find(|(k, _, _)| k == key)
+                        .map(|(_, ls, _)| *ls)
+                        .unwrap_or(0)
+                ),
+                "auto-unsync: would remove (dry run)"
+            );
+        } else {
+            state.remove(path);
+            debug!(path = key, "auto-unsync: removed from state cache");
+        }
+        result.unsynced += 1;
+        result.bytes_reclaimed += size;
+    }
+
+    // Flush state if we made changes
+    if !dry_run && result.unsynced > 0 {
+        if let Err(e) = state.flush() {
+            tracing::warn!(error = %e, "auto-unsync: failed to flush state cache");
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conflict::VectorClock;
+    use crate::policy::FolderPolicy;
+    use crate::state::SyncState;
+
+    fn make_state(last_synced: u64) -> SyncState {
+        SyncState {
+            blake3: "abc123".into(),
+            size: 1024,
+            mtime: last_synced,
+            chunk_count: 1,
+            remote_path: "bucket/test".into(),
+            last_synced,
+            vclock: VectorClock::new(),
+            device_id: String::new(),
+            conflict: None,
+        }
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn test_sweep_skips_young_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+        let policy = PolicyStore::default();
+
+        let file = dir.path().join("recent.txt");
+        std::fs::write(&file, b"data").unwrap();
+        state.set(&file, make_state(now_secs()));
+
+        let result = sweep(&mut state, &policy, 3600, false);
+        assert_eq!(result.scanned, 1);
+        assert_eq!(result.unsynced, 0);
+        assert!(state.get(&file).is_some());
+    }
+
+    #[test]
+    fn test_sweep_removes_old_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+        let policy = PolicyStore::default();
+
+        let file = dir.path().join("old.txt");
+        std::fs::write(&file, b"data").unwrap();
+
+        // Set last_synced to 2 hours ago
+        let old_time = now_secs() - 7200;
+        let mut sync_state = make_state(old_time);
+        // Match current file metadata so needs_sync returns None
+        let meta = std::fs::metadata(&file).unwrap();
+        sync_state.size = meta.len();
+        sync_state.mtime = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        sync_state.blake3 = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_file(&file).unwrap());
+        state.set(&file, sync_state);
+
+        let result = sweep(&mut state, &policy, 3600, false); // max_age = 1 hour
+        assert_eq!(result.unsynced, 1);
+        assert_eq!(result.bytes_reclaimed, meta.len());
+        assert!(state.get(&file).is_none()); // removed from state
+        assert!(file.exists()); // file still on disk
+    }
+
+    #[test]
+    fn test_sweep_respects_exempt() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let policy_path = dir.path().join("policies.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+        let mut policy = PolicyStore::open(&policy_path).unwrap();
+
+        let folder = dir.path().join("important");
+        std::fs::create_dir_all(&folder).unwrap();
+        let file = folder.join("keep.txt");
+        std::fs::write(&file, b"data").unwrap();
+
+        // Mark folder as exempt
+        policy.set(
+            &folder,
+            FolderPolicy {
+                auto_unsync_exempt: true,
+                ..Default::default()
+            },
+        );
+
+        // Old file in exempt folder
+        state.set(&file, make_state(now_secs() - 7200));
+
+        let result = sweep(&mut state, &policy, 3600, false);
+        assert_eq!(result.skipped_exempt, 1);
+        assert_eq!(result.unsynced, 0);
+        assert!(state.get(&file).is_some()); // still tracked
+    }
+
+    #[test]
+    fn test_sweep_skips_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+        let policy = PolicyStore::default();
+
+        let file = dir.path().join("modified.txt");
+        std::fs::write(&file, b"original").unwrap();
+
+        // Old sync state with different content
+        let mut sync_state = make_state(now_secs() - 7200);
+        sync_state.size = 100; // doesn't match actual file size → dirty
+        state.set(&file, sync_state);
+
+        let result = sweep(&mut state, &policy, 3600, false);
+        assert_eq!(result.skipped_dirty, 1);
+        assert_eq!(result.unsynced, 0);
+    }
+
+    #[test]
+    fn test_sweep_dry_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+        let policy = PolicyStore::default();
+
+        let file = dir.path().join("old.txt");
+        std::fs::write(&file, b"data").unwrap();
+
+        let mut sync_state = make_state(now_secs() - 7200);
+        let meta = std::fs::metadata(&file).unwrap();
+        sync_state.size = meta.len();
+        sync_state.mtime = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        sync_state.blake3 = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_file(&file).unwrap());
+        state.set(&file, sync_state);
+
+        let result = sweep(&mut state, &policy, 3600, true); // dry_run = true
+        assert_eq!(result.unsynced, 1);
+        assert!(state.get(&file).is_some()); // NOT removed (dry run)
+    }
+}

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -1,11 +1,13 @@
 //! tcfs-sync: sync engine with state cache, NATS JetStream, and conflict resolution
 
+pub mod auto_unsync;
 pub mod blacklist;
 pub mod conflict;
 pub mod engine;
 pub mod git_safety;
 pub mod manifest;
 pub mod nats;
+pub mod policy;
 pub mod reconcile;
 pub mod scheduler;
 pub mod state;

--- a/crates/tcfs-sync/src/policy.rs
+++ b/crates/tcfs-sync/src/policy.rs
@@ -1,0 +1,302 @@
+//! Per-folder sync policies — controls sync behavior, auto-download thresholds,
+//! and auto-unsync exemptions on a per-directory basis.
+//!
+//! Policies are stored in a JSON file and queried by path with parent-chain
+//! inheritance: a policy set on `/home/user/projects` applies to all files
+//! under that directory unless overridden by a more specific policy.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Sync mode for a folder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncMode {
+    /// Sync on demand — user triggers push/pull explicitly.
+    OnDemand,
+    /// Always keep synced — auto-push changes, auto-pull remote updates.
+    Always,
+    /// Never sync — ignore all changes in this folder.
+    Never,
+}
+
+impl Default for SyncMode {
+    fn default() -> Self {
+        SyncMode::OnDemand
+    }
+}
+
+/// Sync behavior policy for a single folder.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FolderPolicy {
+    /// Sync mode for this folder.
+    pub sync_mode: SyncMode,
+    /// Auto-download files smaller than this (bytes). None = use global default.
+    pub download_threshold: Option<u64>,
+    /// Exempt from auto-unsync (pinned — never automatically unsynced).
+    pub auto_unsync_exempt: bool,
+}
+
+impl Default for FolderPolicy {
+    fn default() -> Self {
+        Self {
+            sync_mode: SyncMode::OnDemand,
+            download_threshold: None,
+            auto_unsync_exempt: false,
+        }
+    }
+}
+
+/// Persistent store for per-folder sync policies.
+///
+/// Loaded from a JSON file, queryable by path with parent-chain inheritance.
+/// Policies set on a directory apply to all descendants unless overridden.
+pub struct PolicyStore {
+    policies: HashMap<String, FolderPolicy>,
+    store_path: PathBuf,
+}
+
+impl Default for PolicyStore {
+    fn default() -> Self {
+        Self {
+            policies: HashMap::new(),
+            store_path: PathBuf::new(),
+        }
+    }
+}
+
+impl PolicyStore {
+    /// Load from JSON file, or create empty if file doesn't exist.
+    pub fn open(path: &Path) -> Result<Self> {
+        let policies = if path.exists() {
+            let content = std::fs::read_to_string(path)
+                .with_context(|| format!("reading policy store: {}", path.display()))?;
+            serde_json::from_str(&content)
+                .with_context(|| format!("parsing policy store: {}", path.display()))?
+        } else {
+            HashMap::new()
+        };
+
+        Ok(Self {
+            policies,
+            store_path: path.to_path_buf(),
+        })
+    }
+
+    /// Get the effective policy for a path by walking up the parent chain.
+    ///
+    /// Returns the first matching policy found at or above the given path.
+    /// Returns None if no policy covers this path.
+    pub fn get(&self, path: &Path) -> Option<&FolderPolicy> {
+        let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+        let mut current = Some(canonical.as_path());
+        while let Some(dir) = current {
+            let key = dir.to_string_lossy();
+            if let Some(policy) = self.policies.get(key.as_ref()) {
+                return Some(policy);
+            }
+            current = dir.parent();
+        }
+        None
+    }
+
+    /// Set a policy for a folder path.
+    pub fn set(&mut self, path: &Path, policy: FolderPolicy) {
+        let key = std::fs::canonicalize(path)
+            .unwrap_or_else(|_| path.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+        self.policies.insert(key, policy);
+    }
+
+    /// Remove a policy for a folder path.
+    pub fn remove(&mut self, path: &Path) -> bool {
+        let key = std::fs::canonicalize(path)
+            .unwrap_or_else(|_| path.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+        self.policies.remove(&key).is_some()
+    }
+
+    /// List all policies.
+    pub fn all(&self) -> &HashMap<String, FolderPolicy> {
+        &self.policies
+    }
+
+    /// Check if a path is exempt from auto-unsync (walks parent chain).
+    pub fn is_auto_unsync_exempt(&self, path: &Path) -> bool {
+        self.get(path)
+            .map(|p| p.auto_unsync_exempt)
+            .unwrap_or(false)
+    }
+
+    /// Flush policies to disk using atomic write (temp file + rename).
+    pub fn flush(&self) -> Result<()> {
+        if let Some(parent) = self.store_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating policy dir: {}", parent.display()))?;
+        }
+
+        let json =
+            serde_json::to_string_pretty(&self.policies).context("serializing policy store")?;
+
+        let tmp_path = self.store_path.with_extension("tmp");
+        std::fs::write(&tmp_path, &json)
+            .with_context(|| format!("writing policy temp: {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &self.store_path)
+            .with_context(|| format!("renaming policy store: {}", self.store_path.display()))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sync_mode_serde() {
+        let json = serde_json::to_string(&SyncMode::Always).unwrap();
+        assert_eq!(json, "\"always\"");
+        let parsed: SyncMode = serde_json::from_str("\"never\"").unwrap();
+        assert_eq!(parsed, SyncMode::Never);
+    }
+
+    #[test]
+    fn test_folder_policy_defaults() {
+        let policy: FolderPolicy = serde_json::from_str("{}").unwrap();
+        assert_eq!(policy.sync_mode, SyncMode::OnDemand);
+        assert!(policy.download_threshold.is_none());
+        assert!(!policy.auto_unsync_exempt);
+    }
+
+    #[test]
+    fn test_policy_store_open_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policies.json");
+        let store = PolicyStore::open(&path).unwrap();
+        assert!(store.all().is_empty());
+    }
+
+    #[test]
+    fn test_policy_set_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policies.json");
+        let mut store = PolicyStore::open(&path).unwrap();
+
+        let folder = dir.path().join("project");
+        std::fs::create_dir_all(&folder).unwrap();
+
+        store.set(
+            &folder,
+            FolderPolicy {
+                sync_mode: SyncMode::Always,
+                download_threshold: Some(10_000_000),
+                auto_unsync_exempt: true,
+            },
+        );
+
+        let policy = store.get(&folder).unwrap();
+        assert_eq!(policy.sync_mode, SyncMode::Always);
+        assert_eq!(policy.download_threshold, Some(10_000_000));
+        assert!(policy.auto_unsync_exempt);
+    }
+
+    #[test]
+    fn test_policy_parent_walk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policies.json");
+        let mut store = PolicyStore::open(&path).unwrap();
+
+        // Set policy on parent
+        let parent = dir.path().join("project");
+        let child = parent.join("subdir");
+        let file = child.join("file.txt");
+        std::fs::create_dir_all(&child).unwrap();
+        std::fs::write(&file, b"data").unwrap();
+
+        store.set(
+            &parent,
+            FolderPolicy {
+                sync_mode: SyncMode::Never,
+                auto_unsync_exempt: true,
+                ..Default::default()
+            },
+        );
+
+        // Child inherits parent policy
+        let policy = store.get(&file).unwrap();
+        assert_eq!(policy.sync_mode, SyncMode::Never);
+        assert!(policy.auto_unsync_exempt);
+    }
+
+    #[test]
+    fn test_policy_exempt_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policies.json");
+        let mut store = PolicyStore::open(&path).unwrap();
+
+        let important = dir.path().join("important");
+        let scratch = dir.path().join("scratch");
+        std::fs::create_dir_all(&important).unwrap();
+        std::fs::create_dir_all(&scratch).unwrap();
+
+        store.set(
+            &important,
+            FolderPolicy {
+                auto_unsync_exempt: true,
+                ..Default::default()
+            },
+        );
+
+        let file_in_important = important.join("data.bin");
+        std::fs::write(&file_in_important, b"keep").unwrap();
+
+        assert!(store.is_auto_unsync_exempt(&file_in_important));
+        assert!(!store.is_auto_unsync_exempt(&scratch.join("temp.txt")));
+    }
+
+    #[test]
+    fn test_policy_flush_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policies.json");
+
+        {
+            let mut store = PolicyStore::open(&path).unwrap();
+            store.set(
+                Path::new("/test/folder"),
+                FolderPolicy {
+                    sync_mode: SyncMode::Always,
+                    download_threshold: Some(5_000_000),
+                    auto_unsync_exempt: true,
+                },
+            );
+            store.flush().unwrap();
+        }
+
+        // Reload and verify
+        let store2 = PolicyStore::open(&path).unwrap();
+        let policy = store2.get(Path::new("/test/folder")).unwrap();
+        assert_eq!(policy.sync_mode, SyncMode::Always);
+        assert!(policy.auto_unsync_exempt);
+    }
+
+    #[test]
+    fn test_policy_remove() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("policies.json");
+        let mut store = PolicyStore::open(&path).unwrap();
+
+        store.set(Path::new("/test"), FolderPolicy::default());
+        assert_eq!(store.all().len(), 1);
+
+        assert!(store.remove(Path::new("/test")));
+        assert_eq!(store.all().len(), 0);
+        assert!(!store.remove(Path::new("/nonexistent")));
+    }
+}


### PR DESCRIPTION
## Summary

Final phase of the "Sync Safety and Reconciliation Engine" milestone — per-folder sync policies and auto-unsync:

### PolicyStore (#152)
- `FolderPolicy` with `SyncMode` (OnDemand/Always/Never), `download_threshold`, `auto_unsync_exempt`
- Parent-chain walk: policy on `/project` applies to all descendants
- JSON persistence with atomic write, `open()` / `set()` / `get()` / `flush()` API
- 8 unit tests

### Auto-Unsync Controller (#153)
- `sweep()` scans state cache for files where `last_synced` exceeds `max_age_secs`
- Respects PolicyStore exemptions (pinned folders skipped)
- Skips dirty files (unsynced local changes detected via `needs_sync()`)
- Removes from state cache only — local files preserved on disk
- `dry_run` mode for safe testing
- `SweepResult` reports scanned/unsynced/skipped/bytes_reclaimed
- 5 unit tests

### Config
- 3 new `SyncConfig` fields: `auto_unsync_max_age_secs` (default: 0/disabled), `auto_unsync_interval_secs` (default: 3600), `auto_unsync_dry_run`

## Test plan
- [x] 69 unit tests pass (`cargo test -p tcfs-sync --lib`)
- [x] `cargo check -p tcfsd` compiles clean
- [x] `cargo fmt` clean

Closes #152, #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)