### PR TITLE
[codex] Add named neo-honey live smoke lane

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -87,6 +87,10 @@ fleet-check:
     @echo "Checking fleet NATS connectivity..."
     nats server info --server nats://nats.tcfs.tummycrypt.dev:4222
 
+# Canonical live fleet acceptance lane: SeaweedFS + NATS + neo↔honey sync path
+neo-honey-smoke:
+    bash scripts/neo-honey-smoke.sh
+
 # ── Nix ─────────────────────────────────────────────────────────────────────
 
 # Build tcfsd via Nix

--- a/docs/ops/fleet-deployment.md
+++ b/docs/ops/fleet-deployment.md
@@ -86,6 +86,42 @@ tcfs status
 tcfs sync-status
 ```
 
+### Canonical Live Acceptance Lane: `neo-honey`
+
+`neo-honey` is the named live fleet smoke lane for tummycrypt. It is the
+canonical manual acceptance path for proving that the real SeaweedFS + NATS
+stack still supports the end-to-end multi-device flow.
+
+What it covers:
+
+- SeaweedFS health check
+- NATS + JetStream connectivity
+- live push → pull roundtrip against the shared bucket
+- two-device sync semantics using the canonical smoke identities `neo` and `honey`
+
+Run it with:
+
+```bash
+export AWS_ACCESS_KEY_ID=<from seaweedfs-admin secret>
+export AWS_SECRET_ACCESS_KEY=<from seaweedfs-admin secret>
+just neo-honey-smoke
+```
+
+Optional overrides:
+
+```bash
+export TCFS_S3_ENDPOINT=http://100.120.66.67:8333
+export TCFS_S3_BUCKET=tcfs
+export TCFS_NATS_URL=nats://nats.tcfs.tummycrypt.dev:4222
+```
+
+Implementation notes:
+
+- wrapper script: `scripts/neo-honey-smoke.sh`
+- underlying test file: `tests/e2e/tests/fleet_live.rs`
+- this is a manual acceptance lane today, not a continuously scheduled CI lane
+- release readiness can cite this lane explicitly instead of referring to ad hoc live test runs
+
 ### Fallback Behavior
 
 tcfs works without NATS. If NATS is unreachable:

--- a/scripts/neo-honey-smoke.sh
+++ b/scripts/neo-honey-smoke.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export TCFS_E2E_LIVE=1
+export TCFS_E2E_SCENARIO="${TCFS_E2E_SCENARIO:-neo-honey}"
+export TCFS_S3_ENDPOINT="${TCFS_S3_ENDPOINT:-http://100.120.66.67:8333}"
+export TCFS_S3_BUCKET="${TCFS_S3_BUCKET:-tcfs}"
+export TCFS_NATS_URL="${TCFS_NATS_URL:-nats://100.71.19.127:4222}"
+
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set for neo-honey smoke}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set for neo-honey smoke}"
+
+echo "==> tcfs live acceptance lane: ${TCFS_E2E_SCENARIO}"
+echo "    S3 endpoint: ${TCFS_S3_ENDPOINT}"
+echo "    S3 bucket:   ${TCFS_S3_BUCKET}"
+echo "    NATS URL:    ${TCFS_NATS_URL}"
+
+tests=(
+  seaweedfs_health_check
+  nats_connect_and_jetstream
+  live_push_pull_roundtrip
+  neo_honey_two_device_sync_smoke
+)
+
+for test_name in "${tests[@]}"; do
+  echo ""
+  echo "==> Running ${test_name}"
+  cargo test -p tcfs-e2e --test fleet_live "${test_name}" -- --nocapture
+done
+
+echo ""
+echo "==> neo-honey smoke lane complete"

--- a/tests/e2e/tests/fleet_live.rs
+++ b/tests/e2e/tests/fleet_live.rs
@@ -5,6 +5,7 @@
 //! - NATS JetStream: nats-tcfs (100.71.19.127:4222)
 //!
 //! Gated by TCFS_E2E_LIVE=1. Skips automatically otherwise.
+//! The canonical live acceptance lane is `neo-honey`.
 //!
 //! Run:
 //!   TCFS_E2E_LIVE=1 \
@@ -14,12 +15,19 @@
 //!   AWS_SECRET_ACCESS_KEY=<from k8s secret seaweedfs-admin> \
 //!   TCFS_NATS_URL=nats://100.71.19.127:4222 \
 //!   cargo test -p tcfs-e2e --test fleet_live -- --nocapture
+//!
+//! Or run the named smoke lane wrapper:
+//!   just neo-honey-smoke
 
 use std::time::Duration;
 
 use futures::StreamExt;
 use tcfs_e2e::write_test_file;
 use tempfile::TempDir;
+
+const NEO_DEVICE: &str = "neo";
+const HONEY_DEVICE: &str = "honey";
+const NEO_HONEY_PREFIX: &str = "neo-honey";
 
 /// Check if live E2E is enabled via env var
 fn live_enabled() -> bool {
@@ -206,7 +214,7 @@ async fn live_nats_pubsub_roundtrip() {
 // ── Two-device sync simulation via NATS ──────────────────────────────────
 
 #[tokio::test]
-async fn live_two_device_sync_via_nats() {
+async fn neo_honey_two_device_sync_smoke() {
     if !live_enabled() {
         eprintln!("SKIP: TCFS_E2E_LIVE not set");
         return;
@@ -219,7 +227,7 @@ async fn live_two_device_sync_via_nats() {
     let tmp_a = TempDir::new().unwrap();
     let tmp_b = TempDir::new().unwrap();
     let test_id = uuid::Uuid::new_v4().to_string();
-    let prefix = format!("e2e-sync/{}", &test_id[..8]);
+    let prefix = format!("{}/{}", NEO_HONEY_PREFIX, &test_id[..8]);
 
     // Subscribe to sync events before pushing
     let subject = format!("tcfs.sync.{}", prefix.replace('/', "."));
@@ -237,7 +245,7 @@ async fn live_two_device_sync_via_nats() {
         &prefix,
         &mut state_a,
         None,
-        "device-a",
+        NEO_DEVICE,
         Some("sync.txt"),
         None,
     )
@@ -246,7 +254,7 @@ async fn live_two_device_sync_via_nats() {
 
     // Device A publishes sync event to NATS
     let event = serde_json::json!({
-        "device": "device-a",
+        "device": NEO_DEVICE,
         "action": "push",
         "path": "sync.txt",
         "manifest": upload.remote_path,
@@ -266,7 +274,7 @@ async fn live_two_device_sync_via_nats() {
 
     let received: serde_json::Value =
         serde_json::from_slice(&msg.payload).expect("parse sync event");
-    assert_eq!(received["device"], "device-a");
+    assert_eq!(received["device"], NEO_DEVICE);
     assert_eq!(received["action"], "push");
 
     // Device B: pull the file using manifest from event
@@ -279,7 +287,7 @@ async fn live_two_device_sync_via_nats() {
         &dst_b,
         &prefix,
         None,
-        "device-b",
+        HONEY_DEVICE,
         None,
         None,
     )
@@ -290,8 +298,11 @@ async fn live_two_device_sync_via_nats() {
     assert_eq!(&pulled, content, "device B got different content");
 
     eprintln!(
-        "Two-device sync verified: A pushed {} bytes, B pulled {} bytes via NATS",
-        upload.bytes, download.bytes
+        "neo-honey smoke verified: {neo} pushed {} bytes, {honey} pulled {} bytes via NATS",
+        upload.bytes,
+        download.bytes,
+        neo = NEO_DEVICE,
+        honey = HONEY_DEVICE,
     );
 
     // Cleanup


### PR DESCRIPTION
## What Changed

- named the canonical live fleet acceptance lane `neo-honey`
- added `scripts/neo-honey-smoke.sh` as the runnable wrapper for the real SeaweedFS + NATS smoke path
- added `just neo-honey-smoke` to the operator command surface
- updated `docs/ops/fleet-deployment.md` to document the lane, required credentials, and what it proves
- aligned the live two-device fleet test to use the canonical smoke identities `neo` and `honey`

## Why

The repo already had real live fleet tests, but they were env-gated and ad hoc. There was no named acceptance lane that release readiness could point at.

This change makes the live path explicit without pretending it is continuously scheduled CI.

## Impact

- gives tummycrypt one clear manual acceptance lane for real infrastructure
- makes ops/docs/repo language consistent around `neo-honey`
- keeps the proof narrow: storage health, JetStream connectivity, push/pull, and two-device sync semantics

## Validation

- `bash -n scripts/neo-honey-smoke.sh`
- `just --list | rg neo-honey-smoke`
- `nix develop . --command cargo fmt --all --check`
- `nix develop . --command cargo test -p tcfs-e2e --test fleet_live neo_honey_two_device_sync_smoke -- --nocapture`

## Tracking

- first implementation slice for #263
