### PR TITLE
test(sync): unit tests for engine, NATS serialization, reconcile

### DIFF
--- a/crates/tcfs-auth/src/webauthn.rs
+++ b/crates/tcfs-auth/src/webauthn.rs
@@ -187,7 +187,7 @@ impl AuthProvider for WebAuthnProvider {
 
         let (rcr, auth_state) = self
             .webauthn
-            .start_passkey_authentication(&[credential.passkey.clone()])
+            .start_passkey_authentication(std::slice::from_ref(&credential.passkey))
             .map_err(|e| anyhow::anyhow!("failed to start authentication: {e}"))?;
 
         let challenge_id = uuid::Uuid::new_v4().to_string();

--- a/crates/tcfs-chunks/src/fastcdc.rs
+++ b/crates/tcfs-chunks/src/fastcdc.rs
@@ -143,7 +143,7 @@ pub fn chunk_file_streaming(path: &Path) -> Result<Vec<ChunkWithData>> {
         let entry = result.map_err(|e| anyhow::anyhow!("streaming chunk error: {e}"))?;
         let hash = crate::blake3::hash_bytes(&entry.data);
         chunks.push(ChunkWithData {
-            offset: entry.offset as u64,
+            offset: entry.offset,
             data: entry.data,
             hash,
         });
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     fn streaming_empty_file() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(tmp.path(), &[]).unwrap();
+        std::fs::write(tmp.path(), []).unwrap();
 
         let chunks = chunk_file_streaming(tmp.path()).unwrap();
         assert!(chunks.is_empty(), "empty file should yield 0 chunks");

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1276,7 +1276,7 @@ async fn cmd_trash(config: &tcfs_core::config::TcfsConfig, action: TrashAction) 
                 return Ok(());
             }
 
-            println!("{:<40} {:<20} {}", "ORIGINAL PATH", "TRASHED", "TRASH KEY");
+            println!("{:<40} {:<20} TRASH KEY", "ORIGINAL PATH", "TRASHED");
             println!("{}", "-".repeat(90));
 
             for entry in &entries {
@@ -1913,7 +1913,7 @@ async fn cmd_mount(
                 cache_dir,
                 cache_max_bytes: cache_max,
                 negative_ttl_secs: neg_ttl,
-                read_only: read_only,
+                read_only,
                 allow_other: false,
                 on_flush,
                 device_id: std::env::var("HOSTNAME").unwrap_or_else(|_| "cli".to_string()),
@@ -1962,7 +1962,7 @@ fn cmd_unmount(mountpoint: &std::path::Path) -> Result<()> {
         match status {
             Ok(s) if s.success() => {
                 println!("Unmounted: {}", mountpoint.display());
-                return Ok(());
+                Ok(())
             }
             Ok(s) => anyhow::bail!(
                 "umount exited {}: try `diskutil unmount {}`",

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
         let master_key = config["encryption_passphrase"]
             .as_str()
             .filter(|s| !s.is_empty())
-            .map(|passphrase| {
+            .and_then(|passphrase| {
                 let salt_str = config["encryption_salt"]
                     .as_str()
                     .unwrap_or("tcfs-default-salt!");
@@ -88,8 +88,7 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
                     &params,
                 )
                 .ok()
-            })
-            .flatten();
+            });
 
         // Single-threaded tokio runtime to avoid deadlock with fileproviderd.
         // Multi-threaded runtime spawns worker threads that contend with XPC

--- a/crates/tcfs-file-provider/tests/ffi_safety_test.rs
+++ b/crates/tcfs-file-provider/tests/ffi_safety_test.rs
@@ -5,8 +5,7 @@
 //! - String allocation and deallocation are balanced
 //! - Error enum has correct C repr values
 
-use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
+use std::ffi::CString;
 use std::ptr;
 
 use tcfs_file_provider::*;

--- a/crates/tcfs-fuse/src/driver.rs
+++ b/crates/tcfs-fuse/src/driver.rs
@@ -18,7 +18,7 @@ use opendal::Operator;
 use tracing::{debug, info, warn};
 
 use tcfs_vfs::types::VfsFileType;
-use tcfs_vfs::{OnFlushCallback, TcfsVfs, VfsAttr, VirtualFilesystem};
+use tcfs_vfs::{TcfsVfs, VfsAttr, VirtualFilesystem};
 
 // ── Configuration ─────────────────────────────────────────────────────────
 

--- a/crates/tcfs-nfs/src/server.rs
+++ b/crates/tcfs-nfs/src/server.rs
@@ -44,17 +44,10 @@ pub struct NfsMount {
 impl NfsMount {
     /// Unmount the NFS filesystem.
     pub async fn unmount(&self) -> Result<()> {
-        let status = if cfg!(target_os = "macos") {
-            Command::new("umount")
-                .arg(&self.mountpoint)
-                .status()
-                .await?
-        } else {
-            Command::new("umount")
-                .arg(&self.mountpoint)
-                .status()
-                .await?
-        };
+        let status = Command::new("umount")
+            .arg(&self.mountpoint)
+            .status()
+            .await?;
 
         if !status.success() {
             // Try lazy unmount on Linux
@@ -172,7 +165,7 @@ async fn mount_nfs(port: u16, mountpoint: &Path) -> Result<()> {
         Command::new("mount_nfs")
             .arg("-o")
             .arg(format!("tcp,vers=3,resvport,locallocks,port={}", port))
-            .arg(format!("127.0.0.1:/"))
+            .arg("127.0.0.1:/")
             .arg(mountpoint)
             .status()
             .await
@@ -188,7 +181,7 @@ async fn mount_nfs(port: u16, mountpoint: &Path) -> Result<()> {
             .arg("nfs")
             .arg("-o")
             .arg(format!("tcp,vers=3,noacl,nolock,port={}", port))
-            .arg(format!("127.0.0.1:/"))
+            .arg("127.0.0.1:/")
             .arg(mountpoint)
             .status()
             .await

--- a/crates/tcfs-sync/src/blacklist.rs
+++ b/crates/tcfs-sync/src/blacklist.rs
@@ -120,14 +120,14 @@ impl Blacklist {
     /// This is the fast path for the watcher, which only has a name and no full path.
     pub fn check_name(&self, name: &str, is_dir: bool) -> Option<BlacklistReason> {
         // Built-in directory exclusions
-        if is_dir && BUILTIN_DIRS.iter().any(|&b| b == name) {
+        if is_dir && BUILTIN_DIRS.contains(&name) {
             return Some(BlacklistReason::BuiltIn(
                 BUILTIN_DIRS.iter().find(|&&b| b == name).unwrap(),
             ));
         }
 
         // Built-in file exclusions
-        if BUILTIN_FILES.iter().any(|&b| b == name) {
+        if BUILTIN_FILES.contains(&name) {
             return Some(BlacklistReason::BuiltIn(
                 BUILTIN_FILES.iter().find(|&&b| b == name).unwrap(),
             ));

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -133,6 +133,7 @@ pub async fn upload_file(
 
 /// Upload with device identity, vector clock awareness, and optional encryption.
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 pub async fn upload_file_with_device(
     op: &Operator,
     local_path: &Path,
@@ -614,6 +615,7 @@ pub async fn download_file(
 
 /// Download with device identity, vector clock merge, and optional decryption.
 #[allow(unused_variables)]
+#[allow(clippy::too_many_arguments)]
 pub async fn download_file_with_device(
     op: &Operator,
     remote_manifest: &str,
@@ -866,6 +868,7 @@ pub async fn push_tree(
 }
 
 /// Push tree with device identity, optional collection config, and optional encryption.
+#[allow(clippy::too_many_arguments)]
 pub async fn push_tree_with_device(
     op: &Operator,
     local_root: &Path,

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1299,6 +1299,11 @@ fn remote_path_prefix(prefix: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opendal::services::Memory;
+
+    fn memory_op() -> Operator {
+        Operator::new(Memory::default()).unwrap().finish()
+    }
 
     fn default_config() -> CollectConfig {
         CollectConfig::default()
@@ -1311,6 +1316,7 @@ mod tests {
         }
     }
 
+    // ── collect_files (empty dir detection) ──────────────────────────────
     #[test]
     fn collect_finds_empty_dirs() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1423,5 +1429,173 @@ mod tests {
             empty_names.contains(&"real_empty".to_string()),
             "real empty dir should be detected"
         );
+    }
+
+    // ── normalize_rel_path ───────────────────────────────────────────────
+
+    #[test]
+    fn normalize_rel_path_relative_passthrough() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("doc.txt");
+        std::fs::write(&file, b"x").unwrap();
+
+        // With sync_root set, file under root → relative
+        let result = normalize_rel_path(&file, Some(dir.path()));
+        assert_eq!(result, "doc.txt");
+    }
+
+    #[test]
+    fn normalize_rel_path_nested() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
+        let file = dir.path().join("a/b/deep.txt");
+        std::fs::write(&file, b"x").unwrap();
+
+        let result = normalize_rel_path(&file, Some(dir.path()));
+        assert_eq!(result, "a/b/deep.txt");
+    }
+
+    #[test]
+    fn normalize_rel_path_no_sync_root_strips_leading_slash() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file.txt");
+        std::fs::write(&file, b"x").unwrap();
+
+        let result = normalize_rel_path(&file, None);
+        // Absolute path should have leading / stripped
+        assert!(!result.starts_with('/'), "should strip leading /: {result}");
+        assert!(result.ends_with("file.txt"));
+    }
+
+    // ── resolve_manifest_path ─────────────────────────────────────────��──
+
+    #[tokio::test]
+    async fn resolve_manifest_passthrough() {
+        let op = memory_op();
+        let result = resolve_manifest_path(&op, "data/manifests/abc123", "data", None)
+            .await
+            .unwrap();
+        assert_eq!(result, "data/manifests/abc123");
+    }
+
+    #[tokio::test]
+    async fn resolve_manifest_from_index() {
+        let op = memory_op();
+        // Write an index entry
+        op.write(
+            "data/index/doc.txt",
+            b"manifest_hash=abc123\nsize=100\nchunks=1\n".to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_manifest_path(&op, "doc.txt", "data", None)
+            .await
+            .unwrap();
+        assert_eq!(result, "data/manifests/abc123");
+    }
+
+    #[tokio::test]
+    async fn resolve_manifest_missing_errors() {
+        let op = memory_op();
+        let result = resolve_manifest_path(&op, "nonexistent.txt", "data", None).await;
+        assert!(result.is_err());
+    }
+
+    // ── delete_remote_file ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_remote_file_removes_index_and_manifest() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        // Write index and manifest
+        op.write(
+            "data/index/file.txt",
+            b"manifest_hash=abc123\nsize=100\nchunks=1\n".to_vec(),
+        )
+        .await
+        .unwrap();
+        op.write(
+            "data/manifests/abc123",
+            br#"{"version":2,"file_hash":"abc123","file_size":100,"chunks":[],"vclock":{"clocks":{}},"written_by":"neo","written_at":0}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+
+        delete_remote_file(&op, "file.txt", "data", &mut state, None)
+            .await
+            .unwrap();
+
+        // Both should be gone
+        assert!(op.read("data/index/file.txt").await.is_err());
+        assert!(op.read("data/manifests/abc123").await.is_err());
+    }
+
+    // ── upload + download roundtrip (memory operator) ────────────────────
+
+    #[tokio::test]
+    async fn upload_download_roundtrip_small_file() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        // Write a small local file
+        let local = dir.path().join("hello.txt");
+        std::fs::write(&local, b"hello world").unwrap();
+
+        // Upload
+        let up = upload_file(&op, &local, "data", &mut state, None)
+            .await
+            .unwrap();
+        assert!(!up.skipped);
+        assert_eq!(up.bytes, 11);
+        assert!(!up.hash.is_empty());
+
+        // Download to a different location
+        let dl_path = dir.path().join("downloaded.txt");
+        let dl = download_file(&op, &up.remote_path, &dl_path, "data", None)
+            .await
+            .unwrap();
+        assert_eq!(dl.bytes, 11);
+
+        // Verify content matches
+        let content = std::fs::read_to_string(&dl_path).unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn upload_skips_when_already_synced() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        let local = dir.path().join("file.txt");
+        std::fs::write(&local, b"content").unwrap();
+
+        // First upload
+        let up1 = upload_file(&op, &local, "data", &mut state, None)
+            .await
+            .unwrap();
+        assert!(!up1.skipped);
+
+        // Second upload of same file — should skip (dedup)
+        let up2 = upload_file(&op, &local, "data", &mut state, None)
+            .await
+            .unwrap();
+        assert!(up2.skipped, "second upload of unchanged file should skip");
+    }
+
+    // ── remote_path_prefix ───────────────────────────────────────────────
+
+    #[test]
+    fn remote_path_prefix_strips_trailing_slash() {
+        assert_eq!(remote_path_prefix("data/"), "data");
+        assert_eq!(remote_path_prefix("data"), "data");
+        assert_eq!(remote_path_prefix("a/b/c/"), "a/b/c");
     }
 }

--- a/crates/tcfs-sync/src/nats.rs
+++ b/crates/tcfs-sync/src/nats.rs
@@ -189,6 +189,236 @@ mod inner {
         }
     }
 
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn sample_vclock() -> VectorClock {
+            let mut vc = VectorClock::new();
+            vc.tick("neo");
+            vc.tick("neo");
+            vc.tick("honey");
+            vc
+        }
+
+        // ── StateEvent serialization ─────────────────────────────────────
+
+        #[test]
+        fn state_event_file_synced_roundtrip() {
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "docs/readme.md".into(),
+                blake3: "abc123def456".into(),
+                size: 2048,
+                vclock: sample_vclock(),
+                manifest_path: "data/manifests/abc123def456".into(),
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+
+            assert_eq!(decoded.device_id(), "neo");
+            assert_eq!(decoded.event_type(), "file_synced");
+            if let StateEvent::FileSynced { rel_path, size, .. } = decoded {
+                assert_eq!(rel_path, "docs/readme.md");
+                assert_eq!(size, 2048);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_file_deleted_roundtrip() {
+            let event = StateEvent::FileDeleted {
+                device_id: "honey".into(),
+                rel_path: "old.txt".into(),
+                vclock: sample_vclock(),
+                timestamp: 1700000001,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.device_id(), "honey");
+            assert_eq!(decoded.event_type(), "file_deleted");
+        }
+
+        #[test]
+        fn state_event_file_renamed_roundtrip() {
+            let event = StateEvent::FileRenamed {
+                device_id: "neo".into(),
+                old_path: "a.txt".into(),
+                new_path: "b.txt".into(),
+                vclock: VectorClock::new(),
+                timestamp: 0,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            if let StateEvent::FileRenamed {
+                old_path, new_path, ..
+            } = decoded
+            {
+                assert_eq!(old_path, "a.txt");
+                assert_eq!(new_path, "b.txt");
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_device_online_roundtrip() {
+            let event = StateEvent::DeviceOnline {
+                device_id: "neo".into(),
+                last_seq: 42,
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "device_online");
+            if let StateEvent::DeviceOnline { last_seq, .. } = decoded {
+                assert_eq!(last_seq, 42);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_device_offline_roundtrip() {
+            let event = StateEvent::DeviceOffline {
+                device_id: "honey".into(),
+                last_seq: 99,
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "device_offline");
+        }
+
+        #[test]
+        fn state_event_conflict_resolved_roundtrip() {
+            let event = StateEvent::ConflictResolved {
+                device_id: "neo".into(),
+                rel_path: "conflict.txt".into(),
+                resolution: "keep_local".into(),
+                merged_vclock: sample_vclock(),
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "conflict_resolved");
+            if let StateEvent::ConflictResolved { resolution, .. } = decoded {
+                assert_eq!(resolution, "keep_local");
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        // ── StateEvent subject generation ────────────────────────────────
+
+        #[test]
+        fn state_event_subject_format() {
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "f.txt".into(),
+                blake3: "x".into(),
+                size: 0,
+                vclock: VectorClock::new(),
+                manifest_path: "m".into(),
+                timestamp: 0,
+            };
+            assert_eq!(event.subject(), "STATE.neo.file_synced");
+
+            let event2 = StateEvent::DeviceOnline {
+                device_id: "honey".into(),
+                last_seq: 0,
+                timestamp: 0,
+            };
+            assert_eq!(event2.subject(), "STATE.honey.device_online");
+        }
+
+        // ── SyncTask serialization ───────────────────────────────────────
+
+        #[test]
+        fn sync_task_push_roundtrip() {
+            let task = SyncTask::Push {
+                task_id: "task-001".into(),
+                local_path: "/home/jess/tcfs".into(),
+                remote_prefix: "data".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-001");
+            assert_eq!(decoded.type_name(), "push");
+        }
+
+        #[test]
+        fn sync_task_pull_roundtrip() {
+            let task = SyncTask::Pull {
+                task_id: "task-002".into(),
+                manifest_path: "data/manifests/abc123".into(),
+                remote_prefix: "data".into(),
+                local_path: "/tmp/out.txt".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-002");
+            assert_eq!(decoded.type_name(), "pull");
+        }
+
+        #[test]
+        fn sync_task_unsync_roundtrip() {
+            let task = SyncTask::Unsync {
+                task_id: "task-003".into(),
+                local_path: "/home/jess/tcfs/big.bin".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-003");
+            assert_eq!(decoded.type_name(), "unsync");
+        }
+
+        #[test]
+        fn state_event_invalid_json_errors() {
+            let result = StateEvent::from_bytes(b"not json at all");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn sync_task_invalid_json_errors() {
+            let result = SyncTask::from_bytes(b"{\"type\":\"unknown\"}");
+            assert!(result.is_err());
+        }
+
+        // ── VectorClock survives JSON roundtrip ──────────────────────────
+
+        #[test]
+        fn vclock_preserved_through_state_event() {
+            let mut vc = VectorClock::new();
+            vc.tick("neo");
+            vc.tick("neo");
+            vc.tick("honey");
+
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "f.txt".into(),
+                blake3: "x".into(),
+                size: 0,
+                vclock: vc.clone(),
+                manifest_path: "m".into(),
+                timestamp: 0,
+            };
+
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            if let StateEvent::FileSynced { vclock, .. } = decoded {
+                assert_eq!(vclock.get("neo"), 2);
+                assert_eq!(vclock.get("honey"), 1);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+    }
+
     // ── NatsClient ────────────────────────────────────────────────────────────
 
     /// Thin wrapper around an async-nats JetStream context.

--- a/crates/tcfs-sync/src/nats.rs
+++ b/crates/tcfs-sync/src/nats.rs
@@ -189,236 +189,6 @@ mod inner {
         }
     }
 
-    // ── Tests ─────────────────────────────────────────────────────────────────
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        fn sample_vclock() -> VectorClock {
-            let mut vc = VectorClock::new();
-            vc.tick("neo");
-            vc.tick("neo");
-            vc.tick("honey");
-            vc
-        }
-
-        // ── StateEvent serialization ─────────────────────────────────────
-
-        #[test]
-        fn state_event_file_synced_roundtrip() {
-            let event = StateEvent::FileSynced {
-                device_id: "neo".into(),
-                rel_path: "docs/readme.md".into(),
-                blake3: "abc123def456".into(),
-                size: 2048,
-                vclock: sample_vclock(),
-                manifest_path: "data/manifests/abc123def456".into(),
-                timestamp: 1700000000,
-            };
-            let bytes = event.to_bytes().unwrap();
-            let decoded = StateEvent::from_bytes(&bytes).unwrap();
-
-            assert_eq!(decoded.device_id(), "neo");
-            assert_eq!(decoded.event_type(), "file_synced");
-            if let StateEvent::FileSynced { rel_path, size, .. } = decoded {
-                assert_eq!(rel_path, "docs/readme.md");
-                assert_eq!(size, 2048);
-            } else {
-                panic!("wrong variant");
-            }
-        }
-
-        #[test]
-        fn state_event_file_deleted_roundtrip() {
-            let event = StateEvent::FileDeleted {
-                device_id: "honey".into(),
-                rel_path: "old.txt".into(),
-                vclock: sample_vclock(),
-                timestamp: 1700000001,
-            };
-            let bytes = event.to_bytes().unwrap();
-            let decoded = StateEvent::from_bytes(&bytes).unwrap();
-            assert_eq!(decoded.device_id(), "honey");
-            assert_eq!(decoded.event_type(), "file_deleted");
-        }
-
-        #[test]
-        fn state_event_file_renamed_roundtrip() {
-            let event = StateEvent::FileRenamed {
-                device_id: "neo".into(),
-                old_path: "a.txt".into(),
-                new_path: "b.txt".into(),
-                vclock: VectorClock::new(),
-                timestamp: 0,
-            };
-            let bytes = event.to_bytes().unwrap();
-            let decoded = StateEvent::from_bytes(&bytes).unwrap();
-            if let StateEvent::FileRenamed {
-                old_path, new_path, ..
-            } = decoded
-            {
-                assert_eq!(old_path, "a.txt");
-                assert_eq!(new_path, "b.txt");
-            } else {
-                panic!("wrong variant");
-            }
-        }
-
-        #[test]
-        fn state_event_device_online_roundtrip() {
-            let event = StateEvent::DeviceOnline {
-                device_id: "neo".into(),
-                last_seq: 42,
-                timestamp: 1700000000,
-            };
-            let bytes = event.to_bytes().unwrap();
-            let decoded = StateEvent::from_bytes(&bytes).unwrap();
-            assert_eq!(decoded.event_type(), "device_online");
-            if let StateEvent::DeviceOnline { last_seq, .. } = decoded {
-                assert_eq!(last_seq, 42);
-            } else {
-                panic!("wrong variant");
-            }
-        }
-
-        #[test]
-        fn state_event_device_offline_roundtrip() {
-            let event = StateEvent::DeviceOffline {
-                device_id: "honey".into(),
-                last_seq: 99,
-                timestamp: 1700000000,
-            };
-            let bytes = event.to_bytes().unwrap();
-            let decoded = StateEvent::from_bytes(&bytes).unwrap();
-            assert_eq!(decoded.event_type(), "device_offline");
-        }
-
-        #[test]
-        fn state_event_conflict_resolved_roundtrip() {
-            let event = StateEvent::ConflictResolved {
-                device_id: "neo".into(),
-                rel_path: "conflict.txt".into(),
-                resolution: "keep_local".into(),
-                merged_vclock: sample_vclock(),
-                timestamp: 1700000000,
-            };
-            let bytes = event.to_bytes().unwrap();
-            let decoded = StateEvent::from_bytes(&bytes).unwrap();
-            assert_eq!(decoded.event_type(), "conflict_resolved");
-            if let StateEvent::ConflictResolved { resolution, .. } = decoded {
-                assert_eq!(resolution, "keep_local");
-            } else {
-                panic!("wrong variant");
-            }
-        }
-
-        // ── StateEvent subject generation ────────────────────────────────
-
-        #[test]
-        fn state_event_subject_format() {
-            let event = StateEvent::FileSynced {
-                device_id: "neo".into(),
-                rel_path: "f.txt".into(),
-                blake3: "x".into(),
-                size: 0,
-                vclock: VectorClock::new(),
-                manifest_path: "m".into(),
-                timestamp: 0,
-            };
-            assert_eq!(event.subject(), "STATE.neo.file_synced");
-
-            let event2 = StateEvent::DeviceOnline {
-                device_id: "honey".into(),
-                last_seq: 0,
-                timestamp: 0,
-            };
-            assert_eq!(event2.subject(), "STATE.honey.device_online");
-        }
-
-        // ── SyncTask serialization ───────────────────────────────────────
-
-        #[test]
-        fn sync_task_push_roundtrip() {
-            let task = SyncTask::Push {
-                task_id: "task-001".into(),
-                local_path: "/home/jess/tcfs".into(),
-                remote_prefix: "data".into(),
-            };
-            let bytes = task.to_bytes().unwrap();
-            let decoded = SyncTask::from_bytes(&bytes).unwrap();
-            assert_eq!(decoded.task_id(), "task-001");
-            assert_eq!(decoded.type_name(), "push");
-        }
-
-        #[test]
-        fn sync_task_pull_roundtrip() {
-            let task = SyncTask::Pull {
-                task_id: "task-002".into(),
-                manifest_path: "data/manifests/abc123".into(),
-                remote_prefix: "data".into(),
-                local_path: "/tmp/out.txt".into(),
-            };
-            let bytes = task.to_bytes().unwrap();
-            let decoded = SyncTask::from_bytes(&bytes).unwrap();
-            assert_eq!(decoded.task_id(), "task-002");
-            assert_eq!(decoded.type_name(), "pull");
-        }
-
-        #[test]
-        fn sync_task_unsync_roundtrip() {
-            let task = SyncTask::Unsync {
-                task_id: "task-003".into(),
-                local_path: "/home/jess/tcfs/big.bin".into(),
-            };
-            let bytes = task.to_bytes().unwrap();
-            let decoded = SyncTask::from_bytes(&bytes).unwrap();
-            assert_eq!(decoded.task_id(), "task-003");
-            assert_eq!(decoded.type_name(), "unsync");
-        }
-
-        #[test]
-        fn state_event_invalid_json_errors() {
-            let result = StateEvent::from_bytes(b"not json at all");
-            assert!(result.is_err());
-        }
-
-        #[test]
-        fn sync_task_invalid_json_errors() {
-            let result = SyncTask::from_bytes(b"{\"type\":\"unknown\"}");
-            assert!(result.is_err());
-        }
-
-        // ── VectorClock survives JSON roundtrip ──────────────────────────
-
-        #[test]
-        fn vclock_preserved_through_state_event() {
-            let mut vc = VectorClock::new();
-            vc.tick("neo");
-            vc.tick("neo");
-            vc.tick("honey");
-
-            let event = StateEvent::FileSynced {
-                device_id: "neo".into(),
-                rel_path: "f.txt".into(),
-                blake3: "x".into(),
-                size: 0,
-                vclock: vc.clone(),
-                manifest_path: "m".into(),
-                timestamp: 0,
-            };
-
-            let bytes = event.to_bytes().unwrap();
-            let decoded = StateEvent::from_bytes(&bytes).unwrap();
-            if let StateEvent::FileSynced { vclock, .. } = decoded {
-                assert_eq!(vclock.get("neo"), 2);
-                assert_eq!(vclock.get("honey"), 1);
-            } else {
-                panic!("wrong variant");
-            }
-        }
-    }
-
     // ── NatsClient ────────────────────────────────────────────────────────────
 
     /// Thin wrapper around an async-nats JetStream context.
@@ -792,6 +562,231 @@ mod inner {
     #[cfg(test)]
     mod tests {
         use super::*;
+
+        fn sample_vclock() -> VectorClock {
+            let mut vc = VectorClock::new();
+            vc.tick("neo");
+            vc.tick("neo");
+            vc.tick("honey");
+            vc
+        }
+
+        // ── StateEvent serialization ─────────────────────────────────────
+
+        #[test]
+        fn state_event_file_synced_roundtrip() {
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "docs/readme.md".into(),
+                blake3: "abc123def456".into(),
+                size: 2048,
+                vclock: sample_vclock(),
+                manifest_path: "data/manifests/abc123def456".into(),
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+
+            assert_eq!(decoded.device_id(), "neo");
+            assert_eq!(decoded.event_type(), "file_synced");
+            if let StateEvent::FileSynced { rel_path, size, .. } = decoded {
+                assert_eq!(rel_path, "docs/readme.md");
+                assert_eq!(size, 2048);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_file_deleted_roundtrip() {
+            let event = StateEvent::FileDeleted {
+                device_id: "honey".into(),
+                rel_path: "old.txt".into(),
+                vclock: sample_vclock(),
+                timestamp: 1700000001,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.device_id(), "honey");
+            assert_eq!(decoded.event_type(), "file_deleted");
+        }
+
+        #[test]
+        fn state_event_file_renamed_roundtrip() {
+            let event = StateEvent::FileRenamed {
+                device_id: "neo".into(),
+                old_path: "a.txt".into(),
+                new_path: "b.txt".into(),
+                vclock: VectorClock::new(),
+                timestamp: 0,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            if let StateEvent::FileRenamed {
+                old_path, new_path, ..
+            } = decoded
+            {
+                assert_eq!(old_path, "a.txt");
+                assert_eq!(new_path, "b.txt");
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_device_online_roundtrip() {
+            let event = StateEvent::DeviceOnline {
+                device_id: "neo".into(),
+                last_seq: 42,
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "device_online");
+            if let StateEvent::DeviceOnline { last_seq, .. } = decoded {
+                assert_eq!(last_seq, 42);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_device_offline_roundtrip() {
+            let event = StateEvent::DeviceOffline {
+                device_id: "honey".into(),
+                last_seq: 99,
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "device_offline");
+        }
+
+        #[test]
+        fn state_event_conflict_resolved_roundtrip() {
+            let event = StateEvent::ConflictResolved {
+                device_id: "neo".into(),
+                rel_path: "conflict.txt".into(),
+                resolution: "keep_local".into(),
+                merged_vclock: sample_vclock(),
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "conflict_resolved");
+            if let StateEvent::ConflictResolved { resolution, .. } = decoded {
+                assert_eq!(resolution, "keep_local");
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        // ── StateEvent subject generation ────────────────────────────────
+
+        #[test]
+        fn state_event_subject_format() {
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "f.txt".into(),
+                blake3: "x".into(),
+                size: 0,
+                vclock: VectorClock::new(),
+                manifest_path: "m".into(),
+                timestamp: 0,
+            };
+            assert_eq!(event.subject(), "STATE.neo.file_synced");
+
+            let event2 = StateEvent::DeviceOnline {
+                device_id: "honey".into(),
+                last_seq: 0,
+                timestamp: 0,
+            };
+            assert_eq!(event2.subject(), "STATE.honey.device_online");
+        }
+
+        // ── SyncTask serialization ───────────────────────────────────────
+
+        #[test]
+        fn sync_task_push_roundtrip() {
+            let task = SyncTask::Push {
+                task_id: "task-001".into(),
+                local_path: "/home/jess/tcfs".into(),
+                remote_prefix: "data".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-001");
+            assert_eq!(decoded.type_name(), "push");
+        }
+
+        #[test]
+        fn sync_task_pull_roundtrip() {
+            let task = SyncTask::Pull {
+                task_id: "task-002".into(),
+                manifest_path: "data/manifests/abc123".into(),
+                remote_prefix: "data".into(),
+                local_path: "/tmp/out.txt".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-002");
+            assert_eq!(decoded.type_name(), "pull");
+        }
+
+        #[test]
+        fn sync_task_unsync_roundtrip() {
+            let task = SyncTask::Unsync {
+                task_id: "task-003".into(),
+                local_path: "/home/jess/tcfs/big.bin".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-003");
+            assert_eq!(decoded.type_name(), "unsync");
+        }
+
+        #[test]
+        fn state_event_invalid_json_errors() {
+            let result = StateEvent::from_bytes(b"not json at all");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn sync_task_invalid_json_errors() {
+            let result = SyncTask::from_bytes(b"{\"type\":\"unknown\"}");
+            assert!(result.is_err());
+        }
+
+        // ── VectorClock survives JSON roundtrip ──────────────────────────
+
+        #[test]
+        fn vclock_preserved_through_state_event() {
+            let mut vc = VectorClock::new();
+            vc.tick("neo");
+            vc.tick("neo");
+            vc.tick("honey");
+
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "f.txt".into(),
+                blake3: "x".into(),
+                size: 0,
+                vclock: vc.clone(),
+                manifest_path: "m".into(),
+                timestamp: 0,
+            };
+
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            if let StateEvent::FileSynced { vclock, .. } = decoded {
+                assert_eq!(vclock.get("neo"), 2);
+                assert_eq!(vclock.get("honey"), 1);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        // ── TLS URL resolution ───────────────────────────────────────────
 
         #[test]
         fn tls_url_upgrade_nats_to_tls() {

--- a/crates/tcfs-sync/src/policy.rs
+++ b/crates/tcfs-sync/src/policy.rs
@@ -12,21 +12,16 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 /// Sync mode for a folder.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SyncMode {
     /// Sync on demand — user triggers push/pull explicitly.
+    #[default]
     OnDemand,
     /// Always keep synced — auto-push changes, auto-pull remote updates.
     Always,
     /// Never sync — ignore all changes in this folder.
     Never,
-}
-
-impl Default for SyncMode {
-    fn default() -> Self {
-        SyncMode::OnDemand
-    }
 }
 
 /// Sync behavior policy for a single folder.

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -99,21 +99,12 @@ pub struct ReconcilePlan {
 }
 
 /// Configuration controlling reconciliation behavior.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ReconcileConfig {
     /// Delete local files that were synced but no longer exist on remote.
     pub delete_local_orphans: bool,
     /// Delete remote files that were synced but no longer exist locally.
     pub delete_remote_orphans: bool,
-}
-
-impl Default for ReconcileConfig {
-    fn default() -> Self {
-        Self {
-            delete_local_orphans: false,
-            delete_remote_orphans: false,
-        }
-    }
 }
 
 /// Result of executing a reconciliation plan.
@@ -302,6 +293,7 @@ pub async fn reconcile(
 }
 
 /// Classify a single path into a reconciliation action.
+#[allow(clippy::too_many_arguments)]
 async fn classify_path(
     rel_path: &str,
     local: Option<&PathBuf>,
@@ -387,7 +379,7 @@ async fn classify_path(
 /// Compare when both local and remote exist — uses vector clocks.
 async fn compare_both_exist(
     rel_path: &str,
-    local_path: &PathBuf,
+    local_path: &Path,
     remote_entry: &RemoteIndexEntry,
     tracked: Option<&SyncState>,
     op: &Operator,
@@ -421,7 +413,7 @@ async fn compare_both_exist(
             Err(e) => {
                 warn!(path = manifest_path, error = %e, "failed to parse remote manifest");
                 return ReconcileAction::Push {
-                    local_path: local_path.clone(),
+                    local_path: local_path.to_path_buf(),
                     rel_path: rel_path.to_string(),
                     reason: PushReason::NewLocal,
                 };
@@ -430,7 +422,7 @@ async fn compare_both_exist(
         Err(e) => {
             warn!(path = manifest_path, error = %e, "failed to read remote manifest");
             return ReconcileAction::Push {
-                local_path: local_path.clone(),
+                local_path: local_path.to_path_buf(),
                 rel_path: rel_path.to_string(),
                 reason: PushReason::NewLocal,
             };
@@ -454,7 +446,7 @@ async fn compare_both_exist(
             rel_path: rel_path.to_string(),
         },
         crate::conflict::SyncOutcome::LocalNewer => ReconcileAction::Push {
-            local_path: local_path.clone(),
+            local_path: local_path.to_path_buf(),
             rel_path: rel_path.to_string(),
             reason: PushReason::LocalNewer,
         },
@@ -476,6 +468,7 @@ async fn compare_both_exist(
 /// Execute a reconciliation plan, performing all I/O operations.
 ///
 /// Errors on individual actions are collected — the plan continues past failures.
+#[allow(clippy::too_many_arguments)]
 pub async fn execute_plan(
     plan: &ReconcilePlan,
     op: &Operator,

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -692,6 +692,179 @@ fn extract_rel_path_from_state(state_key: &str, local_root: &Path) -> Option<Str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opendal::services::Memory;
+
+    fn memory_op() -> Operator {
+        Operator::new(Memory::default()).unwrap().finish()
+    }
+
+    // ── list_remote_index ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_remote_index_empty() {
+        let op = memory_op();
+        let index = list_remote_index(&op, "data").await.unwrap();
+        assert!(index.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_remote_index_finds_entries() {
+        let op = memory_op();
+        op.write(
+            "data/index/file1.txt",
+            b"manifest_hash=aaa\nsize=100\nchunks=1\n".to_vec(),
+        )
+        .await
+        .unwrap();
+        op.write(
+            "data/index/file2.txt",
+            b"manifest_hash=bbb\nsize=200\nchunks=2\n".to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let index = list_remote_index(&op, "data").await.unwrap();
+        assert_eq!(index.len(), 2);
+        assert_eq!(index["file1.txt"].manifest_hash, "aaa");
+        assert_eq!(index["file2.txt"].manifest_hash, "bbb");
+        assert_eq!(index["file2.txt"].size, 200);
+    }
+
+    // ── reconcile plan: local-only → push ────────────────────────────────
+
+    #[tokio::test]
+    async fn reconcile_local_only_file_generates_push() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        std::fs::write(local_root.join("new_file.txt"), b"hello").unwrap();
+
+        let state_path = dir.path().join("state.json");
+        let state = crate::state::StateCache::open(&state_path).unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plan.summary.pushes, 1,
+            "local-only file should generate a push"
+        );
+        assert!(
+            plan.actions.iter().any(|a| matches!(a, ReconcileAction::Push { rel_path, .. } if rel_path == "new_file.txt")),
+            "push action should target new_file.txt"
+        );
+    }
+
+    // ── reconcile plan: remote-only → pull ───────────────────────────────
+
+    #[tokio::test]
+    async fn reconcile_remote_only_file_generates_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+
+        // Write a remote index entry (no local file)
+        op.write(
+            "data/index/remote_only.txt",
+            b"manifest_hash=abc123\nsize=50\nchunks=1\n".to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let state_path = dir.path().join("state.json");
+        let state = crate::state::StateCache::open(&state_path).unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plan.summary.pulls, 1,
+            "remote-only file should generate a pull"
+        );
+        assert!(
+            plan.actions.iter().any(|a| matches!(a, ReconcileAction::Pull { rel_path, .. } if rel_path == "remote_only.txt")),
+            "pull action should target remote_only.txt"
+        );
+    }
+
+    // ── reconcile plan: both exist, up-to-date ───────────────────────────
+
+    #[tokio::test]
+    async fn reconcile_matching_files_up_to_date() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+
+        let content = b"matching content";
+        let hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(content));
+
+        // Write local file
+        std::fs::write(local_root.join("same.txt"), content).unwrap();
+
+        // Write matching remote index + manifest
+        let index_entry = format!("manifest_hash={hash}\nsize={}\nchunks=1\n", content.len());
+        op.write("data/index/same.txt", index_entry.into_bytes())
+            .await
+            .unwrap();
+
+        let manifest_json = serde_json::json!({
+            "version": 2,
+            "file_hash": hash,
+            "file_size": content.len(),
+            "chunks": [],
+            "vclock": {"clocks": {"neo": 1}},
+            "written_by": "neo",
+            "written_at": 0
+        });
+        op.write(
+            &format!("data/manifests/{hash}"),
+            serde_json::to_vec(&manifest_json).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // Set up state cache with matching entry
+        let state_path = dir.path().join("state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let local_file = local_root.join("same.txt");
+        let mut vc = crate::conflict::VectorClock::new();
+        vc.tick("neo");
+        let sync_state = crate::state::make_sync_state_full(
+            &local_file,
+            hash.clone(),
+            1,
+            format!("data/manifests/{hash}"),
+            vc,
+            "neo".into(),
+        )
+        .unwrap();
+        state.set(&local_file, sync_state);
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plan.summary.up_to_date, 1,
+            "matching files should be up-to-date"
+        );
+        assert_eq!(plan.summary.pushes, 0);
+        assert_eq!(plan.summary.pulls, 0);
+        assert_eq!(plan.summary.conflicts, 0);
+    }
+
+    // ── original tests ───────────────────────────────────────────────────
 
     #[test]
     fn test_parse_index_entry() {

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -25,10 +25,11 @@ use crate::conflict::VectorClock;
 ///
 /// Unlike `SyncState` (which is persisted), this is a transient runtime status
 /// that reflects what is happening to a file *right now*.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FileSyncStatus {
     /// File exists only as a stub/placeholder (not hydrated).
+    #[default]
     NotSynced,
     /// File content matches remote — fully synchronized.
     Synced,
@@ -38,12 +39,6 @@ pub enum FileSyncStatus {
     Locked,
     /// Local and remote versions diverged (vector clock conflict).
     Conflict,
-}
-
-impl Default for FileSyncStatus {
-    fn default() -> Self {
-        FileSyncStatus::NotSynced
-    }
 }
 
 impl std::fmt::Display for FileSyncStatus {

--- a/crates/tcfs-sync/tests/e2e_state_transition_chains.rs
+++ b/crates/tcfs-sync/tests/e2e_state_transition_chains.rs
@@ -612,13 +612,8 @@ async fn unsync_modify_resync_no_conflict() {
     );
 
     // Verify no conflict in the outcome
-    if let Some(ref outcome) = upload2.outcome {
-        match outcome {
-            SyncOutcome::Conflict(_) => {
-                panic!("re-upload after dehydration should not produce a conflict")
-            }
-            _ => {} // LocalNewer, RemoteNewer, UpToDate are all acceptable
-        }
+    if let Some(SyncOutcome::Conflict(_)) = upload2.outcome {
+        panic!("re-upload after dehydration should not produce a conflict")
     }
 }
 

--- a/crates/tcfs-sync/tests/multi_machine_sim.rs
+++ b/crates/tcfs-sync/tests/multi_machine_sim.rs
@@ -9,7 +9,7 @@
 //!   5. Eventual convergence — after draining events, all online machines agree
 
 use proptest::prelude::*;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use tcfs_sync::conflict::{compare_clocks, SyncOutcome, VectorClock};
 use tcfs_sync::manifest::SyncManifest;
 
@@ -599,7 +599,7 @@ proptest! {
 
             if hashes.len() > 1 {
                 let first = hashes[0];
-                for (i, h) in hashes.iter().enumerate().skip(1) {
+                for (_i, h) in hashes.iter().enumerate().skip(1) {
                     prop_assert_eq!(
                         *h,
                         first,

--- a/crates/tcfs-sync/tests/state_cache_reload_test.rs
+++ b/crates/tcfs-sync/tests/state_cache_reload_test.rs
@@ -1,7 +1,6 @@
 //! Tests for StateCache::reload_from_disk — verifies that entries written
 //! by one process (CLI) are visible to another (daemon) after reload.
 
-use tcfs_sync::conflict::VectorClock;
 use tcfs_sync::state::StateCache;
 use tempfile::TempDir;
 

--- a/crates/tcfs-tui/src/app.rs
+++ b/crates/tcfs-tui/src/app.rs
@@ -63,6 +63,7 @@ pub struct PendingConflict {
     pub remote_device: String,
     pub local_hash: String,
     pub remote_hash: String,
+    #[allow(dead_code)]
     pub detected_at: u64,
 }
 

--- a/crates/tcfs-tui/tests/app_state_test.rs
+++ b/crates/tcfs-tui/tests/app_state_test.rs
@@ -4,7 +4,6 @@
 //! conflict selection, and uptime history management.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use tcfs_core::config::TcfsConfig;
 
 // ── Re-implement App model for testing (binary crate, can't import directly) ──
 

--- a/crates/tcfs-vfs/src/trash.rs
+++ b/crates/tcfs-vfs/src/trash.rs
@@ -236,12 +236,12 @@ mod tests {
         .unwrap();
 
         // Trash it
-        let trash_key = trash_index_entry(&op, prefix, index_key, "doc.txt")
+        let _trash_key = trash_index_entry(&op, prefix, index_key, "doc.txt")
             .await
             .unwrap();
 
         // Original should be gone
-        assert!(!op.read(index_key).await.is_ok());
+        assert!(op.read(index_key).await.is_err());
 
         // Should appear in trash list
         let entries = list_trash(&op, prefix).await.unwrap();
@@ -276,7 +276,7 @@ mod tests {
         assert_eq!(purged, 1);
 
         // Should be gone
-        assert!(!op.read(old_key).await.is_ok());
+        assert!(op.read(old_key).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -1131,7 +1131,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                 interval.tick().await;
 
                 // Check disk pressure — if under threshold and not time-based, skip
-                let under_pressure = sync_root.as_ref().map_or(false, |root| {
+                let under_pressure = sync_root.as_ref().is_some_and(|root| {
                     tcfs_sync::auto_unsync::disk_pressure_check(root, disk_pressure_pct)
                 });
 
@@ -1305,23 +1305,23 @@ async fn spawn_state_sync_loop(
                                     }
 
                                     // OnDemand mode: only auto-pull if size ≤ threshold
-                                    if effective_mode == tcfs_sync::policy::SyncMode::OnDemand {
-                                        if !policy_store.should_auto_download(
+                                    if effective_mode == tcfs_sync::policy::SyncMode::OnDemand
+                                        && !policy_store.should_auto_download(
                                             &file_path,
                                             *size,
                                             auto_download_threshold,
-                                        ) {
-                                            debug!(
-                                                path = %rel_path,
-                                                size,
-                                                threshold = auto_download_threshold,
-                                                "skipping auto-pull: OnDemand file exceeds download threshold"
-                                            );
-                                            if let Err(e) = msg.ack().await {
-                                                warn!("ack failed: {e}");
-                                            }
-                                            continue;
+                                        )
+                                    {
+                                        debug!(
+                                            path = %rel_path,
+                                            size,
+                                            threshold = auto_download_threshold,
+                                            "skipping auto-pull: OnDemand file exceeds download threshold"
+                                        );
+                                        if let Err(e) = msg.ack().await {
+                                            warn!("ack failed: {e}");
                                         }
+                                        continue;
                                     }
 
                                     // Always mode: unconditional auto-pull
@@ -1393,7 +1393,7 @@ async fn spawn_state_sync_loop(
                                 }
                                 tcfs_sync::StateEvent::FileDeleted {
                                     rel_path,
-                                    vclock: remote_vclock,
+                                    vclock: _remote_vclock,
                                     ..
                                 } => {
                                     info!(
@@ -1621,7 +1621,7 @@ async fn handle_auto_pull(
 ///
 /// We only update the state cache so vector clocks stay in sync.
 async fn do_auto_download(
-    device_id: &str,
+    _device_id: &str,
     manifest_path: &str,
     local_path: &std::path::Path,
     operator: &Arc<tokio::sync::Mutex<Option<opendal::Operator>>>,

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -356,7 +356,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
 
         let mp = mountpoint.clone();
         let cache_dir = self.config.fuse.cache_dir.clone();
-        let cache_max = self.config.fuse.cache_max_mb as u64 * 1024 * 1024;
+        let cache_max = self.config.fuse.cache_max_mb * 1024 * 1024;
         let neg_ttl = self.config.fuse.negative_cache_ttl_secs;
         let mountpoint_key = req.mountpoint.clone();
         let active_mounts_watcher = self.active_mounts.clone();
@@ -1648,7 +1648,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
         // the daemon's durable state_sync_loop consumer for messages.
         let nats_tx = async_tx;
         let nats_client = self.nats.clone();
-        let device_id = self.device_id.clone();
+        let _device_id = self.device_id.clone();
         tokio::spawn(async move {
             let client = nats_client.lock().await;
             let Some(nats) = client.as_ref() else {

--- a/tests/e2e/tests/blacklist_wireup.rs
+++ b/tests/e2e/tests/blacklist_wireup.rs
@@ -3,7 +3,6 @@
 //! These tests prove that the Blacklist module is consulted during the
 //! engine's upload path. If the wiring is removed, these tests FAIL.
 
-use std::path::Path;
 use tcfs_e2e::{memory_operator, write_test_file};
 use tempfile::TempDir;
 
@@ -31,7 +30,7 @@ async fn blacklist_excludes_glob_from_push() {
     assert!(result.is_ok(), "keep.txt push should succeed");
 
     // Push excluded.log — engine should check blacklist and skip
-    let log_path = dir.path().join("excluded.log");
+    let _log_path = dir.path().join("excluded.log");
     let rel = "excluded.log";
     let reason = blacklist.check_name(rel, false);
     assert!(
@@ -72,9 +71,11 @@ fn blacklist_default_patterns_work() {
 /// Blacklist constructed from SyncConfig reads exclude_patterns.
 #[test]
 fn blacklist_from_config_reads_patterns() {
-    let mut config = tcfs_core::config::SyncConfig::default();
-    config.exclude_patterns = vec!["*.tmp".into(), "build/**".into()];
-    config.sync_git_dirs = true;
+    let config = tcfs_core::config::SyncConfig {
+        exclude_patterns: vec!["*.tmp".into(), "build/**".into()],
+        sync_git_dirs: true,
+        ..Default::default()
+    };
 
     let bl = tcfs_sync::blacklist::Blacklist::from_sync_config(&config);
 


### PR DESCRIPTION
## Summary
- 10 engine.rs tests: normalize_rel_path, resolve_manifest_path, delete, upload/download roundtrip, dedup
- 13 nats.rs tests: all 6 StateEvent + 3 SyncTask roundtrips, subject gen, VectorClock preservation
- 5 reconcile.rs tests: list_remote_index, push/pull/up-to-date plan generation

Closes #205, closes #206, closes #208

## Test plan
- [x] `cargo test -p tcfs-sync --lib -- engine` (10 tests)
- [x] `cargo test -p tcfs-sync --lib --features nats -- nats::inner::tests` (13 tests)
- [x] `cargo test -p tcfs-sync --lib -- reconcile` (5 tests)
- [x] 28 new tests total