### PR TITLE
test(fileprovider): 9 functional tests with memory backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -184,9 +184,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -199,7 +199,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -533,7 +533,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -622,16 +622,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq 0.4.2",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -820,7 +820,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1062,6 +1062,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32c"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,7 +1183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1570,9 +1579,9 @@ checksum = "bf51ceb43e96afbfe4dd5c6f6082af5dfd60e220820b8123792d61963f2ce6bc"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
@@ -2019,6 +2028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,9 +2151,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2151,7 +2166,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2302,12 +2316,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2315,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2328,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2342,15 +2357,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2362,15 +2377,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2428,12 +2443,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2536,9 +2551,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2627,10 +2642,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2727,9 +2744,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -2743,14 +2760,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2770,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2781,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -2802,9 +2819,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2942,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -3226,9 +3243,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
@@ -3497,12 +3514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3543,7 +3554,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3555,7 +3566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3577,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3615,7 +3626,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3651,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
+checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
 dependencies = [
  "dtoa",
  "itoa",
@@ -3707,7 +3718,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -3880,7 +3891,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3900,7 +3911,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.3",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4129,9 +4140,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -4427,9 +4438,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4484,7 +4495,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -4533,9 +4544,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4739,9 +4750,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -4899,7 +4910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4910,7 +4921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5325,6 +5336,7 @@ dependencies = [
  "tcfs-crypto",
  "tcfs-storage",
  "tcfs-sync",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -5754,9 +5766,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -5780,9 +5792,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -5798,9 +5810,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5905,9 +5917,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -5928,23 +5940,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -6204,7 +6216,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -6588,9 +6600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6601,23 +6613,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6625,9 +6633,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6638,9 +6646,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6694,9 +6702,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7220,9 +7228,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -7323,9 +7331,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
@@ -7379,9 +7387,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7390,9 +7398,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7458,18 +7466,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7478,18 +7486,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7519,9 +7527,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7530,9 +7538,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -7542,9 +7550,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/tcfs-file-provider/Cargo.toml
+++ b/crates/tcfs-file-provider/Cargo.toml
@@ -46,6 +46,9 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen/main.rs"
 required-features = ["uniffi"]
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [build-dependencies]
 cbindgen = "0.27"
 uniffi = { workspace = true, features = ["build"], optional = true }

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -1045,13 +1045,8 @@ mod tests {
             let c_path = CString::new("").unwrap();
             let mut events: *mut crate::TcfsChangeEvent = ptr::null_mut();
             let mut count: usize = 0;
-            let err = tcfs_provider_enumerate_changes(
-                prov,
-                c_path.as_ptr(),
-                0,
-                &mut events,
-                &mut count,
-            );
+            let err =
+                tcfs_provider_enumerate_changes(prov, c_path.as_ptr(), 0, &mut events, &mut count);
             assert_eq!(err, TcfsError::TcfsErrorNone);
             assert_eq!(count, 0);
 
@@ -1102,8 +1097,15 @@ mod tests {
                 ptr::null(),
             );
             assert_eq!(err, TcfsError::TcfsErrorNone);
-            assert!(PROGRESS_CALLED.load(Ordering::SeqCst), "progress callback should have been called");
-            assert_eq!(LAST_TOTAL.load(Ordering::SeqCst), 4096, "total should match file size");
+            assert!(
+                PROGRESS_CALLED.load(Ordering::SeqCst),
+                "progress callback should have been called"
+            );
+            assert_eq!(
+                LAST_TOTAL.load(Ordering::SeqCst),
+                4096,
+                "total should match file size"
+            );
 
             // Verify data
             let fetched = std::fs::read(&dest).unwrap();

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -814,3 +814,346 @@ pub unsafe extern "C" fn tcfs_provider_free(provider: *mut TcfsProvider) {
         }
     }
 }
