### PR TITLE
[codex] Correct Homebrew tap flow documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1029,8 +1029,10 @@ jobs:
 
             **Homebrew:**
             ```bash
-            brew tap ${{ github.repository }} https://github.com/${{ github.repository }} --branch homebrew-tap
-            brew install tcfs
+            brew tap --custom-remote ${{ github.repository }} https://github.com/${{ github.repository }}.git
+            git -C "$(brew --repo ${{ github.repository }})" fetch origin homebrew-tap
+            git -C "$(brew --repo ${{ github.repository }})" checkout homebrew-tap
+            brew install ${{ github.repository }}/tcfs
             ```
 
             **Container image:**
@@ -1156,8 +1158,10 @@ jobs:
           ## Usage
 
           ```bash
-          brew tap ${{ github.repository }} https://github.com/${{ github.repository }} --branch homebrew-tap
-          brew install tcfs
+          brew tap --custom-remote ${{ github.repository }} https://github.com/${{ github.repository }}.git
+          git -C "$(brew --repo ${{ github.repository }})" fetch origin homebrew-tap
+          git -C "$(brew --repo ${{ github.repository }})" checkout homebrew-tap
+          brew install ${{ github.repository }}/tcfs
           ```
           EOF
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ task check
 # Linux (installer script)
 curl -fsSL https://github.com/Jesssullivan/tummycrypt/releases/latest/download/install.sh | sh
 
-# macOS (Homebrew tap from canonical repo)
-brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap
-brew install tcfs
+# macOS (Homebrew, current manual tap flow)
+brew tap --custom-remote Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt.git
+git -C "$(brew --repo Jesssullivan/tummycrypt)" fetch origin homebrew-tap
+git -C "$(brew --repo Jesssullivan/tummycrypt)" checkout homebrew-tap
+brew install Jesssullivan/tummycrypt/tcfs
 
 # Debian/Ubuntu
 sudo dpkg -i tcfs-*.deb

--- a/dist/homebrew-tcfs.rb
+++ b/dist/homebrew-tcfs.rb
@@ -1,7 +1,9 @@
 # Homebrew formula for tcfs
 # To use:
