### PR TITLE
[codex] align tcfs preflight with opentofu path

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -38,6 +38,10 @@ k8s-status ns="tcfs":
 onprem-preflight:
     bash scripts/tcfs-onprem-preflight.sh
 
+# Regression test the read-only on-prem authority/mobility check
+onprem-preflight-test:
+    bash scripts/test-tcfs-onprem-preflight.sh
+
 # Read-only on-prem data inventory for NATS and SeaweedFS migration planning
 onprem-data-inventory:
     bash scripts/tcfs-onprem-data-inventory.sh

--- a/docs/ops/onprem-authority-recovery.md
+++ b/docs/ops/onprem-authority-recovery.md
@@ -59,9 +59,11 @@ Treat the direct `tcfs-backend` Helm chart as a recovery authority for the
 backend worker objects only. Do not use it as evidence that the whole live
 namespace is Helm-owned.
 
-The durable on-prem path should be OpenTofu migration, not blind Helm adoption,
-unless a future review proves that adopting the manual NATS and SeaweedFS
-objects into Helm is lower risk than replacing them deliberately.
+The durable on-prem path is OpenTofu migration, not blind Helm adoption. The
+current source-owned on-prem environment records retained target PVCs,
+non-canonical candidate workloads, candidate tailnet Services, and render-only
+cutover/rollback commands. Do not switch canonical tailnet hostnames or move
+data outside an approved downtime window.
 
 Reasons:
 
@@ -77,8 +79,8 @@ Reasons:
 Minimum migration gates:
 
 1. capture live NATS JetStream and SeaweedFS data inventory;
-2. choose target storage classes for NATS and SeaweedFS instead of inheriting
-   `local-path`;
+2. use the retained target storage classes for NATS and SeaweedFS instead of
+   inheriting `local-path`;
 3. render or apply retained target PVCs and non-canonical candidate workloads
    only through `infra/tofu/environments/onprem`;
 4. smoke candidate Tailscale Services with selectors that do not point at the
