### PR TITLE
fix(sync): recursive remote index listing + ListFiles fallback

### DIFF
--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -166,7 +166,8 @@ pub async fn list_remote_index(
 ) -> Result<HashMap<String, RemoteIndexEntry>> {
     let index_prefix = format!("{}/index/", remote_prefix.trim_end_matches('/'));
     let entries = op
-        .list(&index_prefix)
+        .list_with(&index_prefix)
+        .recursive(true)
         .await
         .context("listing remote index")?;
 

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1083,15 +1083,30 @@ impl TcfsDaemon for TcfsDaemonImpl {
         let mut dirs_seen = std::collections::HashSet::new();
         let mut files: Vec<FileEntry> = Vec::new();
 
+        let storage_prefix = self.config.storage.resolved_prefix();
+
         for (key, state) in &all {
             // Compute logical relative path from cache key (local abs path).
-            // Skip entries not under sync_root (e.g., /private/tmp/ test artifacts).
+            // Primary: strip sync_root from local path.
+            // Fallback: extract rel_path from remote_path (e.g., "data/manifests/hash"
+            //   → look up original rel_path from the index key pattern).
+            // Skip entries that can't be mapped (e.g., /private/tmp/ test artifacts
+            //   with no usable remote_path).
             let rel_path = match key
                 .strip_prefix(&sync_root_prefix)
                 .or_else(|| key.strip_prefix(&sync_root_str))
             {
                 Some(r) => r.trim_start_matches('/'),
-                None => continue,
+                None => {
+                    // Fallback: derive rel_path from remote_path for entries not
+                    // keyed under sync_root (e.g., FileProvider container temps).
+                    let index_prefix = format!("{}/index/", storage_prefix);
+                    if let Some(rel) = state.remote_path.strip_prefix(&index_prefix) {
+                        rel.trim_start_matches('/')
+                    } else {
+                        continue;
+                    }
+                }
             };
 
             if rel_path.is_empty() {


### PR DESCRIPTION
## Summary
- Fix `list_remote_index()` to use `op.list_with().recursive(true)` — was only discovering 18 of 39 S3 entries because `op.list()` only returns immediate children, missing all files in subdirectories
- Add remote_path-based fallback in `ListFiles` RPC for state cache entries not keyed under sync_root (FileProvider container temps, cross-origin entries)

**Phase 1.1 of the namespace unification plan** ([plan](https://github.com/Jesssullivan/tummycrypt/blob/main/.claude/plans/encapsulated-percolating-karp.md))

## Files changed
- `crates/tcfs-sync/src/reconcile.rs` — recursive listing fix
- `crates/tcfsd/src/grpc.rs` — ListFiles RPC fallback + improved comments

## Test plan
- [x] `cargo build --workspace` — clean (only pre-existing unused var warnings)
- [x] `cargo test --workspace` — 122 tests pass
- [x] `cargo clippy -p tcfsd -p tcfs-sync` — no new warnings
- [ ] Restart daemon → verify state cache discovers all 39 S3 entries (was 18)
- [ ] `tcfs ls` shows full file list
- [ ] FileProvider re-enumerates and shows all files in CloudStorage