### PR TITLE
[codex] add TCFS on-prem data inventory gate

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -38,6 +38,10 @@ k8s-status ns="tcfs":
 onprem-preflight:
     bash scripts/tcfs-onprem-preflight.sh
 
+# Read-only on-prem data inventory for NATS and SeaweedFS migration planning
+onprem-data-inventory:
+    bash scripts/tcfs-onprem-data-inventory.sh
+
 # Validate on-prem OpenTofu migration surfaces without applying live changes
 onprem-tofu-validate:
     bash scripts/tcfs-onprem-tofu-validate.sh

--- a/infra/tofu/environments/onprem/README.md
+++ b/infra/tofu/environments/onprem/README.md
@@ -13,6 +13,9 @@ Live readback on 2026-04-29 shows:
 - `tcfs/nats` and `tcfs/seaweedfs` carry live Tailscale annotations as drift.
 - `data-nats-0` and `data-seaweedfs-0` are `local-path` PVCs pinned to
   `honey`.
+- Durable storage targets now exist in `blahaj` and live Kubernetes:
+  `openebs-bumble-messaging-retain` for NATS and
+  `openebs-bumble-s3-retain` for SeaweedFS.
 
 This environment does not adopt those objects and does not move data. It only
 adds a source-owned candidate path for tailnet exposure once the migration
@@ -22,6 +25,12 @@ gates are ready.
 
 ```bash
 just onprem-tofu-validate
+```
+
+Read-only data inventory before migration work:
+
+```bash
+TCFS_CONTEXT=honey just onprem-data-inventory
 ```
 
 ## Candidate Tailnet Smoke
@@ -44,7 +53,7 @@ cutover plan.
 Before any live apply:
 
 1. capture NATS JetStream and SeaweedFS data inventory;
-2. choose durable storage classes for NATS and SeaweedFS;
+2. migrate or clone data to the selected retained OpenEBS/ZFS classes;
 3. smoke candidate Tailscale Services with `honey-sting-tailnet` placement;
 4. remove the old live annotations through the selected authority path;
 5. cut over canonical tailnet hostnames only after clients pass smoke;