@@ -163,8 +165,8 @@ kubectl rollout status deployment/tcfs-backend-tcfs-backend-worker -n tcfs
 ```
 
 This is a repair path, not a complete Helm adoption. After the worker is
-healthy, follow up by either adopting the existing objects into Helm release
-state or deliberately migrating to the OpenTofu object-name family.
+healthy, follow the downtime-gated OpenTofu migration path for NATS,
+SeaweedFS, and canonical tailnet ownership.
 
 ## Validate Recovery
 

--- a/scripts/tcfs-onprem-preflight.sh
+++ b/scripts/tcfs-onprem-preflight.sh
@@ -3,7 +3,7 @@
 # tcfs-onprem-preflight.sh — read-only authority and mobility check for tcfs
 #
 # This script intentionally does not mutate Kubernetes. It summarizes the live
-# facts needed before choosing between Helm adoption and OpenTofu migration.
+# facts needed before executing the downtime-gated OpenTofu migration.
 #
 # Usage:
 #   scripts/tcfs-onprem-preflight.sh
@@ -116,4 +116,5 @@ if [[ -z "${nats_proxy_class}" || -z "${seaweed_proxy_class}" ]]; then
 fi
 
 warn "Do not treat ProxyClass-only movement as a durable fix."
-warn "Choose Helm adoption or OpenTofu migration before changing live authority."
+warn "Use the source-owned OpenTofu migration path before changing live authority."
+warn "Run storage/data movement and canonical hostname cutover only during an approved downtime window."

--- a/scripts/test-tcfs-onprem-preflight.sh
+++ b/scripts/test-tcfs-onprem-preflight.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Regression tests for tcfs-onprem-preflight.sh.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/tcfs-onprem-preflight.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+cat >"${TMPDIR}/helm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--kube-context" ]]; then
+    shift 2
+fi
+
+if [[ "${1:-}" == "list" ]]; then
+    printf 'NAME\tNAMESPACE\tREVISION\tUPDATED\tSTATUS\tCHART\tAPP VERSION\n'
+    exit 0
+fi
+
+exit 1
+EOF
+chmod +x "${TMPDIR}/helm"
+
+cat >"${TMPDIR}/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+    shift 2
+fi
+
+if [[ "${1:-}" == "-n" ]]; then
+    shift 2
+fi
+
+if [[ "${1:-}" == "config" ]]; then
+    printf 'honey\n'
+    exit 0
+fi
+
+[[ "${1:-}" == "get" ]] || exit 1
+resource="${2:-}"
+shift 2
+
+output=""
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        -o)
+            output="$2"
+            shift 2
+            ;;
+        --ignore-not-found|--no-headers)
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+case "${resource}:${output}" in
+    "svc/nats:jsonpath={.metadata.annotations.tailscale\\.com/expose}") printf 'true' ;;
+    "svc/nats:jsonpath={.metadata.annotations.tailscale\\.com/hostname}") printf 'nats-tcfs' ;;
+    "svc/nats:jsonpath={.metadata.annotations.tailscale\\.com/proxy-class}") ;;
+    "svc/seaweedfs:jsonpath={.metadata.annotations.tailscale\\.com/expose}") printf 'true' ;;
+    "svc/seaweedfs:jsonpath={.metadata.annotations.tailscale\\.com/hostname}") printf 'seaweedfs-tcfs' ;;
+    "svc/seaweedfs:jsonpath={.metadata.annotations.tailscale\\.com/proxy-class}") ;;
+    "pvc/data-nats-0:jsonpath={.spec.storageClassName}") printf 'local-path' ;;
+    "pvc/data-nats-0:jsonpath={.spec.volumeName}") printf 'pv-nats' ;;
+    "pvc/data-seaweedfs-0:jsonpath={.spec.storageClassName}") printf 'local-path' ;;
+    "pvc/data-seaweedfs-0:jsonpath={.spec.volumeName}") printf 'pv-seaweedfs' ;;
+    pv/*:*) printf '%s   Retain   honey   /opt/local-path-provisioner/%s\n' "${resource#pv/}" "${resource#pv/}" ;;
+    pod|deploy) ;;
+    *) ;;
+esac
+EOF
+chmod +x "${TMPDIR}/kubectl"
+
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+
+    if ! grep -Fq "${expected}" "${file}"; then
+        printf 'expected to find %s in %s\n' "${expected}" "${file}" >&2
+        printf '--- output ---\n' >&2
+        cat "${file}" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local file="$1"
+    local unexpected="$2"
+
+    if grep -Fq "${unexpected}" "${file}"; then
+        printf 'did not expect to find %s in %s\n' "${unexpected}" "${file}" >&2
+        printf '--- output ---\n' >&2
+        cat "${file}" >&2
+        exit 1
+    fi
+}
+
+OUT="${TMPDIR}/preflight.out"
+PATH="${TMPDIR}:${PATH}" TCFS_CONTEXT=honey bash "${SCRIPT}" >"${OUT}"
+
+assert_contains "${OUT}" '[WARN] NATS/SeaweedFS tailnet exposure is missing proxy-class ownership.'
+assert_contains "${OUT}" '[WARN] Use the source-owned OpenTofu migration path before changing live authority.'
+assert_contains "${OUT}" '[WARN] Run storage/data movement and canonical hostname cutover only during an approved downtime window.'
+assert_not_contains "${OUT}" 'Choose Helm adoption or OpenTofu migration before changing live authority.'
+
+printf 'tcfs-onprem-preflight tests passed\n'


### PR DESCRIPTION
## Summary

Updates the TCFS on-prem preflight and authority runbook now that the authority decision has moved to the OpenTofu migration path.

- Replaces the stale "choose Helm adoption or OpenTofu migration" preflight warning.
- Points operators at the source-owned OpenTofu migration path and approved downtime window.
- Aligns `docs/ops/onprem-authority-recovery.md` with the selected migration path.
- Adds a regression test with fake `kubectl`/`helm` output so the stale warning does not return.
- Adds `just onprem-preflight-test`.

## Validation

- `bash -n scripts/tcfs-onprem-preflight.sh scripts/test-tcfs-onprem-preflight.sh`
- `just onprem-preflight-test`
- `just onprem-migration-plan-test`
- `just onprem-tofu-candidate-test`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the TCFS on-prem preflight script and associated documentation with the settled decision to use the OpenTofu migration path, replacing the stale "choose Helm adoption or OpenTofu migration" framing. A new regression test with fake `kubectl`/`helm` stubs validates the updated warning text and a `just onprem-preflight-test` recipe wires it in.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only a minor style concern in the test script.

All changes are documentation, warning-text updates, and a new read-only regression test. Logic in the fake kubectl/helm stubs correctly covers all code paths exercised by the preflight script. The only finding is a P2 style issue (TMPDIR shadowing in the test script).

scripts/test-tcfs-onprem-preflight.sh — TMPDIR variable name should be renamed to avoid shadowing the standard env var.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/test-tcfs-onprem-preflight.sh | New regression test with fake kubectl/helm stubs; correct argument parsing logic and assertion coverage, minor TMPDIR shadowing concern. |
| scripts/tcfs-onprem-preflight.sh | Two warning lines updated to reflect the settled OpenTofu migration path; no logic changes. |
| docs/ops/onprem-authority-recovery.md | Documentation updated to replace the conditional "choose Helm or OpenTofu" framing with the settled OpenTofu migration path and downtime-window constraint. |
| Justfile | Adds `onprem-preflight-test` recipe wiring the new regression test; straightforward addition. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[just onprem-preflight-test] --> B[test-tcfs-onprem-preflight.sh]
    B --> C[Create fake kubectl + helm in TMPDIR]
    C --> D[Prepend TMPDIR to PATH]
    D --> E[bash tcfs-onprem-preflight.sh]
    E --> F{Helm release found?}
    F -- No --> G[WARN: No tcfs-backend release]
    F -- Yes --> H[Check proxy-class]
    G --> H
    H --> I{proxy-class missing?}
    I -- Yes --> J[WARN: missing proxy-class ownership]
    I -- No --> K[Emit OpenTofu migration warnings]
    J --> K
    K --> L[assert_contains new warnings]
    L --> M[assert_not_contains stale warning]
    M --> N[Tests passed]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/test-tcfs-onprem-preflight.sh
Line: 10

Comment:
**`TMPDIR` shadows a standard environment variable**

`TMPDIR` is a POSIX-standard env var that many programs (including `mktemp` itself) consult to locate the system temp directory. Assigning to it here overwrites the inherited value for all subprocesses spawned by this test — including the script under test and any tools it invokes. If a future change to the preflight script (or one of its real subprocesses) calls `mktemp`, it will land in the test-owned directory and be deleted by the `trap`, potentially causing hard-to-diagnose failures.

Use a local, non-standard name instead:

```suggestion
_TEST_TMPDIR="$(mktemp -d)"
```

And update the trap and all subsequent uses of `${TMPDIR}` to `${_TEST_TMPDIR}`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: align tcfs authority recovery path"](https://github.com/jesssullivan/tummycrypt/commit/4a3eee972f4e224f63ca71bc96db613fb7b486c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30188008)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->