### PR TITLE
[codex] Converge toolchain and CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,10 +3,13 @@
 # NOTE: mold linker is available in the Nix devShell (nix develop).
 # Outside Nix, the default system linker is used.
 # To enable mold manually: export RUSTFLAGS="-C link-arg=-fuse-ld=mold"
+# Rust itself is pinned by rust-toolchain.toml and flake.nix.
 
 # Cross-compilation targets (via cargo cross or nix)
 [target.x86_64-apple-darwin]
 [target.aarch64-apple-darwin]
+[target.aarch64-apple-ios]
+[target.aarch64-apple-ios-sim]
 
 [env]
 # Ensure RocksDB uses bundled version by default (overridden if system lib found)

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@
 #   cp .env.example .env
 #
 # .env is gitignored and will never be committed.
-# direnv loads .env automatically when you cd into the project.
+# The repo pins Rust 1.93.0 via rust-toolchain.toml and flake.nix.
+# direnv loads .env automatically and checks that rustc meets the workspace minimum.
 #
 # For production/CI, use SOPS-encrypted credentials instead (see credentials/).
 

--- a/.envrc
+++ b/.envrc
@@ -12,6 +12,42 @@
 # The Nix devShell provides: rust toolchain, protobuf, age, sops, opentofu,
 # kubectl, helm, go-task, cargo-watch, cargo-deny, cargo-audit, natscli, etc.
 
