### PR TITLE
[codex] Build release FileProvider staticlib with grpc backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -654,7 +654,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build staticlib
-        run: cargo build -p tcfs-file-provider --release
+        run: cargo build -p tcfs-file-provider --release --no-default-features --features grpc
 
       - name: Import signing certificate
         env:


### PR DESCRIPTION
Refs #262

The `v0.12.1` release run is currently blocked in `Build FileProvider extension` because the workflow builds `tcfs-file-provider` with default features (`direct`), but the Swift FileProvider extension links against the gRPC-only watch symbol `tcfs_provider_start_watch`.

This narrows the fix to the release workflow:
- build the FileProvider staticlib with `--no-default-features --features grpc`

Validation:
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`\n- `nix develop . --command cargo build -p tcfs-file-provider --release --no-default-features --features grpc`\n- `nm -g target/release/libtcfs_file_provider.a | rg tcfs_provider_start_watch`\n\nObserved release failure context:\n- run: https://github.com/Jesssullivan/tummycrypt/actions/runs/24476529299\n- job: `Build FileProvider (macOS)`\n- failure: undefined symbol `_tcfs_provider_start_watch` while linking the Swift extension