### PR TITLE
[codex] Add recovery-aware manifest/index publish durability

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -886,16 +886,8 @@ async fn cmd_push(
             ));
             println!("  skipped (unchanged since last sync)");
         } else {
-            // Write index entry for FUSE discoverability (same pattern as push_tree_with_device)
-            let index_key = format!("{}/index/{}", remote_prefix.trim_end_matches('/'), &rel);
-            let index_entry = format!(
-                "manifest_hash={}\nsize={}\nchunks={}\n",
-                result.hash, result.bytes, result.chunks
-            );
-            if let Err(e) = op.write(&index_key, index_entry.into_bytes()).await {
-                eprintln!("warning: failed to write index entry: {e}");
-            }
-
+            // Path publication is handled inside upload_file_with_device so the
+            // manifest/index sequence remains crash-aware.
             pb.finish_with_message("done".to_string());
             println!("  hash:    {}", &result.hash[..16.min(result.hash.len())]);
             println!("  chunks:  {}", result.chunks);

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
 use crate::conflict::{compare_clocks, SyncOutcome};
-use crate::index_entry::parse_index_entry;
+use crate::index_entry::{parse_index_entry, RemoteIndexEntry};
 use crate::manifest::SyncManifest;
 use crate::state::{make_sync_state_full, StateCache};
 
@@ -997,11 +997,10 @@ pub async fn push_tree_with_device(
                     // create an orphan pointing to a non-existent manifest.
                     let index_key =
                         format!("{}/index/{}", remote_path_prefix(remote_prefix), rel_str);
-                    let index_entry = format!(
-                        "manifest_hash={}\nsize={}\nchunks={}\n",
-                        result.hash, result.bytes, result.chunks
-                    );
-                    if let Err(e) = op.write(&index_key, index_entry.into_bytes()).await {
+                    let index_entry =
+                        RemoteIndexEntry::new(result.hash.clone(), result.bytes, result.chunks)
+                            .to_legacy_bytes();
+                    if let Err(e) = op.write(&index_key, index_entry).await {
                         warn!(path = %path.display(), "failed to write index entry: {e}");
                     }
                     uploaded += 1;
@@ -1553,7 +1552,7 @@ mod tests {
         // Write an index entry
         op.write(
             "data/index/doc.txt",
-            b"manifest_hash=abc123\nsize=100\nchunks=1\n".to_vec(),
+            RemoteIndexEntry::new("abc123", 100, 1).to_legacy_bytes(),
         )
         .await
         .unwrap();
@@ -1583,7 +1582,7 @@ mod tests {
         // Write index and manifest
         op.write(
             "data/index/file.txt",
-            b"manifest_hash=abc123\nsize=100\nchunks=1\n".to_vec(),
+            RemoteIndexEntry::new("abc123", 100, 1).to_legacy_bytes(),
         )
         .await
         .unwrap();

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
 use crate::conflict::{compare_clocks, SyncOutcome};
+use crate::index_entry::parse_index_entry;
 use crate::manifest::SyncManifest;
 use crate::state::{make_sync_state_full, StateCache};
 
@@ -304,13 +305,13 @@ pub async fn upload_file_with_device(
             // Look up the index entry to find what manifest is currently stored
             let index_key = format!("{}/index/{}", remote_prefix.trim_end_matches('/'), rp);
             let idx_manifest = if let Ok(idx_bytes) = op.read(&index_key).await {
-                let idx_raw = idx_bytes.to_bytes();
-                let idx_str = String::from_utf8_lossy(&idx_raw);
-                // Parse "manifest_hash=<hash>\nsize=...\n"
-                idx_str
-                    .lines()
-                    .find_map(|l| l.strip_prefix("manifest_hash="))
-                    .map(|h| format!("{}/manifests/{}", remote_prefix.trim_end_matches('/'), h))
+                parse_index_entry(&idx_bytes.to_vec()).ok().map(|entry| {
+                    format!(
+                        "{}/manifests/{}",
+                        remote_prefix.trim_end_matches('/'),
+                        entry.manifest_hash
+                    )
+                })
             } else {
                 None
             };
@@ -1266,13 +1267,8 @@ pub async fn resolve_manifest_path(
     let index_key = format!("{prefix}/index/{rel}");
 
     if let Ok(idx_bytes) = op.read(&index_key).await {
-        let idx_raw = idx_bytes.to_bytes();
-        let idx_str = String::from_utf8_lossy(&idx_raw);
-        if let Some(manifest_hash) = idx_str
-            .lines()
-            .find_map(|l| l.strip_prefix("manifest_hash="))
-        {
-            return Ok(format!("{prefix}/manifests/{manifest_hash}"));
+        if let Ok(entry) = parse_index_entry(&idx_bytes.to_vec()) {
+            return Ok(format!("{prefix}/manifests/{}", entry.manifest_hash));
         }
     }
 
@@ -1294,13 +1290,8 @@ pub async fn resolve_manifest_path(
         let entry_path = entry.path();
         if entry_path.ends_with(&format!("/{filename}")) || entry_path.ends_with(&filename) {
             if let Ok(idx_bytes) = op.read(entry_path).await {
-                let idx_raw = idx_bytes.to_bytes();
-                let idx_str = String::from_utf8_lossy(&idx_raw);
-                if let Some(manifest_hash) = idx_str
-                    .lines()
-                    .find_map(|l| l.strip_prefix("manifest_hash="))
-                {
-                    return Ok(format!("{prefix}/manifests/{manifest_hash}"));
+                if let Ok(entry) = parse_index_entry(&idx_bytes.to_vec()) {
+                    return Ok(format!("{prefix}/manifests/{}", entry.manifest_hash));
                 }
             }
         }
@@ -1336,12 +1327,9 @@ pub async fn delete_remote_file(
         .with_context(|| format!("reading index entry: {index_key}"))?
         .to_bytes();
 
-    let idx_str = String::from_utf8_lossy(&idx_raw);
-    let manifest_hash = idx_str
-        .lines()
-        .find_map(|l| l.strip_prefix("manifest_hash="))
-        .ok_or_else(|| anyhow::anyhow!("index entry missing manifest_hash: {index_key}"))?
-        .to_string();
+    let manifest_hash = parse_index_entry(&idx_raw)
+        .with_context(|| format!("parsing index entry: {index_key}"))?
+        .manifest_hash;
 
     let manifest_key = format!("{prefix}/manifests/{manifest_hash}");
 

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -15,9 +15,13 @@ use anyhow::{Context, Result};
 use opendal::Operator;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
+use uuid::Uuid;
 
 use crate::conflict::{compare_clocks, SyncOutcome};
-use crate::index_entry::{parse_index_entry, RemoteIndexEntry};
+use crate::index_entry::{
+    manifest_key, read_index_entry_record_from_store, resolve_visible_index_entry,
+    write_committed_index_entry, write_preparing_index_entry, PendingIndexEntry, RemoteIndexEntry,
+};
 use crate::manifest::SyncManifest;
 use crate::state::{make_sync_state_full, StateCache};
 
@@ -112,6 +116,77 @@ async fn read_chunk_with_retry(
             anyhow::anyhow!("chunk download failed after {CHUNK_MAX_RETRIES} retries")
         })
         .context(format!("downloading chunk {chunk_idx}: {key}")))
+}
+
+fn manifest_path_prefix(remote_prefix: &str) -> String {
+    format!("{}/manifests", remote_prefix.trim_end_matches('/'))
+}
+
+async fn publish_index_reference(
+    op: &Operator,
+    remote_prefix: &str,
+    rel_path: &str,
+    entry: RemoteIndexEntry,
+) -> Result<()> {
+    let prefix = remote_prefix.trim_end_matches('/');
+    let index_key = format!("{prefix}/index/{rel_path}");
+    let manifest_prefix = manifest_path_prefix(prefix);
+    let manifest_path = manifest_key(&manifest_prefix, &entry.manifest_hash);
+
+    anyhow::ensure!(
+        op.exists(&manifest_path).await.unwrap_or(false),
+        "cannot point index at missing manifest: {manifest_path}"
+    );
+
+    let _ = resolve_visible_index_entry(op, &index_key, &manifest_prefix).await?;
+    write_committed_index_entry(op, &index_key, &entry).await
+}
+
+async fn publish_manifest_for_rel_path(
+    op: &Operator,
+    remote_prefix: &str,
+    rel_path: &str,
+    manifest_bytes: Vec<u8>,
+    entry: RemoteIndexEntry,
+) -> Result<()> {
+    let prefix = remote_prefix.trim_end_matches('/');
+    let index_key = format!("{prefix}/index/{rel_path}");
+    let manifest_prefix = manifest_path_prefix(prefix);
+    let final_manifest_key = manifest_key(&manifest_prefix, &entry.manifest_hash);
+    let staged_manifest_key = format!(
+        "{prefix}/staging/manifests/{}-{}.json",
+        Uuid::new_v4(),
+        entry.manifest_hash
+    );
+
+    let current = resolve_visible_index_entry(op, &index_key, &manifest_prefix).await?;
+
+    op.write(&staged_manifest_key, manifest_bytes.clone())
+        .await
+        .with_context(|| format!("writing staged manifest: {staged_manifest_key}"))?;
+
+    write_preparing_index_entry(
+        op,
+        &index_key,
+        current,
+        PendingIndexEntry::new(
+            entry.manifest_hash.clone(),
+            entry.size,
+            entry.chunks,
+            staged_manifest_key.clone(),
+        ),
+    )
+    .await?;
+
+    if !op.exists(&final_manifest_key).await.unwrap_or(false) {
+        op.write(&final_manifest_key, manifest_bytes)
+            .await
+            .with_context(|| format!("uploading manifest: {final_manifest_key}"))?;
+    }
+
+    write_committed_index_entry(op, &index_key, &entry).await?;
+    let _ = op.delete(&staged_manifest_key).await;
+    Ok(())
 }
 
 /// Optional encryption context for E2E encrypted push/pull.
@@ -304,17 +379,12 @@ pub async fn upload_file_with_device(
         let remote_manifest_obj = if let Some(rp) = rel_path {
             // Look up the index entry to find what manifest is currently stored
             let index_key = format!("{}/index/{}", remote_prefix.trim_end_matches('/'), rp);
-            let idx_manifest = if let Ok(idx_bytes) = op.read(&index_key).await {
-                parse_index_entry(&idx_bytes.to_vec()).ok().map(|entry| {
-                    format!(
-                        "{}/manifests/{}",
-                        remote_prefix.trim_end_matches('/'),
-                        entry.manifest_hash
-                    )
-                })
-            } else {
-                None
-            };
+            let manifest_prefix = manifest_path_prefix(remote_prefix);
+            let idx_manifest = resolve_visible_index_entry(op, &index_key, &manifest_prefix)
+                .await
+                .ok()
+                .flatten()
+                .map(|entry| manifest_key(&manifest_prefix, &entry.manifest_hash));
             // Read the manifest pointed to by the index entry
             if let Some(ref manifest_path) = idx_manifest {
                 if let Ok(remote_bytes) = op.read(manifest_path).await {
@@ -427,11 +497,29 @@ pub async fn upload_file_with_device(
         && device_id.is_empty()
     {
         debug!(hash = %file_hash_hex, "dedup: manifest already exists");
+        let existing_manifest = op
+            .read(&remote_manifest)
+            .await
+            .with_context(|| format!("reading existing manifest for dedup: {remote_manifest}"))?;
+        let existing_manifest = SyncManifest::from_bytes(&existing_manifest.to_bytes())
+            .with_context(|| format!("parsing existing manifest for dedup: {remote_manifest}"))?;
+        let chunk_count = existing_manifest.chunk_hashes().len();
+
+        if let Some(rp) = rel_path {
+            publish_index_reference(
+                op,
+                remote_prefix,
+                rp,
+                RemoteIndexEntry::new(file_hash_hex.clone(), file_size, chunk_count),
+            )
+            .await?;
+        }
+
         let remote_path = remote_manifest.clone();
         let sync_state = make_sync_state_full(
             local_path,
             file_hash_hex.clone(),
-            0,
+            chunk_count,
             remote_path.clone(),
             local_vclock,
             device_id.to_string(),
@@ -441,7 +529,7 @@ pub async fn upload_file_with_device(
             path: local_path.to_path_buf(),
             remote_path,
             hash: file_hash_hex,
-            chunks: 0,
+            chunks: chunk_count,
             bytes: file_size,
             skipped: false,
             outcome: None,
@@ -635,9 +723,20 @@ pub async fn upload_file_with_device(
     };
 
     let manifest_bytes = manifest.to_bytes()?;
-    op.write(&remote_manifest, manifest_bytes)
-        .await
-        .with_context(|| format!("uploading manifest: {remote_manifest}"))?;
+    if let Some(rp) = rel_path {
+        publish_manifest_for_rel_path(
+            op,
+            remote_prefix,
+            rp,
+            manifest_bytes,
+            RemoteIndexEntry::new(file_hash_hex.clone(), file_size, num_chunks),
+        )
+        .await?;
+    } else {
+        op.write(&remote_manifest, manifest_bytes)
+            .await
+            .with_context(|| format!("uploading manifest: {remote_manifest}"))?;
+    }
 
     // Deferred vclock merge: only merge remote vclock after successful upload
     // to prevent stale vclocks if the upload had failed.
@@ -991,18 +1090,8 @@ pub async fn push_tree_with_device(
                 if result.skipped {
                     skipped += 1;
                 } else {
-                    // Write index entry only when the manifest was actually uploaded.
-                    // Skipped files (RemoteNewer, UpToDate, Conflict) already have
-                    // a valid index entry, and writing one with the local hash would
-                    // create an orphan pointing to a non-existent manifest.
-                    let index_key =
-                        format!("{}/index/{}", remote_path_prefix(remote_prefix), rel_str);
-                    let index_entry =
-                        RemoteIndexEntry::new(result.hash.clone(), result.bytes, result.chunks)
-                            .to_legacy_bytes();
-                    if let Err(e) = op.write(&index_key, index_entry).await {
-                        warn!(path = %path.display(), "failed to write index entry: {e}");
-                    }
+                    // Path publication is owned by upload_file_with_device so
+                    // the manifest and index sequence stays crash-aware.
                     uploaded += 1;
                     bytes += result.bytes;
                 }
@@ -1265,10 +1354,9 @@ pub async fn resolve_manifest_path(
     let rel = normalize_rel_path(Path::new(input), sync_root);
     let index_key = format!("{prefix}/index/{rel}");
 
-    if let Ok(idx_bytes) = op.read(&index_key).await {
-        if let Ok(entry) = parse_index_entry(&idx_bytes.to_vec()) {
-            return Ok(format!("{prefix}/manifests/{}", entry.manifest_hash));
-        }
+    let manifest_prefix = manifest_path_prefix(prefix);
+    if let Ok(Some(entry)) = resolve_visible_index_entry(op, &index_key, &manifest_prefix).await {
+        return Ok(manifest_key(&manifest_prefix, &entry.manifest_hash));
     }
 
     // Try 2: Search index entries for a matching filename.
@@ -1288,10 +1376,10 @@ pub async fn resolve_manifest_path(
     for entry in entries {
         let entry_path = entry.path();
         if entry_path.ends_with(&format!("/{filename}")) || entry_path.ends_with(&filename) {
-            if let Ok(idx_bytes) = op.read(entry_path).await {
-                if let Ok(entry) = parse_index_entry(&idx_bytes.to_vec()) {
-                    return Ok(format!("{prefix}/manifests/{}", entry.manifest_hash));
-                }
+            if let Ok(Some(entry)) =
+                resolve_visible_index_entry(op, entry_path, &manifest_prefix).await
+            {
+                return Ok(manifest_key(&manifest_prefix, &entry.manifest_hash));
             }
         }
     }
@@ -1318,29 +1406,30 @@ pub async fn delete_remote_file(
 ) -> Result<()> {
     let prefix = remote_prefix.trim_end_matches('/');
     let index_key = format!("{prefix}/index/{rel_path}");
-
-    // Read index to find manifest hash
-    let idx_raw = op
-        .read(&index_key)
-        .await
-        .with_context(|| format!("reading index entry: {index_key}"))?
-        .to_bytes();
-
-    let manifest_hash = parse_index_entry(&idx_raw)
-        .with_context(|| format!("parsing index entry: {index_key}"))?
-        .manifest_hash;
-
-    let manifest_key = format!("{prefix}/manifests/{manifest_hash}");
+    let manifest_prefix = manifest_path_prefix(prefix);
+    let parsed = read_index_entry_record_from_store(op, &index_key)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("missing index entry: {index_key}"))?;
+    let current_manifest = parsed
+        .visible_entry()
+        .map(|entry| manifest_key(&manifest_prefix, &entry.manifest_hash));
+    let referenced_keys = parsed.referenced_object_keys(&manifest_prefix);
 
     // Delete index entry and manifest
     op.delete(&index_key)
         .await
         .with_context(|| format!("deleting index entry: {index_key}"))?;
-    op.delete(&manifest_key)
-        .await
-        .with_context(|| format!("deleting manifest: {manifest_key}"))?;
+    for object_key in referenced_keys {
+        if Some(object_key.as_str()) == current_manifest.as_deref() {
+            op.delete(&object_key)
+                .await
+                .with_context(|| format!("deleting manifest: {object_key}"))?;
+        } else if let Err(e) = op.delete(&object_key).await {
+            debug!(rel_path = %rel_path, object = %object_key, "best-effort delete failed: {e}");
+        }
+    }
 
-    info!(rel_path = %rel_path, manifest = %manifest_hash, "deleted remote file");
+    info!(rel_path = %rel_path, "deleted remote file");
 
     // Remove from state cache
     let local_path = sync_root
@@ -1556,6 +1645,12 @@ mod tests {
         )
         .await
         .unwrap();
+        op.write(
+            "data/manifests/abc123",
+            br#"{"version":2,"file_hash":"abc123","file_size":100,"chunks":[],"vclock":{"clocks":{}},"written_by":"neo","written_at":0}"#.to_vec(),
+        )
+        .await
+        .unwrap();
 
         let result = resolve_manifest_path(&op, "doc.txt", "data", None)
             .await
@@ -1633,6 +1728,44 @@ mod tests {
         // Verify content matches
         let content = std::fs::read_to_string(&dl_path).unwrap();
         assert_eq!(content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn upload_file_with_device_publishes_committed_v2_index() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        let local = dir.path().join("hello.txt");
+        std::fs::write(&local, b"hello index").unwrap();
+
+        let upload = upload_file_with_device(
+            &op,
+            &local,
+            "data",
+            &mut state,
+            None,
+            "device-1",
+            Some("hello.txt"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let index_bytes = op.read("data/index/hello.txt").await.unwrap().to_vec();
+        match crate::index_entry::parse_index_entry_record(&index_bytes).unwrap() {
+            crate::index_entry::ParsedIndexEntry::Legacy(_) => {
+                panic!("expected committed v2 index entry")
+            }
+            crate::index_entry::ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry.state, crate::index_entry::IndexEntryState::Committed);
+                let current = entry.current.expect("current committed entry");
+                assert_eq!(current.manifest_hash, upload.hash);
+                assert_eq!(current.size, upload.bytes);
+                assert_eq!(current.chunks, upload.chunks);
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -347,8 +347,11 @@ pub async fn upload_file_with_device(
     rel_path: Option<&str>,
     encryption: OptionalEncryption<'_>,
 ) -> Result<UploadResult> {
+    let tracked_state = state.get(local_path).cloned();
+
     // Fast-path: check if file is already up-to-date
-    match state.needs_sync(local_path)? {
+    let sync_reason = state.needs_sync(local_path)?;
+    match sync_reason.as_deref() {
         None => {
             let cached = state.get(local_path).ok_or_else(|| {
                 anyhow::anyhow!(
@@ -399,10 +402,17 @@ pub async fn upload_file_with_device(
     let remote_manifest = format!("{remote_prefix}/manifests/{file_hash_hex}");
 
     // Get the local vclock from state (or start fresh)
-    let mut local_vclock = state
-        .get(local_path)
+    let mut local_vclock = tracked_state
+        .as_ref()
         .map(|s| s.vclock.clone())
         .unwrap_or_default();
+    let local_edit_inferred = !device_id.is_empty() && tracked_state.is_some();
+    if local_edit_inferred {
+        // The file changed relative to tracked local state, so model the
+        // pending upload as a descendant of the last synced version before
+        // comparing against the current rel_path index entry.
+        local_vclock.tick(device_id);
+    }
 
     // Conflict detection: find the current remote manifest for this rel_path.
     // First try the index entry (covers different-content conflicts), then
@@ -571,7 +581,7 @@ pub async fn upload_file_with_device(
     }
 
     // Tick local vclock before writing
-    if !device_id.is_empty() {
+    if !device_id.is_empty() && !local_edit_inferred {
         local_vclock.tick(device_id);
     }
 

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -142,6 +142,14 @@ async fn publish_index_reference(
     write_committed_index_entry(op, &index_key, &entry).await
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublishStage {
+    StagedManifestWritten,
+    PreparingIndexWritten,
+    FinalManifestWritten,
+    CommittedIndexWritten,
+}
+
 async fn publish_manifest_for_rel_path(
     op: &Operator,
     remote_prefix: &str,
@@ -149,6 +157,28 @@ async fn publish_manifest_for_rel_path(
     manifest_bytes: Vec<u8>,
     entry: RemoteIndexEntry,
 ) -> Result<()> {
+    publish_manifest_for_rel_path_with_hook(
+        op,
+        remote_prefix,
+        rel_path,
+        manifest_bytes,
+        entry,
+        |_| Ok(()),
+    )
+    .await
+}
+
+async fn publish_manifest_for_rel_path_with_hook<F>(
+    op: &Operator,
+    remote_prefix: &str,
+    rel_path: &str,
+    manifest_bytes: Vec<u8>,
+    entry: RemoteIndexEntry,
+    mut after_stage: F,
+) -> Result<()>
+where
+    F: FnMut(PublishStage) -> Result<()>,
+{
     let prefix = remote_prefix.trim_end_matches('/');
     let index_key = format!("{prefix}/index/{rel_path}");
     let manifest_prefix = manifest_path_prefix(prefix);
@@ -164,6 +194,7 @@ async fn publish_manifest_for_rel_path(
     op.write(&staged_manifest_key, manifest_bytes.clone())
         .await
         .with_context(|| format!("writing staged manifest: {staged_manifest_key}"))?;
+    after_stage(PublishStage::StagedManifestWritten)?;
 
     write_preparing_index_entry(
         op,
@@ -177,14 +208,17 @@ async fn publish_manifest_for_rel_path(
         ),
     )
     .await?;
+    after_stage(PublishStage::PreparingIndexWritten)?;
 
     if !op.exists(&final_manifest_key).await.unwrap_or(false) {
         op.write(&final_manifest_key, manifest_bytes)
             .await
             .with_context(|| format!("uploading manifest: {final_manifest_key}"))?;
+        after_stage(PublishStage::FinalManifestWritten)?;
     }
 
     write_committed_index_entry(op, &index_key, &entry).await?;
+    after_stage(PublishStage::CommittedIndexWritten)?;
     let _ = op.delete(&staged_manifest_key).await;
     Ok(())
 }
@@ -1456,6 +1490,9 @@ fn remote_path_prefix(prefix: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::index_entry::{
+        parse_index_entry_record, write_committed_index_entry, IndexEntryState, ParsedIndexEntry,
+    };
     use opendal::services::Memory;
 
     fn memory_op() -> Operator {
@@ -1471,6 +1508,22 @@ mod tests {
             sync_empty_dirs: false,
             ..Default::default()
         }
+    }
+
+    fn test_manifest_bytes(file_hash: &str, file_size: u64) -> Vec<u8> {
+        format!(
+            r#"{{"version":2,"file_hash":"{file_hash}","file_size":{file_size},"chunks":[],"vclock":{{"clocks":{{}}}},"written_by":"tester","written_at":0}}"#
+        )
+        .into_bytes()
+    }
+
+    async fn staging_manifest_keys(op: &Operator) -> Vec<String> {
+        op.list("data/staging/manifests/")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.path().to_string())
+            .collect()
     }
 
     // ── collect_files (empty dir detection) ──────────────────────────────
@@ -1764,6 +1817,221 @@ mod tests {
                 assert_eq!(current.manifest_hash, upload.hash);
                 assert_eq!(current.size, upload.bytes);
                 assert_eq!(current.chunks, upload.chunks);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_crash_after_staged_write_preserves_existing_visible_manifest() {
+        let op = memory_op();
+        let old = RemoteIndexEntry::new("old123", 10, 1);
+        let old_manifest_key = manifest_key("data/manifests", &old.manifest_hash);
+        op.write(
+            &old_manifest_key,
+            test_manifest_bytes(&old.manifest_hash, old.size),
+        )
+        .await
+        .unwrap();
+        write_committed_index_entry(&op, "data/index/doc.txt", &old)
+            .await
+            .unwrap();
+
+        let err = publish_manifest_for_rel_path_with_hook(
+            &op,
+            "data",
+            "doc.txt",
+            test_manifest_bytes("new456", 11),
+            RemoteIndexEntry::new("new456", 11, 1),
+            |stage| {
+                if stage == PublishStage::StagedManifestWritten {
+                    return Err(anyhow::anyhow!("injected crash after staged manifest"));
+                }
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("injected crash"));
+
+        assert_eq!(
+            resolve_manifest_path(&op, "doc.txt", "data", None)
+                .await
+                .unwrap(),
+            "data/manifests/old123"
+        );
+        assert!(!op.exists("data/manifests/new456").await.unwrap());
+        assert_eq!(staging_manifest_keys(&op).await.len(), 1);
+
+        match parse_index_entry_record(&op.read("data/index/doc.txt").await.unwrap().to_vec())
+            .unwrap()
+        {
+            ParsedIndexEntry::Legacy(_) => panic!("expected committed v2 index entry"),
+            ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry.state, IndexEntryState::Committed);
+                assert_eq!(entry.current.unwrap().manifest_hash, "old123");
+                assert!(entry.pending.is_none());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_crash_after_preparing_write_rolls_forward_new_path_on_read() {
+        let op = memory_op();
+
+        let err = publish_manifest_for_rel_path_with_hook(
+            &op,
+            "data",
+            "doc.txt",
+            test_manifest_bytes("new456", 11),
+            RemoteIndexEntry::new("new456", 11, 1),
+            |stage| {
+                if stage == PublishStage::PreparingIndexWritten {
+                    return Err(anyhow::anyhow!("injected crash after preparing index"));
+                }
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("injected crash"));
+        assert!(!op.exists("data/manifests/new456").await.unwrap());
+        assert_eq!(staging_manifest_keys(&op).await.len(), 1);
+
+        match parse_index_entry_record(&op.read("data/index/doc.txt").await.unwrap().to_vec())
+            .unwrap()
+        {
+            ParsedIndexEntry::Legacy(_) => panic!("expected preparing v2 index entry"),
+            ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry.state, IndexEntryState::Preparing);
+                assert!(entry.current.is_none());
+                assert_eq!(entry.pending.unwrap().manifest_hash, "new456");
+            }
+        }
+
+        assert_eq!(
+            resolve_manifest_path(&op, "doc.txt", "data", None)
+                .await
+                .unwrap(),
+            "data/manifests/new456"
+        );
+        assert!(op.exists("data/manifests/new456").await.unwrap());
+        assert!(staging_manifest_keys(&op).await.is_empty());
+
+        match parse_index_entry_record(&op.read("data/index/doc.txt").await.unwrap().to_vec())
+            .unwrap()
+        {
+            ParsedIndexEntry::Legacy(_) => panic!("expected committed v2 index entry"),
+            ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry.state, IndexEntryState::Committed);
+                assert_eq!(entry.current.unwrap().manifest_hash, "new456");
+                assert!(entry.pending.is_none());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_crash_after_final_manifest_write_commits_pending_on_read() {
+        let op = memory_op();
+        let old = RemoteIndexEntry::new("old123", 10, 1);
+        let old_manifest_key = manifest_key("data/manifests", &old.manifest_hash);
+        op.write(
+            &old_manifest_key,
+            test_manifest_bytes(&old.manifest_hash, old.size),
+        )
+        .await
+        .unwrap();
+        write_committed_index_entry(&op, "data/index/doc.txt", &old)
+            .await
+            .unwrap();
+
+        let err = publish_manifest_for_rel_path_with_hook(
+            &op,
+            "data",
+            "doc.txt",
+            test_manifest_bytes("new456", 11),
+            RemoteIndexEntry::new("new456", 11, 1),
+            |stage| {
+                if stage == PublishStage::FinalManifestWritten {
+                    return Err(anyhow::anyhow!("injected crash after final manifest"));
+                }
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("injected crash"));
+        assert!(op.exists("data/manifests/new456").await.unwrap());
+        assert_eq!(staging_manifest_keys(&op).await.len(), 1);
+
+        match parse_index_entry_record(&op.read("data/index/doc.txt").await.unwrap().to_vec())
+            .unwrap()
+        {
+            ParsedIndexEntry::Legacy(_) => panic!("expected preparing v2 index entry"),
+            ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry.state, IndexEntryState::Preparing);
+                assert_eq!(entry.current.unwrap().manifest_hash, "old123");
+                assert_eq!(entry.pending.unwrap().manifest_hash, "new456");
+            }
+        }
+
+        assert_eq!(
+            resolve_manifest_path(&op, "doc.txt", "data", None)
+                .await
+                .unwrap(),
+            "data/manifests/new456"
+        );
+        assert!(staging_manifest_keys(&op).await.is_empty());
+
+        match parse_index_entry_record(&op.read("data/index/doc.txt").await.unwrap().to_vec())
+            .unwrap()
+        {
+            ParsedIndexEntry::Legacy(_) => panic!("expected committed v2 index entry"),
+            ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry.state, IndexEntryState::Committed);
+                assert_eq!(entry.current.unwrap().manifest_hash, "new456");
+                assert!(entry.pending.is_none());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_crash_after_committed_write_keeps_new_manifest_visible() {
+        let op = memory_op();
+
+        let err = publish_manifest_for_rel_path_with_hook(
+            &op,
+            "data",
+            "doc.txt",
+            test_manifest_bytes("new456", 11),
+            RemoteIndexEntry::new("new456", 11, 1),
+            |stage| {
+                if stage == PublishStage::CommittedIndexWritten {
+                    return Err(anyhow::anyhow!("injected crash after committed index"));
+                }
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("injected crash"));
+
+        assert_eq!(
+            resolve_manifest_path(&op, "doc.txt", "data", None)
+                .await
+                .unwrap(),
+            "data/manifests/new456"
+        );
+        assert!(op.exists("data/manifests/new456").await.unwrap());
+        assert_eq!(staging_manifest_keys(&op).await.len(), 1);
+
+        match parse_index_entry_record(&op.read("data/index/doc.txt").await.unwrap().to_vec())
+            .unwrap()
+        {
+            ParsedIndexEntry::Legacy(_) => panic!("expected committed v2 index entry"),
+            ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry.state, IndexEntryState::Committed);
+                assert_eq!(entry.current.unwrap().manifest_hash, "new456");
+                assert!(entry.pending.is_none());
             }
         }
     }

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -11,6 +11,24 @@ pub struct RemoteIndexEntry {
     pub chunks: usize,
 }
 
+impl RemoteIndexEntry {
+    pub fn new(manifest_hash: impl Into<String>, size: u64, chunks: usize) -> Self {
+        Self {
+            manifest_hash: manifest_hash.into(),
+            size,
+            chunks,
+        }
+    }
+
+    pub fn to_legacy_bytes(&self) -> Vec<u8> {
+        format!(
+            "manifest_hash={}\nsize={}\nchunks={}\n",
+            self.manifest_hash, self.size, self.chunks
+        )
+        .into_bytes()
+    }
+}
+
 /// State for a versioned index entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -30,6 +48,22 @@ pub struct PendingIndexEntry {
     pub staged_manifest_key: String,
 }
 
+impl PendingIndexEntry {
+    pub fn new(
+        manifest_hash: impl Into<String>,
+        size: u64,
+        chunks: usize,
+        staged_manifest_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            manifest_hash: manifest_hash.into(),
+            size,
+            chunks,
+            staged_manifest_key: staged_manifest_key.into(),
+        }
+    }
+}
+
 /// Fully parsed index entry, supporting both the legacy text format and the
 /// planned versioned JSON format for durability work.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +78,34 @@ pub struct VersionedIndexEntry {
     pub state: IndexEntryState,
     pub current: Option<RemoteIndexEntry>,
     pub pending: Option<PendingIndexEntry>,
+}
+
+impl VersionedIndexEntry {
+    pub fn committed(current: RemoteIndexEntry) -> Self {
+        Self {
+            state: IndexEntryState::Committed,
+            current: Some(current),
+            pending: None,
+        }
+    }
+
+    pub fn preparing(current: Option<RemoteIndexEntry>, pending: PendingIndexEntry) -> Self {
+        Self {
+            state: IndexEntryState::Preparing,
+            current,
+            pending: Some(pending),
+        }
+    }
+
+    pub fn to_json_bytes(&self) -> Result<Vec<u8>> {
+        serde_json::to_vec_pretty(&VersionedIndexEntryWire {
+            version: 2,
+            state: self.state,
+            current: self.current.clone(),
+            pending: self.pending.clone(),
+        })
+        .context("serializing versioned index entry")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -219,6 +281,28 @@ mod tests {
             pending.staged_manifest_key,
             "data/staging/manifests/txn-1.json"
         );
+    }
+
+    #[test]
+    fn legacy_serializer_roundtrips() {
+        let entry = super::RemoteIndexEntry::new("abc123", 1024, 2);
+        let bytes = entry.to_legacy_bytes();
+        let reparsed = parse_index_entry(&bytes).unwrap();
+        assert_eq!(reparsed, entry);
+    }
+
+    #[test]
+    fn versioned_serializer_roundtrips() {
+        let entry = super::VersionedIndexEntry::preparing(
+            Some(super::RemoteIndexEntry::new("old123", 10, 1)),
+            super::PendingIndexEntry::new("new456", 11, 1, "data/staging/manifests/txn-1.json"),
+        );
+
+        let bytes = entry.to_json_bytes().unwrap();
+        match parse_index_entry_record(&bytes).unwrap() {
+            ParsedIndexEntry::Legacy(_) => panic!("expected v2 entry"),
+            ParsedIndexEntry::V2(reparsed) => assert_eq!(reparsed, entry),
+        }
     }
 
     #[test]

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -1,0 +1,314 @@
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// A parsed remote index entry that points to a committed manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteIndexEntry {
+    pub manifest_hash: String,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub chunks: usize,
+}
+
+/// State for a versioned index entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexEntryState {
+    Committed,
+    Preparing,
+}
+
+/// Pending manifest metadata recorded while a path publish is in-flight.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingIndexEntry {
+    pub manifest_hash: String,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub chunks: usize,
+    pub staged_manifest_key: String,
+}
+
+/// Fully parsed index entry, supporting both the legacy text format and the
+/// planned versioned JSON format for durability work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedIndexEntry {
+    Legacy(RemoteIndexEntry),
+    V2(VersionedIndexEntry),
+}
+
+/// Versioned JSON index entry used by the #224 durability design.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionedIndexEntry {
+    pub state: IndexEntryState,
+    pub current: Option<RemoteIndexEntry>,
+    pub pending: Option<PendingIndexEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct VersionedIndexEntryWire {
+    version: u8,
+    state: IndexEntryState,
+    #[serde(default)]
+    current: Option<RemoteIndexEntry>,
+    #[serde(default)]
+    pending: Option<PendingIndexEntry>,
+}
+
+impl ParsedIndexEntry {
+    pub fn state(&self) -> IndexEntryState {
+        match self {
+            ParsedIndexEntry::Legacy(_) => IndexEntryState::Committed,
+            ParsedIndexEntry::V2(entry) => entry.state,
+        }
+    }
+
+    /// Return the currently visible manifest pointer for path-based reads.
+    ///
+    /// For legacy entries this is the only entry. For versioned entries this is
+    /// the committed/current pointer, which may be absent for a brand-new path
+    /// that is still in a `preparing` state.
+    pub fn visible_entry(&self) -> Option<&RemoteIndexEntry> {
+        match self {
+            ParsedIndexEntry::Legacy(entry) => Some(entry),
+            ParsedIndexEntry::V2(entry) => entry.current.as_ref(),
+        }
+    }
+
+    pub fn pending_entry(&self) -> Option<&PendingIndexEntry> {
+        match self {
+            ParsedIndexEntry::Legacy(_) => None,
+            ParsedIndexEntry::V2(entry) => entry.pending.as_ref(),
+        }
+    }
+}
+
+/// Parse the current visible remote index entry for callers that only support
+/// committed path pointers today.
+pub fn parse_index_entry(data: &[u8]) -> Result<RemoteIndexEntry> {
+    parse_index_entry_record(data)?
+        .visible_entry()
+        .cloned()
+        .context("index entry has no visible current manifest")
+}
+
+/// Parse a remote index entry from either the legacy text format or the
+/// versioned JSON format planned for crash-safe publish.
+pub fn parse_index_entry_record(data: &[u8]) -> Result<ParsedIndexEntry> {
+    let text = std::str::from_utf8(data).context("index entry is not valid UTF-8")?;
+    let trimmed = text.trim_start();
+
+    if trimmed.starts_with('{') {
+        return parse_versioned_index_entry(trimmed);
+    }
+
+    parse_legacy_index_entry(trimmed).map(ParsedIndexEntry::Legacy)
+}
+
+fn parse_versioned_index_entry(text: &str) -> Result<ParsedIndexEntry> {
+    let wire: VersionedIndexEntryWire =
+        serde_json::from_str(text).context("parsing versioned index entry JSON")?;
+
+    if wire.version != 2 {
+        bail!("unsupported index entry version: {}", wire.version);
+    }
+
+    match wire.state {
+        IndexEntryState::Committed => {
+            if wire.current.is_none() {
+                bail!("committed index entry missing current");
+            }
+        }
+        IndexEntryState::Preparing => {
+            if wire.pending.is_none() {
+                bail!("preparing index entry missing pending");
+            }
+        }
+    }
+
+    Ok(ParsedIndexEntry::V2(VersionedIndexEntry {
+        state: wire.state,
+        current: wire.current,
+        pending: wire.pending,
+    }))
+}
+
+fn parse_legacy_index_entry(text: &str) -> Result<RemoteIndexEntry> {
+    let mut manifest_hash = None;
+    let mut size = 0u64;
+    let mut chunks = 0usize;
+
+    for line in text.lines() {
+        if let Some(v) = line.strip_prefix("manifest_hash=") {
+            manifest_hash = Some(v.to_string());
+        } else if let Some(v) = line.strip_prefix("size=") {
+            size = v.parse().context("invalid size in index entry")?;
+        } else if let Some(v) = line.strip_prefix("chunks=") {
+            chunks = v.parse().context("invalid chunk count in index entry")?;
+        }
+    }
+
+    Ok(RemoteIndexEntry {
+        manifest_hash: manifest_hash.context("index entry missing manifest_hash")?,
+        size,
+        chunks,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_index_entry, parse_index_entry_record, IndexEntryState, ParsedIndexEntry};
+
+    #[test]
+    fn parse_legacy_index_entry() {
+        let data = b"manifest_hash=abc123\nsize=1024\nchunks=2\n";
+        let entry = parse_index_entry(data).unwrap();
+        assert_eq!(entry.manifest_hash, "abc123");
+        assert_eq!(entry.size, 1024);
+        assert_eq!(entry.chunks, 2);
+    }
+
+    #[test]
+    fn parse_committed_json_index_entry() {
+        let data = br#"{
+            "version": 2,
+            "state": "committed",
+            "current": {
+                "manifest_hash": "abc123",
+                "size": 1024,
+                "chunks": 2
+            }
+        }"#;
+
+        let parsed = parse_index_entry_record(data).unwrap();
+        assert_eq!(parsed.state(), IndexEntryState::Committed);
+        let visible = parsed.visible_entry().unwrap();
+        assert_eq!(visible.manifest_hash, "abc123");
+        assert_eq!(visible.size, 1024);
+        assert_eq!(visible.chunks, 2);
+        assert!(parsed.pending_entry().is_none());
+    }
+
+    #[test]
+    fn parse_preparing_json_index_entry() {
+        let data = br#"{
+            "version": 2,
+            "state": "preparing",
+            "current": {
+                "manifest_hash": "old123",
+                "size": 10,
+                "chunks": 1
+            },
+            "pending": {
+                "manifest_hash": "new456",
+                "size": 11,
+                "chunks": 1,
+                "staged_manifest_key": "data/staging/manifests/txn-1.json"
+            }
+        }"#;
+
+        let parsed = parse_index_entry_record(data).unwrap();
+        assert_eq!(parsed.state(), IndexEntryState::Preparing);
+        let visible = parsed.visible_entry().unwrap();
+        assert_eq!(visible.manifest_hash, "old123");
+
+        let pending = parsed.pending_entry().unwrap();
+        assert_eq!(pending.manifest_hash, "new456");
+        assert_eq!(
+            pending.staged_manifest_key,
+            "data/staging/manifests/txn-1.json"
+        );
+    }
+
+    #[test]
+    fn preparing_entry_without_current_is_not_visible() {
+        let data = br#"{
+            "version": 2,
+            "state": "preparing",
+            "pending": {
+                "manifest_hash": "new456",
+                "size": 11,
+                "chunks": 1,
+                "staged_manifest_key": "data/staging/manifests/txn-1.json"
+            }
+        }"#;
+
+        let parsed = parse_index_entry_record(data).unwrap();
+        assert!(parsed.visible_entry().is_none());
+        assert!(parse_index_entry(data).is_err());
+    }
+
+    #[test]
+    fn committed_entry_missing_current_errors() {
+        let data = br#"{
+            "version": 2,
+            "state": "committed"
+        }"#;
+
+        assert!(parse_index_entry_record(data).is_err());
+    }
+
+    #[test]
+    fn preparing_entry_missing_pending_errors() {
+        let data = br#"{
+            "version": 2,
+            "state": "preparing",
+            "current": {
+                "manifest_hash": "old123",
+                "size": 10,
+                "chunks": 1
+            }
+        }"#;
+
+        assert!(parse_index_entry_record(data).is_err());
+    }
+
+    #[test]
+    fn unsupported_version_errors() {
+        let data = br#"{
+            "version": 3,
+            "state": "committed",
+            "current": {
+                "manifest_hash": "abc123",
+                "size": 1,
+                "chunks": 1
+            }
+        }"#;
+
+        assert!(parse_index_entry_record(data).is_err());
+    }
+
+    #[test]
+    fn malformed_legacy_size_errors() {
+        let data = b"manifest_hash=abc123\nsize=notanumber\nchunks=5\n";
+        assert!(parse_index_entry(data).is_err());
+    }
+
+    #[test]
+    fn malformed_legacy_chunks_errors() {
+        let data = b"manifest_hash=abc123\nsize=1024\nchunks=xyz\n";
+        assert!(parse_index_entry(data).is_err());
+    }
+
+    #[test]
+    fn parsed_entry_keeps_v2_shape() {
+        let data = br#"{
+            "version": 2,
+            "state": "committed",
+            "current": {
+                "manifest_hash": "abc123",
+                "size": 1,
+                "chunks": 1
+            }
+        }"#;
+
+        match parse_index_entry_record(data).unwrap() {
+            ParsedIndexEntry::Legacy(_) => panic!("expected v2 entry"),
+            ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry.state, IndexEntryState::Committed);
+                assert!(entry.current.is_some());
+            }
+        }
+    }
+}

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use opendal::{ErrorKind, Operator};
 use serde::{Deserialize, Serialize};
 
 /// A parsed remote index entry that points to a committed manifest.
@@ -61,6 +62,10 @@ impl PendingIndexEntry {
             chunks,
             staged_manifest_key: staged_manifest_key.into(),
         }
+    }
+
+    pub fn as_remote_entry(&self) -> RemoteIndexEntry {
+        RemoteIndexEntry::new(self.manifest_hash.clone(), self.size, self.chunks)
     }
 }
 
@@ -144,6 +149,21 @@ impl ParsedIndexEntry {
             ParsedIndexEntry::V2(entry) => entry.pending.as_ref(),
         }
     }
+
+    pub fn referenced_object_keys(&self, manifest_prefix: &str) -> Vec<String> {
+        let mut keys = Vec::new();
+
+        if let Some(current) = self.visible_entry() {
+            keys.push(manifest_key(manifest_prefix, &current.manifest_hash));
+        }
+
+        if let Some(pending) = self.pending_entry() {
+            keys.push(manifest_key(manifest_prefix, &pending.manifest_hash));
+            keys.push(pending.staged_manifest_key.clone());
+        }
+
+        keys
+    }
 }
 
 /// Parse the current visible remote index entry for callers that only support
@@ -196,6 +216,120 @@ fn parse_versioned_index_entry(text: &str) -> Result<ParsedIndexEntry> {
     }))
 }
 
+pub fn manifest_key(manifest_prefix: &str, manifest_hash: &str) -> String {
+    format!(
+        "{}/{}",
+        manifest_prefix.trim_end_matches('/'),
+        manifest_hash
+    )
+}
+
+pub async fn read_index_entry_record_from_store(
+    op: &Operator,
+    index_key: &str,
+) -> Result<Option<ParsedIndexEntry>> {
+    match op.read(index_key).await {
+        Ok(bytes) => parse_index_entry_record(&bytes.to_vec()).map(Some),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+        Err(e) => {
+            Err(anyhow::anyhow!(e)).with_context(|| format!("reading index entry: {index_key}"))
+        }
+    }
+}
+
+pub async fn write_committed_index_entry(
+    op: &Operator,
+    index_key: &str,
+    entry: &RemoteIndexEntry,
+) -> Result<()> {
+    let bytes = VersionedIndexEntry::committed(entry.clone()).to_json_bytes()?;
+    op.write(index_key, bytes)
+        .await
+        .with_context(|| format!("writing committed index entry: {index_key}"))?;
+    Ok(())
+}
+
+pub async fn write_preparing_index_entry(
+    op: &Operator,
+    index_key: &str,
+    current: Option<RemoteIndexEntry>,
+    pending: PendingIndexEntry,
+) -> Result<()> {
+    let bytes = VersionedIndexEntry::preparing(current, pending).to_json_bytes()?;
+    op.write(index_key, bytes)
+        .await
+        .with_context(|| format!("writing preparing index entry: {index_key}"))?;
+    Ok(())
+}
+
+pub async fn resolve_visible_index_entry(
+    op: &Operator,
+    index_key: &str,
+    manifest_prefix: &str,
+) -> Result<Option<RemoteIndexEntry>> {
+    let parsed = match read_index_entry_record_from_store(op, index_key).await? {
+        Some(parsed) => parsed,
+        None => return Ok(None),
+    };
+
+    resolve_visible_parsed_entry(op, index_key, manifest_prefix, parsed).await
+}
+
+async fn resolve_visible_parsed_entry(
+    op: &Operator,
+    index_key: &str,
+    manifest_prefix: &str,
+    parsed: ParsedIndexEntry,
+) -> Result<Option<RemoteIndexEntry>> {
+    if let Some(pending) = parsed.pending_entry() {
+        let pending_manifest_key = manifest_key(manifest_prefix, &pending.manifest_hash);
+        if op.exists(&pending_manifest_key).await.unwrap_or(false) {
+            let committed = pending.as_remote_entry();
+            write_committed_index_entry(op, index_key, &committed).await?;
+            let _ = op.delete(&pending.staged_manifest_key).await;
+            return Ok(Some(committed));
+        }
+
+        if op
+            .exists(&pending.staged_manifest_key)
+            .await
+            .unwrap_or(false)
+        {
+            let staged_bytes = op
+                .read(&pending.staged_manifest_key)
+                .await
+                .with_context(|| {
+                    format!(
+                        "reading staged manifest for recovery: {}",
+                        pending.staged_manifest_key
+                    )
+                })?
+                .to_vec();
+            op.write(&pending_manifest_key, staged_bytes)
+                .await
+                .with_context(|| {
+                    format!("materializing pending manifest: {pending_manifest_key}")
+                })?;
+
+            let committed = pending.as_remote_entry();
+            write_committed_index_entry(op, index_key, &committed).await?;
+            let _ = op.delete(&pending.staged_manifest_key).await;
+            return Ok(Some(committed));
+        }
+    }
+
+    if let Some(current) = parsed.visible_entry() {
+        let current_manifest_key = manifest_key(manifest_prefix, &current.manifest_hash);
+        if op.exists(&current_manifest_key).await.unwrap_or(false) {
+            return Ok(Some(current.clone()));
+        }
+
+        bail!("index entry points to missing manifest: {current_manifest_key}");
+    }
+
+    Ok(None)
+}
+
 fn parse_legacy_index_entry(text: &str) -> Result<RemoteIndexEntry> {
     let mut manifest_hash = None;
     let mut size = 0u64;
@@ -220,7 +354,17 @@ fn parse_legacy_index_entry(text: &str) -> Result<RemoteIndexEntry> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_index_entry, parse_index_entry_record, IndexEntryState, ParsedIndexEntry};
+    use super::{
+        manifest_key, parse_index_entry, parse_index_entry_record, resolve_visible_index_entry,
+        write_preparing_index_entry, IndexEntryState, ParsedIndexEntry, PendingIndexEntry,
+        RemoteIndexEntry, VersionedIndexEntry,
+    };
+    use opendal::services::Memory;
+    use opendal::Operator;
+
+    fn memory_op() -> Operator {
+        Operator::new(Memory::default()).unwrap().finish()
+    }
 
     #[test]
     fn parse_legacy_index_entry() {
@@ -394,5 +538,73 @@ mod tests {
                 assert!(entry.current.is_some());
             }
         }
+    }
+
+    #[tokio::test]
+    async fn resolve_preparing_entry_rolls_forward_from_staged_manifest() {
+        let op = memory_op();
+        let index_key = "data/index/doc.txt";
+        let manifest_prefix = "data/manifests";
+        let staged_key = "data/staging/manifests/txn-1.json";
+
+        op.write(staged_key, br#"{"version":2,"file_hash":"new456","file_size":11,"chunks":[],"vclock":{"clocks":{}},"written_by":"neo","written_at":0}"#.to_vec())
+            .await
+            .unwrap();
+
+        write_preparing_index_entry(
+            &op,
+            index_key,
+            Some(RemoteIndexEntry::new("old123", 10, 1)),
+            PendingIndexEntry::new("new456", 11, 1, staged_key),
+        )
+        .await
+        .unwrap();
+
+        let visible = resolve_visible_index_entry(&op, index_key, manifest_prefix)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(visible.manifest_hash, "new456");
+        assert!(op
+            .exists(&manifest_key(manifest_prefix, "new456"))
+            .await
+            .unwrap());
+        assert!(!op.exists(staged_key).await.unwrap());
+
+        match parse_index_entry_record(&op.read(index_key).await.unwrap().to_vec()).unwrap() {
+            ParsedIndexEntry::Legacy(_) => panic!("expected v2 committed entry"),
+            ParsedIndexEntry::V2(entry) => {
+                assert_eq!(entry, VersionedIndexEntry::committed(visible));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_preparing_entry_keeps_current_when_pending_is_missing() {
+        let op = memory_op();
+        let index_key = "data/index/doc.txt";
+        let manifest_prefix = "data/manifests";
+
+        op.write(
+            &manifest_key(manifest_prefix, "old123"),
+            br#"{"version":2,"file_hash":"old123","file_size":10,"chunks":[],"vclock":{"clocks":{}},"written_by":"neo","written_at":0}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+
+        write_preparing_index_entry(
+            &op,
+            index_key,
+            Some(RemoteIndexEntry::new("old123", 10, 1)),
+            PendingIndexEntry::new("new456", 11, 1, "data/staging/manifests/missing.json"),
+        )
+        .await
+        .unwrap();
+
+        let visible = resolve_visible_index_entry(&op, index_key, manifest_prefix)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(visible.manifest_hash, "old123");
     }
 }

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -5,6 +5,7 @@ pub mod blacklist;
 pub mod conflict;
 pub mod engine;
 pub mod git_safety;
+pub mod index_entry;
 pub mod manifest;
 pub mod nats;
 pub mod policy;

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -17,18 +17,11 @@ use tracing::{debug, info, warn};
 use crate::blacklist::Blacklist;
 use crate::conflict::{compare_clocks, ConflictInfo};
 use crate::engine::{self, OptionalEncryption, ProgressFn};
+use crate::index_entry::{parse_index_entry, parse_index_entry_record, RemoteIndexEntry};
 use crate::manifest::SyncManifest;
 use crate::state::{StateCache, StateCacheBackend, SyncState};
 
 // ── Types ────────────────────────────────────────────────────────────────────
-
-/// A parsed remote index entry.
-#[derive(Debug, Clone)]
-pub struct RemoteIndexEntry {
-    pub manifest_hash: String,
-    pub size: u64,
-    pub chunks: usize,
-}
 
 /// Why a file needs to be pushed.
 #[derive(Debug, Clone)]
@@ -122,32 +115,6 @@ pub struct ExecutionResult {
 
 // ── Remote Index ─────────────────────────────────────────────────────────────
 
-/// Parse a remote index entry from its on-disk format.
-///
-/// Format: `"manifest_hash=<hash>\nsize=<n>\nchunks=<n>\n"`
-pub fn parse_index_entry(data: &[u8]) -> Result<RemoteIndexEntry> {
-    let text = std::str::from_utf8(data).context("index entry is not valid UTF-8")?;
-    let mut manifest_hash = None;
-    let mut size = 0u64;
-    let mut chunks = 0usize;
-
-    for line in text.lines() {
-        if let Some(v) = line.strip_prefix("manifest_hash=") {
-            manifest_hash = Some(v.to_string());
-        } else if let Some(v) = line.strip_prefix("size=") {
-            size = v.parse().context("invalid size in index entry")?;
-        } else if let Some(v) = line.strip_prefix("chunks=") {
-            chunks = v.parse().context("invalid chunk count in index entry")?;
-        }
-    }
-
-    Ok(RemoteIndexEntry {
-        manifest_hash: manifest_hash.context("index entry missing manifest_hash")?,
-        size,
-        chunks,
-    })
-}
-
 /// Fetch the full remote index for a prefix.
 ///
 /// Returns a map of `rel_path → RemoteIndexEntry` for every file in the index.
@@ -176,9 +143,17 @@ pub async fn list_remote_index(
         }
 
         match op.read(full_key).await {
-            Ok(data) => match parse_index_entry(&data.to_vec()) {
+            Ok(data) => match parse_index_entry_record(&data.to_vec()) {
                 Ok(parsed) => {
-                    result.insert(rel_path, parsed);
+                    if let Some(visible) = parsed.visible_entry().cloned() {
+                        result.insert(rel_path, visible);
+                    } else {
+                        debug!(
+                            key = full_key,
+                            state = ?parsed.state(),
+                            "skipping non-visible index entry"
+                        );
+                    }
                 }
                 Err(e) => {
                     warn!(key = full_key, error = %e, "skipping unparseable index entry");
@@ -579,12 +554,9 @@ pub async fn execute_plan(
 
                 // Read index to find manifest hash before deleting
                 let manifest_key = if let Ok(idx_bytes) = op.read(&index_key).await {
-                    let idx_raw = idx_bytes.to_bytes();
-                    let idx_str = String::from_utf8_lossy(&idx_raw);
-                    idx_str
-                        .lines()
-                        .find_map(|l| l.strip_prefix("manifest_hash="))
-                        .map(|h| format!("{prefix}/manifests/{h}"))
+                    parse_index_entry(&idx_bytes.to_vec())
+                        .ok()
+                        .map(|entry| format!("{prefix}/manifests/{}", entry.manifest_hash))
                 } else {
                     None
                 };
@@ -856,32 +828,7 @@ mod tests {
         assert_eq!(plan.summary.pulls, 0);
         assert_eq!(plan.summary.conflicts, 0);
     }
-
     // ── original tests ───────────────────────────────────────────────────
-
-    #[test]
-    fn test_parse_index_entry() {
-        let data = b"manifest_hash=abc123\nsize=1024\nchunks=2\n";
-        let entry = parse_index_entry(data).unwrap();
-        assert_eq!(entry.manifest_hash, "abc123");
-        assert_eq!(entry.size, 1024);
-        assert_eq!(entry.chunks, 2);
-    }
-
-    #[test]
-    fn test_parse_index_entry_missing_hash() {
-        let data = b"size=1024\nchunks=2\n";
-        assert!(parse_index_entry(data).is_err());
-    }
-
-    #[test]
-    fn test_parse_index_entry_partial() {
-        let data = b"manifest_hash=abc123\n";
-        let entry = parse_index_entry(data).unwrap();
-        assert_eq!(entry.manifest_hash, "abc123");
-        assert_eq!(entry.size, 0);
-        assert_eq!(entry.chunks, 0);
-    }
 
     #[test]
     fn test_reconcile_summary_default() {
@@ -896,25 +843,5 @@ mod tests {
         let config = ReconcileConfig::default();
         assert!(!config.delete_local_orphans);
         assert!(!config.delete_remote_orphans);
-    }
-
-    #[test]
-    fn parse_index_entry_garbage_size_errors() {
-        let data = b"manifest_hash=abc123\nsize=notanumber\nchunks=5\n";
-        let result = parse_index_entry(data);
-        assert!(
-            result.is_err(),
-            "garbage size should return error, not default to 0"
-        );
-    }
-
-    #[test]
-    fn parse_index_entry_garbage_chunks_errors() {
-        let data = b"manifest_hash=abc123\nsize=1024\nchunks=xyz\n";
-        let result = parse_index_entry(data);
-        assert!(
-            result.is_err(),
-            "garbage chunks should return error, not default to 0"
-        );
     }
 }

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -17,7 +17,7 @@ use tracing::{debug, info, warn};
 use crate::blacklist::Blacklist;
 use crate::conflict::{compare_clocks, ConflictInfo};
 use crate::engine::{self, OptionalEncryption, ProgressFn};
-use crate::index_entry::{parse_index_entry, parse_index_entry_record, RemoteIndexEntry};
+use crate::index_entry::{resolve_visible_index_entry, RemoteIndexEntry};
 use crate::manifest::SyncManifest;
 use crate::state::{StateCache, StateCacheBackend, SyncState};
 
@@ -143,22 +143,20 @@ pub async fn list_remote_index(
         }
 
         match op.read(full_key).await {
-            Ok(data) => match parse_index_entry_record(&data.to_vec()) {
-                Ok(parsed) => {
-                    if let Some(visible) = parsed.visible_entry().cloned() {
+            Ok(_) => {
+                let manifest_prefix = format!("{}/manifests", remote_prefix.trim_end_matches('/'));
+                match resolve_visible_index_entry(op, full_key, &manifest_prefix).await {
+                    Ok(Some(visible)) => {
                         result.insert(rel_path, visible);
-                    } else {
-                        debug!(
-                            key = full_key,
-                            state = ?parsed.state(),
-                            "skipping non-visible index entry"
-                        );
+                    }
+                    Ok(None) => {
+                        debug!(key = full_key, "skipping non-visible index entry");
+                    }
+                    Err(e) => {
+                        warn!(key = full_key, error = %e, "skipping unreadable index entry");
                     }
                 }
-                Err(e) => {
-                    warn!(key = full_key, error = %e, "skipping unparseable index entry");
-                }
-            },
+            }
             Err(e) => {
                 warn!(key = full_key, error = %e, "skipping unreadable index entry");
             }
@@ -549,38 +547,17 @@ pub async fn execute_plan(
             },
 
             ReconcileAction::DeleteRemote { rel_path } => {
-                let prefix = remote_prefix.trim_end_matches('/');
-                let index_key = format!("{prefix}/index/{rel_path}");
-
-                // Read index to find manifest hash before deleting
-                let manifest_key = if let Ok(idx_bytes) = op.read(&index_key).await {
-                    parse_index_entry(&idx_bytes.to_vec())
-                        .ok()
-                        .map(|entry| format!("{prefix}/manifests/{}", entry.manifest_hash))
-                } else {
-                    None
-                };
-
-                // Delete index entry
-                if let Err(e) = op.delete(&index_key).await {
+                if let Err(e) =
+                    engine::delete_remote_file(op, rel_path, remote_prefix, state, Some(local_root))
+                        .await
+                {
                     result
                         .errors
-                        .push((rel_path.clone(), format!("remote index delete failed: {e}")));
+                        .push((rel_path.clone(), format!("remote delete failed: {e}")));
+                } else {
+                    result.deleted_remote += 1;
                     continue;
                 }
-
-                // Delete manifest (prevents orphaned manifests)
-                if let Some(ref mkey) = manifest_key {
-                    if let Err(e) = op.delete(mkey).await {
-                        tracing::warn!(
-                            rel_path = %rel_path,
-                            manifest = %mkey,
-                            "failed to delete manifest during reconcile: {e}"
-                        );
-                    }
-                }
-
-                result.deleted_remote += 1;
             }
 
             ReconcileAction::Conflict { rel_path, info } => {
@@ -687,6 +664,18 @@ mod tests {
         )
         .await
         .unwrap();
+        op.write(
+            "data/manifests/aaa",
+            br#"{"version":2,"file_hash":"aaa","file_size":100,"chunks":[],"vclock":{"clocks":{}},"written_by":"neo","written_at":0}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+        op.write(
+            "data/manifests/bbb",
+            br#"{"version":2,"file_hash":"bbb","file_size":200,"chunks":[],"vclock":{"clocks":{}},"written_by":"neo","written_at":0}"#.to_vec(),
+        )
+        .await
+        .unwrap();
 
         let index = list_remote_index(&op, "data").await.unwrap();
         assert_eq!(index.len(), 2);
@@ -736,6 +725,12 @@ mod tests {
         op.write(
             "data/index/remote_only.txt",
             RemoteIndexEntry::new("abc123", 50, 1).to_legacy_bytes(),
+        )
+        .await
+        .unwrap();
+        op.write(
+            "data/manifests/abc123",
+            br#"{"version":2,"file_hash":"abc123","file_size":50,"chunks":[],"vclock":{"clocks":{"neo":1}},"written_by":"neo","written_at":0}"#.to_vec(),
         )
         .await
         .unwrap();

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -677,13 +677,13 @@ mod tests {
         let op = memory_op();
         op.write(
             "data/index/file1.txt",
-            b"manifest_hash=aaa\nsize=100\nchunks=1\n".to_vec(),
+            RemoteIndexEntry::new("aaa", 100, 1).to_legacy_bytes(),
         )
         .await
         .unwrap();
         op.write(
             "data/index/file2.txt",
-            b"manifest_hash=bbb\nsize=200\nchunks=2\n".to_vec(),
+            RemoteIndexEntry::new("bbb", 200, 2).to_legacy_bytes(),
         )
         .await
         .unwrap();
@@ -735,7 +735,7 @@ mod tests {
         // Write a remote index entry (no local file)
         op.write(
             "data/index/remote_only.txt",
-            b"manifest_hash=abc123\nsize=50\nchunks=1\n".to_vec(),
+            RemoteIndexEntry::new("abc123", 50, 1).to_legacy_bytes(),
         )
         .await
         .unwrap();
@@ -775,10 +775,9 @@ mod tests {
         std::fs::write(local_root.join("same.txt"), content).unwrap();
 
         // Write matching remote index + manifest
-        let index_entry = format!("manifest_hash={hash}\nsize={}\nchunks=1\n", content.len());
-        op.write("data/index/same.txt", index_entry.into_bytes())
-            .await
-            .unwrap();
+        let index_entry =
+            RemoteIndexEntry::new(hash.clone(), content.len() as u64, 1).to_legacy_bytes();
+        op.write("data/index/same.txt", index_entry).await.unwrap();
 
         let manifest_json = serde_json::json!({
             "version": 2,

--- a/crates/tcfs-sync/tests/e2e_conflict_resolution.rs
+++ b/crates/tcfs-sync/tests/e2e_conflict_resolution.rs
@@ -248,7 +248,7 @@ async fn resolve_keep_local_workflow() {
     let src_a = write_test_file(tmp.path(), "src_a/notes.txt", content_a);
     let mut state_a = StateCache::open(&tmp.path().join("state_a.db")).unwrap();
 
-    let _upload_a = upload_file_with_device(
+    let upload_a = upload_file_with_device(
         &op,
         &src_a,
         prefix,
@@ -263,8 +263,23 @@ async fn resolve_keep_local_workflow() {
 
     // Device B decides to keep its local version and re-upload
     let content_b = b"device B's version that wins the conflict resolution";
-    let src_b = write_test_file(tmp.path(), "src_b/notes.txt", content_b);
+    let src_b = write_test_file(tmp.path(), "src_b/notes.txt", content_a);
     let mut state_b = StateCache::open(&tmp.path().join("state_b.db")).unwrap();
+
+    let a_state = state_a.get(&src_a).expect("A should have state");
+    let mut resolved_b_state = tcfs_sync::state::make_sync_state(
+        &src_b,
+        upload_a.hash.clone(),
+        upload_a.chunks,
+        upload_a.remote_path.clone(),
+    )
+    .expect("resolved B state");
+    // Simulate keep_local resolution: B has observed A's version and then
+    // ticks its own clock before re-uploading its chosen local content.
+    resolved_b_state.vclock = a_state.vclock.clone();
+    resolved_b_state.vclock.tick("device-b");
+    state_b.set(&src_b, resolved_b_state);
+    std::fs::write(&src_b, content_b).expect("device-b writes resolved local version");
 
     let upload_b = upload_file_with_device(
         &op,
@@ -279,7 +294,11 @@ async fn resolve_keep_local_workflow() {
     .await
     .expect("device-b re-upload (keep_local)");
 
-    assert!(!upload_b.skipped);
+    assert!(
+        !upload_b.skipped,
+        "keep_local re-upload should succeed, got outcome: {:?}",
+        upload_b.outcome
+    );
 
     // Verify remote now has B's content
     let verify_path = tmp.path().join("verify/notes.txt");
@@ -450,7 +469,22 @@ async fn resolved_conflict_subsequent_sync() {
 
     // Device B now modifies and pushes v2
     let content_v2 = b"version 2 from device B after resolving";
-    let src_b = write_test_file(tmp.path(), "src_b/v2.txt", content_v2);
+    let src_b = write_test_file(tmp.path(), "src_b/v2.txt", content_v1);
+    let a_cached = state_a.get(&src_a).expect("A state");
+    let mut resolved_b_state = tcfs_sync::state::make_sync_state(
+        &src_b,
+        upload_v1.hash.clone(),
+        upload_v1.chunks,
+        upload_v1.remote_path.clone(),
+    )
+    .expect("resolved B state");
+    // Simulate the post-resolution edit on device B: B has A's clock and then
+    // performs a new local write before uploading v2.
+    resolved_b_state.vclock = a_cached.vclock.clone();
+    resolved_b_state.vclock.tick("device-b");
+    state_b.set(&src_b, resolved_b_state);
+    std::fs::write(&src_b, content_v2).expect("device-b writes v2 after resolving");
+
     let upload_v2 = upload_file_with_device(
         &op,
         &src_b,
@@ -464,7 +498,11 @@ async fn resolved_conflict_subsequent_sync() {
     .await
     .expect("B uploads v2");
 
-    assert!(!upload_v2.skipped, "post-resolution upload should succeed");
+    assert!(
+        !upload_v2.skipped,
+        "post-resolution upload should succeed, got outcome: {:?}",
+        upload_v2.outcome
+    );
 
     // Device A pulls v2
     let dst_a = tmp.path().join("dst_a/doc.txt");

--- a/crates/tcfs-sync/tests/e2e_delete_scenarios.rs
+++ b/crates/tcfs-sync/tests/e2e_delete_scenarios.rs
@@ -109,14 +109,21 @@ async fn delete_and_recreate_same_path() {
 
     assert!(!upload_v1.skipped);
     let hash_v1 = upload_v1.hash.clone();
+    let previous_state = state.get(&src).expect("state after v1 upload").clone();
 
     // Delete the file from disk and state
     std::fs::remove_file(&src).expect("delete v1 from disk");
     state.remove(&src);
 
-    // Recreate at the same path with different content
+    // Recreate at the same path with different content. Preserve the prior
+    // sync lineage and tick the local clock to model a new local edit at the
+    // same rel_path after the deletion.
+    write_test_file(tmp.path(), "src/cycle.txt", content_v1);
+    let mut recreated_state = previous_state;
+    recreated_state.vclock.tick("device-a");
+    state.set(&src, recreated_state);
     let content_v2 = b"v2 content is completely different from v1";
-    write_test_file(tmp.path(), "src/cycle.txt", content_v2);
+    std::fs::write(&src, content_v2).expect("write recreated v2 content");
 
     // Upload v2
     let upload_v2 = upload_file_with_device(
@@ -132,7 +139,11 @@ async fn delete_and_recreate_same_path() {
     .await
     .expect("upload v2");
 
-    assert!(!upload_v2.skipped, "recreated file should be uploaded");
+    assert!(
+        !upload_v2.skipped,
+        "recreated file should be uploaded, got outcome: {:?}",
+        upload_v2.outcome
+    );
     assert_ne!(
         upload_v2.hash, hash_v1,
         "new content should produce a different hash"
@@ -191,9 +202,15 @@ async fn delete_vs_modify_cross_device_conflict() {
     std::fs::remove_file(&src_a).expect("delete from A's disk");
     vclock_a_delete.tick("device-a"); // tick for the delete event
 
-    // Device B modifies and pushes independently
+    // Device B modifies and pushes independently. Seed B's local path with the
+    // downloaded state and tick its clock to model an edit after observing A's
+    // prior version.
+    let src_b = write_test_file(tmp.path(), "src_b/shared.txt", content_v1);
+    let mut b_edit_state = state_b.get(&dst_b).expect("B downloaded state").clone();
+    b_edit_state.vclock.tick("device-b");
+    state_b.set(&src_b, b_edit_state);
     let content_b_v2 = b"device B modified this document while A deleted it";
-    let src_b = write_test_file(tmp.path(), "src_b/shared.txt", content_b_v2);
+    std::fs::write(&src_b, content_b_v2).expect("device-b writes modified content");
 
     let upload_b = upload_file_with_device(
         &op,
@@ -208,7 +225,11 @@ async fn delete_vs_modify_cross_device_conflict() {
     .await
     .expect("device-b upload v2");
 
-    assert!(!upload_b.skipped);
+    assert!(
+        !upload_b.skipped,
+        "device-b edit should upload, got outcome: {:?}",
+        upload_b.outcome
+    );
 
     // Get device B's vclock after upload
     let vclock_b = state_b.get(&src_b).expect("B state").vclock.clone();
@@ -431,16 +452,24 @@ async fn recreate_deleted_file_with_different_size() {
 
     assert!(!upload_1kb.skipped);
     assert_eq!(upload_1kb.bytes, 1024);
+    let previous_state = state.get(&src).expect("state after 1KB upload").clone();
 
     // Delete from disk and state
     std::fs::remove_file(&src).expect("delete 1KB file");
     state.remove(&src);
 
+    // Recreate the tracked path and preserve/tick the prior lineage so the new
+    // upload is compared as a descendant edit rather than an unrelated file.
+    write_test_file(tmp.path(), "src/resized.bin", &content_1kb);
+    let mut recreated_state = previous_state;
+    recreated_state.vclock.tick("device-a");
+    state.set(&src, recreated_state);
+
     // Create 10KB file at the same path
     let content_10kb: Vec<u8> = (0u64..10240)
         .map(|i| (i.wrapping_mul(13) ^ (i >> 5)) as u8)
         .collect();
-    write_test_file(tmp.path(), "src/resized.bin", &content_10kb);
+    std::fs::write(&src, &content_10kb).expect("write recreated 10KB file");
 
     // Upload the 10KB file
     let upload_10kb = upload_file_with_device(
@@ -456,7 +485,11 @@ async fn recreate_deleted_file_with_different_size() {
     .await
     .expect("upload 10KB");
 
-    assert!(!upload_10kb.skipped, "new 10KB file should not be skipped");
+    assert!(
+        !upload_10kb.skipped,
+        "new 10KB file should not be skipped, got outcome: {:?}",
+        upload_10kb.outcome
+    );
     assert_eq!(upload_10kb.bytes, 10240, "upload should reflect 10KB size");
     assert_ne!(
         upload_10kb.hash, upload_1kb.hash,

--- a/crates/tcfs-sync/tests/e2e_file_state_transitions.rs
+++ b/crates/tcfs-sync/tests/e2e_file_state_transitions.rs
@@ -249,6 +249,10 @@ async fn unsync_then_modify_then_resync() {
         state_b.get(&dst_b).is_some(),
         "state_b should have entry after download"
     );
+    let downloaded_state = state_b
+        .get(&dst_b)
+        .expect("downloaded state before unsync")
+        .clone();
 
     // Device B removes from state cache (unsync)
     state_b.remove(&dst_b);
@@ -258,7 +262,11 @@ async fn unsync_then_modify_then_resync() {
         "entry should be gone after unsync"
     );
 
-    // Device B modifies the local copy
+    // Device B modifies the local copy. Seed the path with the last known
+    // lineage and tick B's clock to model a local edit after the unsync.
+    let mut resync_state = downloaded_state;
+    resync_state.vclock.tick("device-b");
+    state_b.set(&dst_b, resync_state);
     let modified = b"modified content by device-b after unsync";
     std::fs::write(&dst_b, modified).expect("modify local copy");
 

--- a/crates/tcfs-sync/tests/e2e_state_transition_chains.rs
+++ b/crates/tcfs-sync/tests/e2e_state_transition_chains.rs
@@ -34,6 +34,17 @@ fn write_test_file(dir: &Path, name: &str, content: &[u8]) -> std::path::PathBuf
     path
 }
 
+fn seed_state_at_new_path(state: &mut StateCache, tracked_path: &Path, new_path: &Path) {
+    let mut seeded = state
+        .get(tracked_path)
+        .expect("tracked state for lineage seed")
+        .clone();
+    // Force needs_sync() to hash-check the new path even when same-size writes
+    // happen within the same one-second mtime granularity window.
+    seeded.mtime = 0;
+    state.set(new_path, seeded);
+}
+
 /// Upload file as device-a. Verify state shows synced. Modify file content
 /// locally. Verify `needs_sync()` returns Some. Re-upload. Verify state
 /// updated with new hash.
@@ -173,6 +184,7 @@ async fn push_pull_modify_push_two_device_chain() {
     // Step 3: Device B modifies
     let content_v2 = b"modified content by device-b in two-device chain";
     let src_b = write_test_file(tmp.path(), "src_b/shared.txt", content_v2);
+    seed_state_at_new_path(&mut state_b, &dst_b, &src_b);
 
     // Step 4: Device B pushes modified version
     let upload_b = upload_file_with_device(
@@ -275,9 +287,11 @@ async fn conflict_detect_resolve_then_continue() {
     // Step 3: Both devices diverge independently
     let content_a = b"device A diverged content after baseline";
     let src_a2 = write_test_file(tmp.path(), "src_a2/doc.txt", content_a);
+    seed_state_at_new_path(&mut state_a, &src_a, &src_a2);
 
     let content_b = b"device B diverged content after baseline";
     let src_b2 = write_test_file(tmp.path(), "src_b2/doc.txt", content_b);
+    seed_state_at_new_path(&mut state_b, &dst_b, &src_b2);
 
     let upload_a = upload_file_with_device(
         &op,
@@ -369,6 +383,7 @@ async fn conflict_detect_resolve_then_continue() {
     // Step 8: Verify no further conflict -- device B pushes new content, A pulls
     let content_v3 = b"post-resolution content from device-b";
     let src_b3 = write_test_file(tmp.path(), "src_b3/doc.txt", content_v3);
+    seed_state_at_new_path(&mut state_b, &resolved_b, &src_b3);
 
     let upload_b3 = upload_file_with_device(
         &op,
@@ -472,6 +487,7 @@ async fn three_device_relay_chain() {
     // Step 3: Device B modifies and pushes
     let content_b = b"modified content by device-b in relay chain";
     let src_b = write_test_file(tmp.path(), "src_b/relay.txt", content_b);
+    seed_state_at_new_path(&mut state_b, &dst_b, &src_b);
 
     let upload_b = upload_file_with_device(
         &op,
@@ -562,6 +578,10 @@ async fn unsync_modify_resync_no_conflict() {
         state.get(&src).is_some(),
         "state should have entry after upload"
     );
+    let tracked_state = state
+        .get(&src)
+        .expect("state entry after initial upload")
+        .clone();
 
     // Step 2: Remove from state cache (simulate unsync/dehydration)
     state.remove(&src);
@@ -571,7 +591,12 @@ async fn unsync_modify_resync_no_conflict() {
         "state entry should be gone after unsync"
     );
 
-    // Step 3: Modify the local file
+    // Step 3: Modify the local file. Restore the prior lineage and tick the
+    // local clock so the follow-up upload is a descendant edit, not a fresh
+    // stateless write against the rel_path index.
+    let mut resync_state = tracked_state;
+    resync_state.vclock.tick("device-a");
+    state.set(&src, resync_state);
     let content_v2 = b"modified content after dehydration unsync";
     std::fs::write(&src, content_v2).expect("modify after unsync");
 
@@ -698,6 +723,7 @@ async fn alternating_device_writes() {
 
     let content_v2 = b"version 2 from device-b";
     let src_b2 = write_test_file(tmp.path(), "round2/src_b/alt.txt", content_v2);
+    seed_state_at_new_path(&mut state_b, &dst_b1, &src_b2);
 
     let upload_v2 = upload_file_with_device(
         &op,
@@ -758,6 +784,7 @@ async fn alternating_device_writes() {
 
     let content_v3 = b"version 3 from device-a final round";
     let src_a3 = write_test_file(tmp.path(), "round3/src_a/alt.txt", content_v3);
+    seed_state_at_new_path(&mut state_a, &dst_a2, &src_a3);
 
     let upload_v3 = upload_file_with_device(
         &op,

--- a/crates/tcfs-sync/tests/e2e_two_device_sync.rs
+++ b/crates/tcfs-sync/tests/e2e_two_device_sync.rs
@@ -26,6 +26,15 @@ fn write_test_file(dir: &Path, name: &str, content: &[u8]) -> std::path::PathBuf
     path
 }
 
+fn seed_state_at_new_path(state: &mut StateCache, tracked_path: &Path, new_path: &Path) {
+    let mut seeded = state
+        .get(tracked_path)
+        .expect("tracked state for lineage seed")
+        .clone();
+    seeded.mtime = 0;
+    state.set(new_path, seeded);
+}
+
 /// Test case 1: Device A pushes a file, Device B pulls it, content matches.
 #[tokio::test]
 async fn two_device_push_then_pull() {
@@ -136,6 +145,7 @@ async fn two_device_modify_and_re_sync() {
     // Step 3: Device B modifies the file and pushes v2
     let content_v2 = b"version 2 modified by device-b with extra changes";
     let src_b = write_test_file(tmp.path(), "src_b/notes.txt", content_v2);
+    seed_state_at_new_path(&mut state_b, &dst_b, &src_b);
 
     let upload_b = upload_file_with_device(
         &op,
@@ -183,13 +193,9 @@ async fn two_device_modify_and_re_sync() {
     );
 }
 
-/// Test case 3: Both devices modify simultaneously — VectorClock detects conflict.
-///
-/// Note: The sync engine uses content-addressed manifest paths, so two devices
-/// writing different content get different remote paths (no collision at the
-/// storage layer). Conflict detection happens at the VectorClock/NATS layer.
-/// This test simulates that layer: both devices push independently, then we
-/// compare their vclocks to verify the conflict is detectable.
+/// Test case 3: Both devices modify from the same baseline. Once one device
+/// publishes the rel_path, the other should be stopped by VectorClock-based
+/// conflict detection rather than silently publishing a second winner.
 #[tokio::test]
 async fn two_device_simultaneous_conflict_detection() {
     let tmp = TempDir::new().unwrap();
@@ -234,11 +240,14 @@ async fn two_device_simultaneous_conflict_detection() {
     // Step 3: Both modify and push independently
     let content_a_v2 = b"device-a made independent changes to the document";
     let src_a_v2 = write_test_file(tmp.path(), "src_a2/shared.txt", content_a_v2);
+    seed_state_at_new_path(&mut state_a, &src_a_v1, &src_a_v2);
 
     let content_b_v2 = b"device-b also made different independent changes";
     let src_b_v2 = write_test_file(tmp.path(), "src_b2/shared.txt", content_b_v2);
+    seed_state_at_new_path(&mut state_b, &dst_b, &src_b_v2);
 
-    // Both push (content-addressed, so no storage collision)
+    // Device A publishes first. Device B should then be rejected as a
+    // concurrent modifier for the same rel_path.
     let upload_a_v2 = upload_file_with_device(
         &op,
         &src_a_v2,
@@ -266,11 +275,21 @@ async fn two_device_simultaneous_conflict_detection() {
     .expect("device-b upload v2");
 
     assert!(!upload_a_v2.skipped);
-    assert!(!upload_b_v2.skipped);
+    assert!(
+        upload_b_v2.skipped,
+        "second independent writer should be stopped by conflict detection"
+    );
+    match &upload_b_v2.outcome {
+        Some(tcfs_sync::conflict::SyncOutcome::Conflict(info)) => {
+            assert_eq!(info.rel_path, "shared.txt");
+            assert_eq!(info.local_device, "device-b");
+            assert_eq!(info.remote_device, "device-a");
+        }
+        other => panic!("expected Conflict for second writer, got: {:?}", other),
+    }
 
-    // Step 4: Simulate NATS-layer conflict detection by comparing vclocks
-    // In production, when device B receives device A's NATS event (or vice versa),
-    // it compares the vclocks to detect the conflict.
+    // Step 4: Compare the recorded local/remote clocks to verify the conflict
+    // is concurrent, not a stale remote overwrite.
     let vclock_a = state_a.get(&src_a_v2).expect("A state").vclock.clone();
     let vclock_b = state_b.get(&src_b_v2).expect("B state").vclock.clone();
 
@@ -286,7 +305,7 @@ async fn two_device_simultaneous_conflict_detection() {
     let outcome = tcfs_sync::conflict::compare_clocks(
         &vclock_b,
         &vclock_a,
-        &upload_b_v2.hash,
+        &state_b.get(&src_b_v2).expect("B state").blake3,
         &upload_a_v2.hash,
         "shared.txt",
         "device-b",
@@ -350,6 +369,7 @@ async fn two_device_multi_round_sync() {
     // Round 2: B modifies and pushes
     let content_r2 = b"round 2 content from device-b";
     let src_b = write_test_file(tmp.path(), "round/2/file.txt", content_r2);
+    seed_state_at_new_path(&mut state_b, &dst_b, &src_b);
     let upload_r2 = upload_file_with_device(
         &op,
         &src_b,

--- a/crates/tcfs-sync/tests/push_pull_roundtrip.rs
+++ b/crates/tcfs-sync/tests/push_pull_roundtrip.rs
@@ -502,11 +502,13 @@ async fn delete_removes_index_and_manifest() {
 
     // Write index entry (normally done by push_tree or cmd_push)
     let index_key = format!("{prefix}/index/to-delete.txt");
-    let index_entry = format!(
-        "manifest_hash={}\nsize={}\nchunks={}\n",
-        upload.hash, upload.bytes, upload.chunks
-    );
-    op.write(&index_key, index_entry.into_bytes())
+    let index_entry = tcfs_sync::index_entry::RemoteIndexEntry::new(
+        upload.hash.clone(),
+        upload.bytes,
+        upload.chunks,
+    )
+    .to_legacy_bytes();
+    op.write(&index_key, index_entry)
         .await
         .expect("write index entry");
 

--- a/crates/tcfs-sync/tests/resolve_conflict_test.rs
+++ b/crates/tcfs-sync/tests/resolve_conflict_test.rs
@@ -22,6 +22,16 @@ fn write_test_file(dir: &Path, name: &str, content: &[u8]) -> std::path::PathBuf
     path
 }
 
+fn seed_state_at_new_path(
+    state: &mut tcfs_sync::state::StateCache,
+    tracked: &tcfs_sync::state::SyncState,
+    new_path: &Path,
+) {
+    let mut seeded = tracked.clone();
+    seeded.mtime = 0;
+    state.set(new_path, seeded);
+}
+
 /// Simulates keep_remote: device A uploads, device B downloads the remote version.
 #[tokio::test]
 async fn resolve_keep_remote_downloads_remote() {
@@ -90,7 +100,7 @@ async fn resolve_keep_local_re_uploads() {
     let src_a = write_test_file(tmp.path(), "src_a/notes.txt", content_a);
     let mut state_a = tcfs_sync::state::StateCache::open(&tmp.path().join("state_a.db")).unwrap();
 
-    let _upload_a = tcfs_sync::engine::upload_file_with_device(
+    let upload_a = tcfs_sync::engine::upload_file_with_device(
         &op,
         &src_a,
         prefix,
@@ -108,10 +118,18 @@ async fn resolve_keep_local_re_uploads() {
     let src_b = write_test_file(tmp.path(), "src_b/notes.txt", content_b);
     let mut state_b = tcfs_sync::state::StateCache::open(&tmp.path().join("state_b.db")).unwrap();
 
-    // Tick B's clock to make it newer
-    let mut vclock = tcfs_sync::conflict::VectorClock::new();
-    vclock.tick("device-b");
-    vclock.tick("device-b"); // Tick twice so B dominates
+    // Seed B's local path with A's observed baseline so the follow-up upload
+    // is a descendant keep_local decision rather than a stateless overwrite.
+    let baseline_b_state = tcfs_sync::state::make_sync_state_full(
+        &src_b,
+        upload_a.hash.clone(),
+        upload_a.chunks,
+        upload_a.remote_path.clone(),
+        state_a.get(&src_a).expect("device A state").vclock.clone(),
+        "device-b".into(),
+    )
+    .expect("make B baseline state");
+    seed_state_at_new_path(&mut state_b, &baseline_b_state, &src_b);
 
     let upload_b = tcfs_sync::engine::upload_file_with_device(
         &op,

--- a/crates/tcfs-sync/tests/two_device_sync_test.rs
+++ b/crates/tcfs-sync/tests/two_device_sync_test.rs
@@ -7,6 +7,7 @@
 use opendal::Operator;
 use std::path::Path;
 use tcfs_sync::conflict::SyncOutcome;
+use tcfs_sync::index_entry::RemoteIndexEntry;
 use tempfile::TempDir;
 
 fn memory_operator() -> Operator {
@@ -54,11 +55,9 @@ async fn two_device_conflict_via_index() {
 
     // Write index entry (simulating what the CLI does after push)
     let index_key = format!("{}/index/hello.txt", prefix);
-    let index_entry = format!(
-        "manifest_hash={}\nsize={}\nchunks={}\n",
-        upload_a.hash, upload_a.bytes, upload_a.chunks
-    );
-    op.write(&index_key, index_entry.into_bytes())
+    let index_entry = RemoteIndexEntry::new(upload_a.hash.clone(), upload_a.bytes, upload_a.chunks)
+        .to_legacy_bytes();
+    op.write(&index_key, index_entry)
         .await
         .expect("write index entry");
 
@@ -135,11 +134,9 @@ async fn sequential_push_no_conflict() {
 
     // Write index entry
     let index_key = format!("{}/index/doc.txt", prefix);
-    let index_entry = format!(
-        "manifest_hash={}\nsize={}\nchunks={}\n",
-        upload_a.hash, upload_a.bytes, upload_a.chunks
-    );
-    op.write(&index_key, index_entry.into_bytes())
+    let index_entry = RemoteIndexEntry::new(upload_a.hash.clone(), upload_a.bytes, upload_a.chunks)
+        .to_legacy_bytes();
+    op.write(&index_key, index_entry)
         .await
         .expect("write index entry");
 
@@ -217,13 +214,9 @@ async fn conflict_records_state() {
 
     // Write index
     let index_key = format!("{}/index/data.bin", prefix);
-    let index_entry = format!(
-        "manifest_hash={}\nsize={}\nchunks={}\n",
-        upload_a.hash, upload_a.bytes, upload_a.chunks
-    );
-    op.write(&index_key, index_entry.into_bytes())
-        .await
-        .unwrap();
+    let index_entry = RemoteIndexEntry::new(upload_a.hash.clone(), upload_a.bytes, upload_a.chunks)
+        .to_legacy_bytes();
+    op.write(&index_key, index_entry).await.unwrap();
 
     // Device B: write old content, record state, then write new content
     let src_b = write_test_file(tmp.path(), "b/data.bin", b"old");


### PR DESCRIPTION
## What changed
- added a shared `index_entry` model/parser that supports legacy text entries plus versioned JSON v2 entries with explicit `committed` and `preparing` states
- routed sync read, delete, reconcile, and publish paths through shared recovery-aware helpers
- moved rel-path publication ownership into `upload_file_with_device()` and publish through staged-manifest -> preparing-index -> final-manifest -> committed-index
- added deterministic crash-window tests covering the staged, preparing, final, and committed publish phases

## Why
Issue #224 tracks the manifest/index crash window where a manifest can be uploaded but never become discoverable by path if the process dies before the index is updated.

## Impact
Path-based visibility now has an explicit durability model: readers can deterministically roll forward or preserve the current committed manifest instead of exposing ambiguous or missing state during publish recovery.

## Validation
- `nix develop . --command cargo fmt --all`
- `nix develop . --command env CARGO_TARGET_DIR=/tmp/tummycrypt-224-index-v2-target cargo test -p tcfs-sync publish_crash_ --locked`
- `nix develop . --command env CARGO_TARGET_DIR=/tmp/tummycrypt-224-index-v2-target cargo test -p tcfs-sync --lib --test two_device_sync_test --test push_pull_roundtrip --locked`
- `nix develop . --command env CARGO_TARGET_DIR=/tmp/tummycrypt-224-index-v2-target cargo check -p tcfs-cli --locked`

Refs #224.