### PR TITLE
[codex] Reduce overstatement in platform support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ releases, or contributor workflow.
 - **Fleet sync**: Multi-machine sync via NATS JetStream with vector clock conflict detection
 - **Content-addressed storage**: FastCDC chunking, BLAKE3 hashing, zstd compression
 - **Git-safe**: Syncs `.git/` directories as atomic bundles with lock detection
-- **Cross-platform**: Linux (FUSE/NFS), macOS (FileProvider/NFS), Windows (Cloud Files API, planned)
+- **Cross-platform**: Linux is the best-supported runtime; macOS has packaged but still experimental desktop surfaces; Windows remains planned
 
 ## Quick Start
 
@@ -111,13 +111,13 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full system design.
 | Feature | Linux | macOS | Windows | iOS |
 |---------|-------|-------|---------|-----|
 | CLI (push/pull/reconcile) | Full | Full | Planned | - |
-| Daemon (gRPC + metrics) | systemd | launchd | Planned | - |
-| Filesystem mount | FUSE3 | NFS loopback | Cloud Files API (skeleton) | - |
-| FileProvider | - | Full (Finder integration) | - | Read-only |
-| Finder/Explorer badges | - | 6 states | - | - |
+| Daemon (gRPC + metrics) | Full | Available, lightly validated | Planned | - |
+| Filesystem mount | Full (FUSE3, NFS fallback) | Experimental | Cloud Files API (skeleton) | - |
+| FileProvider | - | Experimental | - | Proof-of-concept, read-only |
+| Finder/Explorer badges | - | Experimental | - | - |
 | D-Bus integration | Full | - | - | - |
-| Fleet sync (NATS) | Full | Full | Planned | - |
-| E2E encryption | Full | Full | Planned | Full |
+| Fleet sync (NATS) | Full | Core path available, not continuously acceptance-tested | Planned | - |
+| E2E encryption | Full | Full | Planned | Core crypto path available |
 
 See [docs/platform-support.md](docs/platform-support.md) for details.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 **FOSS self-hosted odrive replacement**
 
