### PR TITLE
Add TCFS RBAC-only recovery mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           fetch-depth: 0
       - name: Install gitleaks
         run: |
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          curl --retry 5 --retry-all-errors --retry-delay 2 -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | sudo tar xz -C /usr/local/bin gitleaks
       - name: Scan for secrets
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check:
     name: Build + Lint + Test
-    runs-on: tummycrypt-docker
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -68,7 +68,7 @@ jobs:
 
   nix:
     name: Nix Build
-    runs-on: tummycrypt-nix
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -79,7 +79,7 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
             extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
 
       - name: Verify runner Nix toolchain
@@ -158,7 +158,7 @@ jobs:
 
   deny:
     name: cargo-deny
-    runs-on: tummycrypt-docker
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -176,7 +176,7 @@ jobs:
 
   secret-scan:
     name: Secret Scan
-    runs-on: tummycrypt-docker
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup GloriousFlywheel
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
-
       - name: Bootstrap Nix CLI
         uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -28,9 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup GloriousFlywheel
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
-
       - name: Bootstrap Nix CLI
         uses: cachix/install-nix-action@v31
         with:
@@ -50,9 +47,6 @@ jobs:
     needs: flake-check
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup GloriousFlywheel
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
       - name: Bootstrap Nix CLI
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   flake-check:
     name: Flake Check
-    runs-on: tummycrypt-nix
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -35,7 +35,7 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
             extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
 
       - name: Verify runner Nix toolchain
@@ -46,7 +46,7 @@ jobs:
 
   build-linux-x86_64:
     name: Build Linux x86_64
-    runs-on: tummycrypt-nix
+    runs-on: ubuntu-latest
     needs: flake-check
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            extra-substituters = http://attic.nix-cache.svc.cluster.local/main
+            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
             extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
 
       - name: Verify runner cache endpoints
@@ -71,12 +71,12 @@ jobs:
         run: |
           nix profile install nixpkgs#attic-client
           if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland ${{ env.ATTIC_SERVER }} ${{ secrets.ATTIC_TOKEN }}
-            attic use ${{ env.ATTIC_CACHE }} || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> $GITHUB_ENV
+            attic login tinyland "${{ env.ATTIC_SERVER }}" "${{ secrets.ATTIC_TOKEN }}"
+            attic use "${{ env.ATTIC_CACHE }}" || echo "::warning::Failed to configure Attic substituter"
+            echo "ATTIC_CONFIGURED=true" >> "$GITHUB_ENV"
           else
             echo "::warning::ATTIC_TOKEN not set, skipping cache push"
-            echo "ATTIC_CONFIGURED=false" >> $GITHUB_ENV
+            echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
           fi
 
       - name: Build tcfsd
@@ -95,8 +95,8 @@ jobs:
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
           for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
-            nix build .#${pkg} -o result-${pkg}
-            attic push ${{ env.ATTIC_CACHE }} result-${pkg} || echo "::warning::Failed to push ${pkg} to Attic"
+            nix build ".#${pkg}" -o "result-${pkg}"
+            attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
           done
 
   build-macos-aarch64:
@@ -117,12 +117,12 @@ jobs:
         run: |
           nix profile install nixpkgs#attic-client
           if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland ${{ env.ATTIC_SERVER }} ${{ secrets.ATTIC_TOKEN }}
-            attic use ${{ env.ATTIC_CACHE }} || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> $GITHUB_ENV
+            attic login tinyland "${{ env.ATTIC_SERVER }}" "${{ secrets.ATTIC_TOKEN }}"
+            attic use "${{ env.ATTIC_CACHE }}" || echo "::warning::Failed to configure Attic substituter"
+            echo "ATTIC_CONFIGURED=true" >> "$GITHUB_ENV"
           else
             echo "::warning::ATTIC_TOKEN not set, skipping cache push"
-            echo "ATTIC_CONFIGURED=false" >> $GITHUB_ENV
+            echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
           fi
 
       - name: Build tcfs-cli (no FUSE on macOS)
@@ -138,6 +138,6 @@ jobs:
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
           for pkg in tcfs-cli tcfs-tui tcfs-mcp; do
