### PR TITLE
[codex] render tcfs onprem apply phases

### DIFF
--- a/docs/ops/tcfs-onprem-storage-migration.md
+++ b/docs/ops/tcfs-onprem-storage-migration.md
@@ -82,12 +82,14 @@ Before copying state:
    `enable_stateful_migration_target_pvcs=true`.
 5. Confirm rollback path uses the old StatefulSets and old retained PVCs.
 
-## Recommended Source-Owned Implementation
+## Source-Owned Implementation
 
-The next implementation PR should add migration manifests or OpenTofu resources
-that can be planned and reviewed before live use.
+The source-owned migration lane is now modeled in
+`infra/tofu/environments/onprem` and exposed through render-only operator
+commands. The default OpenTofu environment remains inert until the migration
+variables are explicitly enabled.
 
-Minimum source-owned resources:
+Current source-owned resources:
 
 - target retained PVC for NATS on `openebs-bumble-messaging-retain`
   (`tcfs-nats-openebs-target`)
@@ -103,8 +105,10 @@ Source-owned command rendering now exists for the downtime copy lane:
 
 ```bash
 TCFS_CONTEXT=honey just onprem-migration-plan facts
+TCFS_CONTEXT=honey just onprem-migration-plan render-target-pvc-commands
 TCFS_CONTEXT=honey just onprem-migration-plan render-import-pods
 TCFS_CONTEXT=honey just onprem-migration-plan render-transfer-commands
+TCFS_CONTEXT=honey just onprem-migration-plan render-candidate-apply-commands
 TCFS_CONTEXT=honey just onprem-migration-plan render-candidate-smoke-commands
 TCFS_CONTEXT=honey just onprem-migration-plan render-cutover-commands
 TCFS_CONTEXT=honey just onprem-migration-plan render-rollback-commands
@@ -116,13 +120,16 @@ transfer path streams from the source node-local PV path over SSH into a
 target-PVC import Pod, which avoids the unsafe single-Pod honey-to-bumble mount
 assumption.
 
-`render-candidate-smoke-commands` renders checks for the non-canonical
-candidate StatefulSets and candidate tailnet hostnames. `render-cutover-commands`
-renders the reviewed handoff shape: remove canonical annotations from the old
-kubectl-applied Services, review an OpenTofu plan that assigns canonical
-hostnames to the source-owned tailnet Services, then smoke the canonical
-hostnames. `render-rollback-commands` renders the reverse path while preserving
-old and target retained PVCs for comparison.
+`render-target-pvc-commands` renders the reviewed OpenTofu plan/apply pair for
+creating retained target PVCs only. `render-candidate-apply-commands` renders
+the reviewed OpenTofu plan/apply pair for non-canonical candidate workloads and
+candidate tailnet Services. `render-candidate-smoke-commands` renders checks for
+the non-canonical candidate StatefulSets and candidate tailnet hostnames.
+`render-cutover-commands` renders the reviewed handoff shape: remove canonical
+annotations from the old kubectl-applied Services, review an OpenTofu plan that
+assigns canonical hostnames to the source-owned tailnet Services, then smoke the
+canonical hostnames. `render-rollback-commands` renders the reverse path while
+preserving old and target retained PVCs for comparison.
 
 Acceptable data movement shapes:
 
@@ -133,24 +140,26 @@ Acceptable data movement shapes:
 - operator-mediated tar transfer only if the inventory remains small and the
   transfer transcript is kept with the migration evidence.
 
-## Cutover Order
+## Execution Order
 
 Use this order for the eventual live migration:
 
 1. Run preflight and data inventory.
 2. Quiesce writers.
-3. Create target retained PVCs.
-4. Copy or import data to target PVCs.
-5. Start replacement NATS and SeaweedFS workloads against target PVCs.
-6. Run internal cluster smoke against replacement Services.
-7. Enable candidate tailnet Services with `honey-sting-tailnet`.
-8. Smoke candidate tailnet hostnames.
-9. Remove canonical Tailscale annotations from old Services through the chosen
-   authority path.
-10. Assign canonical hostnames to source-owned Services through reviewed
-    OpenTofu plan/apply output.
-11. Run fleet smoke.
-12. Keep old retained PVs until rollback is explicitly declared unnecessary.
+3. Create target retained PVCs with `render-target-pvc-commands`.
+4. Render and apply import Pods with `render-import-pods`.
+5. Stop the worker and source StatefulSets, then copy/import data with
+   `render-transfer-commands`.
+6. Start replacement NATS and SeaweedFS workloads plus non-canonical candidate
+   tailnet Services with `render-candidate-apply-commands`.
+7. Smoke candidate Services and candidate tailnet hostnames with
+   `render-candidate-smoke-commands`.
+8. Remove canonical Tailscale annotations from old Services through the chosen
+   authority path in `render-cutover-commands`.
+9. Assign canonical hostnames to source-owned Services through reviewed
+    OpenTofu plan/apply output from `render-cutover-commands`.
+10. Run fleet smoke.
+11. Keep old retained PVs until rollback is explicitly declared unnecessary.
 
 ## Rollback
 

--- a/infra/tofu/environments/onprem/README.md
+++ b/infra/tofu/environments/onprem/README.md
@@ -43,8 +43,10 @@ Non-mutating downtime command render:
 
 ```bash
 TCFS_CONTEXT=honey just onprem-migration-plan facts
