### PR TITLE
[codex] add tcfs onprem tailnet tofu skeleton

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -38,6 +38,10 @@ k8s-status ns="tcfs":
 onprem-preflight:
     bash scripts/tcfs-onprem-preflight.sh
 
+# Validate on-prem OpenTofu migration surfaces without applying live changes
+onprem-tofu-validate:
+    bash scripts/tcfs-onprem-tofu-validate.sh
+
 # Tail logs from a workload
 k8s-logs app="tcfsd" ns="tcfs":
     kubectl logs -l app.kubernetes.io/name={{app}} -n {{ns}} --tail=50

--- a/infra/tofu/environments/onprem/README.md
+++ b/infra/tofu/environments/onprem/README.md
@@ -1,0 +1,51 @@
+# TCFS On-Prem OpenTofu Environment
+
+This environment captures the Tinyland on-prem TCFS migration surface. It is
+intentionally inert by default: `enable_tailnet_candidate_services=false`
+creates no resources.
+
+## Current Live Boundary
+
+Live readback on 2026-04-29 shows:
+
+- `nats-0`, `seaweedfs-0`, and `tcfs-backend-tcfs-backend-worker` are healthy.
+- `helm list -n tcfs` has no release state.
+- `tcfs/nats` and `tcfs/seaweedfs` carry live Tailscale annotations as drift.
+- `data-nats-0` and `data-seaweedfs-0` are `local-path` PVCs pinned to
+  `honey`.
+
+This environment does not adopt those objects and does not move data. It only
+adds a source-owned candidate path for tailnet exposure once the migration
+gates are ready.
+
+## Safe Validation
+
+```bash
+just onprem-tofu-validate
+```
+
+## Candidate Tailnet Smoke
+
+Only after `scripts/tcfs-onprem-preflight.sh` is clean enough for migration
+work, run a plan with candidate hostnames that do not collide with the live
+canonical devices:
+
+```bash
+tofu plan \
+  -var='enable_tailnet_candidate_services=true'
+```
+
+Do not switch the candidate hostnames to `nats-tcfs` or `seaweedfs-tcfs` until
+the live Service annotations have been removed through a source-controlled
+cutover plan.
+
+## Migration Gates
+
+Before any live apply:
+
+1. capture NATS JetStream and SeaweedFS data inventory;
+2. choose durable storage classes for NATS and SeaweedFS;
+3. smoke candidate Tailscale Services with `honey-sting-tailnet` placement;
+4. remove the old live annotations through the selected authority path;
+5. cut over canonical tailnet hostnames only after clients pass smoke;
+6. keep rollback instructions and retained data paths explicit.

--- a/infra/tofu/environments/onprem/main.tf
+++ b/infra/tofu/environments/onprem/main.tf
@@ -1,0 +1,83 @@
+# Tinyland on-prem TCFS migration surface.
+#
+# This environment is intentionally inert by default. It records the on-prem
+# tailnet exposure contract without adopting or replacing the live singleton
+# NATS/SeaweedFS StatefulSets. Enable candidate Services only after the
+# read-only preflight and data/storage migration gates are satisfied.
+
+terraform {
+  required_version = ">= 1.6"
+}
+
+provider "kubernetes" {
+  config_path    = var.kubeconfig_path
+  config_context = var.kube_context
+}
+
+locals {
+  common_labels = {
+    "app.kubernetes.io/part-of"    = "tcfs"
+    "app.kubernetes.io/managed-by" = "opentofu"
+    "tummycrypt.dev/environment"   = "onprem"
+  }
+}
+
+module "tailnet_nats_candidate" {
+  count  = var.enable_tailnet_candidate_services ? 1 : 0
+  source = "../../modules/tailscale-service"
+
+  namespace          = var.namespace
+  name               = "nats-tailnet-candidate"
+  tailscale_hostname = var.nats_tailnet_candidate_hostname
+  proxy_class        = var.tailscale_proxy_class
+  selector           = { app = "nats" }
+  labels             = merge(local.common_labels, { "app.kubernetes.io/name" = "nats" })
+
+  ports = [
+    {
+      name        = "client"
+      port        = 4222
+      target_port = 4222
+    },
+    {
+      name        = "monitor"
+      port        = 8222
+      target_port = 8222
+    },
+  ]
+}
+
+module "tailnet_seaweedfs_candidate" {
+  count  = var.enable_tailnet_candidate_services ? 1 : 0
+  source = "../../modules/tailscale-service"
+
+  namespace          = var.namespace
+  name               = "seaweedfs-tailnet-candidate"
+  tailscale_hostname = var.seaweedfs_tailnet_candidate_hostname
+  proxy_class        = var.tailscale_proxy_class
+  selector           = { app = "seaweedfs" }
+  labels             = merge(local.common_labels, { "app.kubernetes.io/name" = "seaweedfs" })
+
+  ports = [
+    {
+      name        = "master"
+      port        = 9333
+      target_port = 9333
+    },
+    {
+      name        = "volume"
+      port        = 8080
+      target_port = 8080
+    },
+    {
+      name        = "filer"
+      port        = 8888
+      target_port = 8888
+    },
+    {
+      name        = "s3"
+      port        = 8333
+      target_port = 8333
+    },
+  ]
+}

