### PR TITLE
[codex] render tcfs onprem cutover commands

### DIFF
--- a/docs/ops/tcfs-onprem-storage-migration.md
+++ b/docs/ops/tcfs-onprem-storage-migration.md
@@ -105,6 +105,9 @@ Source-owned command rendering now exists for the downtime copy lane:
 TCFS_CONTEXT=honey just onprem-migration-plan facts
 TCFS_CONTEXT=honey just onprem-migration-plan render-import-pods
 TCFS_CONTEXT=honey just onprem-migration-plan render-transfer-commands
+TCFS_CONTEXT=honey just onprem-migration-plan render-candidate-smoke-commands
+TCFS_CONTEXT=honey just onprem-migration-plan render-cutover-commands
+TCFS_CONTEXT=honey just onprem-migration-plan render-rollback-commands
 ```
 
 Those commands are render-only. They are meant to create reviewable evidence
@@ -112,6 +115,14 @@ for the maintenance window, not to authorize live mutation. The rendered
 transfer path streams from the source node-local PV path over SSH into a
 target-PVC import Pod, which avoids the unsafe single-Pod honey-to-bumble mount
 assumption.
+
+`render-candidate-smoke-commands` renders checks for the non-canonical
+candidate StatefulSets and candidate tailnet hostnames. `render-cutover-commands`
+renders the reviewed handoff shape: remove canonical annotations from the old
+kubectl-applied Services, review an OpenTofu plan that assigns canonical
+hostnames to the source-owned tailnet Services, then smoke the canonical
+hostnames. `render-rollback-commands` renders the reverse path while preserving
+old and target retained PVCs for comparison.
 
 Acceptable data movement shapes:
 
@@ -136,7 +147,8 @@ Use this order for the eventual live migration:
 8. Smoke candidate tailnet hostnames.
 9. Remove canonical Tailscale annotations from old Services through the chosen
    authority path.
-10. Assign canonical hostnames to source-owned Services.
+10. Assign canonical hostnames to source-owned Services through reviewed
+    OpenTofu plan/apply output.
 11. Run fleet smoke.
 12. Keep old retained PVs until rollback is explicitly declared unnecessary.
 

--- a/infra/tofu/environments/onprem/README.md
+++ b/infra/tofu/environments/onprem/README.md
@@ -45,6 +45,9 @@ Non-mutating downtime command render:
 TCFS_CONTEXT=honey just onprem-migration-plan facts
 TCFS_CONTEXT=honey just onprem-migration-plan render-import-pods
 TCFS_CONTEXT=honey just onprem-migration-plan render-transfer-commands
+TCFS_CONTEXT=honey just onprem-migration-plan render-candidate-smoke-commands
+TCFS_CONTEXT=honey just onprem-migration-plan render-cutover-commands
+TCFS_CONTEXT=honey just onprem-migration-plan render-rollback-commands
 ```
 
 Storage migration planning:
@@ -88,7 +91,9 @@ endpoints; that is safer than exposing the existing honey-local singleton pods.
 
 Do not switch the candidate hostnames to `nats-tcfs` or `seaweedfs-tcfs` until
 the live Service annotations have been removed through a source-controlled
-cutover plan.
+cutover plan. Use `render-cutover-commands` to review that sequence before the
+downtime window; the script only prints commands and does not mutate the
+cluster.
 
 ## Migration Gates
 

--- a/scripts/tcfs-onprem-migration-plan.sh
+++ b/scripts/tcfs-onprem-migration-plan.sh
@@ -11,24 +11,46 @@
 #   scripts/tcfs-onprem-migration-plan.sh facts
 #   scripts/tcfs-onprem-migration-plan.sh render-import-pods
 #   scripts/tcfs-onprem-migration-plan.sh render-transfer-commands
