### PR TITLE
[codex] render tcfs onprem migration commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -42,6 +42,14 @@ onprem-preflight:
 onprem-data-inventory:
     bash scripts/tcfs-onprem-data-inventory.sh
 
+# Render non-mutating downtime migration facts, import Pods, or copy commands
+onprem-migration-plan *ARGS:
+    bash scripts/tcfs-onprem-migration-plan.sh {{ARGS}}
+
+# Regression test the non-mutating TCFS migration command renderer
+onprem-migration-plan-test:
+    bash scripts/test-tcfs-onprem-migration-plan.sh
+
 # Validate on-prem OpenTofu migration surfaces without applying live changes
 onprem-tofu-validate:
     bash scripts/tcfs-onprem-tofu-validate.sh

--- a/docs/ops/tcfs-onprem-storage-migration.md
+++ b/docs/ops/tcfs-onprem-storage-migration.md
@@ -99,6 +99,20 @@ Minimum source-owned resources:
 - candidate Tailscale Services using `honey-sting-tailnet`
 - rollback notes that preserve the old retained PVs and old canonical Services
 
+Source-owned command rendering now exists for the downtime copy lane:
+
+```bash
+TCFS_CONTEXT=honey just onprem-migration-plan facts
+TCFS_CONTEXT=honey just onprem-migration-plan render-import-pods
+TCFS_CONTEXT=honey just onprem-migration-plan render-transfer-commands
+```
+
+Those commands are render-only. They are meant to create reviewable evidence
+for the maintenance window, not to authorize live mutation. The rendered
+transfer path streams from the source node-local PV path over SSH into a
+target-PVC import Pod, which avoids the unsafe single-Pod honey-to-bumble mount
+assumption.
+
 Acceptable data movement shapes:
 
 - app-native export/import if NATS and SeaweedFS tooling can produce complete

--- a/infra/tofu/environments/onprem/README.md
+++ b/infra/tofu/environments/onprem/README.md
@@ -36,6 +36,14 @@ Read-only data inventory before migration work:
 TCFS_CONTEXT=honey just onprem-data-inventory
 ```
 
+Non-mutating downtime command render:
+
+```bash
+TCFS_CONTEXT=honey just onprem-migration-plan facts
+TCFS_CONTEXT=honey just onprem-migration-plan render-import-pods
+TCFS_CONTEXT=honey just onprem-migration-plan render-transfer-commands
+```
+
 Storage migration planning:
 
 ```text

