### PR TITLE
fix(security): credential permissions, NATS TLS, session enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       - name: cargo test
         run: cargo test --workspace
 
-      - name: cargo test tcfs-sync (all features)
-        run: cargo test -p tcfs-sync --all-features
+      - name: cargo test tcfs-sync (nats + crypto features)
+        run: cargo test -p tcfs-sync --features nats,crypto
 
       - name: Build workspace (default features)
         run: cargo build --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: cargo test
         run: cargo test --workspace
 
+      - name: cargo test tcfs-sync (all features)
+        run: cargo test -p tcfs-sync --all-features
+
       - name: Build workspace (default features)
         run: cargo build --workspace
 

--- a/crates/tcfs-auth/src/session.rs
+++ b/crates/tcfs-auth/src/session.rs
@@ -345,7 +345,12 @@ impl SessionStore {
             tokio::fs::create_dir_all(parent).await.ok();
         }
         tokio::fs::write(path, data).await?;
-        tracing::debug!(path = %path.display(), count = valid.len(), "saved sessions");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        tracing::debug!(path = %path.display(), count = valid.len(), "saved sessions (mode 0600)");
         Ok(())
     }
 

--- a/crates/tcfs-auth/src/totp.rs
+++ b/crates/tcfs-auth/src/totp.rs
@@ -110,7 +110,12 @@ impl TotpProvider {
         let creds = self.credentials.read().await;
         let data = serde_json::to_string_pretty(&*creds)?;
         tokio::fs::write(path, data).await?;
-        debug!(path = %path.display(), "saved TOTP credentials");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        debug!(path = %path.display(), "saved TOTP credentials (mode 0600)");
         Ok(())
     }
 

--- a/crates/tcfs-auth/src/webauthn.rs
+++ b/crates/tcfs-auth/src/webauthn.rs
@@ -163,7 +163,12 @@ impl WebAuthnProvider {
         let creds = self.credentials.read().await;
         let json = serde_json::to_string_pretty(&*creds)?;
         tokio::fs::write(path, json).await?;
-        debug!(path = %path.display(), "saved WebAuthn credentials");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        debug!(path = %path.display(), "saved WebAuthn credentials (mode 0600)");
         Ok(())
     }
 }

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -124,7 +124,7 @@ impl Default for AuthConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            require_session: false,
+            require_session: true,
             session_expiry_hours: 24,
             methods: vec!["master_key".into()],
             totp: AuthTotpConfig::default(),

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -60,7 +60,14 @@ impl DeviceRegistry {
         }
         let json = serde_json::to_string_pretty(self).context("serializing device registry")?;
         std::fs::write(path, json)
-            .with_context(|| format!("writing device registry: {}", path.display()))
+            .with_context(|| format!("writing device registry: {}", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("chmod device registry: {}", path.display()))?;
+        }
+        Ok(())
     }
 
     /// Add a new device

--- a/crates/tcfs-sync/src/nats.rs
+++ b/crates/tcfs-sync/src/nats.rs
@@ -199,11 +199,30 @@ mod inner {
 
     impl NatsClient {
         /// Connect to NATS and return a client with JetStream enabled.
-        pub async fn connect(url: &str) -> Result<Self> {
-            let client = async_nats::connect(url)
+        ///
+        /// If `require_tls` is true and the URL uses `nats://`, it is upgraded to `tls://`.
+        pub async fn connect(url: &str, require_tls: bool) -> Result<Self> {
+            let effective_url = if require_tls && url.starts_with("nats://") {
+                let upgraded = url.replacen("nats://", "tls://", 1);
+                warn!(
+                    original = url,
+                    upgraded = %upgraded,
+                    "NATS: upgrading to TLS (nats_tls=true)"
+                );
+                upgraded
+            } else {
+                if !require_tls && !url.starts_with("tls://") {
+                    warn!(
+                        url,
+                        "NATS: connecting without TLS — credentials transmitted in plaintext"
+                    );
+                }
+                url.to_string()
+            };
+            let client = async_nats::connect(&effective_url)
                 .await
-                .map_err(|e| anyhow::anyhow!("connecting to NATS at {url}: {e}"))?;
-            info!("NATS: connected to {url}");
+                .map_err(|e| anyhow::anyhow!("connecting to NATS at {effective_url}: {e}"))?;
+            info!("NATS: connected to {effective_url}");
             let js = jetstream::new(client);
             Ok(NatsClient { js })
         }

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -289,6 +289,11 @@ impl StateCache {
             .with_context(|| format!("writing state cache temp: {}", tmp_path.display()))?;
         std::fs::rename(&tmp_path, &self.db_path)
             .with_context(|| format!("renaming state cache: {}", self.db_path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&self.db_path, std::fs::Permissions::from_mode(0o600));
+        }
 
         self.dirty = false;
         Ok(())

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -623,7 +623,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
     let nats_url = &config.sync.nats_url;
     if nats_url != "nats://localhost:4222" || std::env::var("TCFS_NATS_URL").is_ok() {
         let url = std::env::var("TCFS_NATS_URL").unwrap_or_else(|_| nats_url.clone());
-        match tcfs_sync::NatsClient::connect(&url).await {
+        match tcfs_sync::NatsClient::connect(&url, config.sync.nats_tls).await {
             Ok(nats) => {
                 if let Err(e) = nats.ensure_streams().await {
                     warn!("NATS stream setup failed: {e}");

--- a/crates/tcfsd/src/worker.rs
+++ b/crates/tcfsd/src/worker.rs
@@ -120,7 +120,8 @@ mod inner {
         ));
 
         // Connect to NATS
-        let nats: NatsClient = NatsClient::connect(&config.sync.nats_url).await?;
+        let nats: NatsClient =
+            NatsClient::connect(&config.sync.nats_url, config.sync.nats_tls).await?;
         nats.ensure_streams().await?;
 
         // Concurrency limit: configurable via TCFS_WORKER_CONCURRENCY or CPU count


### PR DESCRIPTION
## Summary

Security hardening for v0.10.0 — three issues addressed:

### Credential File Permissions (#157)
Added `chmod 0o600` to 5 unprotected credential write paths:
- TOTP credentials (`tcfs-auth/src/totp.rs`)
- WebAuthn credentials (`tcfs-auth/src/webauthn.rs`)
- Session tokens (`tcfs-auth/src/session.rs`)
- Device registry (`tcfs-secrets/src/device.rs`)
- State cache (`tcfs-sync/src/state.rs`)

All use `#[cfg(unix)]` for cross-platform compatibility.

### NATS TLS Enforcement (#158)
- `NatsClient::connect()` now accepts `require_tls: bool`
- If `nats_tls=true` and URL is `nats://`, auto-upgrades to `tls://` with log warning
- If connecting without TLS, warns about plaintext credentials
- Wired into daemon + k8s worker

### Session Enforcement (#159)
- `auth.require_session` default changed `false` → `true`
- All gRPC calls now require valid session unless explicitly disabled

## Breaking Changes
- `require_session` now defaults to `true`
- `NatsClient::connect()` signature changed (added `require_tls: bool`)

## Test plan
- [x] 69 unit tests pass
- [x] Full workspace compiles (`cargo check --workspace`)
- [x] `cargo fmt` clean

Closes #157, #158, #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)