+TCFS_CONTEXT=honey just onprem-migration-plan render-target-pvc-commands
 TCFS_CONTEXT=honey just onprem-migration-plan render-import-pods
 TCFS_CONTEXT=honey just onprem-migration-plan render-transfer-commands
+TCFS_CONTEXT=honey just onprem-migration-plan render-candidate-apply-commands
 TCFS_CONTEXT=honey just onprem-migration-plan render-candidate-smoke-commands
 TCFS_CONTEXT=honey just onprem-migration-plan render-cutover-commands
 TCFS_CONTEXT=honey just onprem-migration-plan render-rollback-commands
@@ -63,6 +65,13 @@ tofu plan \
   -var='enable_stateful_migration_target_pvcs=true'
 ```
 
+For the approved downtime window, prefer rendering the reviewed plan/apply
+pair:
+
+```bash
+TCFS_CONTEXT=honey just onprem-migration-plan render-target-pvc-commands
+```
+
 Plan retained PVCs plus non-canonical candidate workloads and candidate tailnet
 Services:
 
@@ -71,6 +80,13 @@ tofu plan \
   -var='enable_stateful_migration_target_pvcs=true' \
   -var='enable_stateful_migration_candidate_workloads=true' \
   -var='enable_tailnet_candidate_services=true'
+```
+
+For the approved downtime window, prefer rendering the reviewed candidate
+plan/apply pair:
+
+```bash
+TCFS_CONTEXT=honey just onprem-migration-plan render-candidate-apply-commands
 ```
 
 ## Candidate Tailnet Smoke

--- a/scripts/tcfs-onprem-migration-plan.sh
+++ b/scripts/tcfs-onprem-migration-plan.sh
@@ -9,8 +9,10 @@
 #
 # Usage:
 #   scripts/tcfs-onprem-migration-plan.sh facts
+#   scripts/tcfs-onprem-migration-plan.sh render-target-pvc-commands
 #   scripts/tcfs-onprem-migration-plan.sh render-import-pods
 #   scripts/tcfs-onprem-migration-plan.sh render-transfer-commands
+#   scripts/tcfs-onprem-migration-plan.sh render-candidate-apply-commands
 #   scripts/tcfs-onprem-migration-plan.sh render-candidate-smoke-commands
 #   scripts/tcfs-onprem-migration-plan.sh render-cutover-commands
 #   scripts/tcfs-onprem-migration-plan.sh render-rollback-commands
