### PR TITLE
fix(sync): clear both conflict and status on resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,7 +3682,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3707,7 +3707,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -3898,7 +3898,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -3958,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6030,7 +6030,7 @@ dependencies = [
  "base32",
  "constant_time_eq 0.3.1",
  "hmac",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "sha1",
  "sha2",
@@ -6753,7 +6753,7 @@ dependencies = [
  "nom",
  "openssl",
  "openssl-sys",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "serde",
  "serde_cbor_2",

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -414,7 +414,7 @@ impl Default for SyncConfig {
             auto_download_threshold: 10 * 1024 * 1024, // 10MB
             trash_enabled: true,
             trash_retention_secs: 30 * 24 * 3600, // 30 days
-            reconcile_interval_secs: 300,          // 5 minutes
+            reconcile_interval_secs: 300,         // 5 minutes
         }
     }
 }

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -332,6 +332,23 @@ impl StateCache {
         }
     }
 
+    /// Clear conflict state after successful resolution.
+    ///
+    /// Sets `conflict` to `None` and `status` to `Synced`. Both fields
+    /// must be updated together — clearing only `conflict` leaves the file
+    /// flagged as conflicted in UI badges and FileProvider decorations.
+    pub fn resolve_conflict(&mut self, local_path: &Path) -> bool {
+        let key = path_key(local_path);
+        if let Some(entry) = self.entries.get_mut(&key) {
+            entry.conflict = None;
+            entry.status = FileSyncStatus::Synced;
+            self.dirty = true;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Remove stale entries whose `remote_path` doesn't match `expected_prefix`
     /// or whose local path (under /tmp/) no longer exists on disk.
     ///
@@ -1126,5 +1143,189 @@ mod tests {
         cache.set_status(&file_path, FileSyncStatus::NotSynced);
         // Should be dirty after set_status
         assert!(cache.dirty);
+    }
+
+    // ── Conflict resolution tests ──────────────────────────────────────
+
+    #[test]
+    fn resolve_conflict_clears_both_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut cache = StateCache::open(&path).unwrap();
+
+        let file_path = dir.path().join("conflicted.txt");
+        std::fs::write(&file_path, b"data").unwrap();
+
+        let conflict_info = crate::conflict::ConflictInfo {
+            rel_path: "conflicted.txt".into(),
+            local_vclock: VectorClock::new(),
+            remote_vclock: VectorClock::new(),
+            local_blake3: "aaa".into(),
+            remote_blake3: "bbb".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 1700000000,
+        };
+
+        cache.set(
+            &file_path,
+            SyncState {
+                blake3: "aaa".into(),
+                size: 4,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/index/conflicted.txt".into(),
+                last_synced: 0,
+                vclock: VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: Some(conflict_info),
+                status: FileSyncStatus::Conflict,
+            },
+        );
+
+        // Verify conflict is set
+        let entry = cache.get(&file_path).unwrap();
+        assert!(entry.conflict.is_some());
+        assert_eq!(entry.status, FileSyncStatus::Conflict);
+
+        // Resolve it
+        let resolved = cache.resolve_conflict(&file_path);
+        assert!(
+            resolved,
+            "resolve_conflict should return true for existing entry"
+        );
+
+        // Both fields must be cleared
+        let entry = cache.get(&file_path).unwrap();
+        assert!(
+            entry.conflict.is_none(),
+            "conflict must be None after resolve"
+        );
+        assert_eq!(
+            entry.status,
+            FileSyncStatus::Synced,
+            "status must be Synced after resolve"
+        );
+
+        // Metadata preserved
+        assert_eq!(entry.blake3, "aaa");
+        assert_eq!(entry.remote_path, "data/index/conflicted.txt");
+        assert_eq!(entry.device_id, "neo");
+    }
+
+    #[test]
+    fn resolve_conflict_marks_dirty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut cache = StateCache::open(&path).unwrap();
+
+        let file_path = dir.path().join("file.txt");
+        std::fs::write(&file_path, b"x").unwrap();
+
+        cache.set(
+            &file_path,
+            SyncState {
+                blake3: "abc".into(),
+                size: 1,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/index/file.txt".into(),
+                last_synced: 0,
+                vclock: VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: Some(crate::conflict::ConflictInfo {
+                    rel_path: "file.txt".into(),
+                    local_vclock: VectorClock::new(),
+                    remote_vclock: VectorClock::new(),
+                    local_blake3: "abc".into(),
+                    remote_blake3: "def".into(),
+                    local_device: "neo".into(),
+                    remote_device: "honey".into(),
+                    detected_at: 0,
+                }),
+                status: FileSyncStatus::Conflict,
+            },
+        );
+        cache.flush().unwrap();
+
+        cache.resolve_conflict(&file_path);
+        assert!(cache.dirty, "cache must be dirty after resolve_conflict");
+    }
+
+    #[test]
+    fn resolve_conflict_returns_false_for_missing_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut cache = StateCache::open(&path).unwrap();
+
+        let nonexistent = dir.path().join("nope.txt");
+        assert!(
+            !cache.resolve_conflict(&nonexistent),
+            "should return false for missing entry"
+        );
+    }
+
+    #[test]
+    fn resolve_conflict_roundtrip_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let file_path = dir.path().join("rt.txt");
+        std::fs::write(&file_path, b"roundtrip").unwrap();
+
+        // Write conflicted state and flush
+        {
+            let mut cache = StateCache::open(&path).unwrap();
+            cache.set(
+                &file_path,
+                SyncState {
+                    blake3: "rt".into(),
+                    size: 9,
+                    mtime: 0,
+                    chunk_count: 1,
+                    remote_path: "data/index/rt.txt".into(),
+                    last_synced: 0,
+                    vclock: VectorClock::new(),
+                    device_id: "neo".into(),
+                    conflict: Some(crate::conflict::ConflictInfo {
+                        rel_path: "rt.txt".into(),
+                        local_vclock: VectorClock::new(),
+                        remote_vclock: VectorClock::new(),
+                        local_blake3: "rt".into(),
+                        remote_blake3: "xx".into(),
+                        local_device: "neo".into(),
+                        remote_device: "honey".into(),
+                        detected_at: 0,
+                    }),
+                    status: FileSyncStatus::Conflict,
+                },
+            );
+            cache.flush().unwrap();
+        }
+
+        // Reload, resolve, flush
+        {
+            let mut cache = StateCache::open(&path).unwrap();
+            let entry = cache.get(&file_path).unwrap();
+            assert!(entry.conflict.is_some(), "conflict should persist on disk");
+            assert_eq!(entry.status, FileSyncStatus::Conflict);
+
+            cache.resolve_conflict(&file_path);
+            cache.flush().unwrap();
+        }
+
+        // Reload again — verify resolved state persisted
+        {
+            let cache = StateCache::open(&path).unwrap();
+            let entry = cache.get(&file_path).unwrap();
+            assert!(
+                entry.conflict.is_none(),
+                "conflict must be None after reload"
+            );
+            assert_eq!(
+                entry.status,
+                FileSyncStatus::Synced,
+                "status must be Synced after reload"
+            );
+        }
     }
 }

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -387,8 +387,8 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
     // On macOS with FileProvider active, the watcher is skipped because
     // ~/Library/CloudStorage/TCFSProvider-TCFS/ is the primary interface.
     // The FileProvider extension handles uploads/downloads via gRPC RPCs.