--- a/infra/tofu/environments/onprem/outputs.tf
+++ b/infra/tofu/environments/onprem/outputs.tf
@@ -1,0 +1,13 @@
+output "candidate_tailnet_services" {
+  description = "Candidate tailnet Service names and hostnames when enabled."
+  value = var.enable_tailnet_candidate_services ? {
+    nats = {
+      service_name = module.tailnet_nats_candidate[0].service_name
+      hostname     = module.tailnet_nats_candidate[0].tailscale_hostname
+    }
+    seaweedfs = {
+      service_name = module.tailnet_seaweedfs_candidate[0].service_name
+      hostname     = module.tailnet_seaweedfs_candidate[0].tailscale_hostname
+    }
+  } : {}
+}

--- a/infra/tofu/environments/onprem/variables.tf
+++ b/infra/tofu/environments/onprem/variables.tf
@@ -1,0 +1,41 @@
+variable "kubeconfig_path" {
+  description = "Path to kubeconfig file."
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "kube_context" {
+  description = "Kubernetes context for the Tinyland on-prem cluster."
+  type        = string
+  default     = "honey"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for TCFS."
+  type        = string
+  default     = "tcfs"
+}
+
+variable "enable_tailnet_candidate_services" {
+  description = "Create non-canonical candidate Tailscale Services for pre-cutover smoke."
+  type        = bool
+  default     = false
+}
+
+variable "tailscale_proxy_class" {
+  description = "Tailscale operator ProxyClass for honey/sting proxy placement."
+  type        = string
+  default     = "honey-sting-tailnet"
+}
+
+variable "nats_tailnet_candidate_hostname" {
+  description = "Candidate NATS tailnet hostname. Keep distinct from the live canonical hostname until cutover."
+  type        = string
+  default     = "nats-tcfs-candidate"
+}
+
+variable "seaweedfs_tailnet_candidate_hostname" {
+  description = "Candidate SeaweedFS tailnet hostname. Keep distinct from the live canonical hostname until cutover."
+  type        = string
+  default     = "seaweedfs-tcfs-candidate"
+}

--- a/infra/tofu/modules/tailscale-nats/main.tf
+++ b/infra/tofu/modules/tailscale-nats/main.tf
@@ -1,50 +1,29 @@
-# Tailscale-only NATS exposure
+# Tailscale-only NATS exposure.
 #
-# Creates a LoadBalancer Service that the Tailscale operator picks up,
-# exposing NATS to the tailnet without a public IP.
-#
-# Prerequisites:
-#   - Tailscale operator installed on the cluster
-#   - NATS deployed via the nats module (pods labelled app.kubernetes.io/name=nats)
-#
-# Lab machines connect via MagicDNS:
-#   nats://nats-tcfs:4222
-# Or via the IaC-managed FQDN (Porkbun A record → Tailscale CGNAT IP):
-#   nats://nats.tcfs.tummycrypt.dev:4222
+# This wrapper preserves the historical module API while delegating the Service
+# shape to the generic tailscale-service module so on-prem and Civo use the same
+# ProxyClass-capable exposure contract.
 
-terraform {
-  required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.26"
-    }
-  }
-}
+module "nats_tailnet" {
+  source = "../tailscale-service"
 
-resource "kubernetes_service_v1" "nats_tailscale" {
-  metadata {
-    name      = "nats-tailscale"
-    namespace = var.namespace
+  namespace          = var.namespace
+  name               = var.service_name
+  tailscale_hostname = var.tailscale_hostname
+  proxy_class        = var.proxy_class
+  selector           = var.selector
 
-    annotations = {
-      "tailscale.com/expose"   = "true"
-      "tailscale.com/hostname" = var.tailscale_hostname
-    }
+  labels = {
+    "app.kubernetes.io/name"       = "nats"
+    "app.kubernetes.io/component"  = "tailnet"
+    "app.kubernetes.io/managed-by" = "opentofu"
   }
 
-  spec {
-    type                = "LoadBalancer"
-    load_balancer_class = "tailscale"
-
-    selector = {
-      "app.kubernetes.io/name" = "nats"
-    }
-
-    port {
+  ports = [
+    {
       name        = "client"
       port        = 4222
       target_port = 4222
-      protocol    = "TCP"
     }
-  }
+  ]
 }

--- a/infra/tofu/modules/tailscale-nats/outputs.tf
+++ b/infra/tofu/modules/tailscale-nats/outputs.tf
@@ -3,10 +3,12 @@ output "tailscale_nats_url" {
   value       = "nats://${var.tailscale_hostname}:4222"
 }
 
+output "service_name" {
+  description = "Kubernetes Service name for the tailnet NATS endpoint"
+  value       = module.nats_tailnet.service_name
+}
+
 output "tailscale_ip" {
   description = "Tailscale CGNAT IP assigned to the NATS LoadBalancer (populated after operator reconciles)"
-  value       = try(
-    [for ingress in kubernetes_service_v1.nats_tailscale.status[0].load_balancer[0].ingress : ingress.ip if ingress.ip != ""][0],
-    ""
-  )
+  value       = module.nats_tailnet.tailscale_ip
 }

--- a/infra/tofu/modules/tailscale-nats/variables.tf
+++ b/infra/tofu/modules/tailscale-nats/variables.tf
@@ -4,8 +4,28 @@ variable "namespace" {
   default     = "tcfs"
 }
 
+variable "service_name" {
+  description = "Kubernetes Service name for the tailnet NATS endpoint"
+  type        = string
+  default     = "nats-tailscale"
+}
+
 variable "tailscale_hostname" {
   description = "Tailnet hostname for the NATS service (resolvable via MagicDNS)"
   type        = string
   default     = "nats-tcfs"
+}
+
+variable "proxy_class" {
+  description = "Optional Tailscale ProxyClass name for proxy pod placement"
+  type        = string
+  default     = ""
+}
+
+variable "selector" {
+  description = "Selector for the NATS backend pods"
+  type        = map(string)
+  default = {
+    "app.kubernetes.io/name" = "nats"
+  }
 }

--- a/infra/tofu/modules/tailscale-service/main.tf
+++ b/infra/tofu/modules/tailscale-service/main.tf
@@ -1,0 +1,55 @@
+# Generic Tailscale operator Service exposure.
+#
+# This creates a source-owned LoadBalancer Service for a tailnet-only endpoint
+# without mutating the selected backend Service/StatefulSet. Use candidate
+# hostnames during migrations to avoid colliding with live Tailscale devices.
+
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.26"
+    }
+  }
+}
+
+locals {
+  proxy_class_annotation = var.proxy_class == "" ? {} : {
+    "tailscale.com/proxy-class" = var.proxy_class
+  }
+
+  annotations = merge(
+    var.extra_annotations,
+    {
+      "tailscale.com/expose"   = "true"
+      "tailscale.com/hostname" = var.tailscale_hostname
+    },
+    local.proxy_class_annotation,
+  )
+}
+
+resource "kubernetes_service_v1" "tailnet" {
+  metadata {
+    name        = var.name
+    namespace   = var.namespace
+    labels      = var.labels
+    annotations = local.annotations
+  }
+
+  spec {
+    type                = "LoadBalancer"
+    load_balancer_class = "tailscale"
+    selector            = var.selector
+
+    dynamic "port" {
+      for_each = var.ports
+
+      content {
+        name        = port.value.name
+        port        = port.value.port
+        target_port = port.value.target_port
+        protocol    = port.value.protocol
+      }
+    }
+  }
+}

