### PR TITLE
ci: initialize macOS smoke logs before validation

### DIFF
--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -25,6 +25,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Initialize log directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          LOG_DIR="$RUNNER_TEMP/tcfs-macos-postinstall"
+          mkdir -p "$LOG_DIR"
+          echo "LOG_DIR=$LOG_DIR" >> "$GITHUB_ENV"
+
       - name: Validate release inputs and storage secrets
         shell: bash
         run: |
@@ -105,7 +113,7 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event.inputs.tag }}"
           VERSION="${TAG#v}"
-          LOG_DIR="$RUNNER_TEMP/tcfs-macos-postinstall"
+          LOG_DIR="${LOG_DIR:-$RUNNER_TEMP/tcfs-macos-postinstall}"
           SYNC_ROOT="$RUNNER_TEMP/tcfs-sync-root"
           CONFIG_DIR="$HOME/.config/tcfs"
           CONFIG_PATH="$CONFIG_DIR/config.toml"
@@ -251,4 +259,5 @@ jobs:
         with:
           name: macos-postinstall-smoke-${{ github.event.inputs.tag }}
           path: ${{ env.LOG_DIR }}
+          if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Summary
- initialize the macOS post-install smoke log directory before secret validation
- keep  stable even when the workflow exits early
- make artifact upload ignore missing files so early validation failures report one clean primary error

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/macos-postinstall-smoke.yml")'
- dispatched branch workflow against  to verify failure shape

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hoists a \"Initialize log directory\" step to the top of the job so `LOG_DIR` is always exported to `$GITHUB_ENV` before the secret-validation step can exit early. It also adds `if-no-files-found: ignore` to the artifact upload so a validation failure surfaces as one clean error instead of a secondary upload failure.

<h3>Confidence Score: 5/5</h3>

Safe to merge — CI-only housekeeping with no logic changes to the product code.

All findings are P2. The early log-dir initialization correctly fixes the undefined LOG_DIR problem for always-run cleanup steps, and if-no-files-found: ignore is the right behavior for early-exit scenarios. No crypto, FFI, or security-sensitive code is touched.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/macos-postinstall-smoke.yml | Adds early log-dir initialization step and `if-no-files-found: ignore` on upload; `LOG_DIR` fallback in "Derive run paths" is now a dead code path but is harmless. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([workflow_dispatch]) --> B[checkout]
    B --> C["Initialize log directory\n(mkdir LOG_DIR, export to GITHUB_ENV)"]
    C --> D{Validate inputs\n& secrets}
    D -- fail --> E["Capture diagnostics\n(if: always)"]
    D -- pass --> F[Derive run paths]
    F --> G[Download & install pkg]
    G --> H[Write config & provision]
    H --> I[Seed fixture & start tcfsd]
    I --> J[Run smoke harness]
    J --> E
    E --> K["Stop tcfsd\n(if: always)"]
    K --> L["Upload smoke logs\n(if: always, if-no-files-found: ignore)"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/macos-postinstall-smoke.yml`, line 116-129 ([link](https://github.com/jesssullivan/tummycrypt/blob/8fa65130ab3156366d4b4660ea9ea496a50cd227/.github/workflows/macos-postinstall-smoke.yml#L116-L129)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant `LOG_DIR` fallback and re-export**

   Now that "Initialize log directory" always sets `LOG_DIR` in `$GITHUB_ENV`, the `:-` default on line 116 is a dead code path and the `echo "LOG_DIR=$LOG_DIR"` on line 129 re-exports the same value unnecessarily. Consider removing both to keep the step self-contained.

   Or simply drop `LOG_DIR` from the local assignment and the `$GITHUB_ENV` append block entirely, since it was already exported by the new initialization step.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/macos-postinstall-smoke.yml
   Line: 116-129

   Comment:
   **Redundant `LOG_DIR` fallback and re-export**

   Now that "Initialize log directory" always sets `LOG_DIR` in `$GITHUB_ENV`, the `:-` default on line 116 is a dead code path and the `echo "LOG_DIR=$LOG_DIR"` on line 129 re-exports the same value unnecessarily. Consider removing both to keep the step self-contained.

   Or simply drop `LOG_DIR` from the local assignment and the `$GITHUB_ENV` append block entirely, since it was already exported by the new initialization step.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/macos-postinstall-smoke.yml
Line: 116-129

Comment:
**Redundant `LOG_DIR` fallback and re-export**

Now that "Initialize log directory" always sets `LOG_DIR` in `$GITHUB_ENV`, the `:-` default on line 116 is a dead code path and the `echo "LOG_DIR=$LOG_DIR"` on line 129 re-exports the same value unnecessarily. Consider removing both to keep the step self-contained.

Or simply drop `LOG_DIR` from the local assignment and the `$GITHUB_ENV` append block entirely, since it was already exported by the new initialization step.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: initialize macOS smoke logs before v..."](https://github.com/jesssullivan/tummycrypt/commit/8fa65130ab3156366d4b4660ea9ea496a50cd227) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28858259)</sub>

<!-- /greptile_comment -->