+#   scripts/tcfs-onprem-migration-plan.sh render-candidate-smoke-commands
+#   scripts/tcfs-onprem-migration-plan.sh render-cutover-commands
+#   scripts/tcfs-onprem-migration-plan.sh render-rollback-commands
 #
 set -euo pipefail
 
 NAMESPACE="${TCFS_NAMESPACE:-tcfs}"
 CONTEXT="${TCFS_CONTEXT:-}"
 KUBECTL_BIN="${TCFS_KUBECTL:-kubectl}"
+TOFU_BIN="${TCFS_TOFU:-tofu}"
+TOFU_DIR="${TCFS_TOFU_DIR:-infra/tofu/environments/onprem}"
 TARGET_NODE="${TCFS_TARGET_NODE:-bumble}"
 IMPORT_IMAGE="${TCFS_IMPORT_IMAGE:-docker.io/library/busybox:1.36}"
+TAILNET_DOMAIN="${TCFS_TAILNET_DOMAIN:-}"
 
 NATS_SOURCE_PVC="${TCFS_NATS_SOURCE_PVC:-data-nats-0}"
 NATS_TARGET_PVC="${TCFS_NATS_TARGET_PVC:-tcfs-nats-openebs-target}"
 NATS_IMPORT_POD="${TCFS_NATS_IMPORT_POD:-tcfs-nats-openebs-import}"
 NATS_TARGET_STORAGE_CLASS="${TCFS_NATS_TARGET_STORAGE_CLASS:-openebs-bumble-messaging-retain}"
+NATS_SOURCE_STATEFULSET="${TCFS_NATS_SOURCE_STATEFULSET:-nats}"
+NATS_SOURCE_SERVICE="${TCFS_NATS_SOURCE_SERVICE:-nats}"
+NATS_CANDIDATE_STATEFULSET="${TCFS_NATS_CANDIDATE_STATEFULSET:-nats-openebs-candidate}"
+NATS_CANDIDATE_SERVICE="${TCFS_NATS_CANDIDATE_SERVICE:-nats-openebs-candidate}"
+NATS_CANDIDATE_TAILNET_SERVICE="${TCFS_NATS_CANDIDATE_TAILNET_SERVICE:-nats-tailnet-candidate}"
+NATS_CANDIDATE_HOSTNAME="${TCFS_NATS_CANDIDATE_HOSTNAME:-nats-tcfs-candidate}"
+NATS_CANONICAL_HOSTNAME="${TCFS_NATS_CANONICAL_HOSTNAME:-nats-tcfs}"
 
 SEAWEEDFS_SOURCE_PVC="${TCFS_SEAWEEDFS_SOURCE_PVC:-data-seaweedfs-0}"
 SEAWEEDFS_TARGET_PVC="${TCFS_SEAWEEDFS_TARGET_PVC:-tcfs-seaweedfs-openebs-target}"
 SEAWEEDFS_IMPORT_POD="${TCFS_SEAWEEDFS_IMPORT_POD:-tcfs-seaweedfs-openebs-import}"
 SEAWEEDFS_TARGET_STORAGE_CLASS="${TCFS_SEAWEEDFS_TARGET_STORAGE_CLASS:-openebs-bumble-s3-retain}"
+SEAWEEDFS_SOURCE_STATEFULSET="${TCFS_SEAWEEDFS_SOURCE_STATEFULSET:-seaweedfs}"
+SEAWEEDFS_SOURCE_SERVICE="${TCFS_SEAWEEDFS_SOURCE_SERVICE:-seaweedfs}"
+SEAWEEDFS_CANDIDATE_STATEFULSET="${TCFS_SEAWEEDFS_CANDIDATE_STATEFULSET:-seaweedfs-openebs-candidate}"
+SEAWEEDFS_CANDIDATE_SERVICE="${TCFS_SEAWEEDFS_CANDIDATE_SERVICE:-seaweedfs-openebs-candidate}"
+SEAWEEDFS_CANDIDATE_TAILNET_SERVICE="${TCFS_SEAWEEDFS_CANDIDATE_TAILNET_SERVICE:-seaweedfs-tailnet-candidate}"
+SEAWEEDFS_CANDIDATE_HOSTNAME="${TCFS_SEAWEEDFS_CANDIDATE_HOSTNAME:-seaweedfs-tcfs-candidate}"
+SEAWEEDFS_CANONICAL_HOSTNAME="${TCFS_SEAWEEDFS_CANONICAL_HOSTNAME:-seaweedfs-tcfs}"
+
+BACKEND_WORKER_DEPLOYMENT="${TCFS_BACKEND_WORKER_DEPLOYMENT:-tcfs-backend-tcfs-backend-worker}"
 
 KUBECTL=("${KUBECTL_BIN}")
 if [[ -n "${CONTEXT}" ]]; then
