### PR TITLE
feat(daemon): hydration state in ListFiles + macOS watcher disable

### DIFF
--- a/crates/tcfs-core/src/proto/tcfs.proto
+++ b/crates/tcfs-core/src/proto/tcfs.proto
@@ -137,6 +137,9 @@ message FileEntry {
   int64 last_synced = 4;
   bool is_directory = 5;
   string blake3 = 6;
+  // Hydration state: "not_synced" (placeholder), "synced" (downloaded),
+  // "active" (downloading/uploading), "conflict", "locked"
+  string hydration_state = 7;
 }
 
 message WatchRequest {

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -383,8 +383,21 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
     // ── File Watcher + Scheduler ─────────────────────────────────────
     // If sync_root is configured, start watching for local file changes
     // and feed them through the priority scheduler for automatic sync.
+    //
+    // On macOS with FileProvider active, the watcher is skipped because
+    // ~/Library/CloudStorage/TCFSProvider-TCFS/ is the primary interface.
+    // The FileProvider extension handles uploads/downloads via gRPC RPCs.
+    let fileprovider_active = cfg!(target_os = "macos")
+        && config.daemon.fileprovider_socket.is_some();
+
     let _watcher_handle = if let Some(ref sync_root) = config.sync.sync_root {
-        if sync_root.exists() {
+        if fileprovider_active {
+            info!(
+                dir = %sync_root.display(),
+                "FileProvider active — sync_root watcher disabled. Use CloudStorage."
+            );
+            None
+        } else if sync_root.exists() {
             let (watch_tx, mut watch_rx) = tokio::sync::mpsc::channel(256);
             let watcher_config = tcfs_sync::watcher::WatcherConfig::default();
 
@@ -456,7 +469,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                     // Scheduler run loop: dispatch tasks to sync engine
                     let sched_operator = operator.clone();
                     let sched_state = state_cache.clone();
-                    let sched_prefix = config.storage.bucket.clone();
+                    let sched_prefix = config.storage.resolved_prefix().to_string();
                     let sched_device = device_id.clone();
                     let sched_sync_root = sync_root.clone();
                     let sched_status_tx = status_tx.clone();

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1159,10 +1159,18 @@ impl TcfsDaemon for TcfsDaemonImpl {
                         last_synced: 0,
                         is_directory: true,
                         blake3: String::new(),
+                        hydration_state: String::new(),
                     });
                 }
             } else {
                 // Immediate child file
+                let hydration = match state.status {
+                    tcfs_sync::state::FileSyncStatus::NotSynced => "not_synced",
+                    tcfs_sync::state::FileSyncStatus::Synced => "synced",
+                    tcfs_sync::state::FileSyncStatus::Active => "active",
+                    tcfs_sync::state::FileSyncStatus::Locked => "locked",
+                    tcfs_sync::state::FileSyncStatus::Conflict => "conflict",
+                };
                 files.push(FileEntry {
                     path: rel_path.to_string(),
                     filename: remainder.clone(),
@@ -1170,6 +1178,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                     last_synced: state.last_synced as i64,
                     is_directory: false,
                     blake3: state.blake3.clone(),
+                    hydration_state: hydration.to_string(),
                 });
             }
         }


### PR DESCRIPTION
## Summary
- Add `hydration_state` field (proto field 7) to `FileEntry` — maps from `FileSyncStatus` enum so FileProvider can render sync badges
- On macOS with FileProvider socket configured, skip `sync_root` file watcher — `~/Library/CloudStorage/TCFSProvider-TCFS/` is the primary interface
- Fix scheduler prefix bug: was using `config.storage.bucket` instead of `resolved_prefix()`

**Phase 1.2 + 1.3 of the namespace unification plan**

## Files changed
- `crates/tcfs-core/src/proto/tcfs.proto` — FileEntry.hydration_state field
- `crates/tcfsd/src/daemon.rs` — conditional watcher + prefix fix
- `crates/tcfsd/src/grpc.rs` — populate hydration_state in ListFiles RPC

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — 159 tests pass
- [ ] Restart daemon on macOS → logs "FileProvider active — sync_root watcher disabled"
- [ ] `tcfs status` reports connected, no watcher
- [ ] FileProvider lists all files with hydration state populated