### PR TITLE
[codex] Ground TCFS parity status docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 #
 # Targets:
 #   - Linux x86_64 (with FUSE)
-#   - Linux aarch64 (with FUSE)
+#   - Linux aarch64 (cross-compiled without FUSE in current release matrix)
 #   - macOS x86_64 (no FUSE, CLI-only — mount disabled)
 #   - macOS aarch64 (no FUSE, CLI-only — mount disabled)
 #   - Container image (k8s-worker mode)
@@ -14,7 +14,7 @@
 # Produces:
 #   - Binary tarballs (.tar.gz) per platform
 #   - .deb package (x86_64 + aarch64)
-#   - .rpm package (x86_64 + aarch64)
+#   - .rpm package (x86_64 daemon package only today)
 #   - Shell installer script (curl | sh)
 #   - Homebrew formula
 #   - Container image (GHCR, multi-arch)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Under active development. Not yet stable. Expect breaking changes.
 
-Self-hosted encrypted file sync with on-demand hydration. Mounted views present remote files as normal names and hydrate on open; offline/dehydrated copies can be represented by small `.tc`/`.tcf` stubs. FOSS odrive/Dropbox replacement.
+Self-hosted encrypted file sync with on-demand hydration. Mounted views present remote files as normal names and hydrate on open; offline/dehydrated copies can be represented by small `.tc`/`.tcf` stubs. FOSS odrive/Dropbox-style alternative under active development.
 
 ## Canonical Home
 
@@ -76,7 +76,7 @@ tcfs status                    # Daemon status, device identity, NATS connection
 tcfs push <path>               # Upload with encryption + vector clock tick
 tcfs pull <manifest> <local>   # Download with conflict detection + decryption
 tcfs mount <remote> <target>   # FUSE mount with clean-name on-demand hydration
-tcfs unsync <path>             # Convert hydrated file back to a physical .tc stub
+tcfs unsync <path>             # Convert clean tracked files/directories back to .tc stubs
 tcfs device enroll             # Register device with age keypair
 tcfs device list               # Show enrolled fleet devices
 ```
@@ -109,7 +109,7 @@ crates/
 ├── tcfs-cloudfilter/    # Windows Cloud Files API (planned)
 ├── tcfs-file-provider/  # macOS/iOS FileProvider FFI (cbindgen + UniFFI)
 ├── tcfs-sops/           # SOPS+age fleet secret propagation
-├── tcfs-dbus/           # D-Bus integration (Linux)
+├── tcfs-dbus/           # Linux D-Bus interface (stub default; gRPC backend feature-gated)
 ├── tcfsd/               # Daemon binary (gRPC + metrics + systemd)
 ├── tcfs-cli/            # CLI binary
 ├── tcfs-tui/            # Terminal UI (ratatui)
@@ -127,14 +127,14 @@ For the bar after install succeeds, see
 
 | Feature | Linux | macOS | Windows | iOS |
 |---------|-------|-------|---------|-----|
-| CLI (push/pull/reconcile) | Full | Full | Planned | - |
-| Daemon (gRPC + metrics) | Full | Available, lightly validated | Planned | - |
-| Filesystem mount | Full (FUSE3, NFS fallback) | Experimental | Cloud Files API (skeleton) | - |
-| FileProvider | - | Experimental | - | Proof-of-concept, read-only |
+| CLI (push/pull/reconcile) | Proven | Proven | Planned | - |
+| Daemon (gRPC + metrics) | Proven | Available, lightly validated | Planned | - |
+| Filesystem mount | Proven on x86_64 FUSE; NFS fallback exists | Experimental | Cloud Files API skeleton | - |
+| FileProvider | - | Lab-proven experimental | - | Proof-of-concept; write hooks unproven |
 | Finder/Explorer badges | - | Experimental | - | - |
-| D-Bus integration | Full | - | - | - |
-| Fleet sync (NATS) | Full | Core path available, not continuously acceptance-tested | Planned | - |
-| E2E encryption | Full | Full | Planned | Core crypto path available |
+| D-Bus integration | Interface exists; release UX not proven | - | - | - |
+| Fleet sync (NATS) | Proven core/live lanes | Core path available, not continuously acceptance-tested | Planned | - |
+| E2E encryption | Proven core path | Proven core path | Planned | Core crypto path available |
 
 See [docs/platform-support.md](docs/platform-support.md) for details.
 For the dated Apple posture, see
@@ -144,7 +144,7 @@ For the dated Apple posture, see
 
 ```bash
 task build          # Build all crates
-task test           # Run all tests (424 tests)
+task test           # Run workspace tests
 task lint           # Clippy + rustfmt
 task deny           # License + advisory check
 task check          # All of the above

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
 title: tcfs — TummyCrypt Filesystem
-description: FOSS self-hosted odrive replacement
+description: FOSS self-hosted odrive-style encrypted sync target
 theme: jekyll-theme-cayman

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # tcfs — TummyCrypt Filesystem
 
-**FOSS self-hosted odrive replacement**
+**FOSS self-hosted odrive-style encrypted sync target**
 