@@ -41,9 +63,13 @@ Usage:
   tcfs-onprem-migration-plan.sh facts
   tcfs-onprem-migration-plan.sh render-import-pods
   tcfs-onprem-migration-plan.sh render-transfer-commands
+  tcfs-onprem-migration-plan.sh render-candidate-smoke-commands
+  tcfs-onprem-migration-plan.sh render-cutover-commands
+  tcfs-onprem-migration-plan.sh render-rollback-commands
 
 This script renders migration evidence and commands only. It does not mutate
-Kubernetes, scale workloads, create PVCs, create Pods, or copy data.
+Kubernetes, scale workloads, create PVCs, create Pods, copy data, or change
+tailnet hostnames.
 EOF
 }
 
@@ -65,6 +91,28 @@ kubectl_command() {
     printf '%s' "$(shell_quote "${KUBECTL_BIN}")"
     if [[ -n "${CONTEXT}" ]]; then
         printf ' --context %s' "$(shell_quote "${CONTEXT}")"
+    fi
+}
+
+tofu_command() {
+    printf '%s -chdir=%s' "$(shell_quote "${TOFU_BIN}")" "$(shell_quote "${TOFU_DIR}")"
+}
+
+tofu_var_arg() {
+    shell_quote "-var=$1"
+}
+
+resource_arg() {
+    shell_quote "$1/$2"
+}
+
+tailnet_host() {
+    local hostname="$1"
+
+    if [[ -n "${TAILNET_DOMAIN}" ]]; then
+        printf '%s.%s' "${hostname}" "${TAILNET_DOMAIN}"
+    else
+        printf '%s' "${hostname}"
     fi
 }
 
@@ -248,6 +296,65 @@ EOF
     transfer_command seaweedfs "${SEAWEEDFS_SOURCE_PVC}" "${SEAWEEDFS_IMPORT_POD}"
 }
 
