### PR TITLE
[codex] Guard macOS release tcfsd linkage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,24 @@ jobs:
             ${EXTRA_FEATURES} \
             -p tcfsd
 
+      - name: Validate tcfsd OpenSSL linkage (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          BIN="target/${{ matrix.target }}/release/tcfsd"
+          if [ ! -f "$BIN" ]; then
+            echo "::error::expected tcfsd at ${BIN}"
+            exit 1
+          fi
+
+          echo "Inspecting ${BIN} linkage..."
+          otool -L "$BIN"
+
+          if otool -L "$BIN" | grep -E 'libssl\.3\.dylib|libcrypto\.3\.dylib' >/dev/null; then
+            echo "::error::macOS release tcfsd still links a dynamic OpenSSL dylib"
+            exit 1
+          fi
+
       # ── Build tcfs-tui ────────────────────────────────────────────────────
 
       - name: Build tcfs-tui


### PR DESCRIPTION
## Summary
- add a macOS release-time guard that runs `otool -L` on the built `tcfsd` binary
- fail the release job if the macOS daemon still links dynamic `libssl.3.dylib` or `libcrypto.3.dylib`
- keep the existing vendored-OpenSSL behavior in `main` honest for future release tags

## Why
Issue `#290` was opened after the first `#280` smoke tranche showed that the `v0.12.1` Apple surfaces were broken: the shipped `tcfsd` binary in both the `.pkg` payload and the Homebrew-staged tarball still linked `/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib`, and macOS rejected that mapping with a Team ID mismatch.

The key timeline is that `v0.12.1` was cut from commit `9942509` on April 15, 2026 at `16:34 -0400`, while the functional fix to vendor OpenSSL for `macos-aarch64` landed later in `34b68f5` / `#282` on April 15, 2026 at `17:51 -0400`.

So the release failure came from a stale tag, not from the current `main` workflow configuration. This PR adds the missing regression guard so a future tag cannot silently ship a dynamic-OpenSSL macOS daemon again.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- `git diff --check`
- verified repo history locally: `v0.12.1` target commit `9942509` predates `34b68f5` / `#282`

Refs: #290

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a regression guard to the `build-binaries` job that runs `otool -L` on the macOS `tcfsd` binary immediately after it is built and fails the job if dynamic `libssl.3.dylib` or `libcrypto.3.dylib` linkage is detected. The guard correctly runs for both macOS matrix entries (`macos-x86_64` and `macos-aarch64`), both of which already carry `vendored-ssl: true`, and is placed before packaging, signing, and artifact upload so a bad binary can never reach the release assets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the guard is a strict improvement over no check; only P2 hardening suggestions remain.

Both findings are P2: one suggests broadening the version pattern so OpenSSL 1.1 linkage is also caught, and one suggests extending the check to all signed macOS binaries. Neither represents a current defect; the guard is meaningfully better than the status quo and is correctly placed before artifact upload.

No files require special attention; both suggestions are in the new validation step in `.github/workflows/release.yml`.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds "Validate tcfsd OpenSSL linkage (macOS)" step (lines 232–248); grep pattern is version-locked to `.3.dylib` and only covers `tcfsd`, leaving OpenSSL 1.1 linkage and other signed binaries unchecked. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/release.yml
Line: 245-248

Comment:
**Guard only covers OpenSSL 3 — OpenSSL 1.1 linkage would slip through**

The grep pattern hard-codes the `.3.dylib` suffix, so if a build environment ever resolves to `libssl.1.1.dylib` (Homebrew `openssl@1.1`, still available on many runners) the check passes silently while the binary would still fail macOS library validation with the same Team ID mismatch. A version-agnostic pattern catches any Homebrew-provided OpenSSL regardless of major version:

```suggestion
          if otool -L "$BIN" | grep -E 'libssl[^/]*\.dylib|libcrypto[^/]*\.dylib' \
               | grep -v '^[[:space:]]*/usr/lib/' >/dev/null; then
            echo "::error::macOS release tcfsd still links a dynamic OpenSSL dylib"
            exit 1
          fi
```

The `/usr/lib/` exclusion ensures the system-provided LibreSSL (which is always acceptable) is not flagged.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/release.yml
Line: 232-248

Comment:
**Only `tcfsd` is validated — other signed macOS binaries are not checked**

`tcfs`, `tcfs-tui`, and `tcfs-mcp` are all built for macOS, signed, and shipped in both the tarball and `.pkg` payload. If any of those crates transitively depend on an OpenSSL crate without `--features openssl-vendored`, they would link the Homebrew dylib and trigger the same Team ID mismatch — but this guard wouldn't catch it. Consider extending the loop to cover all released binaries:

```suggestion
      - name: Validate tcfsd OpenSSL linkage (macOS)
        if: runner.os == 'macOS'
        shell: bash
        run: |
          BINDIR="target/${{ matrix.target }}/release"
          for bin in tcfsd tcfs tcfs-tui tcfs-mcp; do
            BIN="${BINDIR}/${bin}"
            [ -f "$BIN" ] || continue
            echo "Inspecting ${BIN} linkage..."
            otool -L "$BIN"
            if otool -L "$BIN" | grep -E 'libssl\.3\.dylib|libcrypto\.3\.dylib' >/dev/null; then
              echo "::error::macOS release ${bin} still links a dynamic OpenSSL dylib"
              exit 1
            fi
          done
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(release): guard macOS tcfsd linkage"](https://github.com/jesssullivan/tummycrypt/commit/8056b989df1e11c56596c66ee3874bf5494845f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28581397)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->