### PR TITLE
[codex] ci: add macOS post-install smoke lane

### DIFF
--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -1,0 +1,205 @@
+name: macOS Post-Install Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to validate (for example v0.12.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  pkg-postinstall:
+    name: macOS .pkg post-install smoke
+    if: github.repository == 'Jesssullivan/tummycrypt'
+    runs-on: macos-14
+    timeout-minutes: 40
+    env:
+      TCFS_S3_ENDPOINT: ${{ secrets.TCFS_S3_ENDPOINT }}
+      TCFS_S3_BUCKET: ${{ secrets.TCFS_S3_BUCKET }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      TCFS_NATS_URL: ${{ secrets.TCFS_NATS_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release inputs and backend secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag }}"
+          [[ "$TAG" == v* ]] || {
+            echo "::error::tag must start with 'v' (got '$TAG')"
+            exit 1
+          }
+
+          missing=()
+          for name in TCFS_S3_ENDPOINT TCFS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY TCFS_NATS_URL; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required repository secrets: ${missing[*]}"
+            echo "Set the live backend secrets before using this workflow."
+            exit 1
+          fi
+
+      - name: Derive run paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag }}"
+          VERSION="${TAG#v}"
+          LOG_DIR="$RUNNER_TEMP/tcfs-macos-postinstall"
+          SYNC_ROOT="$RUNNER_TEMP/tcfs-sync-root"
+          CONFIG_DIR="$HOME/.config/tcfs"
+          CONFIG_PATH="$CONFIG_DIR/config.toml"
+          APP_GROUP_DIR="$HOME/Library/Group Containers/group.io.tinyland.tcfs"
+          REMOTE_PREFIX="gha/macos-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          FIXTURE_REL="ci-smoke/${VERSION}/postinstall-${GITHUB_RUN_ATTEMPT}.txt"
+
+          mkdir -p "$LOG_DIR" "$SYNC_ROOT" "$CONFIG_DIR" "$APP_GROUP_DIR"
+
+          {
+            echo "TAG=$TAG"
+            echo "VERSION=$VERSION"
+            echo "LOG_DIR=$LOG_DIR"
+            echo "SYNC_ROOT=$SYNC_ROOT"
+            echo "CONFIG_DIR=$CONFIG_DIR"
+            echo "CONFIG_PATH=$CONFIG_PATH"
+            echo "APP_GROUP_DIR=$APP_GROUP_DIR"
+            echo "REMOTE_PREFIX=$REMOTE_PREFIX"
+            echo "FIXTURE_REL=$FIXTURE_REL"
+          } >> "$GITHUB_ENV"
+
+      - name: Download release package
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fL \
+            -o "$RUNNER_TEMP/tcfs-${VERSION}-macos-aarch64.pkg" \
+            "https://github.com/${{ github.repository }}/releases/download/${TAG}/tcfs-${VERSION}-macos-aarch64.pkg"
+
+      - name: Install release package
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo installer -pkg "$RUNNER_TEMP/tcfs-${VERSION}-macos-aarch64.pkg" -target /
+
+      - name: Prove installed-binary smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/install-smoke.sh --expected-version "${VERSION}"
+
+      - name: Write live config
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > "$CONFIG_PATH" <<EOF
+          [daemon]
+          socket = "/tmp/tcfsd-gha.sock"
+          fileprovider_socket = "${APP_GROUP_DIR}/tcfsd.sock"
+          metrics_addr = "127.0.0.1:19100"
+          log_format = "text"
+
+          [storage]
+          endpoint = "${TCFS_S3_ENDPOINT}"
+          region = "us-east-1"
+          bucket = "${TCFS_S3_BUCKET}"
+          remote_prefix = "${REMOTE_PREFIX}"
+
+          [sync]
+          nats_url = "${TCFS_NATS_URL}"
+          state_db = "${RUNNER_TEMP}/tcfs-state.db"
+          sync_root = "${SYNC_ROOT}"
+          device_name = "gha-macos-postinstall"
+
+          device_id = "gha-macos-postinstall"
+          EOF
+          chmod 600 "$CONFIG_PATH"
+
+      - name: Provision FileProvider config
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash swift/fileprovider/provision-config.sh "$CONFIG_PATH"
+
+      - name: Seed remote fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          FIXTURE_PATH="${SYNC_ROOT}/${FIXTURE_REL}"
+          mkdir -p "$(dirname "$FIXTURE_PATH")"
+          printf 'tcfs macOS post-install smoke %s run %s\n' "$TAG" "$GITHUB_RUN_ID" > "$FIXTURE_PATH"
+          tcfs --config "$CONFIG_PATH" push "$FIXTURE_PATH"
+
+      - name: Start tcfsd with live config
+        shell: bash
+        run: |
+          set -euo pipefail
+          nohup tcfsd --config "$CONFIG_PATH" --mode daemon --log-format text \
+            > "$LOG_DIR/tcfsd.log" 2>&1 &
+          echo "$!" > "$LOG_DIR/tcfsd.pid"
+
+          for socket in /tmp/tcfsd-gha.sock "${APP_GROUP_DIR}/tcfsd.sock"; do
+            ready=0
+            for _ in $(seq 1 60); do
+              if [[ -S "$socket" ]]; then
+                ready=1
+                break
+              fi
+              sleep 1
+            done
+            if [[ "$ready" -ne 1 ]]; then
+              echo "::error::Timed out waiting for socket $socket"
+              cat "$LOG_DIR/tcfsd.log" || true
+              exit 1
+            fi
+          done
+
+      - name: Run macOS post-install harness
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/macos-postinstall-smoke.sh \
+            --expected-version "${VERSION}" \
+            --config "$CONFIG_PATH" \
+            --expected-file "${FIXTURE_REL}" \
+            --log-dir "$LOG_DIR/harness"
+
+      - name: Capture diagnostics
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          pluginkit -m -A -D -i io.tinyland.tcfs.fileprovider > "$LOG_DIR/pluginkit.txt" 2>&1
+          if command -v fileproviderctl >/dev/null 2>&1; then
+            fileproviderctl domain list > "$LOG_DIR/fileproviderctl-domains.txt" 2>&1
+          fi
+          log show --style compact --last 5m \
+            --predicate 'subsystem BEGINSWITH "io.tinyland.tcfs"' \
+            > "$LOG_DIR/oslog.txt" 2>&1
+
+      - name: Stop tcfsd
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if [[ -f "$LOG_DIR/tcfsd.pid" ]]; then
+            kill "$(cat "$LOG_DIR/tcfsd.pid")" 2>/dev/null || true
+            wait "$(cat "$LOG_DIR/tcfsd.pid")" 2>/dev/null || true
+          fi
+
+      - name: Upload smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-postinstall-smoke-${{ github.event.inputs.tag }}
+          path: ${{ env.LOG_DIR }}
+          retention-days: 7

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -93,6 +93,32 @@ Notes:
   not fabricate temp-home state or start a fake backend
 - `#309` still tracks where this harness runs from a known-clean host per tag
 
