### PR TITLE
[codex] add TCFS on-prem target PVC scaffold

### DIFF
--- a/docs/ops/tcfs-onprem-storage-migration.md
+++ b/docs/ops/tcfs-onprem-storage-migration.md
@@ -29,6 +29,12 @@ Durable targets now exist:
 - NATS target: `openebs-bumble-messaging-retain`
 - SeaweedFS target: `openebs-bumble-s3-retain`
 
+Source-owned target PVC scaffolding is disabled by default in
+`infra/tofu/environments/onprem`:
+
+- `tcfs-nats-openebs-target` on `openebs-bumble-messaging-retain`
+- `tcfs-seaweedfs-openebs-target` on `openebs-bumble-s3-retain`
+
 ## Non-Negotiable Safety Constraints
 
 - Do not patch `volumeClaimTemplates.storageClassName` in place. StatefulSet
@@ -72,7 +78,8 @@ Before copying state:
 1. Stop external writes and TCFS worker writes.
 2. Capture `just onprem-data-inventory` output.
 3. Record old PVC names, PV names, node, and host paths.
-4. Create target retained PVCs with distinct names.
+4. Create target retained PVCs with distinct names by planning and applying
+   `enable_stateful_migration_target_pvcs=true`.
 5. Confirm rollback path uses the old StatefulSets and old retained PVCs.
 
 ## Recommended Source-Owned Implementation
@@ -83,7 +90,9 @@ that can be planned and reviewed before live use.
 Minimum source-owned resources:
 
 - target retained PVC for NATS on `openebs-bumble-messaging-retain`
+  (`tcfs-nats-openebs-target`)
 - target retained PVC for SeaweedFS on `openebs-bumble-s3-retain`
+  (`tcfs-seaweedfs-openebs-target`)
 - explicit copy/export/import mechanism that handles honey-to-bumble node
   locality
 - replacement or adopted StatefulSet definitions that bind to the target PVCs

--- a/infra/tofu/environments/onprem/README.md
+++ b/infra/tofu/environments/onprem/README.md
@@ -21,6 +21,9 @@ This environment does not adopt those objects and does not move data. It only
 adds a source-owned candidate path for tailnet exposure once the migration
 gates are ready.
 
+All migration resources are disabled by default. The target retained PVCs are
+created only when `enable_stateful_migration_target_pvcs=true`.
+
 ## Safe Validation
 
 ```bash
@@ -37,6 +40,13 @@ Storage migration planning:
 
 ```text
 docs/ops/tcfs-onprem-storage-migration.md
