### PR TITLE
fix(cli): replace bare unwrap() with expect()

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -767,7 +767,8 @@ fn load_device_id(config: &tcfs_core::config::TcfsConfig) -> String {
             match registry.find(&device_name) {
                 Some(d) if d.device_id.is_empty() => {
                     // Backfill device_id for entries created before UUID generation
-                    let new_id = registry.backfill_device_id(&device_name)
+                    let new_id = registry
+                        .backfill_device_id(&device_name)
                         .expect("backfill_device_id with valid device name");
                     if let Err(e) = registry.save(&registry_path) {
                         eprintln!("warning: failed to save backfilled device registry: {e}");

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -730,7 +730,7 @@ fn make_progress_bar(total: u64, prefix: &str) -> ProgressBar {
     let pb = ProgressBar::new(total);
     pb.set_style(
         ProgressStyle::with_template("{prefix:.bold} [{bar:40.cyan/blue}] {pos}/{len} {msg}")
-            .unwrap()
+            .expect("hard-coded progress template")
             .progress_chars("=>-"),
     );
     pb.set_prefix(prefix.to_string());
@@ -740,7 +740,10 @@ fn make_progress_bar(total: u64, prefix: &str) -> ProgressBar {
 
 fn make_spinner(prefix: &str) -> ProgressBar {
     let pb = ProgressBar::new_spinner();
-    pb.set_style(ProgressStyle::with_template("{prefix:.bold} {spinner} {msg}").unwrap());
+    pb.set_style(
+        ProgressStyle::with_template("{prefix:.bold} {spinner} {msg}")
+            .expect("hard-coded spinner template"),
+    );
     pb.set_prefix(prefix.to_string());
     pb.enable_steady_tick(Duration::from_millis(80));
     pb
@@ -764,7 +767,8 @@ fn load_device_id(config: &tcfs_core::config::TcfsConfig) -> String {
             match registry.find(&device_name) {
                 Some(d) if d.device_id.is_empty() => {
                     // Backfill device_id for entries created before UUID generation
-                    let new_id = registry.backfill_device_id(&device_name).unwrap();
+                    let new_id = registry.backfill_device_id(&device_name)
+                        .expect("backfill_device_id with valid device name");
                     if let Err(e) = registry.save(&registry_path) {
                         eprintln!("warning: failed to save backfilled device registry: {e}");
                     } else {
@@ -940,7 +944,7 @@ async fn cmd_push(
                     ProgressStyle::with_template(
                         "{prefix:.bold} [{bar:40.cyan/blue}] {pos}/{len} {msg}",
                     )
-                    .unwrap()
+                    .expect("hard-coded progress template")
                     .progress_chars("=>-"),
                 );
                 pb_clone.set_length(total);


### PR DESCRIPTION
## Summary
- Replace 4 bare `.unwrap()` calls in `tcfs-cli/src/main.rs` with `.expect()` providing context
- Lines 733, 743, 943: `ProgressStyle::with_template(...)` hard-coded templates that cannot fail
- Line 767: `registry.backfill_device_id()` with descriptive panic message

Closes part of Sprint 8 production hazard elimination.

## Test plan
- [x] `cargo clippy -p tcfs-cli --all-targets` passes
- [x] `cargo test -p tcfs-cli` passes
- [x] No behavior change — only panic messages improved