### PR TITLE
fix(sync): surface explicit file sync state

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -793,6 +793,7 @@ enum SyncStatusPathReport {
         chunk_count: usize,
         remote_path: String,
         last_synced_age_secs: u64,
+        sync_status: tcfs_sync::state::FileSyncStatus,
         needs_sync_reason: Option<String>,
     },
     Untracked {
@@ -821,6 +822,7 @@ fn build_sync_status_report(
                 chunk_count: entry.chunk_count,
                 remote_path: entry.remote_path.clone(),
                 last_synced_age_secs: now_epoch().saturating_sub(entry.last_synced),
+                sync_status: entry.status,
                 needs_sync_reason: state.needs_sync(&canonical)?,
             }),
             None => Some(SyncStatusPathReport::Untracked { canonical }),
@@ -1174,6 +1176,7 @@ fn cmd_sync_status(
                 chunk_count,
                 remote_path,
                 last_synced_age_secs,
+                sync_status,
                 needs_sync_reason,
             } => {
                 println!("File: {}", canonical.display());
@@ -1182,9 +1185,10 @@ fn cmd_sync_status(
                 println!("  chunks:     {}", chunk_count);
                 println!("  remote:     {}", remote_path);
                 println!("  last sync:  {} seconds ago", last_synced_age_secs);
+                println!("  sync state: {}", sync_status);
                 match needs_sync_reason {
-                    None => println!("  status:     up to date"),
-                    Some(reason) => println!("  status:     needs sync ({reason})"),
+                    None => println!("  sync check: up to date"),
+                    Some(reason) => println!("  sync check: needs sync ({reason})"),
                 }
             }
             SyncStatusPathReport::Untracked { canonical } => {
@@ -3840,10 +3844,12 @@ mod tests {
         match report.file.unwrap() {
             SyncStatusPathReport::Tracked {
                 remote_path,
+                sync_status,
                 needs_sync_reason,
                 ..
             } => {
                 assert!(remote_path.starts_with("data/manifests/"));
+                assert_eq!(sync_status, tcfs_sync::state::FileSyncStatus::Synced);
                 assert!(needs_sync_reason.is_none());
             }
             other => panic!("expected tracked status, got {other:?}"),
@@ -3892,9 +3898,48 @@ mod tests {
         assert_eq!(report.tracked_files, 2);
         match report.file.unwrap() {
             SyncStatusPathReport::Tracked {
-                needs_sync_reason, ..
+                sync_status,
+                needs_sync_reason,
+                ..
             } => {
+                assert_eq!(sync_status, tcfs_sync::state::FileSyncStatus::Synced);
                 assert!(needs_sync_reason.is_some());
+            }
+            other => panic!("expected tracked status, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_sync_status_reports_explicit_sync_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("tree");
+        std::fs::create_dir_all(&sync_root).unwrap();
+        let tracked = sync_root.join("alpha.txt");
+        std::fs::write(&tracked, b"alpha").unwrap();
+
+        let state_path = dir.path().join("state.json");
+        let config = test_config(&sync_root);
+        let mut state = tcfs_sync::state::StateCache::open(&state_path).unwrap();
+        let mut entry = tcfs_sync::state::make_sync_state(
+            &tracked,
+            "abc123".to_string(),
+            1,
+            "data/manifests/abc123".to_string(),
+        )
+        .unwrap();
+        entry.status = tcfs_sync::state::FileSyncStatus::NotSynced;
+        state.set(&tracked, entry);
+        state.flush().unwrap();
+
+        let report = build_sync_status_report(&config, Some(&tracked), Some(&state_path)).unwrap();
+        match report.file.unwrap() {
+            SyncStatusPathReport::Tracked {
+                sync_status,
+                needs_sync_reason,
+                ..
+            } => {
+                assert_eq!(sync_status, tcfs_sync::state::FileSyncStatus::NotSynced);
+                assert!(needs_sync_reason.is_none());
             }
             other => panic!("expected tracked status, got {other:?}"),
         }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -811,8 +811,8 @@ fn build_sync_status_report(
         .with_context(|| format!("opening state cache: {}", state_path.display()))?;
 
     let file = if let Some(p) = path {
-        let canonical =
-            std::fs::canonicalize(p).with_context(|| format!("resolving path: {}", p.display()))?;
+        let canonical = resolve_sync_status_lookup_path(p)
+            .with_context(|| format!("resolving path: {}", p.display()))?;
 
         match state.get(&canonical) {
             Some(entry) => Some(SyncStatusPathReport::Tracked {
@@ -823,7 +823,13 @@ fn build_sync_status_report(
                 remote_path: entry.remote_path.clone(),
                 last_synced_age_secs: now_epoch().saturating_sub(entry.last_synced),
                 sync_status: entry.status,
-                needs_sync_reason: state.needs_sync(&canonical)?,
+                needs_sync_reason: if entry.status == tcfs_sync::state::FileSyncStatus::NotSynced
+                    || !canonical.exists()
+                {
+                    None
+                } else {
+                    state.needs_sync(&canonical)?
+                },
             }),
             None => Some(SyncStatusPathReport::Untracked { canonical }),
         }
@@ -836,6 +842,41 @@ fn build_sync_status_report(
         tracked_files: state.len(),
         file,
     })
+}
+
+fn resolve_sync_status_lookup_path(path: &Path) -> Result<PathBuf> {
+    if path.exists() {
+        if tcfs_vfs::is_stub_path(path) {
+            let stub = std::fs::canonicalize(path)?;
+            let real_name =
+                tcfs_vfs::stub_to_real_name(stub.file_name().context("stub path has no filename")?)
+                    .context("invalid stub filename")?;
+            let parent = stub.parent().context("stub path has no parent")?;
+            return Ok(parent.join(real_name));
+        }
+        return std::fs::canonicalize(path).map_err(Into::into);
+    }
+
+    if !tcfs_vfs::is_stub_path(path) {
+        let stub_candidate =
+            path.parent()
+                .unwrap_or(Path::new("."))
+                .join(tcfs_vfs::real_to_stub_name(
+                    path.file_name().context("path has no filename")?,
+                ));
+
+        if stub_candidate.exists() {
+            let stub = std::fs::canonicalize(&stub_candidate)?;
+            let parent = stub.parent().context("stub path has no parent")?;
+            return Ok(parent.join(
+                path.file_name()
+                    .context("path has no filename")?
+                    .to_os_string(),
+            ));
+        }
+    }
+
+    std::fs::canonicalize(path).map_err(Into::into)
 }
 
 // ── `tcfs push` ───────────────────────────────────────────────────────────────
@@ -2126,6 +2167,14 @@ async fn cmd_unsync(
     tokio::fs::remove_file(path)
         .await
         .with_context(|| format!("removing hydrated file: {}", path.display()))?;
+
+    let state_path = resolve_state_path(config, None);
+    let mut state = tcfs_sync::state::StateCache::open(&state_path)
+        .with_context(|| format!("opening state cache: {}", state_path.display()))?;
+    state.set_status(path, tcfs_sync::state::FileSyncStatus::NotSynced);
+    state
+        .flush()
+        .with_context(|| format!("flushing state cache: {}", state_path.display()))?;
 
     println!("Unsynced: {} → {}", path.display(), stub_full.display());
     println!("  hash: {}", &hash_hex[..16]);
@@ -3942,6 +3991,58 @@ mod tests {
                 assert!(needs_sync_reason.is_none());
             }
             other => panic!("expected tracked status, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cli_unsync_marks_not_synced_and_reports_via_real_and_stub_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("tree");
+        std::fs::create_dir_all(&sync_root).unwrap();
+        let tracked = sync_root.join("alpha.txt");
+        std::fs::write(&tracked, b"alpha").unwrap();
+
+        let op = memory_op();
+        let state_path = dir.path().join("state.json");
+        let mut config = test_config(&sync_root);
+        config.sync.state_db = dir.path().join("state.db");
+
+        cmd_push_with_operator(&config, &op, &tracked, None, &state_path, "test-device")
+            .await
+            .unwrap();
+
+        cmd_unsync(&config, &tracked, false).await.unwrap();
+
+        let stub_path = sync_root.join("alpha.txt.tc");
+        let canonical_tracked = std::fs::canonicalize(&sync_root).unwrap().join("alpha.txt");
+        assert!(
+            !tracked.exists(),
+            "hydrated file should be removed after unsync"
+        );
+        assert!(stub_path.exists(), "stub should be created after unsync");
+
+        let state = tcfs_sync::state::StateCache::open(&state_path).unwrap();
+        let entry = state
+            .get(&tracked)
+            .expect("tracked state should be preserved");
+        assert_eq!(entry.status, tcfs_sync::state::FileSyncStatus::NotSynced);
+
+        for lookup in [&tracked, &stub_path] {
+            let report =
+                build_sync_status_report(&config, Some(lookup), Some(&state_path)).unwrap();
+            match report.file.unwrap() {
+                SyncStatusPathReport::Tracked {
+                    canonical,
+                    sync_status,
+                    needs_sync_reason,
+                    ..
+                } => {
+                    assert_eq!(canonical, canonical_tracked);
+                    assert_eq!(sync_status, tcfs_sync::state::FileSyncStatus::NotSynced);
+                    assert!(needs_sync_reason.is_none());
+                }
+                other => panic!("expected tracked status after unsync, got {other:?}"),
+            }
         }
     }
 

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -2117,6 +2117,14 @@ async fn cmd_unsync(
         return Ok(());
     }
 
+    let state_path = resolve_state_path(config, None);
+    let state = tcfs_sync::state::StateCache::open(&state_path)
+        .with_context(|| format!("opening state cache: {}", state_path.display()))?;
+    let tracked = state
+        .get(path)
+        .cloned()
+        .with_context(|| format!("{} is not tracked (never pushed)", path.display()))?;
+
     // Read file content and compute hash
     let data = tokio::fs::read(path)
         .await
@@ -2127,22 +2135,23 @@ async fn cmd_unsync(
     let size = data.len() as u64;
 
     if !force {
-        let state_path = resolve_state_path(config, None);
-        let state = tcfs_sync::state::StateCache::open(&state_path)
-            .with_context(|| format!("opening state cache: {}", state_path.display()))?;
-
-        match state.get(path) {
-            None => anyhow::bail!(
-                "{} is not tracked (never pushed). Use --force to unsync anyway.",
-                path.display()
-            ),
-            Some(entry) if entry.blake3 != hash_hex => anyhow::bail!(
+        if tracked.blake3 != hash_hex {
+            anyhow::bail!(
                 "{} has local changes (hash mismatch). Use --force to unsync anyway.",
                 path.display()
-            ),
-            _ => {}
+            );
         }
     }
+
+    let sync_root = config.sync.sync_root.as_deref();
+    let rel_path = tcfs_sync::engine::normalize_rel_path(path, sync_root);
+    let stub = tcfs_vfs::StubMeta::for_upload(
+        &tracked.blake3,
+        tracked.size,
+        tracked.chunk_count,
+        config.storage.resolved_prefix(),
+        &rel_path,
+    );
 
     // Build stub at path.tc
     let stub_path = tcfs_vfs::real_to_stub_name(path.file_name().context("path has no filename")?);
@@ -2150,15 +2159,6 @@ async fn cmd_unsync(
         .parent()
         .unwrap_or(std::path::Path::new("."))
         .join(stub_path);
-
-    let stub = tcfs_vfs::StubMeta {
-        chunks: 0, // unknown without state — leave as 0
-        compressed: false,
-        fetched: false,
-        oid: format!("blake3:{}", hash_hex),
-        origin: format!("seaweedfs://{}/{}", config.storage.endpoint, hash_hex),
-        size,
-    };
 
     // Write stub then remove original
     tokio::fs::write(&stub_full, stub.to_bytes())
@@ -2168,7 +2168,6 @@ async fn cmd_unsync(
         .await
         .with_context(|| format!("removing hydrated file: {}", path.display()))?;
 
-    let state_path = resolve_state_path(config, None);
     let mut state = tcfs_sync::state::StateCache::open(&state_path)
         .with_context(|| format!("opening state cache: {}", state_path.display()))?;
     state.set_status(path, tcfs_sync::state::FileSyncStatus::NotSynced);
@@ -2177,7 +2176,10 @@ async fn cmd_unsync(
         .with_context(|| format!("flushing state cache: {}", state_path.display()))?;
 
     println!("Unsynced: {} → {}", path.display(), stub_full.display());
-    println!("  hash: {}", &hash_hex[..16]);
+    println!(
+        "  hash: {}",
+        &tracked.blake3[..16.min(tracked.blake3.len())]
+    );
     println!("  size: {} freed", fmt_bytes(size));
 
     Ok(())
@@ -4044,6 +4046,72 @@ mod tests {
                 other => panic!("expected tracked status after unsync, got {other:?}"),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn cli_unsync_force_uses_tracked_remote_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("tree");
+        std::fs::create_dir_all(&sync_root).unwrap();
+        let tracked = sync_root.join("alpha.txt");
+        std::fs::write(&tracked, b"alpha").unwrap();
+
+        let op = memory_op();
+        let state_path = dir.path().join("state.json");
+        let mut config = test_config(&sync_root);
+        config.sync.state_db = dir.path().join("state.db");
+
+        cmd_push_with_operator(&config, &op, &tracked, None, &state_path, "test-device")
+            .await
+            .unwrap();
+
+        let tracked_before = tcfs_sync::state::StateCache::open(&state_path)
+            .unwrap()
+            .get(&tracked)
+            .cloned()
+            .unwrap();
+
+        std::fs::write(&tracked, b"alpha updated locally").unwrap();
+
+        cmd_unsync(&config, &tracked, true).await.unwrap();
+
+        let stub_path = sync_root.join("alpha.txt.tc");
+        let stub =
+            tcfs_vfs::StubMeta::parse(&std::fs::read_to_string(&stub_path).unwrap()).unwrap();
+        assert_eq!(
+            stub.blake3_hex(),
+            Some(tracked_before.blake3.as_str()),
+            "forced unsync should preserve tracked remote hash, not local dirty content"
+        );
+        assert_eq!(stub.size, tracked_before.size);
+        assert_eq!(stub.chunks, tracked_before.chunk_count);
+        assert!(
+            stub.origin.ends_with("/alpha.txt"),
+            "stub origin should point at the logical remote path"
+        );
+    }
+
+    #[tokio::test]
+    async fn cli_unsync_force_rejects_untracked_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("tree");
+        std::fs::create_dir_all(&sync_root).unwrap();
+        let local = sync_root.join("never-pushed.txt");
+        std::fs::write(&local, b"local only").unwrap();
+
+        let mut config = test_config(&sync_root);
+        config.sync.state_db = dir.path().join("state.db");
+
+        let err = cmd_unsync(&config, &local, true).await.unwrap_err();
+        assert!(
+            err.to_string().contains("is not tracked"),
+            "unexpected error: {err}"
+        );
+        assert!(local.exists(), "untracked file should be left in place");
+        assert!(
+            !sync_root.join("never-pushed.txt.tc").exists(),
+            "force unsync must not create a fake stub for an untracked file"
+        );
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -24,7 +24,7 @@ use crate::index_entry::{
     write_committed_index_entry, write_preparing_index_entry, PendingIndexEntry, RemoteIndexEntry,
 };
 use crate::manifest::SyncManifest;
-use crate::state::{make_sync_state_full, StateCache};
+use crate::state::{make_sync_state_full, FileSyncStatus, StateCache};
 
 /// Maximum number of retry attempts for chunk upload/download operations.
 const CHUNK_MAX_RETRIES: u32 = 3;
@@ -735,6 +735,7 @@ pub async fn upload_file_with_device(
                         device_id.to_string(),
                     )?;
                     sync_state.conflict = Some(conflict_info.clone());
+                    sync_state.status = FileSyncStatus::Conflict;
                     state.set(local_path, sync_state);
                     return Ok(UploadResult {
                         path: local_path.to_path_buf(),
@@ -2113,6 +2114,75 @@ mod tests {
                 assert_eq!(current.chunks, upload.chunks);
             }
         }
+    }
+
+    #[tokio::test]
+    async fn upload_file_with_device_marks_conflict_status() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        let local = dir.path().join("hello.txt");
+        std::fs::write(&local, b"hello base").unwrap();
+
+        let mut local_vclock = crate::conflict::VectorClock::new();
+        local_vclock.tick("device-1");
+        state.set(
+            &local,
+            crate::state::SyncState {
+                blake3: "basehash123".into(),
+                size: 10,
+                mtime: 0,
+                chunk_count: 0,
+                remote_path: "data/manifests/basehash123".into(),
+                last_synced: 0,
+                vclock: local_vclock,
+                device_id: "device-1".into(),
+                conflict: None,
+                status: FileSyncStatus::Synced,
+            },
+        );
+
+        std::fs::write(&local, b"hello local").unwrap();
+
+        let remote_manifest_hash = "remotehash123";
+        op.write(
+            &format!("data/manifests/{remote_manifest_hash}"),
+            br#"{"version":2,"file_hash":"remotehash123","file_size":12,"chunks":[],"vclock":{"clocks":{"device-2":1}},"written_by":"device-2","written_at":1}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+        write_committed_index_entry(
+            &op,
+            "data/index/hello.txt",
+            &crate::index_entry::RemoteIndexEntry::new(remote_manifest_hash, 12, 0),
+        )
+        .await
+        .unwrap();
+
+        let result = upload_file_with_device(
+            &op,
+            &local,
+            "data",
+            &mut state,
+            None,
+            "device-1",
+            Some("hello.txt"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.skipped);
+        assert!(matches!(result.outcome, Some(SyncOutcome::Conflict(_))));
+
+        let entry = state.get(&local).expect("conflicted state entry");
+        assert_eq!(entry.status, FileSyncStatus::Conflict);
+        assert!(
+            entry.conflict.is_some(),
+            "conflict payload should be preserved"
+        );
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -461,6 +461,27 @@ impl StateCache {
         }
     }
 
+    /// Mark an entry as conflicted while preserving its existing metadata.
+    ///
+    /// Conflict payload and status must move together. Setting only the conflict
+    /// info leaves callers with an internally inconsistent entry that still
+    /// appears synced.
+    pub fn mark_conflict(
+        &mut self,
+        local_path: &Path,
+        conflict: crate::conflict::ConflictInfo,
+    ) -> bool {
+        let key = path_key(local_path);
+        if let Some(entry) = self.entries.get_mut(&key) {
+            entry.conflict = Some(conflict);
+            entry.status = FileSyncStatus::Conflict;
+            self.dirty = true;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Clear conflict state after successful resolution.
     ///
     /// Sets `conflict` to `None` and `status` to `Synced`. Both fields
@@ -1578,6 +1599,52 @@ mod tests {
                 "status must be Synced after reload"
             );
         }
+    }
+
+    #[test]
+    fn mark_conflict_sets_payload_and_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut cache = StateCache::open(&path).unwrap();
+
+        let file_path = dir.path().join("conflicted.txt");
+        std::fs::write(&file_path, b"data").unwrap();
+
+        cache.set(
+            &file_path,
+            SyncState {
+                blake3: "abc".into(),
+                size: 4,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/index/conflicted.txt".into(),
+                last_synced: 0,
+                vclock: VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: None,
+                status: FileSyncStatus::Synced,
+            },
+        );
+
+        let conflict = crate::conflict::ConflictInfo {
+            rel_path: "conflicted.txt".into(),
+            local_vclock: VectorClock::new(),
+            remote_vclock: VectorClock::new(),
+            local_blake3: "abc".into(),
+            remote_blake3: "def".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 0,
+        };
+
+        assert!(cache.mark_conflict(&file_path, conflict.clone()));
+
+        let entry = cache.get(&file_path).unwrap();
+        assert_eq!(entry.status, FileSyncStatus::Conflict);
+        let stored = entry.conflict.as_ref().expect("conflict payload");
+        assert_eq!(stored.rel_path, conflict.rel_path);
+        assert_eq!(stored.local_device, conflict.local_device);
+        assert_eq!(stored.remote_device, conflict.remote_device);
     }
 
     #[test]

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -559,15 +559,10 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                                         "watcher: conflict detected"
                                                     );
                                                     metrics.sync_conflicts.inc();
-                                                    if let Some(entry) =
-                                                        cache.get(&task.path).cloned()
-                                                    {
-                                                        let updated = tcfs_sync::state::SyncState {
-                                                            conflict: Some(info.clone()),
-                                                            ..entry
-                                                        };
-                                                        cache.set(&task.path, updated);
-                                                    }
+                                                    cache.mark_conflict(
+                                                        &task.path,
+                                                        info.clone(),
+                                                    );
                                                     // Emit status change for D-Bus listeners
                                                     let _ = status_tx.try_send((
                                                         task.path.to_string_lossy().to_string(),

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -810,6 +810,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         config.storage.endpoint.clone(),
         state_cache,
         operator.clone(),
+        path_locks.clone(),
         device_id.clone(),
         device_name.clone(),
         master_key,
@@ -1399,6 +1400,7 @@ async fn spawn_state_sync_loop(
                                                 manifest_path,
                                                 &operator,
                                                 &state_cache,
+                                                &path_locks,
                                                 sync_root.as_deref(),
                                                 &storage_prefix,
                                             )
@@ -1555,6 +1557,7 @@ async fn handle_auto_pull(
     manifest_path: &str,
     operator: &Arc<tokio::sync::Mutex<Option<opendal::Operator>>>,
     state_cache: &Arc<tokio::sync::Mutex<tcfs_sync::state::StateCache>>,
+    path_locks: &tcfs_sync::state::PathLocks,
     sync_root: Option<&std::path::Path>,
     storage_prefix: &str,
 ) {
@@ -1576,6 +1579,7 @@ async fn handle_auto_pull(
             }
         }
     };
+    let _lock_guard = path_locks.lock(&local_path).await;
 
     // Compare vector clocks
     let (local_blake3, local_vclock) = {

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -570,55 +570,60 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                                     ));
                                                 }
 
-                                                // Set status = Synced after successful upload
-                                                if let Some(entry) = cache.get(&task.path).cloned() {
-                                                    let synced = tcfs_sync::state::SyncState {
-                                                        status: tcfs_sync::state::FileSyncStatus::Synced,
-                                                        ..entry
-                                                    };
-                                                    cache.set(&task.path, synced);
+                                                if !upload_result.skipped {
+                                                    // Set status = Synced after a committed upload
+                                                    if let Some(entry) = cache.get(&task.path).cloned() {
+                                                        let synced = tcfs_sync::state::SyncState {
+                                                            status: tcfs_sync::state::FileSyncStatus::Synced,
+                                                            ..entry
+                                                        };
+                                                        cache.set(&task.path, synced);
+                                                    }
                                                 }
 
                                                 if let Err(e) = cache.flush() {
                                                     warn!(error = %e, "state cache flush failed");
                                                 }
-                                                info!(
-                                                    path = %task.path.display(),
-                                                    "watcher: auto-pushed"
-                                                );
-                                                metrics.files_pushed.inc();
 
-                                                // Publish NATS event so other hosts learn about the change
-                                                let rel_path = task
-                                                    .path
-                                                    .strip_prefix(&root)
-                                                    .unwrap_or(&task.path)
-                                                    .to_string_lossy()
-                                                    .to_string();
-                                                let nats_device = device.clone();
-                                                let nats_hash = upload_result.hash.clone();
-                                                let nats_size = upload_result.bytes;
-                                                let nats_remote = upload_result.remote_path.clone();
-                                                let nats_handle = nats.clone();
-                                                let pub_metrics = metrics.clone();
-                                                tokio::spawn(async move {
-                                                    if let Some(client) = nats_handle.lock().await.as_ref() {
-                                                        let event = tcfs_sync::StateEvent::FileSynced {
-                                                            device_id: nats_device,
-                                                            rel_path,
-                                                            blake3: nats_hash,
-                                                            size: nats_size,
-                                                            vclock: Default::default(),
-                                                            manifest_path: nats_remote,
-                                                            timestamp: tcfs_sync::StateEvent::now(),
-                                                        };
-                                                        if let Err(e) = client.publish_state_event(&event).await {
-                                                            tracing::warn!("watcher: failed to publish NATS event: {e}");
-                                                        } else {
-                                                            pub_metrics.nats_events_published.inc();
+                                                if !upload_result.skipped {
+                                                    info!(
+                                                        path = %task.path.display(),
+                                                        "watcher: auto-pushed"
+                                                    );
+                                                    metrics.files_pushed.inc();
+
+                                                    // Publish NATS event so other hosts learn about the change
+                                                    let rel_path = task
+                                                        .path
+                                                        .strip_prefix(&root)
+                                                        .unwrap_or(&task.path)
+                                                        .to_string_lossy()
+                                                        .to_string();
+                                                    let nats_device = device.clone();
+                                                    let nats_hash = upload_result.hash.clone();
+                                                    let nats_size = upload_result.bytes;
+                                                    let nats_remote = upload_result.remote_path.clone();
+                                                    let nats_handle = nats.clone();
+                                                    let pub_metrics = metrics.clone();
+                                                    tokio::spawn(async move {
+                                                        if let Some(client) = nats_handle.lock().await.as_ref() {
+                                                            let event = tcfs_sync::StateEvent::FileSynced {
+                                                                device_id: nats_device,
+                                                                rel_path,
+                                                                blake3: nats_hash,
+                                                                size: nats_size,
+                                                                vclock: Default::default(),
+                                                                manifest_path: nats_remote,
+                                                                timestamp: tcfs_sync::StateEvent::now(),
+                                                            };
+                                                            if let Err(e) = client.publish_state_event(&event).await {
+                                                                tracing::warn!("watcher: failed to publish NATS event: {e}");
+                                                            } else {
+                                                                pub_metrics.nats_events_published.inc();
+                                                            }
                                                         }
-                                                    }
-                                                });
+                                                    });
+                                                }
 
                                                 Ok(())
                                             }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -680,12 +680,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                         "push: conflict detected"
                     );
                     let mut cache = state_cache.lock().await;
-                    if let Some(entry) = cache.get(&local_path).cloned() {
-                        let updated = tcfs_sync::state::SyncState {
-                            conflict: Some(info.clone()),
-                            ..entry
-                        };
-                        cache.set(&local_path, updated);
+                    if cache.mark_conflict(&local_path, info.clone()) {
                         let _ = cache.flush();
                     }
                 }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1069,13 +1069,24 @@ impl TcfsDaemon for TcfsDaemonImpl {
         let cache = self.state_cache.lock().await;
 
         match cache.get(&path) {
-            Some(entry) => Ok(tonic::Response::new(SyncStatusResponse {
-                path: req.path,
-                state: "synced".into(),
-                blake3: entry.blake3.clone(),
-                size: entry.size,
-                last_synced: entry.last_synced as i64,
-            })),
+            Some(entry) => {
+                let state = if entry.status == tcfs_sync::state::FileSyncStatus::Synced {
+                    match cache.needs_sync(&path) {
+                        Ok(Some(_)) => "pending".to_string(),
+                        _ => entry.status.to_string(),
+                    }
+                } else {
+                    entry.status.to_string()
+                };
+
+                Ok(tonic::Response::new(SyncStatusResponse {
+                    path: req.path,
+                    state,
+                    blake3: entry.blake3.clone(),
+                    size: entry.size,
+                    last_synced: entry.last_synced as i64,
+                }))
+            }
             None => {
                 // Check if it needs sync
                 let state = match cache.needs_sync(&path) {
@@ -2558,6 +2569,71 @@ mod tests {
 
         // Unknown path returns empty/default state
         assert!(resp.state.is_empty() || resp.state == "unknown");
+    }
+
+    #[tokio::test]
+    async fn sync_status_reports_explicit_conflict_state() {
+        let daemon = test_daemon();
+        let dir = tempfile::tempdir().unwrap();
+        let tracked = dir.path().join("conflicted.txt");
+        std::fs::write(&tracked, b"conflicted").unwrap();
+
+        {
+            let mut cache = daemon.state_cache.lock().await;
+            let mut entry = tcfs_sync::state::make_sync_state(
+                &tracked,
+                "abc123".to_string(),
+                1,
+                "data/manifests/abc123".to_string(),
+            )
+            .unwrap();
+            entry.status = tcfs_sync::state::FileSyncStatus::Conflict;
+            cache.set(&tracked, entry);
+            cache.flush().unwrap();
+        }
+
+        let resp = daemon
+            .sync_status(tonic::Request::new(SyncStatusRequest {
+                path: tracked.display().to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.state, "conflict");
+    }
+
+    #[tokio::test]
+    async fn sync_status_reports_pending_for_modified_tracked_file() {
+        let daemon = test_daemon();
+        let dir = tempfile::tempdir().unwrap();
+        let tracked = dir.path().join("modified.txt");
+        std::fs::write(&tracked, b"alpha").unwrap();
+
+        {
+            let mut cache = daemon.state_cache.lock().await;
+            let entry = tcfs_sync::state::make_sync_state(
+                &tracked,
+                "tracked-alpha".to_string(),
+                1,
+                "data/manifests/alpha".to_string(),
+            )
+            .unwrap();
+            cache.set(&tracked, entry);
+            cache.flush().unwrap();
+        }
+
+        std::fs::write(&tracked, b"alpha updated").unwrap();
+
+        let resp = daemon
+            .sync_status(tonic::Request::new(SyncStatusRequest {
+                path: tracked.display().to_string(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.state, "pending");
     }
 
     #[tokio::test]

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -33,6 +33,7 @@ pub struct TcfsDaemonImpl {
     nats_ok: std::sync::atomic::AtomicBool,
     nats: Arc<TokioMutex<Option<tcfs_sync::NatsClient>>>,
     active_mounts: Arc<TokioMutex<std::collections::HashMap<String, tokio::process::Child>>>,
+    path_locks: tcfs_sync::state::PathLocks,
     /// VFS handle from active FUSE mount — used to invalidate negative cache
     /// on NATS events so remote files appear in readdir immediately.
     pub vfs_handle: tokio::sync::watch::Receiver<Option<std::sync::Arc<tcfs_vfs::TcfsVfs>>>,
@@ -78,6 +79,7 @@ impl TcfsDaemonImpl {
         storage_endpoint: String,
         state_cache: Arc<TokioMutex<tcfs_sync::state::StateCache>>,
         operator: Arc<TokioMutex<Option<opendal::Operator>>>,
+        path_locks: tcfs_sync::state::PathLocks,
         device_id: String,
         device_name: String,
         master_key: Option<tcfs_crypto::MasterKey>,
@@ -126,6 +128,7 @@ impl TcfsDaemonImpl {
             nats_ok: std::sync::atomic::AtomicBool::new(false),
             nats: Arc::new(TokioMutex::new(None)),
             active_mounts: Arc::new(TokioMutex::new(std::collections::HashMap::new())),
+            path_locks,
             vfs_handle: vfs_rx,
             vfs_tx,
             session_store: tcfs_auth::SessionStore::new(),
@@ -236,6 +239,16 @@ impl TcfsDaemonImpl {
     /// Get a handle to the master key for background tasks (e.g., periodic reconciliation).
     pub fn master_key_handle(&self) -> Arc<TokioMutex<Option<tcfs_crypto::MasterKey>>> {
         self.master_key.clone()
+    }
+
+    fn lock_path_for_request(&self, path: &Path) -> std::path::PathBuf {
+        if path.is_absolute() {
+            return path.to_path_buf();
+        }
+        if let Some(root) = self.config.sync.sync_root.as_deref() {
+            return root.join(path);
+        }
+        path.to_path_buf()
     }
 
     /// Publish a ConflictResolved event via NATS (best-effort).
@@ -628,6 +641,8 @@ impl TcfsDaemon for TcfsDaemonImpl {
         }
 
         let path = sanitize_rel_path(&path).map_err(tonic::Status::invalid_argument)?;
+        let lock_path = self.lock_path_for_request(Path::new(&path));
+        let _lock_guard = self.path_locks.lock(&lock_path).await;
 
         // Write to a temp file and upload via sync engine
         let tmp_dir =
@@ -781,6 +796,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
         let state_cache = self.state_cache.clone();
 
         let sync_root = self.config.sync.sync_root.as_deref();
+        let _lock_guard = self.path_locks.lock(&local_path).await;
 
         let resolved_manifest =
             tcfs_sync::engine::resolve_manifest_path(&op, &req.remote_path, &prefix, sync_root)
@@ -881,6 +897,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
         drop(self.operator.lock().await);
 
         let total_bytes = meta.size;
+        let _lock_guard = self.path_locks.lock(&real_path).await;
 
         let result = {
             let mut cache = self.state_cache.lock().await;
@@ -950,6 +967,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
         Self::check_permission(&session, "mount")?;
         let req = request.into_inner();
         let path = std::path::PathBuf::from(&req.path);
+        let _lock_guard = self.path_locks.lock(&path).await;
 
         info!(path = %req.path, force = req.force, "unsync requested");
 
@@ -2343,6 +2361,7 @@ mod tests {
             "http://test:8333".into(),
             state_cache,
             operator,
+            tcfs_sync::state::PathLocks::new(),
             "test-device-id".into(),
             "test-device".into(),
             None,
@@ -2725,6 +2744,59 @@ mod tests {
             server_result.is_ok(),
             "server exited with error: {server_result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn unsync_waits_for_active_path_lock() {
+        let daemon = test_daemon();
+        let dir = tempfile::tempdir().unwrap();
+        let tracked = dir.path().join("tracked.txt");
+        std::fs::write(&tracked, b"tracked").unwrap();
+
+        {
+            let mut cache = daemon.state_cache.lock().await;
+            let entry = tcfs_sync::state::make_sync_state(
+                &tracked,
+                "abc123".to_string(),
+                1,
+                "data/manifests/abc123".to_string(),
+            )
+            .unwrap();
+            cache.set(&tracked, entry);
+            cache.flush().unwrap();
+        }
+
+        let state_cache = daemon.state_cache_handle();
+        let guard = daemon.path_locks.lock(&tracked).await;
+        let tracked_str = tracked.display().to_string();
+
+        let handle = tokio::spawn(async move {
+            daemon
+                .unsync(tonic::Request::new(UnsyncRequest {
+                    path: tracked_str,
+                    force: false,
+                }))
+                .await
+                .unwrap()
+                .into_inner()
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !handle.is_finished(),
+            "unsync should wait while the path lock is held"
+        );
+
+        drop(guard);
+
+        let resp = handle.await.unwrap();
+        assert!(resp.success, "unsync error: {}", resp.error);
+
+        let cache = state_cache.lock().await;
+        let entry = cache
+            .get(&tracked)
+            .expect("state should still exist after unsync");
+        assert_eq!(entry.status, tcfs_sync::state::FileSyncStatus::NotSynced);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make conflict writes consistently set the conflict sync status
- expose persisted sync state in tcfs sync-status
- add targeted tests for conflict marking and sync-status reporting

## Testing
- cargo fmt --all
- cargo test -p tcfs-sync mark_conflict_sets_payload_and_status
- cargo test -p tcfs-cli cli_push_status_pull_workflow_round_trips_file
- cargo test -p tcfs-cli cli_directory_push_and_status_detect_modified_file
- cargo test -p tcfs-cli cli_sync_status_reports_explicit_sync_state
- cargo test -p tcfsd status_returns_version

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a long-standing bug where conflict writes in the sync engine and daemon watcher set `conflict` payload but left `status` unchanged (still `Synced`), causing `sync-status` to report a misleading clean state. The fix is applied consistently across `engine.rs`, `daemon.rs`, and `grpc.rs` via the new `StateCache::mark_conflict` helper, `cmd_unsync` is refactored to record `NotSynced` and build stubs from tracked metadata, and per-path `PathLocks` are wired into gRPC RPCs to serialize concurrent operations.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/reliability improvements that do not block the core fix.

The core bug fix (conflict status and payload moving together) is correct and well-tested. All three inline comments are P2: the `needs_sync` error-swallowing reports "synced" where it previously always reported "synced" (no regression), the ignored `mark_conflict` bool in the watcher only fires for a missing cache entry (shouldn't happen in practice), and the double-open inconsistency window is a failure path requiring disk or permission errors on a simple JSON write. No P0/P1 issues found.

crates/tcfsd/src/grpc.rs (needs_sync error arm), crates/tcfsd/src/daemon.rs (mark_conflict return), crates/tcfs-cli/src/main.rs (cmd_unsync double-open)

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/tcfs-cli/src/main.rs | Adds `sync_status` field to `SyncStatusPathReport::Tracked`, stub-aware path resolution for sync-status lookup, and refactored `cmd_unsync` that now correctly marks state as `NotSynced` and builds stubs from tracked metadata; state cache is opened twice in `cmd_unsync` with destructive ops in between, creating a narrow inconsistency window on flush failure. |
| crates/tcfs-sync/src/engine.rs | Adds `sync_state.status = FileSyncStatus::Conflict` atomically alongside `sync_state.conflict` in the conflict-detection branch, fixing the bug where conflict status was not set. Imports `FileSyncStatus`; new test `upload_file_with_device_marks_conflict_status` verifies both fields move together. |
| crates/tcfs-sync/src/state.rs | Adds `mark_conflict` to `StateCache` that atomically sets both `conflict` payload and `status = Conflict` in one call, with a well-documented docstring explaining why both fields must move together. New test covers the happy path. |
| crates/tcfsd/src/daemon.rs | Replaces manual inline SyncState reconstruction with `mark_conflict`; gates the post-upload `Synced` status assignment on `!upload_result.skipped`, correctly preventing Synced from overwriting Conflict. Adds `path_locks` to `handle_auto_pull`. Watcher silently ignores `mark_conflict`'s bool return, potentially missing a log if entry is absent. |
| crates/tcfsd/src/grpc.rs | Adds `path_locks` field to `TcfsDaemonImpl` and acquires per-path locks in push, pull, hydrate, and unsync RPCs. `sync_status` now surfaces Conflict/NotSynced/pending states from explicit status. Wildcard arm in `needs_sync` match silently swallows IO errors as "synced". |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[File Change Detected] --> B{Upload via engine}
    B -- conflict --> C[engine: set conflict payload + status=Conflict]
    C --> D[UploadResult skipped=true]
    D --> E{daemon/gRPC:\nmark_conflict}
    E --> F[state: conflict + Conflict status persisted]
    F --> G[flush]
    B -- success --> H[UploadResult skipped=false]
    H --> I{!skipped?}
    I -- yes --> J[set status=Synced]
    J --> G
    I -- no --> G

    K[sync-status query] --> L{entry.status?}
    L -- Synced --> M[needs_sync check]
    M -- changed --> N[return pending]
    M -- unchanged --> O[return synced]
    M -- error --> O
    L -- Conflict --> P[return conflict]
    L -- NotSynced --> Q[return not_synced]

    R[cmd_unsync] --> S[open state read-only\nget tracked entry]
    S --> T[read file + hash]
    T --> U{force?}
    U -- no --> V{hash matches?}
    V -- no --> W[bail]
    V -- yes --> X
    U -- yes --> X[build stub from tracked metadata]
    X --> Y[write stub\ndelete original]
    Y --> Z[open state read-write\nset_status NotSynced\nflush]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/tcfsd/src/grpc.rs`, line 822-826 ([link](https://github.com/jesssullivan/tummycrypt/blob/77c26d6b585cae9581646a409d92cab2be5b4944/crates/tcfsd/src/grpc.rs#L822-L826)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`needs_sync` errors silently reported as "synced"**

   The wildcard arm `_ => entry.status.to_string()` collapses both `Ok(None)` (file is genuinely in sync) and `Err(e)` (IO/stat failure) into the same `"synced"` response. A transient filesystem error during the check will be silently swallowed and surfaced to the client as a clean sync state, masking the real problem.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/tcfsd/src/grpc.rs
   Line: 822-826

   Comment:
   **`needs_sync` errors silently reported as "synced"**

   The wildcard arm `_ => entry.status.to_string()` collapses both `Ok(None)` (file is genuinely in sync) and `Err(e)` (IO/stat failure) into the same `"synced"` response. A transient filesystem error during the check will be silently swallowed and surfaced to the client as a clean sync state, masking the real problem.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: crates/tcfsd/src/grpc.rs
Line: 822-826

Comment:
**`needs_sync` errors silently reported as "synced"**

The wildcard arm `_ => entry.status.to_string()` collapses both `Ok(None)` (file is genuinely in sync) and `Err(e)` (IO/stat failure) into the same `"synced"` response. A transient filesystem error during the check will be silently swallowed and surfaced to the client as a clean sync state, masking the real problem.

```suggestion
                let state = if entry.status == tcfs_sync::state::FileSyncStatus::Synced {
                    match cache.needs_sync(&path) {
                        Ok(Some(_)) => "pending".to_string(),
                        Ok(None) => entry.status.to_string(),
                        Err(e) => {
                            tracing::warn!(error = %e, path = %req.path, "needs_sync check failed");
                            entry.status.to_string()
                        }
                    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: crates/tcfsd/src/daemon.rs
Line: 562-565

Comment:
**`mark_conflict` return value silently ignored in watcher path**

`mark_conflict` returns `false` when the entry is not in the state cache, but the watcher discards the return value. If the path is missing from the cache at conflict-detection time, the conflict is silently dropped — neither persisted nor logged. The gRPC push handler checks the return value and flushes only on success, which is the right pattern.

```suggestion
                                                    if !cache.mark_conflict(
                                                        &task.path,
                                                        info.clone(),
                                                    ) {
                                                        warn!(
                                                            path = %task.path.display(),
                                                            "watcher: conflict detected but no state entry found to update"
                                                        );
                                                    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: crates/tcfs-cli/src/main.rs
Line: 2175-2181

Comment:
**State cache reopened after destructive file ops — inconsistency window**

The stub is written and the original file removed before the second `StateCache::open`. If that open call or the subsequent `flush` fails (e.g., disk-full, permissions), the on-disk state still records the file as `Synced` while the hydrated file is gone and a stub exists. A later `sync-status` call would show `sync state: synced` / `sync check: up to date` because the `!canonical.exists()` branch suppresses `needs_sync`, giving a misleading result with no visible error.

Consider holding the same `StateCache` through the entire function and flushing once at the end, or at minimum propagating the error with a clear message that the stub was already written.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sync): preserve conflict state on sk..."](https://github.com/jesssullivan/tummycrypt/commit/77c26d6b585cae9581646a409d92cab2be5b4944) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28716843)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->