### PR TITLE
[codex] Normalize Unicode rel paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,6 +5491,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "unicode-normalization",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ notify = { version = "8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 toml = { version = "0.8" }
+unicode-normalization = { version = "0.1" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/tcfs-sync/Cargo.toml
+++ b/crates/tcfs-sync/Cargo.toml
@@ -22,6 +22,7 @@ base64 = { workspace = true, optional = true }
 notify = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+unicode-normalization = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -15,6 +15,7 @@ use anyhow::{Context, Result};
 use opendal::Operator;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
+use unicode_normalization::UnicodeNormalization;
 use uuid::Uuid;
 
 use crate::conflict::{compare_clocks, SyncOutcome};
@@ -1345,7 +1346,7 @@ pub async fn push_tree_with_device(
 
     for (i, path) in result.files.iter().enumerate() {
         let rel = path.strip_prefix(local_root).unwrap_or(path);
-        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        let rel_str = normalize_rel_path_text(&rel.to_string_lossy());
 
         let msg = format!("[{}/{}] {}", i + 1, total, rel.display());
         if let Some(cb) = progress {
@@ -1387,7 +1388,7 @@ pub async fn push_tree_with_device(
             continue;
         }
         if let Ok(rel) = dir.strip_prefix(local_root) {
-            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            let rel_str = normalize_rel_path_text(&rel.to_string_lossy());
             let marker_key = format!(
                 "{}/index/{}/.tcfs_dir",
                 remote_path_prefix(remote_prefix),
@@ -1584,6 +1585,14 @@ fn collect_files_inner(
 /// - If `sync_root` is provided and the path is under it, returns the relative path.
 /// - Otherwise strips the leading `/` from absolute paths, or returns relative paths as-is.
 /// - Replaces `\` with `/` for cross-platform consistency.
+pub(crate) fn normalize_rel_path_text(path: &str) -> String {
+    path.replace('\\', "/")
+        .split('/')
+        .map(|component| component.nfc().collect::<String>())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 pub fn normalize_rel_path(path: &Path, sync_root: Option<&Path>) -> String {
     let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
 
@@ -1603,7 +1612,7 @@ pub fn normalize_rel_path(path: &Path, sync_root: Option<&Path>) -> String {
         canonical
     };
 
-    rel.to_string_lossy().replace('\\', "/")
+    normalize_rel_path_text(&rel.to_string_lossy())
 }
 
 /// Resolve a file path or manifest path to the actual S3 manifest path.
@@ -1644,6 +1653,7 @@ pub async fn resolve_manifest_path(
         .file_name()
         .map(|f| f.to_string_lossy().to_string())
         .unwrap_or_else(|| input.to_string());
+    let filename = normalize_rel_path_text(&filename);
 
     let index_prefix = format!("{prefix}/index/");
     let entries = op
@@ -1682,6 +1692,7 @@ pub async fn delete_remote_file(
     state: &mut StateCache,
     sync_root: Option<&Path>,
 ) -> Result<()> {
+    let rel_path = normalize_rel_path_text(rel_path.trim_start_matches('/'));
     let prefix = remote_prefix.trim_end_matches('/');
     let index_key = format!("{prefix}/index/{rel_path}");
     let manifest_prefix = manifest_path_prefix(prefix);
@@ -1711,12 +1722,12 @@ pub async fn delete_remote_file(
 
     // Remove from state cache
     let local_path = sync_root
-        .map(|r| r.join(rel_path))
-        .unwrap_or_else(|| PathBuf::from(rel_path));
+        .map(|r| r.join(&rel_path))
+        .unwrap_or_else(|| PathBuf::from(&rel_path));
     state.remove(&local_path);
 
     // Also try to remove by searching the cache (handles path normalization mismatches)
-    if let Some((key, _)) = state.get_by_rel_path(rel_path) {
+    if let Some((key, _)) = state.get_by_rel_path(&rel_path) {
         let key_owned = key.to_string();
         state.remove(Path::new(&key_owned));
     }
@@ -1923,6 +1934,16 @@ mod tests {
         assert!(result.ends_with("file.txt"));
     }
 
+    #[test]
+    fn normalize_rel_path_normalizes_decomposed_unicode() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("cafe\u{301}.txt");
+        std::fs::write(&file, b"x").unwrap();
+
+        let result = normalize_rel_path(&file, Some(dir.path()));
+        assert_eq!(result, "caf\u{e9}.txt");
+    }
+
     // ── resolve_manifest_path ─────────────────────────────────────────��──
 
     #[tokio::test]
@@ -1954,6 +1975,33 @@ mod tests {
         let result = resolve_manifest_path(&op, "doc.txt", "data", None)
             .await
             .unwrap();
+        assert_eq!(result, "data/manifests/abc123");
+    }
+
+    #[tokio::test]
+    async fn resolve_manifest_filename_search_normalizes_unicode() {
+        let op = memory_op();
+        op.write(
+            "data/index/caf\u{e9}.txt",
+            RemoteIndexEntry::new("abc123", 100, 1).to_legacy_bytes(),
+        )
+        .await
+        .unwrap();
+        op.write(
+            "data/manifests/abc123",
+            br#"{"version":2,"file_hash":"abc123","file_size":100,"chunks":[],"vclock":{"clocks":{}},"written_by":"neo","written_at":0}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let host_a = tempfile::tempdir().unwrap();
+        let host_b = tempfile::tempdir().unwrap();
+        let input = host_a.path().join("cafe\u{301}.txt");
+
+        let result =
+            resolve_manifest_path(&op, &input.to_string_lossy(), "data", Some(host_b.path()))
+                .await
+                .unwrap();
         assert_eq!(result, "data/manifests/abc123");
     }
 

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -168,10 +168,9 @@ pub async fn list_remote_index(
     let mut result = HashMap::new();
     for entry in entries {
         let full_key = entry.path();
-        let rel_path = full_key
-            .strip_prefix(&index_prefix)
-            .unwrap_or(full_key)
-            .to_string();
+        let rel_path = crate::engine::normalize_rel_path_text(
+            full_key.strip_prefix(&index_prefix).unwrap_or(full_key),
+        );
 
         // Skip directory markers and empty paths
         if rel_path.is_empty() || rel_path.ends_with('/') {
@@ -824,7 +823,7 @@ fn collect_local_set(local_root: &Path, blacklist: &Blacklist) -> Result<HashMap
     let mut map = HashMap::new();
     for file in result.files {
         if let Ok(rel) = file.strip_prefix(local_root) {
-            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            let rel_str = crate::engine::normalize_rel_path_text(&rel.to_string_lossy());
             map.insert(rel_str, file);
         }
     }
@@ -843,7 +842,7 @@ fn extract_rel_path_from_state(state_key: &str, local_root: &Path) -> Option<Str
                 .ok()
                 .and_then(|canon| key_path.strip_prefix(&canon).ok())
         })
-        .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+        .map(|rel| crate::engine::normalize_rel_path_text(&rel.to_string_lossy()))
 }
 
 #[cfg(test)]
@@ -1192,6 +1191,68 @@ mod tests {
             plan.summary.up_to_date, 1,
             "matching files should be up-to-date"
         );
+        assert_eq!(plan.summary.pushes, 0);
+        assert_eq!(plan.summary.pulls, 0);
+        assert_eq!(plan.summary.conflicts, 0);
+    }
+
+    #[tokio::test]
+    async fn reconcile_unicode_variants_round_trip_as_up_to_date() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+
+        let content = b"matching unicode content";
+        let hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(content));
+        let local_file = local_root.join("cafe\u{301}.txt");
+        std::fs::write(&local_file, content).unwrap();
+
+        let index_entry =
+            RemoteIndexEntry::new(hash.clone(), content.len() as u64, 1).to_legacy_bytes();
+        op.write("data/index/caf\u{e9}.txt", index_entry)
+            .await
+            .unwrap();
+
+        let manifest_json = serde_json::json!({
+            "version": 2,
+            "file_hash": hash,
+            "file_size": content.len(),
+            "chunks": [],
+            "vclock": {"clocks": {"neo": 1}},
+            "written_by": "neo",
+            "written_at": 0,
+            "rel_path": "caf\u{e9}.txt"
+        });
+        op.write(
+            &format!("data/manifests/{hash}"),
+            serde_json::to_vec(&manifest_json).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let state_path = dir.path().join("state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let mut vc = crate::conflict::VectorClock::new();
+        vc.tick("neo");
+        let sync_state = crate::state::make_sync_state_full(
+            &local_file,
+            hash.clone(),
+            1,
+            format!("data/manifests/{hash}"),
+            vc,
+            "neo".into(),
+        )
+        .unwrap();
+        state.set(&local_file, sync_state);
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(plan.summary.up_to_date, 1);
         assert_eq!(plan.summary.pushes, 0);
         assert_eq!(plan.summary.pulls, 0);
         assert_eq!(plan.summary.conflicts, 0);

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -375,16 +375,22 @@ impl StateCache {
     /// the normalized rel_path (`dir/file.txt`) handles cross-host home
     /// directory differences.
     pub fn get_by_rel_path(&self, rel_path: &str) -> Option<(&str, &SyncState)> {
-        let normalized = rel_path.trim_start_matches('/');
+        let normalized = crate::engine::normalize_rel_path_text(rel_path.trim_start_matches('/'));
         // Primary: match cache keys (canonical local paths) by suffix
         self.entries
             .iter()
-            .find(|(key, _)| key.ends_with(&format!("/{}", normalized)) || *key == normalized)
+            .find(|(key, _)| {
+                let normalized_key = crate::engine::normalize_rel_path_text(key);
+                normalized_key.ends_with(&format!("/{}", normalized))
+                    || normalized_key == normalized
+            })
             // Fallback: match remote_path (manifest path) for backward compat
             .or_else(|| {
                 self.entries.iter().find(|(_, state)| {
-                    state.remote_path.ends_with(&format!("/{}", normalized))
-                        || state.remote_path == normalized
+                    let normalized_remote =
+                        crate::engine::normalize_rel_path_text(&state.remote_path);
+                    normalized_remote.ends_with(&format!("/{}", normalized))
+                        || normalized_remote == normalized
                 })
             })
             .map(|(k, v)| (k.as_str(), v))


### PR DESCRIPTION
## What changed
- add Unicode NFC normalization for relative path text before deriving remote index keys
- apply the same normalization in sync upload paths, reconcile local/remote comparisons, and state-cache rel-path lookups
- add regression coverage for decomposed/composed Unicode filenames across normalize, manifest resolution, and reconcile flows

## Why
Relative paths were still derived by stringifying path bytes with `to_string_lossy().replace('\\', "/")`. That preserved filesystem-specific Unicode forms, which can diverge across platforms and turn the same semantic filename into different remote object keys.

## Impact
- composed and decomposed Unicode filenames now converge on a stable remote rel-path form
- cross-host lookup and reconcile behavior stay consistent for Unicode filenames
- existing regression coverage now proves normalize/search/reconcile round-tripping for Unicode variants

## Validation
- `cargo fmt --all --check`
- `cargo test -p tcfs-sync unicode`
- `cargo check -p tcfs-sync`

Closes #225
