### PR TITLE
[codex] docs: reconcile governance and release-proof surfaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1040,7 +1040,7 @@ jobs:
             sudo installer -pkg tcfs-${{ needs.plan.outputs.version }}-macos-aarch64.pkg -target /
             ```
 
-            **Linux / macOS (shell script):**
+            **Linux/macOS tarball convenience installer (CLI-first, not a release-proof surface):**
             ```bash
             curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.tag }}/install.sh | sh
             ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ task check
 ## Installation
 
 ```bash
-# Linux (installer script)
+# Linux/macOS tarball convenience installer
+# Fast CLI install, but not part of the canonical release-proof surface.
 curl -fsSL https://github.com/Jesssullivan/tummycrypt/releases/latest/download/install.sh | sh
 
 # macOS (Homebrew, current manual tap flow)
@@ -63,6 +64,10 @@ podman pull ghcr.io/jesssullivan/tcfsd:latest
 # Nix
 nix build github:Jesssullivan/tummycrypt
 ```
+
+For the supported post-release proof contract across Homebrew, `.pkg`, `.deb`,
+`.rpm`, container, and Nix, see
+[docs/ops/distribution-smoke-matrix.md](docs/ops/distribution-smoke-matrix.md).
 
 ## CLI
 
@@ -115,6 +120,8 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full system design.
 
 For packaged release proof across Homebrew, `.pkg`, `.deb`, `.rpm`, container,
 and Nix surfaces, see [docs/ops/distribution-smoke-matrix.md](docs/ops/distribution-smoke-matrix.md).