+render_candidate_smoke_commands() {
+    cat <<EOF
+# Non-mutating render only. Run only after target PVCs, copied data, and
+# candidate workloads/tailnet Services have been applied during an approved
+# downtime window.
+
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") rollout status $(shell_quote "statefulset/${NATS_CANDIDATE_STATEFULSET}") --timeout=180s
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") rollout status $(shell_quote "statefulset/${SEAWEEDFS_CANDIDATE_STATEFULSET}") --timeout=180s
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") get endpoints $(shell_quote "${NATS_CANDIDATE_SERVICE}") $(shell_quote "${SEAWEEDFS_CANDIDATE_SERVICE}") -o wide
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") get service $(shell_quote "${NATS_CANDIDATE_TAILNET_SERVICE}") $(shell_quote "${SEAWEEDFS_CANDIDATE_TAILNET_SERVICE}") -o wide
+
+curl -fsS $(shell_quote "http://$(tailnet_host "${NATS_CANDIDATE_HOSTNAME}"):8222/healthz")
+curl -fsS $(shell_quote "http://$(tailnet_host "${SEAWEEDFS_CANDIDATE_HOSTNAME}"):9333/cluster/status")
+EOF
+}
+
+render_cutover_commands() {
+    cat <<EOF
+# Mutating commands for the approved downtime window only. Run these after
+# candidate workload and candidate tailnet smoke pass. The OpenTofu plan must
+# be reviewed before the apply line is run.
+
+# Remove canonical Tailscale ownership from the old kubectl-applied Services.
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") annotate $(resource_arg service "${NATS_SOURCE_SERVICE}") $(shell_quote "tailscale.com/expose-") $(shell_quote "tailscale.com/hostname-") $(shell_quote "tailscale.com/proxy-class-") --overwrite
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") annotate $(resource_arg service "${SEAWEEDFS_SOURCE_SERVICE}") $(shell_quote "tailscale.com/expose-") $(shell_quote "tailscale.com/hostname-") $(shell_quote "tailscale.com/proxy-class-") --overwrite
+
+# Assign canonical hostnames to the source-owned tailnet Services.
+$(tofu_command) plan $(tofu_var_arg "enable_stateful_migration_target_pvcs=true") $(tofu_var_arg "enable_stateful_migration_candidate_workloads=true") $(tofu_var_arg "enable_tailnet_candidate_services=true") $(tofu_var_arg "nats_tailnet_candidate_hostname=${NATS_CANONICAL_HOSTNAME}") $(tofu_var_arg "seaweedfs_tailnet_candidate_hostname=${SEAWEEDFS_CANONICAL_HOSTNAME}")
+$(tofu_command) apply $(tofu_var_arg "enable_stateful_migration_target_pvcs=true") $(tofu_var_arg "enable_stateful_migration_candidate_workloads=true") $(tofu_var_arg "enable_tailnet_candidate_services=true") $(tofu_var_arg "nats_tailnet_candidate_hostname=${NATS_CANONICAL_HOSTNAME}") $(tofu_var_arg "seaweedfs_tailnet_candidate_hostname=${SEAWEEDFS_CANONICAL_HOSTNAME}")
+
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") get service $(shell_quote "${NATS_CANDIDATE_TAILNET_SERVICE}") $(shell_quote "${SEAWEEDFS_CANDIDATE_TAILNET_SERVICE}") -o jsonpath=$(shell_quote "{range .items[*]}{.metadata.name}{\"\\t\"}{.metadata.annotations.tailscale\\.com/hostname}{\"\\t\"}{.metadata.annotations.tailscale\\.com/proxy-class}{\"\\n\"}{end}")
+curl -fsS $(shell_quote "http://$(tailnet_host "${NATS_CANONICAL_HOSTNAME}"):8222/healthz")
+curl -fsS $(shell_quote "http://$(tailnet_host "${SEAWEEDFS_CANONICAL_HOSTNAME}"):9333/cluster/status")
+EOF
+}
+
+render_rollback_commands() {
+    cat <<EOF
+# Mutating rollback commands for the approved downtime window only. Use before
+# deleting any old PVC/PV. Review which phase failed before running all lines.
+
+# Stop source-owned candidates and remove their tailnet Services while keeping
+# retained target PVCs for forensic comparison.
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") scale $(resource_arg statefulset "${NATS_CANDIDATE_STATEFULSET}") $(resource_arg statefulset "${SEAWEEDFS_CANDIDATE_STATEFULSET}") --replicas=0
+$(tofu_command) apply $(tofu_var_arg "enable_stateful_migration_target_pvcs=true") $(tofu_var_arg "enable_stateful_migration_candidate_workloads=false") $(tofu_var_arg "enable_tailnet_candidate_services=false")
+
+# Restore old canonical annotations if cutover already removed them.
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") annotate $(resource_arg service "${NATS_SOURCE_SERVICE}") $(shell_quote "tailscale.com/expose=true") $(shell_quote "tailscale.com/hostname=${NATS_CANONICAL_HOSTNAME}") $(shell_quote "tailscale.com/proxy-class-") --overwrite
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") annotate $(resource_arg service "${SEAWEEDFS_SOURCE_SERVICE}") $(shell_quote "tailscale.com/expose=true") $(shell_quote "tailscale.com/hostname=${SEAWEEDFS_CANONICAL_HOSTNAME}") $(shell_quote "tailscale.com/proxy-class-") --overwrite
+
+# Restart old honey-local stateful workloads and TCFS writers.
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") scale $(resource_arg statefulset "${NATS_SOURCE_STATEFULSET}") $(resource_arg statefulset "${SEAWEEDFS_SOURCE_STATEFULSET}") --replicas=1
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") rollout status $(resource_arg statefulset "${NATS_SOURCE_STATEFULSET}") --timeout=180s
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") rollout status $(resource_arg statefulset "${SEAWEEDFS_SOURCE_STATEFULSET}") --timeout=180s
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") scale $(resource_arg deployment "${BACKEND_WORKER_DEPLOYMENT}") --replicas=1
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") rollout status $(resource_arg deployment "${BACKEND_WORKER_DEPLOYMENT}") --timeout=180s
+EOF
+}
+
 main() {
     local command="${1:-}"
 
@@ -262,6 +369,15 @@ main() {
         render-transfer-commands)
             require_command
             render_transfer_commands
+            ;;
+        render-candidate-smoke-commands)
+            render_candidate_smoke_commands
+            ;;
+        render-cutover-commands)
+            render_cutover_commands
+            ;;
+        render-rollback-commands)
+            render_rollback_commands
             ;;
         -h|--help|help)
             usage