+
+// ── Functional tests (memory-backed provider) ────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    /// Create a TcfsProvider backed by opendal::services::Memory (no network).
+    fn memory_provider(prefix: &str) -> *mut TcfsProvider {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+
+        let operator = opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish();
+
+        let provider = TcfsProvider {
+            runtime,
+            operator,
+            remote_prefix: prefix.to_string(),
+            device_id: "test-device".to_string(),
+            master_key: None,
+        };
+
+        Box::into_raw(Box::new(provider))
+    }
+
+    /// Helper: call enumerate and return (items_ptr, count).
+    /// Caller must free items via tcfs_file_items_free.
+    unsafe fn enumerate(
+        prov: *mut TcfsProvider,
+        path: &str,
+    ) -> (TcfsError, *mut TcfsFileItem, usize) {
+        let c_path = CString::new(path).unwrap();
+        let mut items: *mut TcfsFileItem = ptr::null_mut();
+        let mut count: usize = 0;
+        let err = tcfs_provider_enumerate(prov, c_path.as_ptr(), &mut items, &mut count);
+        (err, items, count)
+    }
+
+    // ── Enumerate ────────────────────────────────────────────────────────
+
+    #[test]
+    fn enumerate_empty_returns_zero() {
+        let prov = memory_provider("test");
+        unsafe {
+            let (err, items, count) = enumerate(prov, "");
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert_eq!(count, 0);
+            crate::tcfs_file_items_free(items, count);
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── Upload + Enumerate ───────────────────────────────────────────────
+
+    #[test]
+    fn upload_then_enumerate() {
+        let prov = memory_provider("pfx");
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("hello.txt");
+        std::fs::write(&file, b"Hello, TCFS!").unwrap();
+
+        unsafe {
+            let c_local = CString::new(file.to_str().unwrap()).unwrap();
+            let c_remote = CString::new("hello.txt").unwrap();
+            let err = tcfs_provider_upload(prov, c_local.as_ptr(), c_remote.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+
+            // Enumerate root should show the file
+            let (err, items, count) = enumerate(prov, "");
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert_eq!(count, 1);
+
+            let item = &*items;
+            let name = CStr::from_ptr(item.filename).to_str().unwrap();
+            assert_eq!(name, "hello.txt");
+            assert!(!item.is_directory);
+            // file_size comes from index entry metadata (content_length),
+            // not the actual file — exact value depends on backend.
+
+            crate::tcfs_file_items_free(items, count);
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── Upload + Fetch roundtrip ─────────────────────────────────────────
+
+    #[test]
+    fn upload_then_fetch_roundtrip() {
+        let prov = memory_provider("rt");
+        let dir = tempfile::tempdir().unwrap();
+
+        // Write source file
+        let src = dir.path().join("source.bin");
+        let data = b"binary content for roundtrip test";
+        std::fs::write(&src, data).unwrap();
+
+        // Upload
+        unsafe {
+            let c_local = CString::new(src.to_str().unwrap()).unwrap();
+            let c_remote = CString::new("source.bin").unwrap();
+            let err = tcfs_provider_upload(prov, c_local.as_ptr(), c_remote.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+
+            // Fetch to a different location
+            let dest = dir.path().join("fetched.bin");
+            let c_item = CString::new("source.bin").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch(prov, c_item.as_ptr(), c_dest.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+
+            // Verify content matches
+            let fetched = std::fs::read(&dest).unwrap();
+            assert_eq!(&fetched, data);
+
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── Upload + Delete ──────────────────────────────────────────────────
+
+    #[test]
+    fn upload_then_delete() {
+        let prov = memory_provider("del");
+        let dir = tempfile::tempdir().unwrap();
+
+        let file = dir.path().join("to_delete.txt");
+        std::fs::write(&file, b"delete me").unwrap();
+
+        unsafe {
+            let c_local = CString::new(file.to_str().unwrap()).unwrap();
+            let c_remote = CString::new("to_delete.txt").unwrap();
+            let err = tcfs_provider_upload(prov, c_local.as_ptr(), c_remote.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+
+            // Verify it exists
+            let (_, _, count) = enumerate(prov, "");
+            assert_eq!(count, 1);
+
+            // Delete
+            let c_item = CString::new("to_delete.txt").unwrap();
+            let err = tcfs_provider_delete(prov, c_item.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+
+            // Should be gone
+            let (_, items, count) = enumerate(prov, "");
+            assert_eq!(count, 0);
+            crate::tcfs_file_items_free(items, count);
+
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── Create directory ─────────────────────────────────────────────────
+    // Note: create_dir writes trailing-slash keys which the Memory backend
+    // does not support (it rejects directory-like paths). S3 backends
+    // handle this correctly. The null-safety tests in ffi_safety_test.rs
+    // cover the FFI boundary; functional coverage requires an S3 backend.
+
+    // ── Multiple files ──────────────────────────────────────────────────
+
+    #[test]
+    fn enumerate_multiple_files() {
+        let prov = memory_provider("multi");
+        let dir = tempfile::tempdir().unwrap();
+
+        std::fs::write(dir.path().join("a.txt"), b"aaa").unwrap();
+        std::fs::write(dir.path().join("b.txt"), b"bbb").unwrap();
+        std::fs::write(dir.path().join("c.txt"), b"ccc").unwrap();
+
+        unsafe {
+            for name in &["a.txt", "b.txt", "c.txt"] {
+                let local = dir.path().join(name);
+                let c_local = CString::new(local.to_str().unwrap()).unwrap();
+                let c_remote = CString::new(*name).unwrap();
+                let err = tcfs_provider_upload(prov, c_local.as_ptr(), c_remote.as_ptr());
+                assert_eq!(err, TcfsError::TcfsErrorNone);
+            }
+
+            let (err, items, count) = enumerate(prov, "");
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert_eq!(count, 3);
+
+            // Collect names
+            let mut names: Vec<String> = Vec::new();
+            for i in 0..count {
+                let item = &*items.add(i);
+                names.push(CStr::from_ptr(item.filename).to_str().unwrap().to_string());
+            }
+            names.sort();
+            assert_eq!(names, vec!["a.txt", "b.txt", "c.txt"]);
+
+            crate::tcfs_file_items_free(items, count);
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── Fetch nonexistent file ───────────────────────────────────────────
+
+    #[test]
+    fn fetch_nonexistent_errors() {
+        let prov = memory_provider("miss");
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("output.bin");
+
+        unsafe {
+            let c_item = CString::new("does-not-exist.txt").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch(prov, c_item.as_ptr(), c_dest.as_ptr());
+            // Should fail (storage error or not found)
+            assert_ne!(err, TcfsError::TcfsErrorNone);
+            // Destination should not have been created
+            assert!(!dest.exists());
+
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── Enumerate changes (always empty for direct backend) ──────────────
+
+    #[test]
+    fn enumerate_changes_returns_empty() {
+        let prov = memory_provider("chg");
+        unsafe {
+            let c_path = CString::new("").unwrap();
+            let mut events: *mut crate::TcfsChangeEvent = ptr::null_mut();
+            let mut count: usize = 0;
+            let err = tcfs_provider_enumerate_changes(
+                prov,
+                c_path.as_ptr(),
+                0,
+                &mut events,
+                &mut count,
+            );
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert_eq!(count, 0);
+
+            crate::tcfs_change_events_free(events, count);
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── Fetch with progress callback ─────────────────────────────────────
+
+    #[test]
+    fn fetch_with_progress_reports_bytes() {
+        let prov = memory_provider("prog");
+        let dir = tempfile::tempdir().unwrap();
+
+        // Upload a file first
+        let src = dir.path().join("progress_test.bin");
+        std::fs::write(&src, vec![0xAA; 4096]).unwrap();
+
+        unsafe {
+            let c_local = CString::new(src.to_str().unwrap()).unwrap();
+            let c_remote = CString::new("progress_test.bin").unwrap();
+            let err = tcfs_provider_upload(prov, c_local.as_ptr(), c_remote.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+
+            // Fetch with progress callback — use atomic counters to avoid static mut
+            use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+            static PROGRESS_CALLED: AtomicBool = AtomicBool::new(false);
+            static LAST_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+            unsafe extern "C" fn on_progress(
+                _completed: u64,
+                total: u64,
+                _context: *const std::ffi::c_void,
+            ) {
+                PROGRESS_CALLED.store(true, Ordering::SeqCst);
+                LAST_TOTAL.store(total, Ordering::SeqCst);
+            }
+
+            let dest = dir.path().join("progress_out.bin");
+            let c_item = CString::new("progress_test.bin").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch_with_progress(
+                prov,
+                c_item.as_ptr(),
+                c_dest.as_ptr(),
+                Some(on_progress),
+                ptr::null(),
+            );
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert!(PROGRESS_CALLED.load(Ordering::SeqCst), "progress callback should have been called");
+            assert_eq!(LAST_TOTAL.load(Ordering::SeqCst), 4096, "total should match file size");
+
+            // Verify data
+            let fetched = std::fs::read(&dest).unwrap();
+            assert_eq!(fetched.len(), 4096);
+
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── Subdirectory enumeration ─────────────────────────────────────────
+
+    #[test]
+    fn upload_nested_then_enumerate_parent() {
+        let prov = memory_provider("nest");
+        let dir = tempfile::tempdir().unwrap();
+
+        let file = dir.path().join("readme.md");
+        std::fs::write(&file, b"# Docs").unwrap();
+
+        unsafe {
+            // Upload into a subdirectory
+            let c_local = CString::new(file.to_str().unwrap()).unwrap();
+            let c_remote = CString::new("docs/readme.md").unwrap();
+            let err = tcfs_provider_upload(prov, c_local.as_ptr(), c_remote.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+
+            // Enumerate root — should show "docs" as a directory
+            let (err, items, count) = enumerate(prov, "");
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert_eq!(count, 1);
+
+            let item = &*items;
+            let name = CStr::from_ptr(item.filename).to_str().unwrap();
+            assert_eq!(name, "docs");
+            assert!(item.is_directory);
+
+            crate::tcfs_file_items_free(items, count);
+
+            // Enumerate docs/ — should show the file
+            let (err, items, count) = enumerate(prov, "docs");
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert_eq!(count, 1);
+
+            let item = &*items;
+            let name = CStr::from_ptr(item.filename).to_str().unwrap();
+            assert_eq!(name, "readme.md");
+            assert!(!item.is_directory);
+
+            crate::tcfs_file_items_free(items, count);
+            tcfs_provider_free(prov);
+        }
+    }
+}

--- a/crates/tcfs-file-provider/src/lib.rs
+++ b/crates/tcfs-file-provider/src/lib.rs
@@ -24,6 +24,7 @@ pub type TcfsWatchCallback = Option<unsafe extern "C" fn(*const std::ffi::c_void
 
 /// Error codes returned by FFI functions.
 #[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TcfsError {
     /// Success (no error).
     TcfsErrorNone = 0,


### PR DESCRIPTION
## Summary
- Add 9 functional tests exercising the full FileProvider FFI data path (upload → enumerate → fetch → delete)
- Tests use in-process `TcfsProvider` with `opendal::services::Memory` backend — no network, no credentials
- Derive `Debug + PartialEq` on `TcfsError` for `assert_eq!` in tests
- Add `tempfile` dev-dependency

## Test plan
- [x] `cargo test -p tcfs-file-provider --lib` — 9 new functional tests pass
- [x] `cargo test -p tcfs-file-provider` — 31 total (9 functional + 22 FFI safety)
- [x] `cargo clippy -p tcfs-file-provider` — clean
- [ ] CI green

Closes #207