### PR TITLE
[codex] add tcfs onprem candidate workloads

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -54,6 +54,10 @@ onprem-migration-plan-test:
 onprem-tofu-validate:
     bash scripts/tcfs-onprem-tofu-validate.sh
 
+# Static safety checks for source-owned on-prem candidate workload selectors
+onprem-tofu-candidate-test:
+    bash scripts/test-tcfs-onprem-tofu-candidate-workloads.sh
+
 # Tail logs from a workload
 k8s-logs app="tcfsd" ns="tcfs":
     kubectl logs -l app.kubernetes.io/name={{app}} -n {{ns}} --tail=50

--- a/docs/ops/onprem-authority-recovery.md
+++ b/docs/ops/onprem-authority-recovery.md
@@ -79,12 +79,14 @@ Minimum migration gates:
 1. capture live NATS JetStream and SeaweedFS data inventory;
 2. choose target storage classes for NATS and SeaweedFS instead of inheriting
    `local-path`;
-3. teach the OpenTofu tailnet surface the current cluster ProxyClass contract or
-   record a named exception;
-4. run a dry-run/plan that does not collide with live object names;
-5. cut over only after smoke tests prove NATS, SeaweedFS, and worker
+3. render or apply retained target PVCs and non-canonical candidate workloads
+   only through `infra/tofu/environments/onprem`;
+4. smoke candidate Tailscale Services with selectors that do not point at the
+   live `app=nats` or `app=seaweedfs` pods;
+5. run a dry-run/plan that does not collide with live object names;
+6. cut over only after smoke tests prove NATS, SeaweedFS, and worker
    connectivity on the new path;
-6. remove the old live annotations and retained objects through the same
+7. remove the old live annotations and retained objects through the same
    source-controlled transition.
 
 Use the read-only preflight before changing either path:

--- a/infra/tofu/environments/onprem/README.md
+++ b/infra/tofu/environments/onprem/README.md
@@ -2,7 +2,7 @@
 
 This environment captures the Tinyland on-prem TCFS migration surface. It is
 intentionally inert by default: `enable_tailnet_candidate_services=false`
-creates no resources.
+and `enable_stateful_migration_candidate_workloads=false` create no resources.
 
 ## Current Live Boundary
 
@@ -17,12 +17,15 @@ Live readback on 2026-04-29 shows:
   `openebs-bumble-messaging-retain` for NATS and
   `openebs-bumble-s3-retain` for SeaweedFS.
 
-This environment does not adopt those objects and does not move data. It only
-adds a source-owned candidate path for tailnet exposure once the migration
+This environment does not adopt those objects and does not move data. It adds a
+source-owned candidate path for retained target PVCs, non-canonical
+NATS/SeaweedFS workloads, and candidate tailnet exposure once the migration
 gates are ready.
 
 All migration resources are disabled by default. The target retained PVCs are
-created only when `enable_stateful_migration_target_pvcs=true`.
+created only when `enable_stateful_migration_target_pvcs=true`; candidate
+workloads are created only when
+`enable_stateful_migration_candidate_workloads=true`.
 
 ## Safe Validation
 
@@ -57,6 +60,16 @@ tofu plan \
   -var='enable_stateful_migration_target_pvcs=true'
 ```
 
+Plan retained PVCs plus non-canonical candidate workloads and candidate tailnet
+Services:
+
+```bash
+tofu plan \
+  -var='enable_stateful_migration_target_pvcs=true' \
+  -var='enable_stateful_migration_candidate_workloads=true' \
+  -var='enable_tailnet_candidate_services=true'
+```
+
 ## Candidate Tailnet Smoke
 
 Only after `scripts/tcfs-onprem-preflight.sh` is clean enough for migration
@@ -67,6 +80,11 @@ canonical devices:
 tofu plan \
   -var='enable_tailnet_candidate_services=true'
 ```
+
+The candidate tailnet Services intentionally select the non-canonical candidate
+labels, not the live `app=nats` or `app=seaweedfs` labels. If candidate
+workloads are not enabled, the tailnet Services should have no backend
+endpoints; that is safer than exposing the existing honey-local singleton pods.
 
 Do not switch the candidate hostnames to `nats-tcfs` or `seaweedfs-tcfs` until
 the live Service annotations have been removed through a source-controlled