+```
+
+Plan target retained PVC creation without enabling tailnet candidate Services:
+
+```bash
+tofu plan \
+  -var='enable_stateful_migration_target_pvcs=true'
 ```
 
 ## Candidate Tailnet Smoke

--- a/infra/tofu/environments/onprem/main.tf
+++ b/infra/tofu/environments/onprem/main.tf
@@ -22,6 +22,56 @@ locals {
   }
 }
 
+resource "kubernetes_persistent_volume_claim_v1" "nats_target" {
+  count = var.enable_stateful_migration_target_pvcs ? 1 : 0
+
+  metadata {
+    name      = var.nats_target_pvc_name
+    namespace = var.namespace
+    labels = merge(local.common_labels, {
+      "app.kubernetes.io/name"      = "nats"
+      "app.kubernetes.io/component" = "messaging"
+      "tummycrypt.dev/migration"    = "stateful-openebs-target"
+    })
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = var.nats_target_storage_class
+
+    resources {
+      requests = {
+        storage = var.nats_target_storage_size
+      }
+    }
+  }
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "seaweedfs_target" {
+  count = var.enable_stateful_migration_target_pvcs ? 1 : 0
+
+  metadata {
+    name      = var.seaweedfs_target_pvc_name
+    namespace = var.namespace
+    labels = merge(local.common_labels, {
+      "app.kubernetes.io/name"      = "seaweedfs"
+      "app.kubernetes.io/component" = "object-storage"
+      "tummycrypt.dev/migration"    = "stateful-openebs-target"
+    })
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = var.seaweedfs_target_storage_class
+
+    resources {
+      requests = {
+        storage = var.seaweedfs_target_storage_size
+      }
+    }
+  }
+}
+
 module "tailnet_nats_candidate" {
   count  = var.enable_tailnet_candidate_services ? 1 : 0
   source = "../../modules/tailscale-service"

--- a/infra/tofu/environments/onprem/outputs.tf
+++ b/infra/tofu/environments/onprem/outputs.tf
@@ -11,3 +11,19 @@ output "candidate_tailnet_services" {
     }
   } : {}
 }
+
+output "stateful_migration_target_pvcs" {
+  description = "Target retained PVCs for the downtime-gated NATS/SeaweedFS migration when enabled."
+  value = var.enable_stateful_migration_target_pvcs ? {
+    nats = {
+      pvc_name      = kubernetes_persistent_volume_claim_v1.nats_target[0].metadata[0].name
+      storage_class = kubernetes_persistent_volume_claim_v1.nats_target[0].spec[0].storage_class_name
+      size          = kubernetes_persistent_volume_claim_v1.nats_target[0].spec[0].resources[0].requests.storage
+    }
+    seaweedfs = {
+      pvc_name      = kubernetes_persistent_volume_claim_v1.seaweedfs_target[0].metadata[0].name
+      storage_class = kubernetes_persistent_volume_claim_v1.seaweedfs_target[0].spec[0].storage_class_name
+      size          = kubernetes_persistent_volume_claim_v1.seaweedfs_target[0].spec[0].resources[0].requests.storage
+    }
+  } : {}
+}

--- a/infra/tofu/environments/onprem/variables.tf
+++ b/infra/tofu/environments/onprem/variables.tf
@@ -22,6 +22,48 @@ variable "enable_tailnet_candidate_services" {
   default     = false
 }
 
+variable "enable_stateful_migration_target_pvcs" {
+  description = "Create retained target PVCs for the downtime-gated NATS/SeaweedFS storage migration."
+  type        = bool
+  default     = false
+}
+
+variable "nats_target_pvc_name" {
+  description = "Distinct target PVC name for the NATS migration. Keep separate from live data-nats-0 until cutover."
+  type        = string
+  default     = "tcfs-nats-openebs-target"
+}
+
+variable "nats_target_storage_class" {
+  description = "Retained OpenEBS/ZFS storage class for the NATS target PVC."
+  type        = string
+  default     = "openebs-bumble-messaging-retain"
+}
+
+variable "nats_target_storage_size" {
+  description = "Requested size for the NATS target PVC."
+  type        = string
+  default     = "5Gi"
+}
+
+variable "seaweedfs_target_pvc_name" {
+  description = "Distinct target PVC name for the SeaweedFS migration. Keep separate from live data-seaweedfs-0 until cutover."
+  type        = string
+  default     = "tcfs-seaweedfs-openebs-target"
+}
+
+variable "seaweedfs_target_storage_class" {
+  description = "Retained OpenEBS/ZFS storage class for the SeaweedFS target PVC."
+  type        = string
+  default     = "openebs-bumble-s3-retain"
+}
+
+variable "seaweedfs_target_storage_size" {
+  description = "Requested size for the SeaweedFS target PVC."
+  type        = string
+  default     = "10Gi"
+}
+
 variable "tailscale_proxy_class" {
   description = "Tailscale operator ProxyClass for honey/sting proxy placement."
   type        = string


### PR DESCRIPTION
## Summary

Adds disabled-by-default OpenTofu scaffolding for the TCFS on-prem storage migration target PVCs.

The new opt-in resources create:
- `tcfs-nats-openebs-target` on `openebs-bumble-messaging-retain`, size `5Gi`
- `tcfs-seaweedfs-openebs-target` on `openebs-bumble-s3-retain`, size `10Gi`

They are controlled by `enable_stateful_migration_target_pvcs`, which defaults to `false`.

## Safety Boundary

This PR does not apply live changes and does not enable tailnet candidate Services. It only makes the retained target PVCs source-owned and planable before the downtime-gated data migration.

The opt-in plan result was exactly:
- 2 to add
- 0 to change
- 0 to destroy

No tailnet candidate Services were planned when `enable_tailnet_candidate_services=false`.

## Validation

- `tofu fmt -check -recursive infra/tofu/environments/onprem`
- `git diff --check`
- `just onprem-tofu-validate`
- `tofu plan -input=false -var='enable_stateful_migration_target_pvcs=true' -var='enable_tailnet_candidate_services=false'`

Refs #327.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds disabled-by-default OpenTofu scaffolding for two retained Kubernetes PVCs (`tcfs-nats-openebs-target` and `tcfs-seaweedfs-openebs-target`) that will serve as migration targets for the NATS/SeaweedFS storage cutover. All new resources are gated behind `enable_stateful_migration_target_pvcs` (default `false`), and documentation and README are updated to reflect the new opt-in workflow.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all new resources are opt-in and no live changes are applied by default.

Only P2 findings present (missing prevent_destroy lifecycle guards and a minor README example omission). The feature flag defaulting to false provides a strong safety boundary, and the StorageClass retain policy limits blast radius even if the PVCs were accidentally destroyed.

infra/tofu/environments/onprem/main.tf — consider adding prevent_destroy lifecycle blocks before the data migration phase begins.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| infra/tofu/environments/onprem/main.tf | Adds two count-gated kubernetes_persistent_volume_claim_v1 resources for NATS and SeaweedFS migration targets; disabled by default. Missing prevent_destroy lifecycle guards on the PVCs. |
| infra/tofu/environments/onprem/outputs.tf | Adds stateful_migration_target_pvcs output mirroring the PVC metadata when enabled; guard condition matches resource count gate. |
| infra/tofu/environments/onprem/variables.tf | Adds 7 new well-described variables with safe defaults; all default to false/named values matching PR description. |
| docs/ops/tcfs-onprem-storage-migration.md | Documentation updated to reference the new Tofu variable and PVC names; step 4 of the pre-copy checklist correctly points to the new opt-in variable. |
| infra/tofu/environments/onprem/README.md | Adds planning instructions for the new flag; new plan example omits -input=false used during validation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tofu plan / apply] --> B{enable_stateful_migration_target_pvcs?}
    B -- false default --> C[No PVCs created - No-op]
    B -- true --> D[Create tcfs-nats-openebs-target
StorageClass: openebs-bumble-messaging-retain
5Gi]
    B -- true --> E[Create tcfs-seaweedfs-openebs-target
StorageClass: openebs-bumble-s3-retain
10Gi]
    D --> F[Output: stateful_migration_target_pvcs.nats]
    E --> G[Output: stateful_migration_target_pvcs.seaweedfs]
    H{enable_tailnet_candidate_services?} -- false default --> I[No Tailscale Services - No-op]
    H -- true --> J[tailnet_nats_candidate Service]
    H -- true --> K[tailnet_seaweedfs_candidate Service]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infra/tofu/environments/onprem/main.tf
Line: 25-73

Comment:
**Missing `prevent_destroy` lifecycle on migration PVCs**

Both target PVCs lack a `lifecycle { prevent_destroy = true }` block. Once data has been migrated into them, disabling `enable_stateful_migration_target_pvcs` (or running `tofu destroy`) would produce a plan that deletes both PVCs. The `-retain` suffix on the StorageClass names implies `reclaimPolicy: Retain`, so the underlying PVs would survive in `Released` state — but manually rebinding during an active migration is risky and operationally expensive. A lifecycle guard makes Tofu refuse the destroy outright and forces an explicit override.

```hcl
resource "kubernetes_persistent_volume_claim_v1" "nats_target" {
  count = var.enable_stateful_migration_target_pvcs ? 1 : 0

  lifecycle {
    prevent_destroy = true
  }
  # ... rest unchanged
}

resource "kubernetes_persistent_volume_claim_v1" "seaweedfs_target" {
  count = var.enable_stateful_migration_target_pvcs ? 1 : 0

  lifecycle {
    prevent_destroy = true
  }
  # ... rest unchanged
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infra/tofu/environments/onprem/README.md
Line: 44-50

Comment:
**Plan example missing `-input=false`**

The PR description's validation step used `-input=false` to prevent interactive prompts in CI. The new README example omits it, which could cause the plan to stall waiting for input in an automated context. Consider adding it for consistency with the existing validation workflow.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add tcfs onprem target pvc scaffol..."](https://github.com/jesssullivan/tummycrypt/commit/36d86bdfd8eaa00f8aa3360c251c1b4807c75b5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30130961)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->