### PR TITLE
[codex] Refresh remote governance and Nix fallback status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,16 +92,16 @@ jobs:
           echo "$VERSION" | grep -q "1.93.0"
 
       - name: Build tcfsd
-        run: nix build --accept-flake-config .#tcfsd
+        run: nix build --accept-flake-config --fallback .#tcfsd
 
       - name: Build tcfs-cli
-        run: nix build --accept-flake-config .#tcfs-cli
+        run: nix build --accept-flake-config --fallback .#tcfs-cli
 
       - name: Build tcfs-tui
-        run: nix build --accept-flake-config .#tcfs-tui
+        run: nix build --accept-flake-config --fallback .#tcfs-tui
 
       - name: Build tcfs-mcp
-        run: nix build --accept-flake-config .#tcfs-mcp
+        run: nix build --accept-flake-config --fallback .#tcfs-mcp
 
   fileprovider-staticlib:
     name: FileProvider staticlib (macOS)

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -74,22 +74,22 @@ jobs:
           fi
 
       - name: Build tcfsd
-        run: nix build --accept-flake-config .#tcfsd
+        run: nix build --accept-flake-config --fallback .#tcfsd
 
       - name: Build tcfs-cli
-        run: nix build --accept-flake-config .#tcfs-cli
+        run: nix build --accept-flake-config --fallback .#tcfs-cli
 
       - name: Build tcfs-tui
-        run: nix build --accept-flake-config .#tcfs-tui
+        run: nix build --accept-flake-config --fallback .#tcfs-tui
 
       - name: Build tcfs-mcp
-        run: nix build --accept-flake-config .#tcfs-mcp
+        run: nix build --accept-flake-config --fallback .#tcfs-mcp
 
       - name: Push to Attic
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
           for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
-            nix build --accept-flake-config ".#${pkg}" -o "result-${pkg}"
+            nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
             attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
           done
 
@@ -120,18 +120,18 @@ jobs:
           fi
 
       - name: Build tcfs-cli (no FUSE on macOS)
-        run: nix build --accept-flake-config .#tcfs-cli
+        run: nix build --accept-flake-config --fallback .#tcfs-cli
 
       - name: Build tcfs-tui
-        run: nix build --accept-flake-config .#tcfs-tui
+        run: nix build --accept-flake-config --fallback .#tcfs-tui
 
       - name: Build tcfs-mcp
-        run: nix build --accept-flake-config .#tcfs-mcp
+        run: nix build --accept-flake-config --fallback .#tcfs-mcp
 
       - name: Push to Attic
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
           for pkg in tcfs-cli tcfs-tui tcfs-mcp; do
-            nix build --accept-flake-config ".#${pkg}" -o "result-${pkg}"
+            nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
             attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
           done

--- a/docs/ops/remote-governance.md
+++ b/docs/ops/remote-governance.md
@@ -9,26 +9,28 @@ document makes the consequences of that declaration operational.
 
 ## Current Remote Topology
 
-As of 2026-04-29:
+As of 2026-05-09:
 
 | Remote | URL | Branches | `main` ahead of `origin/main` | `main` behind `origin/main` | Role |
 |--------|-----|----------|-------------------------------|------------------------------|------|
 | `origin` | `https://github.com/Jesssullivan/tummycrypt.git` | 26 | 0 | 0 | canonical source + release authority |
-| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 65 | 21 | 31 | active downstream dev surface |
-| `yoga` | `yoga:git/tummycrypt` (bare SSH) | 10 | 137 | 362 | retired legacy mirror |
+| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 65 | 21 | 132 | active downstream dev surface |
+| `yoga` | `yoga:git/tummycrypt` (bare SSH) | 9 cached remote-tracking branches | 137 | 463 | retired legacy mirror; live fetch timed out on 2026-05-09 |
 
 Divergence points:
 
 - `origin/main` ↔ `tinyland/main`: merge-base is now `796b42e`
   (`origin/main`, 2026-04-17). `tinyland/main` merged `origin/main` via
   tinyland PR #60 on 2026-04-17, but canonical `origin/main` has since moved
-  31 commits ahead. The remaining 21 tinyland-only commits are the 19 pre-sync
+  132 commits ahead. The remaining 21 tinyland-only commits are the 19 pre-sync
   historical commits recorded in
   [Tinyland-Unique Commit Disposition](tinyland-upstream-disposition-2026-04-17.md)
   plus the sync merge pair (`6f7841f`, `987a6b4`).
 - `origin/main` ↔ `yoga/main`: there is no current merge base in this checkout;
   yoga represents a `v0.9.x`-era tcfs snapshot and is not a current development
