### PR TITLE
[codex] Bump checkout action to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build + Lint + Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -70,7 +70,7 @@ jobs:
     name: Nix Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Bootstrap Nix CLI
         uses: cachix/install-nix-action@v31
@@ -107,7 +107,7 @@ jobs:
     name: FileProvider staticlib (macOS)
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -140,7 +140,7 @@ jobs:
     name: iOS FileProvider typecheck
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -157,7 +157,7 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
@@ -175,7 +175,7 @@ jobs:
     name: Secret Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install gitleaks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     name: Check Links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check for broken links
         uses: lycheeverse/lychee-action@v2
@@ -35,7 +35,7 @@ jobs:
     name: Build PDFs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v30
@@ -58,7 +58,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -23,7 +23,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Initialize log directory
         shell: bash

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: Flake Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Bootstrap Nix CLI
         uses: cachix/install-nix-action@v31
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: flake-check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Bootstrap Nix CLI
         uses: cachix/install-nix-action@v31
@@ -98,7 +98,7 @@ jobs:
     runs-on: macos-14
     needs: flake-check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           #   rpm: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -440,7 +440,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: plan
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -497,7 +497,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: plan
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -539,7 +539,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: plan
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Generate shell installer
         run: |
@@ -667,7 +667,7 @@ jobs:
     runs-on: macos-14
     needs: plan
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -789,7 +789,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download macOS CLI binaries
         uses: actions/download-artifact@v4
@@ -1115,7 +1115,7 @@ jobs:
       )
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download release checksums
         run: |


### PR DESCRIPTION
## Summary

- Bumps all `actions/checkout@v4` usages to `actions/checkout@v5`.
- Keeps the change limited to the Node 24 runtime update path.
- Avoids `checkout@v6` for now because v6 also changes credential persistence behavior, which is unnecessary for clearing the Node 20 deprecation annotation.

## Why

The latest green main CI after PR #339 reports GitHub's Node 20 action deprecation annotation for `actions/checkout@v4`. `checkout@v5` is the minimal runtime-only upgrade that removes that warning before GitHub's 2026 Node 24 default/removal window.

## Validation

- `git diff --check`
- Ruby YAML parse for touched workflows
- `nix shell nixpkgs#actionlint -c actionlint -shellcheck= .github/workflows/*.yml`

Full `actionlint` with shellcheck enabled still reports existing shellcheck style/info findings in `release.yml`; those are pre-existing and unrelated to this checkout-version bump.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a uniform mechanical bump of `actions/checkout` from `v4` to `v5` across all five GitHub Actions workflow files (20 total occurrences). The sole purpose is to move from the Node 20 runtime to Node 24, eliminating GitHub's deprecation annotation, without touching any credential-persistence or other behavioral settings that would come with `v6`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely mechanical version bump with no logic changes.

All 20 actions/checkout@v4 references are consistently updated to v5, no occurrences were missed, and no other workflow logic was modified. No crypto, FFI, or unsafe code is touched.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | 6 checkout usages bumped from v4 → v5; no logic changes, no v4 occurrences remain. |
| .github/workflows/docs.yml | 3 checkout usages bumped from v4 → v5; no logic changes. |
| .github/workflows/macos-postinstall-smoke.yml | 1 checkout usage bumped from v4 → v5; no logic changes. |
| .github/workflows/nix-ci.yml | 3 checkout usages bumped from v4 → v5; no logic changes. |
| .github/workflows/release.yml | 7 checkout usages bumped from v4 → v5 across build, publish, and release jobs; no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GitHub Actions Trigger"] --> B["actions/checkout@v5\n(Node 24 runtime)"]
    B --> C1["ci.yml jobs\n(Build, Lint, Test, Nix,\nmacOS, iOS, cargo-deny,\nSecret Scan)"]
    B --> C2["docs.yml jobs\n(Links, PDFs, Pages)"]
    B --> C3["macos-postinstall-smoke.yml"]
    B --> C4["nix-ci.yml jobs\n(flake-check, nix-build,\nmacOS-nix)"]
    B --> C5["release.yml jobs\n(build, docker, nix,\nshell-installer, macOS, publish,\nannounce)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Bump checkout action to Node 24 runtime"](https://github.com/jesssullivan/tummycrypt/commit/58830c4aacdc6659034c90ec53df12d26e1f58be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30248641)</sub>

<!-- /greptile_comment -->