### PR TITLE
[codex] fix macOS FileProvider shared keychain config

### DIFF
--- a/crates/tcfs-fuse/tests/mount_roundtrip.rs
+++ b/crates/tcfs-fuse/tests/mount_roundtrip.rs
@@ -82,7 +82,11 @@ async fn unmount_fuse(mountpoint: &Path) -> Result<()> {
                 "fusermount3 -u {} failed: {}{}{}",
                 mountpoint.display(),
                 output.status,
-                if stderr.trim().is_empty() { "" } else { " stderr: " },
+                if stderr.trim().is_empty() {
+                    ""
+                } else {
+                    " stderr: "
+                },
                 stderr.trim()
             );
         }

--- a/crates/tcfs-fuse/tests/mount_roundtrip.rs
+++ b/crates/tcfs-fuse/tests/mount_roundtrip.rs
@@ -54,13 +54,37 @@ async fn wait_for_mount_state(mountpoint: &Path, mounted: bool) -> Result<()> {
 async fn unmount_fuse(mountpoint: &Path) -> Result<()> {
     let mountpoint = mountpoint.to_path_buf();
     tokio::task::spawn_blocking(move || {
-        let status = Command::new("fusermount3")
-            .arg("-u")
-            .arg(&mountpoint)
-            .status()
-            .with_context(|| format!("running fusermount3 -u {}", mountpoint.display()))?;
-        if !status.success() {
-            anyhow::bail!("fusermount3 -u {} failed: {status}", mountpoint.display());
+        // Real FUSE teardown can briefly report EBUSY while the kernel finishes
+        // releasing the mount. Give fusermount3 a short retry window instead of
+        // failing the remount coverage on the first transient race.
+        for attempt in 0..20 {
+            if !is_mounted(&mountpoint)? {
+                return Ok::<(), anyhow::Error>(());
+            }
+
+            let output = Command::new("fusermount3")
+                .arg("-u")
+                .arg(&mountpoint)
+                .output()
+                .with_context(|| format!("running fusermount3 -u {}", mountpoint.display()))?;
+
+            if output.status.success() || !is_mounted(&mountpoint)? {
+                return Ok::<(), anyhow::Error>(());
+            }
+
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("Device or resource busy") && attempt < 19 {
+                std::thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+
+            anyhow::bail!(
+                "fusermount3 -u {} failed: {}{}{}",
+                mountpoint.display(),
+                output.status,
+                if stderr.trim().is_empty() { "" } else { " stderr: " },
+                stderr.trim()
+            );
         }
         Ok::<(), anyhow::Error>(())
     })

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -50,7 +50,11 @@ In practical terms, the intended operator flow is:
   `~/Applications/TCFSProvider.app`, so that install path should be treated as
   requiring manual app launch and manual verification.
 - The host app provisions config from `~/.config/tcfs/fileprovider/config.json`
-  into Keychain as a best-effort startup step.
+  into the shared app-group keychain as a best-effort startup step.
+- The repo now uses explicit shared-keychain semantics for that config, but the
+  clean-machine validity of the `group.io.tinyland.tcfs` app-group entitlement
+  is still only as good as the signing and provisioning reality of the shipped
+  app bundle.
 
 ## Not Yet Proven
 
@@ -122,6 +126,9 @@ Notes:
   needs S3-backed manifest and chunk access
 - the remaining unknown is backend reachability from GitHub-hosted macOS
   runners; Tailscale-only endpoints are not sufficient for this executor
+- a hosted pass still does not prove that the macOS app-group entitlement and
+  provisioning story are correct on every clean machine; treat keychain/app
+  group failures as a distinct class from storage reachability failures
 - treat this as a clean-host approximation, not as already-proven release
   truth, until at least one tagged run has passed and produced usable logs on
   GitHub

--- a/docs/ops/packaged-install-first-use.md
+++ b/docs/ops/packaged-install-first-use.md
@@ -98,5 +98,6 @@ Record results using a table like this:
   [`.github/workflows/macos-postinstall-smoke.yml`](../../.github/workflows/macos-postinstall-smoke.yml),
   but the remaining blocker is reachable storage from the hosted runner plus at
   least one successful tagged run; NATS is not required for that enumerate +
-  hydrate lane.
+  hydrate lane, and keychain/app-group failures should be treated separately
+  from storage reachability failures.
 - The Nix install path remains blocked on `#307`.

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -4,6 +4,9 @@ import Security
 import os.log
 
 private let logger = Logger(subsystem: "io.tinyland.tcfs.fileprovider", category: "extension")
+private let sharedConfigService = "io.tinyland.tcfs.config"
+private let sharedConfigAccount = "configJSON"
+private let sharedConfigAccessGroup = "group.io.tinyland.tcfs"
 
 /// TCFS FileProvider extension — bridges to Rust via cbindgen C FFI.
 ///
@@ -544,18 +547,19 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         return nil
     }
 
-    /// Read config JSON from the macOS login keychain.
+    /// Read config JSON from the shared data-protection keychain.
     /// Keychain access uses securityd XPC — no filesystem I/O, immune to
     /// fileproviderd's file coordination locks.
     ///
-    /// Uses the legacy macOS keychain (NOT data protection keychain) to avoid
-    /// restricted entitlement requirements. Both host app and extension are
-    /// signed with the same Developer ID, so they share keychain access.
+    /// The host app writes this item with an explicit app-group access group so
+    /// the extension can read it without depending on each target's bundle ID.
     private static func readConfigFromKeychain() -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: "io.tinyland.tcfs.config",
-            kSecAttrAccount as String: "configJSON",
+            kSecUseDataProtectionKeychain as String: true,
+            kSecAttrAccessGroup as String: sharedConfigAccessGroup,
+            kSecAttrService as String: sharedConfigService,
+            kSecAttrAccount as String: sharedConfigAccount,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -4,6 +4,9 @@ import Security
 import os.log
 
 private let hostLogger = Logger(subsystem: "io.tinyland.tcfs", category: "host")
+private let sharedConfigService = "io.tinyland.tcfs.config"
+private let sharedConfigAccount = "configJSON"
+private let sharedConfigAccessGroup = "group.io.tinyland.tcfs"
 
 @main
 struct TCFSProviderApp {
@@ -69,13 +72,12 @@ struct TCFSProviderApp {
 
         guard let data = config.data(using: .utf8) else { return }
 
-        let service = "io.tinyland.tcfs.config"
-        let account = "configJSON"
-
         let updateQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecAttrAccessGroup as String: sharedConfigAccessGroup,
+            kSecAttrService as String: sharedConfigService,
+            kSecAttrAccount as String: sharedConfigAccount,
         ]
         let updateAttrs: [String: Any] = [
             kSecValueData as String: data,
@@ -91,7 +93,13 @@ struct TCFSProviderApp {
         }
 
         if status == errSecSuccess {
-            hostLogger.error("provisionConfig: provisioned \(config.count) bytes to Keychain")
+            hostLogger.error(
+                "provisionConfig: provisioned \(config.count) bytes to shared Keychain group"
+            )
+        } else if status == errSecMissingEntitlement {
+            hostLogger.error(
+                "provisionConfig: Keychain write missing entitlement for \(sharedConfigAccessGroup)"
+            )
         } else {
             hostLogger.error("provisionConfig: Keychain write failed with status \(status)")
         }


### PR DESCRIPTION
## What changed

This patch makes the macOS FileProvider host app and extension use an explicit shared keychain item for FileProvider config, and updates the runbooks to separate that bug from the still-open clean-machine app-group/provisioning question.

## Why it changed

The previous macOS host app wrote `configJSON` with generic `SecItemAdd` / `SecItemUpdate` queries and no explicit access group. The extension then assumed it could read the same item because both targets are signed by the same Developer ID.

Apple's current keychain model does not make that a safe assumption. Without an explicit shared access group, the item can default to the creating target's app identity rather than a group both targets share. That means the extension can fail to load config even when storage reachability is fine.

## Impact

- macOS host app now writes the FileProvider config into the data-protection keychain with explicit app-group semantics
- macOS extension now reads that same shared item instead of relying on bundle-ID-adjacent behavior
- docs now call out that storage reachability and keychain/app-group validity are separate failure classes for `#309`

## Root cause

The repo was relying on an implicit "same Developer ID means shared keychain access" assumption in the macOS FileProvider path. The iOS path in the same repo already uses explicit access-group queries; macOS had drifted into a weaker model.

## Validation

- `git diff --check`
- attempted `just fileprovider-build`

The Darwin build did not reach code-level validation in this environment because the local Swift toolchain and SDK are mismatched (`SwiftShims` / unsupported SDK compiler error from the local Nix-wrapped toolchain). The failure occurred after the Rust staticlib build and during Swift compilation, and does not point at the keychain patch itself.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes macOS FileProvider keychain sharing by switching both the host app and extension to the data-protection keychain with an explicit `group.io.tinyland.tcfs` access group, aligning them with the iOS path that already used explicit access groups. It also hardens the FUSE unmount retry logic in tests against transient `EBUSY` races and updates docs to distinguish storage-reachability failures from keychain/entitlement failures.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core keychain fix is correct and symmetric between host and extension, entitlements already declare the required app group, and all remaining findings are P2 style/observability suggestions.

Both entitlement files already contain group.io.tinyland.tcfs in com.apple.security.application-groups. The write (HostApp) and read (Extension) queries are symmetric on service, account, access group, and data-protection keychain flag. The errSecMissingEntitlement case is explicitly handled on the write path. The Rust retry logic is correct. All findings are P2: duplicated private constants (future drift risk), asymmetric entitlement error logging in the extension, and a redundant loop guard in test code.

The duplicated private constants in HostApp.swift and FileProviderExtension.swift are the highest-value follow-up — a future one-sided edit silently breaks keychain sharing.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| swift/fileprovider/Sources/HostApp/HostApp.swift | Adds explicit kSecUseDataProtectionKeychain and kSecAttrAccessGroup to write path; correctly handles errSecMissingEntitlement but duplicates keychain constants that must stay in sync with the extension. |
| swift/fileprovider/Sources/Extension/FileProviderExtension.swift | Read path now uses the same shared data-protection keychain; errSecMissingEntitlement is logged only at warning with a raw OSStatus integer, unlike the host app's explicit human-readable message. |
| crates/tcfs-fuse/tests/mount_roundtrip.rs | Replaces one-shot fusermount3 call with a 20-attempt EBUSY retry loop; logic is correct and is_mounted checks prevent false failures. |
| docs/ops/macos-fileprovider-reality.md | Updated to document explicit shared-keychain semantics and separate storage-reachability from keychain/app-group failures as distinct diagnostic classes. |
| docs/ops/packaged-install-first-use.md | Minor doc update noting keychain/app-group failures should be treated separately from storage reachability in the macOS clean-host lane. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Operator
    participant HostApp as TCFSProviderApp
    participant DPKeychain as Data-Protection Keychain
    participant Extension as FileProviderExtension
    participant Daemon as tcfsd (Rust)

    Operator->>HostApp: launch app
    HostApp->>HostApp: read config from XDG path
    HostApp->>DPKeychain: SecItemUpdate with explicit access group
    alt item not found
        DPKeychain-->>HostApp: errSecItemNotFound
        HostApp->>DPKeychain: SecItemAdd with AfterFirstUnlock accessibility
    end
    alt missing entitlement
        DPKeychain-->>HostApp: errSecMissingEntitlement
        HostApp->>HostApp: log human-readable error
    end
    HostApp->>HostApp: re-register FileProvider domain

    Operator->>Extension: Finder triggers enumeration
    Extension->>DPKeychain: SecItemCopyMatching with same access group
    alt config found
        DPKeychain-->>Extension: configJSON blob
        Extension->>Daemon: tcfs_provider_new(config)
        Daemon-->>Extension: provider handle
    else not found or entitlement missing
        DPKeychain-->>Extension: error (logged at warning only)
        Extension->>Extension: fallback to XDG then App Group container
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `swift/fileprovider/Sources/Extension/FileProviderExtension.swift`, line 570-571 ([link](https://github.com/jesssullivan/tummycrypt/blob/81512868f80e53c012bebb34d9b072aa5017b0f1/swift/fileprovider/Sources/Extension/FileProviderExtension.swift#L570-L571)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing explicit `errSecMissingEntitlement` handling in extension read path**

   The host app explicitly handles `errSecMissingEntitlement` with a clear, human-readable log message. The extension's `readConfigFromKeychain` logs only a raw `OSStatus` integer at `warning` level, so a provisioning failure (entitlement missing for the shared access group) is indistinguishable from an expected item-not-found unless the reader knows that `-34018` maps to `errSecMissingEntitlement`. When this error occurs, the extension silently falls through to the "deadlock-prone" app-group container path — exactly where the operator least wants to be.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: swift/fileprovider/Sources/Extension/FileProviderExtension.swift
   Line: 570-571

   Comment:
   **Missing explicit `errSecMissingEntitlement` handling in extension read path**

   The host app explicitly handles `errSecMissingEntitlement` with a clear, human-readable log message. The extension's `readConfigFromKeychain` logs only a raw `OSStatus` integer at `warning` level, so a provisioning failure (entitlement missing for the shared access group) is indistinguishable from an expected item-not-found unless the reader knows that `-34018` maps to `errSecMissingEntitlement`. When this error occurs, the extension silently falls through to the "deadlock-prone" app-group container path — exactly where the operator least wants to be.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: swift/fileprovider/Sources/Extension/FileProviderExtension.swift
Line: 570-571

Comment:
**Missing explicit `errSecMissingEntitlement` handling in extension read path**

The host app explicitly handles `errSecMissingEntitlement` with a clear, human-readable log message. The extension's `readConfigFromKeychain` logs only a raw `OSStatus` integer at `warning` level, so a provisioning failure (entitlement missing for the shared access group) is indistinguishable from an expected item-not-found unless the reader knows that `-34018` maps to `errSecMissingEntitlement`. When this error occurs, the extension silently falls through to the "deadlock-prone" app-group container path — exactly where the operator least wants to be.

```suggestion
        if status != errSecSuccess {
            if status == errSecMissingEntitlement {
                logger.error(
                    "readConfigFromKeychain: missing entitlement for \(sharedConfigAccessGroup) — check app-group provisioning"
                )
            } else {
                logger.warning("readConfigFromKeychain: SecItemCopyMatching returned \(status)")
            }
        }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: swift/fileprovider/Sources/HostApp/HostApp.swift
Line: 7-9

Comment:
**Duplicated keychain constants across host and extension**

`sharedConfigService`, `sharedConfigAccount`, and `sharedConfigAccessGroup` are declared as `private` constants independently in both `HostApp.swift` and `FileProviderExtension.swift`. If either file is updated and the other is not, the host will write to a different keychain slot than the extension reads from — a silent config-load failure with no obvious error. A shared `SharedKeychainConfig.swift` (internal, not private) visible to both targets would make this coupling explicit at compile time.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: crates/tcfs-fuse/tests/mount_roundtrip.rs
Line: 76-77

Comment:
**`attempt < 19` guard is redundant with the loop bound**

Since the loop iterates `0..20`, the last iteration is already `attempt == 19`, so `attempt < 19` is always `false` on the final pass and the `continue` branch can never be taken. The guard works correctly as written — the 20th attempt always reaches `bail!` — but the condition makes the intent slightly harder to read.

```suggestion
            if stderr.contains("Device or resource busy") {
                std::thread::sleep(Duration::from_millis(100));
                continue;
            }
```
…with the outer loop changed to `0..19`, or leave the current form and add a comment explaining that `attempt < 19` is intentionally equivalent to "not the last attempt".

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(fuse): format unmount retry helper"](https://github.com/jesssullivan/tummycrypt/commit/81512868f80e53c012bebb34d9b072aa5017b0f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28856164)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->