### PR TITLE
[codex] Prepare v0.12.2 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2026-04-16
+
+### Added
+
+- **Distribution proof runbook**: added the canonical release smoke matrix and corrected Homebrew tap flow so post-cut install verification has one current operator path.
+
+### Changed
+
+- Apple and iOS support surfaces now point to dated April 15, 2026 evidence instead of generic support claims, and the odrive parity backlog is refreshed against the current Linux-first product posture.
+
+### Fixed
+
+- **macOS release packaging**: release builds now vendor OpenSSL for macOS arm64 artifacts, and release CI fails if `tcfsd` still links a dynamic Homebrew OpenSSL dylib.
+- **Sync state keying**: fixed state-key lookup after delete-through-symlink-parent cases so `remove()` and follow-up reads hit the same cached entry.
+
 ## [0.12.1] - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-auth"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-chunks"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cli"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cloudfilter"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-core"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "prost",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-crypto"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "aes-siv",
  "anyhow",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-dbus"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-e2e"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-file-provider"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-fuse"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-mcp"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-nfs"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5404,7 +5404,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-secrets"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sops"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-storage"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sync"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-tui"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-vfs"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "tcfsd"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,7 @@
         tcfsd-app = pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin (
           pkgs.stdenv.mkDerivation {
             pname = "tcfsd-app";
-            version = tcfsd.version or "0.12.1";
+            version = tcfsd.version or "0.12.2";
             dontUnpack = true;
             buildInputs = [ pkgs.darwin.sigtool ];
             installPhase = ''

--- a/swift/daemon/resources/Info.plist
+++ b/swift/daemon/resources/Info.plist
@@ -14,9 +14,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>0.12.1</string>
+    <string>0.12.2</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.12.1</string>
+    <string>0.12.2</string>
     <key>LSMinimumSystemVersion</key>
     <string>15.0</string>
     <key>LSUIElement</key>


### PR DESCRIPTION
## What changed
- bumped the workspace, lockfile, Darwin app bundle metadata, and Nix app derivation from `0.12.1` to `0.12.2`
- added a `0.12.2` changelog entry that captures the post-`v0.12.1` release-packaging fix, sync-state fix, and distribution-proof docs/workflow updates

## Why
Issue #280 is now blocked on release execution rather than missing repo work. `main` contains the post-`v0.12.1` macOS packaging fix from `#282`, the release guard from `#291`, and the release-proof/docs updates needed for the next proof run, but the repo version surfaces were still pinned to `0.12.1`. This prepares the next patch release cleanly so the matrix can be rerun against a fresh tag.

## Impact
- creates a clean `0.12.2` release-prep lane without touching the dirty local checkout
- makes the next `#280` step a release cut plus smoke rerun, not another metadata patch

## Validation
- `cargo metadata --manifest-path /private/tmp/tummycrypt-280-rerun/Cargo.toml --format-version 1 --locked --no-deps >/dev/null`
- `plutil -lint /private/tmp/tummycrypt-280-rerun/swift/daemon/resources/Info.plist`
- `git -C /private/tmp/tummycrypt-280-rerun diff --check`

Refs #280

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the workspace version from `0.12.1` to `0.12.2` across all metadata surfaces: `Cargo.toml` workspace root, `Cargo.lock`, the macOS app bundle `Info.plist`, the Nix flake fallback version, and a new `CHANGELOG.md` entry. All five surfaces are mutually consistent and the changelog entry accurately reflects the post-`v0.12.1` fixes described in the PR description.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a pure version bump with no logic changes.

All five version surfaces are updated consistently to 0.12.2, the changelog entry is well-formed and matches the described fixes, and no code logic, crypto paths, FFI boundaries, or unsafe blocks were touched.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | New [0.12.2] entry added with correct ISO date (2026-04-16), proper Added/Changed/Fixed structure consistent with existing entries, and changelog entries match the described fixes. |
| Cargo.toml | Single-line version bump in [workspace.package] from 0.12.1 to 0.12.2; clean and correct. |
| flake.nix | Fallback version string in tcfsd-app derivation updated from 0.12.1 to 0.12.2; the primary version still derives from tcfsd.version (sourced from Cargo.toml via crane), keeping the hardcoded fallback consistent. |
| swift/daemon/resources/Info.plist | CFBundleVersion and CFBundleShortVersionString both updated to 0.12.2; plist structure is valid and no other keys were touched. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Cargo.toml\n[workspace.package]\nversion = 0.12.2"] -->|"crane reads version"| B["Cargo.lock\nAll workspace crates → 0.12.2"]
    A -->|"tcfsd.version attribute"| C["flake.nix\ntcfsd-app derivation\nversion = tcfsd.version or '0.12.2'"]
    D["swift/daemon/resources/Info.plist\nCFBundleVersion = 0.12.2\nCFBundleShortVersionString = 0.12.2"] -->|"copied into bundle"| E["TCFSDaemon.app/Contents/Info.plist"]
    C -->|"bundles binary + plist"| E
    F["CHANGELOG.md\n[0.12.2] - 2026-04-16\nAdded / Changed / Fixed"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): prepare v0.12.2 metadata"](https://github.com/jesssullivan/tummycrypt/commit/b42f6cf7293450c6156a462f62017f0cb30be764) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28636193)</sub>

<!-- /greptile_comment -->