### PR TITLE
Enroll Linux CI on repo ARC runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,13 @@ jobs:
       - name: Setup GloriousFlywheel
         uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
+      - name: Bootstrap Nix CLI
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+
       - name: Verify runner Nix toolchain
         run: nix --version
 
@@ -147,9 +154,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+      - name: cargo deny check
+        run: cargo deny check
 
   secret-scan:
     name: Secret Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check:
     name: Build + Lint + Test
-    runs-on: ubuntu-latest
+    runs-on: tummycrypt-docker
     steps:
       - uses: actions/checkout@v4
 
@@ -67,16 +67,12 @@ jobs:
 
   nix:
     name: Nix Build
-    runs-on: ubuntu-latest
+    runs-on: tummycrypt-nix
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+      - name: Verify runner Nix toolchain
+        run: nix --version
 
       - name: Nix flake check
         run: nix flake check
@@ -142,7 +138,7 @@ jobs:
 
   deny:
     name: cargo-deny
-    runs-on: ubuntu-latest
+    runs-on: tummycrypt-docker
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -154,7 +150,7 @@ jobs:
 
   secret-scan:
     name: Secret Scan
-    runs-on: ubuntu-latest
+    runs-on: tummycrypt-docker
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup GloriousFlywheel
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+
       - name: Verify runner Nix toolchain
         run: nix --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
+            build-essential \
             protobuf-compiler \
             libfuse3-dev \
             pkg-config \
@@ -155,6 +156,10 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-deny build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends build-essential
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
       - name: cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,17 @@ jobs:
           echo "$VERSION"
           echo "$VERSION" | grep -q "1.93.0"
 
-      - name: Build all packages
-        run: nix build .#tcfsd .#tcfs-cli .#tcfs-tui .#tcfs-mcp
+      - name: Build tcfsd
+        run: nix build .#tcfsd
+
+      - name: Build tcfs-cli
+        run: nix build .#tcfs-cli
+
+      - name: Build tcfs-tui
+        run: nix build .#tcfs-tui
+
+      - name: Build tcfs-mcp
+        run: nix build .#tcfs-mcp
 
   fileprovider-staticlib:
     name: FileProvider staticlib (macOS)

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -24,33 +24,32 @@ env:
 jobs:
   flake-check:
     name: Flake Check
-    runs-on: ubuntu-latest
+    runs-on: tummycrypt-nix
+    env:
+      ATTIC_SERVER: http://attic.nix-cache.svc.cluster.local
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+      - name: Verify runner Nix toolchain
+        run: nix --version
 
       - name: Nix flake check
         run: nix flake check
 
   build-linux-x86_64:
     name: Build Linux x86_64
-    runs-on: ubuntu-latest
+    runs-on: tummycrypt-nix
     needs: flake-check
+    env:
+      ATTIC_SERVER: http://attic.nix-cache.svc.cluster.local
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+      - name: Verify runner cache endpoints
+        run: |
+          echo "ATTIC_SERVER=${ATTIC_SERVER}"
+          echo "ATTIC_CACHE=${ATTIC_CACHE}"
+          echo "BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:-unset}"
 
       - name: Configure Attic
         run: |

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -31,6 +31,13 @@ jobs:
       - name: Setup GloriousFlywheel
         uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
+      - name: Bootstrap Nix CLI
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+
       - name: Verify runner Nix toolchain
         run: nix --version
 
@@ -46,6 +53,13 @@ jobs:
 
       - name: Setup GloriousFlywheel
         uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+
+      - name: Bootstrap Nix CLI
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
 
       - name: Verify runner cache endpoints
         run: |

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -25,10 +25,11 @@ jobs:
   flake-check:
     name: Flake Check
     runs-on: tummycrypt-nix
-    env:
-      ATTIC_SERVER: http://attic.nix-cache.svc.cluster.local
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup GloriousFlywheel
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
       - name: Verify runner Nix toolchain
         run: nix --version
@@ -40,10 +41,11 @@ jobs:
     name: Build Linux x86_64
     runs-on: tummycrypt-nix
     needs: flake-check
-    env:
-      ATTIC_SERVER: http://attic.nix-cache.svc.cluster.local
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup GloriousFlywheel
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
       - name: Verify runner cache endpoints
         run: |


### PR DESCRIPTION
## Summary
- move Linux Rust, deny, and secret-scan jobs onto `tummycrypt-docker`
- move Linux Nix jobs onto `tummycrypt-nix`
- keep macOS workflows hosted and keep public-cache topology concerns separate

## Notes
- this is the first repo-level proof that the new `tummycrypt-docker` and `tummycrypt-nix` ARC lanes are actually consumable from Actions
- this does not resolve #307 or #309; those remain about public cache / Darwin release topology rather than Linux runner enrollment

## Validation
- `git diff --check`
- Ruby YAML parse for `.github/workflows/ci.yml` and `.github/workflows/nix-ci.yml`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enrolls the Linux CI jobs onto custom ARC runners (`tummycrypt-docker` for Rust/deny/secret-scan, `tummycrypt-nix` for Nix builds) by adding a `GloriousFlywheel` setup step, switching the Nix substituter to a cluster-internal HTTP endpoint, and replacing the managed `cargo-deny-action` with a manual `cargo install`.

- **P1 — Supply chain risk**: `tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main` is used in all four Linux jobs without a pinned commit SHA. A compromised push to that `main` branch runs arbitrary code in CI and could exfiltrate `ATTIC_TOKEN`. Pin to a full SHA before merging.

