### PR TITLE
chore(clippy): clear pre-existing lints on main

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -868,11 +868,7 @@ fn resolve_sync_status_lookup_path(path: &Path) -> Result<PathBuf> {
         if stub_candidate.exists() {
             let stub = std::fs::canonicalize(&stub_candidate)?;
             let parent = stub.parent().context("stub path has no parent")?;
-            return Ok(parent.join(
-                path.file_name()
-                    .context("path has no filename")?
-                    .to_os_string(),
-            ));
+            return Ok(parent.join(path.file_name().context("path has no filename")?));
         }
     }
 
@@ -889,7 +885,7 @@ async fn cmd_push_with_operator(
     state_path: &Path,
     device_id: &str,
 ) -> Result<()> {
-    let mut state = tcfs_sync::state::StateCache::open(&state_path)
+    let mut state = tcfs_sync::state::StateCache::open(state_path)
         .with_context(|| format!("opening state cache: {}", state_path.display()))?;
     let collect_cfg = collect_config_from_sync(config);
 
@@ -1128,7 +1124,7 @@ async fn cmd_pull_with_operator(
     });
 
     // Open state cache for vclock merge during pull
-    let mut state = tcfs_sync::state::StateCache::open(&state_path)
+    let mut state = tcfs_sync::state::StateCache::open(state_path)
         .with_context(|| format!("opening state cache: {}", state_path.display()))?;
 
     // Load master key for E2E decryption if configured
@@ -2134,13 +2130,11 @@ async fn cmd_unsync(
     let hash_hex = tcfs_chunks::hash_to_hex(&hash);
     let size = data.len() as u64;
 
-    if !force {
-        if tracked.blake3 != hash_hex {
-            anyhow::bail!(
-                "{} has local changes (hash mismatch). Use --force to unsync anyway.",
-                path.display()
-            );
-        }
+    if !force && tracked.blake3 != hash_hex {
+        anyhow::bail!(
+            "{} has local changes (hash mismatch). Use --force to unsync anyway.",
+            path.display()
+        );
     }
 
     let sync_root = config.sync.sync_root.as_deref();

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -306,12 +306,17 @@ async fn publish_index_reference(
     write_committed_index_entry(op, &index_key, &entry).await
 }
 
+/// Stages of the manifest/index publish pipeline.
+///
+/// Emitted via the `after_stage` hook in `publish_manifest_for_rel_path_with_hook`
+/// so tests can inject failures between steps (see `engine` test module).
+/// Each variant names the artifact that has **just been written**.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PublishStage {
-    StagedManifestWritten,
-    PreparingIndexWritten,
-    FinalManifestWritten,
-    CommittedIndexWritten,
+    StagedManifest,
+    PreparingIndex,
+    FinalManifest,
+    CommittedIndex,
 }
 
 async fn publish_manifest_for_rel_path(
@@ -358,7 +363,7 @@ where
     op.write(&staged_manifest_key, manifest_bytes.clone())
         .await
         .with_context(|| format!("writing staged manifest: {staged_manifest_key}"))?;
-    after_stage(PublishStage::StagedManifestWritten)?;
+    after_stage(PublishStage::StagedManifest)?;
 
     write_preparing_index_entry(
         op,
@@ -372,17 +377,17 @@ where
         ),
     )
     .await?;
-    after_stage(PublishStage::PreparingIndexWritten)?;
+    after_stage(PublishStage::PreparingIndex)?;
 
     if !op.exists(&final_manifest_key).await.unwrap_or(false) {
         op.write(&final_manifest_key, manifest_bytes)
             .await
             .with_context(|| format!("uploading manifest: {final_manifest_key}"))?;
-        after_stage(PublishStage::FinalManifestWritten)?;
+        after_stage(PublishStage::FinalManifest)?;
     }
 
     write_committed_index_entry(op, &index_key, &entry).await?;
-    after_stage(PublishStage::CommittedIndexWritten)?;
+    after_stage(PublishStage::CommittedIndex)?;
     let _ = op.delete(&staged_manifest_key).await;
     Ok(())
 }
