### PR TITLE
[codex] Align canonical home and release surfaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   IMAGE_NAME: tcfsd  # Prefixed with lowercase $REGISTRY/$GITHUB_REPOSITORY_OWNER in tags
+  RUST_TOOLCHAIN: 1.93.0
 
 permissions:
   contents: write
@@ -52,18 +53,25 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      image_repo: ${{ steps.version.outputs.image_repo }}
     steps:
       - name: Determine version
         id: version
         run: |
+          if [[ "${GITHUB_REPOSITORY}" != "Jesssullivan/tummycrypt" ]]; then
+            echo "::error::Release workflow is canonical-only and must run from Jesssullivan/tummycrypt"
+            exit 1
+          fi
           if [[ "${{ github.event_name }}" == "push" ]]; then
             TAG="${GITHUB_REF_NAME}"
           else
             TAG="${{ github.event.inputs.tag }}"
           fi
           VERSION="${TAG#v}"  # strip leading v
+          OWNER_LOWER="$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${{ env.REGISTRY }}/${OWNER_LOWER}/${{ env.IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
           echo "Building release: ${TAG} (version ${VERSION})"
 
   # ── Build client binaries ─────────────────────────────────────────────────
@@ -138,6 +146,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.target }}
 
       - name: Cache Cargo
@@ -428,9 +437,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/jesssullivan/${{ env.IMAGE_NAME }}:${{ needs.plan.outputs.tag }}
-            ghcr.io/jesssullivan/${{ env.IMAGE_NAME }}:${{ needs.plan.outputs.version }}
-            ghcr.io/jesssullivan/${{ env.IMAGE_NAME }}:latest
+            ${{ needs.plan.outputs.image_repo }}:${{ needs.plan.outputs.tag }}
+            ${{ needs.plan.outputs.image_repo }}:${{ needs.plan.outputs.version }}
+            ${{ needs.plan.outputs.image_repo }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: |
@@ -449,9 +458,9 @@ jobs:
         run: |
           # Sign each tag with keyless (OIDC-based) signing
           for TAG in \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.plan.outputs.tag }}" \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.plan.outputs.version }}" \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"; do
+            "${{ needs.plan.outputs.image_repo }}:${{ needs.plan.outputs.tag }}" \
+            "${{ needs.plan.outputs.image_repo }}:${{ needs.plan.outputs.version }}" \
+            "${{ needs.plan.outputs.image_repo }}:latest"; do
             cosign sign --yes "${TAG}"
           done
 
@@ -636,6 +645,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - uses: Swatinem/rust-cache@v2
 
@@ -995,12 +1006,13 @@ jobs:
 
             **Homebrew:**
             ```bash
-            brew install tinyland-inc/tap/tcfs
+            brew tap ${{ github.repository }} https://github.com/${{ github.repository }} --branch homebrew-tap
+            brew install tcfs
             ```
 
             **Container image:**
             ```bash
-            podman pull ghcr.io/${{ env.IMAGE_NAME }}:${{ needs.plan.outputs.tag }}
+            podman pull ${{ needs.plan.outputs.image_repo }}:${{ needs.plan.outputs.tag }}
             ```
 
             **Debian/Ubuntu:**
@@ -1029,7 +1041,7 @@ jobs:
               --signature SHA256SUMS.txt.sig \
               --certificate SHA256SUMS.txt.pem \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-              --certificate-identity-regexp 'github.com/tinyland-inc/tummycrypt' \
+              --certificate-identity-regexp 'github.com/${{ github.repository }}' \
               SHA256SUMS.txt
             ```
 
@@ -1109,14 +1121,14 @@ jobs:
           cp tcfs.rb Formula/tcfs.rb
 
           cat > README.md << 'EOF'
-          # tinyland-inc/homebrew-tap
+          # Canonical tcfs homebrew-tap
 
           Homebrew formulae for [TummyCrypt/tcfs](https://github.com/${{ github.repository }}).
 
           ## Usage
 
           ```bash
