### PR TITLE
[codex] reject non-public macOS smoke endpoints

### DIFF
--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -73,21 +73,23 @@ jobs:
                   f"::error::TCFS_S3_ENDPOINT host {host!r} looks private to a tailnet or local DNS domain."
               )
               raise SystemExit(1)
-          if "." not in host:
-              print(
-                  f"::error::TCFS_S3_ENDPOINT host {host!r} is a bare hostname; GitHub-hosted runners need a publicly routable DNS name."
-              )
-              raise SystemExit(1)
-
           try:
               ip = ipaddress.ip_address(host)
           except ValueError:
+              ip = None
+
+          if ip is None:
+              if "." not in host:
+                  print(
+                      f"::error::TCFS_S3_ENDPOINT host {host!r} is a bare hostname; GitHub-hosted runners need a publicly routable DNS name."
+                  )
+                  raise SystemExit(1)
               raise SystemExit(0)
 
           blocked = []
           if ip in ipaddress.ip_network("100.64.0.0/10"):
               blocked.append("carrier-grade NAT / tailnet")
-          if not ip.is_global:
+          elif not ip.is_global:
               blocked.append("non-global")
 
           if blocked:

--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -48,10 +48,54 @@ jobs:
             exit 1
           fi
 
-          if [[ "${TCFS_S3_ENDPOINT}" =~ ^http://100\. ]] || [[ "${TCFS_S3_ENDPOINT}" =~ ^https://100\. ]]; then
-            echo "::warning::TCFS_S3_ENDPOINT points at a 100.x address. GitHub-hosted runners will usually not reach Tailscale-only endpoints."
-            exit 1
-          fi
+          python3 - "$TCFS_S3_ENDPOINT" <<'PY'
+          import ipaddress
+          import sys
+          from urllib.parse import urlparse
+
+          endpoint = sys.argv[1].strip()
+          parsed = urlparse(endpoint)
+          if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+              print(
+                  f"::error::TCFS_S3_ENDPOINT must be an http(s) URL with a hostname (got {endpoint!r})"
+              )
+              raise SystemExit(1)
+
+          host = parsed.hostname.rstrip(".").lower()
+          blocked_suffixes = (".ts.net", ".local", ".internal", ".home.arpa")
+          if host in {"localhost", "localhost.localdomain"}:
+              print(
+                  f"::error::TCFS_S3_ENDPOINT host {host!r} is local-only and cannot be reached from GitHub-hosted macOS runners."
+              )
+              raise SystemExit(1)
+          if host.endswith(blocked_suffixes):
+              print(
+                  f"::error::TCFS_S3_ENDPOINT host {host!r} looks private to a tailnet or local DNS domain."
+              )
+              raise SystemExit(1)
+          if "." not in host:
+              print(
+                  f"::error::TCFS_S3_ENDPOINT host {host!r} is a bare hostname; GitHub-hosted runners need a publicly routable DNS name."
+              )
+              raise SystemExit(1)
+
+          try:
+              ip = ipaddress.ip_address(host)
+          except ValueError:
+              raise SystemExit(0)
+
+          blocked = []
+          if ip in ipaddress.ip_network("100.64.0.0/10"):
+              blocked.append("carrier-grade NAT / tailnet")
+          if not ip.is_global:
+              blocked.append("non-global")
+
+          if blocked:
+              print(
+                  f"::error::TCFS_S3_ENDPOINT host {host!r} is {' and '.join(blocked)}; GitHub-hosted macOS runners need a publicly reachable storage endpoint."
+              )
+              raise SystemExit(1)
+          PY
 
       - name: Derive run paths
         shell: bash

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -125,7 +125,9 @@ Notes:
   does not require NATS because the post-install enumerate + hydrate lane only
   needs S3-backed manifest and chunk access
 - the remaining unknown is backend reachability from GitHub-hosted macOS
-  runners; Tailscale-only endpoints are not sufficient for this executor
+  runners; Tailscale-only, RFC1918, localhost, and other clearly non-public
+  endpoints are not sufficient for this executor, and the workflow now rejects
+  those classes during preflight
 - a hosted pass still does not prove that the macOS app-group entitlement and
   provisioning story are correct on every clean machine; treat keychain/app
   group failures as a distinct class from storage reachability failures

--- a/docs/ops/packaged-install-first-use.md
+++ b/docs/ops/packaged-install-first-use.md
@@ -97,7 +97,9 @@ Record results using a table like this:
   and the repo now carries a manual GitHub-hosted approximation in
   [`.github/workflows/macos-postinstall-smoke.yml`](../../.github/workflows/macos-postinstall-smoke.yml),
   but the remaining blocker is reachable storage from the hosted runner plus at
-  least one successful tagged run; NATS is not required for that enumerate +
-  hydrate lane, and keychain/app-group failures should be treated separately
-  from storage reachability failures.
+  least one successful tagged run. That hosted lane now rejects obviously
+  non-public endpoint classes during preflight rather than failing later during
+  fixture seeding; NATS is not required for the enumerate + hydrate lane, and
+  keychain/app-group failures should be treated separately from storage
+  reachability failures.
 - The Nix install path remains blocked on `#307`.


### PR DESCRIPTION
## Summary
- fail the hosted macOS post-install workflow early on obviously non-public storage endpoints
- reject tailnet, localhost, bare-hostname, and non-global IP endpoint classes instead of waiting for fixture seeding to fail
- update the macOS post-install docs so the hosted-runner contract matches the workflow

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/macos-postinstall-smoke.yml")'
- python3 classifier sanity check for representative endpoint classes
- git diff --check

Refs #309

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an early-exit Python validation step to the macOS post-install smoke workflow that rejects non-public S3 endpoint classes (localhost, private DNS suffixes, bare hostnames, CGNAT/tailnet IPs, and non-global IPs) before reaching the fixture-seeding stage. The companion doc updates in `macos-fileprovider-reality.md` and `packaged-install-first-use.md` accurately reflect the new preflight contract.

The two issues raised in prior review threads (IPv6 addresses being misclassified as bare hostnames, and duplicate CGNAT/non-global qualifiers in error messages) are both correctly resolved in this iteration: `ipaddress.ip_address()` is now attempted before the dot-presence check, and the CGNAT branch uses `elif` to prevent redundant qualifiers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — CI/workflow change only, no production code modified, and both previously flagged issues are correctly resolved.

All prior P1 findings (IPv6 mis-classification as bare hostname, redundant CGNAT/non-global qualifiers) are addressed in this iteration. The classifier logic is correct for IPv4 loopback, RFC1918, CGNAT, IPv6 loopback/ULA/link-local, and public IPv6. No production crypto, FFI, or security-critical paths are touched.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/macos-postinstall-smoke.yml | Adds a Python endpoint classifier in the "Validate release inputs and storage secrets" step; both previously flagged issues (IPv6 ordering, redundant CGNAT qualifier) are resolved in the current HEAD. |
| docs/ops/macos-fileprovider-reality.md | Updated GitHub-hosted approximation section to document the new preflight endpoint rejection behavior; accurate and consistent with the workflow implementation. |
| docs/ops/packaged-install-first-use.md | Scope notes updated to reference the new early-rejection preflight; no issues found. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TCFS_S3_ENDPOINT input] --> B{Valid http/https URL\nwith hostname?}
    B -- No --> Z1[Error: must be http/https URL]
    B -- Yes --> C[Normalize: rstrip dot, lowercase]
    C --> D{localhost or\nlocalhost.localdomain?}
    D -- Yes --> Z2[Error: local-only host]
    D -- No --> E{Ends with .ts.net\n.local .internal\n.home.arpa?}
    E -- Yes --> Z3[Error: private tailnet/DNS domain]
    E -- No --> F{Parses as IP address?}
    F -- No --> G{dot in host?}
    G -- No --> Z4[Error: bare hostname]
    G -- Yes --> OK[Accept: valid FQDN]
    F -- Yes --> H{IP in 100.64.0.0/10\nCGNAT/tailnet range?}
    H -- Yes --> Z5[Error: carrier-grade NAT / tailnet]
    H -- No --> I{ip.is_global == False?}
    I -- Yes --> Z6[Error: non-global IP]
    I -- No --> OK2[Accept: public IP]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: allow public IPv6 smoke endpoints"](https://github.com/jesssullivan/tummycrypt/commit/b887a0b7d59cb89180ca6566cc1ee053e150e7ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28856541)</sub>

<!-- /greptile_comment -->