### PR TITLE
[codex] Define macOS Finder and FileProvider reality

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -132,6 +132,7 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 - [Neo-Honey Live Acceptance](ops/neo-honey-acceptance.md) — named live fleet sync acceptance lane
 - [Fleet Deployment Guide](ops/fleet-deployment.md) — multi-machine fleet deployment and operational checks
 - [Apple Surface Status](ops/apple-surface-status.md) — current reality for macOS and iOS claims
+- [macOS Finder and FileProvider Reality](ops/macos-fileprovider-reality.md) — current macOS desktop workflow, proof gaps, and manual acceptance lane
 
 ### RFCs
 

--- a/docs/ops/apple-surface-status.md
+++ b/docs/ops/apple-surface-status.md
@@ -50,6 +50,8 @@ Avoid:
 - Keep the Apple CI lanes green.
 - Run post-release distribution smoke from
   [Distribution Smoke Matrix](distribution-smoke-matrix.md).
+- Use [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md) for
+  the current desktop acceptance path and proof gaps.
 - Add a named macOS Finder/FileProvider smoke path before upgrading the public
   posture.
 - Add simulator or device-backed iOS acceptance before claiming an active iOS

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -1,0 +1,135 @@
+# macOS Finder and FileProvider Reality
+
+As of April 15, 2026, macOS is a real packaging and integration lane for tcfs,
+but not yet a continuously proven release-grade desktop surface.
+
+This document defines the actual workflow the repo supports today, separates
+what is proven from what remains experimental, and records the highest-value
+manual smoke path for the Finder/FileProvider surface.
+
+## Supported Workflow In The Repo Today
+
+The macOS FileProvider path currently consists of these pieces:
+
+1. A packaged host app: `TCFSProvider.app`
+2. A packaged non-UI FileProvider extension:
+   `io.tinyland.tcfs.fileprovider`
+3. A host-app registration step that removes and re-adds the
+   `io.tinyland.tcfs` FileProvider domain on launch
+4. A daemon and FileProvider socket path that the extension uses for
+   enumeration, hydration, and watch signaling
+
+In practical terms, the intended operator flow is:
+
+1. install the macOS package or app bundle
+2. ensure `tcfsd` is present and can start with the needed config
+3. ensure the FileProvider extension is registered with `pluginkit`
+4. launch `TCFSProvider.app` so the host app provisions config and re-adds the
+   FileProvider domain
+5. let `fileproviderd` enumerate the domain into `~/Library/CloudStorage/`
+6. use Finder to enumerate and open items, which should hydrate on demand
+
+## Proven Today
+
+- CI proves the Rust staticlib, Swift sources, and macOS FileProvider build
+  surfaces compile.
+- Release automation builds `TCFSProvider.app`, packages it into the Apple
+  Silicon `.pkg`, and runs `pluginkit -a` during package install.
+- The host app does contain a real domain-registration path:
+  it removes then re-adds `NSFileProviderDomainIdentifier("io.tinyland.tcfs")`
+  on launch.
+- The extension contains real enumeration, hydration, watch, and badge
+  decoration code paths.
+
+## Important Constraints
+
+- The package postinstall script only auto-registers the extension if the app is
+  installed at `/Applications/TCFSProvider.app`.
+- The April 15, 2026 smoke path that used
+  `installer -target CurrentUserHomeDirectory` landed the app at
+  `~/Applications/TCFSProvider.app`, so that install path should be treated as
+  requiring manual app launch and manual verification.
+- The host app provisions config from `~/.config/tcfs/fileprovider/config.json`
+  into Keychain as a best-effort startup step.
+
+## Not Yet Proven
+
+- A continuously exercised Finder/FileProvider acceptance lane from install
+  through register, enumerate, hydrate, mutate, and conflict handling
+- Finder badge visibility as a release gate
+- Conflict UX and notification behavior as a release gate
+- Release-day viability of every published macOS artifact without explicit
+  post-cut smoke
+- A stable claim that write flows are supported for end users on macOS
+
+## Highest-Value Manual Smoke Lane
+
+This is the current best manual acceptance path for the macOS desktop surface.
+
+### Preconditions
+
+- a macOS machine with the packaged app and binaries installed
+- a valid tcfs daemon config
+- a valid FileProvider config at
+  `~/.config/tcfs/fileprovider/config.json`
+- a runnable `tcfsd`
+
+### Procedure
+
+1. Verify the expected artifacts exist:
+
+```bash
+test -x /usr/local/bin/tcfsd || test -x "$HOME/usr/local/bin/tcfsd"
+test -d /Applications/TCFSProvider.app || test -d "$HOME/Applications/TCFSProvider.app"
+```
+
+2. Verify the extension is registered with `pluginkit`:
+
+```bash
+pluginkit -m -A -D -i io.tinyland.tcfs.fileprovider
+```
+
+3. Launch the host app from the installed location:
+
+```bash
+open -a TCFSProvider
+```
+
+4. Verify the CloudStorage root appears:
+
+```bash
+ls "$HOME/Library/CloudStorage" | rg '^TCFS'
+```
+
+5. Verify enumeration by listing the mounted root:
+
+```bash
+find "$HOME/Library/CloudStorage" -maxdepth 2 -type f | head
+```
+
+6. Open or read a known remote-backed file and confirm that content hydration
+   succeeds.
+
+7. Record whether badges or equivalent Finder state are visible, but treat that
+   as observational evidence rather than a hard release gate.
+
+### Pass Bar
+
+Treat the current macOS desktop lane as materially proven only when all of the
+following succeed on the same machine:
+
+- extension registration is visible
+- host app launch successfully re-adds the FileProvider domain
+- a CloudStorage root appears
+- enumeration works
+- opening a placeholder-backed file hydrates content successfully
+- `tcfsd` remains healthy throughout the path
+
+## Relationship To Other Runbooks
+
+- Use [Distribution Smoke Matrix](distribution-smoke-matrix.md) for packaged
+  install proof.
+- Use [Apple Surface Status](apple-surface-status.md) for the broader Apple
+  posture.
+- Use this document for the macOS Finder/FileProvider desktop acceptance path
+  itself.


