### PR TITLE
[codex] Fix Attic cache endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+            extra-substituters = https://nix-cache.tinyland.dev/main
+            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
       - name: Verify runner Nix toolchain
         run: nix --version

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   # Public Attic endpoint shared with flake.nix and other workflows.
-  ATTIC_SERVER: https://nix-cache.fuzzy-dev.tinyland.dev
+  ATTIC_SERVER: https://nix-cache.tinyland.dev
   ATTIC_CACHE: main
 
 jobs:
@@ -32,8 +32,8 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+            extra-substituters = https://nix-cache.tinyland.dev/main
+            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
       - name: Verify runner Nix toolchain
         run: nix --version
@@ -52,8 +52,8 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+            extra-substituters = https://nix-cache.tinyland.dev/main
+            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
       - name: Verify runner cache endpoints
         run: |
@@ -104,8 +104,8 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+            extra-substituters = https://nix-cache.tinyland.dev/main
+            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
       - name: Configure Attic
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,14 +503,14 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            extra-substituters = https://nix-cache.fuzzy-dev.tinyland.dev/main
-            extra-trusted-public-keys = main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE=
+            extra-substituters = https://nix-cache.tinyland.dev/main
+            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
       - name: Configure Attic
         run: |
           nix profile install nixpkgs#attic-client
           if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland https://nix-cache.fuzzy-dev.tinyland.dev ${{ secrets.ATTIC_TOKEN }}
+            attic login tinyland https://nix-cache.tinyland.dev ${{ secrets.ATTIC_TOKEN }}
             attic use main || echo "::warning::Failed to configure Attic substituter"
             echo "ATTIC_CONFIGURED=true" >> $GITHUB_ENV
           else

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,10 @@
   # CI/release workflows push with `attic login` separately.
   nixConfig = {
     extra-substituters = [
-      "https://nix-cache.fuzzy-dev.tinyland.dev/main"
+      "https://nix-cache.tinyland.dev/main"
     ];
     extra-trusted-public-keys = [
-      "main:NKRk1XYo/dfd9fcDqgotUJg2DTDHWp5ny+Ba7WzRjgE="
+      "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
     ];
   };
 


### PR DESCRIPTION
## What changed

Updates the active Nix/Attic cache coordinates from the retired `nix-cache.fuzzy-dev.tinyland.dev` endpoint and old `main` public key to the current public Attic cache:

- substituter: `https://nix-cache.tinyland.dev/main`
- server: `https://nix-cache.tinyland.dev`
- public key: `main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=`

Touched only `flake.nix` and active GitHub workflow cache setup/login sites.

## Why

A fresh cache-first adoption check still warned that `nix-cache.fuzzy-dev.tinyland.dev` does not resolve. That endpoint is stale and should not remain in active CI/release surfaces.

## Validation

- `git diff --check -- flake.nix .github/workflows/ci.yml .github/workflows/nix-ci.yml .github/workflows/release.yml`
- `rg -n "nix-cache\\.fuzzy-dev\\.tinyland\\.dev|main:NKRk1XYo" flake.nix .github/workflows` returned no matches
- `nix flake metadata --no-update-lock-file`
- `curl -fsS https://nix-cache.tinyland.dev/main/nix-cache-info`

## Boundary

This is cache endpoint hygiene only. It does not enroll tummycrypt onto GF self-hosted runners, and it does not claim Bazel remote execution.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrates all Attic binary cache references from the retired `nix-cache.fuzzy-dev.tinyland.dev` endpoint to `nix-cache.tinyland.dev`, updating the substituter URL, `ATTIC_SERVER` env var, `attic login` call, and trusted public key consistently across `flake.nix` and three GitHub Actions workflows. The change is purely infrastructure hygiene with no logic modifications.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a cache endpoint update with no code logic changes.

All four files are updated consistently with no remaining references to the old endpoint. The change is self-contained infrastructure hygiene; no Rust, Swift, FFI, or cryptography code is touched.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flake.nix | Updated nixConfig substituter URL and trusted public key to the new `nix-cache.tinyland.dev` endpoint — consistent with workflow changes. |
| .github/workflows/ci.yml | Substituter URL and trusted public key updated in the single `install-nix-action` block; no remaining stale references. |
| .github/workflows/nix-ci.yml | Updated `ATTIC_SERVER` env var plus three `install-nix-action` blocks; all occurrences consistently migrated to the new endpoint. |
| .github/workflows/release.yml | Updated substituter URL, trusted public key, and the `attic login` server URL; all three touch-points correctly updated. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Actions CI / Release Job] --> B[cachix/install-nix-action]
    B --> C["extra-substituters:\nhttps://nix-cache.tinyland.dev/main"]
    B --> D["extra-trusted-public-keys:\nmain:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="]
    A --> E[attic login tinyland\nhttps://nix-cache.tinyland.dev]
    C --> F[(Attic Binary Cache\nnix-cache.tinyland.dev)]
    E --> F
    G[flake.nix nixConfig] --> C
    G --> D
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Attic cache endpoint"](https://github.com/jesssullivan/tummycrypt/commit/5bc3cec4dc826bff36b88c1f67274177ae621b6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30238257)</sub>

<!-- /greptile_comment -->