--- a/scripts/tcfs-onprem-migration-plan.sh
+++ b/scripts/tcfs-onprem-migration-plan.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+#
+# tcfs-onprem-migration-plan.sh - render downtime migration commands.
+#
+# This script is intentionally non-mutating. It reads current PVC/PV locality
+# and renders the import Pod manifests and two-hop transfer commands needed to
+# move TCFS NATS/SeaweedFS data from honey-local local-path PVs to retained
+# OpenEBS/ZFS target PVCs.
+#
+# Usage:
+#   scripts/tcfs-onprem-migration-plan.sh facts
+#   scripts/tcfs-onprem-migration-plan.sh render-import-pods
+#   scripts/tcfs-onprem-migration-plan.sh render-transfer-commands
+#
+set -euo pipefail
+
+NAMESPACE="${TCFS_NAMESPACE:-tcfs}"
+CONTEXT="${TCFS_CONTEXT:-}"
+KUBECTL_BIN="${TCFS_KUBECTL:-kubectl}"
+TARGET_NODE="${TCFS_TARGET_NODE:-bumble}"
+IMPORT_IMAGE="${TCFS_IMPORT_IMAGE:-docker.io/library/busybox:1.36}"
+
+NATS_SOURCE_PVC="${TCFS_NATS_SOURCE_PVC:-data-nats-0}"
+NATS_TARGET_PVC="${TCFS_NATS_TARGET_PVC:-tcfs-nats-openebs-target}"
+NATS_IMPORT_POD="${TCFS_NATS_IMPORT_POD:-tcfs-nats-openebs-import}"
+NATS_TARGET_STORAGE_CLASS="${TCFS_NATS_TARGET_STORAGE_CLASS:-openebs-bumble-messaging-retain}"
+
+SEAWEEDFS_SOURCE_PVC="${TCFS_SEAWEEDFS_SOURCE_PVC:-data-seaweedfs-0}"
+SEAWEEDFS_TARGET_PVC="${TCFS_SEAWEEDFS_TARGET_PVC:-tcfs-seaweedfs-openebs-target}"
+SEAWEEDFS_IMPORT_POD="${TCFS_SEAWEEDFS_IMPORT_POD:-tcfs-seaweedfs-openebs-import}"
+SEAWEEDFS_TARGET_STORAGE_CLASS="${TCFS_SEAWEEDFS_TARGET_STORAGE_CLASS:-openebs-bumble-s3-retain}"
+
+KUBECTL=("${KUBECTL_BIN}")
+if [[ -n "${CONTEXT}" ]]; then
+    KUBECTL+=(--context "${CONTEXT}")
+fi
+
+usage() {
+    cat <<'EOF'
+Usage:
+  tcfs-onprem-migration-plan.sh facts
+  tcfs-onprem-migration-plan.sh render-import-pods
+  tcfs-onprem-migration-plan.sh render-transfer-commands
+
+This script renders migration evidence and commands only. It does not mutate
+Kubernetes, scale workloads, create PVCs, create Pods, or copy data.
+EOF
+}
+
+die() {
+    printf '[ERROR] %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '[INFO] %s\n' "$*"
+}
+
+shell_quote() {
+    local value="$1"
+    printf "'%s'" "${value//\'/\'\\\'\'}"
+}
+
+kubectl_command() {
+    printf '%s' "$(shell_quote "${KUBECTL_BIN}")"
+    if [[ -n "${CONTEXT}" ]]; then
+        printf ' --context %s' "$(shell_quote "${CONTEXT}")"
+    fi
+}
+
+jsonpath_cluster() {
+    local resource="$1"
+    local path="$2"
+    "${KUBECTL[@]}" get "${resource}" -o "jsonpath=${path}" 2>/dev/null || true
+}
+
+jsonpath_namespaced() {
+    local resource="$1"
+    local path="$2"
+    "${KUBECTL[@]}" -n "${NAMESPACE}" get "${resource}" -o "jsonpath=${path}" 2>/dev/null || true
+}
+
+require_command() {
+    command -v "${KUBECTL_BIN}" >/dev/null 2>&1 || die "${KUBECTL_BIN} is required but was not found"
+}
+
+pvc_storage_class() {
+    jsonpath_namespaced "pvc/$1" '{.spec.storageClassName}'
+}
+
+pvc_volume() {
+    jsonpath_namespaced "pvc/$1" '{.spec.volumeName}'
+}
+
+pv_node() {
+    jsonpath_cluster "pv/$1" '{.spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].values[0]}'
+}
+
+pv_path() {
+    local volume="$1"
+    local path
+
+    path="$(jsonpath_cluster "pv/${volume}" '{.spec.hostPath.path}')"
+    if [[ -z "${path}" ]]; then
+        path="$(jsonpath_cluster "pv/${volume}" '{.spec.local.path}')"
+    fi
+
+    printf '%s' "${path}"
+}
+
+target_pvc_storage_class() {
+    jsonpath_namespaced "pvc/$1" '{.spec.storageClassName}'
+}
+
+source_fact_line() {
+    local name="$1"
+    local source_pvc="$2"
+    local target_pvc="$3"
+    local target_storage_class="$4"
+    local source_storage_class volume node path target_current_class
+
+    source_storage_class="$(pvc_storage_class "${source_pvc}")"
+    [[ -n "${source_storage_class}" ]] || die "pvc/${source_pvc} is missing or unreadable"
+
+    volume="$(pvc_volume "${source_pvc}")"
+    [[ -n "${volume}" ]] || die "pvc/${source_pvc} has no bound volume"
+
+    node="$(pv_node "${volume}")"
+    [[ -n "${node}" ]] || die "pv/${volume} has no nodeAffinity node value"
+
+    path="$(pv_path "${volume}")"
+    [[ -n "${path}" ]] || die "pv/${volume} has no hostPath/local path"
+
+    target_current_class="$(target_pvc_storage_class "${target_pvc}")"
+    if [[ -n "${target_current_class}" && "${target_current_class}" != "${target_storage_class}" ]]; then
+        die "pvc/${target_pvc} exists with storageClass=${target_current_class}, expected ${target_storage_class}"
+    fi
+
+    printf 'source/%s pvc=%s pv=%s storage-class=%s node=%s path=%s target-pvc=%s target-storage-class=%s target-present=%s\n' \
+        "${name}" \
+        "${source_pvc}" \
+        "${volume}" \
+        "${source_storage_class}" \
+        "${node}" \
+        "${path}" \
+        "${target_pvc}" \
+        "${target_storage_class}" \
+        "$([[ -n "${target_current_class}" ]] && printf yes || printf no)"
+}
+
+render_facts() {
+    info "Namespace: ${NAMESPACE}"
+    if [[ -n "${CONTEXT}" ]]; then
+        info "Context: ${CONTEXT}"
+    fi
+
+    source_fact_line nats "${NATS_SOURCE_PVC}" "${NATS_TARGET_PVC}" "${NATS_TARGET_STORAGE_CLASS}"
+    source_fact_line seaweedfs "${SEAWEEDFS_SOURCE_PVC}" "${SEAWEEDFS_TARGET_PVC}" "${SEAWEEDFS_TARGET_STORAGE_CLASS}"
+}
+
+render_import_pod() {
+    local name="$1"
+    local component="$2"
+    local target_pvc="$3"
+
+    cat <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${name}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: tcfs
+    app.kubernetes.io/managed-by: manual-downtime-migration
+    app.kubernetes.io/component: ${component}-import
+    tummycrypt.dev/migration: stateful-openebs-import
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    kubernetes.io/hostname: ${TARGET_NODE}
+  containers:
+    - name: import
+      image: ${IMPORT_IMAGE}
+      command:
+        - sh
+        - -lc
+        - trap : TERM INT; sleep 86400 & wait
+      volumeMounts:
+        - name: target
+          mountPath: /target
+  volumes:
+    - name: target
+      persistentVolumeClaim:
+        claimName: ${target_pvc}
+EOF
+}
+
+render_import_pods() {
+    render_import_pod "${NATS_IMPORT_POD}" nats "${NATS_TARGET_PVC}"
+    printf '%s\n' '---'
+    render_import_pod "${SEAWEEDFS_IMPORT_POD}" seaweedfs "${SEAWEEDFS_TARGET_PVC}"
+}
+
+transfer_command() {
+    local label="$1"
+    local source_pvc="$2"
+    local import_pod="$3"
+    local volume node path
+
+    volume="$(pvc_volume "${source_pvc}")"
+    [[ -n "${volume}" ]] || die "pvc/${source_pvc} has no bound volume"
+
+    node="$(pv_node "${volume}")"
+    [[ -n "${node}" ]] || die "pv/${volume} has no nodeAffinity node value"
+
+    path="$(pv_path "${volume}")"
+    [[ -n "${path}" ]] || die "pv/${volume} has no hostPath/local path"
+
+    printf '# Transfer %s from %s:%s into pod/%s:/target\n' "${label}" "${node}" "${path}" "${import_pod}"
+    printf 'ssh %s %s | %s -n %s exec -i %s -- tar -C /target -xpf -\n' \
+        "$(shell_quote "root@${node}")" \
+        "$(shell_quote "tar -C $(shell_quote "${path}") -cpf - .")" \
+        "$(kubectl_command)" \
+        "$(shell_quote "${NAMESPACE}")" \
+        "$(shell_quote "${import_pod}")"
+}
+
+render_transfer_commands() {
+    cat <<EOF
+# Non-mutating render only. Review before running during an approved downtime window.
+# Required setup before these commands:
+# 1. Quiesce external TCFS writers.
+# 2. Apply target PVCs with enable_stateful_migration_target_pvcs=true.
+# 3. Apply import pods from:
+#    scripts/tcfs-onprem-migration-plan.sh render-import-pods | $(kubectl_command) apply -f -
+# 4. Confirm source StatefulSets are scaled down before copying.
+
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") scale deployment/tcfs-backend-tcfs-backend-worker --replicas=0
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") scale statefulset/nats statefulset/seaweedfs --replicas=0
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") wait --for=delete pod/nats-0 --timeout=180s
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") wait --for=delete pod/seaweedfs-0 --timeout=180s
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") wait --for=condition=Ready $(shell_quote "pod/${NATS_IMPORT_POD}") --timeout=180s
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") wait --for=condition=Ready $(shell_quote "pod/${SEAWEEDFS_IMPORT_POD}") --timeout=180s
+
+EOF
+
+    transfer_command nats "${NATS_SOURCE_PVC}" "${NATS_IMPORT_POD}"
+    transfer_command seaweedfs "${SEAWEEDFS_SOURCE_PVC}" "${SEAWEEDFS_IMPORT_POD}"
+}
+
+main() {
+    local command="${1:-}"
+
+    case "${command}" in
+        facts)
+            require_command
+            render_facts
+            ;;
+        render-import-pods)
+            render_import_pods
+            ;;
+        render-transfer-commands)
+            require_command
+            render_transfer_commands
+            ;;
+        -h|--help|help)
+            usage
+            ;;
+        *)
+            usage >&2
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/test-tcfs-onprem-migration-plan.sh
+++ b/scripts/test-tcfs-onprem-migration-plan.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Regression tests for tcfs-onprem-migration-plan.sh.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/tcfs-onprem-migration-plan.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+FAKE_KUBECTL="${TMPDIR}/kubectl"
+cat >"${FAKE_KUBECTL}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+    shift 2
+fi
+
+namespace=""
+if [[ "${1:-}" == "-n" ]]; then
+    namespace="$2"
+    shift 2
+fi
+
+[[ "${1:-}" == "get" ]] || exit 1
+resource="$2"
+shift 2
+
+jsonpath=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        -o)
+            jsonpath="${2#jsonpath=}"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+case "${namespace}:${resource}:${jsonpath}" in
+    "tcfs:pvc/data-nats-0:{.spec.storageClassName}") printf 'local-path' ;;
+    "tcfs:pvc/data-nats-0:{.spec.volumeName}") printf 'pv-nats' ;;
+    "tcfs:pvc/data-seaweedfs-0:{.spec.storageClassName}") printf 'local-path' ;;
+    "tcfs:pvc/data-seaweedfs-0:{.spec.volumeName}") printf 'pv-seaweedfs' ;;
+    "tcfs:pvc/tcfs-nats-openebs-target:{.spec.storageClassName}")
+        if [[ "${FAKE_BAD_TARGET_CLASS:-}" == "1" ]]; then
+            printf 'wrong-class'
+        else
+            printf 'openebs-bumble-messaging-retain'
+        fi
+        ;;
+    "tcfs:pvc/tcfs-seaweedfs-openebs-target:{.spec.storageClassName}") ;;
+    ":pv/pv-nats:{.spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].values[0]}") printf 'honey' ;;
+    ":pv/pv-nats:{.spec.hostPath.path}") printf '/opt/local-path-provisioner/nats data' ;;
+    ":pv/pv-nats:{.spec.local.path}") ;;
+    ":pv/pv-seaweedfs:{.spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].values[0]}") printf 'honey' ;;
+    ":pv/pv-seaweedfs:{.spec.hostPath.path}") printf '/opt/local-path-provisioner/seaweedfs' ;;
+    ":pv/pv-seaweedfs:{.spec.local.path}") ;;
+    *) ;;
+esac
+EOF
+chmod +x "${FAKE_KUBECTL}"
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+
+    if ! grep -Fq "${expected}" "${file}"; then
+        printf 'expected to find %s in %s\n' "${expected}" "${file}" >&2
+        printf '--- output ---\n' >&2
+        cat "${file}" >&2
+        exit 1
+    fi
+}
+
+FACTS_OUT="${TMPDIR}/facts.out"
+TCFS_KUBECTL="${FAKE_KUBECTL}" bash "${SCRIPT}" facts >"${FACTS_OUT}"
+assert_contains "${FACTS_OUT}" 'source/nats pvc=data-nats-0 pv=pv-nats storage-class=local-path node=honey path=/opt/local-path-provisioner/nats data target-pvc=tcfs-nats-openebs-target target-storage-class=openebs-bumble-messaging-retain target-present=yes'
+assert_contains "${FACTS_OUT}" 'source/seaweedfs pvc=data-seaweedfs-0 pv=pv-seaweedfs storage-class=local-path node=honey path=/opt/local-path-provisioner/seaweedfs target-pvc=tcfs-seaweedfs-openebs-target target-storage-class=openebs-bumble-s3-retain target-present=no'
+
+PODS_OUT="${TMPDIR}/pods.out"
+bash "${SCRIPT}" render-import-pods >"${PODS_OUT}"
+assert_contains "${PODS_OUT}" 'name: tcfs-nats-openebs-import'
+assert_contains "${PODS_OUT}" 'claimName: tcfs-nats-openebs-target'
+assert_contains "${PODS_OUT}" 'name: tcfs-seaweedfs-openebs-import'
+assert_contains "${PODS_OUT}" 'kubernetes.io/hostname: bumble'
+
+COMMANDS_OUT="${TMPDIR}/commands.out"
+TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" bash "${SCRIPT}" render-transfer-commands >"${COMMANDS_OUT}"
+assert_contains "${COMMANDS_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' scale statefulset/nats statefulset/seaweedfs --replicas=0"
+assert_contains "${COMMANDS_OUT}" "# Transfer nats from honey:/opt/local-path-provisioner/nats data into pod/tcfs-nats-openebs-import:/target"
+assert_contains "${COMMANDS_OUT}" "ssh 'root@honey' 'tar -C '\\''/opt/local-path-provisioner/nats data'\\'' -cpf - .' | '${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' exec -i 'tcfs-nats-openebs-import' -- tar -C /target -xpf -"
+
+if FAKE_BAD_TARGET_CLASS=1 TCFS_KUBECTL="${FAKE_KUBECTL}" bash "${SCRIPT}" facts >"${TMPDIR}/bad.out" 2>"${TMPDIR}/bad.err"; then
+    printf 'expected mismatched target class to fail\n' >&2
+    exit 1
+fi
+assert_contains "${TMPDIR}/bad.err" 'expected openebs-bumble-messaging-retain'
+
+printf 'tcfs-onprem-migration-plan tests passed\n'