--- a/scripts/tcfs-onprem-data-inventory.sh
+++ b/scripts/tcfs-onprem-data-inventory.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+#
+# tcfs-onprem-data-inventory.sh - read-only data inventory for TCFS migration.
+#
+# This script intentionally does not mutate Kubernetes. It captures the live
+# NATS JetStream and SeaweedFS facts needed before moving their stateful data
+# from honey-local local-path PVCs to the Tinyland OpenEBS/ZFS classes.
+#
+# Usage:
+#   scripts/tcfs-onprem-data-inventory.sh
+#   TCFS_NAMESPACE=tcfs TCFS_CONTEXT=honey scripts/tcfs-onprem-data-inventory.sh
+#
+set -euo pipefail
+
+NAMESPACE="${TCFS_NAMESPACE:-tcfs}"
+CONTEXT="${TCFS_CONTEXT:-}"
+NATS_TARGET_STORAGE_CLASS="${TCFS_NATS_TARGET_STORAGE_CLASS:-openebs-bumble-messaging-retain}"
+SEAWEEDFS_TARGET_STORAGE_CLASS="${TCFS_SEAWEEDFS_TARGET_STORAGE_CLASS:-openebs-bumble-s3-retain}"
+
+KUBECTL=(kubectl)
+if [[ -n "${CONTEXT}" ]]; then
+    KUBECTL+=(--context "${CONTEXT}")
+fi
+
+info() { printf '[INFO] %s\n' "$*"; }
+warn() { printf '[WARN] %s\n' "$*"; }
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        printf '[ERROR] %s is required but was not found in PATH\n' "$1" >&2
+        exit 1
+    fi
+}
+
+jsonpath() {
+    local resource="$1"
+    local path="$2"
+    "${KUBECTL[@]}" -n "${NAMESPACE}" get "${resource}" -o "jsonpath=${path}" 2>/dev/null || true
+}
+
+service_annotation() {
+    local service="$1"
+    local key="$2"
+    jsonpath "svc/${service}" "{.metadata.annotations.${key//./\\.}}"
+}
+
+print_storage_class_summary() {
+    local storage_class="$1"
+
+    if ! "${KUBECTL[@]}" get storageclass "${storage_class}" >/dev/null 2>&1; then
+        warn "storageclass/${storage_class} is missing"
+        return
+    fi
+
+    "${KUBECTL[@]}" get "storageclass/${storage_class}" \
+        -o custom-columns='NAME:.metadata.name,PROVISIONER:.provisioner,RECLAIM:.reclaimPolicy,BINDING:.volumeBindingMode,EXPAND:.allowVolumeExpansion,POOL:.parameters.poolname,RECORDSIZE:.parameters.recordsize,TOPOLOGY:.allowedTopologies[*].matchLabelExpressions[*].values[*]' \
+        --no-headers
+}
+
+print_pvc_summary() {
+    local pvc="$1"
+    local target_storage_class="$2"
+    local storage_class size volume
+
+    storage_class="$(jsonpath "pvc/${pvc}" '{.spec.storageClassName}')"
+    size="$(jsonpath "pvc/${pvc}" '{.spec.resources.requests.storage}')"
+    volume="$(jsonpath "pvc/${pvc}" '{.spec.volumeName}')"
+
+    if [[ -z "${storage_class}" ]]; then
+        warn "pvc/${pvc} is missing"
+        return
+    fi
+
+    printf 'pvc/%s size=%s current-storage-class=%s target-storage-class=%s pv=%s\n' \
+        "${pvc}" \
+        "${size:-MISSING}" \
+        "${storage_class}" \
+        "${target_storage_class}" \
+        "${volume:-MISSING}"
+
+    if [[ "${storage_class}" != "${target_storage_class}" ]]; then
+        warn "pvc/${pvc} is still on ${storage_class}; migration target is ${target_storage_class}"
+    fi
+
+    if [[ -n "${volume}" ]]; then
+        "${KUBECTL[@]}" get "pv/${volume}" \
+            -o custom-columns='PV:.metadata.name,RECLAIM:.spec.persistentVolumeReclaimPolicy,NODE:.spec.nodeAffinity.required.nodeSelectorTerms[*].matchExpressions[*].values[*],HOSTPATH:.spec.hostPath.path,LOCAL:.spec.local.path,CSI:.spec.csi.driver,VOLUMEHANDLE:.spec.csi.volumeHandle' \
+            --no-headers 2>/dev/null || warn "could not read pv/${volume}"
+    fi
+}
+
+print_pod_summary() {
+    local pod="$1"
+
+    if ! "${KUBECTL[@]}" -n "${NAMESPACE}" get "pod/${pod}" >/dev/null 2>&1; then
+        warn "pod/${pod} is missing"
+        return
+    fi
+
+    "${KUBECTL[@]}" -n "${NAMESPACE}" get "pod/${pod}" \
+        -o custom-columns='NAME:.metadata.name,READY:.status.containerStatuses[*].ready,PHASE:.status.phase,NODE:.spec.nodeName,RESTARTS:.status.containerStatuses[*].restartCount,IP:.status.podIP' \
+        --no-headers
+    "${KUBECTL[@]}" -n "${NAMESPACE}" get "pod/${pod}" \
+        -o jsonpath='{range .spec.containers[*]}container={.name} image={.image} args={.args}{"\n"}{end}{range .spec.volumes[*]}volume={.name} pvc={.persistentVolumeClaim.claimName}{"\n"}{end}'
+    printf '\n'
+}
+
+print_service_summary() {
+    local service="$1"
+    local expose hostname proxy_class
+
+    expose="$(service_annotation "${service}" 'tailscale.com/expose')"
+    hostname="$(service_annotation "${service}" 'tailscale.com/hostname')"
+    proxy_class="$(service_annotation "${service}" 'tailscale.com/proxy-class')"
+
+    printf 'service/%s tailscale.expose=%s hostname=%s proxy-class=%s\n' \
+        "${service}" \
+        "${expose:-MISSING}" \
+        "${hostname:-MISSING}" \
+        "${proxy_class:-MISSING}"
+}
+
+pod_exec_inventory() {
+    local pod="$1"
+    local title="$2"
+    local command="$3"
+
+    info "${title}"
+    if ! "${KUBECTL[@]}" -n "${NAMESPACE}" get "pod/${pod}" >/dev/null 2>&1; then
+        warn "pod/${pod} is missing; skipping ${title}"
+        return
+    fi
+
+    if ! "${KUBECTL[@]}" -n "${NAMESPACE}" exec "${pod}" -- sh -lc "${command}"; then
+        warn "pod/${pod} inventory command failed; keep this gate red until readback is understood"
+    fi
+}
+
+require_command kubectl
+
+info "Namespace: ${NAMESPACE}"
+if [[ -n "${CONTEXT}" ]]; then
+    info "Context: ${CONTEXT}"
+else
+    info "Context: $("${KUBECTL[@]}" config current-context 2>/dev/null || printf unknown)"
+fi
+
+info "Target durable storage classes"
+print_storage_class_summary "${NATS_TARGET_STORAGE_CLASS}"
+print_storage_class_summary "${SEAWEEDFS_TARGET_STORAGE_CLASS}"
+
+info "Current state PVCs and backing PVs"
+print_pvc_summary data-nats-0 "${NATS_TARGET_STORAGE_CLASS}"
+print_pvc_summary data-seaweedfs-0 "${SEAWEEDFS_TARGET_STORAGE_CLASS}"
+
+info "Stateful workload pods"
+print_pod_summary nats-0
+print_pod_summary seaweedfs-0
+
+info "Current tailnet Services"
+print_service_summary nats
+print_service_summary seaweedfs
+
+pod_exec_inventory nats-0 "NATS JetStream disk and monitor inventory" '
+printf "tools:"
+for tool in nats nats-server wget curl du df find; do
+    command -v "${tool}" >/dev/null 2>&1 && printf " %s" "${tool}"
+done
+printf "\n\n"
+df -h /data 2>/dev/null || true
+du -sh /data /data/jetstream 2>/dev/null || true
+printf "\njetstream directories\n"
+find /data -maxdepth 3 -type d 2>/dev/null | sort || true
+printf "\nNATS /varz\n"
+wget -qO- "http://127.0.0.1:8222/varz" 2>/dev/null | head -c 2400 || true
+printf "\nNATS /jsz?streams=true&consumer=true\n"
+wget -qO- "http://127.0.0.1:8222/jsz?streams=true&consumer=true" 2>/dev/null | head -c 6000 || true
+printf "\n"
+'
+
+pod_exec_inventory seaweedfs-0 "SeaweedFS disk and topology inventory" '
+printf "tools:"
+for tool in weed wget curl du df find; do
+    command -v "${tool}" >/dev/null 2>&1 && printf " %s" "${tool}"
+done
+printf "\n\n"
+df -h /data 2>/dev/null || true
+du -sh /data /data/filerldb2 2>/dev/null || true
+printf "\nseaweed directories\n"
+find /data -maxdepth 3 -type d 2>/dev/null | sort || true
+printf "\nSeaweedFS master /cluster/status\n"
+wget -qO- "http://127.0.0.1:9333/cluster/status" 2>/dev/null | head -c 2400 || true
+printf "\nSeaweedFS master /dir/status\n"
+wget -qO- "http://127.0.0.1:9333/dir/status" 2>/dev/null | head -c 6000 || true
+printf "\n"
+'
+
+warn "This is inventory only. Do not delete, patch, or rebind the live PVCs from this script output alone."
+warn "Next migration work must preserve rollback for the retained honey local-path PVs and the new OpenEBS/ZFS PVs."