--- a/infra/tofu/environments/onprem/main.tf
+++ b/infra/tofu/environments/onprem/main.tf
@@ -20,6 +20,28 @@ locals {
     "app.kubernetes.io/managed-by" = "opentofu"
     "tummycrypt.dev/environment"   = "onprem"
   }
+
+  nats_candidate_selector = {
+    app                          = var.nats_candidate_app_label
+    "app.kubernetes.io/instance" = var.nats_candidate_workload_name
+  }
+
+  nats_candidate_labels = merge(local.common_labels, local.nats_candidate_selector, {
+    "app.kubernetes.io/name"      = "nats"
+    "app.kubernetes.io/component" = "messaging"
+    "tummycrypt.dev/migration"    = "stateful-openebs-candidate"
+  })
+
+  seaweedfs_candidate_selector = {
+    app                          = var.seaweedfs_candidate_app_label
+    "app.kubernetes.io/instance" = var.seaweedfs_candidate_workload_name
+  }
+
+  seaweedfs_candidate_labels = merge(local.common_labels, local.seaweedfs_candidate_selector, {
+    "app.kubernetes.io/name"      = "seaweedfs"
+    "app.kubernetes.io/component" = "object-storage"
+    "tummycrypt.dev/migration"    = "stateful-openebs-candidate"
+  })
 }
 
 resource "kubernetes_persistent_volume_claim_v1" "nats_target" {
@@ -72,6 +94,256 @@ resource "kubernetes_persistent_volume_claim_v1" "seaweedfs_target" {
   }
 }
 