-tcfs is a FUSE-based file sync daemon backed by [SeaweedFS](https://github.com/seaweedfs/seaweedfs) with end-to-end [age](https://age-encryption.org) encryption, content-defined chunking, on-demand hydration via `.tc` stub files, and multi-machine fleet sync with vector clocks.
+tcfs is a self-hosted encrypted file sync system backed by [SeaweedFS](https://github.com/seaweedfs/seaweedfs) with end-to-end [age](https://age-encryption.org) encryption, content-defined chunking, on-demand hydration via `.tc` stub files, and multi-machine fleet sync with vector clocks. Linux is the best-supported runtime today; Apple desktop and mobile surfaces exist but are still experimental.
 
 ## Installation
 
@@ -57,7 +57,7 @@ nix develop github:Jesssullivan/tummycrypt
 
 1. **Push**: Files are split into content-defined chunks (FastCDC), compressed (zstd), encrypted (age), and uploaded to SeaweedFS via S3. Vector clock is ticked and SyncManifest v2 (JSON) is written.
 2. **Pull**: Manifests describe the chunk layout. Chunks are fetched, verified (BLAKE3), decrypted, decompressed, and reassembled. Vector clock is merged with remote.
-3. **Mount**: FUSE driver presents remote files as local. Files appear as `.tc` stubs until opened — then they're hydrated on demand.
+3. **Mount**: The local filesystem surface presents remote files as local. On Linux this is exercised primarily through FUSE. Apple desktop surfaces are still evolving and should be treated as experimental.
 4. **Unsync**: Convert hydrated files back to stubs, reclaiming disk space while keeping the remote copy.
 5. **Fleet Sync**: NATS JetStream distributes `StateEvent` messages across devices. Vector clocks detect conflicts; pluggable resolvers handle them (auto, interactive, or defer).
 
@@ -136,9 +136,10 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 |----------|--------|-------|
 | Linux x86_64 | Full | FUSE mount, CLI, daemon, TUI, MCP |
 | Linux aarch64 | Full | FUSE mount, CLI, daemon, TUI, MCP |
-| macOS (Apple Silicon) | CLI + FUSE-T | Daemon over Unix socket; FileProvider extension in progress (RFC 0002) |
-| macOS (Intel) | CLI + FUSE-T | Daemon over Unix socket; FileProvider extension in progress (RFC 0002) |
+| macOS (Apple Silicon) | Experimental | CLI and daemon build, release `.pkg`, and FileProvider packaging exist, but user-facing acceptance coverage is still limited |
+| macOS (Intel) | Experimental | CLI binaries ship, but the desktop integration story is not yet as proven as Linux |
 | Windows x86_64 | CLI only | Cloud Files API skeleton; no FUSE or daemon |
+| iOS | Proof-of-concept | Read-only FileProvider direction; CI type-checks Swift, but there is no continuously proven TestFlight/App Store lane |
 | NixOS | Full | Flake + NixOS module + Home Manager module |
 
 ## License

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,10 +1,13 @@
 # Platform Support
 
 tcfs targets Linux, macOS, Windows, and iOS with varying feature completeness.
+The repo is under active development, so "supported" here means "currently
+shipped and evidenced," not "long-term stable."
 
 ## Linux (Primary)
 
-Full feature support. Production-ready.
+Best-supported runtime. This is the platform with the strongest continuous CI
+coverage and the clearest end-to-end validation story.
 
 - **CLI**: All commands (push, pull, reconcile, policy, resolve, mount, unsync)
 - **Daemon**: systemd user service with auto-restart, metrics (Prometheus), health checks
@@ -15,21 +18,22 @@ Full feature support. Production-ready.
 - **Encryption**: XChaCha20-Poly1305 per-chunk, Argon2id KDF
 - **Build targets**: x86_64 (.tar.gz, .deb, .rpm), aarch64 (.tar.gz, .deb)
 
-## macOS (Full)
+## macOS (Experimental Desktop Surface)
 
-Full feature support. Production-ready.
+macOS has real release artifacts and desktop integration code, but the current
+evidence is weaker than Linux. Treat it as an experimental surface rather than
+as a production-proven platform.
 
-- **CLI**: All commands
-- **Daemon**: launchd agent with KeepAlive, auto-restart, Developer ID signed
-- **FileProvider**: Native macOS Finder integration (13,000+ items, on-demand hydration)
-- **Finder Sync**: Badge overlays (synced, syncing, locked, conflict, excluded, pinned)
-- **Progress**: Download progress bars in Finder via NSProgress
-- **NFS loopback**: Primary mount method (no macFUSE/fuse-t dependency)
-- **Fleet sync**: Full NATS JetStream support
-- **Notifications**: macOS User Notifications for conflict detection
-- **Encryption**: Full E2E encryption with BIP-39 recovery
+- **CLI**: Builds and ships for Apple Silicon and Intel
+- **Daemon**: Launchd-oriented runtime exists, but user-facing acceptance coverage is still limited
+- **FileProvider**: Packaged macOS FileProvider app exists in releases, but Finder-level claims should be treated as experimental until stronger acceptance coverage exists
+- **Finder badges / progress**: Implemented in code, not yet continuously proven by system-level tests
+- **Filesystem surface**: Experimental; Linux remains the better-proven mount/runtime path
+- **Fleet sync**: Core sync engine and NATS path are shared with Linux, but macOS-specific acceptance coverage is not yet at the same bar
+- **Encryption**: Core crypto path is shared and available
 - **Build targets**: aarch64 (.tar.gz, .pkg with notarization), x86_64 (.tar.gz)
 - **Homebrew**: `brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap && brew install tcfs`
+- **Current proof**: CI covers Rust builds plus Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts; broader desktop UX proof is still pending
 
 ## Windows (Planned)
 
@@ -61,14 +65,15 @@ Windows 10 1809+ placeholder files. 10 TODOs remain before functional:
 - No CI build matrix for Windows (disabled in release.yml)
 - No Windows test infrastructure
 
-## iOS (Read-only)
+## iOS (Proof-of-Concept)
 
-FileProvider extension with read-only access.
+The iOS direction exists, but it is not yet a continuously proven distribution
+surface.
 
 - **FileProvider**: NSFileProviderExtension with enumeration + hydration
 - **UniFFI**: Swift bindings via uniffi-bindgen
 - **Encryption**: Full E2E decryption support
-- **Build**: Xcode project via xcodegen, type-checked in CI
+- **Build**: Swift sources type-check in CI; Xcode/TestFlight remains a manual lane
 - **Status**: Proof-of-concept, not in App Store
 
 ### Limitations
@@ -76,6 +81,7 @@ FileProvider extension with read-only access.
 - No background sync
 - No conflict resolution UI
 - Requires manual provisioning profile setup
+- No continuously exercised TestFlight or App Store delivery lane
 
 ## Container (K8s Worker)
 


### PR DESCRIPTION
## What Changed

- toned down the top-level platform claims in `README.md`
- updated `docs/index.md` to describe Linux as the best-supported runtime and Apple surfaces as experimental
- rewrote `docs/platform-support.md` so macOS and iOS status reflects the current evidence instead of describing them as production-proven

## Why

The repo has stronger evidence for Linux and the core sync engine than it does for Apple desktop/mobile UX. The previous docs overstated current platform proof, especially around Finder/FileProvider and iOS/TestFlight.

## Impact

- makes the public repo surfaces more truthful relative to shipped artifacts and CI coverage
- reduces the mismatch between the release/testing reality and the platform-support docs
- intentionally does not finish the `CHANGELOG.md` backfill yet; that can land as a follow-on slice under #264

## Validation

- `git diff --check`
- focused manual review of `README.md`, `docs/index.md`, and `docs/platform-support.md`

## Tracking

- partial slice for #264