-          brew tap tinyland-inc/tap https://github.com/${{ github.repository }} --branch homebrew-tap
+          brew tap ${{ github.repository }} https://github.com/${{ github.repository }} --branch homebrew-tap
           brew install tcfs
           ```
           EOF

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ version = "0.12.0"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/tinyland-inc/tummycrypt"
+repository = "https://github.com/Jesssullivan/tummycrypt"
 rust-version = "1.93"
 
 [workspace.dependencies]

--- a/Containerfile
+++ b/Containerfile
@@ -5,12 +5,12 @@
 #   runtime  — distroless/cc for minimal attack surface
 #
 # Build:
-#   podman build -t ghcr.io/tinyland-inc/tcfsd:latest -f Containerfile .
+#   podman build -t ghcr.io/jesssullivan/tcfsd:latest -f Containerfile .
 #
 # Run:
 #   podman run --rm \
 #     --env-file /path/to/s3-credentials.env \
-#     ghcr.io/tinyland-inc/tcfsd:latest \
+#     ghcr.io/jesssullivan/tcfsd:latest \
 #     --mode=worker --config=/etc/tcfsd/config.toml
 
 # ── Stage 1: Rust builder ─────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Self-hosted encrypted file sync with on-demand hydration. Mounts SeaweedFS as a local directory — files appear as zero-byte `.tc` stubs until accessed, then transparently download and decrypt. FOSS odrive/Dropbox replacement.
 
+## Canonical Home
+
+`Jesssullivan/tummycrypt` is the canonical source repository for tcfs.
+If `tinyland-inc/tummycrypt` exists, treat it as a fork or downstream
+distribution surface rather than the source of truth for planning, issues,
+releases, or contributor workflow.
+
 ## Features
 
 - **On-demand hydration**: Files appear as `.tc` stubs, hydrate transparently on open
@@ -18,8 +25,10 @@ Self-hosted encrypted file sync with on-demand hydration. Mounts SeaweedFS as a 
 ```bash
 # Nix devShell (recommended)
 nix develop
+# Or auto-load the committed devShell + env on cd
+direnv allow
 
-# Or manual: Rust 1.93+, protobuf compiler, fuse3 (Linux)
+# Or manual: install the pinned Rust 1.93.0 toolchain, protobuf compiler, fuse3 (Linux)
 
 # Start local dev infrastructure (SeaweedFS + NATS + Prometheus + Grafana)
 task dev
@@ -34,14 +43,15 @@ task check
 # Linux (installer script)
 curl -fsSL https://github.com/Jesssullivan/tummycrypt/releases/latest/download/install.sh | sh
 
-# macOS (Homebrew)
-brew install tinyland-inc/tap/tcfs
+# macOS (Homebrew tap from canonical repo)
+brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap
+brew install tcfs
 
 # Debian/Ubuntu
 sudo dpkg -i tcfs-*.deb
 
 # Container (K8s worker mode)
-podman pull ghcr.io/tinyland-inc/tcfsd:latest
+podman pull ghcr.io/jesssullivan/tcfsd:latest
 
 # Nix
 nix build github:Jesssullivan/tummycrypt

--- a/config/systemd/tcfsd.service
+++ b/config/systemd/tcfsd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=TummyCrypt filesystem daemon (tcfsd)
-Documentation=https://github.com/tinyland-inc/tummycrypt/docs/ARCHITECTURE.md
+Documentation=https://github.com/Jesssullivan/tummycrypt/docs/ARCHITECTURE.md
 After=network.target
 
 [Service]

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1555,7 +1555,7 @@ fn fetch_latest_version() -> Option<String> {
             "5",
             "-H",
             "Accept: application/vnd.github+json",
-            "https://api.github.com/repos/tinyland-inc/tummycrypt/releases/latest",
+            "https://api.github.com/repos/Jesssullivan/tummycrypt/releases/latest",
         ])
         .output()
         .ok()?;
@@ -1593,7 +1593,7 @@ fn print_update_notice(current: &str, latest: &str) {
                 "  A newer version (v{}) is available. You are running v{}.",
                 latest, current
             );
-            println!("  Update: curl -fsSL https://github.com/tinyland-inc/tummycrypt/releases/latest/download/install.sh | sh");
+            println!("  Update: curl -fsSL https://github.com/Jesssullivan/tummycrypt/releases/latest/download/install.sh | sh");
         }
     }
 }

--- a/crates/tcfsd/tcfsd.service
+++ b/crates/tcfsd/tcfsd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=TummyCrypt filesystem daemon (tcfsd)
-Documentation=https://github.com/tinyland-inc/tummycrypt
+Documentation=https://github.com/Jesssullivan/tummycrypt
 After=network-online.target
 Wants=network-online.target
 