### PR DESCRIPTION
## Summary

Adds a read-only `just onprem-data-inventory` gate for the TCFS on-prem migration.

The new script inventories:
- target OpenEBS/ZFS storage classes for NATS and SeaweedFS
- current `local-path` PVC/PV placement
- `nats-0` and `seaweedfs-0` pod/image/volume facts
- current tailnet Service annotation drift
- in-pod NATS JetStream and SeaweedFS disk/topology state through read-only HTTP and filesystem probes

It does not apply, patch, delete, rebind, or migrate any live Kubernetes objects.

## Live Inventory Result

Run against `honey` on 2026-04-29:

- Target classes exist: `openebs-bumble-messaging-retain` and `openebs-bumble-s3-retain`.
- Current state PVCs remain on honey-local `local-path`: `data-nats-0` and `data-seaweedfs-0`.
- `nats-0` and `seaweedfs-0` are running on `honey`.
- `tcfs/nats` and `tcfs/seaweedfs` still expose canonical tailnet hostnames without `tailscale.com/proxy-class`.
- NATS JetStream reports 3 streams, 7 consumers, 2,688 messages, and 788,341 bytes.
- SeaweedFS reports 14 volumes, leader `10.244.0.41:9333.19333`, and `/data` around 61 MiB.

## Validation