+For the bar after install succeeds, see
+[docs/ops/packaged-install-first-use.md](docs/ops/packaged-install-first-use.md).
 
 ## Platform Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ default here.
 Download the latest release from [GitHub Releases](https://github.com/Jesssullivan/tummycrypt/releases):
 
 ```bash
-# Linux (x86_64)
+# Linux/macOS tarball convenience installer
+# Fast CLI install, but not part of the canonical release-proof surface.
 curl -fsSL https://github.com/Jesssullivan/tummycrypt/releases/latest/download/install.sh | sh
 
 # macOS (Homebrew, current manual tap flow)
@@ -129,6 +130,7 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 ### Ops Runbooks
 - [Product Reality and Priority](ops/product-reality-and-priority.md) — current proof surface, honest product posture, and prioritized backlog
 - [Distribution Smoke Matrix](ops/distribution-smoke-matrix.md) — canonical post-release install proof across Homebrew, `.pkg`, `.deb`, `.rpm`, container, and Nix
+- [Packaged Install To First-Real-Use Acceptance](ops/packaged-install-first-use.md) — the bar after artifact smoke passes and before broader host acceptance
 - [Lab Host Acceptance Matrix](ops/lab-host-acceptance-matrix.md) — real-host acceptance lanes across `honey`, `neo`, and `petting-zoo-mini`
 - [Neo-Honey Live Acceptance](ops/neo-honey-acceptance.md) — named live fleet sync acceptance lane
 - [On-Prem Authority Recovery](ops/onprem-authority-recovery.md) — source-of-truth and recovery path for the Helm-managed `tcfs` backend namespace

--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -24,6 +24,19 @@ surfaces below have passed their required smoke checks.
   - container upgrades are normally orchestrator rollouts rather than a host-local installer flow
   - Nix installs are immutable and ref-pinned, so the per-tag fresh install gate is the most meaningful baseline
 
+## Out-Of-Scope Published Helpers
+
+The release workflow also publishes helper installers:
+
+- `install.sh` for Linux/macOS tarball convenience installs
+- `install.ps1` for Windows convenience installs
+
+These are **not** canonical release-proof surfaces today.
+
+- `install.sh` remains convenience tooling until a dedicated smoke lane is added
+- `install.ps1` is convenience-only because Windows is not yet a truthful
+  release-grade user surface
+
 ## Shared Installed-Binary Smoke
 
 For any release surface that places `tcfsd` on `PATH`, run:
@@ -50,9 +63,12 @@ What it does **not** prove:
 - live SeaweedFS or NATS connectivity
 - Finder or FileProvider behavior
 - service-manager integration via systemd or launchd
+- truthful first use against reachable storage
 - Kubernetes rollout semantics
 
-Those remain surface-specific follow-on checks, documented below.
+Those remain surface-specific follow-on checks. For the bridge from
+installed-binary smoke to the first truthful user action, use
+[Packaged Install To First-Real-Use Acceptance](packaged-install-first-use.md).
 
 ## Surface Matrix
 
@@ -202,6 +218,8 @@ using a table like this:
 ## Relationship To Other Acceptance Lanes
 
 - Use this matrix for **distribution surface proof**
+- Use [Packaged Install To First-Real-Use Acceptance](packaged-install-first-use.md)
+  for the **install-to-first-action bar** after artifact smoke passes
 - Use [Neo-Honey Live Acceptance](neo-honey-acceptance.md) for the
   **credentialed live fleet sync path**
 - Use [Lab Host Acceptance Matrix](lab-host-acceptance-matrix.md) for

--- a/docs/ops/packaged-install-first-use.md
+++ b/docs/ops/packaged-install-first-use.md
@@ -1,0 +1,95 @@
+# Packaged Install To First-Real-Use Acceptance
+
+This runbook defines the bridge between:
+
+- [Distribution Smoke Matrix](distribution-smoke-matrix.md), which proves that a
+  shipped artifact installs and starts, and
+- host-backed acceptance lanes, which prove richer operator and end-user-ish
+  behavior on real machines.
+
+The purpose of this document is to answer a narrower question:
+
+Can a released artifact get a user to the first truthful use of `tcfs`, rather
+than only to a runnable binary in a temp home?
+
+## Gate Decision
+
+For `v0.12.x`, packaged-install to first-real-use proof is:
+
+- **required every tag** on the primary mutable user-facing install surfaces:
+  - Homebrew
+  - macOS `.pkg`
+  - Debian/Ubuntu `.deb`
+- **sampled or scenario-driven** on the narrower surfaces:
+  - Fedora/RHEL `.rpm` (daemon-only today)
+  - container image
+  - Nix
+
+This is intentionally stricter than installed-binary smoke, but narrower than
+full host acceptance or desktop UX parity.
+
+## Minimum Contract
+
+Treat a surface as having reached first-real-use proof only when the released
+artifact proves all of the following:
+
+1. **Artifact install is real**
+   - install from the published artifact for that surface
+   - do not swap in local build outputs
+2. **Runtime config is intentional**
+   - use a real config, credentials, or acceptance fixture rather than only the
+     isolated temp-home default used by `scripts/install-smoke.sh`
+3. **Backend reachability is visible**
+   - when the CLI is present, `tcfs status` should report `storage [ok]`
+   - if the surface is daemon-only, use the nearest truthful equivalent
+4. **One real action succeeds**
+   - examples: push/pull, hydrate, enumerate, sync-status against real remote
+     state, or worker startup against real/disposable backend dependencies
+5. **One edge case or power-user action is exercised on primary mutable surfaces**
+   - examples: unsync/rehydrate, conflict recovery, symlink handling, large-file
+     path, or a restart/reconnect path
+
+Passing `scripts/install-smoke.sh` alone is not sufficient to claim this bar.
+
+## Surface Contract
+
+| Surface | Per-tag requirement | First real action | Edge case / follow-on |
+|---------|---------------------|-------------------|-----------------------|
+| Homebrew | every tag | `tcfs status` with `storage [ok]`, then a minimal push/pull or sync-status path | one of: unsync/rehydrate, conflict, symlink, large file |
+| macOS `.pkg` | every tag | package install, then the named Finder/FileProvider lane from [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md) through enumerate + hydrate | clean-host install and one desktop follow-on such as mutate/conflict or unsync/rehydrate |
+| Debian/Ubuntu `.deb` | every tag | `tcfs status` with `storage [ok]`, then minimal push/pull or sync-status | one of: upgrade carry-forward, unsync/rehydrate, conflict, large file |
+| Fedora/RHEL `.rpm` | sampled | daemon/worker startup against intentional config | worker restart or backend reconnect as needed |
+| Container image | sampled | worker startup against real or disposable backend dependencies | restart/reconnect or rollout-oriented check |
+| Nix | sampled until `#307` is resolved | same bar as CLI surfaces once cache/install is truthful | use the same edge-case menu as `.deb` once the install path is stable |
+
+## Relationship To Existing Runbooks
+
+- Use [Distribution Smoke Matrix](distribution-smoke-matrix.md) to prove the
+  published artifact installs and starts.
+- Use this document to prove the released artifact reaches a truthful first use.
+- Use [Lab Host Acceptance Matrix](lab-host-acceptance-matrix.md) for richer
+  real-host acceptance beyond the first user action.
+- Use [Neo-Honey Live Acceptance](neo-honey-acceptance.md) for the named
+  live-backend sync lane.
+- Use [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md) for
+  the Apple desktop path after package install.
+
+## Evidence Capture
+
+Record results using a table like this:
+
+| Surface | Installed artifact | `storage [ok]` or equivalent | First real action | Edge case | Notes |
+|---------|--------------------|------------------------------|-------------------|-----------|-------|
+| Homebrew | pass/fail | pass/fail | pass/fail | pass/fail | |
+| macOS `.pkg` | pass/fail | pass/fail | pass/fail | pass/fail | |
+| Debian/Ubuntu `.deb` | pass/fail | pass/fail | pass/fail | pass/fail | |
+| Fedora/RHEL `.rpm` | pass/fail | n/a or pass/fail | pass/fail | sampled | |
+| Container image | pass/fail | equivalent only | pass/fail | sampled | |
+| Nix | pass/fail | pass/fail | pass/fail | sampled | |
+
+## Current Scope Notes
+
+- `install.sh` is published convenience tooling, not part of the canonical
+  release-proof surface. See [Distribution Smoke Matrix](distribution-smoke-matrix.md).
+- The macOS clean-host lane remains tracked in `#309`.
+- The Nix install path remains blocked on `#307`.

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -40,6 +40,8 @@ This is the narrowest and most important truth for public release claims.
 | Nix install | blocked | cache/builder path is still not proving cleanly enough to count as release proof |
 
 Canonical runbook: [Distribution Smoke Matrix](distribution-smoke-matrix.md).
+Install-to-first-use bridge:
+[Packaged Install To First-Real-Use Acceptance](packaged-install-first-use.md).
 Per-release evidence freeze for `v0.12.2`:
 [v0.12.2 Evidence Matrix](../release/v0.12.2-evidence-matrix.md).
 
@@ -186,18 +188,21 @@ work should be ordered like this:
 
 As of April 17, 2026, the narrow GitHub backlog is:
 
-- `#280`: M10 anchor for distribution install and upgrade proof
-- `#307`: Nix cache externality / operator-host install proof
-- `#308`: Debian 12 `.deb` support-floor decision
-- `#309`: macOS `.pkg` clean-host fresh-install lane
-- `#298`: privileged on-prem authority/namespace reconcile on `honey`
-- `#312`: tinyland branch-tranche triage
-- `#313`: yoga retirement decision
+- M10 release-proof tranche
+  - `#280`: distribution install and upgrade proof umbrella
+  - `#307`: Nix cache externality / operator-host install proof
+  - `#308`: Debian 12 `.deb` support-floor decision
+  - `#309`: macOS `.pkg` clean-host fresh-install lane
+  - `#317`: decide whether published `install.sh` is a supported distribution surface
+  - `#318`: define the packaged-install to first-real-use acceptance bar
+- Adjacent non-M10 lanes
+  - `#298`: privileged on-prem authority/namespace reconcile on `honey`
+  - `#312`: tinyland branch-tranche triage
+  - `#313`: yoga retirement decision
 
-Milestone `#9 M10: Usage Reality & Product Parity` is still open, but only
-because `#280` remains open. The earlier M10 GitHub issues (`#276`-`#279`,
-`#281`) are already closed; the active work has narrowed to release-proof
-follow-through plus governance cleanup.
+Milestone `#9 M10: Usage Reality & Product Parity` remains open because the
+release-proof tranche now consists of six active issues, not just the umbrella.
+The earlier M10 GitHub issues (`#276`-`#279`, `#281`) are already closed.
 
 The broader product backlog still lives mostly in the parity and acceptance
 docs rather than in a large live GitHub issue set.
@@ -205,6 +210,7 @@ docs rather than in a large live GitHub issue set.
 ## Related Documents
 
 - [Distribution Smoke Matrix](distribution-smoke-matrix.md)
+- [Packaged Install To First-Real-Use Acceptance](packaged-install-first-use.md)
 - [v0.12.2 Evidence Matrix](../release/v0.12.2-evidence-matrix.md)
 - [Remote Governance](remote-governance.md)
 - [Lab Host Acceptance Matrix](lab-host-acceptance-matrix.md)

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -1,6 +1,6 @@
 # Product Reality And Priority
 
-As of April 16, 2026, `tummycrypt` is in a much better state operationally than
+As of April 17, 2026, `tummycrypt` is in a much better state operationally than
 its remaining gaps might suggest.
 
 The repo is clean, the latest release is `v0.12.2`, and most release-facing
@@ -184,13 +184,23 @@ work should be ordered like this:
 
 ## Open Issue Map
 
-As of April 16, 2026, the narrow GitHub backlog is:
+As of April 17, 2026, the narrow GitHub backlog is:
 
-- `#280`: release-proof completion and support-truth cleanup
+- `#280`: M10 anchor for distribution install and upgrade proof
+- `#307`: Nix cache externality / operator-host install proof
+- `#308`: Debian 12 `.deb` support-floor decision
+- `#309`: macOS `.pkg` clean-host fresh-install lane
 - `#298`: privileged on-prem authority/namespace reconcile on `honey`
+- `#312`: tinyland branch-tranche triage
+- `#313`: yoga retirement decision
 
-The larger product backlog is mostly represented by the parity analysis rather
-than by many open GitHub issues.
+Milestone `#9 M10: Usage Reality & Product Parity` is still open, but only
+because `#280` remains open. The earlier M10 GitHub issues (`#276`-`#279`,
+`#281`) are already closed; the active work has narrowed to release-proof
+follow-through plus governance cleanup.
+
+The broader product backlog still lives mostly in the parity and acceptance
+docs rather than in a large live GitHub issue set.
 
 ## Related Documents
 

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -1,6 +1,6 @@
 # Product Reality And Priority
 
-As of April 17, 2026, `tummycrypt` is in a much better state operationally than
+As of April 18, 2026, `tummycrypt` is in a much better state operationally than
 its remaining gaps might suggest.
 
 The repo is clean, the latest release is `v0.12.2`, and most release-facing
@@ -186,7 +186,7 @@ work should be ordered like this:
 
 ## Open Issue Map
 
-As of April 17, 2026, the narrow GitHub backlog is:
+As of April 18, 2026, the narrow GitHub backlog is:
 
 - M10 release-proof tranche
   - `#280`: distribution install and upgrade proof umbrella

--- a/docs/ops/remote-governance.md
+++ b/docs/ops/remote-governance.md
@@ -14,15 +14,17 @@ As of 2026-04-17:
 | Remote | URL | Branches | `main` ahead of `origin/main` | `main` behind `origin/main` | Role |
 |--------|-----|----------|-------------------------------|------------------------------|------|
 | `origin` | `https://github.com/Jesssullivan/tummycrypt.git` | 25 | 0 | 0 | canonical source + release authority |
-| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 73 | 19 | 106 | active downstream dev surface |
-| `yoga` | `yoga:git/tummycrypt` (bare SSH) | 10 | 137 | 328 | retired legacy mirror |
+| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 72 | 21 | 0 | active downstream dev surface |
+| `yoga` | `yoga:git/tummycrypt` (bare SSH) | 10 | 137 | 331 | retired legacy mirror |
 
 Divergence points:
 
-- `origin/main` ↔ `tinyland/main`: merge-base is `3b30df6` (#178 streaming
-  chunker, 2026-04-10). Divergence is 7 days old at time of writing. Both
-  sides have merged real work since the split; the two histories are
-  reconcilable but not identical.
+- `origin/main` ↔ `tinyland/main`: merge-base is now `796b42e`
+  (`origin/main`, 2026-04-17). `tinyland/main` merged `origin/main` via
+  tinyland PR #60 on 2026-04-17, so it no longer lags canonical `main`.
+  The remaining 21 tinyland-only commits are the 19 pre-sync historical commits
+  recorded in [Tinyland-Unique Commit Disposition](tinyland-upstream-disposition-2026-04-17.md)
+  plus the sync merge pair (`6f7841f`, `987a6b4`).
 - `origin/main` ↔ `yoga/main`: severely diverged; yoga represents a
   `v0.9.x`-era tcfs snapshot and is not a current development branch.
 
@@ -52,6 +54,7 @@ merged there first and upstreamed to `origin` afterward.
 - `tinyland/main` may **lead** `origin/main` by a small number of commits
   (integration drift). A lead of **greater than 20 commits** is a
   governance smell and should open a tracker issue for reconciliation.
+  That threshold is currently exceeded; see #312 and the disposition doc.
 - `tinyland/main` must **not fall behind** `origin/main` indefinitely.
   Reconcile at release-cut cadence **or** weekly, whichever is more frequent.
 - Reconciliation is done **into `origin` first**, then `origin → tinyland`
@@ -65,7 +68,7 @@ merged there first and upstreamed to `origin` afterward.
 ### `yoga` — retired legacy mirror
 
 `yoga` is a bare SSH remote on a laptop host. It carries a `v0.9.x`-era
-snapshot that predates the current `v0.12.x` line by 328 commits.
+snapshot that predates the current `v0.12.x` line by 331 commits.
 
 - `yoga` is **not pushed to** from this point forward.
 - `yoga/main` and its 10 branches remain as **read-only historical
@@ -78,7 +81,7 @@ snapshot that predates the current `v0.12.x` line by 328 commits.
 
 ## Branch Lifecycle Rules
 
-These rules apply to `origin`. `tinyland` has its own branch tranche (73 at
+These rules apply to `origin`. `tinyland` has its own branch tranche (72 at
 time of writing) which is triaged separately and tracked under the
 [tinyland branch triage issue](#related-trackers).
 
@@ -109,7 +112,8 @@ Mechanical equivalent:
 
 ```bash
 git fetch origin main
-git checkout tinyland/main -b sync/origin-$(date +%Y-%m-%d)
+git fetch tinyland main
+git checkout -b sync/origin-$(date +%Y-%m-%d) tinyland/main
 git merge --no-ff origin/main
 git push tinyland sync/origin-$(date +%Y-%m-%d)
 # open PR against tinyland/main
@@ -149,16 +153,15 @@ Execution work derived from this policy is tracked as separate issues so
 the governance document itself stays a policy statement and not a punch
 list:
 
-- **Upstream current tinyland-unique commits to `origin`**: 19 commits
-  on `tinyland/main` ahead of `origin/main` as of 2026-04-17 (merge-base
-  `3b30df6`). Features include `feat(sync)` trash + bandwidth throttling,
-  `feat(sync)` selective sync policies + D-Bus gRPC backend, `feat`
-  unsync dehydration + auto-unsync with disk pressure, `fix(vfs)` OOM
-  prevention + bounded negative cache, `fix(fuse)` flush via VFS fsync,
-  `fix(daemon)` race guards + deferred vclock merge, `fix(sync)` panic
-  elimination. A tracker issue enumerates per-commit upstream disposition.
+- **Disposition of tinyland-unique history**: #311 is closed. The 19
+  pre-sync tinyland-only commits were audited in
+  [Tinyland-Unique Commit Disposition](tinyland-upstream-disposition-2026-04-17.md)
+  and all were classified as superseded or bookkeeping; zero upstream
+  cherry-picks are required. The current 21-commit lead on `tinyland/main`
+  is therefore 19 historical commits plus the 2 sync-merge commits from
+  the 2026-04-17 origin→tinyland resync.
 
-- **Triage the tinyland branch tranche**: 73 branches under categories
+- **Triage the tinyland branch tranche**: 72 branches under categories
   `feat/*` (~30), `chore/bump-*` (~15), `sid/*` (~15), and migration /
   sprint (~4). A tracker issue proposes per-category disposition
   (mergeable, supersede, close stale).
@@ -178,6 +181,8 @@ list:
   declaration; this document makes it operational
 - [Contributing](../CONTRIBUTING.md) — the PR-based workflow that all
   `origin`-targeted work follows
+- [Tinyland-Unique Commit Disposition](tinyland-upstream-disposition-2026-04-17.md) —
+  audited disposition of the pre-sync tinyland-only commits
 - [v0.12.2 Evidence Matrix](../release/v0.12.2-evidence-matrix.md) —
   release-surface consequences of tinyland-hosted infrastructure
 - [Product Reality and Priority](product-reality-and-priority.md) —
@@ -186,5 +191,6 @@ list:
 ## Revision History
 
 - 2026-04-17 — Initial governance doc. Captures the 3-remote topology at
-  its current divergence state (`tinyland` 19 ahead / 106 behind,
-  `yoga` 137 ahead / 328 behind) and declares roles + sync policy.
+  its current divergence state and declares roles + sync policy.
+- 2026-04-17 — Refreshed after tinyland PR #60 merged `origin/main` into
+  `tinyland/main` and #311 closed with zero upstream cherry-picks required.

--- a/docs/ops/remote-governance.md
+++ b/docs/ops/remote-governance.md
@@ -14,7 +14,7 @@ As of 2026-04-17:
 | Remote | URL | Branches | `main` ahead of `origin/main` | `main` behind `origin/main` | Role |
 |--------|-----|----------|-------------------------------|------------------------------|------|
 | `origin` | `https://github.com/Jesssullivan/tummycrypt.git` | 25 | 0 | 0 | canonical source + release authority |
-| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 70 | 21 | 0 | active downstream dev surface |
+| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 65 | 21 | 0 | active downstream dev surface |
 | `yoga` | `yoga:git/tummycrypt` (bare SSH) | 10 | 137 | 331 | retired legacy mirror |
 
 Divergence points:
@@ -81,7 +81,7 @@ snapshot that predates the current `v0.12.x` line by 331 commits.
 
 ## Branch Lifecycle Rules
 
-These rules apply to `origin`. `tinyland` has its own branch tranche (70 at
+These rules apply to `origin`. `tinyland` has its own branch tranche (65 at
 time of writing) which is triaged separately and tracked under the
 [tinyland branch triage issue](#related-trackers).
 
@@ -161,10 +161,12 @@ list:
   is therefore 19 historical commits plus the 2 sync-merge commits from
   the 2026-04-17 origin→tinyland resync.
 
-- **Triage the tinyland branch tranche**: 70 branches under categories
-  `feat/*` (~30), `chore/bump-*` (~15), `sid/*` (~15), and migration /
-  sprint (~4). A tracker issue proposes per-category disposition
-  (mergeable, supersede, close stale).
+- **Triage the tinyland branch tranche**: 65 branches after two prune
+  tranches removed 7 superseded feature branches. The remaining live mix is
+  `41` `fix/*`, `14` `feat/*`, `4` `test/*`, `3` `chore/*`, `1`
+  `refactor/*`, `1` `homebrew-tap`, and `1` `main`. The tracker issue now
+  focuses on auditing the larger `fix/*` and `chore/*` backlog for
+  "superseded vs. still-needed" status.
 
 - **Retire `yoga` formally**: the remote is already de facto retired.
   A tracker issue decides whether to archive the bare SSH repo,

--- a/docs/ops/remote-governance.md
+++ b/docs/ops/remote-governance.md
@@ -14,7 +14,7 @@ As of 2026-04-17:
 | Remote | URL | Branches | `main` ahead of `origin/main` | `main` behind `origin/main` | Role |
 |--------|-----|----------|-------------------------------|------------------------------|------|
 | `origin` | `https://github.com/Jesssullivan/tummycrypt.git` | 25 | 0 | 0 | canonical source + release authority |
-| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 72 | 21 | 0 | active downstream dev surface |
+| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 70 | 21 | 0 | active downstream dev surface |
 | `yoga` | `yoga:git/tummycrypt` (bare SSH) | 10 | 137 | 331 | retired legacy mirror |
 
 Divergence points:
@@ -81,7 +81,7 @@ snapshot that predates the current `v0.12.x` line by 331 commits.
 
 ## Branch Lifecycle Rules
 
-These rules apply to `origin`. `tinyland` has its own branch tranche (72 at
+These rules apply to `origin`. `tinyland` has its own branch tranche (70 at
 time of writing) which is triaged separately and tracked under the
 [tinyland branch triage issue](#related-trackers).
 
@@ -161,7 +161,7 @@ list:
   is therefore 19 historical commits plus the 2 sync-merge commits from
   the 2026-04-17 origin→tinyland resync.
 
-- **Triage the tinyland branch tranche**: 72 branches under categories
+- **Triage the tinyland branch tranche**: 70 branches under categories
   `feat/*` (~30), `chore/bump-*` (~15), `sid/*` (~15), and migration /
   sprint (~4). A tracker issue proposes per-category disposition
   (mergeable, supersede, close stale).


### PR DESCRIPTION
## What changed
- refreshed `docs/ops/remote-governance.md` and `docs/ops/product-reality-and-priority.md` so they match the live branch topology, milestone shape, and active issue surface
- documented that published `install.sh` / `install.ps1` helpers are convenience tooling, not canonical release-proof surfaces
- added `docs/ops/packaged-install-first-use.md` to define the bar between installed-binary smoke and a truthful first user action
- linked the new release-proof boundaries from the smoke matrix, public install docs, and release notes template

## Why
The repo had drift between what the release workflow publishes, what the docs implied was supported, and what the project actually proves. That made M10 planning fuzzy and let the PM surface overstate or under-specify parts of the install story.

## Impact
The governance and release-proof surfaces now describe the same reality as GitHub:
- M10 is an explicit six-issue release-proof tranche
- `install.sh` is no longer implied to be a first-class proven surface
- the project now has a named runbook for packaged-install to first-real-use proof

## Validation
- `git diff --check`

## Refs
- #280
- #307
- #308
- #309
- #317
- #318

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only PR that reconciles governance and release-proof surfaces across seven files: it demotes `install.sh`/`install.ps1` from implied release-proof status to explicit convenience tooling, introduces a new `packaged-install-first-use.md` runbook bridging artifact smoke and first truthful user action, and refreshes `remote-governance.md` with the updated tinyland topology (post-PR #60 resync) plus a corrected `git checkout` invocation. All cross-references resolve to existing files.

<h3>Confidence Score: 5/5</h3>

Safe to merge — docs-only change with one minor arithmetic inconsistency in a count narrative.

All findings are P2. The only concrete issue is a one-off discrepancy in the branch-count arithmetic (73 − 7 narrated as 65, but equals 66). All cross-references to other runbooks resolve correctly, the git script syntax fix is an improvement, and the new packaged-install-first-use.md is internally consistent.

docs/ops/remote-governance.md — branch-count arithmetic should be reconciled before the number propagates to other tracking docs.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Single label change in Release Notes template clarifies install.sh is convenience-only, not a canonical release-proof surface. |
| README.md | Adds inline warning on install.sh snippet and two cross-references to the distribution smoke matrix and new packaged-install-first-use runbook. |
| docs/index.md | Mirrors README.md changes; adds install.sh convenience caveat and links new packaged-install-first-use runbook to the Ops Runbooks index. |
| docs/ops/distribution-smoke-matrix.md | New 'Out-Of-Scope Published Helpers' section formally excludes install.sh and install.ps1 from release-proof surfaces; adds cross-reference to new packaged-install-first-use runbook. |
| docs/ops/packaged-install-first-use.md | New runbook defining the bar between installed-binary smoke and first truthful user action; all internal cross-references to existing docs resolve correctly. |
| docs/ops/product-reality-and-priority.md | Date bump to April 18, open issue map expanded to show full M10 six-issue release-proof tranche, and related documents section updated with new runbook links. |
| docs/ops/remote-governance.md | Updated remote topology (tinyland now at parity with origin), fixed git checkout syntax, updated branch counts — but '73 − 7 = 65' is off by one (should be 66). |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Published Release Artifact] --> B{Surface type?}
    B -->|install.sh / install.ps1| C[Convenience Installer\nNOT a release-proof surface]
    B -->|Homebrew / .pkg / .deb / .rpm\nContainer / Nix| D[Distribution Smoke Matrix\ndistribution-smoke-matrix.md]
    D --> E{Smoke passed?}
    E -->|No| F[Blocked — do not proceed]
    E -->|Yes| G[Packaged Install to First-Real-Use\npackaged-install-first-use.md]
    G --> H{Per-tag or sampled?}
    H -->|Every tag: Homebrew, .pkg, .deb| I[storage ok + first real action\n+ one edge case]
    H -->|Sampled: .rpm, container, Nix| J[Daemon/worker startup\nagainst intentional config]
    I --> K[Lab Host Acceptance Matrix]
    J --> K
    K --> L[Neo-Honey Live Acceptance]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/ops/remote-governance.md
Line: 160-165

Comment:
**Branch-count arithmetic is off by one**

The text states two prune tranches removed 7 branches, with the count going from 73 to 65 — but 73 − 7 = 66, not 65. The per-category totals (41 + 14 + 4 + 3 + 1 + 1 + 1 = 65) do add up internally, so either the starting count was already 72 before pruning, or 8 branches were actually removed. One of those two numbers needs correcting to keep the narrative consistent.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: refresh tinyland branch tranche af..."](https://github.com/jesssullivan/tummycrypt/commit/eccafcb255a267ea8c722685ad4a676b00716a78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28843009)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->