--- a/dist/homebrew-tcfs.rb
+++ b/dist/homebrew-tcfs.rb
@@ -1,5 +1,7 @@
 # Homebrew formula for tcfs
-# To use: brew tap tinyland-inc/tap && brew install tcfs
+# To use:
+#   brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap
+#   brew install tcfs
 #
 # This template is used by CI to generate the versioned formula.
 # Placeholders: __VERSION__, __SHA256_DARWIN_ARM64__, __SHA256_DARWIN_X86_64__,
@@ -7,26 +9,26 @@
 
 class Tcfs < Formula
   desc "FOSS self-hosted odrive replacement — FUSE-based, SeaweedFS-backed file sync"
-  homepage "https://github.com/tinyland-inc/tummycrypt"
+  homepage "https://github.com/Jesssullivan/tummycrypt"
   version "__VERSION__"
   license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/tinyland-inc/tummycrypt/releases/download/v__VERSION__/tcfs-__VERSION__-macos-aarch64.tar.gz"
+      url "https://github.com/Jesssullivan/tummycrypt/releases/download/v__VERSION__/tcfs-__VERSION__-macos-aarch64.tar.gz"
       sha256 "__SHA256_DARWIN_ARM64__"
     else
-      url "https://github.com/tinyland-inc/tummycrypt/releases/download/v__VERSION__/tcfs-__VERSION__-macos-x86_64.tar.gz"
+      url "https://github.com/Jesssullivan/tummycrypt/releases/download/v__VERSION__/tcfs-__VERSION__-macos-x86_64.tar.gz"
       sha256 "__SHA256_DARWIN_X86_64__"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/tinyland-inc/tummycrypt/releases/download/v__VERSION__/tcfs-__VERSION__-linux-aarch64.tar.gz"
+      url "https://github.com/Jesssullivan/tummycrypt/releases/download/v__VERSION__/tcfs-__VERSION__-linux-aarch64.tar.gz"
       sha256 "__SHA256_LINUX_ARM64__"
     else
-      url "https://github.com/tinyland-inc/tummycrypt/releases/download/v__VERSION__/tcfs-__VERSION__-linux-x86_64.tar.gz"
+      url "https://github.com/Jesssullivan/tummycrypt/releases/download/v__VERSION__/tcfs-__VERSION__-linux-x86_64.tar.gz"
       sha256 "__SHA256_LINUX_X86_64__"
     end
   end

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ The full architecture document is maintained as a LaTeX source file and
 distributed as PDF.
 
 - **Source**: [`docs/tex/architecture.tex`](tex/architecture.tex)
