### PR TITLE
[codex] Record Apple surfaces as experimental

### DIFF
--- a/docs/ops/apple-surface-status.md
+++ b/docs/ops/apple-surface-status.md
@@ -1,0 +1,49 @@
+# Apple Surface Status
+
+As of 2026-04-15, the Apple lane is an experimental surface, not an active
+release target.
+
+## Current Evidence
+
+- CI proves Rust staticlib builds plus Swift type-check coverage.
+- Release automation can package macOS artifacts, including a FileProvider app
+  bundle and Apple Silicon `.pkg`.
+- The repo contains real macOS and iOS FileProvider code paths.
+
+## What Is Not Yet Proven
+
+- No continuously exercised iOS simulator or device acceptance lane.
+- No automated TestFlight promotion or verification lane.
+- No named macOS Finder/FileProvider smoke path comparable to the `neo-honey`
+  fleet lane.
+- No repo-wide evidence that Finder badges, hydration, and conflict flows are
+  exercised end-to-end on every release.
+
+## Posture
+
+Treat Apple surfaces as buildable and manually explorable, but experimental.
+
+That means:
+
+- keep the Swift and Rust Apple code paths compiling
+- keep macOS packaging and codesigning flows functional
+- allow manual TestFlight or local FileProvider experiments
+- avoid claiming production-ready Finder or iOS parity until stronger evidence
+  exists
+
+## Why `swift/fileprovider` And `swift/ios` Both Exist
+
+- `swift/fileprovider` is the macOS packaging lane: FileProvider bundle
+  assembly, Finder-related integration, notarization helpers, and macOS app
+  artifacts
+- `swift/ios` is the iOS lane: host app, iOS FileProvider extension, xcodegen
+  project spec, and manual TestFlight/upload tooling
+
+They are related, but they do not represent the same shipping surface.
+
+## Exit Criteria To Become An Active Release Target
+
+- Simulator or device-backed acceptance coverage for iOS
+- A real macOS Finder/FileProvider smoke path
+- A repeatable TestFlight or equivalent Apple distribution lane
+- Docs that can point to those validation surfaces directly

--- a/docs/rfc/0003-ios-file-provider.md
+++ b/docs/rfc/0003-ios-file-provider.md
@@ -1,9 +1,9 @@
 # RFC 0003: iOS File Provider Extension
 
-**Status**: Phase 7b In Progress (iOS project scaffold)
+**Status**: Experimental scaffold (Phase 7b in progress)
 **Author**: xoxd
 **Date**: 2026-02-22 (updated 2026-03-07)
-**Tracking**: Phase 7b — Swift sources + build script ready, needs Xcode project
+**Tracking**: Swift sources + build script exist, but Apple surfaces remain experimental pending stronger acceptance coverage
 
 ---
 
@@ -14,9 +14,14 @@ tcfs storage in the iOS Files app. The extension reuses existing Rust crates
 (tcfs-storage, tcfs-chunks, tcfs-crypto, tcfs-sync) via Mozilla UniFFI, bridging
 to Swift for the native FileProviderExtension API.
 
+Current posture note: this is still an experimental surface. The repo has
+working scaffolding and build scripts, but not a continuously proven iOS
+distribution lane. See [`docs/ops/apple-surface-status.md`](../ops/apple-surface-status.md).
+
 ## Motivation
 
-iOS is a first-class target for tcfs. Users should be able to:
+iOS remains an experimental target for tcfs. The intent is for users to
+eventually be able to:
 
 - Browse their tcfs files in the iOS Files app
 - Open files on-demand (hydration from SeaweedFS)
