### PR TITLE
fix(secrets): unified credential discovery, AWS file support

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -629,72 +629,42 @@ async fn load_config(path: &Path) -> Result<tcfs_core::config::TcfsConfig> {
     }
 }
 
-// ── Storage operator from environment credentials ─────────────────────────────
+// ── Storage operator from unified credential discovery ───────────────────────
 
-/// Read a credential from a `*_FILE` env var (the var points to a file path).
-fn read_credential_file(env_var: &str) -> Result<String, std::env::VarError> {
-    let path = std::env::var(env_var)?;
-    std::fs::read_to_string(path.trim())
-        .map(|s| s.trim().to_string())
-        .map_err(|_| std::env::VarError::NotPresent)
-}
-
-/// Read a credential from a SOPS-decrypted JSON or KEY=VALUE file.
-fn read_sops_credential(path: &std::path::Path, key: &str) -> Result<String> {
-    let content = std::fs::read_to_string(path)?;
-    if let Ok(map) = serde_json::from_str::<std::collections::HashMap<String, String>>(&content) {
-        if let Some(val) = map.get(key) {
-            return Ok(val.clone());
-        }
-    }
-    for line in content.lines() {
-        if let Some(val) = line.strip_prefix(&format!("{}=", key)) {
-            return Ok(val.trim().to_string());
-        }
-    }
-    anyhow::bail!("key '{}' not found in {}", key, path.display())
-}
-
-/// Build an OpenDAL operator using credentials from environment variables.
+/// Build an OpenDAL operator using the unified credential discovery chain.
 ///