+### GitHub-Hosted Approximation
+
+The repo now also carries a manual GitHub Actions executor for this lane:
+
+- [`.github/workflows/macos-postinstall-smoke.yml`](../../.github/workflows/macos-postinstall-smoke.yml)
+
+This is a `workflow_dispatch` lane on `macos-14` that:
+
+- downloads the published `.pkg` for a tag
+- runs `scripts/install-smoke.sh`
+- writes a real tcfs config from repository secrets
+- seeds a remote-backed fixture with `tcfs push`
+- starts `tcfsd` with both primary and FileProvider sockets
+- runs `scripts/macos-postinstall-smoke.sh`
+
+Required repository secrets:
+
+- `TCFS_S3_ENDPOINT`
+- `TCFS_S3_BUCKET`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `TCFS_NATS_URL`
+
+Treat this as a clean-host approximation, not as already-proven release truth,
+until at least one tagged run has passed and produced usable logs on GitHub.
+
 ### Manual Procedure
 
 The script above codifies the manual steps below. Keep them here as the

--- a/docs/ops/packaged-install-first-use.md
+++ b/docs/ops/packaged-install-first-use.md
@@ -94,5 +94,8 @@ Record results using a table like this:
 - `install.sh` is published convenience tooling, not part of the canonical
   release-proof surface. See [Distribution Smoke Matrix](distribution-smoke-matrix.md).
 - The macOS clean-host lane remains tracked in `#309`; the harness now exists,
-  but its clean-host executor still needs to be chosen.
+  and the repo now carries a manual GitHub-hosted approximation in
+  [`.github/workflows/macos-postinstall-smoke.yml`](../../.github/workflows/macos-postinstall-smoke.yml),
+  but live backend secrets still need to exist and at least one tagged run
+  still needs to pass before that executor can be treated as proven.
 - The Nix install path remains blocked on `#307`.

