### PR TITLE
[codex] Define on-prem authority recovery path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -131,6 +131,7 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 - [Distribution Smoke Matrix](ops/distribution-smoke-matrix.md) — canonical post-release install proof across Homebrew, `.pkg`, `.deb`, `.rpm`, container, and Nix
 - [Lab Host Acceptance Matrix](ops/lab-host-acceptance-matrix.md) — real-host acceptance lanes across `honey`, `neo`, and `petting-zoo-mini`
 - [Neo-Honey Live Acceptance](ops/neo-honey-acceptance.md) — named live fleet sync acceptance lane
+- [On-Prem Authority Recovery](ops/onprem-authority-recovery.md) — source-of-truth and recovery path for the Helm-managed `tcfs` backend namespace
 - [Fleet Deployment Guide](ops/fleet-deployment.md) — multi-machine fleet deployment and operational checks
 - [Apple Surface Status](ops/apple-surface-status.md) — current reality for macOS and iOS claims
 - [macOS Finder and FileProvider Reality](ops/macos-fileprovider-reality.md) — current macOS desktop workflow, proof gaps, and manual acceptance lane

--- a/docs/ops/onprem-authority-recovery.md
+++ b/docs/ops/onprem-authority-recovery.md
@@ -1,0 +1,111 @@
+# On-Prem Authority Recovery
+
+Runbook for restoring or reality-checking the on-prem `tcfs` namespace when
+`honey` (or another local cluster) is intended to be the active authority.
+
+## Current Repo Truth
+
+There are currently three adjacent deployment paths in this repo, and they are
+not resource-name compatible with each other:
+
+1. `infra/k8s/charts/tcfs-backend`
+   - Direct Helm chart for the backend worker deployment and namespace
+     scaffolding.
+   - Default live release name: `tcfs-backend`
+   - Expected resource names:
+     - service account: `tcfs-backend-tcfs-backend`
+     - deployment: `tcfs-backend-tcfs-backend-worker`
+     - config map: `tcfs-backend-tcfs-backend-config`
+   - If Helm is the authority, release state should exist in the namespace as
+     `sh.helm.release.v1.tcfs-backend.vN` secrets.
+
+2. `infra/k8s/charts/tcfs-stack`
+   - Umbrella chart for blank-cluster bootstrap.
+   - Useful when you want Helm to create the broader stack, not when you are
+     reconciling an already-existing direct `tcfs-backend` release.
+
+3. `infra/tofu/modules/tcfs-backend`
+   - OpenTofu-managed backend worker deployment.
+   - Uses different object names (`tcfsd`, `tcfs-sync-worker`) and should not
+     be treated as an in-place reconciler for a Helm-managed
+     `tcfs-backend-tcfs-backend-*` namespace.
+
+The practical consequence is simple: if the live namespace already contains
+Helm-managed `tcfs-backend-tcfs-backend-*` objects, the direct Helm chart is
+the source of truth for restoring that path.
+
+## Preflight
+
+Confirm which cluster you are talking to before making changes:
+
+```bash
+kubectl config current-context
+kubectl get ns tcfs
+helm list -n tcfs
+kubectl get sa,deploy,secret -n tcfs | \
+  rg 'tcfs-backend|sh.helm.release'
+```
+
+Expected direct-chart signs:
+
+- Helm release `tcfs-backend` exists in namespace `tcfs`
+- service account `tcfs-backend-tcfs-backend` is present
+- deployment `tcfs-backend-tcfs-backend-worker` exists
+- Helm release secrets `sh.helm.release.v1.tcfs-backend.vN` exist
+
+If instead the namespace contains `tcfsd` or `tcfs-sync-worker`, you are on
+the OpenTofu-managed path and should not force the Helm recovery flow onto it.
+
+## Recover the Namespace Scaffolding
+
+Use the direct backend chart reconciler from this repo:
+
+```bash
+bash scripts/tcfs-backend-deploy.sh
+```
+
+Defaults:
+
+- release: `tcfs-backend`
+- namespace: `tcfs`
+- chart: `infra/k8s/charts/tcfs-backend`
+
+This path is intentionally narrow: it restores the backend worker deployment,
+service account, role binding, config map, and Helm release state for the
+existing direct chart authority. It does not recreate SeaweedFS or NATS.
+
+Useful flags:
+
+```bash
+bash scripts/tcfs-backend-deploy.sh --dry-run
+TCFS_NAMESPACE=tcfs bash scripts/tcfs-backend-deploy.sh \
+  --set image.tag=v0.12.2
+```
+
+## Validate Recovery
+
+```bash
+helm list -n tcfs
+kubectl get sa tcfs-backend-tcfs-backend -n tcfs
+kubectl rollout status deployment/tcfs-backend-tcfs-backend-worker -n tcfs
+kubectl logs deployment/tcfs-backend-tcfs-backend-worker -n tcfs --tail=50
+```
+
+If the service account is missing but the deployment still references
+`tcfs-backend-tcfs-backend`, re-running the direct Helm release should recreate
+it because `serviceAccount.create` defaults to `true` in the chart values.
+
+## Civo Keep or Retire Signal
+
+Do not retire the preserved Civo PVC tail until the on-prem namespace has all
+of the following:
+
+- an explicit deployment authority (`tcfs-backend` Helm release or an explicit
+  alternative)
+- live Helm release state in the namespace if Helm owns it
+- restored namespace scaffolding for the backend worker path
+- an operator decision recorded on whether Civo remains standby state or can be
+  retired
+
+Once those conditions are true, the residual Civo `tcfs` PVCs stop being a
+guess-driven safety blanket and can be evaluated deliberately.

