### PR TITLE
docs(release): freeze v0.12.2 surface evidence matrix

### DIFF
--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -40,6 +40,8 @@ This is the narrowest and most important truth for public release claims.
 | Nix install | blocked | cache/builder path is still not proving cleanly enough to count as release proof |
 
 Canonical runbook: [Distribution Smoke Matrix](distribution-smoke-matrix.md).
+Per-release evidence freeze for `v0.12.2`:
+[v0.12.2 Evidence Matrix](../release/v0.12.2-evidence-matrix.md).
 
 ### 2. Continuous CI / Build Proof
 
@@ -193,6 +195,7 @@ than by many open GitHub issues.
 ## Related Documents
 
 - [Distribution Smoke Matrix](distribution-smoke-matrix.md)
+- [v0.12.2 Evidence Matrix](../release/v0.12.2-evidence-matrix.md)
 - [Lab Host Acceptance Matrix](lab-host-acceptance-matrix.md)
 - [Neo-Honey Live Acceptance](neo-honey-acceptance.md)
 - [Apple Surface Status](apple-surface-status.md)

--- a/docs/release/v0.12.2-evidence-matrix.md
+++ b/docs/release/v0.12.2-evidence-matrix.md
@@ -25,13 +25,13 @@ surfaces are tracked here.
 
 | # | Surface | Fresh install | Upgrade | Result | Evidence |
 |---|---------|---------------|---------|--------|----------|