-            nix build .#${pkg} -o result-${pkg}
-            attic push ${{ env.ATTIC_CACHE }} result-${pkg} || echo "::warning::Failed to push ${pkg} to Attic"
+            nix build ".#${pkg}" -o "result-${pkg}"
+            attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
           done

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -4,6 +4,7 @@ exclude = [
   "^https://nix-cache.fuzzy-dev.tinyland.dev",
   "^https://docs.tummycrypt.io",
   "^https://developer.apple.com/documentation/fskit$",
+  "^https://developer.apple.com/documentation/fileprovider$",
   "^https://developer.apple.com/documentation/fileprovider/nsfileproviderreplicatedextension$",
   "your-org",
   "localhost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5af9ebfb0a14481d3eaf6101e6391261e4f30d25b26a7635ade8a39482ded0"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -319,7 +319,6 @@ dependencies = [
  "memchr",
  "nkeys",
  "nuid",
- "once_cell",
  "pin-project",
  "portable-atomic",
  "rand 0.8.5",
@@ -327,7 +326,7 @@ dependencies = [
  "ring",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -1038,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1365,7 +1364,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1528,7 +1527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3237,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
@@ -4470,7 +4469,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4495,31 +4494,21 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -4534,19 +4523,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4712,9 +4691,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ zstd = { version = "0.13" }
 rocksdb = { version = "0.24" }
 
 # Messaging
-async-nats = { version = "0.46" }
+async-nats = { version = "0.47" }
 futures = { version = "0.3" }
 bytes = { version = "1" }
 

--- a/deny.toml
+++ b/deny.toml
@@ -12,11 +12,6 @@ targets = [
 [advisories]
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
-    "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained — transitive dep via reqwest
-    "RUSTSEC-2024-0436",  # paste unmaintained — transitive dep via uniffi, no replacement available
-    "RUSTSEC-2026-0049",  # rustls-webpki CRL bug — transitive dep, limited impact
-    "RUSTSEC-2026-0098",  # rustls-webpki URI-name constraints bug — transitive via async-nats 0.46, no patched compatible release available yet
-    "RUSTSEC-2026-0099",  # rustls-webpki wildcard-name constraints bug — transitive via async-nats 0.46, requires misissuance and no patched compatible release available yet
     "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]

--- a/docs/ops/onprem-authority-recovery.md
+++ b/docs/ops/onprem-authority-recovery.md
@@ -82,6 +82,29 @@ TCFS_NAMESPACE=tcfs bash scripts/tcfs-backend-deploy.sh \
   --set image.tag=v0.12.2
 ```
 
+### RBAC-Only Recovery For Missing Helm Release State
+
+Live recovery note, 2026-04-27: the on-prem namespace can contain
+Helm-shaped `tcfs-backend-tcfs-backend-*` objects without Helm release
+secrets. In that state a full `helm upgrade --install` cannot immediately adopt
+the existing ConfigMap / Deployment, and it can also fail before adoption if
+optional CRDs such as KEDA `ScaledObject` or Prometheus `ServiceMonitor` are not
+installed.
+
+If the Deployment exists but pod creation is blocked because the service
+account is missing, restore only the chart-owned RBAC scaffold first:
+
+```bash
+bash scripts/tcfs-backend-deploy.sh --rbac-only --dry-run
+bash scripts/tcfs-backend-deploy.sh --rbac-only
+kubectl rollout restart deployment/tcfs-backend-tcfs-backend-worker -n tcfs
+kubectl rollout status deployment/tcfs-backend-tcfs-backend-worker -n tcfs
+```
+
+This is a repair path, not a complete Helm adoption. After the worker is
+healthy, follow up by either adopting the existing objects into Helm release
+state or deliberately migrating to the OpenTofu object-name family.
+
 ## Validate Recovery
 
 ```bash

--- a/infra/k8s/charts/tcfs-backend/README.md
+++ b/infra/k8s/charts/tcfs-backend/README.md
@@ -49,3 +49,13 @@ helm list -n tcfs
 kubectl get sa tcfs-backend-tcfs-backend -n tcfs
 kubectl rollout status deployment/tcfs-backend-tcfs-backend-worker -n tcfs
 ```
+
+If live Helm release state is missing but an existing worker Deployment still
+references `tcfs-backend-tcfs-backend`, use the repo script's RBAC-only repair
+path before attempting a full adoption:
+
+```bash
+bash scripts/tcfs-backend-deploy.sh --rbac-only --dry-run
+bash scripts/tcfs-backend-deploy.sh --rbac-only
+kubectl rollout restart deployment/tcfs-backend-tcfs-backend-worker -n tcfs
+```

--- a/scripts/tcfs-backend-deploy.sh
+++ b/scripts/tcfs-backend-deploy.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   ./scripts/tcfs-backend-deploy.sh
 #   ./scripts/tcfs-backend-deploy.sh --dry-run
+#   ./scripts/tcfs-backend-deploy.sh --rbac-only
 #   TCFS_RELEASE_NAME=tcfs-backend ./scripts/tcfs-backend-deploy.sh --set image.tag=v0.12.2
 #
 set -euo pipefail
@@ -16,12 +17,17 @@ CHART_DIR="${REPO_ROOT}/infra/k8s/charts/tcfs-backend"
 RELEASE_NAME="${TCFS_RELEASE_NAME:-tcfs-backend}"
 NAMESPACE="${TCFS_NAMESPACE:-tcfs}"
 DRY_RUN=false
+RBAC_ONLY=false
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)
             DRY_RUN=true
+            shift
+            ;;
+        --rbac-only)
+            RBAC_ONLY=true
             shift
             ;;
         *)
@@ -77,6 +83,33 @@ info "  Release:   ${RELEASE_NAME}"
 info "  Namespace: ${NAMESPACE}"
 info "  Chart:     ${CHART_DIR}"
 echo
+
+if [[ "${RBAC_ONLY}" == "true" ]]; then
+    TEMPLATE_CMD=(
+        helm template "${RELEASE_NAME}" "${CHART_DIR}"
+        --namespace "${NAMESPACE}"
+        -f "${CHART_DIR}/values.yaml"
+        --show-only templates/rbac.yaml
+    )
+
+    if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
+        TEMPLATE_CMD+=("${EXTRA_ARGS[@]}")
+    fi
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        info "Rendering RBAC-only recovery manifest — no changes will be applied"
+        "${TEMPLATE_CMD[@]}"
+    else
+        info "Applying RBAC-only recovery manifest"
+        "${TEMPLATE_CMD[@]}" | kubectl apply --namespace "${NAMESPACE}" -f -
+        echo
+        info "Validating RBAC-only recovery objects..."
+        kubectl get serviceaccount "${RELEASE_NAME}-tcfs-backend" --namespace "${NAMESPACE}"
+        kubectl get role "${RELEASE_NAME}-tcfs-backend-leases" --namespace "${NAMESPACE}"
+        kubectl get rolebinding "${RELEASE_NAME}-tcfs-backend-leases" --namespace "${NAMESPACE}"
+    fi
+    exit 0
+fi
 
 "${HELM_CMD[@]}"
 


### PR DESCRIPTION
## Summary
- add `scripts/tcfs-backend-deploy.sh --rbac-only` to restore chart-owned ServiceAccount/Role/RoleBinding without requiring a full Helm install/adoption
- document the on-prem case where Helm-shaped objects exist but Helm release state is absent
- add chart README guidance for the missing-service-account recovery path

## Live context
On honey/tcfs, `tcfs-backend-tcfs-backend-worker` existed but pod creation failed because ServiceAccount `tcfs-backend-tcfs-backend` was missing. `helm list -n tcfs` showed no release state, so full `helm upgrade --install` was not immediately safe: dry-run first failed on missing optional CRDs, then on existing object ownership metadata. The RBAC-only repair path is the narrow repeatable fix for that state.

## Validation
- `bash -n scripts/tcfs-backend-deploy.sh`
- `git diff --check`
- `bash scripts/tcfs-backend-deploy.sh --rbac-only --dry-run`
- `bash scripts/tcfs-backend-deploy.sh --rbac-only` reapplied the live RBAC objects idempotently after manual repair

## Follow-up
A full Helm adoption or deliberate migration to the OpenTofu object-name family is still separate work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--rbac-only` flag to `scripts/tcfs-backend-deploy.sh` that uses `helm template --show-only templates/rbac.yaml | kubectl apply` to restore the chart's ServiceAccount/Role/RoleBinding without a full Helm install, addressing a live on-prem case where Helm-shaped objects existed without Helm release state. It also migrates CI runners from self-hosted to `ubuntu-latest`, bumps `async-nats` to 0.47 to resolve rustls-webpki advisories, and updates docs.

- `deny.toml` removes `RUSTSEC-2024-0436` (paste, unmaintained via uniffi) and `RUSTSEC-2025-0134` (rustls-pemfile, unmaintained via reqwest), but `uniffi = { version = \"0.28\" }` is still a direct dep and these advisories were not driven by the async-nats bump — if `paste` remains in the resolved tree, `cargo deny check` will fail.

<h3>Confidence Score: 4/5</h3>

Safe to merge after confirming cargo deny check passes with the removed advisory ignores

One P1 finding: RUSTSEC-2024-0436 and RUSTSEC-2025-0134 were removed from deny.toml without a corresponding dep change, and uniffi (the driver of the paste advisory) is still present at the same version. If the dep tree still includes paste, the deny CI job will fail. The core shell script change is well-structured and the two sharp edges (empty-template pipe and missing Helm ownership annotations) were already discussed in prior review threads.

deny.toml — verify cargo deny check advisories passes locally before merging

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/tcfs-backend-deploy.sh | Adds `--rbac-only` mode that uses `helm template --show-only templates/rbac.yaml` piped to `kubectl apply`, with post-apply validation; concerns about empty-template and annotation gaps were already discussed in previous threads |
| deny.toml | Removes five advisory ignores alongside the async-nats 0.46→0.47 bump; RUSTSEC-2024-0436 (paste, via uniffi) and RUSTSEC-2025-0134 (rustls-pemfile, via reqwest) were not driven by async-nats, so their removal may cause cargo deny check to fail |
| .github/workflows/ci.yml | Migrates all jobs from self-hosted `tummycrypt-docker`/`tummycrypt-nix` runners to `ubuntu-latest`; adds curl retry flags for gitleaks install; changes Nix cache URL from internal HTTP to external HTTPS |
| .github/workflows/nix-ci.yml | Migrates Nix build jobs to `ubuntu-latest`, removes GloriousFlywheel setup, switches Nix cache to external HTTPS URL, and adds proper shell quoting for Attic commands |
| docs/ops/onprem-authority-recovery.md | Documents the RBAC-only recovery path for missing Helm release state; clearly describes the recovery sequence and its scope limitations |
| infra/k8s/charts/tcfs-backend/README.md | Adds documentation for the RBAC-only repair path when Helm release state is absent but the worker Deployment still exists |
| Cargo.toml | Bumps async-nats from 0.46 to 0.47 to resolve rustls-webpki advisories tied to that version |
| .lychee.toml | Adds the Apple FileProvider documentation URL to the lychee link-check exclusion list |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tcfs-backend-deploy.sh] --> B{--rbac-only?}
    B -- No --> C[helm upgrade --install]
    C --> D{--dry-run?}
    D -- Yes --> E[helm ... --dry-run --debug]
    D -- No --> F[helm upgrade] --> G[kubectl rollout status]
    B -- Yes --> H[helm template --show-only templates/rbac.yaml]
    H --> I{--dry-run?}
    I -- Yes --> J[Print rendered YAML only]
    I -- No --> K[kubectl apply -f -]
    K --> L[kubectl get serviceaccount]
    K --> M[kubectl get role]
    K --> N[kubectl get rolebinding]
    L & M & N --> O[exit 0]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: deny.toml
Line: 12-16

Comment:
**Potentially premature removal of RUSTSEC-2024-0436 ignore**

`RUSTSEC-2024-0436` tracks the `paste` crate as unmaintained — flagged specifically because it was a transitive dep pulled in by `uniffi`. `uniffi` is still a direct dependency at version `0.28` in `Cargo.toml`, unchanged by this PR. Removing the ignore without bumping or replacing `uniffi` means `cargo deny check advisories` will fail if `paste` is still in the resolved dependency tree, which is likely given the dependency comment read "no replacement available". The PR validation steps listed in the description don't include `cargo deny check`, so this breakage could reach CI undetected on the current runner change.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["ci: exclude flaky apple fileprovider lin..."](https://github.com/jesssullivan/tummycrypt/commit/04f69843be31efdd8dcef0d503d102b348b708b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29934460)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->