### PR DESCRIPTION
## Summary

Adds a non-mutating operator renderer for the TCFS on-prem downtime migration lane.

- adds `just onprem-migration-plan` with `facts`, `render-import-pods`, and `render-transfer-commands`
- reads live PVC/PV locality so the rendered downtime plan uses the actual honey-local source paths
- renders bumble-pinned target-PVC import Pods and two-hop SSH-to-kubectl transfer commands
- propagates `TCFS_CONTEXT` into every rendered `kubectl` command, not just the readback phase
- adds a fake-kubectl regression test for source/target class guards, import pod output, context propagation, and shell-safe transfer rendering
- updates the on-prem README and storage migration runbook with render-only usage

## Safety

This PR does not apply Kubernetes changes, create PVCs, create Pods, scale workloads, copy data, or alter tailnet Services. It only reads PVC/PV facts or renders commands for a later approved downtime window.

## Validation

- `bash -n scripts/tcfs-onprem-migration-plan.sh scripts/test-tcfs-onprem-migration-plan.sh`
- `bash scripts/test-tcfs-onprem-migration-plan.sh`
- `just onprem-migration-plan-test`
- `git diff --check`
- `just --list`
- `just onprem-tofu-validate`
- `TCFS_CONTEXT=honey just onprem-migration-plan facts`
- `TCFS_CONTEXT=honey just onprem-migration-plan render-import-pods`
- `TCFS_CONTEXT=honey just onprem-migration-plan render-transfer-commands`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `scripts/tcfs-onprem-migration-plan.sh`, a render-only tool that reads live PVC/PV locality facts and emits reviewable import-Pod manifests and two-hop SSH→`kubectl exec` tar commands for the TCFS NATS/SeaweedFS on-prem storage migration. The script is strictly non-mutating; it also correctly propagates `TCFS_CONTEXT` into every rendered `kubectl` call, and a fake-kubectl regression test covers storage-class guards, space-in-path shell quoting, and context propagation thoroughly.

