### PR TITLE
[codex] Define active iOS surface posture

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -133,12 +133,13 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 - [Fleet Deployment Guide](ops/fleet-deployment.md) — multi-machine fleet deployment and operational checks
 - [Apple Surface Status](ops/apple-surface-status.md) — current reality for macOS and iOS claims
 - [macOS Finder and FileProvider Reality](ops/macos-fileprovider-reality.md) — current macOS desktop workflow, proof gaps, and manual acceptance lane
+- [iOS Surface Status](ops/ios-surface-status.md) — current iOS scope, proof bar, and maintenance expectation
 
 ### RFCs
 
 - [RFC 0001: Fleet Sync Integration](rfc/0001-fleet-sync-integration.md) — multi-machine sync design and rollout plan
 - [RFC 0002: Darwin FUSE Strategy](rfc/0002-darwin-fuse-strategy.md) — FileProvider as primary macOS/iOS path
-- [RFC 0003: iOS File Provider](rfc/0003-ios-file-provider.md) — UniFFI bridge and .appex architecture
+- [RFC 0003: iOS File Provider](rfc/0003-ios-file-provider.md) — UniFFI bridge and experimental iOS scaffold architecture
 
 ## Platform Support
 

--- a/docs/ops/ios-surface-status.md
+++ b/docs/ops/ios-surface-status.md
@@ -1,0 +1,66 @@
+# iOS Surface Status
+
+As of April 15, 2026, iOS is an experimental FileProvider proof-of-concept,
+not an active release target.
+
+## What Exists In The Repo Today
+
+- `swift/ios/` contains a host app, FileProvider extension, generated UniFFI
+  bindings, `project.yml`, and manual signing or upload scripts.
+- `tcfs-file-provider` exposes UniFFI bindings used by the iOS extension.
+- CI runs `bash swift/ios/Scripts/build-ios.sh --simulator` on macOS runners.
+
+## What CI Actually Proves
+
+- the Rust staticlib builds for `aarch64-apple-ios-sim`
+- generated Swift bindings and the Swift sources type-check against the iOS
+  simulator SDK
+- an Xcode project can be generated from `project.yml` when `xcodegen` is
+  present
+
+It does not prove:
+
+- simulator UI automation
+- device-backed Files.app behavior
+- provisioning or signing reality on a real Apple account
+- TestFlight processing
+- App Store readiness
+
+## Near-Term Product Scope
+
+- Public posture: read-only FileProvider direction
+- Maintain browsing, enumeration, and hydration as the documented intent
+- Do not advertise upload, modify, delete, background sync, or conflict UX as
+  supported iOS features, even though experimental hooks exist in code
+
+## Why Read-Only Remains The Posture
+
+- `swift/ios/Extension/FileProviderExtension.swift` contains create, modify, and
+  delete hooks, but they are not backed by a continuously exercised acceptance
+  lane.
+- There is no simulator or device-backed end-to-end validation for iOS write
+  operations.
+- There is no repeatable TestFlight or App Store delivery lane.
+- Release and support decisions would otherwise be based on scaffolded code
+  rather than proof.
+
+## Maintenance Expectation
+
+- Keep the Rust and Swift iOS surfaces compiling.
+- Keep `build-ios.sh --simulator` green in CI.
+- Keep manual signing and upload tooling available for experiments.
+- Treat iOS write paths and distribution tooling as experimental, not release
+  blockers.
+
+## Related Documents
+
+- [Apple Surface Status](apple-surface-status.md) — cross-Apple posture
+- [RFC 0003: iOS File Provider](../rfc/0003-ios-file-provider.md) — design and
+  scaffold details
+
+## Exit Criteria For A Stronger Public Posture
+
+- simulator or device-backed acceptance coverage
+- an explicit decision on whether write support is in or out of near-term scope
+- a repeatable TestFlight or equivalent Apple distribution lane
+- docs that can point to those validation surfaces directly

--- a/docs/rfc/0003-ios-file-provider.md
+++ b/docs/rfc/0003-ios-file-provider.md
@@ -1,9 +1,9 @@
 # RFC 0003: iOS File Provider Extension
 
-**Status**: Experimental scaffold (Phase 7b in progress)
+**Status**: Experimental scaffold and reference design
 **Author**: xoxd
-**Date**: 2026-02-22 (updated 2026-03-07)
-**Tracking**: Swift sources + build script exist, but Apple surfaces remain experimental pending stronger acceptance coverage
+**Date**: 2026-02-22 (updated 2026-04-15)
+**Tracking**: Swift sources + build script exist, but the public iOS posture remains read-only proof-of-concept pending stronger acceptance coverage
 
 ---
 
