### PR TITLE
[codex] Reject traversal paths in gRPC push

### DIFF
--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -44,6 +44,31 @@ pub struct TcfsDaemonImpl {
     rate_limiter: tcfs_auth::RateLimiter,
 }
 
+/// Validate a client-provided relative path before joining it under a tempdir.
+fn sanitize_rel_path(path: &str) -> std::result::Result<String, String> {
+    use std::path::Component;
+
+    if path.is_empty() {
+        return Err("path must not be empty".to_string());
+    }
+
+    let rel_path = Path::new(path);
+    if rel_path.is_absolute() {
+        return Err(format!("absolute path not allowed: {path}"));
+    }
+
+    for component in rel_path.components() {
+        if matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        ) {
+            return Err(format!("path traversal not allowed: {path}"));
+        }
+    }
+
+    Ok(path.to_string())
+}
+
 impl TcfsDaemonImpl {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -601,6 +626,8 @@ impl TcfsDaemon for TcfsDaemonImpl {
                 "no path provided in push stream",
             ));
         }
+
+        let path = sanitize_rel_path(&path).map_err(tonic::Status::invalid_argument)?;
 
         // Write to a temp file and upload via sync engine
         let tmp_dir =
@@ -2471,5 +2498,34 @@ mod tests {
 
         // Should return error status for invalid resolution
         assert!(resp.is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_parent_traversal() {
+        assert!(sanitize_rel_path("../../etc/passwd").is_err());
+        assert!(sanitize_rel_path("foo/../../../bar").is_err());
+        assert!(sanitize_rel_path("..").is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_absolute_paths() {
+        assert!(sanitize_rel_path("/etc/passwd").is_err());
+        assert!(sanitize_rel_path("/tmp/file.txt").is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_empty_path() {
+        assert!(sanitize_rel_path("").is_err());
+    }
+
+    #[test]
+    fn sanitize_accepts_valid_relative_paths() {
+        assert_eq!(sanitize_rel_path("file.txt").unwrap(), "file.txt");
+        assert_eq!(sanitize_rel_path("a/b/c.txt").unwrap(), "a/b/c.txt");
+        assert_eq!(
+            sanitize_rel_path("docs/nested/deep.md").unwrap(),
+            "docs/nested/deep.md"
+        );
+        assert_eq!(sanitize_rel_path("./current.txt").unwrap(), "./current.txt");
     }
 }


### PR DESCRIPTION
## What changed
- added `sanitize_rel_path` in `crates/tcfsd/src/grpc.rs`
- reject empty, absolute, and `..`-traversal paths before joining the client-supplied path under the upload tempdir
- added focused unit tests covering accepted and rejected path shapes

## Why
The gRPC `Push` handler accepted a client-provided path and joined it directly under a tempdir. A malicious path like `../../etc/passwd` could escape that tempdir before upload handling, which is the bug tracked in #226 and previously explored in `tinyland-inc/tummycrypt#57`.

## Impact
The daemon now rejects unsafe client paths up front with `invalid_argument` instead of writing outside the temp staging directory.

## Validation
- `nix develop /Users/jess/git/tummycrypt --command cargo fmt --all -- --check`
- `nix develop /Users/jess/git/tummycrypt --command env CARGO_TARGET_DIR=/tmp/tummycrypt-pr57-target cargo test -p tcfsd sanitize_`

Closes #226
