### PR TITLE
[codex] Define distribution smoke matrix for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1042,11 +1042,12 @@ jobs:
 
             **Debian/Ubuntu:**
             ```bash
+            curl -LO https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.tag }}/tcfsd-${{ needs.plan.outputs.version }}-amd64.deb
             curl -LO https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.tag }}/tcfs-${{ needs.plan.outputs.version }}-amd64.deb
-            sudo dpkg -i tcfs-${{ needs.plan.outputs.version }}-amd64.deb
+            sudo dpkg -i tcfsd-${{ needs.plan.outputs.version }}-amd64.deb tcfs-${{ needs.plan.outputs.version }}-amd64.deb
             ```
 
-            **RPM (Fedora/RHEL/Rocky):**
+            **RPM (Fedora/RHEL/Rocky, daemon-only today):**
             ```bash
             curl -LO https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.tag }}/tcfsd-${{ needs.plan.outputs.version }}-x86_64.rpm
             sudo rpm -i tcfsd-${{ needs.plan.outputs.version }}-x86_64.rpm

--- a/Justfile
+++ b/Justfile
@@ -91,6 +91,10 @@ fleet-check:
 neo-honey-smoke:
     bash scripts/neo-honey-smoke.sh
 
+# Installed-binary smoke for release surfaces that ship tcfsd (and optionally tcfs)
+install-smoke *ARGS:
+    bash scripts/install-smoke.sh {{ARGS}}
+
 # ── Nix ─────────────────────────────────────────────────────────────────────
 
 # Build tcfsd via Nix

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ git -C "$(brew --repo Jesssullivan/tummycrypt)" checkout homebrew-tap
 brew install Jesssullivan/tummycrypt/tcfs
 
 # Debian/Ubuntu
-sudo dpkg -i tcfs-*.deb
+sudo dpkg -i tcfsd-*.deb tcfs-*.deb
+
+# RPM (Fedora/RHEL/Rocky, daemon-only today)
+sudo rpm -i tcfsd-*.rpm
 
 # Container (K8s worker mode)
 podman pull ghcr.io/jesssullivan/tcfsd:latest
@@ -107,6 +110,9 @@ crates/
 ```
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full system design.
+
+For packaged release proof across Homebrew, `.pkg`, `.deb`, `.rpm`, container,
+and Nix surfaces, see [docs/ops/distribution-smoke-matrix.md](docs/ops/distribution-smoke-matrix.md).
 
 ## Platform Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,9 @@ git -C "$(brew --repo Jesssullivan/tummycrypt)" checkout homebrew-tap
 brew install Jesssullivan/tummycrypt/tcfs
 
 # Debian/Ubuntu
-sudo dpkg -i tcfs-*.deb
+sudo dpkg -i tcfsd-*.deb tcfs-*.deb
 
