### PR TITLE
[codex] add TCFS on-prem storage migration runbook

### DIFF
--- a/docs/ops/tcfs-onprem-storage-migration.md
+++ b/docs/ops/tcfs-onprem-storage-migration.md
@@ -1,0 +1,149 @@
+# TCFS On-Prem Storage Migration Runbook
+
+Date: 2026-04-29
+
+This runbook captures the safe migration shape for moving the live TCFS NATS
+and SeaweedFS state off honey-local `local-path` PVCs and onto retained
+OpenEBS/ZFS storage classes.
+
+It is intentionally not an apply script. Do not use this as approval to mutate
+the live cluster without an explicit downtime window.
+
+## Current Authority
+
+Live readback shows `nats` and `seaweedfs` are kubectl-applied singleton
+StatefulSets. They are not currently owned by Helm or OpenTofu.
+
+Current live state:
+
+- `statefulset/nats`: `replicas=1`, selector `app=nats`, `serviceName=nats`
+- `statefulset/seaweedfs`: `replicas=1`, selector `app=seaweedfs`,
+  `serviceName=seaweedfs`
+- `pvc/data-nats-0`: `local-path`, retained PV on `honey`
+- `pvc/data-seaweedfs-0`: `local-path`, retained PV on `honey`
+- `service/nats`: canonical Tailscale annotations, no ProxyClass
+- `service/seaweedfs`: canonical Tailscale annotations, no ProxyClass
+
+Durable targets now exist:
+
+- NATS target: `openebs-bumble-messaging-retain`
+- SeaweedFS target: `openebs-bumble-s3-retain`
+
+## Non-Negotiable Safety Constraints
+
+- Do not patch `volumeClaimTemplates.storageClassName` in place. StatefulSet
+  PVC templates are not a safe mutable migration surface.
+- Do not delete old PVCs or PVs during the first migration pass. They are the
+  rollback source.
+- Do not treat adding `tailscale.com/proxy-class` to the old Services as a
+  durable fix. That would hide authority drift without solving storage.
+- Do not schedule one helper Pod expecting to mount both old and new PVCs. The
+  old PVs are honey-local and the target OpenEBS/ZFS PVs are bumble-local, so
+  a single Pod cannot satisfy both node-locality constraints.
+- Do not cut canonical tailnet hostnames over until candidate endpoints pass
+  smoke.
+
+## Required Preflight
+
+Run from `tummycrypt`:
+
+```bash
+TCFS_CONTEXT=honey just onprem-data-inventory
+TCFS_CONTEXT=honey just onprem-preflight
+just onprem-tofu-validate
+```
+
+Expected current inventory while this runbook was written:
+
+- NATS JetStream: 3 streams, 7 consumers, 2,688 messages, 788,341 bytes
+- SeaweedFS: 14 volumes and about 61 MiB under `/data`
+- both current PVCs remain `local-path` on `honey`
+- both target retained OpenEBS/ZFS classes exist on `bumble`
+
+If those facts change materially, stop and update the plan before migrating.
+
+## Downtime Gate
+
+This migration needs an explicit maintenance window unless a source-owned
+app-native online export/import path is added first.
+
+Before copying state:
+
+1. Stop external writes and TCFS worker writes.
+2. Capture `just onprem-data-inventory` output.
+3. Record old PVC names, PV names, node, and host paths.
+4. Create target retained PVCs with distinct names.
+5. Confirm rollback path uses the old StatefulSets and old retained PVCs.
+
+## Recommended Source-Owned Implementation
+
+The next implementation PR should add migration manifests or OpenTofu resources
+that can be planned and reviewed before live use.
+
+Minimum source-owned resources:
+
+- target retained PVC for NATS on `openebs-bumble-messaging-retain`
+- target retained PVC for SeaweedFS on `openebs-bumble-s3-retain`
+- explicit copy/export/import mechanism that handles honey-to-bumble node
+  locality
+- replacement or adopted StatefulSet definitions that bind to the target PVCs
+- candidate Tailscale Services using `honey-sting-tailnet`
+- rollback notes that preserve the old retained PVs and old canonical Services
+
+Acceptable data movement shapes:
+
+- app-native export/import if NATS and SeaweedFS tooling can produce complete
+  snapshots;
+- two-hop copy where a honey-side reader exports old PVC contents and a
+  bumble-side writer imports into target PVCs;
+- operator-mediated tar transfer only if the inventory remains small and the
+  transfer transcript is kept with the migration evidence.
+
+## Cutover Order
+
+Use this order for the eventual live migration:
+
+1. Run preflight and data inventory.
+2. Quiesce writers.
+3. Create target retained PVCs.
+4. Copy or import data to target PVCs.
+5. Start replacement NATS and SeaweedFS workloads against target PVCs.
+6. Run internal cluster smoke against replacement Services.
+7. Enable candidate tailnet Services with `honey-sting-tailnet`.
+8. Smoke candidate tailnet hostnames.
+9. Remove canonical Tailscale annotations from old Services through the chosen
+   authority path.
+10. Assign canonical hostnames to source-owned Services.
+11. Run fleet smoke.
+12. Keep old retained PVs until rollback is explicitly declared unnecessary.
+
+## Rollback
+
+Rollback before canonical tailnet cutover:
+
+1. Stop replacement workloads.
+2. Keep target PVCs retained for forensic comparison.
+3. Restart old StatefulSets against `data-nats-0` and `data-seaweedfs-0`.
+4. Leave old canonical Services unchanged.
+5. Run `just onprem-preflight` and app smoke.
+
+Rollback after canonical tailnet cutover:
+
+1. Stop replacement workloads.
+2. Restore old canonical Tailscale annotations or Services through source
+   control.
+3. Restart old StatefulSets against old PVCs.
+4. Re-run fleet and tailnet smoke.
+5. Preserve both old and target PVs until data consistency is verified.
+
+## Completion Criteria
+
+The migration is not complete until all of the following are true:
+
+- NATS and SeaweedFS StatefulSets are source-owned.
+- Their state PVCs use retained OpenEBS/ZFS classes.
+- `just onprem-data-inventory` reports target classes for live state PVCs.
+- canonical tailnet Services are source-owned and use `honey-sting-tailnet`.
+- `blahaj` tailnet proxy placement no longer fails on `tcfs/nats` or
+  `tcfs/seaweedfs`.
+- rollback evidence is recorded in the tracker.