@@ -2456,7 +2461,7 @@ mod tests {
             test_manifest_bytes("new456", 11),
             RemoteIndexEntry::new("new456", 11, 1),
             |stage| {
-                if stage == PublishStage::StagedManifestWritten {
+                if stage == PublishStage::StagedManifest {
                     return Err(anyhow::anyhow!("injected crash after staged manifest"));
                 }
                 Ok(())
@@ -2498,7 +2503,7 @@ mod tests {
             test_manifest_bytes("new456", 11),
             RemoteIndexEntry::new("new456", 11, 1),
             |stage| {
-                if stage == PublishStage::PreparingIndexWritten {
+                if stage == PublishStage::PreparingIndex {
                     return Err(anyhow::anyhow!("injected crash after preparing index"));
                 }
                 Ok(())
@@ -2564,7 +2569,7 @@ mod tests {
             test_manifest_bytes("new456", 11),
             RemoteIndexEntry::new("new456", 11, 1),
             |stage| {
-                if stage == PublishStage::FinalManifestWritten {
+                if stage == PublishStage::FinalManifest {
                     return Err(anyhow::anyhow!("injected crash after final manifest"));
                 }
                 Ok(())
@@ -2618,7 +2623,7 @@ mod tests {
             test_manifest_bytes("new456", 11),
             RemoteIndexEntry::new("new456", 11, 1),
             |stage| {
-                if stage == PublishStage::CommittedIndexWritten {
+                if stage == PublishStage::CommittedIndex {
                     return Err(anyhow::anyhow!("injected crash after committed index"));
                 }
                 Ok(())

--- a/crates/tcfs-sync/tests/multi_machine_sim.rs
+++ b/crates/tcfs-sync/tests/multi_machine_sim.rs
@@ -803,7 +803,7 @@ fn test_nats_reconnect_replays_missed_updates() {
         &SimOp::ProcessEvents { machine: 2 },
     );
     assert!(
-        machines[2].files.get("report.txt").is_none(),
+        !machines[2].files.contains_key("report.txt"),
         "machine should not receive replay while NATS is disconnected"
     );
 
@@ -859,7 +859,7 @@ fn test_storage_recovery_allows_retry_and_replay() {
     );
     assert_eq!(failed_push, Some(false));
     assert!(
-        remote.manifests.get("offline.txt").is_none(),
+        !remote.manifests.contains_key("offline.txt"),
         "failed push must not leave a remote manifest behind"
     );
     assert!(


### PR DESCRIPTION
## Summary

Clears the pre-existing clippy lints that were called out as "known unrelated" in the bodies of PRs #302 / #303 / #304. With this landed, `cargo clippy --workspace --all-targets -- -D warnings` is green on main.

All six lint sites were verified pre-existing on `main @ 8745d40`. No behavior change — pure lint hygiene.

### Lints cleared

- `crates/tcfs-sync/src/engine.rs` — **`enum_variant_names`** on `PublishStage`: renamed the 4 variants to drop the redundant `Written` suffix (`StagedManifestWritten` → `StagedManifest`, etc.) and added a doc-comment explaining the test-injection contract. Module-internal type; 8 call sites updated atomically.
- `crates/tcfs-cli/src/main.rs`:
  - line 872: **`unnecessary_to_owned`** — dropped `.to_os_string()`; `Path::join` takes `AsRef<Path>` and `&OsStr` already satisfies that.
  - lines 892 / 1131: **`needless_borrow`** — dropped `&` on `StateCache::open(state_path)` where the binding is already `&Path`. The other two call sites (1481, 2165) keep their `&` because the binding there is `PathBuf` — not over-collapsing was the subtle part.
  - line 2137: **`collapsible_if`** — collapsed `if !force { if X { ... } }` into `if !force && X { ... }`.
- `crates/tcfs-sync/tests/multi_machine_sim.rs` lines 806 / 862: **`unnecessary_get_then_check`** — replaced `.get(k).is_none()` with `!.contains_key(k)`.

### Semantic invariants preserved

- `PublishStage` is `enum PublishStage` (private, module-internal). All 8 call sites (4 emit, 4 match in tests) updated in one atomic edit pass.
- `StateCache::open` takes `&Path`. Passing `&state_path` where `state_path: &Path` is double-borrow; passing `&state_path` where `state_path: PathBuf` is the correct deref. The fix differentiates by local binding type.
- `Path::join` takes `AsRef<Path>`; `OsStr: AsRef<Path>` so the `.to_os_string()` allocation was never needed.
- `HashMap::get(k).is_none()` ≡ `!HashMap::contains_key(k)` for `K: Eq + Hash` — same underlying lookup, simpler signature.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0, full workspace
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p tcfs-sync --test multi_machine_sim` — 10/10 pass (includes the two assertions rewritten in this PR)
- [x] `cargo test -p tcfs-cli` — 8 unit + 17 parsing all pass
- [ ] CI green on push

Refs: #302 #303 #304

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pure lint-hygiene PR that clears six pre-existing Clippy warnings across three files, making `cargo clippy --workspace --all-targets -- -D warnings` green on `main`. All changes are mechanical: an enum variant rename, two needless-borrow drops, one collapsible-if collapse, one unnecessary-to-owned removal, and two `get().is_none()` → `!contains_key()` rewrites. No behaviour change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are mechanical lint fixes with no behaviour change.

Every fix is a direct, verified equivalence transformation (enum rename with all 8 call sites updated, borrow-drop where the binding is already &Path, unnecessary allocation removed, logical collapse of nested ifs, and contains_key substitution). No new unwrap/expect, no unsafe, no crypto/FFI changes. All remaining findings would be P2 at most.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/tcfs-sync/src/engine.rs | Drops `Written` suffix from all four `PublishStage` variants; adds doc-comment explaining the test-injection contract. All 8 call sites (4 emit + 4 match) updated atomically. |
| crates/tcfs-cli/src/main.rs | Removes unnecessary `.to_os_string()` allocation (line ~864), drops `&` on two `StateCache::open` calls where the binding is already `&Path` (lines ~888, ~1127), and collapses a nested `if !force { if X }` into `if !force && X` (~line 2133). The two other `StateCache::open(&state_path)` sites correctly retain `&` because those bindings are `PathBuf`. |
| crates/tcfs-sync/tests/multi_machine_sim.rs | Two `.get(k).is_none()` assertions replaced with `!contains_key(k)` — semantically identical, idiomatic Rust. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[publish_manifest_for_rel_path_with_hook] --> B[write staged manifest]
    B -->|after_stage| S1[PublishStage::StagedManifest]
    S1 --> C[write_preparing_index_entry]
    C -->|after_stage| S2[PublishStage::PreparingIndex]
    S2 --> D{final manifest exists?}
    D -- No --> E[write final manifest]
    E -->|after_stage| S3[PublishStage::FinalManifest]
    D -- Yes --> F[write_committed_index_entry]
    S3 --> F
    F -->|after_stage| S4[PublishStage::CommittedIndex]
    S4 --> G[delete staged manifest]
    style S1 fill:#d4edda
    style S2 fill:#d4edda
    style S3 fill:#d4edda
    style S4 fill:#d4edda
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(clippy): clear pre-existing lints ..."](https://github.com/jesssullivan/tummycrypt/commit/ec734ea8c8afca75af0069b6df7a0e07904adfe4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28741690)</sub>

<!-- /greptile_comment -->