-# RPM (Fedora/RHEL/Rocky)
+# RPM (Fedora/RHEL/Rocky, daemon-only today)
 sudo rpm -i tcfsd-*.rpm
 ```
 
@@ -125,6 +125,13 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 - [Contributing](CONTRIBUTING.md) — development setup, PR workflow
 - [Benchmarks](BENCHMARKS.md) — performance characteristics
 - [Changelog](../CHANGELOG.md) — release history
+
+### Ops Runbooks
+
+- [Distribution Smoke Matrix](ops/distribution-smoke-matrix.md) — canonical post-release install proof across Homebrew, `.pkg`, `.deb`, `.rpm`, container, and Nix
+- [Neo-Honey Live Acceptance](ops/neo-honey-acceptance.md) — named live fleet sync acceptance lane
+- [Fleet Deployment Guide](ops/fleet-deployment.md) — multi-machine fleet deployment and operational checks
+- [Apple Surface Status](ops/apple-surface-status.md) — current reality for macOS and iOS claims
 
 ### RFCs
 

--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -1,0 +1,208 @@
+# Distribution Smoke Matrix
+
+Canonical post-release proof for packaged distribution surfaces.
+
+As of 2026-04-16, release quality for `tcfs` means more than "artifacts exist."
+A tagged release is not considered fully proven until the shipped install
+surfaces below have passed their required smoke checks.
+
+## Gate Decision
+
+- **Fresh install proof is required on every shipped release surface for every `v0.12.x+` tag**:
+  - Homebrew
+  - macOS `.pkg`
+  - Debian/Ubuntu `.deb`
+  - Fedora/RHEL `.rpm`
+  - container image
+  - Nix package path
+- **Upgrade proof is required on the primary mutable installer surfaces**:
+  - Homebrew
+  - macOS `.pkg`
+  - Debian/Ubuntu `.deb`
+- **RPM, container, and Nix upgrade proof is sampled rather than mandatory on every tag**:
+  - RPM is daemon-only today, so its proof surface is narrower than Homebrew, `.pkg`, or `.deb`
+  - container upgrades are normally orchestrator rollouts rather than a host-local installer flow
+  - Nix installs are immutable and ref-pinned, so the per-tag fresh install gate is the most meaningful baseline
+
+## Shared Installed-Binary Smoke
+
+For any release surface that places `tcfsd` on `PATH`, run:
+
+```bash
+bash scripts/install-smoke.sh --expected-version "${VERSION}"
+```
+
+If the surface is daemon-only and does not ship `tcfs` today, run:
+
+```bash
+bash scripts/install-smoke.sh --expected-version "${VERSION}" --skip-cli
+```
+
+What this helper proves:
+
+- the installed binaries are executable
+- `tcfsd` can start with an isolated default config
+- the daemon creates its Unix socket
+- `tcfs status` works when the CLI is present on that surface
+
+What it does **not** prove:
+
+- live SeaweedFS or NATS connectivity
+- Finder or FileProvider behavior
+- service-manager integration via systemd or launchd
+- Kubernetes rollout semantics
+
+Those remain surface-specific follow-on checks, documented below.
+
+## Surface Matrix
+
+| Surface | Fresh install gate every tag | Upgrade gate every tag | Required smoke | Notes |
+|---------|------------------------------|------------------------|----------------|-------|
+| Homebrew | Yes | Yes | `scripts/install-smoke.sh` | Current manual `homebrew-tap` checkout flow |
+| macOS `.pkg` | Yes | Yes | `scripts/install-smoke.sh` | Apple Silicon package path; desktop UX still experimental |
+| Debian/Ubuntu `.deb` | Yes | Yes | `scripts/install-smoke.sh` | Install both `tcfsd` and `tcfs` packages |
+| Fedora/RHEL `.rpm` | Yes | Sampled | `scripts/install-smoke.sh --skip-cli` | RPM ships `tcfsd` only today |
+| Container image | Yes | Sampled | worker-image startup check | Pull + entrypoint/startup proof, not CLI status |
+| Nix | Yes | Sampled | `scripts/install-smoke.sh` | Fresh install from the tagged flake is the primary proof |
+
+## Surface Procedures
+
+Set the release variables first:
+
+```bash
+export TAG=v0.12.1
+export VERSION="${TAG#v}"
+```
+
+### Homebrew
+
+Fresh install:
+
+```bash
+brew untap Jesssullivan/tummycrypt 2>/dev/null || true
+brew tap --custom-remote Jesssullivan/tummycrypt https://github.com/Jesssullivan/tummycrypt.git
+git -C "$(brew --repo Jesssullivan/tummycrypt)" fetch origin homebrew-tap
+git -C "$(brew --repo Jesssullivan/tummycrypt)" checkout homebrew-tap
+brew install Jesssullivan/tummycrypt/tcfs
+bash scripts/install-smoke.sh --expected-version "${VERSION}"
+```
+
+Upgrade:
+
+```bash
+git -C "$(brew --repo Jesssullivan/tummycrypt)" fetch origin homebrew-tap
+git -C "$(brew --repo Jesssullivan/tummycrypt)" checkout homebrew-tap
+brew upgrade Jesssullivan/tummycrypt/tcfs
+bash scripts/install-smoke.sh --expected-version "${VERSION}"
+```
+
+### macOS `.pkg`
+
+Fresh install:
+
+```bash
+curl -LO "https://github.com/Jesssullivan/tummycrypt/releases/download/${TAG}/tcfs-${VERSION}-macos-aarch64.pkg"
+sudo installer -pkg "tcfs-${VERSION}-macos-aarch64.pkg" -target /
+bash scripts/install-smoke.sh --expected-version "${VERSION}"
+```
+
+Upgrade:
+
+```bash
+sudo installer -pkg "tcfs-${VERSION}-macos-aarch64.pkg" -target /
+bash scripts/install-smoke.sh --expected-version "${VERSION}"
+```
+
+### Debian/Ubuntu `.deb`
+
+Fresh install:
+
+```bash
+curl -LO "https://github.com/Jesssullivan/tummycrypt/releases/download/${TAG}/tcfsd-${VERSION}-amd64.deb"
+curl -LO "https://github.com/Jesssullivan/tummycrypt/releases/download/${TAG}/tcfs-${VERSION}-amd64.deb"
+sudo dpkg -i "tcfsd-${VERSION}-amd64.deb" "tcfs-${VERSION}-amd64.deb"
+bash scripts/install-smoke.sh --expected-version "${VERSION}"
+```
+
+Upgrade:
+
+```bash
+sudo dpkg -i "tcfsd-${VERSION}-amd64.deb" "tcfs-${VERSION}-amd64.deb"
+bash scripts/install-smoke.sh --expected-version "${VERSION}"
+```
+
+### Fedora/RHEL/Rocky `.rpm`
+
+Fresh install:
+
+```bash
+curl -LO "https://github.com/Jesssullivan/tummycrypt/releases/download/${TAG}/tcfsd-${VERSION}-x86_64.rpm"
+sudo rpm -i "tcfsd-${VERSION}-x86_64.rpm"
+bash scripts/install-smoke.sh --expected-version "${VERSION}" --skip-cli
+```
+
+Upgrade is sampled unless the RPM packaging path changes materially:
+
+```bash
+sudo rpm -Uvh "tcfsd-${VERSION}-x86_64.rpm"
+bash scripts/install-smoke.sh --expected-version "${VERSION}" --skip-cli
+```
+
+### Container Image
+
+Fresh install proof for the worker image is:
+
+```bash
+podman pull "ghcr.io/jesssullivan/tcfsd:${TAG}"
+podman run --rm "ghcr.io/jesssullivan/tcfsd:${TAG}" --version
+timeout 10s podman run --rm --entrypoint /tcfsd \
+  "ghcr.io/jesssullivan/tcfsd:${TAG}" \
+  --mode=worker \
+  --config /tmp/missing.toml \
+  --log-format text
+```
+
+Success criteria:
+
+- the image pulls successfully
+- `tcfsd --version` reports the expected release version
+- the worker binary starts cleanly enough to emit startup logs before `timeout` stops it
+
+Full cluster rollout proof remains an infra-level check and should be paired with
+the live fleet runbooks when container packaging or worker behavior changes.
+
+### Nix
+
+Fresh install:
+
+```bash
+nix profile install \
+  "github:Jesssullivan/tummycrypt?ref=${TAG}#tcfsd" \
+  "github:Jesssullivan/tummycrypt?ref=${TAG}#tcfs-cli"
+bash scripts/install-smoke.sh --expected-version "${VERSION}"
+```
+
+Upgrade is sampled unless the flake packaging path or install story changes
+materially between releases.
+
+## Evidence Capture
+
+Record the outcome for each tag in the release issue, PR, or a maintainer comment
+using a table like this:
+
+| Surface | Fresh install | Upgrade | Smoke output captured | Notes |
+|---------|---------------|---------|-----------------------|-------|
+| Homebrew | pass/fail | pass/fail | yes/no | |
+| macOS `.pkg` | pass/fail | pass/fail | yes/no | |
+| Debian/Ubuntu `.deb` | pass/fail | pass/fail | yes/no | |
+| Fedora/RHEL `.rpm` | pass/fail | sampled/n-a | yes/no | |
+| Container image | pass/fail | sampled/n-a | yes/no | |
+| Nix | pass/fail | sampled/n-a | yes/no | |
+
+## Relationship To Other Acceptance Lanes
+
+- Use this matrix for **distribution surface proof**
+- Use [Neo-Honey Live Acceptance](neo-honey-acceptance.md) for the
+  **credentialed live fleet sync path**
+- Use [Apple Surface Status](apple-surface-status.md) for the current limits of
+  Finder, FileProvider, and iOS claims

--- a/scripts/install-smoke.sh
+++ b/scripts/install-smoke.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/install-smoke.sh [options]
+
+Starts an installed tcfsd in an isolated temp environment, waits for its socket,
+and runs `tcfs status` when the CLI is available.
+
+Options:
+  --expected-version <version>  Require tcfs/tcfsd --version output to include this string
+  --tcfs <path-or-name>         CLI binary to use (default: tcfs)
+  --tcfsd <path-or-name>        Daemon binary to use (default: tcfsd)
+  --skip-cli                    Skip tcfs status smoke; useful for daemon-only surfaces
+  --require-storage-ok          Require tcfs status to report storage [ok]
+  -h, --help                    Show this help
+EOF
+}
+
+EXPECTED_VERSION=""
+TCFS_BIN="${TCFS_BIN:-tcfs}"
+TCFSD_BIN="${TCFSD_BIN:-tcfsd}"
+SKIP_CLI=0
+REQUIRE_STORAGE_OK=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expected-version)
+      EXPECTED_VERSION="$2"
+      shift 2
+      ;;
+    --tcfs)
+      TCFS_BIN="$2"
+      shift 2
+      ;;
+    --tcfsd)
+      TCFSD_BIN="$2"
+      shift 2
+      ;;
+    --skip-cli)
+      SKIP_CLI=1
+      shift
+      ;;
+    --require-storage-ok)
+      REQUIRE_STORAGE_OK=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+resolve_bin() {
+  local candidate="$1"
+  if [[ "$candidate" == */* ]]; then
+    [[ -x "$candidate" ]] || {
+      echo "binary is not executable: $candidate" >&2
+      exit 1
+    }
+    printf '%s\n' "$candidate"
+    return
+  fi
+
+  command -v "$candidate" >/dev/null 2>&1 || {
+    echo "command not found: $candidate" >&2
+    exit 1
+  }
+  command -v "$candidate"
+}
+
+assert_version() {
+  local label="$1"
+  local bin="$2"
+  local output
+
+  output="$("$bin" --version)"
+  echo "$label version: $output"
+
+  if [[ -n "$EXPECTED_VERSION" && "$output" != *"$EXPECTED_VERSION"* ]]; then
+    echo "$label version mismatch: expected output containing '$EXPECTED_VERSION'" >&2
+    exit 1
+  fi
+}
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-install-smoke.XXXXXX")"
+CONFIG_PATH="$TMP_DIR/missing-config.toml"
+HOME_DIR="$TMP_DIR/home"
+STATE_DIR="$HOME_DIR/.local/state"
+CONFIG_DIR="$HOME_DIR/.config"
+SOCKET_PATH="$STATE_DIR/tcfsd/tcfsd.sock"
+DAEMON_LOG="$TMP_DIR/tcfsd.log"
+STATUS_LOG="$TMP_DIR/tcfs-status.log"
+daemon_pid=""
+
+cleanup() {
+  if [[ -n "$daemon_pid" ]] && kill -0 "$daemon_pid" 2>/dev/null; then
+    kill "$daemon_pid" 2>/dev/null || true
+    wait "$daemon_pid" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$STATE_DIR" "$CONFIG_DIR"
+export HOME="$HOME_DIR"
+export XDG_STATE_HOME="$STATE_DIR"
+export XDG_CONFIG_HOME="$CONFIG_DIR"
+
+TCFSD_PATH="$(resolve_bin "$TCFSD_BIN")"
+assert_version "tcfsd" "$TCFSD_PATH"
+
+if [[ "$SKIP_CLI" -eq 0 ]]; then
+  TCFS_PATH="$(resolve_bin "$TCFS_BIN")"
+  assert_version "tcfs" "$TCFS_PATH"
+else
+  TCFS_PATH=""
+fi
+
+echo "starting daemon smoke with temp home: $HOME_DIR"
+"$TCFSD_PATH" --config "$CONFIG_PATH" --log-format text >"$DAEMON_LOG" 2>&1 &
+daemon_pid="$!"
+
+for _ in $(seq 1 30); do
+  if [[ -S "$SOCKET_PATH" ]]; then
+    break
+  fi
+  if ! kill -0 "$daemon_pid" 2>/dev/null; then
+    echo "tcfsd exited before creating socket" >&2
+    cat "$DAEMON_LOG" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ ! -S "$SOCKET_PATH" ]]; then
+  echo "tcfsd did not create socket at $SOCKET_PATH" >&2
+  cat "$DAEMON_LOG" >&2 || true
+  exit 1
+fi
+
+echo "daemon socket ready: $SOCKET_PATH"
+
+if [[ "$SKIP_CLI" -eq 1 ]]; then
+  echo "CLI smoke skipped"
+  exit 0
+fi
+
+"$TCFS_PATH" --config "$CONFIG_PATH" status >"$STATUS_LOG" 2>&1 || {
+  echo "tcfs status failed" >&2
+  cat "$STATUS_LOG" >&2 || true
+  echo "--- daemon log ---" >&2
+  cat "$DAEMON_LOG" >&2 || true
+  exit 1
+}
+
+grep -q "tcfsd v" "$STATUS_LOG" || {
+  echo "tcfs status output did not include daemon version" >&2
+  cat "$STATUS_LOG" >&2 || true
+  exit 1
+}
+
+if [[ "$REQUIRE_STORAGE_OK" -eq 1 ]]; then
+  grep -Eq 'storage:.*\[ok\]' "$STATUS_LOG" || {
+    echo "tcfs status did not report storage [ok]" >&2
+    cat "$STATUS_LOG" >&2 || true
+    exit 1
+  }
+fi
+
+cat "$STATUS_LOG"
+echo "install smoke passed"


### PR DESCRIPTION
## Summary
- add `docs/ops/distribution-smoke-matrix.md` as the canonical post-release proof runbook for Homebrew, macOS `.pkg`, Debian/Ubuntu `.deb`, Fedora/RHEL `.rpm`, container, and Nix surfaces
- add `scripts/install-smoke.sh` plus a `just install-smoke` wrapper so surfaces that ship installed binaries can prove the same daemon-startup and `tcfs status` behavior without depending on a production config
- correct the incomplete `.deb` install snippets in `README.md`, `docs/index.md`, and the release body so they install both `tcfsd` and `tcfs`, and explicitly label RPM as daemon-only today

## Why
Issue `#280` is operational, not just descriptive: the repo could cut release artifacts, but it had no canonical definition of which install surfaces had to be proven, which ones required upgrade proof every tag, or what smoke command counted as success.