- `bash -n scripts/tcfs-onprem-data-inventory.sh scripts/tcfs-onprem-preflight.sh scripts/tcfs-onprem-tofu-validate.sh`
- `just --list`
- `git diff --check`
- `TCFS_CONTEXT=honey just onprem-data-inventory`
- `TCFS_CONTEXT=honey just onprem-preflight`
- `just onprem-tofu-validate`

Refs #327.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new read-only `just onprem-data-inventory` gate (`scripts/tcfs-onprem-data-inventory.sh`) that inventories OpenEBS/ZFS storage classes, current `local-path` PVC/PV placement, pod facts, tailnet Service annotation drift, and in-pod NATS JetStream and SeaweedFS state via read-only HTTP and filesystem probes. The script follows the same conventions as the existing `tcfs-onprem-preflight.sh` and makes no mutations to live Kubernetes objects.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are P2 style/robustness suggestions on a read-only inventory script with no live mutations

Only P2 findings present: the `sh -lc` login-shell flag in pod exec and the indirect PVC existence check via `storageClassName` emptiness. Neither causes incorrect inventory output under normal conditions, and the script cannot mutate cluster state.

scripts/tcfs-onprem-data-inventory.sh — minor robustness issues in `print_pvc_summary` and `pod_exec_inventory`

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/tcfs-onprem-data-inventory.sh | New read-only inventory script for NATS JetStream and SeaweedFS; well-structured and follows existing preflight patterns, with two minor P2 issues: `sh -lc` login flag in pod exec, and PVC existence check via storageClassName emptiness rather than direct resource lookup |
| Justfile | Adds `onprem-data-inventory` recipe invoking the new script; follows existing recipe conventions cleanly |
| infra/tofu/environments/onprem/README.md | Documentation update: adds storage-class existence note, inventory usage example, and updates step 2 of migration plan to reflect that classes now exist; accurate and consistent with script behaviour |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as Operator
    participant J as just
    participant S as tcfs-onprem-data-inventory.sh
    participant K as kubectl / k8s API
    participant P as nats-0 / seaweedfs-0 pods

    U->>J: TCFS_CONTEXT=honey just onprem-data-inventory
    J->>S: bash scripts/tcfs-onprem-data-inventory.sh
    S->>K: get storageclass (openebs-bumble-*)
    K-->>S: StorageClass facts
    S->>K: get pvc/data-nats-0, pvc/data-seaweedfs-0
    K-->>S: PVC spec (storageClassName, size, volumeName)
    S->>K: get pv/<volumeName>
    K-->>S: PV spec (reclaimPolicy, nodeAffinity, CSI driver)
    S->>K: get pod/nats-0, pod/seaweedfs-0
    K-->>S: Pod status (phase, node, image, volumes)
    S->>K: get svc/nats, svc/seaweedfs (annotations)
    K-->>S: Tailscale annotation values
    S->>P: kubectl exec nats-0 -- sh -c df/du/find/wget /varz /jsz
    P-->>S: JetStream disk + stream/consumer facts (read-only)
    S->>P: kubectl exec seaweedfs-0 -- sh -c df/du/find/wget /cluster/status /dir/status
    P-->>S: SeaweedFS volume + topology facts (read-only)
    S-->>U: Inventory report (stdout)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/tcfs-onprem-data-inventory.sh
Line: 123

Comment:
**Login shell flag unnecessary in minimal containers**

`sh -lc` sources `/etc/profile` and `~/.profile` inside the target pod. Most NATS/SeaweedFS containers are minimal images where those files either don't exist (harmless) or carry unexpected side-effects (modified `PATH`, aliases, `umask`, or proxy settings) that could silently alter the inventory output. `sh -c` is sufficient and more predictable across container base images.

```suggestion
    if ! "${KUBECTL[@]}" -n "${NAMESPACE}" exec "${pod}" -- sh -c "${command}"; then
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/tcfs-onprem-data-inventory.sh
Line: 65-70

Comment:
**Empty `storageClassName` conflated with missing PVC**

`storage_class` will be empty both when the PVC does not exist *and* when the PVC exists but has no `storageClassName` (e.g., created without one or the field was cleared). In the second case the function silently returns with a misleading `"pvc/… is missing"` warning instead of reporting actual state. A more reliable guard checks PVC existence directly, matching the pattern used in `print_pod_summary`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add tcfs onprem data inventory"](https://github.com/jesssullivan/tummycrypt/commit/88a8c574044ee50a0015d62ec69da2087edfc83c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30129557)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->