--- a/infra/k8s/charts/tcfs-backend/README.md
+++ b/infra/k8s/charts/tcfs-backend/README.md
@@ -7,16 +7,45 @@ Helm chart for deploying the tcfs sync workers and metadata service to Kubernete
 - **sync-worker**: Stateless NATS JetStream consumer pods (HPA-scaled via KEDA)
 - **metadata-service**: Leader-elected coordination service (Kubernetes Lease API)
 
-## Phase 4 Status
+## Current Status
 
-Chart implementation is scheduled for Phase 4. See `infra/tofu/modules/tcfs-backend/` for
-OpenTofu module that will deploy this chart.
+This chart is the direct Helm authority for the backend-worker namespace
+scaffolding when the live cluster already contains Helm-managed
+`tcfs-backend-tcfs-backend-*` objects.
 
-## Usage (future)
+Do not assume it is interchangeable with `infra/tofu/modules/tcfs-backend`.
+The OpenTofu module uses different object names (`tcfsd`, `tcfs-sync-worker`)
+and should be treated as a separate deployment path.
+
+## Expected Objects
+
+With the default release name `tcfs-backend`, this chart creates:
+
+- service account: `tcfs-backend-tcfs-backend`
+- deployment: `tcfs-backend-tcfs-backend-worker`
+- config map: `tcfs-backend-tcfs-backend-config`
+- Helm release secrets: `sh.helm.release.v1.tcfs-backend.vN`
+
+## Usage
 
 ```bash
-helm install tcfs-backend ./infra/k8s/charts/tcfs-backend \
+bash scripts/tcfs-backend-deploy.sh
+```
+
+Or directly:
+
+```bash
+helm upgrade --install tcfs-backend ./infra/k8s/charts/tcfs-backend \
   --namespace tcfs \
+  --create-namespace \
   --set image.tag=latest \
-  --set nats.url=nats://nats.tcfs.svc:4222
+  --set config.natsUrl=nats://nats.tcfs.svc.cluster.local:4222
+```
+
+After reconcile:
+
+```bash
+helm list -n tcfs
+kubectl get sa tcfs-backend-tcfs-backend -n tcfs
+kubectl rollout status deployment/tcfs-backend-tcfs-backend-worker -n tcfs
 ```

--- a/infra/k8s/charts/tcfs-stack/templates/NOTES.txt
+++ b/infra/k8s/charts/tcfs-stack/templates/NOTES.txt
@@ -8,7 +8,7 @@
 
 2. Check the tcfs-backend deployment:
 
-     kubectl rollout status deployment/tcfs-backend -n {{ .Values.global.namespace }}
+     kubectl rollout status deployment/{{ .Release.Name }}-tcfs-backend-worker -n {{ .Release.Namespace }}
 
 3. Verify the SeaweedFS secret exists:
 