--- a/scripts/test-tcfs-onprem-migration-plan.sh
+++ b/scripts/test-tcfs-onprem-migration-plan.sh
@@ -95,6 +95,26 @@ assert_contains "${COMMANDS_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -
 assert_contains "${COMMANDS_OUT}" "# Transfer nats from honey:/opt/local-path-provisioner/nats data into pod/tcfs-nats-openebs-import:/target"
 assert_contains "${COMMANDS_OUT}" "ssh 'root@honey' 'tar -C '\\''/opt/local-path-provisioner/nats data'\\'' -cpf - .' | '${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' exec -i 'tcfs-nats-openebs-import' -- tar -C /target -xpf -"
 
+SMOKE_OUT="${TMPDIR}/candidate-smoke.out"
+TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" TCFS_TAILNET_DOMAIN="tail.example" bash "${SCRIPT}" render-candidate-smoke-commands >"${SMOKE_OUT}"
+assert_contains "${SMOKE_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' rollout status 'statefulset/nats-openebs-candidate' --timeout=180s"
+assert_contains "${SMOKE_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' get service 'nats-tailnet-candidate' 'seaweedfs-tailnet-candidate' -o wide"
+assert_contains "${SMOKE_OUT}" "curl -fsS 'http://nats-tcfs-candidate.tail.example:8222/healthz'"
+assert_contains "${SMOKE_OUT}" "curl -fsS 'http://seaweedfs-tcfs-candidate.tail.example:9333/cluster/status'"
+
+CUTOVER_OUT="${TMPDIR}/cutover.out"
+TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" TCFS_TOFU="/opt/tofu bin/tofu" bash "${SCRIPT}" render-cutover-commands >"${CUTOVER_OUT}"
+assert_contains "${CUTOVER_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' annotate 'service/nats' 'tailscale.com/expose-' 'tailscale.com/hostname-' 'tailscale.com/proxy-class-' --overwrite"
+assert_contains "${CUTOVER_OUT}" "'/opt/tofu bin/tofu' -chdir='infra/tofu/environments/onprem' plan '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=true' '-var=enable_tailnet_candidate_services=true' '-var=nats_tailnet_candidate_hostname=nats-tcfs' '-var=seaweedfs_tailnet_candidate_hostname=seaweedfs-tcfs'"
+assert_contains "${CUTOVER_OUT}" "curl -fsS 'http://nats-tcfs:8222/healthz'"
+
+ROLLBACK_OUT="${TMPDIR}/rollback.out"
+TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" bash "${SCRIPT}" render-rollback-commands >"${ROLLBACK_OUT}"
+assert_contains "${ROLLBACK_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' scale 'statefulset/nats-openebs-candidate' 'statefulset/seaweedfs-openebs-candidate' --replicas=0"
+assert_contains "${ROLLBACK_OUT}" "'tofu' -chdir='infra/tofu/environments/onprem' apply '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=false' '-var=enable_tailnet_candidate_services=false'"
+assert_contains "${ROLLBACK_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' annotate 'service/nats' 'tailscale.com/expose=true' 'tailscale.com/hostname=nats-tcfs' 'tailscale.com/proxy-class-' --overwrite"
+assert_contains "${ROLLBACK_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' scale 'deployment/tcfs-backend-tcfs-backend-worker' --replicas=1"
+
 if FAKE_BAD_TARGET_CLASS=1 TCFS_KUBECTL="${FAKE_KUBECTL}" bash "${SCRIPT}" facts >"${TMPDIR}/bad.out" 2>"${TMPDIR}/bad.err"; then
     printf 'expected mismatched target class to fail\n' >&2
     exit 1


