### PR TITLE
[codex] Pin gitleaks in Secret Scan CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   RUST_TOOLCHAIN: 1.93.0
+  GITLEAKS_VERSION: 8.30.1
 
 jobs:
   check:
@@ -160,8 +161,8 @@ jobs:
           fetch-depth: 0
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep tag_name | cut -d '"' -f 4 | sed 's/^v//')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | sudo tar xz -C /usr/local/bin gitleaks
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin gitleaks
       - name: Scan for secrets
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then


### PR DESCRIPTION
## Summary
- pin the gitleaks release version used by the `Secret Scan` job
- stop scraping GitHub's unauthenticated `releases/latest` API during CI startup
- keep the install path aligned with the currently published `linux_x64` release asset

## Why
`#283` exposed that the `Secret Scan` job can fail even on benign branches because it shells out to the unauthenticated GitHub API, extracts a version string, and then builds a download URL dynamically. In practice that produced a `404` during CI startup rather than a real secret finding.

Pinning the gitleaks asset removes that source of CI drift and gives us a stable secret-scan baseline again.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `curl .../gitleaks_8.30.1_linux_x64.tar.gz | tar tz | head`
