### PR TITLE
[codex] Wire orphan chunk cleanup into reconcile surfaces

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -16,7 +16,7 @@ use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use secrecy::ExposeSecret;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 #[cfg(unix)]
 use tonic::transport::{Channel, Endpoint, Uri};
@@ -3403,6 +3403,8 @@ async fn cmd_reconcile(
 
     let blacklist = tcfs_sync::blacklist::Blacklist::from_sync_config(&config.sync);
     let reconcile_config = tcfs_sync::reconcile::ReconcileConfig::default();
+    let orphan_chunk_cleanup_grace =
+        Duration::from_secs(config.sync.orphan_chunk_cleanup_grace_secs);
 
     println!(
         "Reconciling {} ↔ {}:{}/",
@@ -3437,7 +3439,6 @@ async fn cmd_reconcile(
 
     if plan.actions.is_empty() {
         println!("Nothing to do — local and remote are in sync.");
-        return Ok(());
     }
 
     for action in &plan.actions {
@@ -3472,58 +3473,95 @@ async fn cmd_reconcile(
     if !execute {
         println!();
         println!("Dry run — no changes made. Use --execute to apply.");
+        if !orphan_chunk_cleanup_grace.is_zero() {
+            println!(
+                "Orphan chunk cleanup runs during execute with a {} second grace period.",
+                config.sync.orphan_chunk_cleanup_grace_secs
+            );
+        }
         return Ok(());
     }
 
-    // Execute the plan
-    println!();
-    println!("Executing plan...");
+    if !plan.actions.is_empty() {
+        println!();
+        println!("Executing plan...");
 
-    let mut state = tcfs_sync::state::StateCache::open(&state_path)?;
+        let mut state = tcfs_sync::state::StateCache::open(&state_path)?;
 
-    let master_key = config
-        .crypto
-        .master_key_file
-        .as_ref()
-        .and_then(|p| std::fs::read(p).ok())
-        .filter(|k| k.len() == 32)
-        .map(|bytes| {
-            let mut key = [0u8; 32];
-            key.copy_from_slice(&bytes);
-            tcfs_crypto::MasterKey::from_bytes(key)
-        });
-    let enc_ctx = master_key
-        .as_ref()
-        .map(|mk| tcfs_sync::engine::EncryptionContext {
-            master_key: mk.clone(),
-        });
+        let master_key = config
+            .crypto
+            .master_key_file
+            .as_ref()
+            .and_then(|p| std::fs::read(p).ok())
+            .filter(|k| k.len() == 32)
+            .map(|bytes| {
+                let mut key = [0u8; 32];
+                key.copy_from_slice(&bytes);
+                tcfs_crypto::MasterKey::from_bytes(key)
+            });
+        let enc_ctx = master_key
+            .as_ref()
+            .map(|mk| tcfs_sync::engine::EncryptionContext {
+                master_key: mk.clone(),
+            });
 
-    let result = tcfs_sync::reconcile::execute_plan(
-        &plan,
-        &op,
-        &local_root,
-        &remote_prefix,
-        &mut state,
-        &device_id,
-        enc_ctx.as_ref(),
-        None,
-    )
-    .await
-    .context("executing reconciliation plan")?;
+        let result = tcfs_sync::reconcile::execute_plan(
+            &plan,
+            &op,
+            &local_root,
+            &remote_prefix,
+            &mut state,
+            &device_id,
+            enc_ctx.as_ref(),
+            None,
+        )
+        .await
+        .context("executing reconciliation plan")?;
 
-    state.flush().context("flushing state cache")?;
+        state.flush().context("flushing state cache")?;
 
-    println!(
-        "Done: {} pushed, {} pulled, {} deleted, {} conflicts, {} errors",
-        result.pushed,
-        result.pulled,
-        result.deleted_local + result.deleted_remote,
-        result.conflicts_recorded,
-        result.errors.len()
-    );
+        println!(
+            "Done: {} pushed, {} pulled, {} deleted, {} conflicts, {} errors",
+            result.pushed,
+            result.pulled,
+            result.deleted_local + result.deleted_remote,
+            result.conflicts_recorded,
+            result.errors.len()
+        );
 
-    for (path, err) in &result.errors {
-        eprintln!("  error: {path}: {err}");
+        for (path, err) in &result.errors {
+            eprintln!("  error: {path}: {err}");
+        }
+    }
+
+    if !orphan_chunk_cleanup_grace.is_zero() {
+        println!();
+        println!(
+            "Sweeping orphaned remote chunks older than {} seconds...",
+            config.sync.orphan_chunk_cleanup_grace_secs
+        );
+
+        let cleanup = tcfs_sync::reconcile::cleanup_orphaned_chunks(
+            &op,
+            &remote_prefix,
+            orphan_chunk_cleanup_grace,
+            SystemTime::now(),
+        )
+        .await
+        .context("cleaning orphaned remote chunks")?;
+
+        println!(
+            "Orphan cleanup: {} found, {} deleted, {} within grace, {} missing timestamps, {} errors",
+            cleanup.orphaned_chunks_found,
+            cleanup.deleted_chunks.len(),
+            cleanup.skipped_within_grace.len(),
+            cleanup.skipped_missing_last_modified.len(),
+            cleanup.delete_errors.len()
+        );
+
+        for (chunk, err) in &cleanup.delete_errors {
+            eprintln!("  orphan cleanup error: {chunk}: {err}");
+        }
     }
 
     Ok(())

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -272,6 +272,9 @@ pub struct SyncConfig {
     /// Reconciles local sync_root against remote index, applying per-folder policies.
     /// Default: 300 (5 minutes).
     pub reconcile_interval_secs: u64,
+    /// Grace period before orphaned remote chunk objects are eligible for cleanup.
+    /// 0 = disabled. Default: 86400 (24 hours).
+    pub orphan_chunk_cleanup_grace_secs: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -420,6 +423,7 @@ impl Default for SyncConfig {
             trash_enabled: true,
             trash_retention_secs: 30 * 24 * 3600, // 30 days
             reconcile_interval_secs: 300,         // 5 minutes
+            orphan_chunk_cleanup_grace_secs: 24 * 3600,
         }
     }
 }
@@ -463,6 +467,7 @@ nats_tls = true
 workers = 4
 max_retries = 5
 sync_root = "/home/user/tcfs"
+orphan_chunk_cleanup_grace_secs = 7200
 
 [fuse]
 negative_cache_ttl_secs = 60
@@ -488,6 +493,7 @@ argon2_parallelism = 8
             config.sync.sync_root,
             Some(PathBuf::from("/home/user/tcfs"))
         );
+        assert_eq!(config.sync.orphan_chunk_cleanup_grace_secs, 7200);
         assert_eq!(config.fuse.cache_max_mb, 20480);
         assert!(config.crypto.enabled);
         assert_eq!(config.crypto.argon2_mem_cost_kib, 131072);
@@ -513,6 +519,7 @@ argon2_parallelism = 8
         assert_eq!(config.storage.bucket, "tcfs");
         assert_eq!(config.sync.nats_url, "nats://localhost:4222");
         assert!(config.sync.nats_tls);
+        assert_eq!(config.sync.orphan_chunk_cleanup_grace_secs, 24 * 3600);
         assert!(!config.crypto.enabled);
         assert_eq!(config.crypto.argon2_mem_cost_kib, 65536);
         assert!(config.config_file_mode_check);

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use secrecy::ExposeSecret;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 use tcfs_core::config::TcfsConfig;
 use tcfs_sync::conflict::ConflictResolver;
 use tracing::{debug, error, info, warn};
@@ -996,6 +997,14 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             let recon_op = operator.clone();
             let recon_device = device_id.clone();
             let recon_master_key = impl_.master_key_handle();
+            let orphan_chunk_cleanup_grace_secs = config.sync.orphan_chunk_cleanup_grace_secs;
+            let orphan_chunk_cleanup_sweep_interval_secs = if orphan_chunk_cleanup_grace_secs > 0 {
+                orphan_chunk_cleanup_grace_secs
+                    .min(3600)
+                    .max(recon_interval)
+            } else {
+                0
+            };
             let _recon_policy_path = data_dir.join("folder-policies.json");
 
             info!(
@@ -1004,10 +1013,21 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                 root = %recon_root.display(),
                 "periodic reconciliation enabled"
             );
+            if orphan_chunk_cleanup_sweep_interval_secs > 0 {
+                info!(
+                    grace_secs = orphan_chunk_cleanup_grace_secs,
+                    sweep_interval_secs = orphan_chunk_cleanup_sweep_interval_secs,
+                    "periodic orphan chunk cleanup enabled"
+                );
+            }
 
             tokio::spawn(async move {
-                let mut interval =
-                    tokio::time::interval(std::time::Duration::from_secs(recon_interval));
+                let mut interval = tokio::time::interval(Duration::from_secs(recon_interval));
+                let orphan_chunk_cleanup_grace =
+                    Duration::from_secs(orphan_chunk_cleanup_grace_secs);
+                let orphan_chunk_cleanup_sweep_interval =
+                    Duration::from_secs(orphan_chunk_cleanup_sweep_interval_secs);
+                let mut last_orphan_chunk_sweep = None;
                 // Skip the first immediate tick — startup index discovery covers it
                 interval.tick().await;
 
@@ -1050,54 +1070,99 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                     let s = &plan.summary;
                     if s.pushes == 0 && s.pulls == 0 && s.conflicts == 0 {
                         debug!(up_to_date = s.up_to_date, "reconcile: nothing to do");
-                        continue;
-                    }
+                    } else {
+                        info!(
+                            pushes = s.pushes,
+                            pulls = s.pulls,
+                            conflicts = s.conflicts,
+                            up_to_date = s.up_to_date,
+                            "reconcile: executing plan"
+                        );
 
-                    info!(
-                        pushes = s.pushes,
-                        pulls = s.pulls,
-                        conflicts = s.conflicts,
-                        up_to_date = s.up_to_date,
-                        "reconcile: executing plan"
-                    );
+                        // Build encryption context from master key (if loaded)
+                        let mk_guard = recon_master_key.lock().await;
+                        let enc_ctx =
+                            mk_guard
+                                .as_ref()
+                                .map(|k| tcfs_sync::engine::EncryptionContext {
+                                    master_key: k.clone(),
+                                });
+                        drop(mk_guard);
 
-                    // Build encryption context from master key (if loaded)
-                    let mk_guard = recon_master_key.lock().await;
-                    let enc_ctx = mk_guard
-                        .as_ref()
-                        .map(|k| tcfs_sync::engine::EncryptionContext {
-                            master_key: k.clone(),
-                        });
-                    drop(mk_guard);
-
-                    let mut cache = recon_state.lock().await;
-                    match tcfs_sync::reconcile::execute_plan(
-                        &plan,
-                        &op,
-                        &recon_root,
-                        &recon_prefix,
-                        &mut cache,
-                        &recon_device,
-                        enc_ctx.as_ref(),
-                        None,
-                    )
-                    .await
-                    {
-                        Ok(result) => {
-                            info!(
-                                pushed = result.pushed,
-                                pulled = result.pulled,
-                                errors = result.errors.len(),
-                                bytes_up = result.bytes_uploaded,
-                                bytes_down = result.bytes_downloaded,
-                                "reconcile: plan executed"
-                            );
-                            if let Err(e) = cache.flush() {
-                                warn!("reconcile: state cache flush failed: {e}");
+                        let mut cache = recon_state.lock().await;
+                        match tcfs_sync::reconcile::execute_plan(
+                            &plan,
+                            &op,
+                            &recon_root,
+                            &recon_prefix,
+                            &mut cache,
+                            &recon_device,
+                            enc_ctx.as_ref(),
+                            None,
+                        )
+                        .await
+                        {
+                            Ok(result) => {
+                                info!(
+                                    pushed = result.pushed,
+                                    pulled = result.pulled,
+                                    errors = result.errors.len(),
+                                    bytes_up = result.bytes_uploaded,
+                                    bytes_down = result.bytes_downloaded,
+                                    "reconcile: plan executed"
+                                );
+                                if let Err(e) = cache.flush() {
+                                    warn!("reconcile: state cache flush failed: {e}");
+                                }
+                            }
+                            Err(e) => {
+                                warn!("reconcile: plan execution failed: {e}");
                             }
                         }
-                        Err(e) => {
-                            warn!("reconcile: plan execution failed: {e}");
+                    }
+
+                    let now = SystemTime::now();
+                    let should_sweep_orphan_chunks = orphan_chunk_cleanup_sweep_interval_secs > 0
+                        && last_orphan_chunk_sweep
+                            .and_then(|last| now.duration_since(last).ok())
+                            .map(|elapsed| elapsed >= orphan_chunk_cleanup_sweep_interval)
+                            .unwrap_or(true);
+
+                    if should_sweep_orphan_chunks {
+                        match tcfs_sync::reconcile::cleanup_orphaned_chunks(
+                            &op,
+                            &recon_prefix,
+                            orphan_chunk_cleanup_grace,
+                            now,
+                        )
+                        .await
+                        {
+                            Ok(report) => {
+                                last_orphan_chunk_sweep = Some(now);
+                                if report.orphaned_chunks_found == 0
+                                    && report.delete_errors.is_empty()
+                                {
+                                    debug!(
+                                        scanned = report.scanned_chunks,
+                                        "reconcile: no orphaned chunks found"
+                                    );
+                                } else {
+                                    info!(
+                                        orphaned_found = report.orphaned_chunks_found,
+                                        deleted = report.deleted_chunks.len(),
+                                        within_grace = report.skipped_within_grace.len(),
+                                        missing_last_modified =
+                                            report.skipped_missing_last_modified.len(),
+                                        delete_errors = report.delete_errors.len(),
+                                        scanned = report.scanned_chunks,
+                                        referenced = report.referenced_chunks,
+                                        "reconcile: orphan chunk sweep completed"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                warn!("reconcile: orphan chunk cleanup failed: {e}");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- add sync config for orphan chunk cleanup grace so cleanup policy is explicit
- run orphan chunk cleanup from tcfs reconcile --execute and report the cleanup outcome
- run periodic daemon orphan chunk sweeps on a bounded cadence derived from the grace period

## Validation
- cargo fmt --all --check
- cargo test -p tcfs-core test_parse_ --offline
- cargo test -p tcfs-sync cleanup_orphaned_chunks --offline
- cargo check -p tcfs-cli -p tcfsd --offline

Closes #231.