-- **PDF**: Built by CI and available as a [release artifact](https://github.com/tinyland-inc/tummycrypt/actions/workflows/docs.yml)
+- **PDF**: Built by CI and available as a [release artifact](https://github.com/Jesssullivan/tummycrypt/actions/workflows/docs.yml)
 
 To build locally:
 
@@ -19,7 +19,7 @@ tcfs is a Rust monorepo of 14 workspace crates organized around a daemon (`tcfsd
 
 ## Quick Reference
 
-See the [Architecture PDF](https://github.com/tinyland-inc/tummycrypt/actions/workflows/docs.yml) for full details including:
+See the [Architecture PDF](https://github.com/Jesssullivan/tummycrypt/actions/workflows/docs.yml) for full details including:
 
 - System architecture (client + server components)
 - Crate map (14 workspace crates)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -87,7 +87,7 @@ Benchmarks measured on:
 - **RAM**: 16 GB DDR4
 - **Storage**: Samsung MZVLW256 NVMe SSD (238.5 GB)
 - **OS**: Rocky Linux 10 (kernel 6.12.0)
-- **Rust**: 1.93+ (edition 2021, `opt-level = 3`, `lto = "thin"`)
+- **Rust**: 1.93.0 (repo-pinned toolchain, edition 2021, `opt-level = 3`, `lto = "thin"`)
 - **Benchmark framework**: divan 0.1
 
 ## Running Benchmarks
@@ -97,6 +97,6 @@ Benchmarks measured on:
 task bench
 
 # Individual suites
-~/.cargo/bin/cargo bench -p tcfs-chunks --bench chunks
-~/.cargo/bin/cargo bench -p tcfs-crypto --bench crypto
+cargo bench -p tcfs-chunks --bench chunks
+cargo bench -p tcfs-crypto --bench crypto
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-- Rust 1.93+ (via rustup or Nix)
+- Rust 1.93.0 (pinned via `rust-toolchain.toml`, rustup, or Nix)
 - protobuf-compiler (`protoc`)
 - pkg-config, libssl-dev, libfuse3-dev (Linux)
 - [Task](https://taskfile.dev) (task runner)
@@ -14,9 +14,11 @@
 
 ```bash
 # Clone and enter devShell
-git clone https://github.com/tinyland-inc/tummycrypt.git
+git clone https://github.com/Jesssullivan/tummycrypt.git
 cd tummycrypt
-nix develop    # or: echo 'use flake' > .envrc && direnv allow
+nix develop
+# Or auto-load the committed .envrc once:
+direnv allow
 
 # Build everything
 task build
@@ -25,13 +27,15 @@ task build
 task test
 ```
 
-> **Rocky Linux note**: `cargo` is not in `$PATH` by default. Use `~/.cargo/bin/cargo` for all cargo commands outside the Nix devShell.
+> **System Rust note**: outside the Nix devShell, ensure rustup's cargo bin dir is on `PATH` (for example `source "$HOME/.cargo/env"`). The committed `.envrc` does this automatically when direnv is enabled.
 
 ### Quick Start without Nix
 
 ```bash
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup toolchain install 1.93.0
+rustup override set 1.93.0
 
 # Install system dependencies (Debian/Ubuntu)
 sudo apt install protobuf-compiler pkg-config libssl-dev libfuse3-dev
@@ -120,11 +124,13 @@ cargo run -p tcfs-cli -- mount seaweedfs://localhost:8333/tcfs /tmp/tcfs-mount
 ## Pull Request Guidelines
 
 1. **Branch from** `main` (use `sid/` prefix for feature branches)
-2. **Run checks locally** before pushing: `task check` (fmt + clippy + test + build)
-3. **Keep PRs focused** - one feature or fix per PR
-4. **Add tests** for new functionality
-5. **Update docs** if you change user-facing behavior
-6. CI runs: `cargo fmt --check`, `cargo clippy`, `cargo test`, `cargo-deny`, security audit
+2. **Treat `Jesssullivan/tummycrypt` as canonical** for PRs, issues, and release flow
+3. **Use org forks as downstreams only** unless a specific distribution task requires them
+4. **Run checks locally** before pushing: `task check` (fmt + clippy + test + build)
+5. **Keep PRs focused** - one feature or fix per PR
+6. **Add tests** for new functionality
+7. **Update docs** if you change user-facing behavior
+8. CI runs: `cargo fmt --check`, `cargo clippy`, `cargo test`, `cargo-deny`, security audit
 
 ## Code Style
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -4,7 +4,7 @@ The full protocol specification is maintained as a LaTeX source file and
 distributed as PDF.
 
 - **Source**: [`docs/tex/protocol.tex`](tex/protocol.tex)
-- **PDF**: Built by CI and available as a [release artifact](https://github.com/tinyland-inc/tummycrypt/actions/workflows/docs.yml)
+- **PDF**: Built by CI and available as a [release artifact](https://github.com/Jesssullivan/tummycrypt/actions/workflows/docs.yml)
 
 To build locally:
 
@@ -15,7 +15,7 @@ task docs:pdf
 
 ## Quick Reference
 
-See the [Protocol PDF](https://github.com/tinyland-inc/tummycrypt/actions/workflows/docs.yml) for full details including:
+See the [Protocol PDF](https://github.com/Jesssullivan/tummycrypt/actions/workflows/docs.yml) for full details including:
 
 - `.tc` file stub format (JSON schema)
 - `.tcf` folder stub format

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,7 +4,7 @@ The full security model document is maintained as a LaTeX source file and
 distributed as PDF.
 
 - **Source**: [`docs/tex/security.tex`](tex/security.tex)
-- **PDF**: Built by CI and available as a [release artifact](https://github.com/tinyland-inc/tummycrypt/actions/workflows/docs.yml)
+- **PDF**: Built by CI and available as a [release artifact](https://github.com/Jesssullivan/tummycrypt/actions/workflows/docs.yml)
 
 To build locally:
 
@@ -19,7 +19,7 @@ tcfs encrypts all file content client-side before upload using XChaCha20-Poly130
 
 ## Quick Reference
 
-See the [Security PDF](https://github.com/tinyland-inc/tummycrypt/actions/workflows/docs.yml) for full details including:
+See the [Security PDF](https://github.com/Jesssullivan/tummycrypt/actions/workflows/docs.yml) for full details including:
 
 - Threat model (storage, network, client, credential threats)
 - Encryption architecture (XChaCha20-Poly1305, Argon2id, HKDF)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,14 +8,19 @@ tcfs is a FUSE-based file sync daemon backed by [SeaweedFS](https://github.com/s
 
 ### Binary Releases
 
-Download the latest release from [GitHub Releases](https://github.com/tinyland-inc/tummycrypt/releases):
+`Jesssullivan/tummycrypt` is the canonical source repository. Downstream org
+forks may exist for distribution, but releases and source references should
+default here.
+
+Download the latest release from [GitHub Releases](https://github.com/Jesssullivan/tummycrypt/releases):
 
 ```bash
 # Linux (x86_64)
-curl -fsSL https://github.com/tinyland-inc/tummycrypt/releases/latest/download/install.sh | sh
+curl -fsSL https://github.com/Jesssullivan/tummycrypt/releases/latest/download/install.sh | sh
 
-# macOS (Homebrew)
-brew install tinyland-inc/tap/tcfs
+# macOS (Homebrew tap from canonical repo)
+brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap
+brew install tcfs
 
 # Debian/Ubuntu
 sudo dpkg -i tcfs-*.deb
@@ -27,14 +32,14 @@ sudo rpm -i tcfsd-*.rpm
 ### Container (K8s worker mode)
 
 ```bash
-podman pull ghcr.io/tinyland-inc/tcfsd:latest
+podman pull ghcr.io/jesssullivan/tcfsd:latest
 ```
 
 ### From Source
 
 ```bash
-# Requires Rust 1.93+, protoc, libfuse3-dev
-git clone https://github.com/tinyland-inc/tummycrypt.git
+# Requires the pinned Rust 1.93.0 toolchain (see rust-toolchain.toml), protoc, libfuse3-dev
+git clone https://github.com/Jesssullivan/tummycrypt.git
 cd tummycrypt
 cargo build --release
 # Binaries: target/release/tcfs, target/release/tcfsd, target/release/tcfs-tui, target/release/tcfs-mcp
@@ -43,9 +48,9 @@ cargo build --release
 ### Nix
 
 ```bash
-nix build github:tinyland-inc/tummycrypt
+nix build github:Jesssullivan/tummycrypt
 # Or enter a devShell:
-nix develop github:tinyland-inc/tummycrypt
+nix develop github:Jesssullivan/tummycrypt
 ```
 
 ## How It Works

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -29,7 +29,7 @@ Full feature support. Production-ready.
 - **Notifications**: macOS User Notifications for conflict detection
 - **Encryption**: Full E2E encryption with BIP-39 recovery
 - **Build targets**: aarch64 (.tar.gz, .pkg with notarization), x86_64 (.tar.gz)
-- **Homebrew**: `brew install tinyland-inc/tap/tcfs`
+- **Homebrew**: `brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap && brew install tcfs`
 
 ## Windows (Planned)
 

--- a/docs/tex/architecture.tex
+++ b/docs/tex/architecture.tex
@@ -204,7 +204,7 @@ auto-reloads credentials when the file changes on disk.
   Namespace        & tcfs \\
   In-cluster SeaweedFS & seaweedfs.tcfs.svc.cluster.local:8333 \\
   In-cluster NATS  & nats.tcfs.svc.cluster.local:4222 \\
-  Container image  & ghcr.io/tinyland-inc/tcfsd \\
+  Container image  & ghcr.io/jesssullivan/tcfsd \\
   \bottomrule
 \end{longtable}
 

--- a/infra/k8s/charts/tcfs-backend/Chart.yaml
+++ b/infra/k8s/charts/tcfs-backend/Chart.yaml
@@ -9,8 +9,8 @@ keywords:
   - tummycrypt
   - sync
   - seaweedfs
-home: https://github.com/tinyland-inc/tummycrypt
+home: https://github.com/Jesssullivan/tummycrypt
 sources:
-  - https://github.com/tinyland-inc/tummycrypt
+  - https://github.com/Jesssullivan/tummycrypt
 maintainers:
   - name: TummyCrypt Contributors

--- a/infra/k8s/charts/tcfs-backend/values.yaml
+++ b/infra/k8s/charts/tcfs-backend/values.yaml
@@ -2,7 +2,7 @@
 # Override with: helm install tcfs-backend ./infra/k8s/charts/tcfs-backend -f my-values.yaml
 
 image:
-  repository: ghcr.io/tinyland-inc/tcfsd
+  repository: ghcr.io/jesssullivan/tcfsd
   tag: latest
   pullPolicy: Always
 

--- a/infra/k8s/charts/tcfs-stack/Chart.yaml
+++ b/infra/k8s/charts/tcfs-stack/Chart.yaml
@@ -13,9 +13,9 @@ keywords:
   - s3
   - sync
 
-home: https://github.com/tinyland-inc/tummycrypt
+home: https://github.com/Jesssullivan/tummycrypt
 sources:
-  - https://github.com/tinyland-inc/tummycrypt
+  - https://github.com/Jesssullivan/tummycrypt
 
 maintainers:
   - name: jsullivan2

--- a/infra/k8s/charts/tcfs-stack/templates/NOTES.txt
+++ b/infra/k8s/charts/tcfs-stack/templates/NOTES.txt
@@ -36,4 +36,4 @@
 
      kubectl logs -l app.kubernetes.io/name=tcfs-backend -n {{ .Values.global.namespace }} -f
 
-For more information visit: https://github.com/tinyland-inc/tummycrypt
+For more information visit: https://github.com/Jesssullivan/tummycrypt

--- a/infra/tofu/environments/civo/main.tf
+++ b/infra/tofu/environments/civo/main.tf
@@ -95,7 +95,7 @@ module "tcfs_backend" {
   depends_on = [module.observability]  # CRD: ServiceMonitor
 
   namespace  = var.namespace
-  image      = "ghcr.io/tinyland-inc/tcfsd:${var.image_tag}"
+  image      = "ghcr.io/jesssullivan/tcfsd:${var.image_tag}"
   nats_url   = module.nats.nats_url
 
   # Point workers at the in-cluster SeaweedFS

--- a/infra/tofu/environments/local/main.tf
+++ b/infra/tofu/environments/local/main.tf
@@ -56,7 +56,7 @@ module "tcfs_backend" {
   source = "../../modules/tcfs-backend"
 
   namespace  = var.namespace
-  image      = "ghcr.io/tinyland-inc/tcfsd:${var.image_tag}"
+  image      = "ghcr.io/jesssullivan/tcfsd:${var.image_tag}"
   nats_url   = module.nats.nats_url
 
   s3_endpoint    = "http://localhost:8333"

--- a/infra/tofu/modules/tcfs-backend/variables.tf
+++ b/infra/tofu/modules/tcfs-backend/variables.tf
@@ -5,9 +5,9 @@ variable "namespace" {
 }
 
 variable "image" {
-  description = "tcfsd container image (repository:tag)"
+  description = "tcfsd container image (repository:tag). Defaults to the canonical Jesssullivan GHCR image; downstream org deployments can override it."
   type        = string
-  default     = "ghcr.io/tinyland-inc/tcfsd:latest"
+  default     = "ghcr.io/jesssullivan/tcfsd:latest"
 }
 
 variable "worker_replicas" {


### PR DESCRIPTION
## What changed
- switched repo metadata, docs, install guidance, release defaults, and distribution surfaces to `Jesssullivan/tummycrypt`
- updated release automation, Homebrew instructions, container metadata, and deployment defaults to stop treating the Tinyland fork as canonical
- added a release guard so canonical releases only run from `Jesssullivan/tummycrypt`

## Why
Project reality was split across docs, local config, release surfaces, and backlog tracking. The repo needed one canonical home before the reliability backlog could be managed coherently.

## Impact
`Jesssullivan/tummycrypt` becomes the explicit source of truth across code, docs, and release/distribution defaults, while `tinyland-inc/tummycrypt` can now remain downstream-only.

## Validation
- `git diff --check`
- `nix develop . --command cargo fmt --all -- --check`
- `nix develop . --command env CARGO_TARGET_DIR=/tmp/tummycrypt-canonical-home-target cargo check -p tcfs-cli --locked`

Related to canonical backlog migration issue #223 and the current sprint's reality-consolidation work.