### PR TITLE
[codex] Preserve state keying after delete

### DIFF
--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -923,10 +923,20 @@ impl StateCacheBackend for StateBackend {
     }
 }
 
-/// Convert a path to a normalized string key for the HashMap
+/// Convert a path to a normalized string key for the HashMap.
+///
+/// Uses `canonicalize` to resolve symlinks (for example `/var` ->
+/// `/private/var` on macOS). When the file itself is gone, fall back to
+/// canonicalizing the parent directory and reattaching the filename so remove
+/// and lookup still hit the same key that was used while the file existed.
 fn path_key(path: &Path) -> String {
-    // Use the canonicalized absolute path as the key
     std::fs::canonicalize(path)
+        .or_else(|_| {
+            path.parent()
+                .and_then(|parent| std::fs::canonicalize(parent).ok())
+                .map(|parent| parent.join(path.file_name().unwrap_or_default()))
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "no parent"))
+        })
         .unwrap_or_else(|_| path.to_path_buf())
         .to_string_lossy()
         .into_owned()
@@ -1061,6 +1071,48 @@ mod tests {
         cache.remove(&fake_path);
         assert_eq!(cache.len(), 0);
         assert!(cache.get(&fake_path).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_entry_after_delete_through_symlinked_parent() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut cache = StateCache::open(&path).unwrap();
+
+        let real_dir = dir.path().join("real");
+        let link_dir = dir.path().join("link");
+        std::fs::create_dir_all(&real_dir).unwrap();
+        symlink(&real_dir, &link_dir).unwrap();
+
+        let linked_path = link_dir.join("to_remove.txt");
+        let real_path = real_dir.join("to_remove.txt");
+        std::fs::write(&linked_path, b"data").unwrap();
+
+        cache.set(
+            &linked_path,
+            SyncState {
+                blake3: "hash1".into(),
+                size: 4,
+                mtime: 1000,
+                chunk_count: 1,
+                remote_path: "bucket/to_remove.txt".into(),
+                last_synced: 9999,
+                vclock: VectorClock::new(),
+                device_id: String::new(),
+                conflict: None,
+                status: Default::default(),
+            },
+        );
+        assert_eq!(cache.len(), 1);
+
+        std::fs::remove_file(&real_path).unwrap();
+        cache.remove(&linked_path);
+
+        assert_eq!(cache.len(), 0);
+        assert!(cache.get(&linked_path).is_none());
     }
 
     #[test]

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -690,18 +690,9 @@ impl TcfsDaemon for TcfsDaemonImpl {
                     }
                 }
 
-                // Write index entry for discoverability (same as CLI push)
-                if !upload.skipped {
-                    let index_key =
-                        format!("{}/index/{}", prefix.trim_end_matches('/'), &normalized_rel);
-                    let index_entry = format!(
-                        "manifest_hash={}\nsize={}\nchunks={}\n",
-                        upload.hash, total_bytes, upload.chunks
-                    );
-                    if let Err(e) = op.write(&index_key, index_entry.into_bytes()).await {
-                        tracing::warn!("failed to write index entry: {e}");
-                    }
-                }
+                // Rel-path publication is owned by upload_file_with_device so
+                // the daemon follows the same crash-aware manifest/index flow
+                // as CLI and tree push.
 
                 // Publish state event if NATS is connected and file was actually uploaded
                 if !upload.skipped {


### PR DESCRIPTION
## Summary
- preserve state-cache keying when a tracked file is deleted through a symlinked parent path
- add a regression test covering the delete-after-canonicalize case on Unix
- remove the daemon-side duplicate rel-path index rewrite so gRPC push stays on the engine's crash-aware publish flow

## Why
Deleting a tracked file through a symlinked parent could leave a stale state entry behind because `path_key()` canonicalized existing files but fell back to the raw input path after deletion.

The daemon also rewrote the rel-path index entry after `upload_file_with_device` had already published it, bypassing the engine's single crash-aware manifest/index path.

## Validation
- `nix develop . --command cargo test -p tcfs-sync --lib test_remove_entry_after_delete_through_symlinked_parent`
- `nix develop . --command cargo test -p tcfs-sync --test e2e_conflict_resolution --test e2e_state_transition_chains --test e2e_two_device_sync`
- `nix develop . --command cargo test -p tcfsd status_returns_version`
- `nix develop . --command cargo fmt --all --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a stale-entry bug in `path_key()` where deleting a file through a symlinked parent would leave the state cache entry behind because the post-deletion fallback skipped symlink resolution on the parent. It also removes a duplicate index write in the gRPC push handler that bypassed the engine's staged, crash-aware `publish_manifest_for_rel_path` flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are well-reasoned, correctly implemented, and covered by tests.

No P0 or P1 findings. The `path_key()` fix is logically correct (parent canonicalization produces the same key used during `set()`), verified by the new regression test. The grpc.rs removal eliminates a duplicate, protocol-bypassing index write without any loss of functionality since `upload_file_with_device` already owns the full staged/committed flow. Both remaining comments are P2 style suggestions.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tcfs-sync/src/state.rs | Adds parent-canonicalization fallback to `path_key()` so post-deletion remove/get calls resolve the same HashMap key as the original set; regression test added under `#[cfg(unix)]`. |
| crates/tcfsd/src/grpc.rs | Removes the redundant direct index write after `upload_file_with_device`; the engine already handles the full staged/committed index flow when `rel_path` is provided. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["path_key(path)"] --> B{"canonicalize(path) succeeds?"}
    B -- Yes --> C["Use full canonical path as key"]
    B -- No --> D{"canonicalize(parent) succeeds?"}
    D -- Yes --> E["canonical_parent + file_name()"]
    D -- No --> F["Raw path.to_path_buf() fallback"]
    E --> G["HashMap key"]
    C --> G
    F --> G

    subgraph grpc_push ["gRPC Push flow (after PR)"]
        H["upload_file_with_device(rel_path=Some)"] --> I["publish_manifest_for_rel_path"]
        I --> I1["Write staged manifest"]
        I1 --> I2["Write preparing index entry"]
        I2 --> I3["Write final manifest"]
        I3 --> I4["Write committed index entry"]
        I4 --> I5["Delete staged manifest"]
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: crates/tcfs-sync/src/state.rs
Line: 937

Comment:
**`file_name()` silent empty-key edge case**

`path.file_name().unwrap_or_default()` returns an empty `OsStr` when the path has no filename component (e.g. `"/"`, `"."`, `".."`). In that case `parent.join("")` produces just the canonical parent, which could silently collide with a directory key. This can't happen for real tracked files, but a small inline comment would make the intent explicit.

Or simply add:
```rust
// file_name() is None only for root / `.` / `..`; those cannot be tracked
// file paths, so the empty fallback is unreachable in practice.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: crates/tcfs-sync/src/state.rs
Line: 1076-1120

Comment:
**Consider testing when the symlink itself is removed before `remove()`**

The new test covers deletion of the *target file* while the symlink directory still resolves. A complementary case worth considering: the symlink `link_dir` is also removed before `cache.remove()`. In that scenario both `canonicalize(linked_path)` and `canonicalize(link_dir)` fail, so `path_key()` falls back to the raw path — which won't match the original canonicalized key. The entry would remain stale. A test or a doc comment on `path_key()` noting this known limitation would help future readers understand the boundary of the fix.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sync): preserve state keying after d..."](https://github.com/jesssullivan/tummycrypt/commit/d829ccdb34d829e3ace9ac454ee2c96e283ea13d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28575814)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->