### PR DESCRIPTION
## Summary

Adds source-only TCFS on-prem migration renderers for the post-copy phase:

- candidate workload and candidate tailnet smoke commands
- canonical tailnet cutover commands through reviewed OpenTofu plan/apply output
- rollback commands that preserve both old and target retained PVCs

This keeps the upcoming downtime window out of terminal folklore. The script still only prints commands; it does not mutate Kubernetes, OpenTofu state, data, or tailnet hostnames.

## Validation

- `bash -n scripts/tcfs-onprem-migration-plan.sh scripts/test-tcfs-onprem-migration-plan.sh`
- `just onprem-migration-plan-test`
- `just onprem-tofu-candidate-test`
- `just onprem-tofu-validate`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `tcfs-onprem-migration-plan.sh` with three new render-only subcommands (`render-candidate-smoke-commands`, `render-cutover-commands`, `render-rollback-commands`) that print the post-copy phase of the TCFS on-prem storage migration, along with corresponding documentation and test updates.

- **`render_cutover_commands` renders `tofu plan` + `tofu apply` with identical `-var` flags but no `-out=<planfile>` handoff**, meaning `apply` recomputes the plan at runtime; any state change between the two commands could silently execute different changes than those reviewed — this directly undermines the PR's own requirement that \"the OpenTofu plan must be reviewed before the apply line is run.\"
- The rollback `tofu apply` is rendered without a preceding `tofu plan`, making it the only path in the script where an infrastructure apply is issued without an operator review step.
- The rollback annotation restores `tailscale.com/expose` and `tailscale.com/hostname` but issues `tailscale.com/proxy-class-` (removal), which may leave the old source Services without a Tailscale proxy class if one was originally set.

<h3>Confidence Score: 3/5</h3>

Hold for the tofu plan/apply TOCTOU gap — the reviewed plan is not the one that gets applied.

One P1 finding (plan output not saved and re-used on apply, breaking the review guarantee) pulls the score below the P1 ceiling of 4; two P2 findings (missing plan step in rollback, incomplete proxy-class restoration) add further concern for a safety-critical migration script used during a downtime window.