--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -29,6 +29,7 @@ Options:
   --tcfs <path-or-name>       CLI binary to use (default: tcfs)
   --tcfsd <path-or-name>      Daemon binary to use (default: tcfsd)
   --timeout <seconds>         Wait timeout for async steps (default: 45)
+  --log-dir <path>            Persist status logs instead of using a temp dir
   --skip-status               Skip `tcfs status` checks
   -h, --help                  Show this help
 EOF
@@ -44,6 +45,7 @@ DOMAIN_ID="${TCFS_DOMAIN_ID:-io.tinyland.tcfs}"
 TCFS_BIN="${TCFS_BIN:-tcfs}"
 TCFSD_BIN="${TCFSD_BIN:-tcfsd}"
 TIMEOUT_SECS="${TIMEOUT_SECS:-45}"
+LOG_DIR_OVERRIDE=""
 SKIP_STATUS=0
 LOG_DIR=""
 
@@ -87,6 +89,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --timeout)
       TIMEOUT_SECS="$2"
+      shift 2
+      ;;
+    --log-dir)
+      LOG_DIR_OVERRIDE="$2"
       shift 2
       ;;
     --skip-status)
@@ -349,8 +355,13 @@ hydrate_expected_file() {
 }
 
 APP_PATH="$(detect_app_path)"
-LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-macos-postinstall.XXXXXX")"
-trap 'rm -rf "$LOG_DIR"' EXIT
+if [[ -n "$LOG_DIR_OVERRIDE" ]]; then
+  LOG_DIR="$LOG_DIR_OVERRIDE"
+  mkdir -p "$LOG_DIR"
+else
+  LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-macos-postinstall.XXXXXX")"
+  trap 'rm -rf "$LOG_DIR"' EXIT
+fi
 
 TCFSD_PATH="$(resolve_bin "$TCFSD_BIN")"
 assert_version "tcfsd" "$TCFSD_PATH"
@@ -364,6 +375,7 @@ else
 fi
 
 require_file "$HOME/.config/tcfs/fileprovider/config.json"
+echo "status logs: $LOG_DIR"
 check_pluginkit
 
 echo "launching host app: $APP_PATH"

--- a/swift/fileprovider/provision-config.sh
+++ b/swift/fileprovider/provision-config.sh
@@ -34,11 +34,15 @@ extract_toml() {
 }
 S3_ENDPOINT="$(extract_toml endpoint)"
 S3_BUCKET="$(extract_toml bucket)"
+REMOTE_PREFIX="$(extract_toml remote_prefix)"
 DEVICE_ID="$(extract_toml device_id)"
+DEVICE_NAME="$(extract_toml device_name)"
+DAEMON_SOCKET="$(extract_toml fileprovider_socket)"
 
 S3_ENDPOINT="${S3_ENDPOINT:-http://212.2.245.145:8333}"
 S3_BUCKET="${S3_BUCKET:-tcfs}"
-DEVICE_ID="${DEVICE_ID:-$(hostname -s)}"
+DEVICE_ID="${DEVICE_ID:-${DEVICE_NAME:-$(hostname -s)}}"
+REMOTE_PREFIX="${REMOTE_PREFIX:-devices/$DEVICE_ID}"
 
 # --- Resolve S3 credentials ---
 if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
@@ -77,16 +81,30 @@ GROUP_CONTAINER="$DEV_DIR"
 
 CONFIG_JSON="$GROUP_CONTAINER/config.json"
 
+if [ -n "$DAEMON_SOCKET" ]; then
 cat > "$CONFIG_JSON" <<CONFIGEOF
 {
   "s3_endpoint": "$S3_ENDPOINT",
   "s3_bucket": "$S3_BUCKET",
   "s3_access": "$S3_ACCESS",
   "s3_secret": "$S3_SECRET",
-  "remote_prefix": "devices/$DEVICE_ID",
+  "remote_prefix": "$REMOTE_PREFIX",
+  "device_id": "$DEVICE_ID",
+  "daemon_socket": "$DAEMON_SOCKET"
+}
+CONFIGEOF
+else
+cat > "$CONFIG_JSON" <<CONFIGEOF
+{
+  "s3_endpoint": "$S3_ENDPOINT",
+  "s3_bucket": "$S3_BUCKET",
+  "s3_access": "$S3_ACCESS",
+  "s3_secret": "$S3_SECRET",
+  "remote_prefix": "$REMOTE_PREFIX",
   "device_id": "$DEVICE_ID"
 }
 CONFIGEOF
+fi
 
 chmod 600 "$CONFIG_JSON"
 
