### PR TITLE
docs: add tcfs onprem authority preflight

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,10 @@ k8s-status ns="tcfs":
     @echo "---"
     kubectl get svc -n {{ns}}
 
+# Read-only on-prem authority/mobility check for tcfs
+onprem-preflight:
+    bash scripts/tcfs-onprem-preflight.sh
+
 # Tail logs from a workload
 k8s-logs app="tcfsd" ns="tcfs":
     kubectl logs -l app.kubernetes.io/name={{app}} -n {{ns}} --tail=50

--- a/docs/ops/onprem-authority-recovery.md
+++ b/docs/ops/onprem-authority-recovery.md
@@ -34,6 +34,65 @@ The practical consequence is simple: if the live namespace already contains
 Helm-managed `tcfs-backend-tcfs-backend-*` objects, the direct Helm chart is
 the source of truth for restoring that path.
 
+## Current Honey Readback
+
+Live readback from the Tinyland `honey` cluster on 2026-04-28 changed the
+operator call from "repair a broken worker" to "decide authority before moving
+placement":
+
+- `nats-0`, `seaweedfs-0`, and `tcfs-backend-tcfs-backend-worker` are Running.
+- NATS health returns OK, SeaweedFS reports a leader, and the worker logs show
+  a live NATS connection.
+- `helm list -n tcfs` reports no release state.
+- `tcfs/nats` and `tcfs/seaweedfs` have live Tailscale exposure annotations,
+  but their last-applied Service configuration had empty annotations.
+- `data-nats-0` and `data-seaweedfs-0` are `local-path` PVCs whose backing PVs
+  have node affinity to `honey`.
+
+That means a ProxyClass-only patch would be cosmetic. It could move the
+generated Tailscale proxy pods, but it would not source-own the exposure, create
+release state, or make NATS/SeaweedFS data drain-mobile.
+
+## Current Decision
+
+Treat the direct `tcfs-backend` Helm chart as a recovery authority for the
+backend worker objects only. Do not use it as evidence that the whole live
+namespace is Helm-owned.
+
+The durable on-prem path should be OpenTofu migration, not blind Helm adoption,
+unless a future review proves that adopting the manual NATS and SeaweedFS
+objects into Helm is lower risk than replacing them deliberately.
+
+Reasons:
+
+- The backend worker objects are Helm-shaped, but NATS and SeaweedFS are not.
+- The OpenTofu modules already model NATS, SeaweedFS, backend workers, and
+  tailnet exposure as separate source-owned concerns.
+- The live backing state is honey-local `local-path`, so honey/sting mobility
+  requires storage/data planning either way.
+- A migration plan can preserve the current healthy singleton while building
+  new source-owned objects with explicit storage class, Tailscale exposure, and
+  smoke gates.
+
+Minimum migration gates:
+
+1. capture live NATS JetStream and SeaweedFS data inventory;
+2. choose target storage classes for NATS and SeaweedFS instead of inheriting
+   `local-path`;
+3. teach the OpenTofu tailnet surface the current cluster ProxyClass contract or
+   record a named exception;
+4. run a dry-run/plan that does not collide with live object names;
+5. cut over only after smoke tests prove NATS, SeaweedFS, and worker
+   connectivity on the new path;
+6. remove the old live annotations and retained objects through the same
+   source-controlled transition.
+
+Use the read-only preflight before changing either path:
+
+```bash
+bash scripts/tcfs-onprem-preflight.sh
+```
+
 ## Preflight
 
 Confirm which cluster you are talking to before making changes:

