### PR TITLE
[codex] Accept flake config in Nix workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,25 +83,25 @@ jobs:
         run: nix --version
 
       - name: Nix flake check
-        run: nix flake check
+        run: nix flake check --accept-flake-config
 
       - name: Verify devShell Rust version
         run: |
-          VERSION="$(nix develop --command rustc --version)"
+          VERSION="$(nix develop --accept-flake-config --command rustc --version)"
           echo "$VERSION"
           echo "$VERSION" | grep -q "1.93.0"
 
       - name: Build tcfsd
-        run: nix build .#tcfsd
+        run: nix build --accept-flake-config .#tcfsd
 
       - name: Build tcfs-cli
-        run: nix build .#tcfs-cli
+        run: nix build --accept-flake-config .#tcfs-cli
 
       - name: Build tcfs-tui
-        run: nix build .#tcfs-tui
+        run: nix build --accept-flake-config .#tcfs-tui
 
       - name: Build tcfs-mcp
-        run: nix build .#tcfs-mcp
+        run: nix build --accept-flake-config .#tcfs-mcp
 
   fileprovider-staticlib:
     name: FileProvider staticlib (macOS)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
         uses: cachix/install-nix-action@v30
 
       - name: Build PDF docs
-        run: nix develop --command task docs:pdf
+        run: nix develop --accept-flake-config --command task docs:pdf
 
       - name: Upload PDF artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: nix --version
 
       - name: Nix flake check
-        run: nix flake check
+        run: nix flake check --accept-flake-config
 
   build-linux-x86_64:
     name: Build Linux x86_64
@@ -74,22 +74,22 @@ jobs:
           fi
 
       - name: Build tcfsd
-        run: nix build .#tcfsd
+        run: nix build --accept-flake-config .#tcfsd
 
       - name: Build tcfs-cli
-        run: nix build .#tcfs-cli
+        run: nix build --accept-flake-config .#tcfs-cli
 
       - name: Build tcfs-tui
-        run: nix build .#tcfs-tui
+        run: nix build --accept-flake-config .#tcfs-tui
 
       - name: Build tcfs-mcp
-        run: nix build .#tcfs-mcp
+        run: nix build --accept-flake-config .#tcfs-mcp
 
       - name: Push to Attic
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
           for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
-            nix build ".#${pkg}" -o "result-${pkg}"
+            nix build --accept-flake-config ".#${pkg}" -o "result-${pkg}"
             attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
           done
 
@@ -120,18 +120,18 @@ jobs:
           fi
 
       - name: Build tcfs-cli (no FUSE on macOS)
-        run: nix build .#tcfs-cli
+        run: nix build --accept-flake-config .#tcfs-cli
 
       - name: Build tcfs-tui
-        run: nix build .#tcfs-tui
+        run: nix build --accept-flake-config .#tcfs-tui
 
       - name: Build tcfs-mcp
-        run: nix build .#tcfs-mcp
+        run: nix build --accept-flake-config .#tcfs-mcp
 
       - name: Push to Attic
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
           for pkg in tcfs-cli tcfs-tui tcfs-mcp; do
-            nix build ".#${pkg}" -o "result-${pkg}"
+            nix build --accept-flake-config ".#${pkg}" -o "result-${pkg}"
             attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -522,7 +522,7 @@ jobs:
         run: |
           for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
             echo "Building ${pkg}..."
-            nix build .#${pkg} -o result-${pkg}
+            nix build --accept-flake-config .#${pkg} -o result-${pkg}
           done
 
       - name: Push to Attic cache


### PR DESCRIPTION
## What changed

- Add `--accept-flake-config` to repo-flake `nix flake check`, `nix develop`, and `nix build` commands in CI, Nix CI, docs, and release workflows.
- Leave `nix profile install nixpkgs#attic-client` unchanged because it does not evaluate this repo flake.

## Why

PR #338 proved the new Attic endpoint and cache publication/consumption path, but the workflows still emitted noisy `warning: ignoring untrusted flake configuration setting` messages. That warning makes the cache-first adoption story look broken even when Attic is configured and working.

## Validation

- `git diff --check`
- Ruby YAML parse for the touched workflow files
- `nix build --accept-flake-config --dry-run .#tcfs-cli`
- `nix develop --accept-flake-config --command rustc --version`
- `nix flake check --accept-flake-config --no-build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consistently adds `--accept-flake-config` to every `nix flake check`, `nix develop`, and `nix build` invocation that evaluates the repo's own flake across all four CI workflows. The `nix profile install nixpkgs#attic-client` calls are correctly left unchanged since they pull from nixpkgs rather than the local flake. The change is mechanical, complete, and aligned with the stated goal of silencing the untrusted-flake-config warnings introduced after the Attic endpoint landed in PR #338.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a focused, mechanical flag addition with no logic changes.

All nix commands that evaluate the repo flake have been updated consistently across every touched workflow file, no occurrences were missed, and the intentional carve-out for `nix profile install nixpkgs#attic-client` is correctly documented. No new logic, secrets handling, or security boundaries are introduced.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Added `--accept-flake-config` to all 6 nix commands (flake check, develop, 4× build); changes are consistent and complete. |
| .github/workflows/nix-ci.yml | Added `--accept-flake-config` to flake check, 4 individual builds, and the Attic push loop for both Linux and macOS jobs; `nix profile install nixpkgs#attic-client` correctly left unchanged. |
| .github/workflows/docs.yml | Single `nix develop` call updated with `--accept-flake-config`; no other nix commands present. |
| .github/workflows/release.yml | The one `nix build` loop in the release job updated with `--accept-flake-config`; only a single occurrence was present and it was caught. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI Trigger] --> B{Workflow}
    B --> C[ci.yml]
    B --> D[nix-ci.yml]
    B --> E[docs.yml]
    B --> F[release.yml]

    C --> C1["nix flake check --accept-flake-config"]
    C --> C2["nix develop --accept-flake-config --command rustc --version"]
    C --> C3["nix build --accept-flake-config .#tcfsd/cli/tui/mcp"]

    D --> D1["nix flake check --accept-flake-config"]
    D --> D2["nix build --accept-flake-config .#pkg (Linux + macOS)"]
    D --> D3["nix build --accept-flake-config in Attic push loop"]
    D --> D4["nix profile install nixpkgs#attic-client\n(unchanged — not repo flake)"]

    E --> E1["nix develop --accept-flake-config --command task docs:pdf"]

    F --> F1["nix build --accept-flake-config .#pkg in release loop"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Accept flake config in Nix workflows"](https://github.com/jesssullivan/tummycrypt/commit/2184471edf45fa41b16bcb37529833ef12ef8470) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30246479)</sub>

<!-- /greptile_comment -->