### PR TITLE
[codex] TIN-67 add Greptile canary

### DIFF
--- a/docs/TIN-67_GREPTILE_CANARY.md
+++ b/docs/TIN-67_GREPTILE_CANARY.md
@@ -1,0 +1,13 @@
+# TIN-67 Greptile Canary
+
+This file exists only to create a minimal pull request that validates whether
+Greptile is actively reviewing pull requests in `Jesssullivan/tummycrypt`, which
+is the canonical repo home for tummycrypt.
+
+The canary should answer:
+
+- does a `Greptile Review` check appear on the PR
+- is the review signal useful and not excessively noisy
+- should Greptile follow the canonical repo instead of the org fork here
+
+This change does not affect runtime behavior.


### PR DESCRIPTION
## What changed

Adds a single docs-only file at `docs/TIN-67_GREPTILE_CANARY.md`.

## Why

This PR is an intentional canary for `TIN-67` to verify whether Greptile is
active on `Jesssullivan/tummycrypt`, which is the canonical repo home.

It should let us confirm:

- whether a `Greptile Review` check appears
- whether the review signal is useful and not excessively noisy
- whether Greptile should follow the canonical repo instead of the org fork here

## Impact

No runtime behavior changes.

## Validation

- `git diff --check`
- docs-only change in a fresh temporary checkout