--- a/scripts/tcfs-onprem-preflight.sh
+++ b/scripts/tcfs-onprem-preflight.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# tcfs-onprem-preflight.sh — read-only authority and mobility check for tcfs
+#
+# This script intentionally does not mutate Kubernetes. It summarizes the live
+# facts needed before choosing between Helm adoption and OpenTofu migration.
+#
+# Usage:
+#   scripts/tcfs-onprem-preflight.sh
+#   TCFS_NAMESPACE=tcfs TCFS_CONTEXT=honey scripts/tcfs-onprem-preflight.sh
+#
+set -euo pipefail
+
+NAMESPACE="${TCFS_NAMESPACE:-tcfs}"
+CONTEXT="${TCFS_CONTEXT:-}"
+
+KUBECTL=(kubectl)
+HELM=(helm)
+if [[ -n "${CONTEXT}" ]]; then
+    KUBECTL+=(--context "${CONTEXT}")
+    HELM+=(--kube-context "${CONTEXT}")
+fi
+
+info() { printf '[INFO] %s\n' "$*"; }
+warn() { printf '[WARN] %s\n' "$*"; }
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        printf '[ERROR] %s is required but was not found in PATH\n' "$1" >&2
+        exit 1
+    fi
+}
+
+jsonpath() {
+    local resource="$1"
+    local path="$2"
+    "${KUBECTL[@]}" -n "${NAMESPACE}" get "${resource}" -o "jsonpath=${path}" 2>/dev/null || true
+}
+
+service_annotation() {
+    local service="$1"
+    local key="$2"
+    jsonpath "svc/${service}" "{.metadata.annotations.${key//./\\.}}"
+}
+
+print_service_summary() {
+    local service="$1"
+    local expose hostname proxy_class
+    expose="$(service_annotation "${service}" 'tailscale.com/expose')"
+    hostname="$(service_annotation "${service}" 'tailscale.com/hostname')"
+    proxy_class="$(service_annotation "${service}" 'tailscale.com/proxy-class')"
+
+    printf 'service/%s tailscale.expose=%s hostname=%s proxy-class=%s\n' \
+        "${service}" \
+        "${expose:-MISSING}" \
+        "${hostname:-MISSING}" \
+        "${proxy_class:-MISSING}"
+}
+
+print_pvc_summary() {
+    local pvc="$1"
+    local storage_class volume
+    storage_class="$(jsonpath "pvc/${pvc}" '{.spec.storageClassName}')"
+    volume="$(jsonpath "pvc/${pvc}" '{.spec.volumeName}')"
+
+    printf 'pvc/%s storage-class=%s pv=%s\n' \
+        "${pvc}" \
+        "${storage_class:-MISSING}" \
+        "${volume:-MISSING}"
+
+    if [[ -n "${volume}" ]]; then
+        "${KUBECTL[@]}" get "pv/${volume}" \
+            -o custom-columns='PV:.metadata.name,RECLAIM:.spec.persistentVolumeReclaimPolicy,NODE:.spec.nodeAffinity.required.nodeSelectorTerms[*].matchExpressions[*].values[*],PATH:.spec.hostPath.path' \
+            --no-headers 2>/dev/null || true
+    fi
+}
+
+require_command kubectl
+require_command helm
+
+info "Namespace: ${NAMESPACE}"
+if [[ -n "${CONTEXT}" ]]; then
+    info "Context: ${CONTEXT}"
+else
+    info "Context: $("${KUBECTL[@]}" config current-context 2>/dev/null || printf unknown)"
+fi
+
+info "Helm release state"
+"${HELM[@]}" list -n "${NAMESPACE}" || true
+
+info "Core workload health"
+"${KUBECTL[@]}" -n "${NAMESPACE}" get pod nats-0 seaweedfs-0 \
+    -o custom-columns='NAME:.metadata.name,READY:.status.containerStatuses[*].ready,PHASE:.status.phase,NODE:.spec.nodeName,RESTARTS:.status.containerStatuses[*].restartCount' \
+    --ignore-not-found
+"${KUBECTL[@]}" -n "${NAMESPACE}" get deploy tcfs-backend-tcfs-backend-worker \
+    -o custom-columns='NAME:.metadata.name,READY:.status.readyReplicas,AVAILABLE:.status.availableReplicas,DESIRED:.spec.replicas' \
+    --ignore-not-found
+
+info "Tailnet Service exposure"
+print_service_summary nats
+print_service_summary seaweedfs
+
+info "Local state PVCs"
+print_pvc_summary data-nats-0
+print_pvc_summary data-seaweedfs-0
+
+info "Authority call"
+if ! "${HELM[@]}" list -n "${NAMESPACE}" | grep -q '^tcfs-backend[[:space:]]'; then
+    warn "No tcfs-backend Helm release state was found."
+fi
+
+nats_proxy_class="$(service_annotation nats 'tailscale.com/proxy-class')"
+seaweed_proxy_class="$(service_annotation seaweedfs 'tailscale.com/proxy-class')"
+if [[ -z "${nats_proxy_class}" || -z "${seaweed_proxy_class}" ]]; then
+    warn "NATS/SeaweedFS tailnet exposure is missing proxy-class ownership."
+fi
+
+warn "Do not treat ProxyClass-only movement as a durable fix."
+warn "Choose Helm adoption or OpenTofu migration before changing live authority."


### PR DESCRIPTION
## Summary

Adds a read-only on-prem TCFS authority/mobility preflight and records the current honey decision point.

