### PR TITLE
[codex] Let manual release dispatch exercise tag-gated jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # Release pipeline for tummycrypt/tcfs
 #
-# Triggered by git tag push (v*.*.*) or manual dispatch.
+# Triggered by git tag push (v*.*.*) or manual dispatch with an explicit tag.
 # Builds cross-platform binaries, .deb/.rpm packages, container images,
 # creates GitHub Release with installers and Homebrew formula.
 #
@@ -759,7 +759,11 @@ jobs:
     name: Build macOS installer (.pkg)
     runs-on: macos-14
     needs: [plan, build-binaries, build-fileprovider]
-    if: startsWith(github.ref, 'refs/tags/v') && !cancelled()
+    if: |
+      !cancelled() && (
+        startsWith(github.ref, 'refs/tags/v') ||
+        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
+      )
     steps:
       - uses: actions/checkout@v4
 
@@ -946,7 +950,11 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [plan, build-binaries, build-image, generate-installers, build-fileprovider, build-pkg]
-    if: startsWith(github.ref, 'refs/tags/v') && !cancelled()
+    if: |
+      !cancelled() && (
+        startsWith(github.ref, 'refs/tags/v') ||
+        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
+      )
 
     steps:
       - name: Download all artifacts
@@ -1066,7 +1074,11 @@ jobs:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
     needs: [plan, create-release]
-    if: startsWith(github.ref, 'refs/tags/v') && !cancelled()
+    if: |
+      !cancelled() && (
+        startsWith(github.ref, 'refs/tags/v') ||
+        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
+      )
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- let `workflow_dispatch` with an explicit `v*` tag reach the `.pkg`, GitHub Release, and Homebrew jobs
- make the workflow comment match the actual behavior
- keep the existing tag-push behavior unchanged

## Validation
- git diff --check

Refs #262