+resource "kubernetes_service_v1" "nats_candidate" {
+  count = var.enable_stateful_migration_candidate_workloads ? 1 : 0
+
+  wait_for_load_balancer = false
+
+  metadata {
+    name      = var.nats_candidate_workload_name
+    namespace = var.namespace
+    labels    = local.nats_candidate_labels
+  }
+
+  spec {
+    cluster_ip = "None"
+    selector   = local.nats_candidate_selector
+
+    port {
+      name        = "client"
+      port        = 4222
+      target_port = 4222
+      protocol    = "TCP"
+    }
+
+    port {
+      name        = "monitor"
+      port        = 8222
+      target_port = 8222
+      protocol    = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_stateful_set_v1" "nats_candidate" {
+  count = var.enable_stateful_migration_candidate_workloads ? 1 : 0
+
+  metadata {
+    name      = var.nats_candidate_workload_name
+    namespace = var.namespace
+    labels    = local.nats_candidate_labels
+  }
+
+  spec {
+    replicas     = 1
+    service_name = kubernetes_service_v1.nats_candidate[0].metadata[0].name
+
+    selector {
+      match_labels = local.nats_candidate_selector
+    }
+
+    template {
+      metadata {
+        labels = local.nats_candidate_labels
+      }
+
+      spec {
+        container {
+          name  = "nats"
+          image = var.nats_image
+          args  = ["-js", "-sd", "/data", "-m", "8222"]
+
+          port {
+            name           = "client"
+            container_port = 4222
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "monitor"
+            container_port = 8222
+            protocol       = "TCP"
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8222
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+          }
+
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+            limits = {
+              cpu    = "500m"
+              memory = "512Mi"
+            }
+          }
+
+          volume_mount {
+            name       = "data"
+            mount_path = "/data"
+          }
+        }
+
+        volume {
+          name = "data"
+          persistent_volume_claim {
+            claim_name = var.nats_target_pvc_name
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "seaweedfs_candidate" {
+  count = var.enable_stateful_migration_candidate_workloads ? 1 : 0
+
+  wait_for_load_balancer = false
+
+  metadata {
+    name      = var.seaweedfs_candidate_workload_name
+    namespace = var.namespace
+    labels    = local.seaweedfs_candidate_labels
+  }
+
+  spec {
+    cluster_ip = "None"
+    selector   = local.seaweedfs_candidate_selector
+
+    port {
+      name        = "master"
+      port        = 9333
+      target_port = 9333
+      protocol    = "TCP"
+    }
+
+    port {
+      name        = "volume"
+      port        = 8080
+      target_port = 8080
+      protocol    = "TCP"
+    }
+
+    port {
+      name        = "filer"
+      port        = 8888
+      target_port = 8888
+      protocol    = "TCP"
+    }
+
+    port {
+      name        = "s3"
+      port        = 8333
+      target_port = 8333
+      protocol    = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_stateful_set_v1" "seaweedfs_candidate" {
+  count = var.enable_stateful_migration_candidate_workloads ? 1 : 0
+
+  metadata {
+    name      = var.seaweedfs_candidate_workload_name
+    namespace = var.namespace
+    labels    = local.seaweedfs_candidate_labels
+  }
+
+  spec {
+    replicas     = 1
+    service_name = kubernetes_service_v1.seaweedfs_candidate[0].metadata[0].name
+
+    selector {
+      match_labels = local.seaweedfs_candidate_selector
+    }
+
+    template {
+      metadata {
+        labels = local.seaweedfs_candidate_labels
+      }
+
+      spec {
+        container {
+          name  = "seaweedfs"
+          image = var.seaweedfs_image
+          args = [
+            "server",
+            "-master.port=9333",
+            "-volume.port=8080",
+            "-filer",
+            "-s3",
+            "-s3.port=8333",
+            "-dir=/data",
+          ]
+
+          port {
+            name           = "master"
+            container_port = 9333
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "volume"
+            container_port = 8080
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "filer"
+            container_port = 8888
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "s3"
+            container_port = 8333
+            protocol       = "TCP"
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/cluster/status"
+              port = 9333
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 10
+          }
+
+          resources {
+            requests = {
+              cpu    = "200m"
+              memory = "256Mi"
+            }
+            limits = {
+              cpu    = "1"
+              memory = "1Gi"
+            }
+          }
+
+          volume_mount {
+            name       = "data"
+            mount_path = "/data"
+          }
+        }
+
+        volume {
+          name = "data"
+          persistent_volume_claim {
+            claim_name = var.seaweedfs_target_pvc_name
+          }
+        }
+      }
+    }
+  }
+}
+
 module "tailnet_nats_candidate" {
   count  = var.enable_tailnet_candidate_services ? 1 : 0
   source = "../../modules/tailscale-service"
@@ -80,8 +352,8 @@ module "tailnet_nats_candidate" {
   name               = "nats-tailnet-candidate"
   tailscale_hostname = var.nats_tailnet_candidate_hostname
   proxy_class        = var.tailscale_proxy_class
-  selector           = { app = "nats" }
-  labels             = merge(local.common_labels, { "app.kubernetes.io/name" = "nats" })
+  selector           = local.nats_candidate_selector
+  labels             = local.nats_candidate_labels
 
   ports = [
     {
@@ -105,8 +377,8 @@ module "tailnet_seaweedfs_candidate" {
   name               = "seaweedfs-tailnet-candidate"
   tailscale_hostname = var.seaweedfs_tailnet_candidate_hostname
   proxy_class        = var.tailscale_proxy_class
-  selector           = { app = "seaweedfs" }
-  labels             = merge(local.common_labels, { "app.kubernetes.io/name" = "seaweedfs" })
+  selector           = local.seaweedfs_candidate_selector
+  labels             = local.seaweedfs_candidate_labels
 
   ports = [
     {

--- a/infra/tofu/environments/onprem/outputs.tf
+++ b/infra/tofu/environments/onprem/outputs.tf
@@ -4,10 +4,12 @@ output "candidate_tailnet_services" {
     nats = {
       service_name = module.tailnet_nats_candidate[0].service_name
       hostname     = module.tailnet_nats_candidate[0].tailscale_hostname
+      selector     = local.nats_candidate_selector
     }
     seaweedfs = {
       service_name = module.tailnet_seaweedfs_candidate[0].service_name
       hostname     = module.tailnet_seaweedfs_candidate[0].tailscale_hostname
+      selector     = local.seaweedfs_candidate_selector
     }
   } : {}
 }
@@ -24,6 +26,26 @@ output "stateful_migration_target_pvcs" {
       pvc_name      = kubernetes_persistent_volume_claim_v1.seaweedfs_target[0].metadata[0].name
       storage_class = kubernetes_persistent_volume_claim_v1.seaweedfs_target[0].spec[0].storage_class_name
       size          = kubernetes_persistent_volume_claim_v1.seaweedfs_target[0].spec[0].resources[0].requests.storage
+    }
+  } : {}
+}
+
+output "stateful_migration_candidate_workloads" {
+  description = "Candidate NATS/SeaweedFS workload names, images, selectors, and target PVCs when enabled."
+  value = var.enable_stateful_migration_candidate_workloads ? {
+    nats = {
+      stateful_set = kubernetes_stateful_set_v1.nats_candidate[0].metadata[0].name
+      service      = kubernetes_service_v1.nats_candidate[0].metadata[0].name
+      image        = var.nats_image
+      selector     = local.nats_candidate_selector
+      target_pvc   = var.nats_target_pvc_name
+    }
+    seaweedfs = {
+      stateful_set = kubernetes_stateful_set_v1.seaweedfs_candidate[0].metadata[0].name
+      service      = kubernetes_service_v1.seaweedfs_candidate[0].metadata[0].name
+      image        = var.seaweedfs_image
+      selector     = local.seaweedfs_candidate_selector
+      target_pvc   = var.seaweedfs_target_pvc_name
     }
   } : {}
 }

--- a/infra/tofu/environments/onprem/variables.tf
+++ b/infra/tofu/environments/onprem/variables.tf
@@ -28,6 +28,12 @@ variable "enable_stateful_migration_target_pvcs" {
   default     = false
 }
 
+variable "enable_stateful_migration_candidate_workloads" {
+  description = "Create non-canonical candidate NATS/SeaweedFS StatefulSets that mount the retained target PVCs."
+  type        = bool
+  default     = false
+}
+
 variable "nats_target_pvc_name" {
   description = "Distinct target PVC name for the NATS migration. Keep separate from live data-nats-0 until cutover."
   type        = string
@@ -46,6 +52,24 @@ variable "nats_target_storage_size" {
   default     = "5Gi"
 }
 
+variable "nats_candidate_workload_name" {
+  description = "Distinct candidate NATS StatefulSet and headless Service name. Keep separate from live nats."
+  type        = string
+  default     = "nats-openebs-candidate"
+}
+
+variable "nats_candidate_app_label" {
+  description = "Distinct app label for the candidate NATS workload and tailnet Service selector."
+  type        = string
+  default     = "nats-openebs-candidate"
+}
+
+variable "nats_image" {
+  description = "NATS image for the on-prem candidate workload. Mirrors current live readback until a pinned production tag is selected."
+  type        = string
+  default     = "nats:2.10-alpine"
+}
+
 variable "seaweedfs_target_pvc_name" {
   description = "Distinct target PVC name for the SeaweedFS migration. Keep separate from live data-seaweedfs-0 until cutover."
   type        = string
@@ -62,6 +86,24 @@ variable "seaweedfs_target_storage_size" {
   description = "Requested size for the SeaweedFS target PVC."
   type        = string
   default     = "10Gi"
+}
+
+variable "seaweedfs_candidate_workload_name" {
+  description = "Distinct candidate SeaweedFS StatefulSet and headless Service name. Keep separate from live seaweedfs."
+  type        = string
+  default     = "seaweedfs-openebs-candidate"
+}
+
+variable "seaweedfs_candidate_app_label" {
+  description = "Distinct app label for the candidate SeaweedFS workload and tailnet Service selector."
+  type        = string
+  default     = "seaweedfs-openebs-candidate"
+}
+
+variable "seaweedfs_image" {
+  description = "SeaweedFS image for the on-prem candidate workload. Mirrors current live readback until a pinned production tag is selected."
+  type        = string
+  default     = "chrislusf/seaweedfs:latest"
 }
 
 variable "tailscale_proxy_class" {

--- a/scripts/tcfs-onprem-tofu-validate.sh
+++ b/scripts/tcfs-onprem-tofu-validate.sh
@@ -28,5 +28,8 @@ validate_env() {
 
 require_command tofu
 
+tofu fmt -check -recursive "${ROOT}/infra/tofu/environments/onprem"
+bash "${ROOT}/scripts/test-tcfs-onprem-tofu-candidate-workloads.sh"
+
 validate_env onprem
 validate_env civo

--- a/scripts/test-tcfs-onprem-tofu-candidate-workloads.sh
+++ b/scripts/test-tcfs-onprem-tofu-candidate-workloads.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Static regression tests for the source-only TCFS on-prem candidate workload
+# surface. These tests intentionally avoid kubectl/tofu apply; their job is to
+# catch authority regressions before an operator reaches a live cluster.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAIN_TF="${ROOT}/infra/tofu/environments/onprem/main.tf"
+VARIABLES_TF="${ROOT}/infra/tofu/environments/onprem/variables.tf"
+OUTPUTS_TF="${ROOT}/infra/tofu/environments/onprem/outputs.tf"
+
+assert_contains() {
+    local file="$1"
+    local needle="$2"
+
+    if ! grep -Fq "${needle}" "${file}"; then
+        printf '[ERROR] expected %s to contain: %s\n' "${file}" "${needle}" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local needle="$2"
+
+    if grep -Fq "${needle}" "${file}"; then
+        printf '[ERROR] expected %s not to contain: %s\n' "${file}" "${needle}" >&2
+        exit 1
+    fi
+}
+
+assert_contains "${VARIABLES_TF}" 'variable "enable_stateful_migration_candidate_workloads"'
+assert_contains "${MAIN_TF}" 'resource "kubernetes_stateful_set_v1" "nats_candidate"'
+assert_contains "${MAIN_TF}" 'resource "kubernetes_stateful_set_v1" "seaweedfs_candidate"'
+assert_contains "${MAIN_TF}" 'selector           = local.nats_candidate_selector'
+assert_contains "${MAIN_TF}" 'selector           = local.seaweedfs_candidate_selector'
+assert_contains "${MAIN_TF}" 'claim_name = var.nats_target_pvc_name'
+assert_contains "${MAIN_TF}" 'claim_name = var.seaweedfs_target_pvc_name'
+assert_contains "${OUTPUTS_TF}" 'output "stateful_migration_candidate_workloads"'
+
+assert_not_contains "${MAIN_TF}" 'selector           = { app = "nats" }'
+assert_not_contains "${MAIN_TF}" 'selector           = { app = "seaweedfs" }'
+
+printf '[INFO] TCFS on-prem candidate workload static checks passed\n'


### PR DESCRIPTION
## Summary

- add disabled-by-default OpenTofu candidate NATS and SeaweedFS StatefulSets for the on-prem storage migration
- mount the retained OpenEBS target PVC names instead of creating new live-style volumeClaimTemplates
- move candidate tailnet Services onto unique candidate selectors so they cannot expose the live honey-local singleton pods
- document the opt-in plan flow and add static selector-safety regression coverage

## Validation

- `just onprem-tofu-candidate-test`
- `just onprem-migration-plan-test`
- `tofu fmt -check -recursive infra/tofu/environments/onprem`
- `just onprem-tofu-validate`
- `tofu -chdir=infra/tofu/environments/onprem plan -no-color -refresh=false -input=false -var=enable_stateful_migration_target_pvcs=true -var=enable_stateful_migration_candidate_workloads=true -var=enable_tailnet_candidate_services=true -out=/tmp/tcfs-onprem-candidate.tfplan`

## Live Safety

No live Kubernetes apply was run. The plan is opt-in and creates non-canonical names only:

- `nats-openebs-candidate`
- `seaweedfs-openebs-candidate`
- `nats-tailnet-candidate`
- `seaweedfs-tailnet-candidate`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces disabled-by-default OpenTofu candidate StatefulSets for NATS and SeaweedFS that mount retained OpenEBS PVCs under non-canonical names, and fixes the tailnet candidate Services to use isolated selectors so they cannot accidentally back the live singleton pods. The selector isolation is well-enforced through locals, and the static regression script provides a solid guard against future regressions.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are opt-in behind feature flags with no live cluster apply; only P2 findings present.

All findings are P2 (style/best-practices): unpinned `seaweedfs:latest` image default and missing liveness probes on both StatefulSets. No logic errors, no security concerns, and the selector-isolation regression coverage is solid.

`infra/tofu/environments/onprem/variables.tf` (unpinned SeaweedFS image) and `infra/tofu/environments/onprem/main.tf` (missing liveness probes).

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| infra/tofu/environments/onprem/main.tf | Adds candidate NATS and SeaweedFS StatefulSets/headless Services with isolated selectors and PVC mounts; tailnet modules updated to use candidate selectors. No liveness probes on either StatefulSet. |
| infra/tofu/environments/onprem/variables.tf | Adds well-structured variables for candidate workload names, labels, and images; SeaweedFS image defaults to `latest` rather than a pinned tag unlike the NATS variable. |
| infra/tofu/environments/onprem/outputs.tf | Adds `stateful_migration_candidate_workloads` output and enriches `candidate_tailnet_services` with selectors; guarded correctly by the feature flag. |
| scripts/test-tcfs-onprem-tofu-candidate-workloads.sh | Static regression script using grep-based assertions to guard selector isolation and PVC wiring; no live cluster calls, runs before `tofu validate`. |
| Justfile | Adds `onprem-tofu-candidate-test` recipe wiring the new regression script. |
| scripts/tcfs-onprem-tofu-validate.sh | Integrates `tofu fmt -check` and the new candidate workload test into the existing validate script, running before `validate_env` calls. |
| docs/ops/onprem-authority-recovery.md | Migration gate list updated to include candidate workload and Tailscale selector smoke steps; numbering corrected. |
| infra/tofu/environments/onprem/README.md | README updated to reflect the new feature flag, opt-in plan flow, and candidate tailnet selector safety explanation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tofu plan / apply] --> B{enable_stateful_migration_target_pvcs?}
    B -- true --> C[kubernetes_persistent_volume_claim_v1\nnats-openebs-target\nseaweedfs-openebs-target]
    B -- false --> X1[no PVCs created]
    A --> D{enable_stateful_migration_candidate_workloads?}
    D -- true --> E[kubernetes_stateful_set_v1\nnats-openebs-candidate]
    D -- true --> F[kubernetes_stateful_set_v1\nseaweedfs-openebs-candidate]
    D -- true --> G[kubernetes_service_v1 headless\nnats-openebs-candidate]
    D -- true --> H[kubernetes_service_v1 headless\nseaweedfs-openebs-candidate]
    E -- mounts --> C
    F -- mounts --> C
    D -- false --> X2[no candidate workloads]
    A --> I{enable_tailnet_candidate_services?}
    I -- true --> J[tailscale-service\nnats-tailnet-candidate\nselects: nats-openebs-candidate]
    I -- true --> K[tailscale-service\nseaweedfs-tailnet-candidate\nselects: seaweedfs-openebs-candidate]
    J -- no endpoints if workloads disabled --> E
    K -- no endpoints if workloads disabled --> F
    I -- false --> X3[no tailnet services]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: infra/tofu/environments/onprem/variables.tf
Line: 107

Comment:
**`seaweedfs_image` defaults to `latest` tag**

`latest` is a floating tag: if the candidate pod is ever rescheduled, evicted, or the image cache is cleared, Kubernetes will pull whatever is current at that moment. For a workload that mounts a retained OpenEBS PVC with real data, a silent minor/major version bump could cause on-disk format incompatibilities. The NATS sibling variable already pins to `2.10-alpine`; SeaweedFS should do the same.

```suggestion
  default     = "chrislusf/seaweedfs:3.68"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infra/tofu/environments/onprem/main.tf
Line: 149-157

Comment:
**No liveness probe on NATS candidate container**

Only a readiness probe is defined. Without a liveness probe, a stuck or deadlocked NATS process (e.g. a JetStream stall with the TCP socket still open) will never be automatically restarted by the kubelet — the pod stays `Ready` indefinitely while serving no traffic. Consider adding an HTTP liveness probe with a conservative `failure_threshold`:

```hcl
          liveness_probe {
            http_get {
              path = "/healthz"
              port = 8222
            }
            initial_delay_seconds = 15
            period_seconds        = 20
            failure_threshold     = 3
          }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: infra/tofu/environments/onprem/main.tf
Line: 270-278

Comment:
**No liveness probe on SeaweedFS candidate container**

Same pattern as the NATS StatefulSet — only a readiness probe is present. A crashed master or a filer that has locked its journal but still responds to TCP will never be restarted. A liveness probe on the master HTTP port provides a low-cost safety net:

```hcl
          liveness_probe {
            http_get {
              path = "/cluster/status"
              port = 9333
            }
            initial_delay_seconds = 20
            period_seconds        = 20
            failure_threshold     = 3
          }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add tcfs onprem candidate workload..."](https://github.com/jesssullivan/tummycrypt/commit/955a9c71d29853624b1581588269be26079df90d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30179471)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->