### PR DESCRIPTION
## What changed

- added `docs/ops/macos-fileprovider-reality.md` as the canonical current-state document for the macOS Finder/FileProvider surface
- documented the actual supported operator flow: install, extension registration, host-app domain registration, CloudStorage enumeration, and on-demand hydration
- captured a key packaging nuance from the April 15, 2026 smoke: `.pkg` postinstall only auto-registers `/Applications/TCFSProvider.app`, while user-home installs require manual verification
- linked the new macOS reality doc from `docs/ops/apple-surface-status.md` and `docs/index.md`

## Why

Issue #278 is about separating real macOS desktop proof from code and packaging presence. After #292, the repo posture was more honest, but it still lacked a concrete macOS Finder/FileProvider acceptance document. This PR defines that desktop workflow and the current proof gaps explicitly.

## Impact

- gives maintainers one canonical runbook for the macOS desktop surface
- makes the current proof bar and packaging caveats explicit
- creates the named macOS acceptance lane that the broader Apple status doc was still missing

## Validation

- `git -C /tmp/tummycrypt-278b diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only PR that adds `docs/ops/macos-fileprovider-reality.md` as the canonical runbook for the macOS Finder/FileProvider acceptance lane and cross-links it from `apple-surface-status.md` and `docs/index.md`. Content is well-scoped, internally consistent, and accurately separates what is proven from what remains experimental.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only, no code changes, all findings are P2 style suggestions.

All three changed files are Markdown docs. No code, no Rust, no Swift, no crypto, no FFI, no migrations. The only finding is a P2 portability nit (`rg` vs `grep` in a smoke-test command). Content is accurate and cross-references resolve correctly.

docs/ops/macos-fileprovider-reality.md — single minor nit on the smoke test command (rg → grep).

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/ops/macos-fileprovider-reality.md | New canonical runbook for macOS Finder/FileProvider acceptance; uses `rg` (ripgrep) in step 4 of the smoke procedure, which is not a macOS default tool |
| docs/ops/apple-surface-status.md | Added cross-reference link to new macos-fileprovider-reality.md in the Validation Path section; link is correct and relative paths resolve properly |
| docs/index.md | Added macOS Finder and FileProvider Reality entry to the Ops Runbooks list; relative path and description are correct |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Install .pkg or app bundle] --> B[Start tcfsd with config]
    B --> C{Extension registered\nwith pluginkit?}
    C -- No --> D[Manual: pluginkit -a\nor re-run pkg installer]
    C -- Yes --> E[Launch TCFSProvider.app]
    E --> F[Host app removes + re-adds\nio.tinyland.tcfs domain]
    F --> G[fileproviderd enumerates domain\ninto ~/Library/CloudStorage/]
    G --> H[Finder shows TCFS root]
    H --> I[Open placeholder-backed file]
    I --> J{Content hydrates\nfrom tcfsd?}
    J -- Yes --> K[✅ Pass bar met]
    J -- No --> L[❌ Investigate tcfsd / socket / config]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/ops/macos-fileprovider-reality.md
Line: 100

Comment:
**`rg` not available on stock macOS**

`rg` (ripgrep) is not installed by default on macOS — an operator following this runbook on a fresh machine will get `command not found` at step 4, which could look like an enumeration failure rather than a missing-tool error. `grep` is always present.

```suggestion
ls "$HOME/Library/CloudStorage" | grep '^TCFS'
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(macos): define fileprovider reality"](https://github.com/jesssullivan/tummycrypt/commit/71687ec4a40b06227bd6ea1a0ea5b53dbf4d5079) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28582375)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->