@@ -61,8 +63,10 @@ usage() {
     cat <<'EOF'
 Usage:
   tcfs-onprem-migration-plan.sh facts
+  tcfs-onprem-migration-plan.sh render-target-pvc-commands
   tcfs-onprem-migration-plan.sh render-import-pods
   tcfs-onprem-migration-plan.sh render-transfer-commands
+  tcfs-onprem-migration-plan.sh render-candidate-apply-commands
   tcfs-onprem-migration-plan.sh render-candidate-smoke-commands
   tcfs-onprem-migration-plan.sh render-cutover-commands
   tcfs-onprem-migration-plan.sh render-rollback-commands
@@ -160,6 +164,19 @@ target_pvc_storage_class() {
     jsonpath_namespaced "pvc/$1" '{.spec.storageClassName}'
 }
 
+target_pvc_var_args() {
+    printf '%s %s' \
+        "$(tofu_var_arg "enable_stateful_migration_target_pvcs=true")" \
+        "$(tofu_var_arg "enable_stateful_migration_candidate_workloads=false")"
+}
+
+candidate_var_args() {
+    printf '%s %s %s' \
+        "$(tofu_var_arg "enable_stateful_migration_target_pvcs=true")" \
+        "$(tofu_var_arg "enable_stateful_migration_candidate_workloads=true")" \
+        "$(tofu_var_arg "enable_tailnet_candidate_services=true")"
+}
+
 source_fact_line() {
     local name="$1"
     local source_pvc="$2"
@@ -249,6 +266,18 @@ render_import_pods() {
     render_import_pod "${SEAWEEDFS_IMPORT_POD}" seaweedfs "${SEAWEEDFS_TARGET_PVC}"
 }
 
+render_target_pvc_commands() {
+    cat <<EOF
+# Mutating commands for the approved downtime window only. Review the plan
+# before running apply. This creates retained target PVCs only; it does not
+# start candidate workloads or expose tailnet Services.
+
+$(tofu_command) plan $(target_pvc_var_args)
+$(tofu_command) apply $(target_pvc_var_args)
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") get pvc $(shell_quote "${NATS_TARGET_PVC}") $(shell_quote "${SEAWEEDFS_TARGET_PVC}") -o wide
+EOF
+}
+
 transfer_command() {
     local label="$1"
     local source_pvc="$2"
@@ -278,7 +307,8 @@ render_transfer_commands() {
 # Non-mutating render only. Review before running during an approved downtime window.
 # Required setup before these commands:
 # 1. Quiesce external TCFS writers.
-# 2. Apply target PVCs with enable_stateful_migration_target_pvcs=true.
+# 2. Apply target PVCs from:
+#    scripts/tcfs-onprem-migration-plan.sh render-target-pvc-commands
 # 3. Apply import pods from:
 #    scripts/tcfs-onprem-migration-plan.sh render-import-pods | $(kubectl_command) apply -f -
 # 4. Confirm source StatefulSets are scaled down before copying.
@@ -294,6 +324,19 @@ EOF
 
     transfer_command nats "${NATS_SOURCE_PVC}" "${NATS_IMPORT_POD}"
     transfer_command seaweedfs "${SEAWEEDFS_SOURCE_PVC}" "${SEAWEEDFS_IMPORT_POD}"
+}
+
+render_candidate_apply_commands() {
+    cat <<EOF
+# Mutating commands for the approved downtime window only. Run after target
+# PVCs exist and data has been copied into them. Review the plan before running
+# apply. Candidate tailnet hostnames intentionally remain non-canonical.
+
+$(tofu_command) plan $(candidate_var_args)
+$(tofu_command) apply $(candidate_var_args)
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") get statefulset $(shell_quote "${NATS_CANDIDATE_STATEFULSET}") $(shell_quote "${SEAWEEDFS_CANDIDATE_STATEFULSET}") -o wide
+$(kubectl_command) -n $(shell_quote "${NAMESPACE}") get service $(shell_quote "${NATS_CANDIDATE_SERVICE}") $(shell_quote "${SEAWEEDFS_CANDIDATE_SERVICE}") $(shell_quote "${NATS_CANDIDATE_TAILNET_SERVICE}") $(shell_quote "${SEAWEEDFS_CANDIDATE_TAILNET_SERVICE}") -o wide
+EOF
 }
 
 render_candidate_smoke_commands() {
@@ -363,12 +406,18 @@ main() {
             require_command
             render_facts
             ;;
+        render-target-pvc-commands)
+            render_target_pvc_commands
+            ;;
         render-import-pods)
             render_import_pods
             ;;
         render-transfer-commands)
             require_command
             render_transfer_commands
+            ;;
+        render-candidate-apply-commands)
+            render_candidate_apply_commands
             ;;
         render-candidate-smoke-commands)
             render_candidate_smoke_commands

