### PR TITLE
feat(greptile): add review configuration and coding standards

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,28 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style"],
+  "triggerOnUpdates": true,
+  "triggerOnDrafts": false,
+  "ignorePatterns": "target/**\nCargo.lock\nbuild/**\n*.generated.*\n.build/**\nDerivedData/**",
+  "statusCheck": true,
+  "fixWithAI": true,
+  "shouldUpdateDescription": true,
+  "summarySection": { "included": true, "collapsible": false, "defaultOpen": true },
+  "issuesTableSection": { "included": true, "collapsible": true, "defaultOpen": true },
+  "sequenceDiagramSection": { "included": true, "collapsible": true, "defaultOpen": false },
+  "instructions": "Encrypted filesystem with iOS/macOS FileProvider integration. Security-critical codebase. Review all crypto operations, unsafe blocks, and FFI boundaries with extra scrutiny. Ensure Swift/Rust bridging is memory-safe.",
+  "patternRepositories": ["tinyland-inc/ci-templates"],
+  "customContext": {
+    "rules": [
+      "Every `unsafe` block must have a SAFETY comment explaining the invariants",
+      "Crypto operations must use audited crates (ring, rustcrypto), never hand-rolled",
+      "FFI boundaries between Rust and Swift must validate all pointer arguments",
+      "Error types must implement Display and Error traits",
+      "No unwrap() or expect() in library code; use proper error propagation"
+    ],
+    "files": [
+      { "path": "CLAUDE.md", "description": "Project conventions and context", "scope": ["**"] },
+      { "path": "Cargo.toml", "description": "Rust workspace and dependency definitions", "scope": ["**/*.rs"] }
+    ]
+  }
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,4 @@
+[
+  { "path": "CLAUDE.md", "description": "Project conventions and context", "scope": ["**"] },
+  { "path": "Cargo.toml", "description": "Rust workspace and dependency definitions", "scope": ["**/*.rs"] }
+]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,30 @@
+# tummycrypt: Repo-Specific Review Rules
+
+Inherits all rules from `_org-enforced-rules.md`.
+
+## Rust
+
+- Every `unsafe` block requires a `// SAFETY:` comment explaining why it is sound and what invariants must hold.
+- No `unwrap()` or `expect()` in library code. Use `?` operator and proper `Result`/`Option` handling.
+- Error types must implement `std::fmt::Display` and `std::error::Error`.
+- Use `#[must_use]` on functions that return values the caller should not ignore.
+- Prefer `&str` over `String` in function parameters where ownership is not needed.
+- Run `cargo clippy` clean before merging.
+
+## Cryptography
+
+- Only use audited cryptography crates (`ring`, `rustcrypto` ecosystem, `sodiumoxide`). Never hand-roll crypto.
+- Key material must be zeroized on drop (`zeroize` crate).
+- Review any changes to encryption/decryption paths with heightened scrutiny.
+
+## Swift / Apple Integration
+
+- FileProvider extension must handle all NSFileProviderError cases.
+- Rust-Swift FFI: validate all raw pointers at the boundary. Null checks are mandatory.
+- Use `@objc` only where required for system framework callbacks.
+- Memory passed across FFI must have clear ownership semantics documented in comments.
+
+## Nix
+
+- Build expressions must produce reproducible outputs.
+- Flake checks should include `cargo test` and `cargo clippy`.


### PR DESCRIPTION
Adds .greptile/ configuration folder with:
- config.json: review behavior, crypto-focused strictness, ignore patterns
- rules.md: Rust safety, crypto auditing, FFI boundary, and error handling standards
- files.json: reference to CLAUDE.md and Cargo.toml for context

Part of Greptile Phase 1 rollout (TIN-58).