-#   brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap
-#   brew install tcfs
+#   brew tap --custom-remote Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt.git
+#   git -C "$(brew --repo Jesssullivan/tummycrypt)" fetch origin homebrew-tap
+#   git -C "$(brew --repo Jesssullivan/tummycrypt)" checkout homebrew-tap
+#   brew install Jesssullivan/tummycrypt/tcfs
 #
 # This template is used by CI to generate the versioned formula.
 # Placeholders: __VERSION__, __SHA256_DARWIN_ARM64__, __SHA256_DARWIN_X86_64__,

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,11 @@ Download the latest release from [GitHub Releases](https://github.com/Jesssulliv
 # Linux (x86_64)
 curl -fsSL https://github.com/Jesssullivan/tummycrypt/releases/latest/download/install.sh | sh
 
-# macOS (Homebrew tap from canonical repo)
-brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap
-brew install tcfs
+# macOS (Homebrew, current manual tap flow)
+brew tap --custom-remote Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt.git
+git -C "$(brew --repo Jesssullivan/tummycrypt)" fetch origin homebrew-tap
+git -C "$(brew --repo Jesssullivan/tummycrypt)" checkout homebrew-tap
+brew install Jesssullivan/tummycrypt/tcfs
 
 # Debian/Ubuntu
 sudo dpkg -i tcfs-*.deb

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -31,8 +31,8 @@ as a production-proven platform.
 - **Filesystem surface**: Experimental; Linux remains the better-proven mount/runtime path
 - **Fleet sync**: Core sync engine and NATS path are shared with Linux, but macOS-specific acceptance coverage is not yet at the same bar
 - **Encryption**: Core crypto path is shared and available
-- **Build targets**: aarch64 (.tar.gz, .pkg with notarization), x86_64 (.tar.gz)
-- **Homebrew**: `brew tap Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt --branch homebrew-tap && brew install tcfs`
+- **Build targets**: aarch64 (.tar.gz, .pkg; notarization attempted but non-blocking), x86_64 (.tar.gz)
+- **Homebrew**: manual tap flow required today because the formula is published on the `homebrew-tap` branch, not the default branch
 - **Current proof**: CI covers Rust builds plus Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts; broader desktop UX proof is still pending
 
 ## Windows (Planned)


### PR DESCRIPTION
## Summary
- replace the stale `brew tap ... --branch homebrew-tap` instructions with the current working custom-remote flow
- update release-generated Homebrew guidance and the generated `homebrew-tap` branch README to match the real current branch layout
- narrow the macOS platform support wording so it no longer implies notarization is guaranteed for the `.pkg` path

## Why
The first real M10 `v0.12.1` smoke found that the documented Homebrew command is invalid on current Homebrew. The published formula is on the `homebrew-tap` branch, but `brew tap` no longer accepts `--branch`, so the current user-facing instructions are wrong in README, docs, the formula template comments, and the release notes template.

This PR does not solve the longer-term tap layout problem; it makes the current reality truthful and reproducible.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- verified the stale `brew tap ... --branch homebrew-tap` command no longer appears in the touched user-facing surfaces

Refs: #280

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only PR that replaces the broken `brew tap ... --branch homebrew-tap` command (flag removed in current Homebrew) with a working 4-step `--custom-remote` + manual `git checkout` flow, applied consistently across `README.md`, `docs/index.md`, `dist/homebrew-tcfs.rb`, and both Homebrew blocks in the release workflow. `docs/platform-support.md` also tightens the notarization claim to "attempted but non-blocking".

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no functional or security impact.

Changes are documentation-only and consistently correct across all five files. Both P2 comments are optional improvements (a brew update caveat and a missing link), neither of which blocks the core goal of this PR.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Installation section updated with corrected 4-step Homebrew tap flow; instructions match the other docs changes consistently. |
| .github/workflows/release.yml | Two Homebrew code blocks updated (release-notes template ~L1032 and homebrew-tap branch README generator ~L1161); both are consistent with the rest of the PR. |
| dist/homebrew-tcfs.rb | Comment header updated to reflect new tap flow; no functional formula changes. |
| docs/index.md | Installation quick-start updated with the new 4-step Homebrew flow, consistent with README.md. |
| docs/platform-support.md | Notarization claim narrowed to 'attempted but non-blocking'; Homebrew entry replaced with prose description (no inline command). |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User wants to install via Homebrew"] --> B["brew tap --custom-remote\nJesssullivan/tummycrypt\nhttps://github.com/...git"]
    B --> C["Clones repo at default branch (main)"]
    C --> D["git -C $(brew --repo ...) fetch origin homebrew-tap"]
    D --> E["git -C $(brew --repo ...) checkout homebrew-tap"]
    E --> F["Formula/tcfs.rb now visible"]
    F --> G["brew install Jesssullivan/tummycrypt/tcfs"]
    G --> H["✅ Installed"]
    G --> I["brew update (future)"]
    I --> J{"Homebrew resets tap\nto default branch?"}
    J -->|Yes| K["❌ Formula disappears\nneeds git checkout again"]
    J -->|No - tracks homebrew-tap| L["✅ Formula stays available"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 47-50

Comment:
**`brew update` silently abandons the manual checkout**

After a user runs `brew update`, Homebrew updates each tap by fetching and merging the remote's _default_ branch rather than the locally-checked-out one. For this repo (whose default branch is `main`, not `homebrew-tap`), that means the tap will silently revert to a state where the `Formula/` directory doesn't exist, and the next `brew install` or `brew upgrade` will fail with "No available formula or cask with the name 'Jesssullivan/tummycrypt/tcfs'".

Adding a one-line warning would save users the confusion:

```suggestion
# macOS (Homebrew, current manual tap flow)
# Note: run the git checkout step again after `brew update` to restore the formula branch.
brew tap --custom-remote Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt.git
git -C "$(brew --repo Jesssullivan/tummycrypt)" fetch origin homebrew-tap
git -C "$(brew --repo Jesssullivan/tummycrypt)" checkout homebrew-tap
brew install Jesssullivan/tummycrypt/tcfs
```

The same caveat applies in `docs/index.md` and both Homebrew blocks in `release.yml`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/platform-support.md
Line: 35

Comment:
**Homebrew entry no longer provides actionable install guidance**

The old line included the actual command inline; the replacement describes _why_ a manual flow is needed but doesn't point users anywhere to find the commands. Someone reading only `platform-support.md` would be left without a path to install. Consider linking to `README.md` or `docs/index.md`:

```suggestion
- **Homebrew**: manual tap flow required today because the formula is published on the `homebrew-tap` branch, not the default branch; see [README.md](../README.md#installation) for the full tap commands
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(release): correct Homebrew tap flow"](https://github.com/jesssullivan/tummycrypt/commit/d6bd2f145c9ee02a221be5e8783e1bb4dd3fa93b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28556243)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->