scripts/tcfs-onprem-migration-plan.sh — render_cutover_commands and render_rollback_commands functions

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/tcfs-onprem-migration-plan.sh | Adds three new render functions (candidate smoke, cutover, rollback); cutover renders plan+apply without plan-file output, so the reviewed plan is not guaranteed to be the one executed. |
| scripts/test-tcfs-onprem-migration-plan.sh | Tests for the three new render commands; coverage looks correct for rendered output matching expected quoting/flags. |
| docs/ops/tcfs-onprem-storage-migration.md | Documentation updated to list the three new render subcommands and expand step 10 to mention reviewed OpenTofu plan/apply output. |
| infra/tofu/environments/onprem/README.md | README updated with the new render subcommands and clarification that render-cutover-commands is non-mutating to the script itself. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[render-candidate-smoke-commands] --> B{Smoke passes?}
    B -- yes --> C[render-cutover-commands]
    B -- no --> R[render-rollback-commands]

    C --> C1["kubectl annotate source Services\n(remove expose/hostname/proxy-class)"]
    C1 --> C2["tofu plan -var=...canonical_hostnames\n(operator reviews output)"]
    C2 --> C3["tofu apply -var=...canonical_hostnames\n⚠️ recomputes plan — no -out file"]
    C3 --> C4["kubectl get service -o jsonpath\n(verify annotations)"]
    C4 --> C5["curl canonical hostname smoke"]
    C5 --> D{Canonical smoke passes?}
    D -- yes --> E[Migration complete]
    D -- no --> R

    R --> R1["kubectl scale candidates --replicas=0"]
    R1 --> R2["tofu apply disable candidates/tailnet\n⚠️ no plan step"]
    R2 --> R3["kubectl annotate source Services\n(restore expose+hostname; proxy-class removed)"]
    R3 --> R4["kubectl scale source StatefulSets --replicas=1"]
    R4 --> R5["kubectl scale backend worker --replicas=1"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/tcfs-onprem-migration-plan.sh
Line: 326-327

Comment:
**`tofu plan` output not used by `tofu apply`**

`tofu plan` and `tofu apply` are rendered as independent commands with the same `-var` flags, but without `-out=<planfile>` + `apply <planfile>`. If any state changes between the operator running the `plan` line and the `apply` line (e.g., another process modifies the tailnet Services, or a Kubernetes reconciler fires), `apply` will silently recompute a new plan that may differ from the one that was reviewed. The PR's own stated requirement is "The OpenTofu plan must be reviewed before the apply line is run," which this workflow cannot fully guarantee.

The safe pattern saves the plan to a file and then applies exactly that artifact:

```bash
# Assign canonical hostnames to the source-owned tailnet Services.
$(tofu_command) plan -out=$(shell_quote "tofu-cutover.tfplan") $(tofu_var_arg "enable_stateful_migration_target_pvcs=true") ...
$(tofu_command) show $(shell_quote "tofu-cutover.tfplan")
$(tofu_command) apply $(shell_quote "tofu-cutover.tfplan")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/tcfs-onprem-migration-plan.sh
Line: 343

Comment:
**Rollback `tofu apply` rendered without a preceding `plan` step**

Unlike `render_cutover_commands`, the rollback path goes straight to `tofu apply` without first rendering a `tofu plan` for operator review. During an active incident, running an unreviewed apply against the live cluster is the highest-risk moment. At minimum, a `tofu plan` line (or `plan -out=` + `apply`) should precede the `apply` for consistency and safety.

```bash
$(tofu_command) plan '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=false' '-var=enable_tailnet_candidate_services=false'
$(tofu_command) apply '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=false' '-var=enable_tailnet_candidate_services=false'
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/tcfs-onprem-migration-plan.sh
Line: 346-347

Comment:
**Rollback removes `proxy-class` annotation rather than restoring it**

The cutover step removes `tailscale.com/proxy-class` (using the `kubectl annotate key-` removal idiom) from the old source Services. The rollback step also issues `tailscale.com/proxy-class-`, which removes the annotation rather than restoring it to its pre-cutover value. If the original kubectl-applied Services relied on a specific `proxy-class` value for Tailscale's operator to handle them, the rollback will leave the annotation absent, potentially leaving the old services without a functioning Tailscale proxy after rollback.

Consider whether the original source Services had `proxy-class` set, and if so, add the correct value to the rollback annotation lines (e.g., `tailscale.com/proxy-class=default`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: render tcfs onprem cutover command..."](https://github.com/jesssullivan/tummycrypt/commit/787f6e05afab849a5d20f6b8fbf8a714eaefa08d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30184094)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->