--- a/infra/tofu/modules/tailscale-service/outputs.tf
+++ b/infra/tofu/modules/tailscale-service/outputs.tf
@@ -1,0 +1,17 @@
+output "service_name" {
+  description = "Kubernetes Service name."
+  value       = kubernetes_service_v1.tailnet.metadata[0].name
+}
+
+output "tailscale_hostname" {
+  description = "Tailnet hostname requested for the Service."
+  value       = var.tailscale_hostname
+}
+
+output "tailscale_ip" {
+  description = "Tailscale CGNAT IP assigned to the Service after reconciliation."
+  value = try(
+    [for ingress in kubernetes_service_v1.tailnet.status[0].load_balancer[0].ingress : ingress.ip if ingress.ip != ""][0],
+    ""
+  )
+}

--- a/infra/tofu/modules/tailscale-service/variables.tf
+++ b/infra/tofu/modules/tailscale-service/variables.tf
@@ -1,0 +1,47 @@
+variable "namespace" {
+  description = "Kubernetes namespace where the Service is created."
+  type        = string
+}
+
+variable "name" {
+  description = "Kubernetes Service name for the Tailscale-exposed endpoint."
+  type        = string
+}
+
+variable "tailscale_hostname" {
+  description = "Tailnet hostname assigned by the Tailscale operator."
+  type        = string
+}
+
+variable "proxy_class" {
+  description = "Optional Tailscale ProxyClass name for proxy pod placement."
+  type        = string
+  default     = ""
+}
+
+variable "selector" {
+  description = "Service selector for the backend pods."
+  type        = map(string)
+}
+
+variable "ports" {
+  description = "Service ports to expose through Tailscale."
+  type = list(object({
+    name        = string
+    port        = number
+    target_port = number
+    protocol    = optional(string, "TCP")
+  }))
+}
+
+variable "labels" {
+  description = "Labels applied to the generated Service."
+  type        = map(string)
+  default     = {}
+}
+
+variable "extra_annotations" {
+  description = "Additional annotations applied before Tailscale annotations."
+  type        = map(string)
+  default     = {}
+}