<h3>Confidence Score: 4/5</h3>

Safe to merge — render-only, no Kubernetes mutations; all findings are P2 style/readability concerns.

Only P2 findings: hardcoded nodeAffinity index [0] in pv_node that could mislead if PVs have non-standard affinity (fails loudly at execution time), unquoted path field in space-delimited facts output, mutable Docker Hub tag for the import image, and unquoted {{ARGS}} in the Justfile recipe. No logic errors or security issues.

scripts/tcfs-onprem-migration-plan.sh — minor robustness concerns in pv_node and source_fact_line output format.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/tcfs-onprem-migration-plan.sh | New render-only migration planner: reads live PVC/PV locality, emits import-pod YAML and shell-safe two-hop SSH→kubectl transfer commands. Minor issues: hardcoded `[0]` nodeAffinity indices in `pv_node`, unquoted path value in space-delimited facts output, and floating Docker Hub tag for the import image. |
| scripts/test-tcfs-onprem-migration-plan.sh | Fake-kubectl regression suite covering storage-class guard, facts output, import-pod YAML, context propagation, and space-in-path shell quoting. Comprehensive coverage for a render-only script. |
| Justfile | Adds `onprem-migration-plan *ARGS` and `onprem-migration-plan-test` recipes. Unquoted `{{ARGS}}` is consistent with other variadic recipes in the file; safe for documented subcommand names. |
| docs/ops/tcfs-onprem-storage-migration.md | Adds render-only usage examples and explains the two-hop SSH→import-pod transfer rationale. Documentation is accurate and consistent with the script. |
| infra/tofu/environments/onprem/README.md | Adds non-mutating command examples section to the on-prem README. No issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([operator]) -->|"TCFS_CONTEXT=honey just onprem-migration-plan"| B{subcommand}
    B -->|facts| C[require_command]
    C --> D[source_fact_line nats + seaweedfs]
    D --> F([stdout: space-delimited fact lines])
    B -->|render-import-pods| G[render_import_pod NATS]
    G --> H[render_import_pod SeaweedFS]
    H --> I([stdout: two Pod manifests])
    B -->|render-transfer-commands| J[require_command]
    J --> K[render scale/wait preamble]
    K --> L[transfer_command nats + seaweedfs]
    L --> N([stdout: reviewable shell script])
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/tcfs-onprem-migration-plan.sh
Line: 96-97