--- a/scripts/tcfs-backend-deploy.sh
+++ b/scripts/tcfs-backend-deploy.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# tcfs-backend-deploy.sh — reconcile the direct tcfs-backend Helm release
+#
+# Usage:
+#   ./scripts/tcfs-backend-deploy.sh
+#   ./scripts/tcfs-backend-deploy.sh --dry-run
+#   TCFS_RELEASE_NAME=tcfs-backend ./scripts/tcfs-backend-deploy.sh --set image.tag=v0.12.2
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CHART_DIR="${REPO_ROOT}/infra/k8s/charts/tcfs-backend"
+
+RELEASE_NAME="${TCFS_RELEASE_NAME:-tcfs-backend}"
+NAMESPACE="${TCFS_NAMESPACE:-tcfs}"
+DRY_RUN=false
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { printf "${GREEN}[INFO]${NC}  %s\n" "$*"; }
+warn()  { printf "${YELLOW}[WARN]${NC}  %s\n" "$*"; }
+error() { printf "${RED}[ERROR]${NC} %s\n" "$*" >&2; }
+
+check_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        error "$1 is required but not found in PATH"
+        exit 1
+    fi
+}
+
+info "Checking prerequisites..."
+check_command helm
+check_command kubectl
+
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    error "Cannot connect to Kubernetes cluster. Check your kubeconfig."
+    exit 1
+fi
+
+HELM_CMD=(
+    helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}"
+    --namespace "${NAMESPACE}"
+    --create-namespace
+    -f "${CHART_DIR}/values.yaml"
+)
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+    info "Dry-run mode enabled — no changes will be applied"
+    HELM_CMD+=(--dry-run --debug)
+fi
+
+if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
+    HELM_CMD+=("${EXTRA_ARGS[@]}")
+fi
+
+info "Reconciling direct tcfs-backend release..."
+info "  Release:   ${RELEASE_NAME}"
+info "  Namespace: ${NAMESPACE}"
+info "  Chart:     ${CHART_DIR}"
+echo
+
+"${HELM_CMD[@]}"
+
+if [[ "${DRY_RUN}" == "false" ]]; then
+    DEPLOYMENT_NAME="${RELEASE_NAME}-tcfs-backend-worker"
+    SERVICE_ACCOUNT_NAME="${RELEASE_NAME}-tcfs-backend"
+    echo
+    info "Validating Helm-managed scaffolding..."
+    kubectl get serviceaccount "${SERVICE_ACCOUNT_NAME}" --namespace "${NAMESPACE}" \
+        >/dev/null 2>&1 || warn "service account ${SERVICE_ACCOUNT_NAME} not visible yet"
+    kubectl rollout status deployment/"${DEPLOYMENT_NAME}" \
+        --namespace "${NAMESPACE}" \
+        --timeout=120s 2>/dev/null || warn "${DEPLOYMENT_NAME} rollout not ready yet"
+    echo
+    info "Helm release state:"
+    helm list --namespace "${NAMESPACE}" || true
+fi

--- a/scripts/tcfs-deploy.sh
+++ b/scripts/tcfs-deploy.sh
@@ -8,6 +8,9 @@
 #   ./scripts/tcfs-deploy.sh --dry-run          # template only, no install
 #   ./scripts/tcfs-deploy.sh --set global.imageTag=v0.2.0
 #
+# This is the blank-cluster umbrella path. For reconciling an already-existing
+# direct `tcfs-backend` Helm release, use `scripts/tcfs-backend-deploy.sh`.
+#
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -113,7 +116,7 @@ echo
 if [[ "${DRY_RUN}" == "false" ]]; then
     echo
     info "Waiting for rollout..."
-    kubectl rollout status deployment/"${RELEASE_NAME}-tcfs-backend" \
+    kubectl rollout status deployment/"${RELEASE_NAME}-tcfs-backend-worker" \
         --namespace "${NAMESPACE}" \
         --timeout=120s 2>/dev/null || warn "tcfs-backend rollout not ready yet"
     echo


### PR DESCRIPTION
## Why
Issue #298 is blocked by a source-of-truth mismatch more than by missing YAML. The repo currently exposes three adjacent deployment paths for the tcfs backend, and they do not share object names:
- direct Helm chart: `tcfs-backend-tcfs-backend-*`
- umbrella stack chart: release-scoped `*-tcfs-backend-worker`
- OpenTofu module: `tcfsd` / `tcfs-sync-worker`

That makes it too easy to look at a live namespace and guess the wrong owner.

## What This Does
- adds an explicit on-prem authority recovery runbook
- adds a direct `tcfs-backend` Helm reconcile script for the current live naming path
- updates the tcfs-backend chart README to describe the real object names and Helm release state
- fixes the umbrella deploy script and chart notes to check the actual backend worker deployment name

## Reality Check
- local `kubectl` here is pointed at `tinyland-civo-dev`, not `honey`
- in that Civo namespace, the Helm release state and `tcfs-backend-tcfs-backend` service account already exist
- I could reach `honey` over SSH, but this session does not have noninteractive sudo there, so I am not claiming the on-prem cluster is already repaired

## Validation
- `bash -n scripts/tcfs-backend-deploy.sh scripts/tcfs-deploy.sh`
- `git diff --check`
- `helm template tcfs-backend infra/k8s/charts/tcfs-backend | rg ...`
- `helm dependency update infra/k8s/charts/tcfs-stack >/dev/null && helm template tcfs infra/k8s/charts/tcfs-stack | rg ...`