-tcfs is a self-hosted encrypted file sync system backed by [SeaweedFS](https://github.com/seaweedfs/seaweedfs) with end-to-end [age](https://age-encryption.org) encryption, content-defined chunking, clean-name on-demand hydration in mounted views, physical `.tc`/`.tcf` stubs for offline/dehydrated paths, and multi-machine fleet sync with vector clocks. Linux is the best-supported runtime today; Apple desktop and mobile surfaces exist but are still experimental.
+tcfs is a self-hosted encrypted file sync system backed by [SeaweedFS](https://github.com/seaweedfs/seaweedfs) with client-side XChaCha20-Poly1305 content encryption, SOPS/age-managed credentials, content-defined chunking, clean-name on-demand hydration in mounted views, physical `.tc`/`.tcf` stubs for offline/dehydrated paths, and multi-machine fleet sync with vector clocks. Linux is the best-supported runtime today; Apple desktop and mobile surfaces exist but are still experimental.
 
 ## Installation
 
@@ -58,7 +58,7 @@ nix develop github:Jesssullivan/tummycrypt
 
 ## How It Works
 
-1. **Push**: Files are split into content-defined chunks (FastCDC), compressed (zstd), encrypted (age), and uploaded to SeaweedFS via S3. Vector clock is ticked and SyncManifest v2 (JSON) is written.
+1. **Push**: Files are split into content-defined chunks (FastCDC), compressed (zstd), encrypted client-side with XChaCha20-Poly1305, and uploaded to SeaweedFS via S3. Vector clock is ticked and SyncManifest v2 (JSON) is written.
 2. **Pull**: Manifests describe the chunk layout. Chunks are fetched, verified (BLAKE3), decrypted, decompressed, and reassembled. Vector clock is merged with remote.
 3. **Mount**: The local filesystem surface presents remote files as local names and hydrates on open. On Linux this is exercised primarily through FUSE. Apple desktop surfaces are still evolving and should be treated as experimental.
 4. **Unsync**: Convert hydrated files back to physical `.tc` stubs or platform placeholders, reclaiming disk space while keeping the remote copy.
@@ -155,13 +155,13 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 
 | Platform | Status | Notes |
 |----------|--------|-------|
-| Linux x86_64 | Full | FUSE mount, CLI, daemon, TUI, MCP |
-| Linux aarch64 | Full | FUSE mount, CLI, daemon, TUI, MCP |
+| Linux x86_64 | Proven primary lane | FUSE mount lifecycle, CLI, daemon, TUI, MCP |
+| Linux aarch64 | Available | Release tarball and `.deb`; FUSE is not built in the current cross-compiled release artifact |
 | macOS (Apple Silicon) | Experimental | CLI and daemon build, release `.pkg`, and FileProvider packaging exist, but user-facing acceptance coverage is still limited |
 | macOS (Intel) | Experimental | CLI binaries ship, but the desktop integration story is not yet as proven as Linux |
-| Windows x86_64 | CLI only | Cloud Files API skeleton; no FUSE or daemon |
-| iOS | Proof-of-concept | Read-only FileProvider direction; CI type-checks Swift, but there is no continuously proven TestFlight/App Store lane |
-| NixOS | Full | Flake + NixOS module + Home Manager module |
+| Windows x86_64 | Planned / skeleton | Cloud Files API skeleton; no release-grade CLI, daemon, or Explorer flow |
+| iOS | Proof-of-concept | FileProvider direction with unproven write hooks; CI type-checks Swift, but there is no continuously proven device/TestFlight/App Store lane |
+| NixOS | Available / evidence pending | Flake + NixOS module + Home Manager module; current `v0.12.12` evidence is Darwin Nix profile install |
 
 ## License
 

--- a/docs/ops/apple-surface-status.md
+++ b/docs/ops/apple-surface-status.md
@@ -2,7 +2,8 @@
 
 As of May 8, 2026, Apple support is a buildable and partially proven lane. The
 macOS FileProvider testing-mode lab now has green enumerate, hydrate, evict,
-and rehydrate proof on PZM, but Apple surfaces are still not a full
+rehydrate, mutation upload/readback, and deterministic conflict/status content
+preservation proof on PZM, but Apple surfaces are still not a full
 release-grade desktop or iOS product.
 
 ## macOS: Proven Today
@@ -33,6 +34,8 @@ release-grade desktop or iOS product.
   into deterministic conflict/status proof: CLI status reported
   `sync state: conflict` and FileProvider readback preserved exact content.
   Finder badges/progress remain observational.
+- GitHub Actions links for the current PZM runs are indexed in
+  [Release Evidence Index](../release/evidence/README.md).
 
 ## macOS: Not Yet Proven As A Release-Grade Desktop Surface
 
@@ -58,7 +61,7 @@ release-grade desktop or iOS product.
 
 Use:
 
-- `macOS: CLI/daemon plus lab-proven experimental FileProvider read/hydrate`
+- `macOS: CLI/daemon plus lab-proven experimental FileProvider lifecycle`
 - `iOS: proof-of-concept FileProvider direction`
 
 Avoid:
@@ -75,8 +78,9 @@ Avoid:
   [Distribution Smoke Matrix](distribution-smoke-matrix.md).
 - Use [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md) for
   the current desktop acceptance path and proof gaps.
-- Extend the named macOS Finder/FileProvider smoke path beyond read/hydrate
-  before upgrading the public desktop posture.
+- Keep extending the named macOS Finder/FileProvider smoke path, but do not
+  upgrade the public desktop posture until production Developer ID clean-host
+  acceptance is green.
 - Add simulator or device-backed iOS acceptance before claiming an active iOS
   product surface.
 

--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -24,6 +24,12 @@ surfaces below have passed their required smoke checks.
   - container upgrades are normally orchestrator rollouts rather than a host-local installer flow
   - Nix installs are immutable and ref-pinned, so the per-tag fresh install gate is the most meaningful baseline
 
+Current evidence note for `v0.12.12`: the archived current-tag packet in this
+repo proves Homebrew fresh/upgrade and Darwin Nix profile install only. Linux
+`.deb`, `.rpm`, container, and production macOS `.pkg` current-tag proof remain
+separate follow-up checks even though older release and CI evidence exists for
+parts of those surfaces.
+
 ## Out-Of-Scope Published Helpers
 
 The release workflow also publishes helper installers:

--- a/docs/ops/fleet-deployment.md
+++ b/docs/ops/fleet-deployment.md
@@ -369,6 +369,8 @@ NATS and the tcfsd gRPC socket also run unencrypted. For production hardening:
 - Set `storage.enforce_tls = true` in tcfs config for HTTPS S3
 - Set `sync.nats_tls = true` for TLS NATS connections
 - Wire `security.toml` into SeaweedFS Ansible roles / Helm values for mTLS
+- Wire JetStream `sync_always: true` into the Helm/OpenTofu NATS path before
+  claiming production-grade NATS durability
 
 ---
 
@@ -382,6 +384,10 @@ is used. **All production NATS servers MUST set `sync_always: true`** in
 the jetstream configuration block.
 
 See `config/nats-server.conf` for a reference configuration.
+
+Current repo reality: the reference config carries this setting, but the
+OpenTofu/Helm NATS module path has not yet been audited as carrying it through.
+Treat that as a production-hardening tracker item, not a completed guarantee.
 
 ### Architectural Note
 

--- a/docs/ops/ios-surface-status.md
+++ b/docs/ops/ios-surface-status.md
@@ -1,6 +1,6 @@
 # iOS Surface Status
 
-As of May 6, 2026, iOS is an experimental FileProvider proof-of-concept,
+As of May 8, 2026, iOS is an experimental FileProvider proof-of-concept,
 not an active release target.
 
 ## What Exists In The Repo Today
@@ -43,6 +43,12 @@ It does not prove:
 - There is no repeatable TestFlight or App Store delivery lane.
 - Release and support decisions would otherwise be based on scaffolded code
   rather than proof.
+- The current entitlement files declare the App Group, but shared Keychain
+  behavior still needs real-device proof before claiming credentials work
+  across the host app and extension.
+- The FileProvider item capabilities can expose write affordances in Files.app;
+  those affordances are unsupported until create/modify/delete flows have
+  device-backed acceptance.
 
 ## Maintenance Expectation
 
@@ -61,6 +67,7 @@ It does not prove:
 ## Exit Criteria For A Stronger Public Posture
 
 - simulator or device-backed acceptance coverage
+- real-device Keychain/App Group entitlement proof
 - an explicit decision on whether write support is in or out of near-term scope
 - a repeatable TestFlight or equivalent Apple distribution lane
 - docs that can point to those validation surfaces directly

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -2,13 +2,17 @@
 
 As of May 8, 2026, macOS is a real packaging and integration lane for tcfs.
 The non-production PZM testing-mode FileProvider lane is proven end to end on
-`v0.12.12` through enumerate, exact-content hydrate, evict, and rehydrate when
-the lab `SystemPolicyRule` profile is installed. Production Finder lifecycle
-behavior is still not a continuously proven release-grade desktop surface.
+`v0.12.12` through enumerate, exact-content hydrate, evict, rehydrate,
+mutation upload/readback, and deterministic CLI conflict/status content
+preservation when the lab `SystemPolicyRule` profile is installed. Production
+Developer ID clean-host Finder lifecycle behavior is still not a continuously
+proven release-grade desktop surface.
 
 This document defines the actual workflow the repo supports today, separates
 what is proven from what remains experimental, and records the highest-value
 smoke path for the Finder/FileProvider surface.
+For the current PZM GitHub Actions run links, see the
+[Release Evidence Index](../release/evidence/README.md).
 
 ## Supported Workflow In The Repo Today
 
@@ -65,10 +69,12 @@ sync-root stub representation, not the desired primary Finder UX.
 - The `v0.12.12` PZM testing-mode lane passes package install, signing,
   profile, E2EE, storage, daemon startup, installed host policy probe,
   FileProvider registration, enumeration, requestDownload, evict, re-request,
-  and exact-content hydration when the computer-level
-  `TCFS FileProvider Lab Gatekeeper Rules` `SystemPolicyRule` profile is
-  installed. This is a non-production Mac App Development/testing-mode proof,
-  not a production Developer ID clean-host claim.
+  exact-content hydration, CloudStorage mutation upload/readback, and
+  deterministic CLI conflict/status content preservation when the
+  computer-level `TCFS FileProvider Lab Gatekeeper Rules` `SystemPolicyRule`
+  profile is installed. This is a non-production Mac App
+  Development/testing-mode proof, not a production Developer ID clean-host
+  claim.
 
 ## Important Constraints
 
@@ -93,7 +99,8 @@ sync-root stub representation, not the desired primary Finder UX.
 - A production clean-host Finder/FileProvider lifecycle smoke beyond
   install/signing/storage gates
 - Finder badge visibility as a release gate
-- Conflict UX and notification behavior as a release gate
+- Conflict UX, notification behavior, and Finder badge/progress visibility as
+  release gates
 - Release-day viability of every published macOS artifact without explicit
   post-cut smoke
 - A stable claim that write flows are supported for end users on macOS

--- a/docs/ops/macos-fileprovider-testing-mode-strategy.md
+++ b/docs/ops/macos-fileprovider-testing-mode-strategy.md
@@ -524,7 +524,7 @@ Feature goals remain:
 2. Keep `spctl`, `syspolicy_check`, xattr, codesign, embedded-profile,
    `taskgated-helper`, `amfid`, and AppleSystemPolicy diagnostics attached to
    every FileProvider lab failure.
-3. Expand the PZM lab proof beyond evict/rehydrate into mutation,
-   conflict/status, badges/progress, and recovery evidence.
-4. Expand the successful read/hydrate proof into Linux/Finder parity follow-on
-   gates.
+3. Keep the PZM mutation and conflict/status gates green, and expand the lab
+   evidence next into badges/progress and recovery behavior.
+4. Keep production Developer ID clean-host Finder acceptance separate from the
+   non-production Mac App Development/testing-mode lane.

--- a/docs/ops/packaged-install-first-use.md
+++ b/docs/ops/packaged-install-first-use.md
@@ -56,7 +56,7 @@ Passing `scripts/install-smoke.sh` alone is not sufficient to claim this bar.
 | Surface | Per-tag requirement | First real action | Edge case / follow-on |
 |---------|---------------------|-------------------|-----------------------|
 | Homebrew | every tag | `tcfs status` with `storage [ok]`, then a minimal push/pull or sync-status path | one of: unsync/rehydrate, conflict, symlink, large file |
-| macOS `.pkg` | every tag | package install, then the named Finder/FileProvider lane from [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md) through enumerate + hydrate | clean-host install and one desktop follow-on such as mutate/conflict or unsync/rehydrate |
+| macOS `.pkg` | every tag | package install, then the named Finder/FileProvider lane from [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md) through enumerate + hydrate | clean-host install and one desktop follow-on such as mutate/conflict or unsync/rehydrate; PZM testing-mode evidence is useful but does not replace production Developer ID clean-host proof |
 | Ubuntu 24.04+ / Debian 13+ `.deb` | every tag | `tcfs status` with `storage [ok]`, then minimal push/pull or sync-status | one of: upgrade carry-forward, unsync/rehydrate, conflict, large file |
 | Fedora/RHEL `.rpm` | sampled | daemon/worker startup against intentional config | worker restart or backend reconnect as needed |
 | Container image | sampled | worker startup against real or disposable backend dependencies | restart/reconnect or rollout-oriented check |
@@ -93,21 +93,26 @@ Record results using a table like this:
 
 - `install.sh` is published convenience tooling, not part of the canonical
   release-proof surface. See [Distribution Smoke Matrix](distribution-smoke-matrix.md).
-- The macOS clean-host lane remains tracked in `#309`; the harness now exists,
-  and the repo now carries a manual GitHub-hosted approximation in
-  [`.github/workflows/macos-postinstall-smoke.yml`](../../.github/workflows/macos-postinstall-smoke.yml),
-  but the remaining blocker is at least one successful tagged run. It uses
-  GitHub's `macos-15` arm64 runner because the packaged FileProvider app cannot
-  launch on `macos-14`. That hosted
-  lane uses the workflow ref's acceptance harness, downloads the requested
-  release tag's published `.pkg`, uses the `tcfs-macos-smoke` GitHub
-  environment secrets, rejects non-public endpoint classes during preflight,
-  decodes a 32-byte E2EE master key for the run, proves the seeded fixture
-  cannot be pulled without that key, and runs the signed package structure
-  smoke before installer runs. Current-postinstall equality is opt-in so older
-  published tags can still reach install/Finder proof. NATS is not required for
-  the enumerate + hydrate lane, and keychain/app-group failures should be
-  treated separately from storage reachability failures.
+- The macOS production clean-host lane remains tracked in `#309`. The repo has
+  two different harness families:
+  - [`.github/workflows/macos-postinstall-smoke.yml`](../../.github/workflows/macos-postinstall-smoke.yml)
+    exercises published packages and production-style install/signing/storage
+    gates, but production Finder enablement is still not continuously green.
+  - [`.github/workflows/macos-fileprovider-testing-mode-pkg.yml`](../../.github/workflows/macos-fileprovider-testing-mode-pkg.yml)
+    plus the PZM smoke path exercises a non-production Mac App
+    Development/testing-mode package with the lab `SystemPolicyRule` profile.
+    That lane now proves enumerate, hydrate, evict, rehydrate, mutation
+    upload/readback, and CLI conflict/status content preservation on `v0.12.12`,
+    but it is not a production Developer ID clean-host claim.
+- The hosted/package lane uses the workflow ref's acceptance harness, downloads
+  the requested release tag's published `.pkg`, uses the `tcfs-macos-smoke`
+  GitHub environment secrets, rejects non-public endpoint classes during
+  preflight, decodes a 32-byte E2EE master key for the run, proves the seeded
+  fixture cannot be pulled without that key, and runs the signed package
+  structure smoke before installer runs. Current-postinstall equality is opt-in
+  so older published tags can still reach install/Finder proof. NATS is not
+  required for the enumerate + hydrate lane, and keychain/app-group failures
+  should be treated separately from storage reachability failures.
 - The FileProvider testing-mode lane is separate from that production hosted
   approximation. It targets the registered `petting-zoo-mini` self-hosted Mac
   through the same post-install workflow's `runner_label` input and installs a

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -18,7 +18,7 @@ Use this document as the short answer to:
 
 | Surface | Current truth | Source of proof |
 | --- | --- | --- |
-| Linux CLI + daemon | strongest and most routinely proven path | CI, release smoke, live host acceptance |
+| Linux CLI + daemon | strongest and most routinely proven path; x86_64 FUSE lifecycle has current real-host evidence | CI, release smoke, live host acceptance, archived Linux lifecycle evidence |
 | Fleet sync / backend path | materially proven on real hosts | `neo-honey` live acceptance plus lab host matrix |
 | Lazy traversal / hydration | core code and harnesses exist; Linux FUSE proves browse-before-download, exact `cat` hydration, mounted write/readback, cache clear/rehydrate, and recursive safe-unsync refusal/success on real host evidence; PZM proves macOS FileProvider enumerate, exact-content hydrate, evict, rehydrate, and mutation-through-CloudStorage under testing mode with the installed lab `SystemPolicyRule` profile; production Finder lifecycle evidence is still pending | `tcfs-vfs`/FUSE implementation, archived Linux evidence, PZM testing-mode smoke, and the lazy hydration demo runbook |
 | macOS | experimental but real; current packages prove package/signing/storage/daemon startup, and PZM proves non-production lab FileProvider enumeration/hydration/evict/rehydrate plus mutation upload/readback and CLI conflict/exact-content preservation under Apple's testing-mode entitlement plus a managed SystemPolicyRule profile; production Finder enablement/conflict/status UX are still not release-grade | build + packaging + PZM smoke + local desktop evidence |
@@ -33,12 +33,12 @@ This is the narrowest and most important truth for public release claims.
 
 | Surface | Status | Current reality |
 | --- | --- | --- |
-| Homebrew | pass | fresh install and upgrade proved on `v0.12.12`; current evidence is `docs/release/evidence/distribution-v01212-20260508T205913Z/` |
+| Homebrew | current-tag pass | fresh install and upgrade proved on `v0.12.12`; current evidence is `docs/release/evidence/distribution-v01212-20260508T205913Z/` |
 | macOS `.pkg` | partial pass | production packages install/sign/provision/start and prove E2EE; the PZM non-production testing-mode package proves FileProvider enumerate, hydrate, evict, rehydrate, mutation, and conflict/status content preservation on runs `25562087555`, `25565943781`, and `25569596910`; production Finder remains separate |
-| `.deb` | partial pass | Ubuntu 24.04 fresh install and upgrade proved; current support floor is Ubuntu 24.04+ / Debian 13+; Debian 12 is excluded unless a separate bookworm-targeted package is produced |
-| `.rpm` | pass | fresh install proved in Fedora container |
-| container image | pass | version and worker-mode startup proved |
-| Nix install | pass | `v0.12.12` fresh install proved from the tagged flake into a temporary profile on `neo`; current evidence is `docs/release/evidence/distribution-v01212-20260508T205913Z/` |
+| `.deb` | floor decided; current-tag refresh pending | support floor is Ubuntu 24.04+ / Debian 13+; Debian 12 is excluded unless a separate bookworm-targeted package is produced; `v0.12.12` repo-archived evidence currently does not include `.deb` fresh/upgrade |
+| `.rpm` | historical/sample proof; current-tag refresh pending | RPM is daemon-only today; `v0.12.12` repo-archived evidence currently does not include Fedora/RHEL/Rocky smoke |
+| container image | historical/sample proof; current-tag refresh pending | worker-mode startup is modeled in CI/release, but `v0.12.12` repo-archived evidence currently does not include a pulled-image startup smoke |
+| Nix install | current-tag pass | `v0.12.12` fresh install proved from the tagged flake into a temporary Darwin profile on `neo`; current evidence is `docs/release/evidence/distribution-v01212-20260508T205913Z/` |
 
 Canonical runbook: [Distribution Smoke Matrix](distribution-smoke-matrix.md).
 Install-to-first-use bridge:
@@ -47,6 +47,8 @@ Historical per-release evidence freeze for `v0.12.2`:
 [v0.12.2 Evidence Matrix](../release/v0.12.2-evidence-matrix.md).
 Current Homebrew/Nix distribution evidence for `v0.12.12`:
 [distribution-v01212-20260508T205913Z](../release/evidence/distribution-v01212-20260508T205913Z/).
+Current evidence index with GitHub Actions run links:
+[Release Evidence Index](../release/evidence/README.md).
 
 ### 2. Continuous CI / Build Proof
 
@@ -238,18 +240,18 @@ work should be ordered like this:
    - remaining Linux work is product polish around conflict/status surfacing,
      not the lifecycle proof packet itself
 2. **Apple desktop acceptance**
-  - stop retrying hosted production packages until FileProvider can be enabled
-  - treat PZM testing-mode read/hydrate/evict/rehydrate as green under the
-    installed lab `SystemPolicyRule` profile
-  - treat PZM testing-mode mutation as green under smoke run `25565943781`
-  - treat PZM testing-mode conflict/status content preservation as green under
-    smoke run `25569596910`
-  - keep the installed-host policy probe and profile verification in the PZM
-    postinstall workflow so install/provenance failures stay classified before
-    deeper Finder assertions
-  - keep Finder badges/progress as observational evidence until there is a
-    reliable assertion for those UI signals
-  - keep production Developer ID clean-host Finder acceptance separate from
+   - stop retrying hosted production packages until FileProvider can be enabled
+   - treat PZM testing-mode read/hydrate/evict/rehydrate as green under the
+     installed lab `SystemPolicyRule` profile
+   - treat PZM testing-mode mutation as green under smoke run `25565943781`
+   - treat PZM testing-mode conflict/status content preservation as green under
+     smoke run `25569596910`
+   - keep the installed-host policy probe and profile verification in the PZM
+     postinstall workflow so install/provenance failures stay classified before
+     deeper Finder assertions
+   - keep Finder badges/progress as observational evidence until there is a
+     reliable assertion for those UI signals
+   - keep production Developer ID clean-host Finder acceptance separate from
      non-production testing-mode evidence
 3. **odrive-style lifecycle productionization**
    - surface `FileSyncStatus`, progress, and conflict state in CLI/TUI/Finder
@@ -268,9 +270,12 @@ work should be ordered like this:
    - keep Homebrew and Nix proof current in the distribution matrix
    - Debian 12 posture is decided for the current packages: do not claim it as
      a supported `.deb` target until a bookworm-specific build exists
-6. **Accessibility**
+6. **Credential hygiene**
+   - rotate and migrate legacy plaintext Ansible inventory credentials into the
+     SOPS-managed path before claiming repo-wide secret handling is complete
+7. **Accessibility**
    - define an explicit AX bar before claiming mature desktop UX
-7. **Diagnostics and recovery UX**
+8. **Diagnostics and recovery UX**
    - on-demand diagnostic dump
    - clearer support/recovery flows for operator and end-user failures
 
@@ -279,11 +284,13 @@ work should be ordered like this:
 As of May 8, 2026, the narrow GitHub backlog is:
 
 - M10 release-proof tranche
-  - `#280`: distribution install and upgrade proof umbrella
+  - `#280`: distribution install and upgrade proof umbrella. Homebrew/Nix
+    current-tag proof is archived for `v0.12.12`; Linux package/container and
+    production macOS `.pkg` current-tag proof remain named follow-ups.
   - `#309`: macOS `.pkg` clean-host and FileProvider acceptance lane. PZM
-    testing-mode enumerate/hydrate/evict/rehydrate is green under the installed
-    lab `SystemPolicyRule` profile; production Finder lifecycle proof remains
-    open.
+    testing-mode enumerate/hydrate/evict/rehydrate/mutation/conflict-status is
+    green under the installed lab `SystemPolicyRule` profile; production Finder
+    lifecycle proof remains open.
 - Adjacent non-M10 lanes
   - `#298`: residual Civo TCFS PVC retirement after on-prem recovery
   - `#327`: TCFS on-prem OpenTofu migration and cutover

--- a/docs/ops/usage-reality-sprint-plan-2026-05-06.md
+++ b/docs/ops/usage-reality-sprint-plan-2026-05-06.md
@@ -1,6 +1,7 @@
 # TCFS Usage Reality Sprint Plan
 
-Date: May 6, 2026
+Started: May 6, 2026
+Last updated: May 8, 2026
 
 This is the short-lived execution plan for turning the current TCFS surface
 matrix into archived, repeatable proof. It is intentionally separate from

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -11,10 +11,10 @@ coverage and the clearest end-to-end validation story.
 
 - **CLI**: All commands (push, pull, reconcile, policy, resolve, mount, unsync)
 - **Daemon**: systemd user service with auto-restart, metrics (Prometheus), health checks
-- **Filesystem**: FUSE3 mount with clean-name on-demand hydration; physical `.tc` stubs are used by unsync/offline paths
+- **Filesystem**: FUSE3 mount with clean-name on-demand hydration on the primary x86_64 release artifact; physical `.tc` stubs are used by unsync/offline paths
 - **NFS loopback**: Alternative to FUSE (no kernel modules required)
 - **Fleet sync**: NATS JetStream with vector clock conflict detection
-- **D-Bus**: Status change signals for desktop integration
+- **D-Bus**: Interface crate exists, but the default backend is a stub and release UX/status integration is not yet proven
 - **Encryption**: XChaCha20-Poly1305 per-chunk, Argon2id KDF
 - **Build targets**: x86_64 (.tar.gz, .deb, .rpm), aarch64 (.tar.gz, .deb)
   with `.deb` install support claimed for Ubuntu 24.04+ and Debian 13
@@ -30,21 +30,22 @@ as a production-proven platform.
 
 - **CLI**: Builds and ships for Apple Silicon and Intel
 - **Daemon**: Launchd-oriented runtime exists, but user-facing acceptance coverage is still limited
-- **FileProvider**: Packaged macOS FileProvider app exists in releases, but Finder-level claims should be treated as experimental until stronger acceptance coverage exists
-- **Finder badges / progress**: Implemented in code, not yet continuously proven by system-level tests
+- **FileProvider**: Packaged macOS FileProvider app exists in releases; the PZM testing-mode lab proves enumerate, hydrate, evict, rehydrate, mutation upload/readback, and CLI conflict/status content preservation, but production Finder claims remain experimental
+- **Finder badges / progress**: Implemented in code and observed only as evidence; not yet a reliable release gate
 - **Filesystem surface**: Experimental; Linux remains the better-proven mount/runtime path
 - **Fleet sync**: Core sync engine and NATS path are shared with Linux, but macOS-specific acceptance coverage is not yet at the same bar
 - **Encryption**: Core crypto path is shared and available
 - **Build targets**: aarch64 (.tar.gz, .pkg; notarization attempted but non-blocking), x86_64 (.tar.gz)
 - **Homebrew**: manual tap flow required today because the formula is published on the `homebrew-tap` branch, not the default branch
-- **Current proof**: CI covers Rust builds plus Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts; broader desktop UX proof is still pending
+- **Current proof**: CI covers Rust builds plus Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts; PZM testing-mode lab proof is green beyond read/hydrate; production clean-host Finder proof is still pending
 - **Current posture**: see [Apple Surface Status](ops/apple-surface-status.md)
   and [Distribution Smoke Matrix](ops/distribution-smoke-matrix.md)
 
 ### Not Yet Proven
 
-- Fresh-install Finder/FileProvider acceptance from install through register,
-  enumerate, hydrate, mutate, and conflict handling
+- Production Developer ID clean-host Finder/FileProvider acceptance from
+  install through user enablement, register, enumerate, hydrate, mutate, and
+  conflict handling
 - Finder badges, progress UI, or notification behavior as release gates
 - Every published macOS artifact on day zero without explicit post-cut smoke
 
@@ -83,7 +84,7 @@ Windows 10 1809+ placeholder files. 10 TODOs remain before functional:
 The iOS direction exists, but it is not yet a continuously proven distribution
 surface.
 
-- **FileProvider**: NSFileProviderExtension with enumeration + hydration
+- **FileProvider**: NSFileProviderExtension with enumeration + hydration; experimental write hooks exist but are not accepted as supported behavior
 - **UniFFI**: Swift bindings via uniffi-bindgen
 - **Encryption**: Full E2E decryption support
 - **Build**: Swift sources type-check in CI; Xcode/TestFlight remains a manual lane
@@ -91,10 +92,12 @@ surface.
 - **Current posture**: see [Apple Surface Status](ops/apple-surface-status.md)
 
 ### Limitations
-- Read-only (no upload/push from iOS)
+- Public posture remains read-only; write affordances may appear because hooks
+  exist in code, but upload/push/delete flows are not accepted product behavior
 - No background sync
 - No conflict resolution UI
 - Requires manual provisioning profile setup
+- Shared Keychain/App Group behavior still needs real-device entitlement proof
 - No continuously exercised TestFlight or App Store delivery lane
 
 ## Container (K8s Worker)

--- a/docs/release/evidence/README.md
+++ b/docs/release/evidence/README.md
@@ -1,0 +1,28 @@
+# Release Evidence Index
+
+This directory stores repo-archived evidence packets and links to external CI
+run logs when the evidence lives in GitHub Actions artifacts instead of files in
+the repository.
+
+## Current `v0.12.12` Packets
+
+| Packet | Scope | Evidence |
+| --- | --- | --- |
+| `distribution-v01212-20260508T205913Z/` | Homebrew fresh/upgrade and Darwin Nix tagged-profile install | repo-archived README and metadata |
+| `lazy-linux-20260508T170825Z/` | Linux FUSE lifecycle on `honey`: browse before hydration, exact `cat`, mounted write/readback, cache clear/rehydrate, dirty recursive `unsync` refusal, clean recursive `.tc` conversion, persisted `NotSynced` state | repo-archived transcript, config, mount log, remote prefix, remote pullback, unsync outputs, redacted metadata |
+| PZM testing-mode FileProvider package run | Mac App Development/testing-mode package build for deterministic conflict/status proof | <https://github.com/Jesssullivan/tummycrypt/actions/runs/25569345240> |
+| PZM testing-mode FileProvider smoke run | Enumerate/hydrate/evict/rehydrate, mutation proof already present from prior run, deterministic CLI conflict/status and exact FileProvider content preservation | <https://github.com/Jesssullivan/tummycrypt/actions/runs/25569596910> |
+| PZM testing-mode mutation package run | Mac App Development/testing-mode package build for mutation proof | <https://github.com/Jesssullivan/tummycrypt/actions/runs/25565895586> |
+| PZM testing-mode mutation smoke run | CloudStorage mutation upload and exact 68-byte remote pullback | <https://github.com/Jesssullivan/tummycrypt/actions/runs/25565943781> |
+| PZM testing-mode evict/rehydrate smoke run | Installed host policy probe, E2EE, daemon startup, FileProvider registration, enumeration, requestDownload, evict, re-requestDownload, exact 55-byte hydration | <https://github.com/Jesssullivan/tummycrypt/actions/runs/25562087555> |
+
+## Scope Notes
+
+- PZM FileProvider runs are non-production Mac App Development/testing-mode
+  evidence with the lab `SystemPolicyRule` profile. They do not prove a
+  production Developer ID clean-host Finder lane.
+- `distribution-v01212-20260508T205913Z/` covers Homebrew and Nix only. It does
+  not cover current-tag `.deb`, `.rpm`, container, or production macOS `.pkg`
+  smoke.
+- Linux `lazy-linux-20260508T170825Z/` proves the mounted lifecycle and
+  recursive safe-unsync behavior, not Linux package fresh/upgrade install.

--- a/docs/rfc/0003-ios-file-provider.md
+++ b/docs/rfc/0003-ios-file-provider.md
@@ -56,7 +56,7 @@ As of April 15, 2026:
 │  │  - FileProviderExtension.swift             │  │
 │  │  - FileProviderItem.swift                  │  │
 │  │  - FileProviderEnumerator.swift            │  │
-│  │  - ContentKeychain.swift (~2000 LOC)       │  │
+│  │  - Keychain helpers in host/extension code │  │
 │  └────────────────┬───────────────────────────┘  │
 │                   │ UniFFI (C ABI)               │
 │  ┌────────────────┴───────────────────────────┐  │
@@ -307,7 +307,7 @@ tcfs-core (proto types, config)
             │
             └── tcfs-file-provider (UniFFI bridge) ← NEW
                     │
-                    └── Swift FileProviderExtension (Xcode project) ← FUTURE
+                    └── Swift FileProviderExtension (Xcode project) ← scaffold exists; acceptance pending
 ```
 
 ## References

--- a/docs/rfc/0004-fuse-free-architecture.md
+++ b/docs/rfc/0004-fuse-free-architecture.md
@@ -309,9 +309,11 @@ stay in userspace with zero kernel dependencies.
 ## Migration Impact
 
 ### Users
-- **macOS**: No visible change — FileProvider already works. NFS mount replaces FUSE
-  mount for terminal users who want a mount point.
-- **iOS**: No change — FileProvider is already the only backend.
+- **macOS**: The FileProvider direction exists, but the production Finder
+  surface remains experimental. NFS mount replaces FUSE mount for terminal
+  users who want a mount point.
+- **iOS**: FileProvider remains the only intended backend, but the current
+  product posture is proof-of-concept pending device acceptance.
 - **Linux**: `tcfs mount` switches from FUSE to NFS. Same UX, no kernel module needed.
 
 ### Packagers

--- a/infra/k8s/charts/tcfs-backend/README.md
+++ b/infra/k8s/charts/tcfs-backend/README.md
@@ -1,11 +1,15 @@
 # tcfs-backend Helm Chart
 
-Helm chart for deploying the tcfs sync workers and metadata service to Kubernetes.
+Helm chart for deploying tcfs sync workers to Kubernetes.
 
 ## Components
 
 - **sync-worker**: Stateless NATS JetStream consumer pods (HPA-scaled via KEDA)
-- **metadata-service**: Leader-elected coordination service (Kubernetes Lease API)
+- **coordination RBAC**: Kubernetes Lease permissions for worker coordination
+
+There is no separate metadata-service Deployment in this chart today. Treat any
+older metadata-service references as planned or historical until an actual
+Deployment exists.
 
 ## Current Status
 

--- a/infra/k8s/charts/tcfs-stack/Chart.yaml
+++ b/infra/k8s/charts/tcfs-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tcfs-stack
-description: Umbrella Helm chart for the tcfs (tummycrypt) stack
+description: Umbrella Helm chart for tcfs backend workers, NATS, KEDA, and monitoring
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/infra/k8s/charts/tcfs-stack/values.yaml
+++ b/infra/k8s/charts/tcfs-stack/values.yaml
@@ -3,7 +3,8 @@ global:
   # -- Kubernetes namespace for tcfs resources
   namespace: tcfs
 
-  # -- SeaweedFS S3-compatible endpoint
+  # -- Existing SeaweedFS S3-compatible endpoint. This umbrella chart does not
+  # -- deploy SeaweedFS.
   seaweedfsEndpoint: "http://seaweedfs.tcfs.svc.cluster.local:8333"
 
   # -- NATS server URL
@@ -24,7 +25,7 @@ global:
       cpu: "1"
       memory: 512Mi
 
-# -- SeaweedFS S3 credentials (populate via --set or sealed-secrets)
+# -- Existing SeaweedFS S3 credentials (populate via --set or sealed-secrets)
 seaweedfs:
   # -- S3 access key ID
   accessKeyId: ""

--- a/infra/tofu/environments/civo/main.tf
+++ b/infra/tofu/environments/civo/main.tf
@@ -1,8 +1,8 @@
 # Civo Kubernetes environment: tinyland-civo-dev
 #
-# Deploy the full tcfs stack to Civo K8s.
-# SeaweedFS and NATS run in-cluster in the tcfs namespace;
-# sync workers + observability also run in K8s.
+# Deploy the Civo tcfs worker stack.
+# NATS, sync workers, and observability are modeled here. SeaweedFS is expected
+# as an existing S3 endpoint/secret; this environment does not create it.
 #
 # To deploy:
 #   task infra:apply ENV=civo
@@ -98,7 +98,8 @@ module "tcfs_backend" {
   image      = "ghcr.io/jesssullivan/tcfsd:${var.image_tag}"
   nats_url   = module.nats.nats_url
 
-  # Point workers at the in-cluster SeaweedFS
+  # Point workers at the expected SeaweedFS S3 endpoint. This environment
+  # expects the service and credentials to exist already.
   s3_endpoint    = "http://seaweedfs.tcfs.svc.cluster.local:8333"
   s3_bucket      = "tcfs"
   s3_region      = "us-east-1"

--- a/infra/tofu/modules/tcfs-backend/main.tf
+++ b/infra/tofu/modules/tcfs-backend/main.tf
@@ -1,10 +1,10 @@
-# tcfs-backend: sync-worker Deployment + metadata-service + RBAC
+# tcfs-backend: sync-worker Deployment + RBAC
 #
 # Sync workers are stateless NATS consumers (tcfsd --mode=worker --features k8s-worker).
 # KEDA scales them based on NATS JetStream lag (see keda module).
 #
-# Metadata-service is a 2-replica Deployment using Kubernetes Lease API
-# for leader election — coordinates distributed sync-worker locking per repo.
+# This module grants Kubernetes Lease permissions for worker coordination, but
+# it does not create a separate metadata-service Deployment today.
 
 terraform {
   required_providers {


### PR DESCRIPTION
## Summary

- Ground README, docs index, platform support, and release workflow comments against the current proof surface after PR #341.
- Split PZM testing-mode FileProvider proof from production Developer ID clean-host Finder claims, and add a release evidence index with GitHub Actions run links.
- Clarify backend/K8s chart reality, iOS proof-of-concept limits, Linux artifact scope, distribution evidence gaps, and credential-hygiene follow-up.

## Validation

- `git diff --check`
- `task docs:links`
