### PR TITLE
[codex] scripts: add macOS post-install smoke harness

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -3,6 +3,7 @@ exclude = [
   "^https://github.com/tinyland-inc/remote-juggler",
   "^https://nix-cache.fuzzy-dev.tinyland.dev",
   "^https://docs.tummycrypt.io",
+  "^https://developer.apple.com/documentation/fskit$",
   "^https://developer.apple.com/documentation/fileprovider/nsfileproviderreplicatedextension$",
   "your-org",
   "localhost",

--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -122,6 +122,16 @@ sudo installer -pkg "tcfs-${VERSION}-macos-aarch64.pkg" -target /
 bash scripts/install-smoke.sh --expected-version "${VERSION}"
 ```
 
+If this tag also needs packaged-install to first-real-use proof on macOS, follow
+the package smoke with the named FileProvider harness:
+
+```bash
+bash scripts/macos-postinstall-smoke.sh \
+  --expected-version "${VERSION}" \
+  --config "$HOME/.config/tcfs/config.toml" \
+  --expected-file "path/to/known/remote-backed-file"
+```
+
 Upgrade:
 
 ```bash
@@ -220,6 +230,8 @@ using a table like this:
 - Use this matrix for **distribution surface proof**
 - Use [Packaged Install To First-Real-Use Acceptance](packaged-install-first-use.md)
   for the **install-to-first-action bar** after artifact smoke passes
+- Use [`scripts/macos-postinstall-smoke.sh`](../../scripts/macos-postinstall-smoke.sh)
+  for the current macOS package-to-FileProvider harness
 - Use [Neo-Honey Live Acceptance](neo-honey-acceptance.md) for the
   **credentialed live fleet sync path**
 - Use [Lab Host Acceptance Matrix](lab-host-acceptance-matrix.md) for

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -5,7 +5,7 @@ but not yet a continuously proven release-grade desktop surface.
 
 This document defines the actual workflow the repo supports today, separates
 what is proven from what remains experimental, and records the highest-value
-manual smoke path for the Finder/FileProvider surface.
+smoke path for the Finder/FileProvider surface.
 
 ## Supported Workflow In The Repo Today
 
@@ -54,17 +54,17 @@ In practical terms, the intended operator flow is:
 
 ## Not Yet Proven
 
-- A continuously exercised Finder/FileProvider acceptance lane from install
-  through register, enumerate, hydrate, mutate, and conflict handling
+- A continuously exercised clean-host Finder/FileProvider acceptance lane from
+  install through register, enumerate, hydrate, mutate, and conflict handling
 - Finder badge visibility as a release gate
 - Conflict UX and notification behavior as a release gate
 - Release-day viability of every published macOS artifact without explicit
   post-cut smoke
 - A stable claim that write flows are supported for end users on macOS
 
-## Highest-Value Manual Smoke Lane
+## Highest-Value Smoke Lane
 
-This is the current best manual acceptance path for the macOS desktop surface.
+This is the current best acceptance path for the macOS desktop surface.
 
 ### Preconditions
 
@@ -74,7 +74,29 @@ This is the current best manual acceptance path for the macOS desktop surface.
   `~/.config/tcfs/fileprovider/config.json`
 - a runnable `tcfsd`
 
-### Procedure
+### Named Harness
+
+The repo now carries a named operator-facing harness for this lane:
+
+```bash
+bash scripts/macos-postinstall-smoke.sh \
+  --expected-version "${VERSION}" \
+  --config "$HOME/.config/tcfs/config.toml" \
+  --expected-file "path/to/known/remote-backed-file"
+```
+
+Notes:
+
+- `--expected-file` should point at a known remote-backed fixture relative to
+  the `~/Library/CloudStorage/TCFS*` root for the current domain
+- the helper assumes `tcfsd` is already runnable with a real config; it does
+  not fabricate temp-home state or start a fake backend
+- `#309` still tracks where this harness runs from a known-clean host per tag
+
+### Manual Procedure
+
+The script above codifies the manual steps below. Keep them here as the
+operator-readable fallback and review path.
 
 1. Verify the expected artifacts exist:
 
@@ -108,7 +130,7 @@ find "$HOME/Library/CloudStorage" -maxdepth 2 -type f | head
 ```
 
 6. Open or read a known remote-backed file and confirm that content hydration
-   succeeds.
+   succeeds. This is the `--expected-file` target in the named harness.
 
 7. Record whether badges or equivalent Finder state are visible, but treat that
    as observational evidence rather than a hard release gate.
@@ -129,6 +151,8 @@ following succeed on the same machine:
 
 - Use [Distribution Smoke Matrix](distribution-smoke-matrix.md) for packaged
   install proof.
+- Use [`scripts/macos-postinstall-smoke.sh`](../../scripts/macos-postinstall-smoke.sh)
+  for the named post-install harness that exercises this lane.
 - Use [Apple Surface Status](apple-surface-status.md) for the broader Apple
   posture.
 - Use this document for the macOS Finder/FileProvider desktop acceptance path

--- a/docs/ops/packaged-install-first-use.md
+++ b/docs/ops/packaged-install-first-use.md
@@ -73,6 +73,8 @@ Passing `scripts/install-smoke.sh` alone is not sufficient to claim this bar.
   live-backend sync lane.
 - Use [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md) for
   the Apple desktop path after package install.
+- Use [`scripts/macos-postinstall-smoke.sh`](../../scripts/macos-postinstall-smoke.sh)
+  as the current named harness for the macOS package-to-FileProvider lane.
 
 ## Evidence Capture
 
@@ -91,5 +93,6 @@ Record results using a table like this:
 
 - `install.sh` is published convenience tooling, not part of the canonical
   release-proof surface. See [Distribution Smoke Matrix](distribution-smoke-matrix.md).
-- The macOS clean-host lane remains tracked in `#309`.
+- The macOS clean-host lane remains tracked in `#309`; the harness now exists,
+  but its clean-host executor still needs to be chosen.
 - The Nix install path remains blocked on `#307`.

--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/macos-postinstall-smoke.sh [options]
+
+Verify the installed macOS FileProvider path after package/app install:
+artifact presence, pluginkit registration, host-app launch, domain re-add,
+CloudStorage appearance, enumeration, and optional hydration of a known file.
+
+This helper assumes a real operator config and a running tcfsd. It does not
+start the daemon or fabricate backend fixtures.
+
+Options:
+  --config <path>             tcfs config for `tcfs status`
+                              (default: ~/.config/tcfs/config.toml)
+  --expected-version <ver>    Require tcfs/tcfsd --version output to include this string
+  --expected-file <relpath>   Relative path under the CloudStorage root to
+                              enumerate and hydrate
+  --app-path <path>           Installed TCFSProvider.app path
+                              (default: auto-detect /Applications or ~/Applications)
+  --cloud-root <path>         CloudStorage root path
+                              (default: auto-detect ~/Library/CloudStorage/TCFS*)
+  --plugin-id <id>            FileProvider extension bundle id
+                              (default: io.tinyland.tcfs.fileprovider)
+  --domain-id <id>            FileProvider domain id
+                              (default: io.tinyland.tcfs)
+  --tcfs <path-or-name>       CLI binary to use (default: tcfs)
+  --tcfsd <path-or-name>      Daemon binary to use (default: tcfsd)
+  --timeout <seconds>         Wait timeout for async steps (default: 45)
+  --skip-status               Skip `tcfs status` checks
+  -h, --help                  Show this help
+EOF
+}
+
+EXPECTED_VERSION=""
+CONFIG_PATH="${TCFS_CONFIG:-$HOME/.config/tcfs/config.toml}"
+EXPECTED_FILE_REL=""
+APP_PATH="${TCFS_APP_PATH:-}"
+CLOUD_ROOT="${TCFS_CLOUD_ROOT:-}"
+PLUGIN_ID="${TCFS_PLUGIN_ID:-io.tinyland.tcfs.fileprovider}"
+DOMAIN_ID="${TCFS_DOMAIN_ID:-io.tinyland.tcfs}"
+TCFS_BIN="${TCFS_BIN:-tcfs}"
+TCFSD_BIN="${TCFSD_BIN:-tcfsd}"
+TIMEOUT_SECS="${TIMEOUT_SECS:-45}"
+SKIP_STATUS=0
+LOG_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)
+      CONFIG_PATH="$2"
+      shift 2
+      ;;
+    --expected-version)
+      EXPECTED_VERSION="$2"
+      shift 2
+      ;;
+    --expected-file)
+      EXPECTED_FILE_REL="$2"
+      shift 2
+      ;;
+    --app-path)
+      APP_PATH="$2"
+      shift 2
+      ;;
+    --cloud-root)
+      CLOUD_ROOT="$2"
+      shift 2
+      ;;
+    --plugin-id)
+      PLUGIN_ID="$2"
+      shift 2
+      ;;
+    --domain-id)
+      DOMAIN_ID="$2"
+      shift 2
+      ;;
+    --tcfs)
+      TCFS_BIN="$2"
+      shift 2
+      ;;
+    --tcfsd)
+      TCFSD_BIN="$2"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT_SECS="$2"
+      shift 2
+      ;;
+    --skip-status)
+      SKIP_STATUS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "scripts/macos-postinstall-smoke.sh only runs on macOS" >&2
+  exit 1
+fi
+
+resolve_bin() {
+  local candidate="$1"
+  if [[ "$candidate" == */* ]]; then
+    [[ -x "$candidate" ]] || {
+      echo "binary is not executable: $candidate" >&2
+      exit 1
+    }
+    printf '%s\n' "$candidate"
+    return
+  fi
+
+  command -v "$candidate" >/dev/null 2>&1 || {
+    echo "command not found: $candidate" >&2
+    exit 1
+  }
+  command -v "$candidate"
+}
+
+assert_version() {
+  local label="$1"
+  local bin="$2"
+  local output
+
+  output="$("$bin" --version)"
+  echo "$label version: $output"
+
+  if [[ -n "$EXPECTED_VERSION" && "$output" != *"$EXPECTED_VERSION"* ]]; then
+    echo "$label version mismatch: expected output containing '$EXPECTED_VERSION'" >&2
+    exit 1
+  fi
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "$path" ]] || {
+    echo "required file not found: $path" >&2
+    exit 1
+  }
+}
+
+require_dir() {
+  local path="$1"
+  [[ -d "$path" ]] || {
+    echo "required directory not found: $path" >&2
+    exit 1
+  }
+}
+
+detect_app_path() {
+  if [[ -n "$APP_PATH" ]]; then
+    require_dir "$APP_PATH"
+    printf '%s\n' "$APP_PATH"
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "/Applications/TCFSProvider.app" \
+    "$HOME/Applications/TCFSProvider.app"
+  do
+    if [[ -d "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  echo "TCFSProvider.app not found in /Applications or ~/Applications" >&2
+  exit 1
+}
+
+status_log() {
+  local label="$1"
+  printf '%s/%s-status.log\n' "$LOG_DIR" "$label"
+}
+
+run_status() {
+  local label="$1"
+  local log_path
+
+  if [[ "$SKIP_STATUS" -eq 1 ]]; then
+    echo "status check skipped ($label)"
+    return
+  fi
+
+  require_file "$CONFIG_PATH"
+
+  log_path="$(status_log "$label")"
+  "$TCFS_PATH" --config "$CONFIG_PATH" status >"$log_path" 2>&1 || {
+    echo "tcfs status failed during $label" >&2
+    cat "$log_path" >&2 || true
+    exit 1
+  }
+
+  grep -q "tcfsd v" "$log_path" || {
+    echo "tcfs status output did not include daemon version during $label" >&2
+    cat "$log_path" >&2 || true
+    exit 1
+  }
+
+  grep -Eq 'storage:.*\[ok\]' "$log_path" || {
+    echo "tcfs status did not report storage [ok] during $label" >&2
+    cat "$log_path" >&2 || true
+    exit 1
+  }
+
+  echo "tcfs status ($label):"
+  cat "$log_path"
+}
+
+check_pluginkit() {
+  local output
+  output="$(pluginkit -m -A -D -i "$PLUGIN_ID" 2>&1)" || {
+    echo "pluginkit lookup failed for $PLUGIN_ID" >&2
+    echo "$output" >&2
+    exit 1
+  }
+
+  echo "pluginkit registration:"
+  echo "$output"
+
+  grep -q "$PLUGIN_ID" <<<"$output" || {
+    echo "pluginkit output did not include $PLUGIN_ID" >&2
+    exit 1
+  }
+}
+
+check_host_log() {
+  local output
+  output="$(log show --style compact --last 45s \
+    --predicate 'subsystem == "io.tinyland.tcfs" && category == "host"' 2>/dev/null || true)"
+
+  [[ -n "$output" ]] || return 1
+  grep -q "add: OK" <<<"$output"
+}
+
+check_domain_listing() {
+  command -v fileproviderctl >/dev/null 2>&1 || return 2
+
+  local output
+  output="$(fileproviderctl domain list 2>&1)" || return 2
+  grep -q "$DOMAIN_ID" <<<"$output"
+}
+
+discover_cloud_root() {
+  if [[ -n "$CLOUD_ROOT" ]]; then
+    require_dir "$CLOUD_ROOT"
+    printf '%s\n' "$CLOUD_ROOT"
+    return
+  fi
+
+  local roots=()
+  local candidate
+  while IFS= read -r candidate; do
+    roots+=("$candidate")
+  done < <(find "$HOME/Library/CloudStorage" -mindepth 1 -maxdepth 1 -type d -name 'TCFS*' 2>/dev/null | sort)
+
+  case "${#roots[@]}" in
+    0)
+      return 1
+      ;;
+    1)
+      printf '%s\n' "${roots[0]}"
+      ;;
+    *)
+      echo "multiple TCFS CloudStorage roots found; pass --cloud-root explicitly" >&2
+      printf '  %s\n' "${roots[@]}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+wait_for_cloud_root() {
+  local attempt=0
+  local root=""
+  while (( attempt < TIMEOUT_SECS )); do
+    if root="$(discover_cloud_root)"; then
+      printf '%s\n' "$root"
+      return
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+
+  echo "timed out waiting for CloudStorage root under $HOME/Library/CloudStorage" >&2
+  exit 1
+}
+
+wait_for_expected_file() {
+  local path="$1"
+  local attempt=0
+  while (( attempt < TIMEOUT_SECS )); do
+    if [[ -e "$path" ]]; then
+      return
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+
+  echo "timed out waiting for expected file: $path" >&2
+  exit 1
+}
+
+enumerate_root() {
+  local root="$1"
+  local listing
+  local attempt=0
+
+  while (( attempt < TIMEOUT_SECS )); do
+    listing="$(find "$root" -mindepth 1 -maxdepth 4 | head -n 10 || true)"
+    if [[ -n "$listing" ]]; then
+      echo "enumeration sample:"
+      echo "$listing"
+      return
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+
+  echo "enumeration found no entries under $root" >&2
+  exit 1
+}
+
+hydrate_expected_file() {
+  local path="$1"
+  [[ -f "$path" ]] || {
+    echo "expected path is not a regular file: $path" >&2
+    exit 1
+  }
+
+  dd if="$path" of=/dev/null bs=4096 count=1 status=none || {
+    echo "failed to read expected file for hydration: $path" >&2
+    exit 1
+  }
+
+  echo "hydrated file: $path"
+  stat -f '  size: %z bytes' "$path"
+}
+
+APP_PATH="$(detect_app_path)"
+LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-macos-postinstall.XXXXXX")"
+trap 'rm -rf "$LOG_DIR"' EXIT
+
+TCFSD_PATH="$(resolve_bin "$TCFSD_BIN")"
+assert_version "tcfsd" "$TCFSD_PATH"
+
+if [[ "$SKIP_STATUS" -eq 0 ]]; then
+  TCFS_PATH="$(resolve_bin "$TCFS_BIN")"
+  assert_version "tcfs" "$TCFS_PATH"
+  run_status "preflight"
+else
+  TCFS_PATH=""
+fi
+
+require_file "$HOME/.config/tcfs/fileprovider/config.json"
+check_pluginkit
+
+echo "launching host app: $APP_PATH"
+open "$APP_PATH"
+
+HOST_LOG_WAIT=0
+until check_host_log; do
+  sleep 1
+  HOST_LOG_WAIT=$((HOST_LOG_WAIT + 1))
+  if (( HOST_LOG_WAIT >= TIMEOUT_SECS )); then
+    echo "timed out waiting for host app log showing domain re-add" >&2
+    log show --style compact --last 2m \
+      --predicate 'subsystem == "io.tinyland.tcfs" && category == "host"' || true
+    exit 1
+  fi
+done
+
+echo "host app log confirmed domain re-add"
+if check_domain_listing; then
+  echo "fileproviderctl domain listing includes $DOMAIN_ID"
+else
+  echo "warning: could not confirm domain via fileproviderctl; relying on host log + CloudStorage root" >&2
+fi
+
+CLOUD_ROOT="$(wait_for_cloud_root)"
+echo "CloudStorage root: $CLOUD_ROOT"
+
+enumerate_root "$CLOUD_ROOT"
+
+if [[ -n "$EXPECTED_FILE_REL" ]]; then
+  EXPECTED_PATH="$CLOUD_ROOT/$EXPECTED_FILE_REL"
+  wait_for_expected_file "$EXPECTED_PATH"
+  hydrate_expected_file "$EXPECTED_PATH"
+else
+  echo "warning: --expected-file not provided; hydration was not exercised" >&2
+fi
+
+run_status "post-hydrate"
+
+echo "macOS post-install FileProvider smoke passed"


### PR DESCRIPTION
## What changed
- added `scripts/macos-postinstall-smoke.sh` as a named macOS post-install FileProvider harness
- wired the harness into `docs/ops/macos-fileprovider-reality.md`
- linked the harness from the distribution smoke matrix and the packaged-install to first-real-use runbook

## Why
`#309` was missing more than a clean host. The repo did not yet have a concrete, repeatable harness for the post-install desktop path after `.pkg` install.

This patch codifies the in-repo part of that gap:
- verify installed artifacts and versions
- verify `pluginkit` registration
- launch the host app and confirm the domain re-add path
- wait for the `~/Library/CloudStorage/TCFS*` root
- exercise enumeration and optional hydration of a known remote-backed file
- re-check `tcfs status` with `storage [ok]`

## Impact
This does not solve the clean-host executor question by itself. `#309` still needs a decision on where this harness runs from a known-clean state per tag.

What it does do is replace pure prose/manual steps with a named repo-local harness, so the next step can be "where does this run?" instead of "what exactly are we trying to run?"

## Validation
- `bash -n scripts/macos-postinstall-smoke.sh`
- `git diff --check`

## Refs
- #309
- #280

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `scripts/macos-postinstall-smoke.sh`, a named operator harness that verifies the post-install macOS FileProvider path (artifact presence, `pluginkit` registration, host-app launch, domain re-add, CloudStorage root appearance, enumeration, and optional hydration), and wires it into three operations docs. The script is well-structured — `set -euo pipefail`, proper `trap` cleanup, configurable via env vars or flags — but has one correctness issue worth addressing before the harness is used in a repeatable CI context.

- **`check_host_log` false-positive risk**: `log show --last 45s` looks back from the current wall clock, not from when `open \"$APP_PATH\"` was called. If a prior invocation produced `\"add: OK\"` within the last 45 seconds, the domain re-add check passes immediately even if the newly-launched app hasn't registered the domain yet. Anchoring with `--start <timestamp>` captured before calling `open` is the fix."

<h3>Confidence Score: 4/5</h3>

Safe to merge for documentation value; the P1 log-anchoring bug should be fixed before the harness is used in any repeatable or automated context.

One P1 finding: check_host_log can return a false positive from a prior run's log event because the 45s lookback window is not anchored to the current open call. All other findings are P2. Docs and lychee changes are clean.

scripts/macos-postinstall-smoke.sh — specifically the check_host_log function (lines 240-245)

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/macos-postinstall-smoke.sh | New macOS FileProvider post-install smoke harness; well-structured with proper set -euo pipefail and trap cleanup, but check_host_log uses a hardcoded --last 45s window that can produce false positives from prior runs and is inconsistent with TIMEOUT_SECS |
| .lychee.toml | Adds ^https://developer.apple.com/documentation/fskit$ to the link-checker exclusion list to suppress a flaky Apple documentation URL from CI; straightforward and correct |
| docs/ops/distribution-smoke-matrix.md | Adds a reference to scripts/macos-postinstall-smoke.sh in the macOS .pkg surface procedure and the relationship-to-other-lanes section; links and prose are accurate |
| docs/ops/macos-fileprovider-reality.md | Wires the named harness into the highest-value smoke lane section and cross-references the new script; documentation is clear and consistent with the script's interface |
| docs/ops/packaged-install-first-use.md | Adds a link to scripts/macos-postinstall-smoke.sh in the relationship section and notes the clean-host executor gap tracked in #309; accurate and well-scoped |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Op as Operator
    participant Script as macos-postinstall-smoke.sh
    participant FS as Filesystem
    participant PK as pluginkit
    participant App as TCFSProvider.app
    participant Log as macOS log(1)
    participant FP as fileproviderd
    participant TCFS as tcfs CLI

    Op->>Script: bash scripts/macos-postinstall-smoke.sh --expected-version X --expected-file Y

    Script->>FS: resolve tcfsd / tcfs binaries
    Script->>Script: assert_version (tcfsd, tcfs)
    Script->>TCFS: tcfs status (preflight)
    TCFS-->>Script: storage [ok]

    Script->>FS: require ~/.config/tcfs/fileprovider/config.json
    Script->>PK: pluginkit -m -A -D -i io.tinyland.tcfs.fileprovider
    PK-->>Script: registration confirmed

    Script->>App: open TCFSProvider.app
    App->>FP: remove + re-add NSFileProviderDomain
    App-)Log: log add: OK

    loop poll every 1s up to TIMEOUT_SECS
        Script->>Log: log show --last 45s --predicate ...
        Log-->>Script: output
        Script->>Script: grep add: OK
    end

    Script->>FP: wait for CloudStorage root
    FP-->>Script: CloudStorage root appears

    Script->>FS: find root -maxdepth 4 enumerate
    FS-->>Script: listing

    Script->>FS: dd if=expected-file of=/dev/null hydrate
    FP-->>FS: fetch content from tcfsd

    Script->>TCFS: tcfs status post-hydrate
    TCFS-->>Script: storage [ok]

    Script-->>Op: macOS post-install FileProvider smoke passed
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/macos-postinstall-smoke.sh
Line: 240-245

Comment:
**False-positive risk from stale log events**

`--last 45s` looks back 45 seconds from the current wall clock, not from the moment `open "$APP_PATH"` was called. If this script (or any other invocation of the host app) produced an `"add: OK"` log entry within the last 45 seconds before this run, `check_host_log` returns true immediately — before the newly-launched app has actually re-added the domain.

The fix is to snapshot the current time before calling `open`, then anchor the `log show` query to that timestamp:

```bash
_OPEN_TS=""

# Before calling open:
_OPEN_TS="$(date -u +"%Y-%m-%d %H:%M:%S")"

# In check_host_log:
output="$(log show --style compact --start "$_OPEN_TS" \
  --predicate 'subsystem == "io.tinyland.tcfs" && category == "host"' 2>/dev/null || true)"
```

This eliminates the window where a recent prior run masks a broken domain-registration path.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/macos-postinstall-smoke.sh
Line: 241-243

Comment:
**Hardcoded `45s` log window is inconsistent with `TIMEOUT_SECS`**

The `--last 45s` value is fixed regardless of `--timeout`. If an operator passes `--timeout 10` to keep the harness fast, the log window is still 45 seconds — wide enough to match events from a much older launch. Conversely, if `--timeout 120` is used for a very slow machine, the 45s window is narrower than the polling budget.

```suggestion
  output="$(log show --style compact --last "${TIMEOUT_SECS}s" \
    --predicate 'subsystem == "io.tinyland.tcfs" && category == "host"' 2>/dev/null || true)"
```

(Best combined with the timestamp-anchoring fix above; if anchoring is added, the `--last` flag can be dropped entirely.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/macos-postinstall-smoke.sh
Line: 342-349

Comment:
**Single-block read may not fully exercise the hydration path**

`dd count=1` reads only the first 4096 bytes. Reading only one block means the harness never verifies that the provider can deliver a *complete* file — a truncated-delivery bug would pass undetected.

Consider reading the full file to `/dev/null`:

```suggestion
  dd if="$path" of=/dev/null bs=65536 status=none || {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: exclude flaky Apple FSKit docs link"](https://github.com/jesssullivan/tummycrypt/commit/2fc54758139ca998ad3fd98c279b490b1ed3b3c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28843795)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->