-  branch.
+  branch. A May 9, 2026 `git fetch yoga --prune` attempt timed out over SSH,
+  so current governance decisions should treat the cached `yoga/*` refs as
+  historical evidence, not as a live collaboration surface.
 
 ## Declared Roles
 
@@ -71,12 +73,12 @@ merged there first and upstreamed to `origin` afterward.
 ### `yoga` — retired legacy mirror
 
 `yoga` is a bare SSH remote on a laptop host. It carries a `v0.9.x`-era
-snapshot that predates the current `v0.12.x` line by 362 commits in the current
-remote comparison.
+snapshot that predates the current `v0.12.x` line by 463 commits in the current
+cached remote comparison.
 
 - `yoga` is **not pushed to** from this point forward.
-- `yoga/main` and its 10 branches remain as **read-only historical
-  reference** only.
+- Cached `yoga/*` remote-tracking refs, including `yoga/main`, remain as
+  **read-only historical reference** only.
 - When the host is decommissioned the remote can be dropped with
   `git remote remove yoga` without information loss, provided anything
   worth preserving has been audited first.
@@ -170,7 +172,9 @@ list:
   `41` `fix/*`, `14` `feat/*`, `4` `test/*`, `3` `chore/*`, `1`
   `refactor/*`, `1` `homebrew-tap`, and `1` `main`. The tracker issue now
   focuses on auditing the larger `fix/*` and `chore/*` backlog for
-  "superseded vs. still-needed" status.
+  "superseded vs. still-needed" status. As of May 9, 2026, no remote branches
+  were deleted during the TCFS parity proof push; the next action should be an
+  explicit operator-approved prune tranche, not opportunistic cleanup.
 
 - **Retire `yoga` formally**: the remote is already de facto retired.
   A tracker issue decides whether to archive the bare SSH repo,
@@ -209,3 +213,7 @@ list:
   deleted remotes, and product proof is still actively moving through the next
   FileProvider/conflict and distribution packets. Do not prune or delete
   branches as part of this sprint until the next proof packet is chosen.
+- 2026-05-09 — Refreshed remote counts after parity proof PRs #341 and #342
+  merged. `origin/main` is current and all #342 checks passed. `tinyland` still
+  has the 65-branch tranche; `yoga` live fetch timed out and remains retired.
+  Branch deletion remains a separate explicit-approval action.

--- a/docs/ops/usage-reality-sprint-plan-2026-05-06.md
+++ b/docs/ops/usage-reality-sprint-plan-2026-05-06.md
@@ -118,7 +118,7 @@ Each packet should produce an archived evidence directory or a linked CI run.
 | E. Finder lifecycle depth | macOS lab after A | Evict/rehydrate is green in run `25562087555`; mutation upload/readback is green in run `25565943781`; CLI conflict state and exact FileProvider content preservation are green in run `25569596910`; badges/progress remain observational | B, C, D |
 | F. On-prem authority | infra/backend | Deferred for this sprint unless a maintenance window is explicitly scheduled; when resumed, `#327` needs candidate service/cutover proof and post-cut tailnet endpoint smoke | A, B, C, D |
 | G. iOS posture | product/docs | Explicit keep-as-scaffold or create a real device/Files.app lane | all |
-| H. Remote/branch hygiene | repo governance | Deferred until product proof is no longer actively moving. Current pass only inspected branches; do not delete local or remote branches until the next proof packet is chosen. | A, D, E |
+| H. Remote/branch hygiene | repo governance | Parity proof PRs #341 and #342 are merged and green. Current May 9 pass refreshed remote counts and confirmed `yoga` fetch timeout, but did not delete local or remote branches. Next action is an explicit operator-approved tinyland/yoga prune or archive decision. | A, D, E |
 
 ## SLA Bar For This Week
 


### PR DESCRIPTION
## Summary

- Refresh remote governance counts after parity proof PRs #341 and #342 merged.
- Record current `tinyland/main` divergence and the live `yoga` SSH fetch timeout.
- Clarify that no branch deletion happened; the next tinyland/yoga prune or archive action needs explicit operator approval.
- Make Nix CI builds use `--fallback` so an Attic cache 502/520 can fall back to source builds instead of failing immediately.

## Validation

- `git diff --check`
- `task docs:links`
- Confirmed all Nix CI `nix build --accept-flake-config` calls in `.github/workflows/ci.yml` and `.github/workflows/nix-ci.yml` now include `--fallback`