@@ -223,7 +228,7 @@ enum ProviderError {
 - [x] Sync status dashboard in host app (live file count + error display)
 - [x] Host app type-checks with UniFFI bindings
 - [ ] Share extension for uploading
-- [ ] TestFlight beta (requires Apple Developer Program enrollment)
+- [ ] Manual TestFlight beta path (requires Apple Developer Program enrollment)
 
 ## Technical Challenges
 

--- a/docs/rfc/0004-fuse-free-architecture.md
+++ b/docs/rfc/0004-fuse-free-architecture.md
@@ -15,6 +15,10 @@ persistent source of deployment friction — macFUSE requires a kernel extension
 users must manually approve, FUSE-T works but adds an unnecessary abstraction layer
 over NFS, and both require third-party libraries that complicate packaging.
 
+This RFC describes a target architecture, not the current Apple release posture.
+As of M9, macOS and iOS surfaces remain experimental. See
+[`docs/ops/apple-surface-status.md`](../ops/apple-surface-status.md).
+
 The replacement architecture uses three platform-native backends:
 
 | Platform | Backend | Kernel Module? | Mount Path |
@@ -167,9 +171,13 @@ pub trait VirtualFilesystem: Send + Sync {
 
 ### FileProvider as primary macOS/iOS backend
 
-FileProvider is already working (iOS TestFlight deployed, macOS .appex exists).
+FileProvider code exists on both macOS and iOS, but the Apple lane is not yet a
+fully proven release target. Current evidence is build scripts, packaging work,
+and Swift type-check coverage rather than a continuously exercised user-facing
+acceptance path.
+
 With the `VirtualFilesystem` trait, the FileProvider extension's `DirectBackend`
-becomes a thin adapter:
+can become a thin adapter:
 
 ```swift
 // FileProviderExtension.swift (existing)
@@ -234,7 +242,7 @@ Future Linux backend priority:
 4. Update fleet deployment: remove FUSE-T installation from Nix config
 5. Update E2E tests to validate NFS mounts
 
-### Phase 4: FileProvider as primary macOS path (parallel with Phase 2)
+### Phase 4: FileProvider as future primary macOS path (parallel with Phase 2)
 
 1. Complete macOS FileProvider domain registration (already scaffolded)
 2. Wire FileProvider's `DirectBackend` to use `VirtualFilesystem` trait

--- a/swift/README.md
+++ b/swift/README.md
@@ -1,0 +1,21 @@
+# Swift Surface Layout
+
+The Apple code in this repo is split intentionally.
+
+- `fileprovider/`
+  - macOS-oriented packaging lane
+  - FileProvider bundle assembly
+  - Finder-related integration and notarization helpers
+- `ios/`
+  - iOS host app and FileProvider extension
+  - xcodegen project spec
+  - manual build and TestFlight upload tooling
+
+Both surfaces are experimental as of M9.
+
+The current contract is:
+
+- keep them buildable
+- keep packaging scripts usable for manual validation
+- avoid presenting them as continuously proven release surfaces until stronger
+  simulator, Finder, and distribution evidence exists

--- a/swift/fileprovider/build.sh
+++ b/swift/fileprovider/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build script for TCFS FileProvider extension.
+# Build script for the experimental TCFS macOS FileProvider extension.
 # Compiles Swift sources, links Rust staticlib, assembles .appex bundle.
 #
 # Usage:

--- a/swift/ios/Scripts/upload.sh
+++ b/swift/ios/Scripts/upload.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Upload IPA to TestFlight.
+# Upload an experimental IPA build to TestFlight.
 #
 # Usage:
 #   ./Scripts/upload.sh              # Upload build/export/TCFS.ipa
@@ -24,7 +24,7 @@ if [ ! -f "$ASC_KEY_PATH" ]; then
     exit 1
 fi
 
-echo "==> Uploading to TestFlight"
+echo "==> Uploading experimental build to TestFlight"
 echo "    IPA: $UPLOAD_IPA ($(du -h "$UPLOAD_IPA" | cut -f1))"
 
 clean_exec /usr/bin/xcrun altool --upload-app \
@@ -34,5 +34,5 @@ clean_exec /usr/bin/xcrun altool --upload-app \
     --apiIssuer "$ASC_ISSUER_ID"
 
 echo ""
-echo "==> Upload complete! Check App Store Connect for processing."
+echo "==> Experimental upload complete. Check App Store Connect for processing."
 echo "    https://appstoreconnect.apple.com"


### PR DESCRIPTION
## Summary
- add an explicit Apple surface status note declaring macOS and iOS experimental
- reconcile RFC 0003 and RFC 0004 with that posture
- explain why `swift/fileprovider` and `swift/ios` both exist and tone down Apple build-script claims

## Validation
- git diff --check
- bash -n swift/ios/Scripts/upload.sh

Closes #265