--- a/scripts/tcfs-onprem-tofu-validate.sh
+++ b/scripts/tcfs-onprem-tofu-validate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Validate the source-only TCFS on-prem OpenTofu migration surface.
+#
+# This is intentionally non-mutating: it initializes providers with
+# -backend=false and runs tofu validate only. It also validates the legacy Civo
+# environment because that path consumes the tailscale-nats wrapper.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        printf '[ERROR] %s is required but was not found in PATH\n' "$1" >&2
+        exit 1
+    fi
+}
+
+validate_env() {
+    local env="$1"
+    local dir="${ROOT}/infra/tofu/environments/${env}"
+
+    printf '[INFO] validating infra/tofu/environments/%s\n' "${env}"
+    tofu -chdir="${dir}" init -backend=false
+    tofu -chdir="${dir}" validate
+}
+
+require_command tofu
+
+validate_env onprem
+validate_env civo


### PR DESCRIPTION
## Summary

Adds a source-only OpenTofu skeleton for the TCFS on-prem migration path.

- adds a generic `tailscale-service` module for Tailscale operator LoadBalancer Services with optional ProxyClass ownership
- refactors the existing `tailscale-nats` wrapper to use the generic module without changing its default public API
- adds an inert `infra/tofu/environments/onprem` environment that creates no resources unless candidate Services are explicitly enabled
- adds `just onprem-tofu-validate` for non-mutating validation of the on-prem and existing Civo Tofu surfaces

## Why

Live on-prem TCFS still has healthy NATS/SeaweedFS pods, but no Helm release authority, missing Tailscale ProxyClass ownership, and local-path state PVCs pinned to honey. This PR gives the migration a source-controlled OpenTofu landing zone without adopting or mutating the live singleton objects.

## Validation

- `git diff --check`
- `bash -n scripts/tcfs-onprem-tofu-validate.sh scripts/tcfs-onprem-preflight.sh`
- `just onprem-tofu-validate`
- `TCFS_CONTEXT=honey just onprem-preflight` confirms the existing live authority warnings remain and no live mutation was applied

## Live Mutation

None. The on-prem environment defaults `enable_tailnet_candidate_services=false`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a generic `tailscale-service` module for Tailscale operator LoadBalancer Services, refactors `tailscale-nats` to delegate to it, and adds an inert on-prem OpenTofu environment as a migration landing zone.

- **P1 — live Civo Service will be destroyed on next apply**: The `tailscale-nats` refactoring changes the Civo state resource address from `module.tailscale_nats.kubernetes_service_v1.nats_tailscale` to `module.tailscale_nats.module.nats_tailnet.kubernetes_service_v1.tailnet`. Without a `moved {}` block in `tailscale-nats/main.tf`, the next `tofu apply` on Civo will destroy and recreate the live NATS tailnet Service, briefly dropping the tailnet endpoint.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without a `moved {}` block in `tailscale-nats/main.tf` — the Civo environment will destroy and recreate the live NATS tailnet Service on next apply.

One P1 finding (missing `moved` block causing a destroy/create cycle on the live Civo NATS Service) pulls the score below the P1 ceiling of 4. The rest of the PR is well-structured and the on-prem environment itself is inert by default, limiting blast radius.

