### PR TITLE
[codex] docs: narrow macOS postinstall blocker

### DIFF
--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -22,11 +22,10 @@ jobs:
       TCFS_S3_BUCKET: ${{ secrets.TCFS_S3_BUCKET }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      TCFS_NATS_URL: ${{ secrets.TCFS_NATS_URL }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate release inputs and backend secrets
+      - name: Validate release inputs and storage secrets
         shell: bash
         run: |
           set -euo pipefail
@@ -37,7 +36,7 @@ jobs:
           }
 
           missing=()
-          for name in TCFS_S3_ENDPOINT TCFS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY TCFS_NATS_URL; do
+          for name in TCFS_S3_ENDPOINT TCFS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
             if [[ -z "${!name:-}" ]]; then
               missing+=("$name")
             fi
@@ -45,7 +44,12 @@ jobs:
 
           if (( ${#missing[@]} > 0 )); then
             echo "::error::Missing required repository secrets: ${missing[*]}"
-            echo "Set the live backend secrets before using this workflow."
+            echo "Set the storage-side secrets before using this workflow."
+            exit 1
+          fi
+
+          if [[ "${TCFS_S3_ENDPOINT}" =~ ^http://100\. ]] || [[ "${TCFS_S3_ENDPOINT}" =~ ^https://100\. ]]; then
+            echo "::warning::TCFS_S3_ENDPOINT points at a 100.x address. GitHub-hosted runners will usually not reach Tailscale-only endpoints."
             exit 1
           fi
 
@@ -115,7 +119,6 @@ jobs:
           remote_prefix = "${REMOTE_PREFIX}"
 
           [sync]
-          nats_url = "${TCFS_NATS_URL}"
           state_db = "${RUNNER_TEMP}/tcfs-state.db"
           sync_root = "${SYNC_ROOT}"
           device_name = "gha-macos-postinstall"

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -114,10 +114,17 @@ Required repository secrets:
 - `TCFS_S3_BUCKET`
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
-- `TCFS_NATS_URL`
 
-Treat this as a clean-host approximation, not as already-proven release truth,
-until at least one tagged run has passed and produced usable logs on GitHub.
+Notes:
+
+- this workflow is intentionally **storage-driven**, not fleet-sync-driven; it
+  does not require NATS because the post-install enumerate + hydrate lane only
+  needs S3-backed manifest and chunk access
+- the remaining unknown is backend reachability from GitHub-hosted macOS
+  runners; Tailscale-only endpoints are not sufficient for this executor
+- treat this as a clean-host approximation, not as already-proven release
+  truth, until at least one tagged run has passed and produced usable logs on
+  GitHub
 
 ### Manual Procedure
 

--- a/docs/ops/packaged-install-first-use.md
+++ b/docs/ops/packaged-install-first-use.md
@@ -96,6 +96,7 @@ Record results using a table like this:
 - The macOS clean-host lane remains tracked in `#309`; the harness now exists,
   and the repo now carries a manual GitHub-hosted approximation in
   [`.github/workflows/macos-postinstall-smoke.yml`](../../.github/workflows/macos-postinstall-smoke.yml),
-  but live backend secrets still need to exist and at least one tagged run
-  still needs to pass before that executor can be treated as proven.
+  but the remaining blocker is reachable storage from the hosted runner plus at
+  least one successful tagged run; NATS is not required for that enumerate +
+  hydrate lane.
 - The Nix install path remains blocked on `#307`.


### PR DESCRIPTION
## What changed

- remove the unnecessary `TCFS_NATS_URL` requirement from the hosted macOS post-install workflow
- document that the hosted lane is intentionally storage-driven rather than fleet-sync-driven
- restate the remaining blocker as backend reachability from GitHub-hosted runners, not NATS wiring

## Why

The repo already documents that tcfs push/pull works without NATS and that the hosted post-install lane only needs enumerate + hydrate against remote manifests and chunks. Keeping `TCFS_NATS_URL` in the workflow made `#309` look broader than it is and obscured the real uncertainty: whether the storage endpoint is reachable from a GitHub-hosted macOS runner.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/macos-postinstall-smoke.yml")'`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows the documented macOS post-install blocker by removing the unnecessary `TCFS_NATS_URL` requirement from the hosted workflow and clarifying in two ops docs that the enumerate + hydrate lane is storage-driven, not fleet-sync-driven. The only remaining blocker is storage-endpoint reachability from GitHub-hosted macOS runners, which is now correctly stated across the workflow and docs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation and a targeted workflow cleanup with no functional regressions.

The only finding is a P2 style issue where ::warning:: is used alongside exit 1 — semantically inconsistent but causes no incorrect behavior. All other changes are straightforward docs corrections that narrow an overstated blocker. No logic, crypto, FFI, or security paths are touched.

.github/workflows/macos-postinstall-smoke.yml line 52 — minor annotation-level mismatch worth fixing but not blocking.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/macos-postinstall-smoke.yml | Removes TCFS_NATS_URL from env and validation; minor annotation-level mismatch (::warning:: + exit 1) at line 52. |
| docs/ops/macos-fileprovider-reality.md | Adds clarifying notes that the hosted lane is storage-driven (not NATS-dependent) and restates the remaining blocker as storage reachability from GitHub-hosted runners. |
| docs/ops/packaged-install-first-use.md | Updates scope note to explicitly state NATS is not required for the enumerate + hydrate lane, narrowing the #309 blocker description. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[workflow_dispatch: tag input] --> B[Validate tag format + storage secrets]
    B -->|Missing secrets| FAIL1[❌ Exit 1: missing secrets]
    B -->|100.x endpoint| FAIL2[❌ Exit 1: Tailscale-only endpoint]
    B -->|OK| C[Derive run paths]
    C --> D[Download .pkg for tag]
    D --> E[Install .pkg via sudo installer]
    E --> F[scripts/install-smoke.sh]
    F --> G[Write live config from secrets]
    G --> H[Provision FileProvider config]
    H --> I[Seed remote fixture via tcfs push]
    I --> J[Start tcfsd daemon]
    J --> K[scripts/macos-postinstall-smoke.sh]
    K --> L[Capture diagnostics]
    L --> M[Stop tcfsd]
    M --> N[Upload smoke logs artifact]

    style FAIL1 fill:#f66
    style FAIL2 fill:#f66
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/macos-postinstall-smoke.yml
Line: 51-54

Comment:
**`::warning::` annotation contradicts `exit 1`**

The step emits a `::warning::` annotation (yellow triangle in the Actions UI) and then immediately exits with code 1, which marks the step as failed (red X). This is misleading: a reader scanning the Actions summary sees a warning annotation and may assume the step passed with a caution, when the step actually failed hard. Using `::error::` keeps the annotation level consistent with the exit status.

```suggestion
          echo "::error::TCFS_S3_ENDPOINT points at a 100.x address. GitHub-hosted runners will usually not reach Tailscale-only endpoints."
          exit 1
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: narrow macOS postinstall blocker"](https://github.com/jesssullivan/tummycrypt/commit/0663822799a9e1066332c82f1dcfa7695ba763e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28845721)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->