--- a/scripts/test-tcfs-onprem-migration-plan.sh
+++ b/scripts/test-tcfs-onprem-migration-plan.sh
@@ -82,6 +82,12 @@ TCFS_KUBECTL="${FAKE_KUBECTL}" bash "${SCRIPT}" facts >"${FACTS_OUT}"
 assert_contains "${FACTS_OUT}" 'source/nats pvc=data-nats-0 pv=pv-nats storage-class=local-path node=honey path=/opt/local-path-provisioner/nats data target-pvc=tcfs-nats-openebs-target target-storage-class=openebs-bumble-messaging-retain target-present=yes'
 assert_contains "${FACTS_OUT}" 'source/seaweedfs pvc=data-seaweedfs-0 pv=pv-seaweedfs storage-class=local-path node=honey path=/opt/local-path-provisioner/seaweedfs target-pvc=tcfs-seaweedfs-openebs-target target-storage-class=openebs-bumble-s3-retain target-present=no'
 
+TARGET_PVC_OUT="${TMPDIR}/target-pvc.out"
+TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" TCFS_TOFU="/opt/tofu bin/tofu" bash "${SCRIPT}" render-target-pvc-commands >"${TARGET_PVC_OUT}"
+assert_contains "${TARGET_PVC_OUT}" "'/opt/tofu bin/tofu' -chdir='infra/tofu/environments/onprem' plan '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=false'"
+assert_contains "${TARGET_PVC_OUT}" "'/opt/tofu bin/tofu' -chdir='infra/tofu/environments/onprem' apply '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=false'"
+assert_contains "${TARGET_PVC_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' get pvc 'tcfs-nats-openebs-target' 'tcfs-seaweedfs-openebs-target' -o wide"
+
 PODS_OUT="${TMPDIR}/pods.out"
 bash "${SCRIPT}" render-import-pods >"${PODS_OUT}"
 assert_contains "${PODS_OUT}" 'name: tcfs-nats-openebs-import'
@@ -94,6 +100,12 @@ TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" bash "${SCRIPT}" ren
 assert_contains "${COMMANDS_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' scale statefulset/nats statefulset/seaweedfs --replicas=0"
 assert_contains "${COMMANDS_OUT}" "# Transfer nats from honey:/opt/local-path-provisioner/nats data into pod/tcfs-nats-openebs-import:/target"
 assert_contains "${COMMANDS_OUT}" "ssh 'root@honey' 'tar -C '\\''/opt/local-path-provisioner/nats data'\\'' -cpf - .' | '${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' exec -i 'tcfs-nats-openebs-import' -- tar -C /target -xpf -"
+
+CANDIDATE_APPLY_OUT="${TMPDIR}/candidate-apply.out"
+TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" TCFS_TOFU="/opt/tofu bin/tofu" bash "${SCRIPT}" render-candidate-apply-commands >"${CANDIDATE_APPLY_OUT}"
+assert_contains "${CANDIDATE_APPLY_OUT}" "'/opt/tofu bin/tofu' -chdir='infra/tofu/environments/onprem' plan '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=true' '-var=enable_tailnet_candidate_services=true'"
+assert_contains "${CANDIDATE_APPLY_OUT}" "'/opt/tofu bin/tofu' -chdir='infra/tofu/environments/onprem' apply '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=true' '-var=enable_tailnet_candidate_services=true'"
+assert_contains "${CANDIDATE_APPLY_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' get service 'nats-openebs-candidate' 'seaweedfs-openebs-candidate' 'nats-tailnet-candidate' 'seaweedfs-tailnet-candidate' -o wide"
 
 SMOKE_OUT="${TMPDIR}/candidate-smoke.out"
 TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" TCFS_TAILNET_DOMAIN="tail.example" bash "${SCRIPT}" render-candidate-smoke-commands >"${SMOKE_OUT}"


### PR DESCRIPTION
## Summary

- add render-only commands for the TCFS downtime target-PVC apply phase and candidate workload/tailnet apply phase
- update the migration runbook and onprem OpenTofu README so the execution order is explicit and source-owned
- cover the new render surfaces in the migration-plan regression script

## Validation

- bash -n scripts/tcfs-onprem-migration-plan.sh scripts/test-tcfs-onprem-migration-plan.sh
- just onprem-migration-plan-test
- just onprem-preflight-test
- just onprem-tofu-candidate-test
- just onprem-tofu-validate
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new render-only subcommands — `render-target-pvc-commands` and `render-candidate-apply-commands` — to `tcfs-onprem-migration-plan.sh`, making the OpenTofu plan/apply pairs for each migration phase source-owned and reviewable before live use. The runbook and onprem OpenTofu README are updated to reflect the now-explicit execution order, and the test script gains regression coverage for both new surfaces.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are render-only shell additions with no mutation risk and the one P2 gap is a missing test assertion.

