### PR TITLE
[codex] Ignore flaky Apple FileProvider API link in docs check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -3,6 +3,7 @@ exclude = [
   "^https://github.com/tinyland-inc/remote-juggler",
   "^https://nix-cache.fuzzy-dev.tinyland.dev",
   "^https://docs.tummycrypt.io",
+  "^https://developer.apple.com/documentation/fileprovider/nsfileproviderreplicatedextension$",
   "your-org",
   "localhost",
   "127\\.0\\.0\\.1",


### PR DESCRIPTION
## Summary
- ignore the Apple FileProvider API URL that is intermittently returning 502 to lychee
- keep the exception scoped to the exact URL already referenced in 
- unblock unrelated docs PRs from inheriting a flaky external check

## Validation
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single lychee exclusion for `https://developer.apple.com/documentation/fileprovider/nsfileproviderreplicatedextension` to prevent the intermittent 502 responses from that Apple developer docs URL from failing CI link checks. The exclusion is tightly scoped with both `^` and `$` anchors, so it matches only that exact URL and won't suppress checks for any other Apple documentation links.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line config exclusion with no functional code changes.

The change is a one-line addition to a link-checker exclusion list, anchored precisely with ^ and $ so it covers only the exact flaky URL. No Rust, Swift, crypto, or FFI code is touched. All remaining findings are P2 or lower, so 5/5 is appropriate.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .lychee.toml | Adds one tightly-anchored regex exclusion for the flaky Apple FileProvider API doc URL; no other changes to the config. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[lychee scans docs] --> B{URL in exclude list?}
    B -- Yes: exact match via regex --> C[Skip / pass silently]
    B -- No --> D[HTTP request to URL]
    D --> E{Response code?}
    E -- 2xx --> F[✅ Link OK]
    E -- 502 / error --> G[❌ CI failure]
    C -.->|"new: ^https://developer.apple.com/documentation/fileprovider/nsfileproviderreplicatedextension$"| H[Apple FileProvider doc bypassed]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(docs): ignore flaky Apple FileProvide..."](https://github.com/jesssullivan/tummycrypt/commit/d3914c630387f4ba6bb5b1225341fedff0ede624) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28560965)</sub>

<!-- /greptile_comment -->