It also still documented Debian install as `tcfs-*.deb` only, which is incomplete for the actual CLI + daemon runtime.

This PR defines the gate and the shared helper, but it does **not** claim that a full tagged release-surface run has already been executed from this branch alone.

## Validation
- `bash -n scripts/install-smoke.sh`
- `bash scripts/install-smoke.sh --help`
- `just --justfile Justfile --list | rg "install-smoke|neo-honey-smoke"`
- `git diff --check`

Refs: #280

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defines the canonical post-release distribution smoke matrix (`docs/ops/distribution-smoke-matrix.md`) and a shared install-smoke helper script (`scripts/install-smoke.sh`) that proves daemon startup and `tcfs status` behavior across Homebrew, `.pkg`, `.deb`, `.rpm`, container, and Nix surfaces. It also corrects the previously incomplete `.deb` install snippets across `README.md`, `docs/index.md`, and the release workflow body to install both `tcfsd` and `tcfs` packages, and labels RPM as daemon-only.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 quality suggestions with no impact on correctness or security.

No Rust, crypto, FFI, or runtime-critical code is touched. The three inline comments are style-level: a missing timeout guard on `tcfs status`, a `timeout` exit-code ambiguity in the container runbook, and a fragile grep string. None of these block correct function of the smoke test today. The `.deb` fix and RPM label are straightforwardly correct.