@@ -16,7 +16,8 @@ to Swift for the native FileProviderExtension API.
 
 Current posture note: this is still an experimental surface. The repo has
 working scaffolding and build scripts, but not a continuously proven iOS
-distribution lane. See [`docs/ops/apple-surface-status.md`](../ops/apple-surface-status.md).
+distribution lane. See [iOS Surface Status](../ops/ios-surface-status.md) and
+[Apple Surface Status](../ops/apple-surface-status.md).
 
 ## Motivation
 
@@ -31,6 +32,17 @@ eventually be able to:
 The iOS File Provider framework provides the system integration point, similar to
 how tcfs-fuse provides Linux integration and tcfs-cloudfilter provides Windows
 integration.
+
+## Current Maintenance Scope
+
+As of April 15, 2026:
+
+- keep the iOS Rust and Swift surfaces buildable in CI
+- treat browsing, enumeration, and hydration as the documented product direction
+- treat create, modify, and delete hooks as experimental code paths rather than
+  supported user-facing scope
+- keep TestFlight and App Store tooling manual-only until there is a repeatable
+  distribution lane
 
 ## Architecture
 
@@ -195,7 +207,7 @@ enum ProviderError {
 
 ### Phase 7b: iOS Project Scaffold (IN PROGRESS)
 
-- [x] `FileProviderExtension.swift` — full CRUD via UniFFI (item, fetchContents, createItem, modifyItem, deleteItem)
+- [x] `FileProviderExtension.swift` — read path plus experimental create, modify, and delete hooks via UniFFI
 - [x] `FileProviderEnumerator.swift` — directory listing via `provider.listItems(path:)`
 - [x] `FileProviderItem.swift` — NSFileProviderItem with placeholder support
 - [x] `HostApp.swift` — SwiftUI app with credential config + domain registration
@@ -228,7 +240,7 @@ enum ProviderError {
 - [x] Sync status dashboard in host app (live file count + error display)
 - [x] Host app type-checks with UniFFI bindings
 - [ ] Share extension for uploading
-- [ ] Manual TestFlight beta path (requires Apple Developer Program enrollment)
+- [ ] Manual TestFlight beta path (requires Apple Developer Program enrollment; not a continuously proven release lane)
 
 ## Technical Challenges
 


### PR DESCRIPTION
## What changed

- added `docs/ops/ios-surface-status.md` as the canonical current-state document for the iOS surface
- tightened RFC 0003 so it describes an experimental scaffold and manual-only distribution tooling instead of implying a stronger product commitment
- linked the new iOS status doc from `docs/index.md` and clarified the RFC summary there

## Why

Issue #277 is about deciding what the repo actively maintains on iOS versus what merely exists in scaffold form. The codebase has real iOS extension code and manual TestFlight/App Store tooling, but the continuous proof bar is still only simulator-target build plus Swift type-check coverage. This PR makes that maintenance expectation explicit.

## Impact

- keeps the public iOS posture at read-only proof-of-concept
- preserves experimental write-path scaffolding in code without advertising it as supported product scope
- gives future Apple work one canonical iOS status doc to update

## Validation

- `git -C /tmp/tummycrypt-277 diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `docs/ops/ios-surface-status.md` as the dedicated canonical reference for the iOS surface posture, tightens RFC 0003 to describe an experimental scaffold rather than implying product commitment, and links both from `docs/index.md`. All three changed files are documentation only — no code, build, or CI configuration is touched.

<h3>Confidence Score: 5/5</h3>

Documentation-only PR with no code, build, or CI changes — safe to merge immediately.

All three changed files are Markdown documentation. Links resolve to existing files, content is accurate and consistent with apple-surface-status.md, and the new status doc follows the same structural pattern as the existing macos-fileprovider-reality.md. No code paths, no runtime impact. No P0 or P1 findings.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/ops/ios-surface-status.md | New file: comprehensive iOS surface status doc covering what CI proves, maintenance expectations, and exit criteria — well-structured and accurate |
| docs/rfc/0003-ios-file-provider.md | Updated status, date, cross-references, and Phase 7b description to accurately reflect read-only posture; added Current Maintenance Scope section aligned with the new status doc |
| docs/index.md | Added iOS Surface Status link to Ops Runbooks and updated RFC 0003 description to say 'experimental iOS scaffold architecture' — both changes are accurate |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CI["CI: ios-typecheck job"]

    CI --> BUILD["Rust staticlib\naarch64-apple-ios-sim ✅"]
    CI --> TYPECHECK["Swift sources type-check\nvs iOS simulator SDK ✅"]
    CI --> XCODEGEN["Xcode project generated\nfrom project.yml ✅"]

    BUILD --> NOTPROVEN["Not Proven by CI"]
    TYPECHECK --> NOTPROVEN
    XCODEGEN --> NOTPROVEN

    NOTPROVEN --> SIM["Simulator UI automation ❌"]
    NOTPROVEN --> DEVICE["Device-backed Files.app ❌"]
    NOTPROVEN --> SIGN["Provisioning / signing\non real Apple account ❌"]
    NOTPROVEN --> TF["TestFlight processing ❌"]
    NOTPROVEN --> AS["App Store readiness ❌"]

    POSTURE["Public Posture"]
    SIM --> POSTURE
    DEVICE --> POSTURE
    SIGN --> POSTURE
    TF --> POSTURE
    AS --> POSTURE

    POSTURE --> RO["Read-only FileProvider\nproof-of-concept"]
    POSTURE --> EXP["Write hooks exist\nbut are experimental,\nnot advertised"]

    style RO fill:#d4edda,stroke:#28a745
    style EXP fill:#fff3cd,stroke:#ffc107
    style NOTPROVEN fill:#f8d7da,stroke:#dc3545
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `docs/rfc/0003-ios-file-provider.md`, line 256 ([link](https://github.com/jesssullivan/tummycrypt/blob/e2f4b0c03261c864e1bb58a0e3cf8c9a0d23d9d5/docs/rfc/0003-ios-file-provider.md#L256)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`unwrap()` in code example contradicts repo rule**

   `Runtime::new().unwrap()` in this snippet will panic on allocation failure. The repo rule prohibits `unwrap()` in library code, and `tcfs-file-provider` is a library crate — a developer who copies this pattern verbatim into the actual crate source would introduce a violation. Consider adding a brief callout that this is a simplified illustration and the real implementation should propagate the error (e.g. via a `once_cell`/`OnceLock` with explicit error handling or a `Result`-returning init function).

   

   (Or, even better, wire it through a `Result`-returning initialiser so callers can handle the failure.)

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/rfc/0003-ios-file-provider.md
   Line: 256

   Comment:
   **`unwrap()` in code example contradicts repo rule**

   `Runtime::new().unwrap()` in this snippet will panic on allocation failure. The repo rule prohibits `unwrap()` in library code, and `tcfs-file-provider` is a library crate — a developer who copies this pattern verbatim into the actual crate source would introduce a violation. Consider adding a brief callout that this is a simplified illustration and the real implementation should propagate the error (e.g. via a `once_cell`/`OnceLock` with explicit error handling or a `Result`-returning init function).

   

   (Or, even better, wire it through a `Result`-returning initialiser so callers can handle the failure.)

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `docs/rfc/0003-ios-file-provider.md`, line 202 ([link](https://github.com/jesssullivan/tummycrypt/blob/e2f4b0c03261c864e1bb58a0e3cf8c9a0d23d9d5/docs/rfc/0003-ios-file-provider.md#L202)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Phase 7a exposes more symbols than the UDL shows**

   The Phase 7a bullet says the UniFFI bindings expose `delete_item` and `create_directory`, but neither appears in the UDL interface block above (lines 138–158). With the PR explicitly designating those as "experimental code paths rather than supported user-facing scope", it would help to either add a note in the UDL section ("write operations omitted from this reference UDL; see `uniffi_bridge.rs` for full surface") or align the phase description to avoid the appearance that the UDL is incomplete.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/rfc/0003-ios-file-provider.md
   Line: 202

   Comment:
   **Phase 7a exposes more symbols than the UDL shows**

   The Phase 7a bullet says the UniFFI bindings expose `delete_item` and `create_directory`, but neither appears in the UDL interface block above (lines 138–158). With the PR explicitly designating those as "experimental code paths rather than supported user-facing scope", it would help to either add a note in the UDL section ("write operations omitted from this reference UDL; see `uniffi_bridge.rs` for full surface") or align the phase description to avoid the appearance that the UDL is incomplete.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs(ios): define active surface posture"](https://github.com/jesssullivan/tummycrypt/commit/968f8c8bf40c5ec1e04da029a9d8f246ec777528) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28582374)</sub>

<!-- /greptile_comment -->