### PR TITLE
[codex] Align Apple support claims with current evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ and Nix surfaces, see [docs/ops/distribution-smoke-matrix.md](docs/ops/distribut
 | E2E encryption | Full | Full | Planned | Core crypto path available |
 
 See [docs/platform-support.md](docs/platform-support.md) for details.
+For the dated Apple posture, see
+[docs/ops/apple-surface-status.md](docs/ops/apple-surface-status.md).
 
 ## Development
 

--- a/docs/ops/apple-surface-status.md
+++ b/docs/ops/apple-surface-status.md
@@ -1,23 +1,59 @@
 # Apple Surface Status
 
-As of 2026-04-15, the Apple lane is an experimental surface, not an active
-release target.
+As of April 15, 2026, Apple support is a buildable and manually explorable lane,
+not a continuously proven release target.
 
-## Current Evidence
+## macOS: Proven Today
 
-- CI proves Rust staticlib builds plus Swift type-check coverage.
-- Release automation can package macOS artifacts, including a FileProvider app
-  bundle and Apple Silicon `.pkg`.
-- The repo contains real macOS and iOS FileProvider code paths.
+- CI proves the Rust staticlib and Swift build surfaces needed for FileProvider
+  packaging.
+- Release automation can build Apple Silicon artifacts, package
+  `TCFSProvider.app`, and publish `.pkg` plus tarball assets.
+- The repo contains real macOS daemon, launchd, NFS loopback, and FileProvider
+  code paths.
 
-## What Is Not Yet Proven
+## macOS: Not Yet Proven As A Release-Grade Desktop Surface
 
-- No continuously exercised iOS simulator or device acceptance lane.
-- No automated TestFlight promotion or verification lane.
-- No named macOS Finder/FileProvider smoke path comparable to the `neo-honey`
-  fleet lane.
-- No repo-wide evidence that Finder badges, hydration, and conflict flows are
-  exercised end-to-end on every release.
+- There is no continuously exercised Finder/FileProvider acceptance lane from
+  install through register, enumerate, hydrate, mutate, and conflict handling.
+- Finder badges, progress UI, and notification behavior are not release gates.
+- Post-release smoke on April 15, 2026 showed that `v0.12.1` could install on
+  Apple Silicon, but the shipped `tcfsd` failed at runtime because it linked
+  Homebrew OpenSSL dylibs with an incompatible Team ID.
+- Packaged macOS artifacts therefore still require explicit post-cut smoke even
+  when CI and packaging are green.
+
+## iOS: Current Posture
+
+- The repo carries real iOS FileProvider and UniFFI code plus CI Swift
+  type-check coverage.
+- There is still no continuously exercised simulator or device acceptance lane.
+- There is no repeatable TestFlight or App Store delivery path.
+- Treat iOS as proof-of-concept and read-only in practice until stronger
+  end-to-end evidence exists.
+
+## Working Wording
+
+Use:
+
+- `macOS: CLI/daemon plus experimental FileProvider desktop surfaces`
+- `iOS: proof-of-concept FileProvider direction`
+
+Avoid:
+
+- `macOS: full` or `production-ready`
+- `iOS: active release target`
+- claims that Finder badges, hydration, or conflict UX are release-verified
+
+## Validation Path
+
+- Keep the Apple CI lanes green.
+- Run post-release distribution smoke from
+  [Distribution Smoke Matrix](distribution-smoke-matrix.md).
+- Add a named macOS Finder/FileProvider smoke path before upgrading the public
+  posture.
+- Add simulator or device-backed iOS acceptance before claiming an active iOS
+  product surface.
 
 ## Posture
 
@@ -37,13 +73,13 @@ That means:
   assembly, Finder-related integration, notarization helpers, and macOS app
   artifacts
 - `swift/ios` is the iOS lane: host app, iOS FileProvider extension, xcodegen
-  project spec, and manual TestFlight/upload tooling
+  project spec, and manual TestFlight or upload tooling
 
 They are related, but they do not represent the same shipping surface.
 
 ## Exit Criteria To Become An Active Release Target
 
-- Simulator or device-backed acceptance coverage for iOS
 - A real macOS Finder/FileProvider smoke path
+- Simulator or device-backed acceptance coverage for iOS
 - A repeatable TestFlight or equivalent Apple distribution lane
 - Docs that can point to those validation surfaces directly

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -34,6 +34,15 @@ as a production-proven platform.
 - **Build targets**: aarch64 (.tar.gz, .pkg; notarization attempted but non-blocking), x86_64 (.tar.gz)
 - **Homebrew**: manual tap flow required today because the formula is published on the `homebrew-tap` branch, not the default branch
 - **Current proof**: CI covers Rust builds plus Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts; broader desktop UX proof is still pending
+- **Current posture**: see [Apple Surface Status](ops/apple-surface-status.md)
+  and [Distribution Smoke Matrix](ops/distribution-smoke-matrix.md)
+
+### Not Yet Proven
+
+- Fresh-install Finder/FileProvider acceptance from install through register,
+  enumerate, hydrate, mutate, and conflict handling
+- Finder badges, progress UI, or notification behavior as release gates
+- Every published macOS artifact on day zero without explicit post-cut smoke
 
 ## Windows (Planned)
 
@@ -75,6 +84,7 @@ surface.
 - **Encryption**: Full E2E decryption support
 - **Build**: Swift sources type-check in CI; Xcode/TestFlight remains a manual lane
 - **Status**: Proof-of-concept, not in App Store
+- **Current posture**: see [Apple Surface Status](ops/apple-surface-status.md)
 
 ### Limitations
 - Read-only (no upload/push from iOS)


### PR DESCRIPTION
## What changed

- enriched `docs/ops/apple-surface-status.md` with concrete April 15, 2026 macOS and iOS posture evidence
- linked `docs/platform-support.md` directly to the Apple status and distribution smoke documents
- added a README pointer so the dated Apple posture is easy to find from the main support table

## Why

The repo already narrowed its public Apple wording in some places, but the dedicated platform-support surface and Apple status doc still left the current reality too generic. This keeps the support claims anchored to the actual evidence collected during M10.

## Impact

- reduces the chance of overstating macOS Finder/FileProvider readiness
- keeps iOS positioned as proof-of-concept until there is stronger end-to-end validation
- gives future Apple-related PRs one canonical doc to update instead of drifting across multiple surfaces

## Validation

- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR enriches `docs/ops/apple-surface-status.md` with dated (April 15, 2026) macOS and iOS posture evidence and cross-links it from `docs/platform-support.md` and the README, replacing generic Apple support language with concrete observations including the `v0.12.1` runtime failure caused by Homebrew OpenSSL dylib Team ID mismatch.

All three relative Markdown links added by the PR resolve correctly: `distribution-smoke-matrix.md` in `apple-surface-status.md` is in the same `docs/ops/` directory, and `ops/apple-surface-status.md` / `ops/distribution-smoke-matrix.md` from `docs/platform-support.md` correctly resolve to `docs/ops/`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only changes with no impact on code, crypto, or FFI paths.

All three files are Markdown documentation. No code, configuration, or build artifacts are modified. Links resolve correctly, and the new content accurately narrows Apple support claims rather than overstating them. No P0 or P1 findings.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds a two-line pointer to the dated Apple posture doc beneath the platform support table; no content changes elsewhere. |
| docs/ops/apple-surface-status.md | New document providing the April 15, 2026 macOS/iOS posture snapshot with concrete evidence, wording guidance, and exit criteria; all relative links are valid. |
| docs/platform-support.md | macOS and iOS sections updated with explicit experimental/proof-of-concept caveats and links to the new Apple status and distribution smoke docs. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    README["README.md\n(Platform Support table)"] -->|"links to"| PS["docs/platform-support.md"]
    README -->|"new: dated Apple posture"| AS["docs/ops/apple-surface-status.md"]
    PS -->|"macOS section"| AS
    PS -->|"macOS section"| DSM["docs/ops/distribution-smoke-matrix.md"]
    PS -->|"iOS section"| AS
    AS -->|"Validation Path"| DSM
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(apple): align support claims with e..."](https://github.com/jesssullivan/tummycrypt/commit/3dc8d75844f28545b8135650c3e5189e2422b8ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28581591)</sub>

<!-- /greptile_comment -->