-    let fileprovider_active = cfg!(target_os = "macos")
-        && config.daemon.fileprovider_socket.is_some();
+    let fileprovider_active =
+        cfg!(target_os = "macos") && config.daemon.fileprovider_socket.is_some();
 
     let _watcher_handle = if let Some(ref sync_root) = config.sync.sync_root {
         if fileprovider_active {
@@ -1047,10 +1047,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
 
                     let s = &plan.summary;
                     if s.pushes == 0 && s.pulls == 0 && s.conflicts == 0 {
-                        debug!(
-                            up_to_date = s.up_to_date,
-                            "reconcile: nothing to do"
-                        );
+                        debug!(up_to_date = s.up_to_date, "reconcile: nothing to do");
                         continue;
                     }
 
@@ -1064,11 +1061,11 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
 
                     // Build encryption context from master key (if loaded)
                     let mk_guard = recon_master_key.lock().await;
-                    let enc_ctx = mk_guard.as_ref().map(|k| {
-                        tcfs_sync::engine::EncryptionContext {
+                    let enc_ctx = mk_guard
+                        .as_ref()
+                        .map(|k| tcfs_sync::engine::EncryptionContext {
                             master_key: k.clone(),
-                        }
-                    });
+                        });
                     drop(mk_guard);
 
                     let mut cache = recon_state.lock().await;

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1289,7 +1289,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                 }
                 drop(op);
 
-                // Update state cache (clear conflict)
+                // Update state cache (clear conflict + status)
                 {
                     let mut cache = self.state_cache.lock().await;
                     if let Some(entry) = cache.get(&path).cloned() {
@@ -1297,6 +1297,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                             vclock,
                             last_synced: tcfs_sync::StateEvent::now(),
                             conflict: None,
+                            status: tcfs_sync::state::FileSyncStatus::Synced,
                             ..entry
                         };
                         cache.set(&path, updated);
@@ -1356,6 +1357,13 @@ impl TcfsDaemon for TcfsDaemonImpl {
 
                 match result {
                     Ok(_dl) => {
+                        // Ensure conflict is fully cleared (download_file_with_device
+                        // creates fresh state, but belt-and-suspenders)
+                        {
+                            let mut cache = self.state_cache.lock().await;
+                            cache.resolve_conflict(&path);
+                            let _ = cache.flush();
+                        }
                         self.publish_conflict_resolved(&req.path, "keep_remote")
                             .await;
                         Ok(tonic::Response::new(ResolveConflictResponse {
@@ -1458,6 +1466,13 @@ impl TcfsDaemon for TcfsDaemonImpl {
                                     "failed to push conflict copy to S3: {e}"
                                 );
                             }
+                        }
+
+                        // Ensure conflict is fully cleared on the original path
+                        {
+                            let mut cache = self.state_cache.lock().await;
+                            cache.resolve_conflict(&path);
+                            let _ = cache.flush();
                         }
 
                         self.publish_conflict_resolved(&req.path, "keep_both").await;

--- a/deny.toml
+++ b/deny.toml
@@ -13,8 +13,9 @@ targets = [
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained — transitive dep via reqwest
-    "RUSTSEC-2024-0436",  # paste unmaintained — transitive dep via uniffi
+    "RUSTSEC-2024-0436",  # paste unmaintained — transitive dep via uniffi, no replacement available
     "RUSTSEC-2026-0049",  # rustls-webpki CRL bug — transitive dep, limited impact
+    "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]
 


### PR DESCRIPTION
## Summary
- Add `StateCache::resolve_conflict()` method that atomically clears `conflict: None` + `status: Synced`
- Fix `keep_local` resolution where `..entry` struct spread preserved `status: Conflict`
- Add belt-and-suspenders `resolve_conflict()` calls after `keep_remote`/`keep_both` downloads

## Test plan
- [x] 4 new unit tests in `state.rs` for conflict resolution
- [x] `cargo test -p tcfs-sync -- resolve_conflict`
- [x] `cargo test --workspace`