@@ -94,7 +112,11 @@ echo "==> Config written to $CONFIG_JSON"
 echo "    Endpoint: $S3_ENDPOINT"
 echo "    Bucket:   $S3_BUCKET"
 echo "    Device:   $DEVICE_ID"
-echo "    Credentials: $(echo "$S3_ACCESS" | head -c 4)****"
+echo "    Prefix:   $REMOTE_PREFIX"
+if [ -n "$DAEMON_SOCKET" ]; then
+    echo "    Socket:   $DAEMON_SOCKET"
+fi
+echo "    Credentials: present"
 
 # Also copy to App Group container if it already exists (for sandboxed .appex)
 APP_GROUP_DIR="$HOME/Library/Group Containers/group.io.tinyland.tcfs"


### PR DESCRIPTION
## What changed

- add a manual `workflow_dispatch` macOS post-install smoke workflow for released `.pkg` tags on `macos-14`
- align `swift/fileprovider/provision-config.sh` with real config `remote_prefix` and `fileprovider_socket` instead of inventing its own prefix
- let `scripts/macos-postinstall-smoke.sh` keep logs for CI artifact upload
- document the GitHub-hosted clean-host approximation and its required secrets in the macOS runbooks

## Why

`#309` no longer needed a vague executor discussion. The repo needed a concrete runner lane that can install the published package, seed a real remote-backed fixture, start `tcfsd`, and execute the named post-install harness on a clean-ish hosted macOS machine.

This still does not make the lane fully proven today: the repo currently needs live backend secrets configured, and the workflow still needs its first successful tagged run.

## Validation

- `bash -n scripts/macos-postinstall-smoke.sh swift/fileprovider/provision-config.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/macos-postinstall-smoke.yml")'`
- `git diff --check`
- temp-home provision smoke verifying emitted `remote_prefix`, `device_id`, and `daemon_socket`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a manual `workflow_dispatch` GitHub Actions lane that downloads a released `.pkg`, installs it on `macos-14`, seeds a remote-backed fixture, starts `tcfsd`, and runs the named post-install harness. It also aligns `provision-config.sh` to read `remote_prefix` and `fileprovider_socket` from the actual TOML config rather than hardcoding them, lets the smoke script retain logs when `--log-dir` is provided, and documents the new executor and its required secrets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style and best-practice suggestions; no correctness or data-loss issues on the changed path

The workflow is well-structured: input validation, secret handling via env vars, proper socket readiness polling, always-run diagnostics and cleanup, and 7-day log retention. The three flagged issues (script injection pattern, ineffective wait, unescaped JSON) are all low-severity — exploitation of the injection requires write access, the wait failure is invisible due to || true, and AWS credentials are safe in practice. No Rust unsafe blocks, FFI, or crypto paths were touched.

.github/workflows/macos-postinstall-smoke.yml (script injection pattern on lines 33 and 56)

<details open><summary><h3>Security Review</h3></summary>

- **Script injection** in `.github/workflows/macos-postinstall-smoke.yml` (lines 33, 56): `${{ github.event.inputs.tag }}` is expanded textually into `run:` scripts before shell parsing. A v-prefixed input containing shell metacharacters (e.g. `v1.0\"; cmd #`) can execute arbitrary commands. Exploitation requires repository write access to trigger `workflow_dispatch`, but is still a violation of GitHub's recommended security practice.
- **Unescaped credentials in JSON output** in `swift/fileprovider/provision-config.sh` (lines 85–107): S3 and other config values are interpolated directly into a JSON heredoc without escaping. Malformed JSON would prevent the FileProvider extension from loading its config. Low practical risk with standard AWS credentials, but `REMOTE_PREFIX` and `DAEMON_SOCKET` paths could contain backslashes on non-standard setups.
- No hardcoded secrets, no new network-facing code, and file permissions on emitted JSON configs are correctly set to 600.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/macos-postinstall-smoke.yml | New manual workflow_dispatch lane for macOS post-install smoke testing; contains a shell injection pattern and an ineffective wait call in the cleanup step |
| scripts/macos-postinstall-smoke.sh | Adds --log-dir passthrough so logs are retained for CI artifact upload instead of being deleted by the exit trap; logic is clean and correct |
| swift/fileprovider/provision-config.sh | Now reads remote_prefix and fileprovider_socket from the actual TOML config instead of hardcoding; credentials written into JSON without escaping (low practical risk with AWS keys) |
| docs/ops/macos-fileprovider-reality.md | Documents the new GitHub-hosted approximation lane, required secrets, and clean-host caveats; no issues |
| docs/ops/packaged-install-first-use.md | Records the new GHA executor reference and its unproven status clearly; no issues |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions (macos-14)
    participant GHR as GitHub Releases
    participant S3 as S3 Backend
    participant tcfsd
    participant FP as FileProvider Extension

    GHA->>GHA: Validate tag input (v* prefix + secrets)
    GHA->>GHR: curl .pkg for tag
    GHR-->>GHA: tcfs-VERSION-macos-aarch64.pkg
    GHA->>GHA: sudo installer -pkg
    GHA->>GHA: scripts/install-smoke.sh (binary version check)
    GHA->>GHA: Write config.toml (S3 + NATS secrets)
    GHA->>GHA: provision-config.sh → config.json
    GHA->>S3: tcfs push fixture file
    GHA->>tcfsd: nohup tcfsd --mode daemon
    tcfsd-->>GHA: sockets ready
    GHA->>GHA: macos-postinstall-smoke.sh
    GHA->>FP: open TCFSProvider.app (domain re-add)
    FP->>tcfsd: enumerate via fileprovider socket
    tcfsd->>S3: fetch remote-backed fixture
    S3-->>tcfsd: fixture data
    tcfsd-->>FP: hydrated file
    GHA->>GHA: Capture diagnostics
    GHA->>GHA: Upload logs artifact (retention 7d)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/macos-postinstall-smoke.yml