All findings are P2. The new render functions follow the established pattern (no require_command needed for pure-render paths, consistent variable-arg helpers, heredoc expansion identical to existing render commands). The only gap is a missing get statefulset assertion in the test for render-candidate-apply-commands.

scripts/test-tcfs-onprem-migration-plan.sh — missing one statefulset assertion in the new candidate-apply test block

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/tcfs-onprem-migration-plan.sh | Adds render_target_pvc_commands and render_candidate_apply_commands functions plus their target_pvc_var_args/candidate_var_args helpers; dispatch cases added without require_command guards (consistent with other pure-render paths) |
| scripts/test-tcfs-onprem-migration-plan.sh | Adds regression coverage for both new render commands; the render-candidate-apply-commands block asserts the service query but omits an assertion for the statefulset query line |
| docs/ops/tcfs-onprem-storage-migration.md | Execution order tightened from 12 to 11 steps, two new render commands documented, Recommended Source-Owned Implementation section updated to reflect current state |
| infra/tofu/environments/onprem/README.md | Two new render command references added to the non-mutating command list and new prose blocks added recommending the render paths for approved downtime windows |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[facts] --> B[render-target-pvc-commands]
    B -->|tofu plan/apply\nenable_stateful_migration_target_pvcs=true| C[Target PVCs created]
    C --> D[render-import-pods]
    D -->|kubectl apply -f -| E[Import Pods running on bumble]
    E --> F[render-transfer-commands]
    F -->|SSH tar pipe into import Pod| G[Data copied to target PVCs]
    G --> H[render-candidate-apply-commands]
    H -->|tofu plan/apply\n+target_pvcs +candidate_workloads +tailnet_services| I[Candidate StatefulSets + tailnet Services live]
    I --> J[render-candidate-smoke-commands]
    J -->|rollout status + curl checks| K{Smoke passes?}
    K -- Yes --> L[render-cutover-commands]
    K -- No --> M[render-rollback-commands]
    L -->|annotate old Services\ntofu apply canonical hostnames| N[Canonical cutover complete]
    M -->|scale down candidates\nrestore old annotations| O[Rolled back to honey-local PVs]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/test-tcfs-onprem-migration-plan.sh
Line: 107-112

Comment:
**Missing statefulset assertion for `render-candidate-apply-commands`**

The test block asserts the `tofu plan`, `tofu apply`, and `get service` lines from `render_candidate_apply_commands`, but omits a corresponding assertion for the `get statefulset` line that the function also emits. If a future change accidentally drops or mis-renders that line, the test won't catch it.

```suggestion
CANDIDATE_APPLY_OUT="${TMPDIR}/candidate-apply.out"
TCFS_CONTEXT="honey context" TCFS_KUBECTL="${FAKE_KUBECTL}" TCFS_TOFU="/opt/tofu bin/tofu" bash "${SCRIPT}" render-candidate-apply-commands >"${CANDIDATE_APPLY_OUT}"
assert_contains "${CANDIDATE_APPLY_OUT}" "'/opt/tofu bin/tofu' -chdir='infra/tofu/environments/onprem' plan '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=true' '-var=enable_tailnet_candidate_services=true'"
assert_contains "${CANDIDATE_APPLY_OUT}" "'/opt/tofu bin/tofu' -chdir='infra/tofu/environments/onprem' apply '-var=enable_stateful_migration_target_pvcs=true' '-var=enable_stateful_migration_candidate_workloads=true' '-var=enable_tailnet_candidate_services=true'"
assert_contains "${CANDIDATE_APPLY_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' get statefulset 'nats-openebs-candidate' 'seaweedfs-openebs-candidate' -o wide"
assert_contains "${CANDIDATE_APPLY_OUT}" "'${FAKE_KUBECTL}' --context 'honey context' -n 'tcfs' get service 'nats-openebs-candidate' 'seaweedfs-openebs-candidate' 'nats-tailnet-candidate' 'seaweedfs-tailnet-candidate' -o wide"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: render tcfs onprem apply phases"](https://github.com/jesssullivan/tummycrypt/commit/da3a2657bc9f099ef48ac6db1b1a07e3722f94fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30205810)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->