--- a/infra/tofu/environments/onprem/README.md
+++ b/infra/tofu/environments/onprem/README.md
@@ -33,6 +33,12 @@ Read-only data inventory before migration work:
 TCFS_CONTEXT=honey just onprem-data-inventory
 ```
 
+Storage migration planning:
+
+```text
+docs/ops/tcfs-onprem-storage-migration.md
+```
+
 ## Candidate Tailnet Smoke
 
 Only after `scripts/tcfs-onprem-preflight.sh` is clean enough for migration


### PR DESCRIPTION
## Summary

Adds a source-owned runbook for the TCFS on-prem storage migration after the inventory gate added in PR #330.

The runbook records:
- current live authority and PVC placement
- unsafe paths to avoid
- required preflight and downtime gates
- source-owned implementation requirements
- cutover order
- rollback behavior
- completion criteria for clearing the TCFS tailnet proxy gate

It intentionally does not add live migration automation or mutate Kubernetes.

## Key Decision Captured

The current `local-path` PVs are honey-local, while the target OpenEBS/ZFS retained PVs are bumble-local. A single copy Pod cannot mount both old and new PVCs, and `volumeClaimTemplates.storageClassName` is not a safe in-place mutation surface. The next implementation needs a downtime-aware two-hop or app-native export/import plan.

## Validation

- `git diff --check`

Refs #327.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a source-owned ops runbook (`docs/ops/tcfs-onprem-storage-migration.md`) documenting the safe migration shape for moving TCFS NATS and SeaweedFS state from honey-local `local-path` PVCs to retained OpenEBS/ZFS storage classes on `bumble`, plus a one-liner cross-reference in the onprem OpenTofu README. No code is mutated; the runbook is intentionally read-only planning material.

<h3>Confidence Score: 5/5</h3>

Documentation-only PR with no code mutations — safe to merge.

Both changed files are markdown documentation. The runbook is internally consistent with the existing onprem README state, correctly captures the node-locality constraint (honey vs. bumble), includes explicit rollback steps for both pre- and post-cutover phases, and is intentionally non-automating. No Rust, crypto, Swift, or Nix code is touched, so none of the security-critical review rules apply.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/ops/tcfs-onprem-storage-migration.md | New 149-line runbook capturing migration shape, safety constraints, preflight gates, cutover order, rollback steps, and completion criteria — no code changes, content is internally consistent with existing README state |
| infra/tofu/environments/onprem/README.md | Adds a six-line cross-reference block pointing to the new runbook under "Storage migration planning" — minimal, clean change |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run preflight & data inventory] --> B[Quiesce writers]
    B --> C[Create target retained PVCs\nopenebs-bumble-messaging-retain\nopenebs-bumble-s3-retain]
    C --> D[Copy / import data to target PVCs\napp-native export, two-hop, or tar]
    D --> E[Start replacement NATS & SeaweedFS\nagainst target PVCs]
    E --> F[Internal cluster smoke\nagainst replacement Services]
    F --> G[Enable candidate tailnet Services\nhoney-sting-tailnet]
    G --> H[Smoke candidate tailnet hostnames]
    H --> I{Pass?}
    I -- No --> RB1[Rollback: stop replacement,\nrestart old StatefulSets\nagainst data-nats-0 / data-seaweedfs-0]
    I -- Yes --> J[Remove canonical Tailscale annotations\nfrom old Services]
    J --> K[Assign canonical hostnames\nto source-owned Services]
    K --> L[Run fleet smoke]
    L --> M{Pass?}
    M -- No --> RB2[Rollback: restore old annotations,\nrestart old StatefulSets,\nre-run fleet & tailnet smoke]
    M -- Yes --> N[Keep old retained PVs\nuntil rollback declared unnecessary]
    N --> O[Migration Complete ✓]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add tcfs onprem storage migration ..."](https://github.com/jesssullivan/tummycrypt/commit/9aed030e680c5ee0c339495040b9499933ebb2b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30130220)</sub>

<!-- /greptile_comment -->