infra/tofu/modules/tailscale-nats/main.tf — needs a `moved {}` block to preserve Civo state continuity across the resource address rename.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| infra/tofu/modules/tailscale-nats/main.tf | Refactored to delegate to tailscale-service module, but missing a `moved {}` block means the Civo live Service resource address changes and will be destroyed/recreated on next apply. |
| infra/tofu/modules/tailscale-service/main.tf | New generic Tailscale LoadBalancer Service module; clean use of dynamic ports, optional ProxyClass annotation, and merge ordering protects required annotations from being overridden. |
| infra/tofu/environments/onprem/main.tf | Inert on-prem environment defaulting to disabled; NATS candidate exposes monitor port 8222 over tailnet alongside the client port — intentional but worth reviewing separately. |
| scripts/tcfs-onprem-tofu-validate.sh | Non-mutating validation script with `set -euo pipefail`, checks for `tofu` in PATH, and validates both onprem and existing civo environments. |
| infra/tofu/modules/tailscale-service/variables.tf | Well-typed variable definitions; `optional(string, "TCP")` on `protocol` is correctly supported in OpenTofu >= 1.6. |
| infra/tofu/modules/tailscale-nats/variables.tf | New `service_name`, `proxy_class`, and `selector` variables added with backward-compatible defaults; public API preserved. |
| infra/tofu/environments/onprem/variables.tf | Clean variable definitions with safe defaults; candidate hostnames kept distinct from live canonical names by default. |
| Justfile | Adds `onprem-tofu-validate` recipe delegating to the new validation script; no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Civo["environments/civo"]
        C[module.tailscale_nats]
    end

    subgraph OnPrem["environments/onprem (inert by default)"]
        ON1["module.tailnet_nats_candidate\ncount = enable ? 1 : 0"]
        ON2["module.tailnet_seaweedfs_candidate\ncount = enable ? 1 : 0"]
    end

    subgraph NATS_MOD["modules/tailscale-nats (wrapper)"]
        NW[module.nats_tailnet]
        WARN["⚠ missing moved block:\nold: kubernetes_service_v1.nats_tailscale\nnew: module.nats_tailnet.kubernetes_service_v1.tailnet"]
    end

    subgraph SVC_MOD["modules/tailscale-service (new generic)"]
        SVC["kubernetes_service_v1.tailnet\nLoadBalancer / tailscale class\n+ ProxyClass annotation optional"]
    end

    C --> NW
    NW --> SVC
    ON1 --> SVC
    ON2 --> SVC
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infra/tofu/modules/tailscale-nats/main.tf
Line: 7-29

Comment:
**Missing `moved` block will destroy live Civo Service**

The Civo environment has existing OpenTofu state with the resource at address `module.tailscale_nats.kubernetes_service_v1.nats_tailscale`. After this refactoring, the address becomes `module.tailscale_nats.module.nats_tailnet.kubernetes_service_v1.tailnet`. Without a `moved {}` block, the next `tofu apply` on Civo will destroy the live `nats-tailscale` Kubernetes Service and recreate it as a brand-new object — briefly dropping the NATS tailnet endpoint and forcing Tailscale operator to re-provision the IP.

Add a `moved` block to remap the old address to the new one, preserving state continuity:

```hcl
moved {
  from = kubernetes_service_v1.nats_tailscale
  to   = module.nats_tailnet.kubernetes_service_v1.tailnet
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infra/tofu/modules/tailscale-nats/main.tf
Line: 1-6

Comment:
**`required_providers` declaration removed from module**

The `terraform { required_providers { kubernetes = ... } }` block was dropped when converting to a wrapper. The `kubernetes` provider constraint is now only declared transitively inside `tailscale-service/main.tf`. While OpenTofu resolves provider requirements across child modules at the root level, the explicit declaration in `tailscale-nats` made its own contract clear and allowed the module to be validated in isolation. Consider keeping the block here for explicitness and standalone usability.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infra/tofu/environments/onprem/main.tf
Line: 40-51

Comment:
**NATS monitor port 8222 exposed over tailnet**

The `monitor` port (8222) is added to the NATS candidate Service in the on-prem environment. The NATS HTTP monitoring endpoint exposes internal server info, JetStream stats, active connections, and subscription details without any built-in authentication. While the tailnet boundary limits exposure to authorised Tailscale devices, consider whether monitoring access should be gated separately from the NATS client port rather than included in the same tailnet-exposed Service.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add tcfs onprem tailnet tofu skele..."](https://github.com/jesssullivan/tummycrypt/commit/2c1de3febf31fe7edc26393d476990eec82f4885) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30127341)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->