### PR TITLE
test(fuzz): cargo-fuzz targets + proptest for manifest, crypto, paths

### DIFF
--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1680,3 +1680,35 @@ mod tests {
         assert_eq!(remote_path_prefix("a/b/c/"), "a/b/c");
     }
 }
+
+#[cfg(test)]
+mod proptest_suite {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        /// normalize_rel_path must never panic on arbitrary path strings.
+        #[test]
+        fn normalize_never_panics(input in ".*") {
+            let _ = normalize_rel_path(Path::new(&input), None);
+        }
+
+        /// Output never contains backslashes (Windows path separators).
+        #[test]
+        fn normalize_no_backslash(input in ".*") {
+            let result = normalize_rel_path(Path::new(&input), None);
+            prop_assert!(!result.contains('\\'), "backslash in output: {result}");
+        }
+
+        /// With a real tempdir as sync_root, file paths under it are relativized.
+        #[test]
+        fn normalize_under_root_is_relative(filename in "[a-zA-Z][a-zA-Z0-9._-]{0,63}") {
+            let dir = tempfile::tempdir().unwrap();
+            let file = dir.path().join(&filename);
+            std::fs::write(&file, b"x").unwrap();
+
+            let result = normalize_rel_path(&file, Some(dir.path()));
+            prop_assert_eq!(result, filename);
+        }
+    }
+}

--- a/crates/tcfs-sync/src/manifest.rs
+++ b/crates/tcfs-sync/src/manifest.rs
@@ -145,3 +145,66 @@ mod tests {
         assert_eq!(parsed.chunks, vec!["single_hash"]);
     }
 }
+
+#[cfg(test)]
+mod proptest_suite {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        /// from_bytes must never panic on arbitrary bytes — it returns Ok or Err.
+        #[test]
+        fn from_bytes_never_panics(data in proptest::collection::vec(any::<u8>(), 0..=4096)) {
+            let _ = SyncManifest::from_bytes(&data);
+        }
+
+        /// Valid v2 manifests must roundtrip through to_bytes/from_bytes.
+        #[test]
+        fn v2_roundtrip(
+            file_hash in "[a-f0-9]{64}",
+            file_size in any::<u64>(),
+            chunk_count in 1..10usize,
+            written_by in "[a-z]{1,16}",
+            written_at in any::<u64>(),
+        ) {
+            let chunks: Vec<String> = (0..chunk_count)
+                .map(|i| format!("chunk_{i:016x}"))
+                .collect();
+
+            let mut vc = VectorClock::new();
+            vc.tick(&written_by);
+
+            let manifest = SyncManifest {
+                version: 2,
+                file_hash,
+                file_size,
+                chunks,
+                vclock: vc,
+                written_by,
+                written_at,
+                rel_path: None,
+                mode: None,
+                encrypted_file_key: None,
+            };
+
+            let bytes = manifest.to_bytes().unwrap();
+            let parsed = SyncManifest::from_bytes(&bytes).unwrap();
+
+            prop_assert_eq!(parsed.version, 2);
+            prop_assert_eq!(parsed.file_hash, manifest.file_hash);
+            prop_assert_eq!(parsed.file_size, manifest.file_size);
+            prop_assert_eq!(parsed.chunks.len(), manifest.chunks.len());
+        }
+
+        /// v1 text manifests: any non-empty newline-separated text should parse as v1.
+        #[test]
+        fn v1_any_lines_parse(
+            lines in proptest::collection::vec("[a-f0-9]{8,64}", 1..20)
+        ) {
+            let text = lines.join("\n") + "\n";
+            let parsed = SyncManifest::from_bytes(text.as_bytes()).unwrap();
+            prop_assert!(parsed.is_legacy());
+            prop_assert_eq!(parsed.chunks.len(), lines.len());
+        }
+    }
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "tcfs-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+tcfs-sync = { path = "../crates/tcfs-sync" }
+tcfs-crypto = { path = "../crates/tcfs-crypto" }
+arbitrary = { version = "1", features = ["derive"] }
+
+[[bin]]
+name = "manifest_parse"
+path = "fuzz_targets/manifest_parse.rs"
+doc = false
+
+[[bin]]
+name = "crypto_roundtrip"
+path = "fuzz_targets/crypto_roundtrip.rs"
+doc = false
+
+[[bin]]
+name = "path_sanitize"
+path = "fuzz_targets/path_sanitize.rs"
+doc = false
+
+[[bin]]
+name = "name_encrypt"
+path = "fuzz_targets/name_encrypt.rs"
+doc = false