Refs #298

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an on-prem authority recovery runbook, a new `tcfs-backend-deploy.sh` script for reconciling the direct Helm release, and fixes the umbrella deploy script (`tcfs-deploy.sh`) and `tcfs-stack` NOTES.txt to use the correct release-scoped deployment name (`${RELEASE_NAME}-tcfs-backend-worker` / `{{ .Release.Name }}-tcfs-backend-worker`) rather than a hard-coded or mismatched name. The `_helpers.tpl` fullname formula (`{{ .Release.Name }}-{{ .Chart.Name }}`) confirms that `tcfs-backend-tcfs-backend-worker` (direct chart) and `tcfs-tcfs-backend-worker` (umbrella) are the correct targets.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style suggestions with no correctness or data-integrity impact.

The deployment name fix in both `tcfs-deploy.sh` and NOTES.txt is verified correct against the `_helpers.tpl` fullname formula. The new `tcfs-backend-deploy.sh` is well-structured, skips the unnecessary dependency update (tcfs-backend has no sub-chart deps), and correctly derives object names from the release name. Only remaining finding is a pre-existing namespace reference inconsistency in NOTES.txt.

No files require special attention; `NOTES.txt` has a minor pre-existing namespace inconsistency worth cleaning up.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/tcfs-backend-deploy.sh | New script that reconciles the direct tcfs-backend Helm release; correctly computes deployment/SA names from release name, handles dry-run, and skips unnecessary dependency update (tcfs-backend has no sub-chart deps) |
| scripts/tcfs-deploy.sh | Fixed post-deploy rollout check from a mismatched hard-coded name to `${RELEASE_NAME}-tcfs-backend-worker`, which correctly matches the sub-chart's Helm fullname formula |
| infra/k8s/charts/tcfs-stack/templates/NOTES.txt | Fixed deployment name in step 2 to use `{{ .Release.Name }}-tcfs-backend-worker`; minor pre-existing inconsistency where step 2 uses `.Release.Namespace` while other steps use `.Values.global.namespace` |
| docs/ops/onprem-authority-recovery.md | New runbook clearly documents the three deployment paths, their incompatible object names, and recovery steps; preflight checks and retire criteria are well-defined |
| infra/k8s/charts/tcfs-backend/README.md | Updated to accurately document real object names and Helm release state, correctly distinguished from the OpenTofu module's naming scheme |
| docs/index.md | Added link to the new on-prem authority recovery runbook in the Ops Runbooks section |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Operator: kubectl config current-context] --> B{Which objects exist in tcfs ns?}
    B -->|tcfs-backend-tcfs-backend-*| C[Direct Helm Chart Path\nRelease: tcfs-backend]
    B -->|tcfs-tcfs-backend-*| D[Umbrella Stack Path\nRelease: tcfs]
    B -->|tcfsd / tcfs-sync-worker| E[OpenTofu Module Path\nDo NOT use Helm recovery]
    C --> F[bash scripts/tcfs-backend-deploy.sh\nhelm upgrade --install tcfs-backend]
    D --> G[bash scripts/tcfs-deploy.sh\nhelm upgrade --install tcfs]
    F --> H[Validate: SA tcfs-backend-tcfs-backend\nDeployment: tcfs-backend-tcfs-backend-worker]
    G --> I[Validate: Deployment tcfs-tcfs-backend-worker]
    H --> J{Civo Retire Decision}
    I --> J
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infra/k8s/charts/tcfs-stack/templates/NOTES.txt
Line: 11

Comment:
**Namespace reference inconsistency across NOTES steps**

Step 2 now uses `{{ .Release.Namespace }}` (accurate — it reflects where Helm actually deployed the release), while steps 1, 3, and 4 still use `{{ .Values.global.namespace }}`. If the release is ever applied with `--namespace` differing from `global.namespace`, those other steps will point to the wrong namespace. Since `.Release.Namespace` is strictly more reliable here, consider aligning the rest of the file as a follow-up — updating the remaining `{{ .Values.global.namespace }}` references in steps 1, 3, and 4 to `{{ .Release.Namespace }}`.

```suggestion
     kubectl rollout status deployment/{{ .Release.Name }}-tcfs-backend-worker -n {{ .Release.Namespace }}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(ops): define on-prem authority reco..."](https://github.com/jesssullivan/tummycrypt/commit/dfa6cdff6908684ee44b133ddaa07db15bfa6cd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28674930)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->