### PR TITLE
[codex] Ground release proof status docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@
 #   - .rpm package (x86_64 daemon package only today)
 #   - Shell installer script (curl | sh)
 #   - Homebrew formula
-#   - Container image (GHCR, multi-arch)
+#   - Container image (GHCR, linux/amd64 today)
 #   - SHA256SUMS.txt
 
 name: Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Current release-proof posture is tracked in `docs/release/evidence/` and
+`docs/ops/product-reality-and-priority.md`; older entries below may describe
+historical release intent rather than the current supported/proven surface.
+
+## [0.12.3 - 0.12.12] - 2026-04-17 to 2026-05-08
+
+### Added
+
+- **Release evidence packets**: current proof after `0.12.2` is tracked in
+  `docs/release/evidence/`, including Linux lifecycle, PZM testing-mode
+  FileProvider lifecycle/conflict, Homebrew/Nix, container, and Linux package
+  distribution packets.
+
+### Changed
+
+- Public docs now separate packaged artifact smoke, host-proven lifecycle,
+  non-production Apple testing-mode evidence, production Finder acceptance, and
+  Kubernetes rollout proof.
+
 ## [0.12.2] - 2026-04-16
 
 ### Added
@@ -45,7 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Finder status surfaces**: macOS FileProvider gained Finder Sync badge support, download progress reporting, and policy-aware excluded or pinned status badges.
 - **Conflict UX improvements**: conflict notifications, conflict-copy remote writes, and CLI policy controls for handling sync conflicts.
-- **Apple packaging updates**: release artifacts include notarized Apple Silicon `.pkg` installers and bundled `TCFSProvider.app` payloads.
+- **Apple packaging updates**: release artifacts include Apple Silicon `.pkg`
+  installers and bundled `TCFSProvider.app` payloads; current notarization
+  posture is tracked in the Apple surface docs and later release-proof evidence.
 
 ### Changed
 
@@ -342,7 +363,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - K8s worker mode with KEDA auto-scaling
 - Prometheus metrics endpoint with systemd `sd_notify(READY=1)`
 - Cross-platform release pipeline: Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64
-- Container image: `ghcr.io/tinyland-inc/tcfsd` (multi-arch distroless)
+- Container image publishing path for `tcfsd`; current registry and
+  architecture proof are tracked in the release evidence docs.
 - Nix flake with NixOS module and Home Manager module
 - Homebrew formula, `.deb`/`.rpm` packages, install scripts
 - 77 tests, cargo-deny license/advisory checks, security audit CI

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ sudo dpkg -i tcfsd-*.deb tcfs-*.deb
 # RPM (Fedora/RHEL/Rocky, daemon-only today)
 sudo rpm -i tcfsd-*.rpm
 
-# Container (K8s worker mode)
-podman pull ghcr.io/jesssullivan/tcfsd:latest
+# Container (K8s worker mode; amd64 image is the current proven lane)
+podman pull --arch amd64 ghcr.io/jesssullivan/tcfsd:latest
 
 # Nix
 nix build github:Jesssullivan/tummycrypt
@@ -129,7 +129,7 @@ For the bar after install succeeds, see
 |---------|-------|-------|---------|-----|
 | CLI (push/pull/reconcile) | Proven | Proven | Planned | - |
 | Daemon (gRPC + metrics) | Proven | Available, lightly validated | Planned | - |