Line: 56-57

Comment:
**Script injection via `${{ github.event.inputs.tag }}` re-injection**

`${{ github.event.inputs.tag }}` is expanded by the GitHub Actions expression engine before the shell parses the script, so a v-prefixed input like `v1.0"; evil_cmd #` would execute `evil_cmd` here even though the validation step only checks for the `v` prefix. After the "Validate release inputs" step succeeds and writes `TAG` to `$GITHUB_ENV`, this step could simply read `$TAG` from the environment instead of re-injecting the raw input.

```suggestion
          TAG="$TAG"
          VERSION="${TAG#v}"
```

The same injection pattern exists at line 33 (step 1). The safest fix for both steps is to declare `TAG` at the job `env:` level:

```yaml
env:
  TAG: ${{ github.event.inputs.tag }}
```

and then reference `$TAG` in all `run:` scripts without any `${{ }}` interpolation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/macos-postinstall-smoke.yml
Line: 194-197

Comment:
**`wait` on a non-child PID is a no-op**

`wait` is a shell built-in that only operates on child processes of the current shell. Since `tcfsd` was backgrounded in a previous step (a separate shell invocation), its PID is not a child here and `wait` returns immediately with a non-zero exit that is swallowed by `|| true`. The `kill` call above it is still effective, so cleanup works in practice, but the `wait` adds no grace period. You could use a short `sleep` or poll the socket's disappearance if you need a true drain window.

```suggestion
          if [[ -f "$LOG_DIR/tcfsd.pid" ]]; then
            kill "$(cat "$LOG_DIR/tcfsd.pid")" 2>/dev/null || true
            sleep 2
          fi
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: swift/fileprovider/provision-config.sh
Line: 85-107

Comment:
**JSON values written without character escaping**

Variables like `$S3_ACCESS`, `$S3_SECRET`, `$REMOTE_PREFIX`, and `$DAEMON_SOCKET` are expanded directly into the JSON heredoc with no escaping of `"`, `\`, or control characters. Standard AWS secret access keys are base64-alphabet and safe in practice, but `REMOTE_PREFIX` is derived from the TOML config and `DAEMON_SOCKET` is a filesystem path — either could legally contain backslashes on non-standard setups, producing malformed JSON that the FileProvider extension will fail to parse. Consider using `jq -n` to construct the payload, which handles escaping automatically:

```bash
jq -n \
  --arg ep  "$S3_ENDPOINT" \
  --arg bkt "$S3_BUCKET" \
  --arg acc "$S3_ACCESS" \
  --arg sec "$S3_SECRET" \
  --arg pfx "$REMOTE_PREFIX" \
  --arg dev "$DEVICE_ID" \
  --arg sock "$DAEMON_SOCKET" \
  '{s3_endpoint:$ep,s3_bucket:$bkt,s3_access:$acc,s3_secret:$sec,
    remote_prefix:$pfx,device_id:$dev,daemon_socket:$sock}' \
  > "$CONFIG_JSON"
```

(Drop the `daemon_socket` key from the `jq` call when `$DAEMON_SOCKET` is empty.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add macOS post-install smoke lane"](https://github.com/jesssullivan/tummycrypt/commit/925f1a6204a7483d8c78156847b2e11c3944cbf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28845290)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->