### PR TITLE
[codex] Prepare v0.12.1 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2026-04-15
+
+### Added
+
+- **Named live acceptance lane**: `neo-honey` is now the canonical live SeaweedFS + NATS + two-device smoke path, with a documented script and matching e2e naming.
+- **Failure-oriented validation**: added targeted coverage for manifest/index crash windows, retry backoff behavior, NATS durable replay semantics, live storage outage recovery, and CLI/gRPC/MCP/FUSE workflow paths.
+- **Orphan chunk reporting and cleanup**: reconcile can now surface orphaned remote chunks and clean them up conservatively after a grace period.
+
+### Changed
+
+- Release workflow now signs GHCR images by immutable digest, honors explicit tags on manual proof runs, and no longer lets Apple notarization outages fail the entire release.
+- Release notes and platform/docs surfaces now describe Apple notarization as attempted rather than guaranteed, and keep Apple packaging positioned as experimental.
+
+### Fixed
+
+- **Crash-safe rel-path publish**: manifest/index publication now uses recovery-aware staged, preparing, and committed index states with deterministic crash-window recovery.
+- **Upload and path correctness**: fixed upload TOCTOU races, Unicode rel-path normalization, gRPC push path traversal rejection, manifest-read retries, and resumable key rotation.
+- **State and lifecycle correctness**: fixed StateCache metadata persistence, PathLocks cleanup under contention, orphan cleanup wiring, and rename/delete sync lifecycle handling across CLI and FUSE flows.
+
 ## [0.12.0] - 2026-04-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-auth"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-chunks"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cloudfilter"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "prost",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-crypto"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aes-siv",
  "anyhow",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-dbus"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-e2e"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-file-provider"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-fuse"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-mcp"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-nfs"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-secrets"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sops"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-storage"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sync"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-tui"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-vfs"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "tcfsd"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,7 @@
         tcfsd-app = pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin (
           pkgs.stdenv.mkDerivation {
             pname = "tcfsd-app";
-            version = tcfsd.version or "0.12.0";
+            version = tcfsd.version or "0.12.1";
             dontUnpack = true;
             buildInputs = [ pkgs.darwin.sigtool ];
             installPhase = ''

--- a/swift/daemon/resources/Info.plist
+++ b/swift/daemon/resources/Info.plist
@@ -14,9 +14,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>0.12.0</string>
+    <string>0.12.1</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.12.0</string>
+    <string>0.12.1</string>
     <key>LSMinimumSystemVersion</key>
     <string>15.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
Refs #262

This prepares the next real release from current `main` so the release-hardening work can be proven on an honest new tag instead of mutating `v0.12.0`.

Scope:
- bump workspace/package surfaces from `0.12.0` to `0.12.1`
- update `Cargo.lock` workspace package versions
- update the Darwin daemon bundle version metadata
- add a `0.12.1` changelog entry summarizing the post-`v0.12.0` durability, validation, and release-hardening delta

Validation:
- `git diff --check`
- `plutil -lint swift/daemon/resources/Info.plist`
- `nix develop . --command cargo check --workspace --locked`

Once this lands, the next step is a real `v0.12.1` tag and release workflow run from current `main`.