-| Filesystem mount | Proven on x86_64 FUSE; NFS fallback exists | Experimental | Cloud Files API skeleton | - |
+| Filesystem mount | x86_64 FUSE lifecycle is host-proven; packaged mount/systemd first-use is still separate; NFS fallback evidence pending | Experimental | Cloud Files API skeleton | - |
 | FileProvider | - | Lab-proven experimental | - | Proof-of-concept; write hooks unproven |
 | Finder/Explorer badges | - | Experimental | - | - |
 | D-Bus integration | Interface exists; release UX not proven | - | - | - |

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2,6 +2,9 @@
 
 Performance characteristics of tcfs operations, measured with [divan](https://github.com/nvzqz/divan).
 
+Status: partial benchmark snapshot. Sections marked `TBD` are backlog items,
+not release evidence or current performance claims.
+
 ## Chunking Throughput
 
 FastCDC content-defined chunking with BLAKE3 hashing (single-threaded, in-memory):

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,8 +133,8 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 - [Packaged Install To First-Real-Use Acceptance](ops/packaged-install-first-use.md) — the bar after artifact smoke passes and before broader host acceptance
 - [Lab Host Acceptance Matrix](ops/lab-host-acceptance-matrix.md) — real-host acceptance lanes across `honey`, `neo`, and `petting-zoo-mini`
 - [Neo-Honey Live Acceptance](ops/neo-honey-acceptance.md) — named live fleet sync acceptance lane
-- [On-Prem Authority Recovery](ops/onprem-authority-recovery.md) — source-of-truth and recovery path for the Helm-managed `tcfs` backend namespace
-- [Fleet Deployment Guide](ops/fleet-deployment.md) — multi-machine fleet deployment and operational checks
+- [On-Prem Authority Recovery](ops/onprem-authority-recovery.md) — backend-worker Helm recovery plus the on-prem OpenTofu migration boundary
+- [Fleet Deployment Guide](ops/fleet-deployment.md) — legacy Civo-era fleet deployment notes plus operational checks
 - [Lazy Hydration Demo Acceptance](ops/lazy-hydration-demo.md) — terminal and Finder proof target for lazy `ls`/`cat`/dehydrate flows
 - [Lazy Desktop-to-Honey Evidence](release/lazy-desktop-honey-evidence-2026-04-30.md) — live proof of Desktop-originated remote traversal and `cat` hydration on honey
 - [macOS FileProvider Local Evidence](release/macos-fileprovider-local-evidence-2026-04-30.md) — local CloudStorage enumeration and exact-content hydration proof
@@ -161,7 +161,8 @@ Build locally: `task docs:pdf` (outputs to `dist/docs/`)
 | macOS (Intel) | Experimental | CLI binaries ship, but the desktop integration story is not yet as proven as Linux |
 | Windows x86_64 | Planned / skeleton | Cloud Files API skeleton; no release-grade CLI, daemon, or Explorer flow |
 | iOS | Proof-of-concept | FileProvider direction with unproven write hooks; CI type-checks Swift, but there is no continuously proven device/TestFlight/App Store lane |
-| NixOS | Available / evidence pending | Flake + NixOS module + Home Manager module; current `v0.12.12` evidence is Darwin Nix profile install |
+| Nix package/profile | Available / Darwin evidence current | Flake package/profile install is proven on Darwin for `v0.12.12`; Linux Nix install proof and NixOS module host proof are separate |
+| NixOS module | Available / host evidence pending | NixOS and Home Manager modules exist, but current evidence is not a NixOS host acceptance run |
 
 ## License
 

--- a/docs/ops/apple-surface-status.md
+++ b/docs/ops/apple-surface-status.md
@@ -8,8 +8,9 @@ release-grade desktop or iOS product.
 
 ## macOS: Proven Today
 
-- CI proves the Rust staticlib and Swift build surfaces needed for FileProvider
-  packaging.
+- CI proves the Rust staticlib/header needed for FileProvider packaging, plus
+  the iOS Swift type-check lane. The regular CI workflow does not yet build the
+  macOS FileProvider Swift bundle.
 - Release automation can build Apple Silicon artifacts, package
   `TCFSProvider.app`, and publish `.pkg` plus tarball assets.
 - The repo contains real macOS daemon, launchd, NFS loopback, and FileProvider

--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -86,16 +86,16 @@ installed-binary smoke to the first truthful user action, use
 | Homebrew | Yes | Yes | `scripts/install-smoke.sh` | Current manual `homebrew-tap` checkout flow |
 | macOS `.pkg` | Yes | Yes | `scripts/install-smoke.sh` | Apple Silicon package path; desktop UX still experimental |
 | Ubuntu 24.04+ / Debian 13+ `.deb` | Yes | Yes | `scripts/install-smoke.sh` | Install both `tcfsd` and `tcfs` packages |
-| Fedora/RHEL `.rpm` | Yes | Sampled | `scripts/install-smoke.sh --skip-cli` | RPM ships `tcfsd` only today |
-| Container image | Yes | Sampled | worker-image startup check | Pull + entrypoint/startup proof, not CLI status |
-| Nix | Yes | Sampled | `scripts/install-smoke.sh` | Fresh install from the tagged flake is the primary proof |
+| Fedora/RHEL `.rpm` | Yes | Sampled | `scripts/install-smoke.sh --skip-cli` | Fedora 42 x86_64 is currently proven; RHEL/Rocky remain target surfaces pending smoke |
+| Container image | Yes | Sampled | worker-image startup check | amd64 pull + entrypoint/startup proof, not CLI status or cluster rollout |
+| Nix | Yes | Sampled | `scripts/install-smoke.sh` | Current `v0.12.12` proof is Darwin profile install; Linux/NixOS host proof is separate |
 
 ## Surface Procedures
 
 Set the release variables first:
 
 ```bash
-export TAG=v0.12.1
+export TAG=v0.12.12
 export VERSION="${TAG#v}"
 ```
 
@@ -198,9 +198,10 @@ bash scripts/install-smoke.sh --expected-version "${VERSION}" --skip-cli
 Fresh install proof for the worker image is:
 
 ```bash
-podman pull "ghcr.io/jesssullivan/tcfsd:${TAG}"
-podman run --rm "ghcr.io/jesssullivan/tcfsd:${TAG}" --version
+podman pull --arch amd64 "ghcr.io/jesssullivan/tcfsd:${TAG}"
+podman run --rm --arch amd64 "ghcr.io/jesssullivan/tcfsd:${TAG}" --version
 timeout 10s podman run --rm --entrypoint /tcfsd \
+  --arch amd64 \
   "ghcr.io/jesssullivan/tcfsd:${TAG}" \
   --mode=worker \
   --config /tmp/missing.toml \
@@ -209,12 +210,14 @@ timeout 10s podman run --rm --entrypoint /tcfsd \
 
 Success criteria:
 
-- the image pulls successfully
+- the image pulls successfully on the architecture under test
 - `tcfsd --version` reports the expected release version
 - the worker binary starts cleanly enough to emit startup logs before `timeout` stops it
 
 Full cluster rollout proof remains an infra-level check and should be paired with
 the live fleet runbooks when container packaging or worker behavior changes.
+The current `v0.12.12` evidence proves amd64 only; native `linux/arm64/v8`
+pulls are not yet published.
 
 ### Nix
 
@@ -226,6 +229,10 @@ nix profile install \
   "github:Jesssullivan/tummycrypt?ref=${TAG}#tcfs-cli"
 bash scripts/install-smoke.sh --expected-version "${VERSION}"
 ```
+
+Record the host platform in evidence. The current `v0.12.12` packet proves a
+Darwin temporary profile install; Linux Nix profile and NixOS module host proof
+remain separate acceptance lanes.
 
 Upgrade is sampled unless the flake packaging path or install story changes
 materially between releases.

--- a/docs/ops/fleet-deployment.md
+++ b/docs/ops/fleet-deployment.md
@@ -6,6 +6,11 @@ Companion to [RFC 0001: Fleet Sync Integration](../rfc/0001-fleet-sync-integrati
 For the named live acceptance lane built on this fleet, see
 [Neo-Honey Live Acceptance](neo-honey-acceptance.md).
 
+Current authority note: this guide still contains the Civo-era deployment path.
+Treat those commands as legacy/standby unless an operator explicitly targets the
+Civo environment. The active on-prem authority path is honey/on-prem and is
+tracked in [On-Prem Authority Recovery](onprem-authority-recovery.md).
+
 ## Prerequisites
 
 - tcfs v0.3.0+ installed on all machines
@@ -17,8 +22,10 @@ For the named live acceptance lane built on this fleet, see
 
 ## 1. NATS Access Path
 
-NATS JetStream runs in the Civo K8s cluster (`nats.tcfs.svc.cluster.local:4222`).
-Lab machines access it via the Tailscale operator — no public IP, tailnet only.
+The historical Civo path ran NATS JetStream in the Civo K8s cluster
+(`nats.tcfs.svc.cluster.local:4222`). Current live/on-prem authority is moving
+through the honey OpenTofu migration lane; lab machines still access NATS via a
+tailnet-only path rather than a public IP.
 
 ### Tailscale Exposure + DNS
 
@@ -330,7 +337,8 @@ tcfs sync-status
 
 ## 4. IaC Operations
 
-All Civo infrastructure is managed via OpenTofu. Use the Justfile for common operations:
+For the legacy Civo environment, infrastructure is managed via OpenTofu. Use the
+Justfile for common operations:
 
 ```bash
 # List all recipes
@@ -351,7 +359,8 @@ just nats-streams
 just k8s-logs app=tcfsd
 ```
 
-The Justfile is at the project root. All recipes use the `civo` environment by default.
+The Justfile is at the project root. Older recipes use the `civo` environment
+by default; verify the intended environment before applying changes.
 
 ---
 

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -21,7 +21,7 @@ The macOS FileProvider path currently consists of these pieces:
 1. A packaged host app: `TCFSProvider.app`
 2. A packaged non-UI FileProvider extension:
    `io.tinyland.tcfs.fileprovider`
-3. A host-app registration step that removes and re-adds the
+3. A host-app registration step that adds or updates the
    `io.tinyland.tcfs` FileProvider domain on launch
 4. A daemon and FileProvider socket path that the extension uses for
    enumeration, hydration, and watch signaling
@@ -43,8 +43,9 @@ sync-root stub representation, not the desired primary Finder UX.
 
 ## Proven Today
 
-- CI proves the Rust staticlib, Swift sources, and macOS FileProvider build
-  surfaces compile.
+- CI proves the Rust staticlib/header required by the macOS FileProvider bridge
+  and separately type-checks the iOS Swift lane. The regular CI workflow does
+  not yet build the macOS FileProvider Swift bundle.
 - Release automation builds `TCFSProvider.app`, packages it into the Apple
   Silicon `.pkg`, and asks LaunchServices to register the containing app in the
   active console user's context. The

--- a/docs/ops/macos-fileprovider-testing-mode-strategy.md
+++ b/docs/ops/macos-fileprovider-testing-mode-strategy.md
@@ -508,7 +508,8 @@ for an Apple consent boundary that GitHub-hosted macOS cannot cross.
 
 Feature goals remain:
 
-1. production `v0.12.x` packages stay Developer ID signed and notarized
+1. production `v0.12.x` packages attempt Developer ID signing/notarization and
+   are accepted only after explicit post-cut smoke proves the shipped artifacts
 2. user-enabled lab Mac proves production Finder behavior without testing mode
 3. development testing-mode lane proves repeatable CI FileProvider behavior
    through the explicit PZM `SystemPolicyRule` lab trust profile

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -18,8 +18,8 @@ Use this document as the short answer to:
 
 | Surface | Current truth | Source of proof |
 | --- | --- | --- |
-| Linux CLI + daemon | strongest and most routinely proven path; x86_64 FUSE lifecycle has current real-host evidence | CI, release smoke, live host acceptance, archived Linux lifecycle evidence |
-| Fleet sync / backend path | materially proven on real hosts | `neo-honey` live acceptance plus lab host matrix |
+| Linux CLI + daemon | strongest and most routinely proven path; x86_64 FUSE lifecycle has current real-host evidence, while packaged systemd/mount first-use remains a separate gate | CI, release smoke, live host acceptance, archived Linux lifecycle evidence |
+| Fleet sync / backend path | materially exercised on real hosts, but current live transcripts should be archived per run before treating them as release evidence | `neo-honey` live acceptance plus lab host matrix |
 | Lazy traversal / hydration | core code and harnesses exist; Linux FUSE proves browse-before-download, exact `cat` hydration, mounted write/readback, cache clear/rehydrate, and recursive safe-unsync refusal/success on real host evidence; PZM proves macOS FileProvider enumerate, exact-content hydrate, evict, rehydrate, and mutation-through-CloudStorage under testing mode with the installed lab `SystemPolicyRule` profile; production Finder lifecycle evidence is still pending | `tcfs-vfs`/FUSE implementation, archived Linux evidence, PZM testing-mode smoke, and the lazy hydration demo runbook |
 | macOS | experimental but real; current packages prove package/signing/storage/daemon startup, and PZM proves non-production lab FileProvider enumeration/hydration/evict/rehydrate plus mutation upload/readback and CLI conflict/exact-content preservation under Apple's testing-mode entitlement plus a managed SystemPolicyRule profile; production Finder enablement/conflict/status UX are still not release-grade | build + packaging + PZM smoke + local desktop evidence |
 | iOS | proof-of-concept | Swift type-check and scaffold only |
@@ -58,13 +58,16 @@ Current CI proves:
 - sync feature tests in `tcfs-sync`
 - wireup tests in `tcfs-e2e`
 - Nix flake evaluation/build surfaces
-- macOS FileProvider staticlib and Swift header/build integration
+- macOS FileProvider staticlib/header integration
 - iOS simulator-oriented Swift type-check/build surface
 
 Current CI does **not** prove:
 
 - production Finder/FileProvider install-to-enable-to-conflict/status UX
 - real iOS Files.app behavior on simulator or device
+- macOS FileProvider Swift bundle build in the regular CI workflow
+- Helm/Kubernetes rollout, OpenTofu apply, live NATS/SeaweedFS health, or
+  worker deployment semantics
 - accessibility behavior
 - user-facing badges, progress, notifications, or recovery ergonomics
 
@@ -72,7 +75,8 @@ Primary workflow: `.github/workflows/ci.yml`.
 
 ### 3. Live Usage Proof
 
-`tummycrypt` does now have real non-CI usage lanes:
+`tummycrypt` does now have real non-CI usage lanes. Treat them as live/manual
+acceptance unless the specific run has a dated repo-archived transcript:
 
 - [Neo-Honey Live Acceptance](neo-honey-acceptance.md): canonical live backend and two-device sync smoke
 - [Lab Host Acceptance Matrix](lab-host-acceptance-matrix.md): real host acceptance using `honey`, `neo`, and `petting-zoo-mini`

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -10,17 +10,18 @@ Best-supported runtime. This is the platform with the strongest continuous CI
 coverage and the clearest end-to-end validation story.
 
 - **CLI**: All commands (push, pull, reconcile, policy, resolve, mount, unsync)
-- **Daemon**: systemd user service with auto-restart, metrics (Prometheus), health checks
-- **Filesystem**: FUSE3 mount with clean-name on-demand hydration on the primary x86_64 release artifact; physical `.tc` stubs are used by unsync/offline paths
-- **NFS loopback**: Alternative to FUSE (no kernel modules required)
+- **Daemon**: package artifacts install daemon binaries and service files; isolated daemon smoke is proven, while systemd-managed service behavior is a separate release gate
+- **Filesystem**: FUSE3 mount with clean-name on-demand hydration is host-proven on Linux x86_64 from repo-pinned tooling; packaged install-to-mount proof is still separate
+- **NFS loopback**: Alternative to FUSE (no kernel modules required), with current release evidence pending
 - **Fleet sync**: NATS JetStream with vector clock conflict detection
 - **D-Bus**: Interface crate exists, but the default backend is a stub and release UX/status integration is not yet proven
 - **Encryption**: XChaCha20-Poly1305 per-chunk, Argon2id KDF
-- **Build targets**: x86_64 (.tar.gz, .deb, .rpm), aarch64 (.tar.gz, .deb)
-  with `.deb` install support claimed for Ubuntu 24.04+ and Debian 13
-  `trixie`+. Debian 12 `bookworm` is not a truthful target for the current
-  shipped `.deb` assets because the packages require newer glibc/OpenSSL ABI
-  floors than bookworm provides.
+- **Build targets**: x86_64 (.tar.gz, .deb, .rpm) with the primary FUSE lane;
+  aarch64 (.tar.gz, .deb) is install-smoke proven but cross-compiled without
+  FUSE in the current release matrix. `.deb` install support is claimed for
+  Ubuntu 24.04+ and Debian 13 `trixie`+. Debian 12 `bookworm` is not a truthful
+  target for the current shipped `.deb` assets because the packages require
+  newer glibc/OpenSSL ABI floors than bookworm provides.
 
 ## macOS (Experimental Desktop Surface)
 
@@ -37,7 +38,10 @@ as a production-proven platform.
 - **Encryption**: Core crypto path is shared and available
 - **Build targets**: aarch64 (.tar.gz, .pkg; notarization attempted but non-blocking), x86_64 (.tar.gz)
 - **Homebrew**: manual tap flow required today because the formula is published on the `homebrew-tap` branch, not the default branch
-- **Current proof**: CI covers Rust builds plus Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts; PZM testing-mode lab proof is green beyond read/hydrate; production clean-host Finder proof is still pending
+- **Current proof**: CI covers the Rust FileProvider staticlib/header and iOS
+  Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts;
+  PZM testing-mode lab proof is green beyond read/hydrate; production
+  clean-host Finder proof is still pending
 - **Current posture**: see [Apple Surface Status](ops/apple-surface-status.md)
   and [Distribution Smoke Matrix](ops/distribution-smoke-matrix.md)
 
@@ -108,3 +112,5 @@ Stateless worker for horizontal scaling.
 - **Mode**: `--mode=worker` (NATS consumer, no FUSE)
 - **Features**: k8s-worker feature flag, KEDA auto-scaling support
 - **Metrics**: Prometheus on port 9100
+- **Current proof**: `v0.12.12` proves explicit amd64 pull/version/startup
+  only; native arm64 manifests and full Kubernetes rollout proof remain open

--- a/docs/rfc/0001-fleet-sync-integration.md
+++ b/docs/rfc/0001-fleet-sync-integration.md
@@ -66,7 +66,13 @@ Current pain points:
 
 ## Infrastructure Prerequisites
 
-### Already Running (Civo K8s)
+Historical note: this section records the original Civo-era fleet plan. Current
+backend/on-prem authority is tracked in
+[Fleet Deployment Guide](../ops/fleet-deployment.md),
+[On-Prem Authority Recovery](../ops/onprem-authority-recovery.md), and
+[Product Reality And Priority](../ops/product-reality-and-priority.md).
+
+### Historical Civo K8s State
 
 | Service | Endpoint | Namespace |
 |---------|----------|-----------|
@@ -139,9 +145,15 @@ tinyland.host.tummycrypt = {
 
 ## Rollout Plan
 
+Historical note: this section records the original `v0.3.0` rollout plan.
+Current live fleet proof should be taken from
+[Neo-Honey Live Acceptance](../ops/neo-honey-acceptance.md) and the current
+[Product Reality And Priority](../ops/product-reality-and-priority.md), not
+from the unchecked historical task list below.
+
 ### Phase 1: Merge + Package (Day 0)
 
-1. Merge PR #18 to `main` in tummycrypt
+1. PR #18 merged to `main` in tummycrypt
 2. Tag `v0.3.0` release
 3. Nix flake update in crush-dots: `nix flake update tummycrypt`
 4. Verify `nix build .#tcfs-cli` succeeds on all platforms
@@ -192,6 +204,8 @@ tinyland.host.tummycrypt = {
 4. Take one machine offline, modify files on others, bring back online, verify catch-up
 
 ## Verification Checklist
+
+Historical checklist for the original RFC rollout:
 
 - [ ] PR #18 CI all green (Build + Lint + Test, Nix Build, Security Audit, cargo-deny)
 - [ ] All 133 tests pass locally on each platform (linux-x86_64, darwin-aarch64)

--- a/docs/rfc/0003-ios-file-provider.md
+++ b/docs/rfc/0003-ios-file-provider.md
@@ -233,7 +233,7 @@ enum ProviderError {
 - Background refresh via `NSFileProviderManager.signalEnumerator`
 - Push notifications for real-time updates (APNs or polling)
 
-### Phase 7e: UI + Polish (PR #65, IN PROGRESS)
+### Phase 7e: UI + Polish (PR #65 merged; broader iOS proof remains incomplete)
 
 - [x] Progress reporting during hydration (UniFFI callback interface → NSProgress)
 - [x] Conflict detection via vclock divergence (`check_conflict_async`)

--- a/docs/tex/architecture.tex
+++ b/docs/tex/architecture.tex
@@ -200,7 +200,11 @@ auto-reloads credentials when the file changes on disk.
   \bottomrule
 \end{longtable}
 
-\subsection{Civo Kubernetes}
+\subsection{Legacy Civo Kubernetes}
+
+This table records the earlier Civo deployment shape. Current live/on-prem
+authority is tracked in \texttt{docs/ops/onprem-authority-recovery.md} and
+\texttt{docs/ops/product-reality-and-priority.md}.
 
 \begin{longtable}{ll}
   \toprule


### PR DESCRIPTION
## Summary
- ground Linux, container, Nix, Apple, backend/K8s, RFC, benchmark, changelog, and PDF architecture docs against the proof boundaries found in the broad truthing pass
- clarify package smoke vs host-proven lifecycle vs systemd/mount first-use vs cluster rollout proof
- narrow Apple CI/signing/notarization wording and mark Civo fleet docs as legacy/standby rather than active authority

## Validation
- git diff --check origin/main...HEAD
- task docs:links
- task docs:pdf

## Follow-up proof gaps still open
- production macOS .pkg clean-host Finder proof
- native linux/arm64/v8 container manifest proof
- packaged Linux FUSE/systemd first-use proof if we want that as release acceptance
- repo-archived neo-honey/PZM artifact logs for durable evidence beyond linked Actions runs