scripts/install-smoke.sh (no timeout on CLI call, fragile version grep)

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/install-smoke.sh | New smoke-test helper; correctly isolates env via XDG overrides and traps cleanup, but `tcfs status` has no timeout guard and the version-string check is fragile. |
| docs/ops/distribution-smoke-matrix.md | Comprehensive runbook for all distribution surfaces; container smoke command exits non-zero (124) on the expected success path, which can confuse scripted use. |
| .github/workflows/release.yml | Release body corrected to download and install both `tcfsd` and `tcfs` `.deb` packages; RPM correctly labelled daemon-only; no logic changes to build or publish jobs. |
| Justfile | Adds `install-smoke` recipe forwarding `*ARGS` to the new script; consistent with existing `neo-honey-smoke` pattern. |
| README.md | `.deb` install snippet corrected to show both packages; RPM explicitly labelled daemon-only; smoke matrix cross-reference added. |
| docs/index.md | Mirrors README fix for `.deb` two-package install and RPM label; distribution smoke matrix linked under Ops Runbooks. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Release tag pushed"] --> B["release.yml: build-binaries / build-image / nix-build"]
    B --> C["create-release: GitHub Release published"]
    C --> D["Maintainer runs distribution smoke matrix"]
    D --> E{Surface}
    E --> F["Homebrew\nbrew install → install-smoke.sh"]
    E --> G["macOS .pkg\nsudo installer → install-smoke.sh"]
    E --> H["Debian/Ubuntu .deb\ndpkg -i tcfsd+tcfs → install-smoke.sh"]
    E --> I["Fedora/RHEL .rpm\nrpm -i tcfsd → install-smoke.sh --skip-cli"]
    E --> J["Container image\npodman run tcfsd --version + timeout startup"]
    E --> K["Nix\nnix profile install → install-smoke.sh"]
    F & G & H & I & K --> L["install-smoke.sh\n1. resolve binaries\n2. start tcfsd in isolated $TMPDIR\n3. wait for Unix socket\n4. tcfs status → grep 'tcfsd v'"]
    L --> M{Pass?}
    M -->|yes| N["Record in release issue table"]
    M -->|no| O["Investigate daemon log\n$TMP_DIR/tcfsd.log"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/install-smoke.sh
Line: 157-163

Comment:
**No timeout guard on `tcfs status`**

If the daemon socket exists but becomes unresponsive after creation, `tcfs status` will block indefinitely, hanging the smoke test with no cleanup. Given the script uses `set -euo pipefail` and a `trap cleanup EXIT`, a stuck CLI still prevents the exit trap from ever firing until the shell is killed externally.

```suggestion
timeout 30s "$TCFS_PATH" --config "$CONFIG_PATH" status >"$STATUS_LOG" 2>&1 || {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/ops/distribution-smoke-matrix.md
Line: 158-163

Comment:
**`timeout` exits non-zero (code 124) in container smoke**

`timeout 10s podman run ...` always exits 124 when the timer fires, which is the expected success path here. If a user pastes this block into a shell script with `set -e` or chains it with `&&`, the step fails even though the binary started correctly. Consider appending `|| [ $? -eq 124 ]` (or a prose note) so the expected success condition is unambiguous.

```suggestion
timeout 10s podman run --rm --entrypoint /tcfsd \
  "ghcr.io/jesssullivan/tcfsd:${TAG}" \
  --mode=worker \
  --config /tmp/missing.toml \
  --log-format text || { code=$?; [ "$code" -eq 124 ] || exit "$code"; }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/install-smoke.sh
Line: 165-169

Comment:
**Fragile literal string check for daemon version**

`grep -q "tcfsd v"` will silently break if the status output format changes from `"tcfsd v1.x.x"` to any other scheme (e.g., `"daemon: v1.x.x"` or `"tcfsd version 1.x.x"`). Since `EXPECTED_VERSION` is already validated earlier in `assert_version`, consider also using it here, or at minimum anchoring the pattern more precisely with something like `grep -qE 'tcfsd v[0-9]'` to catch obvious format drifts sooner.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(release): define distribution smoke..."](https://github.com/jesssullivan/tummycrypt/commit/c23117b63915e704f9aec133de877131a5299991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28580516)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->