- Adds scripts/tcfs-onprem-preflight.sh for Helm state, workload health, Tailscale exposure, and PVC locality readback.
- Adds just onprem-preflight as the operator entrypoint.
- Updates docs/ops/onprem-authority-recovery.md to keep direct Helm as backend-worker recovery only and recommend a deliberate OpenTofu migration path unless future review proves Helm adoption is lower risk.

## Validation

- bash -n scripts/tcfs-onprem-preflight.sh scripts/tcfs-backend-deploy.sh scripts/tcfs-deploy.sh
- git diff --check
- just --list | rg 'onprem-preflight|k8s-status|neo-honey-smoke'
- TCFS_CONTEXT=honey just onprem-preflight

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a read-only on-prem preflight script (`scripts/tcfs-onprem-preflight.sh`) that checks Helm release state, workload health, Tailscale service annotations, and PVC locality before committing to either Helm adoption or OpenTofu migration. It also wires that script into the Justfile as `onprem-preflight` and records the current `honey` cluster authority decision in the ops runbook.

- The `jsonpath()` helper uses `2>/dev/null || true`, silently swallowing auth failures and unreachable-API-server errors — every field shows as `MISSING` on a misconfigured context, indistinguishable from a genuinely empty cluster, which could cause an operator to act on fabricated data.

<h3>Confidence Score: 3/5</h3>

Safe to merge after addressing the silent error suppression in jsonpath(), which can produce misleading MISSING readings on API connectivity failures.

One P1 finding: jsonpath() discards all kubectl stderr, making unreachable-cluster errors indistinguishable from absent resources. Since this script drives the authority decisions documented in the runbook, acting on silently-failed output is a real operational risk. No crypto, Rust, Swift, or FFI concerns. P1 caps the score at 4 and the operational risk of misleading preflight output pulls it to 3.

scripts/tcfs-onprem-preflight.sh — specifically the jsonpath() function and the pv/ lookup in print_pvc_summary.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/tcfs-onprem-preflight.sh | New read-only preflight script; `jsonpath()` silently swallows all kubectl errors making auth failures indistinguishable from missing resources, which could mislead authority decisions. |
| Justfile | Adds `onprem-preflight` recipe — minimal and consistent with existing `bash scripts/…` invocations. |
| docs/ops/onprem-authority-recovery.md | Adds honey-cluster readback findings and a clear decision record recommending OpenTofu migration over blind Helm adoption. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([just onprem-preflight]) --> B[bash scripts/tcfs-onprem-preflight.sh]
    B --> C{TCFS_CONTEXT set?}
    C -- yes --> D[kubectl --context / helm --kube-context]
    C -- no --> E[current-context]
    D & E --> F[require_command kubectl + helm]
    F --> G[helm list -n NAMESPACE]
    G --> H[kubectl get pod nats-0 seaweedfs-0]
    H --> I[kubectl get deploy tcfs-backend-worker]
    I --> J[print_service_summary nats + seaweedfs]
    J --> K[print_pvc_summary data-nats-0 + data-seaweedfs-0]
    K --> L{helm list has tcfs-backend release?}
    L -- no --> M[[WARN: No tcfs-backend Helm release]]
    L -- yes --> N[Check proxy-class annotations]
    M --> N
    N --> O{proxy-class missing on either svc?}
    O -- yes --> P[[WARN: missing proxy-class ownership]]
    O -- no --> Q[[WARN: Do not use ProxyClass-only movement]]
    P --> Q
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/tcfs-onprem-preflight.sh
Line: 34-38

Comment:
**Silent error suppression hides unreachable API server**

`2>/dev/null || true` in `jsonpath()` (and the `pv/` lookup in `print_pvc_summary`) discards every `kubectl` error — authentication failures, wrong context, unreachable API server, and RBAC denials all produce an empty string, which gets printed as `MISSING`. An operator running this against a misconfigured `TCFS_CONTEXT` will see every field as `MISSING`, triggering the authority-call warnings, and may act on completely stale/fabricated data. Consider routing stderr to the script's own stderr rather than `/dev/null` so connectivity problems remain visible while still returning an empty value for missing resources.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/tcfs-onprem-preflight.sh
Line: 88-89

Comment:
**`helm list` called twice; results may diverge**

`helm list -n "${NAMESPACE}"` is run once for display (line 89) and again inside the authority check (line 108). The two invocations are independent API calls. If Helm state changes between them, the displayed output and the authority logic could reflect different moments in time. Capturing the output once into a variable and reusing it keeps both sections consistent.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add tcfs onprem authority prefligh..."](https://github.com/jesssullivan/tummycrypt/commit/3b9dd5724271e4d9c4273f683e7f1fd19b9fe23d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30117582)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->