-| 1 | Homebrew | pass | pass | ✅ | [#280 macOS pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4260990239) |
-| 2 | macOS `.pkg` | not run on clean host | pass on maintainer workstation | ⚠️ partial | [#280 macOS pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4260990239) |
-| 3 | `.deb` on Ubuntu 24.04 | pass | pass (`0.12.1 → 0.12.2`) | ✅ | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
-| 4 | `.deb` on Debian 12 bookworm | fail | fail | ❌ blocked | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
-| 5 | `.rpm` on Fedora 42 | pass (`--skip-cli`) | sampled | ✅ daemon-only | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
-| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.2` | pass | sampled | ✅ | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
-| 7 | Nix flake install | blocked | sampled | ❌ blocked | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
+| 1 | Homebrew | pass | pass | ✅ | [#280 macOS smoke 2026-04-16](https://github.com/Jesssullivan/tummycrypt/issues/280) |
+| 2 | macOS `.pkg` | not run on clean host | pass on maintainer workstation | ⚠️ partial | [#280 macOS smoke 2026-04-16](https://github.com/Jesssullivan/tummycrypt/issues/280) |
+| 3 | `.deb` on Ubuntu 24.04 | pass | pass (`0.12.1 → 0.12.2`) | ✅ | [#280 Linux smoke 2026-04-16](https://github.com/Jesssullivan/tummycrypt/issues/280) |
+| 4 | `.deb` on Debian 12 bookworm | fail | fail | ❌ blocked | [#280 Linux smoke 2026-04-16](https://github.com/Jesssullivan/tummycrypt/issues/280) |
+| 5 | `.rpm` on Fedora 42 | pass (`--skip-cli`) | sampled | ✅ daemon-only | [#280 Linux smoke 2026-04-16](https://github.com/Jesssullivan/tummycrypt/issues/280) |
+| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.2` | pass | sampled | ✅ | [#280 Linux smoke 2026-04-16](https://github.com/Jesssullivan/tummycrypt/issues/280) |
+| 7 | Nix flake install | blocked | sampled | ❌ blocked | [#280 Linux smoke 2026-04-16](https://github.com/Jesssullivan/tummycrypt/issues/280) |
 
 Rollup: **4 pass · 1 partial · 2 blocked**.
 

--- a/docs/release/v0.12.2-evidence-matrix.md
+++ b/docs/release/v0.12.2-evidence-matrix.md
@@ -1,0 +1,263 @@
+# v0.12.2 Release Surface Evidence Matrix
+
+Concrete proof table for `tcfs v0.12.2`, anchored against the tagged release and
+the [Distribution Smoke Matrix](../ops/distribution-smoke-matrix.md) runbook.
+
+This document is the evidence freeze that issue #280 asks for: every shipped
+release surface, what was actually proven, what was not, and what specifically
+blocks the remaining proof. Use it as a link target from tracker comments and
+from [`product-reality-and-priority.md`](../ops/product-reality-and-priority.md)
+rather than re-describing release state in prose.
+
+## Release Metadata
+
+- Tag: `v0.12.2`
+- Released: 2026-04-16T14:21:24Z
+- Release commit: `2d26c11` ([`2d26c115a50e343952fd9e8999c06864f97706a0`](https://github.com/Jesssullivan/tummycrypt/commit/2d26c115a50e343952fd9e8999c06864f97706a0))
+- Release workflow run: [`actions/runs/24515122140`](https://github.com/Jesssullivan/tummycrypt/actions/runs/24515122140)
+- Release notes: [`releases/tag/v0.12.2`](https://github.com/Jesssullivan/tummycrypt/releases/tag/v0.12.2)
+
+## Summary Table
+
+The canonical smoke matrix lists six surfaces. This matrix splits `.deb` into
+Ubuntu 24.04 and Debian 12 because their outcomes differ materially, so seven
+surfaces are tracked here.
+
+| # | Surface | Fresh install | Upgrade | Result | Evidence |
+|---|---------|---------------|---------|--------|----------|
+| 1 | Homebrew | pass | pass | ✅ | [#280 macOS pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4260990239) |
+| 2 | macOS `.pkg` | not run on clean host | pass on maintainer workstation | ⚠️ partial | [#280 macOS pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4260990239) |
+| 3 | `.deb` on Ubuntu 24.04 | pass | pass (`0.12.1 → 0.12.2`) | ✅ | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
+| 4 | `.deb` on Debian 12 bookworm | fail | fail | ❌ blocked | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
+| 5 | `.rpm` on Fedora 42 | pass (`--skip-cli`) | sampled | ✅ daemon-only | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
+| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.2` | pass | sampled | ✅ | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
+| 7 | Nix flake install | blocked | sampled | ❌ blocked | [#280 Linux pass](https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4262754046) |
+
+Rollup: **4 pass · 1 partial · 2 blocked**.
+
+## Per-Surface Evidence
+
+### 1. Homebrew — pass
+
+- Host: `neo` (macOS 26.5 arm64, maintainer workstation)
+- Fresh install and upgrade both reached `tcfs 0.12.2` / `tcfsd 0.12.2`
+- `otool -L /opt/homebrew/opt/tcfs/bin/tcfsd` no longer shows
+  `libssl.3.dylib` / `libcrypto.3.dylib`, confirming the post-`v0.12.1` OpenSSL
+  linkage fix is live
+- `tcfsd` is signed by `John Sullivan (QP994XQKNH)` on this lane
+
+Residual note: the `homebrew-tap` checkout flow is still manual on the tap side
+(`brew tap --custom-remote` + `git checkout homebrew-tap`) because upstream
+Homebrew rejects the historical `brew tap ... --branch homebrew-tap` form. That
+is a UX wart, not a release-surface failure.
+
+### 2. macOS `.pkg` — partial pass
+
+- Host: `neo` (macOS 26.5 arm64, maintainer workstation)
+- Upgrade path proven in place: the pre-existing `~/usr/local/bin/tcfs{,d}` were
+  real `v0.12.1` package installs and reproduced the original OpenSSL Team ID
+  failure; `installer -pkg tcfs-0.12.2-macos-aarch64.pkg -target CurrentUserHomeDirectory`
+  upgraded them cleanly to `0.12.2`, removed the OpenSSL dylib linkage, and
+  smoke passed
+- Checksum and signature posture: `pkgutil --check-signature` passed with a
+  Developer ID Installer chain and trusted timestamp; `spctl --assess` reports
+  `Unnotarized Developer ID`, matching the
+  [Apple Surface Status](../ops/apple-surface-status.md) non-fatal notarization
+  posture
+
+Not proven: **fresh install on a clean macOS host**. The upgrade path is
+specific to this workstation. A first-install-on-pristine-VM pass is still
+owed; without it the `.pkg` surface cannot claim full fresh-install proof for
+`v0.12.2`.
+
+Host-specific caveat: on `neo`, `scripts/install-smoke.sh` did not pass
+unmodified because inherited credential discovery, a pre-existing
+`127.0.0.1:9100` listener, and `SUN_LEN` truncation on `/var/folders/...`
+required local neutralizations (stripped env, short `/tmp/...sock` with
+symlink back to the helper's expected path, metrics remapped to
+`127.0.0.1:39100`). These are workstation state issues, not release-surface
+defects, but the helper should be reviewed for pristine-host assumptions.
+
+### 3. Debian/Ubuntu `.deb` on Ubuntu 24.04 — pass
+
+- Host: `honey` (Rocky Linux 10.1 x86_64 running Ubuntu 24.04 container)
+- Fresh install: `dpkg -i tcfsd-0.12.2-amd64.deb tcfs-0.12.2-amd64.deb` +
+  `scripts/install-smoke.sh` passed
+- Upgrade: `0.12.1 → 0.12.2` passed with `tcfs`/`tcfsd` reporting `0.12.2`
+
+### 4. Debian/Ubuntu `.deb` on Debian 12 bookworm — blocked
+
+- Host: `honey` (Rocky Linux 10.1 x86_64 running Debian 12 container)
+- Failure mode: dependency resolution rejects install on bookworm
+- `tcfsd-0.12.2-amd64.deb` requires `libc6 >= 2.39` and `libssl3t64`
+- `tcfs-0.12.2-amd64.deb` also requires `libc6 >= 2.39`
+- Debian 12 ships `libc6 2.36-9+deb12u13` and has no `libssl3t64` package at
+  all (that is a Trixie / Ubuntu 24.04 transitional package name)
+- Consequence: `.deb` surface is proven on Ubuntu 24.04 but **not** on the
+  current Debian stable floor
+
+Unblock paths: see [Blockers and Unblock Paths](#blockers-and-unblock-paths).
+
+### 5. Fedora/RHEL `.rpm` on Fedora 42 — pass (daemon-only)
+
+- Host: `honey` (Rocky Linux 10.1 x86_64 running Fedora 42 container)
+- `dnf install /work/tcfsd-0.12.2-x86_64.rpm` succeeded
+- Daemon-only smoke with `scripts/install-smoke.sh --skip-cli` passed
+- Reported: `tcfsd version: tcfsd 0.12.2`; `CLI smoke skipped`
+
+Structural note: the RPM surface ships `tcfsd` only today. `tcfs` CLI is not
+part of the `.rpm` assets, which is why `--skip-cli` is the required flag
+rather than a concession. This is documented in the
+[Distribution Smoke Matrix](../ops/distribution-smoke-matrix.md#surface-matrix).
+
+### 6. Container image `ghcr.io/jesssullivan/tcfsd:v0.12.2` — pass
+
+- Host: `honey` (Rocky Linux 10.1 x86_64, rootless Podman 5.4.1)
+- `podman pull ghcr.io/jesssullivan/tcfsd:v0.12.2` succeeded
+- `podman run --rm ... --version` returned `tcfsd 0.12.2`
+- Worker-mode smoke: `worker pool ready`, followed by clean SIGTERM drain
+  after the 10s timeout, with a disposable local NATS JetStream and
+  `nats_tls = false` set explicitly in the test config
+
+Structural note: image is Linux `amd64` only. On Apple Silicon the native pull
+fails; `docker run --platform linux/amd64 ghcr.io/jesssullivan/tcfsd:v0.12.2 --help`
+succeeds under emulation, but multi-arch manifests are not yet published. This
+is not new in `v0.12.2`; it is the documented container surface posture.
+
+### 7. Nix flake install — blocked
+
+- Host: `honey` (Rocky Linux 10.1 x86_64, user-space Nix 2.33.3)
+- Command: `nix profile install github:Jesssullivan/tummycrypt?ref=v0.12.2#tcfsd github:Jesssullivan/tummycrypt?ref=v0.12.2#tcfs-cli`
+- Failure mode: the configured custom binary cache hostname
+  `nix-cache.fuzzy-dev.tinyland.dev` does not resolve externally from
+  `honey`, so the install fell back to a full local build. After hundreds of
+  derivations the run was interrupted without yielding a usable profile.
+
+This is the same failure mode reported for the `v0.12.1` Nix lane. The tag
+change alone does not unblock this surface; the cache-reachability problem is
+environmental, not release-artifact-level.
+
+Unblock paths: see [Blockers and Unblock Paths](#blockers-and-unblock-paths).
+
+## Blockers And Unblock Paths
+
+Three concrete blockers stand between the current `4 pass · 1 partial · 2
+blocked` rollup and a fully green matrix. Each has more than one viable
+unblock path; the decision is operator-level and is tracked in follow-up
+issues, not resolved in this document.
+
+### Blocker A — Nix cache externality
+
+**Root cause:** `nix-cache.fuzzy-dev.tinyland.dev` is a tinyland-hosted Attic
+instance that does not resolve externally. Any Nix install off a non-tinyland
+host falls back to full local build.
+
+**Unblock paths:**
+
+1. Expose the Attic instance publicly (for example via a Cloudflare Tunnel in
+   front of the existing Attic service), so `v0.12.x` Nix installs on operator
+   hosts can pull prebuilt binaries rather than re-derive them
+2. Add a secondary cache (Cachix is the zero-infra option) and point the
+   flake-provided `nixConfig.extra-substituters` at both the tinyland cache
+   and the public one, so externality is no longer a single point of failure
+3. Explicitly narrow the supported install story in documentation: keep
+   `nix profile install` as a developer-level path that assumes a reachable
+   cache, and declare "operator builds from source" as the only release-proof
+   Nix lane for unowned hosts
+
+Scope note: option (1) is also relevant to Task #6 (remote governance), since
+the tinyland-hosted cache is infrastructure coupling between `Jesssullivan/tummycrypt`
+(canonical source per README) and `tinyland-inc/tummycrypt` (active downstream
+dev surface). Externalizing the cache simplifies both the release surface and
+the governance story.
+
+### Blocker B — Debian 12 bookworm support floor
+
+**Root cause:** `tcfsd` links against `libc6 >= 2.39` and `libssl3t64`.
+Debian 12 bookworm ships `libc6 2.36` and does not provide `libssl3t64` at
+all. The current `.deb` assets are therefore not installable on the current
+Debian stable.
+
+**Unblock paths:**
+
+1. Add a bookworm-targeted build variant that uses an older sysroot and the
+   bookworm-native `libssl3` (non-`t64`) so the published `.deb` works on
+   Debian 12 without dropping support for Ubuntu 24.04
+2. Ship a static build: use the `openssl` crate's `vendored` feature and
+   target `x86_64-unknown-linux-musl`, producing `.deb` assets whose
+   dependencies are narrow enough to install cleanly on any glibc-based or
+   musl-based distro (including bookworm)
+3. Drop Debian 12 from the claimed support floor honestly: mark the `.deb`
+   surface as Ubuntu 24.04+ (and Debian Trixie once released) in
+   [`platform-support.md`](../platform-support.md), and note Debian 12 as
+   out of scope for packaged install
+
+Scope note: option (2) is the broadest fix and also benefits non-Debian
+glibc-old distros, but it is a build-system change (musl toolchain) with
+downstream implications for FUSE linking and any OpenSSL-dependent runtime
+paths. Option (1) is the narrowest targeted fix. Option (3) is the honest
+documentation fix if neither (1) nor (2) is acceptable.
+
+### Blocker C — macOS `.pkg` fresh install on clean host
+
+**Root cause:** the v0.12.2 `.pkg` upgrade path is proven on `neo`, but a
+fresh-install-on-pristine-macOS pass is only inferred from the post-upgrade
+`otool` / `spctl` state. Without a clean VM the fresh lane is documented as
+"not run on a clean host," not proven.
+
+**Unblock paths:**
+
+1. Add a once-per-tag pristine macOS VM lane (Tart or UTM) to the release
+   acceptance workflow, executing `scripts/install-smoke.sh` against the
+   downloaded `.pkg` from a known-clean starting state
+2. Accept the current upgrade-pass-on-workstation posture as sufficient proof
+   for `v0.12.x` and document that the first fresh install on a clean host
+   is covered by community bug reports rather than maintainer VM proof
+3. Use a scheduled CI job (GitHub Actions macOS runner is close enough to a
+   clean host) to install from the release `.pkg` and run the smoke helper
+   nightly
+
+This blocker is the smallest of the three in terms of risk to claimed
+behavior, because the post-upgrade binary state on `neo` already exercises
+the shipped artifact. It is the largest gap in terms of operator confidence
+on first-time install, because operators are more likely to hit `installer`
+edge cases than upgrade edge cases.
+
+## Recommended Follow-Up Issues
+
+Closing `#280` at the documentation level requires that the remaining proof
+work is trackable somewhere other than this frozen matrix. The recommended
+split is:
+
+- **Nix cache externality** (Blocker A): one issue with options 1-3 as
+  decision points, owner is a release/infra lane rather than a code lane
+- **Debian 12 support decision** (Blocker B): one issue framed as a support
+  posture decision, not a build fix; the output is either a new build target
+  or an explicit support-floor narrowing
+- **Clean-host macOS `.pkg` lane** (Blocker C): one issue scoped to the
+  acceptance workflow rather than the release workflow
+
+These three follow-ups are the minimum needed to claim that `#280` has no
+silent blockers after close. They are intentionally scoped narrowly; broader
+work on Apple desktop acceptance, iOS, and accessibility already has tracking
+elsewhere in [`product-reality-and-priority.md`](../ops/product-reality-and-priority.md).
+
+## Relationship To Other Acceptance Lanes
+
+- Use this matrix as the **evidence freeze for a tagged release**; one doc per
+  release tag where release-surface proof is non-trivial
+- Use the [Distribution Smoke Matrix](../ops/distribution-smoke-matrix.md) as
+  the **runbook** for how the proof is gathered on each surface; the runbook
+  is stable across releases
+- Use [`product-reality-and-priority.md`](../ops/product-reality-and-priority.md)
+  as the **current-state summary** across all surfaces and lanes, not per-release
+- Use the [Lab Host Acceptance Matrix](../ops/lab-host-acceptance-matrix.md)
+  for **host-level acceptance**, which is orthogonal to release surface proof
+- Use the [Neo-Honey Live Acceptance](../ops/neo-honey-acceptance.md) doc for
+  **live backend sync proof**, which is orthogonal to both release surface and
+  host acceptance
+
+## Revision History
+
+- 2026-04-17 — Initial matrix captured from #280 comments on 2026-04-16;
+  release commit `2d26c11`; matrix rollup `4 pass · 1 partial · 2 blocked`


### PR DESCRIPTION
## Summary

Seeds the per-release evidence freeze that #280 asks for.

Canonical runbook [docs/ops/distribution-smoke-matrix.md](https://github.com/Jesssullivan/tummycrypt/blob/main/docs/ops/distribution-smoke-matrix.md) is stable across releases; this new file at `docs/release/v0.12.2-evidence-matrix.md` captures **what was actually proven on `v0.12.2`** so tracker comments can link here instead of re-describing state in prose.

### Rollup

**4 pass · 1 partial · 2 blocked** across 7 tracked surfaces (the six canonical surfaces plus `.deb` split into Ubuntu 24.04 and Debian 12 because their outcomes differ materially).

| # | Surface | Fresh | Upgrade | Result |
|---|---------|-------|---------|--------|
| 1 | Homebrew | pass | pass | ✅ |
| 2 | macOS `.pkg` | not run on clean host | pass on neo | ⚠️ partial |
| 3 | `.deb` Ubuntu 24.04 | pass | pass | ✅ |
| 4 | `.deb` Debian 12 bookworm | fail | fail | ❌ blocked |
| 5 | `.rpm` Fedora 42 | pass (`--skip-cli`) | sampled | ✅ |
| 6 | Container `ghcr.io/...:v0.12.2` | pass | sampled | ✅ |
| 7 | Nix flake install | blocked | sampled | ❌ blocked |

Every row links to its source [#280](https://github.com/Jesssullivan/tummycrypt/issues/280) comment.

### Blockers documented with unblock paths

Each blocker has **multiple** unblock paths enumerated so follow-up tracking doesn't lock in a single fix:

- **Nix cache externality** — `nix-cache.fuzzy-dev.tinyland.dev` not reachable externally. Options: externalize Attic via Cloudflare Tunnel, add Cachix fallback, or narrow supported install story.
- **Debian 12 bookworm** — `libc6 >= 2.39` / `libssl3t64` unavailable on bookworm floor. Options: add bookworm-targeted build variant, static build via `openssl` vendored + musl target, or drop Debian 12 from claimed support floor.
- **macOS `.pkg` fresh install on clean host** — only upgrade proven. Options: pristine macOS VM lane (Tart/UTM), accept upgrade-pass-on-workstation posture, or scheduled GitHub Actions macOS runner.

### What this PR is not

- Not a runbook change (the runbook is [`docs/ops/distribution-smoke-matrix.md`](https://github.com/Jesssullivan/tummycrypt/blob/main/docs/ops/distribution-smoke-matrix.md))
- Not an attempt to resolve blockers; three follow-up issues will be opened separately so #280 can close with no silent blockers
- Not a product-state summary (that's [`docs/ops/product-reality-and-priority.md`](https://github.com/Jesssullivan/tummycrypt/blob/main/docs/ops/product-reality-and-priority.md), which now links to this freeze)

## Test plan

- [x] `lychee --offline docs/release/v0.12.2-evidence-matrix.md docs/ops/product-reality-and-priority.md` — 16 OK, 0 errors, 5 excluded (tinyland-hosted URLs per `.lychee.toml`)
- [x] GPG-signed commit
- [ ] docs CI lychee + Jekyll build on push
- [ ] Greptile review

Refs: #280

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the per-release evidence freeze for `v0.12.2` (`docs/release/v0.12.2-evidence-matrix.md`) and wires it into `docs/ops/product-reality-and-priority.md` via two cross-references. The matrix honestly documents a `4 pass · 1 partial · 2 blocked` rollup across seven surfaces, with concrete blocker root-causes and multiple unblock paths for each.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only PR with no code changes and one minor P2 clarity suggestion.

All findings are P2 style suggestions. The document structure is sound, internal cross-references resolve correctly, and the runbook anchor (#surface-matrix) is valid. The one ambiguity (Nix "sampled" upgrade cell) is a readability note, not a factual error that would mislead operators.

No files require special attention; docs/release/v0.12.2-evidence-matrix.md has a minor clarity note on the Nix upgrade column.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/release/v0.12.2-evidence-matrix.md | New evidence freeze document for v0.12.2 release surfaces. Well-structured, but "sampled" in the Upgrade column is used without definition and is ambiguous for the Nix row where fresh install is also blocked. |
| docs/ops/product-reality-and-priority.md | Adds two cross-references to the new v0.12.2 evidence matrix (one inline, one in Related Documents). Both relative paths resolve correctly against the new file's location. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["product-reality-and-priority.md\n(current-state summary)"] -->|links to| B["v0.12.2-evidence-matrix.md\n(per-release evidence freeze)"]
    A -->|links to| C["distribution-smoke-matrix.md\n(canonical runbook)"]
    B -->|anchored against| C
    B -->|sources evidence from| D["#280 comments\n(issue tracker)"]
    B --> E{Result}
    E -->|4 pass| F["Homebrew ✅\nUbuntu 24.04 .deb ✅\nFedora 42 .rpm ✅ daemon-only\nContainer ghcr.io ✅"]
    E -->|1 partial| G["macOS .pkg ⚠️\nupgrade only"]
    E -->|2 blocked| H["Debian 12 .deb ❌\nNix flake ❌"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/release/v0.12.2-evidence-matrix.md
Line: 34

Comment:
**"sampled" upgrade cell unsupported for blocked Nix row**

The Upgrade column for row 7 (Nix flake) reads `sampled`, but §7 describes only a single fresh-install attempt that was interrupted — no upgrade attempt is documented. For rows 5 (`.rpm`) and 6 (container), `sampled` is ambiguous too, but the blocked fresh-install context makes it especially unclear here: does `sampled` mean "an upgrade was partially attempted and also failed," or does it mean "upgrade is runbook-optional for this surface, so we didn't try it"? The `distribution-smoke-matrix.md` runbook does mark Nix upgrade as "Sampled" (policy-optional), so the latter interpretation is consistent — but a brief parenthetical like `sampled (policy — not attempted; fresh blocked)` or a legend footnote would remove the ambiguity for readers who follow links here without reading the runbook first.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(release): drop issuecomment fragmen..."](https://github.com/jesssullivan/tummycrypt/commit/dd67ec37292335f15f84390c935ca237be6cba51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28743890)</sub>

<!-- /greptile_comment -->