+watch_file Cargo.toml
+watch_file flake.nix
+watch_file rust-toolchain.toml
+watch_file .env.example
+
+if [[ -f .env ]]; then
+  watch_file .env
+fi
+
+tcfs_min_rust_version="$(awk -F'"' '/^rust-version = / { print $2; exit }' Cargo.toml)"
+tcfs_pinned_rust_toolchain="$(awk -F'"' '/^channel = / { print $2; exit }' rust-toolchain.toml)"
+
+version_ge() {
+  local lhs rhs i lhs_part rhs_part
+  local -a lhs_parts rhs_parts
+
+  IFS='.' read -r -a lhs_parts <<< "$1"
+  IFS='.' read -r -a rhs_parts <<< "$2"
+
+  for ((i = 0; i < 3; i++)); do
+    lhs_part="${lhs_parts[i]:-0}"
+    rhs_part="${rhs_parts[i]:-0}"
+    if ((10#${lhs_part} > 10#${rhs_part})); then
+      return 0
+    fi
+    if ((10#${lhs_part} < 10#${rhs_part})); then
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+export TCFS_RUST_TOOLCHAIN="${TCFS_RUST_TOOLCHAIN:-${tcfs_pinned_rust_toolchain}}"
+export TCFS_RUST_VERSION_MIN="${TCFS_RUST_VERSION_MIN:-${tcfs_min_rust_version}}"
+
 # ── Nix devShell ─────────────────────────────────────────────────────────────
 # nix-direnv (v3.0.6 via Home Manager) caches the devShell evaluation,
 # so subsequent cd's into this directory are near-instant.
@@ -31,6 +67,15 @@ else
       log_error "Missing: $cmd (would be provided by 'nix develop')"
     fi
   done
+fi
+
+if has rustc; then
+  tcfs_active_rustc_version="$(rustc --version | awk '{ print $2 }')"
+  if ! version_ge "$tcfs_active_rustc_version" "$TCFS_RUST_VERSION_MIN"; then
+    log_error "rustc ${tcfs_active_rustc_version} is below workspace minimum ${TCFS_RUST_VERSION_MIN}; use nix develop or install ${TCFS_RUST_TOOLCHAIN}"
+  fi
+else
+  log_error "Missing: rustc (install ${TCFS_RUST_TOOLCHAIN} or use 'nix develop')"
 fi
 
 # ── Secrets (.env) ───────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_TOOLCHAIN: 1.93.0
 
 jobs:
   check:
@@ -20,6 +21,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -78,6 +80,12 @@ jobs:
       - name: Nix flake check
         run: nix flake check
 
+      - name: Verify devShell Rust version
+        run: |
+          VERSION="$(nix develop --command rustc --version)"
+          echo "$VERSION"
+          echo "$VERSION" | grep -q "1.93.0"
+
       - name: Build all packages
         run: nix build .#tcfsd .#tcfs-cli .#tcfs-tui .#tcfs-mcp
 
@@ -89,6 +97,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - uses: Swatinem/rust-cache@v2
 
@@ -121,6 +131,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: aarch64-apple-ios-sim
 
       - uses: Swatinem/rust-cache@v2
@@ -133,6 +144,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -17,9 +17,8 @@ on:
   workflow_dispatch:
 
 env:
-  # Attic on honey RKE2 via Tailscale. CI runners can't reach this directly;
-  # push will gracefully fail. Public ingress or Tailscale sidecar needed for CI push.
-  ATTIC_SERVER: http://nix-cache-attic
+  # Public Attic endpoint shared with flake.nix and other workflows.
+  ATTIC_SERVER: https://nix-cache.fuzzy-dev.tinyland.dev
   ATTIC_CACHE: main
 
 jobs:

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,6 @@
 # tcfs project Justfile
 # Run `just --list` to see all recipes
+# cargo is expected to come from the pinned rust-toolchain or Nix devShell.
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
@@ -100,24 +101,32 @@ nix-check:
 nix-devshell:
     nix develop
 
+# Show active toolchain and local environment helpers
+toolchain-status:
+    rustc --version
+    cargo --version
+    just --version
+    @if command -v nix >/dev/null 2>&1; then nix --version; else echo "nix: not installed"; fi
+    @if command -v direnv >/dev/null 2>&1; then direnv version; else echo "direnv: not installed"; fi
+
 # ── Cargo ───────────────────────────────────────────────────────────────────
 
 # Build workspace
 build:
-    ~/.cargo/bin/cargo build --workspace
+    cargo build --workspace
 
 # Run all tests
 test:
-    ~/.cargo/bin/cargo test --workspace
+    cargo test --workspace
 
 # Lint (clippy + fmt check)
 lint:
-    ~/.cargo/bin/cargo clippy --workspace --all-targets
-    ~/.cargo/bin/cargo fmt --all -- --check
+    cargo clippy --workspace --all-targets
+    cargo fmt --all -- --check
 
 # cargo-deny license and advisory check
 deny:
-    ~/.cargo/bin/cargo deny check
+    cargo deny check
 
 # ── iOS (TestFlight) ─────────────────────────────────────────────────────
 # Pipeline: Rust staticlib → xcodegen → archive → export IPA → TestFlight
@@ -180,7 +189,7 @@ fileprovider-build:
         exit 1
     fi
     echo "==> Building Rust staticlib..."
-    ~/.cargo/bin/cargo build -p tcfs-file-provider --release -j 4
+    cargo build -p tcfs-file-provider --release -j 4
     HEADER=$(find target/release/build -name "tcfs_file_provider.h" | head -1)
     if [ -z "$HEADER" ]; then
         echo "ERROR: cbindgen header not found" >&2

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,14 @@
 {
   description = "tummycrypt/tcfs - FOSS self-hosted odrive replacement";
 
-  # Attic binary cache on honey RKE2 (Tailscale-only access)
-  # Cache was recreated 2026-04-08 with fresh signing key after
-  # the old cache served stale cargoArtifacts missing fuse3 deps.
+  # Public Attic read endpoint used by local dev and CI.
+  # CI/release workflows push with `attic login` separately.
   nixConfig = {
     extra-substituters = [
-      "http://nix-cache-attic/main"
+      "https://nix-cache.fuzzy-dev.tinyland.dev/main"
     ];
     extra-trusted-public-keys = [
-      "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
+      "main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE="
     ];
   };
 
@@ -19,10 +18,7 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -31,16 +27,18 @@
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+        rustVersion = "1.93.0";
+        rustTargets = [
+          "x86_64-unknown-linux-gnu"
+          "aarch64-unknown-linux-gnu"
+          "x86_64-apple-darwin"
+          "aarch64-apple-darwin"
+          "aarch64-apple-ios"
+          "aarch64-apple-ios-sim"
+        ];
+        rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = [ "rust-src" "rust-analyzer" "clippy" "rustfmt" ];
-          targets = [
-            "x86_64-unknown-linux-gnu"
-            "aarch64-unknown-linux-gnu"
-            "x86_64-apple-darwin"
-            "aarch64-apple-darwin"
-            "aarch64-apple-ios"
-            "aarch64-apple-ios-sim"
-          ];
+          targets = rustTargets;
         };
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
@@ -192,9 +190,11 @@
             just
             yq-go
           ]);
+          TCFS_RUST_TOOLCHAIN = rustVersion;
 
           shellHook = ''
             echo "tcfs devShell (tummycrypt monorepo)"
+            echo "  rustc --version  # pinned toolchain should report ${rustVersion}"
             echo "  just --list      # show available recipes"
             echo "  task --list      # show go-task tasks"
             echo "  cargo build      # build workspace"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,11 @@
 [toolchain]
-channel = "stable"
+channel = "1.93.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 targets = [
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-apple-ios-sim",
 ]


### PR DESCRIPTION
## What changed
- pinned local and CI toolchains to Rust 1.93.0 across `rust-toolchain.toml`, `flake.nix`, `.envrc`, and the `Justfile`
- aligned the Nix/dev-shell path so `direnv` and CI converge on the same toolchain and cache setup
- updated CI workflows and local config to use the same cache and shell assumptions

## Why
The repo was carrying toolchain drift between the declared workspace MSRV, the Nix shell, local onboarding, and CI. That made repo health checks depend on which environment happened to be active.

## Impact
Local development, direnv/Nix shells, and CI now resolve the same Rust/tooling story instead of silently diverging.

## Validation
- `nix develop . --command rustc --version`
- `direnv exec . just toolchain-status`
- `direnv exec . cargo check --workspace --locked`