Comment:
**Hardcoded `[0]` indices in `pv_node` jsonpath**

The jsonpath `{.spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].values[0]}` assumes exactly one selector term, one match expression, and one value. For local-path provisioner PVs this holds, but if a PV has additional affinity rules (e.g. `preferred` + `required`), it silently reads the first term and could return a node that does not actually host the data, causing the rendered SSH command to target the wrong host. The failure would surface at execution time as a failed SSH or a missing path, but the rendered plan would look plausible.

Consider asserting on `jq` output or at minimum documenting this assumption alongside the function with a guard that validates the result against the known source node (`TARGET_NODE` = `honey`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/tcfs-onprem-migration-plan.sh
Line: 21

Comment:
**`IMPORT_IMAGE` uses a mutable tag**

`docker.io/library/busybox:1.36` references a floating tag. Docker Hub tags are mutable and can be force-pushed; if the tag resolves to a different layer at apply time, the import pod would run with an unexpected image. For a one-off maintenance operation this is low risk, but pinning to a digest (`busybox@sha256:...`) would make the rendered plan fully reproducible regardless of registry state.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: Justfile
Line: 46-47

Comment:
**`{{ARGS}}` is not quoted in the recipe**

Just expands `{{ARGS}}` without quoting, so a future subcommand with a space would be word-split before reaching bash. Other variadic recipes in this file (e.g. `install-smoke`, `ios-rust`) share the same pattern, so this is consistent, but worth noting as a fragility point if subcommand names ever gain spaces or special characters.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/tcfs-onprem-migration-plan.sh
Line: 139-149

Comment:
**Ambiguous facts output when path contains spaces**

The `path=` field is not quoted in the space-delimited output line. The test fixture explicitly uses a PV path containing a space, so that field runs into the next token, making it hard to visually verify the correct source path at a glance during a maintenance window. Quoting the value or switching to a per-field newline format would make the facts unambiguous.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: render tcfs onprem migration comma..."](https://github.com/jesssullivan/tummycrypt/commit/be0725f51f6eaad7d413814ad8453a8041086e38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30172564)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->