### PR TITLE
[codex] Vendor OpenSSL for macOS arm64 release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
             deb: false
             rpm: false
             sign: true
+            vendored-ssl: true
 
           # Windows x86_64 — disabled until tcfs-cli compiles on Windows
           # (connect_daemon uses Unix sockets, needs cfg(windows) TCP fallback)
@@ -181,7 +182,10 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install protobuf
-          # Native target uses system OpenSSL; cross targets use vendored (openssl-vendored feature)
+          # Only install Homebrew OpenSSL for targets that intentionally link it.
+          # Release artifacts that ship signed binaries should prefer vendored
+          # OpenSSL so they do not depend on a Homebrew dylib being present and
+          # accepted by macOS library validation on the destination machine.
           if [[ "${{ matrix.vendored-ssl }}" != "true" ]]; then
             brew install openssl@3
             echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
@@ -213,7 +217,8 @@ jobs:
           if [[ "${{ matrix.fuse }}" == "true" ]]; then
             FEATURES=""  # use default features (includes fuse)
           fi
-          # Vendor OpenSSL for cross-compilation targets (no system libssl available)
+          # Vendor OpenSSL for release targets that should not depend on a
+          # Homebrew libssl runtime on the destination machine.
           EXTRA_FEATURES=""
           if [[ "${{ matrix.vendored-ssl }}" == "true" ]]; then
             EXTRA_FEATURES="--features openssl-vendored"


### PR DESCRIPTION
## Summary
- vendor OpenSSL for the `macos-aarch64` release target like the existing `macos-x86_64` target
- stop teaching the release workflow to rely on a Homebrew `openssl@3` dylib for shipped signed macOS artifacts
- document that signed release binaries should avoid Homebrew libssl runtime dependencies on destination machines

## Why
First M10 `v0.12.1` install smoke found a real macOS runtime defect:
- Homebrew install only worked via a custom-tap workaround because the documented tap command is stale
- both the Homebrew-installed and `.pkg`-installed `tcfsd` binaries failed to launch because dyld rejected `/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib` with a Team ID mismatch against the hardened Developer ID-signed daemon binary

This change targets the release workflow regression behind that failure. `macos-x86_64` already uses `vendored-ssl`; `macos-aarch64` was the outlier.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- local `aarch64-apple-darwin` release build with `--features openssl-vendored` started cleanly and reached the final `tcfsd` link path using the vendored OpenSSL archive path

Refs: #281