<h3>Confidence Score: 4/5</h3>

Safe to merge after pinning GloriousFlywheel to a commit SHA; remaining findings are non-blocking style suggestions.

One P1 supply chain risk (GloriousFlywheel@main) needs to be addressed before merging, especially given this is a security-critical codebase with CI access to secrets like ATTIC_TOKEN. The two P2 findings (HTTP substituter, unpinned cargo-deny version) are non-blocking improvements.

.github/workflows/ci.yml — GloriousFlywheel action pin and cargo-deny version; .github/workflows/nix-ci.yml — GloriousFlywheel action pin in both Linux jobs.

<details open><summary><h3>Security Review</h3></summary>

- **Unpinned third-party action (`@main`)** — `tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main` is referenced in all four Linux jobs without a commit SHA pin. A compromised or accidental push to that branch executes arbitrary code in the CI environment, which has access to `ATTIC_TOKEN` and the full checkout. Affected jobs: `nix` and `check`/`deny`/`secret-scan` in `ci.yml`; `flake-check` and `build-linux-x86_64` in `nix-ci.yml`.
- **Unencrypted Nix substituter** — `http://attic.nix-cache.svc.cluster.local/main` uses plain HTTP. Store-path integrity is preserved by Nix's signature check, but cache-fetch metadata is visible in plaintext to any cluster-internal observer.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Migrates check/deny/secret-scan jobs to tummycrypt-docker and nix job to tummycrypt-nix; adds GloriousFlywheel setup (unpinned @main), switches Nix substituter to plain-HTTP cluster-internal URL, splits nix builds into separate steps, and replaces cargo-deny-action with an unpinned cargo install. |
| .github/workflows/nix-ci.yml | Migrates flake-check and build-linux-x86_64 jobs to tummycrypt-nix; adds GloriousFlywheel setup (unpinned @main), switches Linux Nix substituter to plain-HTTP cluster-internal URL, and adds a runner endpoint verification step. macOS job is unchanged and still uses the public HTTPS endpoint. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph ci.yml
        A[check\ntummycrypt-docker] --> |apt-get + cargo| B[Rust build + test]
        C[nix\ntummycrypt-nix] --> D[GloriousFlywheel setup]
        D --> E[Bootstrap Nix CLI\nhttp://attic.nix-cache.svc.cluster.local]
        E --> F[nix flake check\n+ 4x nix build]
        G[deny\ntummycrypt-docker] --> H[cargo install cargo-deny\nunpinned version]
        I[secret-scan\ntummycrypt-docker] --> J[gitleaks detect]
        K[fileprovider-staticlib\nmacos-14] --> L[unchanged]
        M[ios-typecheck\nmacos-14] --> N[unchanged]
    end
    subgraph nix-ci.yml
        P[flake-check\ntummycrypt-nix] --> Q[GloriousFlywheel setup]
        Q --> R[Bootstrap Nix CLI\nhttp://attic cluster endpoint]
        R --> S[nix flake check]
        T[build-linux-x86_64\ntummycrypt-nix] --> U[GloriousFlywheel setup]
        U --> V[Bootstrap Nix CLI]
        V --> W[4x nix build\n+ Attic push]
        X[build-macos-aarch64\nmacos-14] --> Y[unchanged\nhttps public endpoint]
    end
    style D fill:#f9a,stroke:#c33
    style Q fill:#f9a,stroke:#c33
    style U fill:#f9a,stroke:#c33
    style H fill:#ffc,stroke:#990
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 76

Comment:
**Unpinned third-party action — supply chain risk**

`tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main` is pinned to a branch tip, not a commit SHA. Any push to that `main` branch — including a compromised one — runs arbitrary code in these workflows. For a security-critical codebase this is a real supply chain risk: a single poisoned commit could exfiltrate `ATTIC_TOKEN` or tamper with build artifacts mid-CI.

Pin to a full SHA instead:
```suggestion
        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@<commit-sha>
```

The same pattern repeats in the `nix` job (`ci.yml` line 76) and both Linux jobs in `nix-ci.yml` (lines 32 and 55).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 173

Comment:
**`cargo-deny` version unpinned**

`cargo install cargo-deny --locked` installs the *latest published* version of `cargo-deny` on each run; `--locked` only locks the dependency tree of `cargo-deny` itself, not which release is fetched. Different runs can get different versions, causing the deny check to either silently drop rules that were added in a newer version or fail on rules that were changed. The previous `EmbarkStudios/cargo-deny-action@v2` at least bounded to a major version.

Add an explicit `--version` to make the check deterministic:
```suggestion
        run: cargo install cargo-deny --locked --version 0.18.1
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 82

Comment:
**Plain HTTP for in-cluster Nix substituter**

`extra-substituters = http://attic.nix-cache.svc.cluster.local/main` uses unencrypted HTTP. Because Nix verifies every downloaded path against `extra-trusted-public-keys`, a tampered binary would fail signature verification and be rejected — so the integrity guarantee holds even over HTTP. However, an adversary on the cluster network can still observe exactly which store paths are being fetched (metadata leakage) and, in principle, perform a denial-of-service by blocking paths. If TLS termination is feasible at the cluster-internal endpoint, `https://` would be the safer default for a security-critical codebase.

The same pattern appears in `nix-ci.yml` (lines 39, 62).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: split nix package builds across step..."](https://github.com/jesssullivan/tummycrypt/commit/fa9f1eb88e14fff4106ceafc330e83e54f902440) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28863412)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->