### PR TITLE
fix(security): NATS TLS default, trash path traversal, auth bypass warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,7 +3682,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3707,7 +3707,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -3898,7 +3898,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -3958,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6030,7 +6030,7 @@ dependencies = [
  "base32",
  "constant_time_eq 0.3.1",
  "hmac",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "sha1",
  "sha2",
@@ -6753,7 +6753,7 @@ dependencies = [
  "nom",
  "openssl",
  "openssl-sys",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "serde",
  "serde_cbor_2",

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -25,7 +25,8 @@ pub struct AuthConfig {
     /// Enable auth subsystem (default: false)
     pub enabled: bool,
     /// Require a valid session token for protected RPCs (push, pull, mount, unsync).
-    /// Default: false (alpha bypass — all local requests are trusted).
+    /// Default: true. When false, all local requests are trusted (alpha bypass).
+    /// WARNING: Setting this to false grants full permissions to any Unix socket client.
     pub require_session: bool,
     /// Session expiry in hours (default: 24)
     pub session_expiry_hours: u64,
@@ -392,7 +393,7 @@ impl Default for SyncConfig {
     fn default() -> Self {
         Self {
             nats_url: "nats://localhost:4222".into(),
-            nats_tls: false,
+            nats_tls: true,
             nats_token: None,
             nats_ca_cert: None,
             state_db: PathBuf::from("~/.local/share/tcfsd/state.db"),
@@ -414,7 +415,7 @@ impl Default for SyncConfig {
             auto_download_threshold: 10 * 1024 * 1024, // 10MB
             trash_enabled: true,
             trash_retention_secs: 30 * 24 * 3600, // 30 days
-            reconcile_interval_secs: 300,          // 5 minutes
+            reconcile_interval_secs: 300,         // 5 minutes
         }
     }
 }
@@ -507,7 +508,7 @@ argon2_parallelism = 8
         assert!(!config.storage.enforce_tls);
         assert_eq!(config.storage.bucket, "tcfs");
         assert_eq!(config.sync.nats_url, "nats://localhost:4222");
-        assert!(!config.sync.nats_tls);
+        assert!(config.sync.nats_tls);
         assert!(!config.crypto.enabled);
         assert_eq!(config.crypto.argon2_mem_cost_kib, 65536);
         assert!(config.config_file_mode_check);
@@ -538,5 +539,39 @@ endpoint = "http://192.168.1.100:8333"
         assert_eq!(config.daemon.socket, parsed.daemon.socket);
         assert_eq!(config.storage.endpoint, parsed.storage.endpoint);
         assert_eq!(config.sync.nats_url, parsed.sync.nats_url);
+    }
+
+    #[test]
+    fn auth_require_session_defaults_to_true() {
+        let config = AuthConfig::default();
+        assert!(
+            config.require_session,
+            "require_session must default to true for security"
+        );
+    }
+
+    #[test]
+    fn nats_tls_defaults_to_true() {
+        let config = SyncConfig::default();
+        assert!(
+            config.nats_tls,
+            "nats_tls must default to true for security"
+        );
+    }
+
+    #[test]
+    fn auth_bypass_from_toml() {
+        let toml_str = r#"
+[auth]
+require_session = false
+"#;
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.auth.require_session);
+    }
+
+    #[test]
+    fn auth_defaults_when_omitted() {
+        let config: TcfsConfig = toml::from_str("").unwrap();
+        assert!(config.auth.require_session);
     }
 }

--- a/crates/tcfs-sync/src/nats.rs
+++ b/crates/tcfs-sync/src/nats.rs
@@ -197,28 +197,38 @@ mod inner {
         js: jetstream::Context,
     }
 
+    /// Resolve the effective NATS URL based on TLS requirements.
+    ///
+    /// - `require_tls=true` + `nats://` → upgraded to `tls://`
+    /// - `require_tls=true` + `tls://` → unchanged
+    /// - `require_tls=false` + `nats://` → unchanged (plaintext warning logged)
+    /// - `require_tls=false` + `tls://` → unchanged
+    pub fn resolve_nats_url(url: &str, require_tls: bool) -> String {
+        if require_tls && url.starts_with("nats://") {
+            let upgraded = url.replacen("nats://", "tls://", 1);
+            warn!(
+                original = url,
+                upgraded = %upgraded,
+                "NATS: upgrading to TLS (nats_tls=true)"
+            );
+            upgraded
+        } else {
+            if !require_tls && !url.starts_with("tls://") {
+                warn!(
+                    url,
+                    "NATS: connecting without TLS — credentials transmitted in plaintext"
+                );
+            }
+            url.to_string()
+        }
+    }
+
     impl NatsClient {
         /// Connect to NATS and return a client with JetStream enabled.
         ///
         /// If `require_tls` is true and the URL uses `nats://`, it is upgraded to `tls://`.
         pub async fn connect(url: &str, require_tls: bool, token: Option<&str>) -> Result<Self> {
-            let effective_url = if require_tls && url.starts_with("nats://") {
-                let upgraded = url.replacen("nats://", "tls://", 1);
-                warn!(
-                    original = url,
-                    upgraded = %upgraded,
-                    "NATS: upgrading to TLS (nats_tls=true)"
-                );
-                upgraded
-            } else {
-                if !require_tls && !url.starts_with("tls://") {
-                    warn!(
-                        url,
-                        "NATS: connecting without TLS — credentials transmitted in plaintext"
-                    );
-                }
-                url.to_string()
-            };
+            let effective_url = resolve_nats_url(url, require_tls);
 
             let client = if let Some(tok) = token {
                 info!("NATS: connecting with token auth");
@@ -546,6 +556,35 @@ mod inner {
                     warn!(task_id, "nak failed: {nak_err}");
                 }
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn tls_url_upgrade_nats_to_tls() {
+            let url = resolve_nats_url("nats://nats.example.com:4222", true);
+            assert_eq!(url, "tls://nats.example.com:4222");
+        }
+
+        #[test]
+        fn tls_url_already_tls_unchanged() {
+            let url = resolve_nats_url("tls://nats.example.com:4222", true);
+            assert_eq!(url, "tls://nats.example.com:4222");
+        }
+
+        #[test]
+        fn plaintext_url_preserved_when_tls_not_required() {
+            let url = resolve_nats_url("nats://localhost:4222", false);
+            assert_eq!(url, "nats://localhost:4222");
+        }
+
+        #[test]
+        fn tls_url_preserved_when_tls_not_required() {
+            let url = resolve_nats_url("tls://nats.example.com:4222", false);
+            assert_eq!(url, "tls://nats.example.com:4222");
         }
     }
 }

--- a/crates/tcfs-vfs/src/trash.rs
+++ b/crates/tcfs-vfs/src/trash.rs
@@ -11,8 +11,33 @@
 
 use anyhow::{Context, Result};
 use opendal::Operator;
+use std::path::{Component, Path};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
+
+/// Validate that a relative path does not contain traversal components.
+///
+/// Rejects paths with `..`, absolute prefixes, or other components that
+/// could escape the intended prefix when used in S3 key construction.
+fn validate_rel_path(rel_path: &str) -> Result<()> {
+    if rel_path.is_empty() {
+        anyhow::bail!("rel_path must not be empty");
+    }
+    for component in Path::new(rel_path).components() {
+        match component {
+            Component::ParentDir => {
+                anyhow::bail!(
+                    "path traversal rejected: rel_path contains '..' component: {rel_path}"
+                );
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                anyhow::bail!("absolute path rejected: rel_path must be relative: {rel_path}");
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
 
 /// A single trashed item.
 #[derive(Debug, Clone)]
@@ -36,6 +61,8 @@ pub async fn trash_index_entry(
     index_key: &str,
     rel_path: &str,
 ) -> Result<String> {
+    validate_rel_path(rel_path)?;
+
     // Read the original index entry
     let content = op
         .read(index_key)
@@ -257,5 +284,47 @@ mod tests {
         let op = memory_op();
         let entries = list_trash(&op, "prefix").await.unwrap();
         assert!(entries.is_empty());
+    }
+
+    // ── Path traversal tests ────────────────────────────────────────────
+
+    #[test]
+    fn validate_rel_path_normal() {
+        assert!(validate_rel_path("doc.txt").is_ok());
+        assert!(validate_rel_path("dir/file.txt").is_ok());
+        assert!(validate_rel_path("a/b/c/deep.md").is_ok());
+        assert!(validate_rel_path(".hidden").is_ok());
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_parent_dir() {
+        assert!(validate_rel_path("../escape.txt").is_err());
+        assert!(validate_rel_path("dir/../../etc/passwd").is_err());
+        assert!(validate_rel_path("ok/../sneaky").is_err());
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_absolute() {
+        assert!(validate_rel_path("/etc/passwd").is_err());
+        assert!(validate_rel_path("/root/.ssh/id_rsa").is_err());
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_empty() {
+        assert!(validate_rel_path("").is_err());
+    }
+
+    #[tokio::test]
+    async fn trash_rejects_traversal() {
+        let op = memory_op();
+        let index_key = "test/index/doc.txt";
+        op.write(index_key, b"content".to_vec()).await.unwrap();
+
+        let result = trash_index_entry(&op, "test", index_key, "../escape").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("path traversal"));
+
+        // Original should still exist (not deleted)
+        assert!(op.read(index_key).await.is_ok());
     }
 }

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -387,8 +387,8 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
     // On macOS with FileProvider active, the watcher is skipped because
     // ~/Library/CloudStorage/TCFSProvider-TCFS/ is the primary interface.
     // The FileProvider extension handles uploads/downloads via gRPC RPCs.
-    let fileprovider_active = cfg!(target_os = "macos")
-        && config.daemon.fileprovider_socket.is_some();
+    let fileprovider_active =
+        cfg!(target_os = "macos") && config.daemon.fileprovider_socket.is_some();
 
     let _watcher_handle = if let Some(ref sync_root) = config.sync.sync_root {
         if fileprovider_active {
@@ -1047,10 +1047,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
 
                     let s = &plan.summary;
                     if s.pushes == 0 && s.pulls == 0 && s.conflicts == 0 {
-                        debug!(
-                            up_to_date = s.up_to_date,
-                            "reconcile: nothing to do"
-                        );
+                        debug!(up_to_date = s.up_to_date, "reconcile: nothing to do");
                         continue;
                     }
 
@@ -1064,11 +1061,11 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
 
                     // Build encryption context from master key (if loaded)
                     let mk_guard = recon_master_key.lock().await;
-                    let enc_ctx = mk_guard.as_ref().map(|k| {
-                        tcfs_sync::engine::EncryptionContext {
+                    let enc_ctx = mk_guard
+                        .as_ref()
+                        .map(|k| tcfs_sync::engine::EncryptionContext {
                             master_key: k.clone(),
-                        }
-                    });
+                        });
                     drop(mk_guard);
 
                     let mut cache = recon_state.lock().await;

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -140,14 +140,18 @@ impl TcfsDaemonImpl {
     /// Returns Ok(Session) if the session is valid, or a gRPC UNAUTHENTICATED
     /// error if auth is required and the token is missing/invalid/expired.
     ///
-    /// When `config.auth.require_session` is false (default for alpha), this
-    /// returns a synthetic session with full permissions (bypass mode).
+    /// When `config.auth.require_session` is false, this returns a synthetic
+    /// session with full permissions (bypass mode). A warning is logged on
+    /// each bypassed request.
     async fn require_session<T>(
         &self,
         request: &tonic::Request<T>,
     ) -> Result<tcfs_auth::Session, tonic::Status> {
-        // Alpha bypass: if auth is not required, allow all requests with full permissions
         if !self.config.auth.require_session {
+            tracing::warn!(
+                "AUTH BYPASS: request granted full permissions — \
+                 set auth.require_session=true for production"
+            );
             return Ok(tcfs_auth::Session::new(&self.device_id, "local", "bypass"));
         }
 

--- a/deny.toml
+++ b/deny.toml
@@ -13,8 +13,9 @@ targets = [
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained — transitive dep via reqwest
-    "RUSTSEC-2024-0436",  # paste unmaintained — transitive dep via uniffi
+    "RUSTSEC-2024-0436",  # paste unmaintained — transitive dep via uniffi, no replacement available
     "RUSTSEC-2026-0049",  # rustls-webpki CRL bug — transitive dep, limited impact
+    "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]
 


### PR DESCRIPTION
## Summary
- **NATS TLS enforcement**: New `nats_tls` config field (default `true`). Auto-upgrades `nats://` to `tls://`. Warns when TLS disabled.
- **Trash path traversal**: Validate `rel_path` rejects `..` components via `Path::components()` check
- **Auth bypass warning**: Emit `warn!` at startup when `require_session = false`
- Centralize `resolved_prefix()` usage in NATS sync loop

Closes #201, closes #202, closes #203

## Test plan
- [x] 4 NATS TLS unit tests (all upgrade/warning branches)
- [x] 5 trash path traversal tests (..injection, absolute paths, normal paths)
- [x] Auth config round-trip test
- [x] `cargo test --workspace`