### PR TITLE
feat(daemon): self-sufficiency — socket, credentials, unlock, dirs, security

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,16 +2769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4831,6 +4821,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4871,21 +4874,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -5392,7 +5380,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "tcfs-core",
  "tempfile",
  "thiserror 1.0.69",
@@ -6436,6 +6424,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -246,6 +246,9 @@ enum AuthAction {
         /// Path to master key file (default: ~/.config/tcfs/master.key)
         #[arg(long)]
         key_file: Option<PathBuf>,
+        /// Path to a passphrase file (derives key via configured key_derivation method)
+        #[arg(long, conflicts_with = "key_file")]
+        passphrase_file: Option<PathBuf>,
     },
     /// Lock the encryption session (clear master key from daemon memory)
     Lock,
@@ -420,8 +423,11 @@ async fn main() -> Result<()> {
         Commands::Auth { action } => {
             #[cfg(unix)]
             match action {
-                AuthAction::Unlock { key_file } => {
-                    cmd_auth_unlock(&config, key_file.as_deref()).await
+                AuthAction::Unlock {
+                    key_file,
+                    passphrase_file,
+                } => {
+                    cmd_auth_unlock(&config, key_file.as_deref(), passphrase_file.as_deref()).await
                 }
                 AuthAction::Lock => cmd_auth_lock(&config).await,
                 AuthAction::Status => cmd_auth_status(&config).await,
@@ -492,22 +498,66 @@ async fn load_config(path: &Path) -> Result<tcfs_core::config::TcfsConfig> {
 
 // ── Storage operator from environment credentials ─────────────────────────────
 
+/// Read a credential from a `*_FILE` env var (the var points to a file path).
+fn read_credential_file(env_var: &str) -> Result<String, std::env::VarError> {
+    let path = std::env::var(env_var)?;
+    std::fs::read_to_string(path.trim())
+        .map(|s| s.trim().to_string())
+        .map_err(|_| std::env::VarError::NotPresent)
+}
+
+/// Read a credential from a SOPS-decrypted JSON or KEY=VALUE file.
+fn read_sops_credential(path: &std::path::Path, key: &str) -> Result<String> {
+    let content = std::fs::read_to_string(path)?;
+    if let Ok(map) = serde_json::from_str::<std::collections::HashMap<String, String>>(&content) {
+        if let Some(val) = map.get(key) {
+            return Ok(val.clone());
+        }
+    }
+    for line in content.lines() {
+        if let Some(val) = line.strip_prefix(&format!("{}=", key)) {
+            return Ok(val.trim().to_string());
+        }
+    }
+    anyhow::bail!("key '{}' not found in {}", key, path.display())
+}
+
 /// Build an OpenDAL operator using credentials from environment variables.
 ///
-/// Reads AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (standard S3 env vars).
-/// These override any config file credentials for direct CLI use.
+/// Discovery chain: direct env var -> *_FILE env var -> config credentials_file (SOPS)
 fn build_operator_from_env(config: &tcfs_core::config::TcfsConfig) -> Result<opendal::Operator> {
     let access_key = std::env::var("AWS_ACCESS_KEY_ID")
         .or_else(|_| std::env::var("TCFS_ACCESS_KEY_ID"))
+        .or_else(|_| read_credential_file("TCFS_S3_ACCESS_FILE"))
+        .or_else(|_| read_credential_file("AWS_ACCESS_KEY_ID_FILE"))
+        .or_else(|_| {
+            config
+                .storage
+                .credentials_file
+                .as_ref()
+                .and_then(|p| read_sops_credential(p, "access_key_id").ok())
+                .ok_or(std::env::VarError::NotPresent)
+        })
         .context(
             "S3 credentials not set\n\
-             Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.\n\
+             Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables,\n\
+             or use *_FILE variants pointing to credential files.\n\
              Example:\n\
              \texport AWS_ACCESS_KEY_ID=your-key\n\
              \texport AWS_SECRET_ACCESS_KEY=your-secret",
         )?;
     let secret_key = std::env::var("AWS_SECRET_ACCESS_KEY")
         .or_else(|_| std::env::var("TCFS_SECRET_ACCESS_KEY"))
+        .or_else(|_| read_credential_file("TCFS_S3_SECRET_FILE"))
+        .or_else(|_| read_credential_file("AWS_SECRET_ACCESS_KEY_FILE"))
+        .or_else(|_| {
+            config
+                .storage
+                .credentials_file
+                .as_ref()
+                .and_then(|p| read_sops_credential(p, "secret_access_key").ok())
+                .ok_or(std::env::VarError::NotPresent)
+        })
         .context("AWS_SECRET_ACCESS_KEY environment variable not set")?;
 
     tcfs_storage::operator::build_from_core_config(&config.storage, &access_key, &secret_key)
@@ -1771,28 +1821,43 @@ fn cmd_device_status() -> Result<()> {
 async fn cmd_auth_unlock(
     config: &tcfs_core::config::TcfsConfig,
     key_file: Option<&Path>,
+    passphrase_file: Option<&Path>,
 ) -> Result<()> {
-    // Resolve master key file path
-    let key_path = key_file
-        .map(|p| p.to_path_buf())
-        .or_else(|| config.crypto.master_key_file.clone())
-        .unwrap_or_else(|| {
-            tcfs_secrets::device::default_registry_path()
-                .parent()
-                .unwrap_or(Path::new("."))
-                .join("master.key")
-        });
+    let key_bytes = if let Some(pf) = passphrase_file {
+        // Derive key from passphrase file using configured key_derivation method
+        let passphrase = std::fs::read_to_string(pf)
+            .with_context(|| format!("reading passphrase file: {}", pf.display()))?;
+        let passphrase = passphrase.trim();
+        let mk = tcfs_crypto::recovery::derive_from_passphrase(
+            passphrase,
+            &config.crypto.key_derivation,
+        )
+        .context("deriving key from passphrase")?;
+        mk.as_bytes().to_vec()
+    } else {
+        // Resolve master key file path
+        let key_path = key_file
+            .map(|p| p.to_path_buf())
+            .or_else(|| config.crypto.master_key_file.clone())
+            .unwrap_or_else(|| {
+                tcfs_secrets::device::default_registry_path()
+                    .parent()
+                    .unwrap_or(Path::new("."))
+                    .join("master.key")
+            });
 
-    let key_bytes = std::fs::read(&key_path)
-        .with_context(|| format!("reading master key: {}", key_path.display()))?;
+        let bytes = std::fs::read(&key_path)
+            .with_context(|| format!("reading master key: {}", key_path.display()))?;
 
-    if key_bytes.len() != tcfs_crypto::KEY_SIZE {
-        anyhow::bail!(
-            "master key file has wrong size: {} bytes (expected {})",
-            key_bytes.len(),
-            tcfs_crypto::KEY_SIZE
-        );
-    }
+        if bytes.len() != tcfs_crypto::KEY_SIZE {
+            anyhow::bail!(
+                "master key file has wrong size: {} bytes (expected {})",
+                bytes.len(),
+                tcfs_crypto::KEY_SIZE
+            );
+        }
+        bytes
+    };
 
     // Send to daemon via gRPC
     let mut client = connect_daemon(&config.daemon.socket).await?;

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -253,6 +253,10 @@ pub struct CryptoConfig {
     pub master_key_file: Option<PathBuf>,
     /// Path to the device identity file
     pub device_identity: Option<PathBuf>,
+    /// Path to a passphrase file — if set, daemon derives key on startup (auto-unlock)
+    pub passphrase_file: Option<PathBuf>,
+    /// Key derivation method: "argon2id" (default) or "sha256" (legacy crush-dots compat)
+    pub key_derivation: String,
 }
 
 impl Default for CryptoConfig {
@@ -264,6 +268,8 @@ impl Default for CryptoConfig {
             argon2_parallelism: 4,
             master_key_file: None,
             device_identity: None,
+            passphrase_file: None,
+            key_derivation: "argon2id".into(),
         }
     }
 }
@@ -301,8 +307,15 @@ impl Default for SopsConfig {
 
 impl Default for DaemonConfig {
     fn default() -> Self {
+        let socket = std::env::var("XDG_STATE_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+                PathBuf::from(home).join(".local/state")
+            })
+            .join("tcfsd/tcfsd.sock");
         Self {
-            socket: PathBuf::from("/run/tcfsd/tcfsd.sock"),
+            socket,
             fileprovider_socket: None,
             listen: None,
             metrics_addr: Some("127.0.0.1:9100".into()),
@@ -423,7 +436,15 @@ argon2_parallelism = 8
     fn test_parse_defaults() {
         let config: TcfsConfig = toml::from_str("").unwrap();
 
-        assert_eq!(config.daemon.socket, PathBuf::from("/run/tcfsd/tcfsd.sock"));
+        assert!(
+            config
+                .daemon
+                .socket
+                .to_string_lossy()
+                .ends_with("tcfsd/tcfsd.sock"),
+            "socket path should end with tcfsd/tcfsd.sock, got: {}",
+            config.daemon.socket.display()
+        );
         assert_eq!(config.daemon.log_level, "info");
         assert_eq!(config.storage.endpoint, "http://localhost:8333");
         assert!(!config.storage.enforce_tls);

--- a/crates/tcfs-crypto/src/recovery.rs
+++ b/crates/tcfs-crypto/src/recovery.rs
@@ -52,6 +52,33 @@ pub fn mnemonic_to_master_key(words: &str) -> anyhow::Result<MasterKey> {
     derive_master_key(&SecretString::from(words.to_string()), &salt, &params)
 }
 
+/// Derive a master key using SHA-256 (legacy crush-dots compatibility).
+pub fn sha256_master_key(passphrase: &str) -> anyhow::Result<MasterKey> {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(passphrase.as_bytes());
+    let mut key = [0u8; crate::KEY_SIZE];
+    key.copy_from_slice(&hash);
+    Ok(MasterKey::from_bytes(key))
+}
+
+/// Derive master key using the specified method.
+/// "argon2id" -> BIP-39 validated + Argon2id KDF (recommended)
+/// "sha256" -> SHA-256 hash (legacy crush-dots compat)
+pub fn derive_from_passphrase(passphrase: &str, method: &str) -> anyhow::Result<MasterKey> {
+    match method {
+        "sha256" => sha256_master_key(passphrase),
+        _ => {
+            if passphrase.split_whitespace().count() >= 12 {
+                mnemonic_to_master_key(passphrase)
+            } else {
+                let salt: [u8; 16] = *b"tcfs-recovery-v1";
+                let params = KdfParams::default();
+                derive_master_key(&SecretString::from(passphrase.to_string()), &salt, &params)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,6 +108,22 @@ mod tests {
     fn test_invalid_mnemonic() {
         let result = mnemonic_to_master_key("not a valid mnemonic at all");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sha256_master_key() {
+        use sha2::{Digest, Sha256};
+        let passphrase = "test passphrase";
+        let key = sha256_master_key(passphrase).unwrap();
+        let expected = Sha256::digest(passphrase.as_bytes());
+        assert_eq!(key.as_bytes(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_derive_from_passphrase_sha256() {
+        let key = derive_from_passphrase("test", "sha256").unwrap();
+        let direct = sha256_master_key("test").unwrap();
+        assert_eq!(key.as_bytes(), direct.as_bytes());
     }
 
     #[test]

--- a/crates/tcfs-mcp/src/main.rs
+++ b/crates/tcfs-mcp/src/main.rs
@@ -20,10 +20,39 @@ async fn main() -> Result<()> {
 
     tracing::info!("tcfs-mcp starting");
 
-    let socket_path =
-        std::env::var("TCFS_SOCKET").unwrap_or_else(|_| "/run/tcfsd/tcfsd.sock".to_string());
+    let socket_path = std::env::var("TCFS_SOCKET").unwrap_or_else(|_| {
+        let state_dir = std::env::var("XDG_STATE_HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+                std::path::PathBuf::from(home).join(".local/state")
+            });
+        state_dir
+            .join("tcfsd/tcfsd.sock")
+            .to_string_lossy()
+            .to_string()
+    });
 
     let config_path = std::env::var("TCFS_CONFIG").ok();
+
+    // Parent death detection: if the parent process (e.g. Claude Code) exits,
+    // we should exit too to avoid orphaned MCP servers.
+    let parent_pid = std::os::unix::process::parent_id();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+        loop {
+            interval.tick().await;
+            let current_ppid = std::os::unix::process::parent_id();
+            if current_ppid != parent_pid {
+                tracing::warn!(
+                    original_ppid = parent_pid,
+                    current_ppid,
+                    "parent process changed (reparented to init), exiting"
+                );
+                std::process::exit(0);
+            }
+        }
+    });
 
     let server = server::TcfsMcp::new(socket_path.into(), config_path.map(|p| p.into()));
 

--- a/crates/tcfs-secrets/src/lib.rs
+++ b/crates/tcfs-secrets/src/lib.rs
@@ -187,10 +187,14 @@ impl CredStore {
         let access_key = std::env::var("TCFS_S3_ACCESS")
             .or_else(|_| std::env::var("AWS_ACCESS_KEY_ID"))
             .or_else(|_| std::env::var("SEAWEED_ACCESS_KEY"))
+            .or_else(|_| read_env_file("TCFS_S3_ACCESS_FILE"))
+            .or_else(|_| read_env_file("AWS_ACCESS_KEY_ID_FILE"))
             .unwrap_or_default();
         let mut secret_key = std::env::var("TCFS_S3_SECRET")
             .or_else(|_| std::env::var("AWS_SECRET_ACCESS_KEY"))
             .or_else(|_| std::env::var("SEAWEED_SECRET_KEY"))
+            .or_else(|_| read_env_file("TCFS_S3_SECRET_FILE"))
+            .or_else(|_| read_env_file("AWS_SECRET_ACCESS_KEY_FILE"))
             .unwrap_or_default();
 
         let s3 = if !access_key.is_empty() {
@@ -211,4 +215,12 @@ impl CredStore {
             source: "env".into(),
         })
     }
+}
+
+/// Read a credential value by resolving a `*_FILE` env var to a file path, then reading the file.
+fn read_env_file(env_var: &str) -> Result<String, std::env::VarError> {
+    let path = std::env::var(env_var)?;
+    std::fs::read_to_string(path.trim())
+        .map(|s| s.trim().to_string())
+        .map_err(|_| std::env::VarError::NotPresent)
 }

--- a/crates/tcfs-secrets/src/sops.rs
+++ b/crates/tcfs-secrets/src/sops.rs
@@ -49,7 +49,8 @@ pub struct SopsFile {
 
 impl SopsFile {
     pub fn parse(yaml_str: &str) -> Result<Self> {
-        let data: serde_norway::Value = serde_norway::from_str(yaml_str).context("parsing SOPS YAML")?;
+        let data: serde_norway::Value =
+            serde_norway::from_str(yaml_str).context("parsing SOPS YAML")?;
 
         let age_enc = extract_age_enc(&data)?;
 

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -269,9 +269,7 @@ impl StateCache {
         // Primary: match cache keys (canonical local paths) by suffix
         self.entries
             .iter()
-            .find(|(key, _)| {
-                key.ends_with(&format!("/{}", normalized)) || *key == normalized
-            })
+            .find(|(key, _)| key.ends_with(&format!("/{}", normalized)) || *key == normalized)
             // Fallback: match remote_path (manifest path) for backward compat
             .or_else(|| {
                 self.entries.iter().find(|(_, state)| {

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -15,6 +15,9 @@ use crate::grpc::TcfsDaemonImpl;
 pub async fn run(config: TcfsConfig) -> Result<()> {
     info!("daemon starting");
 
+    // Ensure all required directories exist before anything else
+    ensure_dirs(&config);
+
     // ── Device identity ──────────────────────────────────────────────────
     let device_name = config
         .sync
@@ -95,7 +98,8 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
 
     // ── Load master key for E2E encryption ─────────────────────────────
     let master_key: Option<MasterKey> = if config.crypto.enabled {
-        if let Some(ref key_path) = config.crypto.master_key_file {
+        // Try master_key_file first
+        let from_file = if let Some(ref key_path) = config.crypto.master_key_file {
             match std::fs::read(key_path) {
                 Ok(bytes) if bytes.len() == tcfs_crypto::KEY_SIZE => {
                     let mut key_bytes = [0u8; tcfs_crypto::KEY_SIZE];
@@ -108,20 +112,61 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                         path = %key_path.display(),
                         size = bytes.len(),
                         expected = tcfs_crypto::KEY_SIZE,
-                        "master key file has wrong size, encryption disabled"
+                        "master key file has wrong size"
                     );
                     None
                 }
                 Err(e) => {
                     warn!(
                         path = %key_path.display(),
-                        "failed to read master key file: {e} (encryption disabled)"
+                        "failed to read master key file: {e}"
                     );
                     None
                 }
             }
         } else {
-            warn!("crypto.enabled = true but no master_key_file configured");
+            None
+        };
+
+        // Fallback: derive from passphrase_file (auto-unlock)
+        if from_file.is_some() {
+            from_file
+        } else if let Some(ref pf) = config.crypto.passphrase_file {
+            match std::fs::read_to_string(pf) {
+                Ok(passphrase) => {
+                    match tcfs_crypto::recovery::derive_from_passphrase(
+                        passphrase.trim(),
+                        &config.crypto.key_derivation,
+                    ) {
+                        Ok(mk) => {
+                            info!(
+                                path = %pf.display(),
+                                method = %config.crypto.key_derivation,
+                                "master key derived from passphrase file (auto-unlock)"
+                            );
+                            Some(mk)
+                        }
+                        Err(e) => {
+                            warn!(
+                                path = %pf.display(),
+                                "passphrase key derivation failed: {e}"
+                            );
+                            None
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        path = %pf.display(),
+                        "failed to read passphrase file: {e}"
+                    );
+                    None
+                }
+            }
+        } else {
+            if config.crypto.master_key_file.is_none() {
+                warn!("crypto.enabled = true but no master_key_file or passphrase_file configured");
+            }
             None
         }
     } else {
@@ -1172,6 +1217,44 @@ fn notify_stopping() {
         if let Ok(sock) = UnixDatagram::unbound() {
             let _ = sock.send_to(b"STOPPING=1\n", &socket);
             tracing::debug!(notify_socket = %socket, "sent systemd STOPPING=1");
+        }
+    }
+}
+
+/// Create directories needed by the daemon at startup.
+fn ensure_dirs(config: &TcfsConfig) {
+    // Socket parent directory
+    if let Some(parent) = config.daemon.socket.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            warn!(path = %parent.display(), "failed to create socket dir: {e}");
+        }
+    }
+
+    // State cache parent directory
+    if let Some(parent) = config.sync.state_db.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            warn!(path = %parent.display(), "failed to create state dir: {e}");
+        }
+    }
+
+    // FUSE cache directory
+    if let Err(e) = std::fs::create_dir_all(&config.fuse.cache_dir) {
+        warn!(path = %config.fuse.cache_dir.display(), "failed to create cache dir: {e}");
+    }
+
+    // sync_root (mount target)
+    if let Some(ref root) = config.sync.sync_root {
+        if let Err(e) = std::fs::create_dir_all(root) {
+            warn!(path = %root.display(), "failed to create sync_root dir: {e}");
+        }
+    }
+
+    // FileProvider App Group Container directory (macOS)
+    if let Some(ref fp_socket) = config.daemon.fileprovider_socket {
+        if let Some(parent) = fp_socket.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                warn!(path = %parent.display(), "failed to create FileProvider socket dir: {e}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Consolidated PR addressing #128, #129, #130 — makes the daemon self-sufficient, eliminating ~330 lines of crush-dots compensating logic.

### Socket Path (#129)
- Default `$XDG_STATE_HOME/tcfsd/tcfsd.sock` (was `/run/tcfsd/tcfsd.sock`)
- Fixed in daemon config, CLI, and MCP

### Credential Sourcing (#129)
- CLI reads `TCFS_S3_*_FILE` env vars + `config.storage.credentials_file`
- Daemon `CredStore::load_from_env()` reads `*_FILE` env vars natively
- Supports JSON and key=value credential file formats

### Passphrase Unlock (#128)
- New `--passphrase-file` CLI flag (conflicts with `--key-file`)
- Auto-detects BIP-39 mnemonics (12+ words)
- Configurable `crypto.key_derivation`: `"argon2id"` (default) or `"sha256"` (legacy)
- `sha256_master_key()` for crush-dots backward compatibility

### Auto-Unlock + MCP Lifecycle (#130)
- `crypto.passphrase_file` derives key at daemon startup
- MCP parent death detection via ppid polling (prevents orphans)

### Daemon Self-Sufficiency
- `ensure_dirs()` creates socket, state, cache, mount, FileProvider dirs at startup
- Eliminates crush-dots `ensureTcfsDirs` activation script

## Key Derivation Compatibility

crush-dots uses SHA-256 for BIP-39 → master key. tummycrypt uses Argon2id. These produce different keys from the same mnemonic.

**Solution**: `crypto.key_derivation = "sha256"` in config for existing crush-dots deployments. New deployments default to `"argon2id"`. `derive_from_passphrase()` routes by config.

## Test plan
- [x] 31 tcfs-crypto tests pass (2 new: sha256, derive routing)
- [x] 4 tcfs-core config tests pass (socket path test updated)
- [x] 69 tcfs-sync tests pass
- [x] Full workspace compiles
- [x] `cargo fmt` clean

Closes #128, #129, #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)