### PR TITLE
fix(cli): add --passphrase-file for BIP-39 mnemonic unlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,16 +2769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4831,6 +4821,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4871,21 +4874,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -5392,7 +5380,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "tcfs-core",
  "tempfile",
  "thiserror 1.0.69",
@@ -6436,6 +6424,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -243,9 +243,12 @@ enum DeviceAction {
 enum AuthAction {
     /// Unlock the encryption session (load master key into daemon)
     Unlock {
-        /// Path to master key file (default: ~/.config/tcfs/master.key)
+        /// Path to raw 32-byte master key file (default: ~/.config/tcfs/master.key)
         #[arg(long)]
         key_file: Option<PathBuf>,
+        /// Path to passphrase or BIP-39 mnemonic file (derives key via Argon2id)
+        #[arg(long, conflicts_with = "key_file")]
+        passphrase_file: Option<PathBuf>,
     },
     /// Lock the encryption session (clear master key from daemon memory)
     Lock,
@@ -420,8 +423,11 @@ async fn main() -> Result<()> {
         Commands::Auth { action } => {
             #[cfg(unix)]
             match action {
-                AuthAction::Unlock { key_file } => {
-                    cmd_auth_unlock(&config, key_file.as_deref()).await
+                AuthAction::Unlock {
+                    key_file,
+                    passphrase_file,
+                } => {
+                    cmd_auth_unlock(&config, key_file.as_deref(), passphrase_file.as_deref()).await
                 }
                 AuthAction::Lock => cmd_auth_lock(&config).await,
                 AuthAction::Status => cmd_auth_status(&config).await,
@@ -1771,28 +1777,56 @@ fn cmd_device_status() -> Result<()> {
 async fn cmd_auth_unlock(
     config: &tcfs_core::config::TcfsConfig,
     key_file: Option<&Path>,
+    passphrase_file: Option<&Path>,
 ) -> Result<()> {
-    // Resolve master key file path
-    let key_path = key_file
-        .map(|p| p.to_path_buf())
-        .or_else(|| config.crypto.master_key_file.clone())
-        .unwrap_or_else(|| {
-            tcfs_secrets::device::default_registry_path()
-                .parent()
-                .unwrap_or(Path::new("."))
-                .join("master.key")
-        });
+    let key_bytes = if let Some(pp_path) = passphrase_file {
+        // Derive master key from passphrase/mnemonic file via KDF
+        let passphrase = std::fs::read_to_string(pp_path)
+            .with_context(|| format!("reading passphrase file: {}", pp_path.display()))?;
+        let passphrase = passphrase.trim();
 
-    let key_bytes = std::fs::read(&key_path)
-        .with_context(|| format!("reading master key: {}", key_path.display()))?;
+        // Try BIP-39 mnemonic first (24 words), fall back to arbitrary passphrase
+        let master = if passphrase.split_whitespace().count() >= 12 {
+            println!("Deriving key from BIP-39 mnemonic...");
+            tcfs_crypto::recovery::mnemonic_to_master_key(passphrase)
+                .context("BIP-39 key derivation failed")?
+        } else {
+            println!("Deriving key from passphrase (Argon2id)...");
+            let salt: [u8; 16] = *b"tcfs-recovery-v1";
+            let params = tcfs_crypto::kdf::KdfParams::default();
+            tcfs_crypto::kdf::derive_master_key(
+                &secrecy::SecretString::from(passphrase.to_string()),
+                &salt,
+                &params,
+            )
+            .context("Argon2id key derivation failed")?
+        };
+        master.as_bytes().to_vec()
+    } else {
+        // Read raw 32-byte key file
+        let key_path = key_file
+            .map(|p| p.to_path_buf())
+            .or_else(|| config.crypto.master_key_file.clone())
+            .unwrap_or_else(|| {
+                tcfs_secrets::device::default_registry_path()
+                    .parent()
+                    .unwrap_or(Path::new("."))
+                    .join("master.key")
+            });
 
-    if key_bytes.len() != tcfs_crypto::KEY_SIZE {
-        anyhow::bail!(
-            "master key file has wrong size: {} bytes (expected {})",
-            key_bytes.len(),
-            tcfs_crypto::KEY_SIZE
-        );
-    }
+        let raw = std::fs::read(&key_path)
+            .with_context(|| format!("reading master key: {}", key_path.display()))?;
+
+        if raw.len() != tcfs_crypto::KEY_SIZE {
+            anyhow::bail!(
+                "master key file has wrong size: {} bytes (expected {}). \
+                 For BIP-39 mnemonics or passphrases, use --passphrase-file instead.",
+                raw.len(),
+                tcfs_crypto::KEY_SIZE
+            );
+        }
+        raw
+    };
 
     // Send to daemon via gRPC
     let mut client = connect_daemon(&config.daemon.socket).await?;


### PR DESCRIPTION
## Summary

`tcfs auth unlock --key-file` only accepted raw 32-byte key files. BIP-39 mnemonics (~155 bytes) were rejected with a size error.

### New flag: `--passphrase-file <PATH>`
- Reads passphrase/mnemonic from file
- Auto-detects: 12+ words → BIP-39 (lighter KDF), otherwise → Argon2id (full params)
- Derives 32-byte key, sends to daemon via existing AuthUnlock RPC
- Mutually exclusive with `--key-file` (enforced by clap)

### Error improvement
`--key-file` error now suggests `--passphrase-file` for non-32-byte files.

## Test plan
- [x] `cargo check -p tcfs-cli` clean
- [x] `cargo fmt` clean

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)