--- a/fuzz/fuzz_targets/crypto_roundtrip.rs
+++ b/fuzz/fuzz_targets/crypto_roundtrip.rs
@@ -1,0 +1,39 @@
+#![no_main]
+//! Fuzz target: chunk encrypt/decrypt roundtrip.
+//!
+//! For any plaintext and valid key material, encrypt → decrypt must yield
+//! the original plaintext. Also verifies that decrypt with wrong key fails
+//! gracefully (returns Err, never panics).
+
+use libfuzzer_sys::fuzz_target;
+use tcfs_crypto::{encrypt_chunk, decrypt_chunk, keys::FileKey};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 33 {
+        // Need at least 1 byte of plaintext + 32 bytes for key seed
+        return;
+    }
+
+    let (key_seed, plaintext) = data.split_at(32);
+    let mut key_bytes = [0u8; 32];
+    key_bytes.copy_from_slice(key_seed);
+    let file_key = FileKey::from_bytes(key_bytes);
+
+    let file_id = [0xABu8; 32];
+    let chunk_index: u64 = 0;
+
+    // Encrypt must succeed for valid inputs
+    let ciphertext = match encrypt_chunk(&file_key, chunk_index, &file_id, plaintext) {
+        Ok(ct) => ct,
+        Err(_) => return,
+    };
+
+    // Decrypt with correct key must roundtrip
+    let decrypted = decrypt_chunk(&file_key, chunk_index, &file_id, &ciphertext)
+        .expect("decrypt with correct key must succeed");
+    assert_eq!(decrypted, plaintext, "roundtrip mismatch");
+
+    // Decrypt with wrong key must not panic
+    let wrong_key = FileKey::from_bytes([0xFFu8; 32]);
+    let _ = decrypt_chunk(&wrong_key, chunk_index, &file_id, &ciphertext);
+});

--- a/fuzz/fuzz_targets/manifest_parse.rs
+++ b/fuzz/fuzz_targets/manifest_parse.rs
@@ -1,0 +1,11 @@
+#![no_main]
+//! Fuzz target: SyncManifest::from_bytes() must never panic on arbitrary input.
+//!
+//! Valid inputs parse to a manifest; invalid inputs return Err — but never panic.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // from_bytes must not panic regardless of input
+    let _ = tcfs_sync::manifest::SyncManifest::from_bytes(data);
+});

--- a/fuzz/fuzz_targets/name_encrypt.rs
+++ b/fuzz/fuzz_targets/name_encrypt.rs
@@ -1,0 +1,41 @@
+#![no_main]
+//! Fuzz target: AES-SIV name encryption roundtrip.
+//!
+//! Properties:
+//! - encrypt_name never panics on valid UTF-8 input
+//! - encrypt → decrypt roundtrips for any valid name
+//! - Deterministic: same key + name = same ciphertext
+
+use libfuzzer_sys::fuzz_target;
+use tcfs_crypto::{encrypt_name, decrypt_name, KEY_SIZE};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < KEY_SIZE + 1 {
+        return;
+    }
+
+    let (key_bytes, name_bytes) = data.split_at(KEY_SIZE);
+    let mut key = [0u8; KEY_SIZE];
+    key.copy_from_slice(key_bytes);
+
+    let Ok(name) = std::str::from_utf8(name_bytes) else {
+        return;
+    };
+    if name.is_empty() {
+        return;
+    }
+
+    // Encrypt must succeed
+    let encrypted = match encrypt_name(&key, name) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    // Deterministic: second encryption must match
+    let encrypted2 = encrypt_name(&key, name).unwrap();
+    assert_eq!(encrypted, encrypted2, "AES-SIV must be deterministic");
+
+    // Roundtrip
+    let decrypted = decrypt_name(&key, &encrypted).expect("decrypt must succeed");
+    assert_eq!(decrypted, name, "roundtrip mismatch");
+});

--- a/fuzz/fuzz_targets/path_sanitize.rs
+++ b/fuzz/fuzz_targets/path_sanitize.rs
@@ -1,0 +1,39 @@
+#![no_main]
+//! Fuzz target: normalize_rel_path must never panic on arbitrary path strings.
+//!
+//! Properties checked:
+//! - Never panics
+//! - Output never starts with '/' (leading slash always stripped)
+//! - Output never contains backslashes (normalized to forward slash)
+
+use libfuzzer_sys::fuzz_target;
+use std::path::Path;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(input) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    // Test without sync_root
+    let result = tcfs_sync::engine::normalize_rel_path(Path::new(input), None);
+    assert!(
+        !result.starts_with('/'),
+        "output must not start with /: {result}"
+    );
+    assert!(
+        !result.contains('\\'),
+        "output must not contain backslash: {result}"
+    );
+
+    // Test with a sync_root
+    let tmp = std::env::temp_dir();
+    let result2 = tcfs_sync::engine::normalize_rel_path(Path::new(input), Some(&tmp));
+    assert!(
+        !result2.starts_with('/'),
+        "output must not start with / (with root): {result2}"
+    );
+    assert!(
+        !result2.contains('\\'),
+        "output must not contain backslash (with root): {result2}"
+    );
+});


### PR DESCRIPTION
## Summary
- Add 4 `cargo-fuzz` targets (nightly) for manifest parsing, chunk crypto roundtrip, path normalization, and name encryption
- Add 6 proptest properties (stable CI) covering the same invariants: `from_bytes_never_panics`, `v2_roundtrip`, `v1_any_lines_parse`, `normalize_never_panics`, `normalize_no_backslash`, `normalize_under_root_is_relative`
- Existing crypto proptests (chunk roundtrip, name roundtrip) already cover the encryption surface

Closes #209, completes M6.

## Test plan
- [x] `cargo test -p tcfs-sync -- proptest` — 14 passed (8 existing + 6 new)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p tcfs-sync -p tcfs-crypto --all-targets` clean
- [ ] `cargo +nightly fuzz run manifest_parse -- -max_total_time=30` (manual, nightly only)