-/// Discovery chain: direct env var -> *_FILE env var -> config credentials_file (SOPS)
-fn build_operator_from_env(config: &tcfs_core::config::TcfsConfig) -> Result<opendal::Operator> {
-    let access_key = std::env::var("AWS_ACCESS_KEY_ID")
-        .or_else(|_| std::env::var("TCFS_ACCESS_KEY_ID"))
-        .or_else(|_| read_credential_file("TCFS_S3_ACCESS_FILE"))
-        .or_else(|_| read_credential_file("AWS_ACCESS_KEY_ID_FILE"))
-        .or_else(|_| {
-            config
-                .storage
-                .credentials_file
-                .as_ref()
-                .and_then(|p| read_sops_credential(p, "access_key_id").ok())
-                .ok_or(std::env::VarError::NotPresent)
-        })
-        .context(
-            "S3 credentials not set\n\
-             Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables,\n\
-             or use *_FILE variants pointing to credential files.\n\
-             Example:\n\
-             \texport AWS_ACCESS_KEY_ID=your-key\n\
-             \texport AWS_SECRET_ACCESS_KEY=your-secret",
-        )?;
-    let secret_key = std::env::var("AWS_SECRET_ACCESS_KEY")
-        .or_else(|_| std::env::var("TCFS_SECRET_ACCESS_KEY"))
-        .or_else(|_| read_credential_file("TCFS_S3_SECRET_FILE"))
-        .or_else(|_| read_credential_file("AWS_SECRET_ACCESS_KEY_FILE"))
-        .or_else(|_| {
-            config
-                .storage
-                .credentials_file
-                .as_ref()
-                .and_then(|p| read_sops_credential(p, "secret_access_key").ok())
-                .ok_or(std::env::VarError::NotPresent)
-        })
-        .context("AWS_SECRET_ACCESS_KEY environment variable not set")?;
+/// Delegates to `tcfs_secrets::CredStore::load()` which tries (in order):
+///   1. SOPS-encrypted credential file
+///   2. RemoteJuggler KDBX store
+///   3. TCFS-specific env vars (TCFS_S3_ACCESS/SECRET)
+///   4. AWS env vars (with warning)
+///   5. Legacy SeaweedFS env vars
+///   6. File-pointer env vars (*_FILE)
+///   7. AWS shared credentials file (~/.aws/credentials)
+async fn build_operator(config: &tcfs_core::config::TcfsConfig) -> Result<opendal::Operator> {
+    let cred_store =
+        tcfs_secrets::CredStore::load(&config.secrets, &config.storage)
+            .await
+            .context("credential discovery failed")?;
 
-    tcfs_storage::operator::build_from_core_config(&config.storage, &access_key, &secret_key)
-        .context("building storage operator")
+    let s3 = cred_store.s3.context(
+        "S3 credentials not found.\n\
+         Set TCFS_S3_ACCESS and TCFS_S3_SECRET environment variables,\n\
+         or configure storage.credentials_file in tcfs.toml,\n\
+         or use ~/.aws/credentials file.\n\
+         Example:\n\
+         \texport TCFS_S3_ACCESS=your-key\n\
+         \texport TCFS_S3_SECRET=your-secret",
+    )?;
+
+    tracing::info!(source = %cred_store.source, "CLI credentials loaded");
+
+    tcfs_storage::operator::build_from_core_config(
+        &config.storage,
+        &s3.access_key_id,
+        s3.secret_access_key.expose_secret(),
+    )
+    .context("building storage operator")
 }
 
 /// Expand `~` in path to the user's home directory
@@ -811,7 +781,7 @@ async fn cmd_push(
     prefix: Option<&str>,
     state_override: Option<&Path>,
 ) -> Result<()> {
-    let op = build_operator_from_env(config)?;
+    let op = build_operator(config).await?;
     let state_path = resolve_state_path(config, state_override);
     let mut state = tcfs_sync::state::StateCache::open(&state_path)
         .with_context(|| format!("opening state cache: {}", state_path.display()))?;
@@ -987,7 +957,7 @@ async fn cmd_pull(
     prefix: Option<&str>,
     state_override: Option<&Path>,
 ) -> Result<()> {
-    let op = build_operator_from_env(config)?;
+    let op = build_operator(config).await?;
     let device_id = load_device_id(config);
 
     // Detect whether input looks like a file path vs a manifest path
@@ -1156,7 +1126,7 @@ fn cmd_sync_status(
 // ── `tcfs migrate-prefix` ────────────────────────────────────────────────────
 
 async fn cmd_migrate_prefix(config: &tcfs_core::config::TcfsConfig, dry_run: bool) -> Result<()> {
-    let op = build_operator_from_env(config)?;
+    let op = build_operator(config).await?;
     let target = config.storage.resolved_prefix();
 
     println!(
@@ -1253,7 +1223,7 @@ async fn cmd_migrate_prefix(config: &tcfs_core::config::TcfsConfig, dry_run: boo
 // ── `tcfs trash` ─────────────────────────────────────────────────────────────
 
 async fn cmd_trash(config: &tcfs_core::config::TcfsConfig, action: TrashAction) -> Result<()> {
-    let op = build_operator_from_env(config)?;
+    let op = build_operator(config).await?;
 
     let resolve_prefix = |p: Option<&str>| -> String {
         p.map(|s| s.trim_end_matches('/').to_string())
@@ -1389,7 +1359,7 @@ async fn cmd_rm(
     prefix: Option<&str>,
     state_override: Option<&Path>,
 ) -> Result<()> {
-    let op = build_operator_from_env(config)?;
+    let op = build_operator(config).await?;
     let state_path = resolve_state_path(config, state_override);
     let mut state = tcfs_sync::state::StateCache::open(&state_path)
         .with_context(|| format!("opening state cache: {}", state_path.display()))?;
@@ -3136,7 +3106,7 @@ async fn cmd_reconcile(
     execute: bool,
     state_override: Option<&Path>,
 ) -> Result<()> {
-    let op = build_operator_from_env(config)?;
+    let op = build_operator(config).await?;
     let device_id = load_device_id(config);
 
     let local_root = path

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -642,10 +642,9 @@ async fn load_config(path: &Path) -> Result<tcfs_core::config::TcfsConfig> {
 ///   6. File-pointer env vars (*_FILE)
 ///   7. AWS shared credentials file (~/.aws/credentials)
 async fn build_operator(config: &tcfs_core::config::TcfsConfig) -> Result<opendal::Operator> {
-    let cred_store =
-        tcfs_secrets::CredStore::load(&config.secrets, &config.storage)
-            .await
-            .context("credential discovery failed")?;
+    let cred_store = tcfs_secrets::CredStore::load(&config.secrets, &config.storage)
+        .await
+        .context("credential discovery failed")?;
 
     let s3 = cred_store.s3.context(
         "S3 credentials not found.\n\

--- a/crates/tcfs-secrets/src/lib.rs
+++ b/crates/tcfs-secrets/src/lib.rs
@@ -286,14 +286,19 @@ fn read_env_file(env_var: &str) -> Result<String, std::env::VarError> {
 /// Respects `$AWS_SHARED_CREDENTIALS_FILE` for custom path and
 /// `$AWS_PROFILE` for non-default profile selection.
 fn parse_aws_credentials_file() -> Option<(String, String)> {
-    let cred_path = std::env::var("AWS_SHARED_CREDENTIALS_FILE").ok().map(
-        std::path::PathBuf::from,
-    ).or_else(|| {
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .ok()?;
-        Some(std::path::PathBuf::from(home).join(".aws").join("credentials"))
-    })?;
+    let cred_path = std::env::var("AWS_SHARED_CREDENTIALS_FILE")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            let home = std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .ok()?;
+            Some(
+                std::path::PathBuf::from(home)
+                    .join(".aws")
+                    .join("credentials"),
+            )
+        })?;
 
     let content = std::fs::read_to_string(&cred_path).ok()?;
     let profile = std::env::var("AWS_PROFILE").unwrap_or_else(|_| "default".into());
@@ -419,7 +424,11 @@ mod tests {
         let mut f = std::fs::File::create(&cred_path).unwrap();
         writeln!(f, "[default]").unwrap();
         writeln!(f, "aws_access_key_id = AKIAIOSFODNN7EXAMPLE").unwrap();
-        writeln!(f, "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY").unwrap();
+        writeln!(
+            f,
+            "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+        .unwrap();
         drop(f);
 
         std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", cred_path.to_str().unwrap());

--- a/crates/tcfs-secrets/src/lib.rs
+++ b/crates/tcfs-secrets/src/lib.rs
@@ -1,6 +1,15 @@
 //! tcfs-secrets: SOPS/age/KDBX credential management
 //!
-//! Identity discovery chain (in order of precedence):
+//! S3 credential discovery chain (in order of precedence):
+//!   1. SOPS-encrypted file (`storage.credentials_file`)
+//!   2. RemoteJuggler KDBX store (`$REMOTE_JUGGLER_IDENTITY`)
+//!   3. TCFS-specific env: `TCFS_S3_ACCESS` / `TCFS_S3_SECRET`
+//!   4. AWS env: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (warns)
+//!   5. Legacy env: `SEAWEED_ACCESS_KEY` / `SEAWEED_SECRET_KEY`
+//!   6. File variants: `TCFS_S3_ACCESS_FILE`, `AWS_ACCESS_KEY_ID_FILE`
+//!   7. AWS shared credentials file: `~/.aws/credentials`
+//!
+//! Age identity discovery chain (in order of precedence):
 //!   1. $CREDENTIALS_DIRECTORY/age-identity  (systemd LoadCredentialEncrypted)
 //!   2. $SOPS_AGE_KEY_FILE env var (path to key file)
 //!   3. $SOPS_AGE_KEY env var (literal key content)
@@ -184,27 +193,67 @@ impl CredStore {
     }
 
     fn load_from_env(storage: &tcfs_core::config::StorageConfig) -> Result<Self> {
-        let access_key = std::env::var("TCFS_S3_ACCESS")
-            .or_else(|_| std::env::var("AWS_ACCESS_KEY_ID"))
-            .or_else(|_| std::env::var("SEAWEED_ACCESS_KEY"))
-            .or_else(|_| read_env_file("TCFS_S3_ACCESS_FILE"))
-            .or_else(|_| read_env_file("AWS_ACCESS_KEY_ID_FILE"))
-            .unwrap_or_default();
-        let mut secret_key = std::env::var("TCFS_S3_SECRET")
+        // Track which source provided the credentials for logging
+        let mut source = "env";
+
+        // Try TCFS-specific env first (preferred — namespaced, intentional)
+        let access_key = if let Ok(v) = std::env::var("TCFS_S3_ACCESS") {
+            source = "env:TCFS_S3_ACCESS";
+            Some(v)
+        } else if let Ok(v) = std::env::var("AWS_ACCESS_KEY_ID") {
+            // AWS env vars are visible in `ps aux` and crash dumps — warn
+            tracing::warn!(
+                "S3 credentials loaded from AWS_ACCESS_KEY_ID env var. \
+                 Prefer SOPS file, TCFS_S3_ACCESS, or ~/.aws/credentials for production."
+            );
+            source = "env:AWS_ACCESS_KEY_ID";
+            Some(v)
+        } else if let Ok(v) = std::env::var("SEAWEED_ACCESS_KEY") {
+            source = "env:SEAWEED_ACCESS_KEY";
+            Some(v)
+        } else if let Ok(v) = read_env_file("TCFS_S3_ACCESS_FILE") {
+            source = "file:TCFS_S3_ACCESS_FILE";
+            Some(v)
+        } else if let Ok(v) = read_env_file("AWS_ACCESS_KEY_ID_FILE") {
+            source = "file:AWS_ACCESS_KEY_ID_FILE";
+            Some(v)
+        } else {
+            None
+        };
+
+        let secret_key = std::env::var("TCFS_S3_SECRET")
             .or_else(|_| std::env::var("AWS_SECRET_ACCESS_KEY"))
             .or_else(|_| std::env::var("SEAWEED_SECRET_KEY"))
             .or_else(|_| read_env_file("TCFS_S3_SECRET_FILE"))
             .or_else(|_| read_env_file("AWS_SECRET_ACCESS_KEY_FILE"))
-            .unwrap_or_default();
+            .ok();
 
-        let s3 = if !access_key.is_empty() {
+        // If env vars didn't work, try AWS shared credentials file
+        if access_key.is_none() || secret_key.is_none() {
+            if let Some((ak, mut sk)) = parse_aws_credentials_file() {
+                source = "aws-credentials-file";
+                let s3 = S3Credentials {
+                    access_key_id: ak,
+                    secret_access_key: SecretString::from(std::mem::take(&mut sk)),
+                    endpoint: storage.endpoint.clone(),
+                    region: storage.region.clone(),
+                };
+                sk.zeroize();
+                return Ok(CredStore {
+                    s3: Some(s3),
+                    source: source.into(),
+                });
+            }
+        }
+
+        let s3 = if let (Some(ak), Some(mut sk)) = (access_key, secret_key) {
             let creds = S3Credentials {
-                access_key_id: access_key,
-                secret_access_key: SecretString::from(std::mem::take(&mut secret_key)),
+                access_key_id: ak,
+                secret_access_key: SecretString::from(std::mem::take(&mut sk)),
                 endpoint: storage.endpoint.clone(),
                 region: storage.region.clone(),
             };
-            secret_key.zeroize();
+            sk.zeroize();
             Some(creds)
         } else {
             None
@@ -212,7 +261,7 @@ impl CredStore {
 
         Ok(CredStore {
             s3,
-            source: "env".into(),
+            source: source.into(),
         })
     }
 }
@@ -223,4 +272,244 @@ fn read_env_file(env_var: &str) -> Result<String, std::env::VarError> {
     std::fs::read_to_string(path.trim())
         .map(|s| s.trim().to_string())
         .map_err(|_| std::env::VarError::NotPresent)
+}
+
+/// Parse the AWS shared credentials file (`~/.aws/credentials`).
+///
+/// Supports the standard INI format:
+/// ```ini
+/// [default]
+/// aws_access_key_id = AKIA...
+/// aws_secret_access_key = wJal...
+/// ```
+///
+/// Respects `$AWS_SHARED_CREDENTIALS_FILE` for custom path and
+/// `$AWS_PROFILE` for non-default profile selection.
+fn parse_aws_credentials_file() -> Option<(String, String)> {
+    let cred_path = std::env::var("AWS_SHARED_CREDENTIALS_FILE").ok().map(
+        std::path::PathBuf::from,
+    ).or_else(|| {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .ok()?;
+        Some(std::path::PathBuf::from(home).join(".aws").join("credentials"))
+    })?;
+
+    let content = std::fs::read_to_string(&cred_path).ok()?;
+    let profile = std::env::var("AWS_PROFILE").unwrap_or_else(|_| "default".into());
+    let section_header = format!("[{}]", profile);
+
+    let mut in_section = false;
+    let mut access_key = None;
+    let mut secret_key = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_section = trimmed == section_header;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if let Some((key, value)) = trimmed.split_once('=') {
+            let key = key.trim();
+            let value = value.trim();
+            match key {
+                "aws_access_key_id" => access_key = Some(value.to_string()),
+                "aws_secret_access_key" => secret_key = Some(value.to_string()),
+                _ => {}
+            }
+        }
+    }
+
+    match (access_key, secret_key) {
+        (Some(ak), Some(sk)) => {
+            tracing::info!("credentials loaded from AWS shared credentials file");
+            Some((ak, sk))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::Mutex;
+
+    /// Serialize env-var tests to avoid races (env vars are process-global).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Helper: clear all credential env vars to isolate tests.
+    fn clear_cred_env() {
+        for var in &[
+            "TCFS_S3_ACCESS",
+            "TCFS_S3_SECRET",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "SEAWEED_ACCESS_KEY",
+            "SEAWEED_SECRET_KEY",
+            "TCFS_S3_ACCESS_FILE",
+            "TCFS_S3_SECRET_FILE",
+            "AWS_ACCESS_KEY_ID_FILE",
+            "AWS_SECRET_ACCESS_KEY_FILE",
+            "AWS_SHARED_CREDENTIALS_FILE",
+            "AWS_PROFILE",
+            "REMOTE_JUGGLER_IDENTITY",
+        ] {
+            std::env::remove_var(var);
+        }
+    }
+
+    fn default_storage() -> tcfs_core::config::StorageConfig {
+        tcfs_core::config::StorageConfig {
+            endpoint: "http://localhost:8333".into(),
+            region: "us-east-1".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn tcfs_env_takes_precedence_over_aws() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cred_env();
+        std::env::set_var("TCFS_S3_ACCESS", "tcfs-key");
+        std::env::set_var("TCFS_S3_SECRET", "tcfs-secret");
+        std::env::set_var("AWS_ACCESS_KEY_ID", "aws-key");
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", "aws-secret");
+
+        let store = CredStore::load_from_env(&default_storage()).unwrap();
+        let s3 = store.s3.unwrap();
+        assert_eq!(s3.access_key_id, "tcfs-key");
+        assert!(store.source.contains("TCFS_S3_ACCESS"));
+
+        clear_cred_env();
+    }
+
+    #[test]
+    fn file_variant_reads_content() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cred_env();
+        let dir = tempfile::tempdir().unwrap();
+
+        let ak_path = dir.path().join("access_key");
+        let sk_path = dir.path().join("secret_key");
+        std::fs::write(&ak_path, "  file-access-key  \n").unwrap();
+        std::fs::write(&sk_path, "file-secret-key\n").unwrap();
+
+        std::env::set_var("TCFS_S3_ACCESS_FILE", ak_path.to_str().unwrap());
+        std::env::set_var("TCFS_S3_SECRET_FILE", sk_path.to_str().unwrap());
+
+        let store = CredStore::load_from_env(&default_storage()).unwrap();
+        let s3 = store.s3.unwrap();
+        assert_eq!(s3.access_key_id, "file-access-key"); // trimmed
+        assert!(store.source.contains("FILE"));
+
+        clear_cred_env();
+    }
+
+    #[test]
+    fn aws_credentials_file_parsing() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cred_env();
+        let dir = tempfile::tempdir().unwrap();
+        let cred_path = dir.path().join("credentials");
+
+        let mut f = std::fs::File::create(&cred_path).unwrap();
+        writeln!(f, "[default]").unwrap();
+        writeln!(f, "aws_access_key_id = AKIAIOSFODNN7EXAMPLE").unwrap();
+        writeln!(f, "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY").unwrap();
+        drop(f);
+
+        std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", cred_path.to_str().unwrap());
+
+        let result = parse_aws_credentials_file();
+        assert!(result.is_some());
+        let (ak, sk) = result.unwrap();
+        assert_eq!(ak, "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(sk, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+        clear_cred_env();
+    }
+
+    #[test]
+    fn aws_credentials_file_with_profile() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cred_env();
+        let dir = tempfile::tempdir().unwrap();
+        let cred_path = dir.path().join("credentials");
+
+        let mut f = std::fs::File::create(&cred_path).unwrap();
+        writeln!(f, "[default]").unwrap();
+        writeln!(f, "aws_access_key_id = default-key").unwrap();
+        writeln!(f, "aws_secret_access_key = default-secret").unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, "[staging]").unwrap();
+        writeln!(f, "aws_access_key_id = staging-key").unwrap();
+        writeln!(f, "aws_secret_access_key = staging-secret").unwrap();
+        drop(f);
+
+        std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", cred_path.to_str().unwrap());
+        std::env::set_var("AWS_PROFILE", "staging");
+
+        let result = parse_aws_credentials_file();
+        assert!(result.is_some());
+        let (ak, _sk) = result.unwrap();
+        assert_eq!(ak, "staging-key");
+
+        clear_cred_env();
+    }
+
+    #[test]
+    fn missing_credentials_returns_none() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cred_env();
+        // Point to a nonexistent file to prevent ~/.aws/credentials from being found
+        std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent/path");
+
+        let store = CredStore::load_from_env(&default_storage()).unwrap();
+        assert!(store.s3.is_none());
+
+        clear_cred_env();
+    }
+
+    #[test]
+    fn aws_credentials_file_used_as_fallback() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cred_env();
+        let dir = tempfile::tempdir().unwrap();
+        let cred_path = dir.path().join("credentials");
+
+        let mut f = std::fs::File::create(&cred_path).unwrap();
+        writeln!(f, "[default]").unwrap();
+        writeln!(f, "aws_access_key_id = file-ak").unwrap();
+        writeln!(f, "aws_secret_access_key = file-sk").unwrap();
+        drop(f);
+
+        std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", cred_path.to_str().unwrap());
+
+        let store = CredStore::load_from_env(&default_storage()).unwrap();
+        let s3 = store.s3.unwrap();
+        assert_eq!(s3.access_key_id, "file-ak");
+        assert_eq!(store.source, "aws-credentials-file");
+
+        clear_cred_env();
+    }
+
+    #[test]
+    fn seaweed_legacy_vars_work() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_cred_env();
+        std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent");
+        std::env::set_var("SEAWEED_ACCESS_KEY", "sw-ak");
+        std::env::set_var("SEAWEED_SECRET_KEY", "sw-sk");
+
+        let store = CredStore::load_from_env(&default_storage()).unwrap();
+        let s3 = store.s3.unwrap();
+        assert_eq!(s3.access_key_id, "sw-ak");
+        assert!(store.source.contains("SEAWEED"));
+
+        clear_cred_env();
+    }
 }


### PR DESCRIPTION
## Summary
- Unify S3 credential discovery into single `CredStore::load()` chain used by both daemon and CLI
- Add `~/.aws/credentials` file parsing as fallback (respects `AWS_PROFILE`, `AWS_SHARED_CREDENTIALS_FILE`)
- Warn when credentials loaded from raw AWS env vars (visible in `ps aux`, crash dumps)
- Track credential source through all 7 discovery tiers for structured logging
- Refactor CLI to delegate to `tcfs-secrets::CredStore::load()` — removes 40 lines of duplicated credential logic

## Test plan
- [x] 7 new unit tests for credential discovery chain
- [x] `cargo test -p tcfs-secrets` — 19 pass
- [x] `cargo test -p tcfs-cli` — 17 pass (existing parsing tests)
- [x] `cargo clippy -p tcfs-secrets -p tcfs-cli` — clean
- [ ] CI green

Closes #204