### PR TITLE
[codex] Sign release container image by digest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,6 +430,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push image
+        id: build_image
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -456,13 +457,15 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
-          # Sign each tag with keyless (OIDC-based) signing
-          for TAG in \
-            "${{ needs.plan.outputs.image_repo }}:${{ needs.plan.outputs.tag }}" \
-            "${{ needs.plan.outputs.image_repo }}:${{ needs.plan.outputs.version }}" \
-            "${{ needs.plan.outputs.image_repo }}:latest"; do
-            cosign sign --yes "${TAG}"
-          done
+          # Sign the pushed image digest once. The tags above all resolve to the
+          # same manifest, so signing mutable tags individually is unnecessary
+          # and more failure-prone than signing the immutable digest directly.
+          IMAGE_DIGEST="${{ steps.build_image.outputs.digest }}"
+          if [ -z "$IMAGE_DIGEST" ]; then
+            echo "::error::docker/build-push-action did not return an image digest"
+            exit 1
+          fi
+          cosign sign --yes "${{ needs.plan.outputs.image_repo }}@${IMAGE_DIGEST}"
 
   # ── Nix build + Attic cache push ─────────────────────────────────────────
 


### PR DESCRIPTION
## What Changed

- changed the release workflow to sign the pushed GHCR image by immutable digest instead of signing three mutable tags individually
- gave the `docker/build-push-action` step an `id` so the digest output can be referenced directly by the Cosign step

## Why

`v0.12.0` published real release artifacts and container tags, but the overall release workflow still concluded `failure`. The most plausible weak point is keyless-signing the mutable tags one-by-one after the image push.

Signing the single pushed digest is the tighter contract and avoids unnecessary tag-level signing churn.

## Impact

- narrows the release contract to the actual immutable artifact we publish
- should improve the odds that tagged release runs finish fully green
- does not change the container tags users pull; it only changes how we sign the image

## Validation

- `git diff --check`
- workflow stanza reviewed locally in clean worktree off `origin/main`
- still requires a real tagged release run in GitHub Actions to prove end-to-end

## Tracking

- closes the first implementation slice for #262
