### PR TITLE
[codex] Ground repo reality hygiene

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -622,43 +622,10 @@ jobs:
           # tcfs installer for Windows (PowerShell)
           $ErrorActionPreference = "Stop"
 
-          $repo = "__REPO__"
           $tag = "__TAG__"
-          $version = $tag.TrimStart("v")
-          $platform = "windows-x86_64"
-          $tarball = "tcfs-${version}-${platform}.zip"
-          $url = "https://github.com/${repo}/releases/download/${tag}/${tarball}"
-
-          $installDir = if ($env:TCFS_INSTALL_DIR) { $env:TCFS_INSTALL_DIR } else { "$env:LOCALAPPDATA\tcfs\bin" }
-
-          Write-Host "Downloading tcfs ${tag} for Windows..."
-          New-Item -ItemType Directory -Force -Path $installDir | Out-Null
-
-          $tmpFile = [System.IO.Path]::GetTempFileName() + ".zip"
-          Invoke-WebRequest -Uri $url -OutFile $tmpFile
-
-          $tmpDir = [System.IO.Path]::GetTempFileName() + "_extract"
-          Expand-Archive -Path $tmpFile -DestinationPath $tmpDir -Force
-
-          Copy-Item "${tmpDir}\tcfs-${version}-${platform}\tcfs.exe" "${installDir}\tcfs.exe" -Force
-          Copy-Item "${tmpDir}\tcfs-${version}-${platform}\tcfsd.exe" "${installDir}\tcfsd.exe" -Force
-          Copy-Item "${tmpDir}\tcfs-${version}-${platform}\tcfs-tui.exe" "${installDir}\tcfs-tui.exe" -Force
-
-          Remove-Item -Recurse -Force $tmpFile, $tmpDir
-
-          # Add to PATH if not already there
-          $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-          if ($userPath -notlike "*${installDir}*") {
-            [Environment]::SetEnvironmentVariable("PATH", "${installDir};${userPath}", "User")
-            Write-Host "Added ${installDir} to PATH"
-          }
-
-          Write-Host ""
-          Write-Host "tcfs ${tag} installed successfully!"
-          Write-Host "  Restart your shell, then run: tcfs status"
+          Write-Error "tcfs ${tag} does not publish Windows artifacts. Windows support is planned, but this release has no tcfs-*-windows-x86_64.zip asset."
           PSINSTALLER
 
-          sed -i "s|__REPO__|${{ github.repository }}|g" install.ps1
           sed -i "s|__TAG__|${{ needs.plan.outputs.tag }}|g" install.ps1
 
       - name: Upload installers

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > Under active development. Not yet stable. Expect breaking changes.
 
 Self-hosted encrypted file sync with on-demand hydration. The Linux FUSE mounted
-view is host-proven for clean-name traversal and hydrate-on-open; offline or
+view is host-proven for clean-name traversal, hydrate-on-open, mounted
+write/readback, cache clear/rehydrate, and recursive safe-unsync; offline or
 dehydrated sync-root copies can be represented by small `.tc`/`.tcf` stubs. FOSS
 odrive/Dropbox-style alternative under active development.
 

--- a/docs/ops/apple-surface-status.md
+++ b/docs/ops/apple-surface-status.md
@@ -1,6 +1,6 @@
 # Apple Surface Status
 
-As of May 8, 2026, Apple support is a buildable and partially proven lane. The
+As of May 9, 2026, Apple support is a buildable and partially proven lane. The
 macOS FileProvider testing-mode lab now has green enumerate, hydrate, evict,
 rehydrate, mutation upload/readback, and deterministic conflict/status content
 preservation proof on PZM, but Apple surfaces are still not a full

--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -40,13 +40,15 @@ release and CI evidence exists for parts of that surface.
 The release workflow also publishes helper installers:
 
 - `install.sh` for Linux/macOS tarball convenience installs
-- `install.ps1` for Windows convenience installs
+- `install.ps1` for Windows, currently an explicit unsupported-release stub
+  while Windows artifacts are disabled
 
 These are **not** canonical release-proof surfaces today.
 
 - `install.sh` remains convenience tooling until a dedicated smoke lane is added
-- `install.ps1` is convenience-only because Windows is not yet a truthful
-  release-grade user surface
+- `install.ps1` must not claim install success until the release workflow
+  publishes a matching Windows zip; today it fails with an unsupported-release
+  message because Windows is not yet a truthful release-grade user surface
 
 ## Shared Installed-Binary Smoke
 

--- a/docs/ops/fleet-deployment.md
+++ b/docs/ops/fleet-deployment.md
@@ -300,7 +300,16 @@ systemctl --user start tcfsd
 
 ### macOS (launchd, non-Nix)
 
-For manual installs without Home Manager:
+For packaged installs, the current postinstall path writes
+`/Library/LaunchAgents/io.tinyland.tcfsd.plist` and starts `tcfsd` with:
+
+```bash
+--config "$HOME/.config/tcfs/config.toml"
+```
+
+The older `dist/com.tummycrypt.tcfsd.plist` file is a historical/manual helper,
+not the active package evidence path. If you use it for a manual install, treat
+the result as local operator setup, not release proof.
 
 ```bash
 # Copy plist

--- a/docs/ops/ios-surface-status.md
+++ b/docs/ops/ios-surface-status.md
@@ -1,6 +1,6 @@
 # iOS Surface Status
 
-As of May 8, 2026, iOS is an experimental FileProvider proof-of-concept,
+As of May 9, 2026, iOS is an experimental FileProvider proof-of-concept,
 not an active release target.
 
 ## What Exists In The Repo Today

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -302,8 +302,15 @@ GitHub state before acting on exact issue or milestone status.
 - Adjacent non-M10 lanes
   - `#298`: residual Civo TCFS PVC retirement after on-prem recovery
   - `#327`: TCFS on-prem OpenTofu migration and cutover
-  - `#312`: tinyland branch-tranche triage
-  - `#313`: yoga retirement decision
+  - `#312`: tinyland branch-tranche triage. PR #351 recorded a concrete
+    non-destructive prune proposal; the remaining decision is operator
+    approve/defer for Tranche A.
+
+Closed during the May 9 branch-hygiene pass:
+
+- `#313`: yoga retirement decision. The recorded decision is
+  documentation-only retirement; no archive, host deletion, key revocation,
+  local remote removal, or branch deletion was performed.
 
 Milestone `#9 M10: Usage Reality & Product Parity` remains open because the
 release-proof tranche still has active issues beyond the umbrella. The earlier
@@ -337,13 +344,14 @@ The current parity summary and Desktop/honey demo contract live in
 
 ## Linear Mirror State
 
-As of May 6, 2026, Linear is a useful management mirror but is not the
+As of May 9, 2026, Linear is a useful management mirror but is not the
 freshest truth source for `tummycrypt`.
 
-- `TIN-133` has been retitled to `Prove lazy traversal and Finder/FileProvider
-  hydration reality` and now points at GitHub `#309` plus the current repo docs.
-  The latest comments mirror the `v0.12.12` PZM testing-mode lifecycle success
-  and the remaining production Finder lifecycle gaps.
+- `TIN-133` is `In Progress`, is titled `Prove lazy traversal and
+  Finder/FileProvider hydration reality`, and points at GitHub `#309` plus the
+  current repo docs. The latest comments mirror the `v0.12.12` PZM
+  testing-mode lifecycle success and the remaining production Finder lifecycle
+  gaps.
 - `TIN-131` and `TIN-132` remain in Backlog under `Tummycrypt M10: Usage
   Reality & Product Parity`; their descriptions were refreshed on April 29,
   2026 to separate current repo truth from the older GitHub issue framing they
@@ -377,4 +385,5 @@ Linear hygiene decision on April 29, 2026:
 - [Apple Surface Status](apple-surface-status.md)
 - [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md)
 - [iOS Surface Status](ios-surface-status.md)
+- [TCFS Workstream Reality Check - 2026-05-09](workstream-reality-check-2026-05-09.md)
 - [Feature Parity Gap Analysis](../../odrive-re/docs/feature-parity-gap-analysis.md)

--- a/docs/ops/remote-governance.md
+++ b/docs/ops/remote-governance.md
@@ -14,15 +14,15 @@ As of 2026-05-09:
 | Remote | URL | Branches | `main` ahead of `origin/main` | `main` behind `origin/main` | Role |
 |--------|-----|----------|-------------------------------|------------------------------|------|
 | `origin` | `https://github.com/Jesssullivan/tummycrypt.git` | 26 | 0 | 0 | canonical source + release authority |
-| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 65 | 21 | 140 | active downstream dev surface |
-| `yoga` | `yoga:git/tummycrypt` (bare SSH) | 9 cached remote-tracking branches | 137 | 471 | retired legacy mirror; live fetch timed out on 2026-05-09 |
+| `tinyland` | `git@github.com:tinyland-inc/tummycrypt.git` | 65 | 21 | 141 | active downstream dev surface |
+| `yoga` | `yoga:git/tummycrypt` (bare SSH) | 9 cached remote-tracking branches | 137 | 472 | retired legacy mirror; live fetch timed out on 2026-05-09 |
 
 Divergence points:
 
 - `origin/main` ↔ `tinyland/main`: merge-base is now `796b42e`
   (`origin/main`, 2026-04-17). `tinyland/main` merged `origin/main` via
   tinyland PR #60 on 2026-04-17, but canonical `origin/main` has since moved
-  140 commits ahead. The remaining 21 tinyland-only commits are the 19 pre-sync
+  141 commits ahead. The remaining 21 tinyland-only commits are the 19 pre-sync
   historical commits recorded in
   [Tinyland-Unique Commit Disposition](tinyland-upstream-disposition-2026-04-17.md)
   plus the sync merge pair (`6f7841f`, `987a6b4`).
@@ -74,7 +74,7 @@ merged there first and upstreamed to `origin` afterward.
 ### `yoga` — retired legacy mirror
 
 `yoga` is a bare SSH remote on a laptop host. It carries a `v0.9.x`-era
-snapshot that predates the current `v0.12.x` line by 471 commits in the current
+snapshot that predates the current `v0.12.x` line by 472 commits in the current
 cached remote comparison.
 
 - `yoga` is **not pushed to** from this point forward.
@@ -242,3 +242,8 @@ list:
   deletion tranche, 17 feature/test branches for short human review before
   deletion, and keeps `main`, `homebrew-tap`, `feat/fuse-free-vfs-nfs`, and
   `refactor/retire-fuse-crates`.
+- 2026-05-09 — Refreshed divergence after PR #351 merged as `26e9fab3e08d`.
+  `tinyland/main` remains 21 commits ahead and is now 141 commits behind
+  `origin/main`; cached `yoga/main` remains 137 commits ahead and is now 472
+  commits behind `origin/main`. The `origin` branch count remains 26 after
+  pruning the deleted PR branch.

--- a/docs/ops/tinyland-branch-prune-proposal-2026-05-09.md
+++ b/docs/ops/tinyland-branch-prune-proposal-2026-05-09.md
@@ -257,8 +257,9 @@ git rev-list --left-right --count origin/main...tinyland/main
 ```
 
 Expected result after Tranche A only: the `tinyland` remote branch count drops
-from 65 to 21, while `tinyland/main` remains 21 ahead / 140 behind
-`origin/main`.
+from 65 to 21. At proposal creation, `tinyland/main` remained 21 ahead / 140
+behind `origin/main`; after PR #351 merged, the current comparison is 21 ahead
+/ 141 behind `origin/main`.
 
 Expected result after Tranche A and B: the `tinyland` remote branch count drops
 from 65 to 4, leaving only:
@@ -274,7 +275,7 @@ tinyland/refactor/retire-fuse-crates
 
 - #312 can close once this proposal is merged and an operator either approves
   or explicitly defers the Tranche A deletion.
-- #313 can close on the documentation-only retirement decision already recorded
+- #313 closed after PR #351 recorded the documentation-only retirement decision
   in [Remote Governance](remote-governance.md). No `yoga` archive, SSH host
   deletion, key revocation, or local remote removal is part of this branch
   hygiene lane.

--- a/docs/ops/usage-reality-sprint-plan-2026-05-06.md
+++ b/docs/ops/usage-reality-sprint-plan-2026-05-06.md
@@ -118,7 +118,7 @@ Each packet should produce an archived evidence directory or a linked CI run.
 | E. Finder lifecycle depth | macOS lab after A | Evict/rehydrate is green in run `25562087555`; mutation upload/readback is green in run `25565943781`; CLI conflict state and exact FileProvider content preservation are green in run `25569596910`; badges/progress remain observational | B, C, D |
 | F. On-prem authority | infra/backend | Deferred for this sprint unless a maintenance window is explicitly scheduled; when resumed, `#327` needs candidate service/cutover proof and post-cut tailnet endpoint smoke | A, B, C, D |
 | G. iOS posture | product/docs | Explicit keep-as-scaffold or create a real device/Files.app lane | all |
-| H. Remote/branch hygiene | repo governance | Parity proof PRs #341 and #342 are merged and green. Current May 9 pass refreshed remote counts and confirmed `yoga` fetch timeout, but did not delete local or remote branches. Next action is an explicit operator-approved tinyland/yoga prune or archive decision. | A, D, E |
+| H. Remote/branch hygiene | repo governance | PR #351 recorded the current non-destructive truth: `tinyland` has a prune proposal with 44 fix/chore Tranche A candidates, 17 feature/test review candidates, and two architecture-sensitive hold branches; `yoga` is documentation-only retired under #313. No tinyland branch deletion, yoga archive, host deletion, key revocation, or local remote removal was performed. | A, D, E |
 
 ## SLA Bar For This Week
 
@@ -134,7 +134,8 @@ The minimum credible M10 proof bar is:
 3. One updated product-status document that does not conflate testing-mode lab
    proof with production Finder proof.
 4. Linear/GitHub trackers updated with run IDs, artifact paths, and the next
-   owner packet.
+   owner packet. The May 9 tracker reality is summarized in
+   [TCFS Workstream Reality Check - 2026-05-09](workstream-reality-check-2026-05-09.md).
 
 Anything below that is still useful engineering work, but not enough to claim
 the desktop/lazy-hydration story is release-proven.

--- a/docs/ops/workstream-reality-check-2026-05-09.md
+++ b/docs/ops/workstream-reality-check-2026-05-09.md
@@ -1,0 +1,93 @@
+# TCFS Workstream Reality Check - 2026-05-09
+
+This checkpoint records the repo, tracker, and proof state after PR #351 merged.
+It is meant to keep planning language grounded while the remaining M10 work
+continues.
+
+## Source Snapshot
+
+| Surface | Current state |
+| --- | --- |
+| Canonical repo | `Jesssullivan/tummycrypt` |
+| Current `main` | `26e9fab3e08d` |
+| Open PRs | none at audit time |
+| Current release | `v0.12.12` |
+| Primary milestone | GitHub milestone `#9 M10: Usage Reality & Product Parity` |
+
+## GitHub Tracker Reality
+
+Open issues at audit time:
+
+| Issue | Current decision |
+| --- | --- |
+| `#280` distribution proof | Keep open. Homebrew/Nix, Linux `.deb`/`.rpm`, and amd64 container proof are archived for `v0.12.12`; remaining blockers are production macOS `.pkg` clean-host proof and native arm64 container registry proof on a future tag. |
+| `#309` production macOS `.pkg`/Finder proof | Keep open. PZM testing-mode FileProvider proof is green but explicitly non-production. |
+| `#312` tinyland branch tranche | Keep open. PR #351 recorded a non-destructive prune proposal; next decision is operator approve/defer for Tranche A. |
+| `#327` on-prem OpenTofu migration/cutover | Keep open. Source/runbook work is ready, but live mutation waits on a named downtime window, rollback owner, and post-cut smoke owner. |
+| `#298` residual Civo PVC retirement | Keep open until `#327` completes or an operator explicitly overrides the dependency. |
+
+Closed in this pass:
+
+- `#313`: `yoga` retirement is now option 1, documentation-only retirement.
+  No archive, host deletion, key revocation, local remote removal, or branch
+  deletion was performed.
+
+## Linear Reality
+
+The Linear project `Tummycrypt M10: Usage Reality & Product Parity` is a useful
+management mirror, but the repo docs and GitHub issues remain the operational
+truth.
+
+| Linear issue | State | Current role |
+| --- | --- | --- |
+| `TIN-131` | Backlog | Mirror for GitHub `#280` distribution install/upgrade proof. |
+| `TIN-132` | Backlog | Mirror for live backend / `neo-honey` acceptance. |
+| `TIN-133` | In Progress | Mirror for lazy traversal and Finder/FileProvider hydration reality, currently pointing at GitHub `#309` and repo evidence docs. |
+| `TIN-134` | Done | iOS posture decision is superseded by Apple/iOS status docs. |
+| `TIN-135` | Done | odrive/desktop parity analysis is superseded by product reality and parity docs. |
+| `TIN-151` | Done | macOS OpenSSL-linked daemon runtime defect was closed before the current proof push. |
+| `TIN-720` | In Progress | Infrastructure/on-prem tailnet source-ownership lane; relevant to `#327`, not a blocker for disposable lazy/Finder proof. |
+
+## Workstream Fronts
+
+| Front | Current truth | Do not claim yet |
+| --- | --- | --- |
+| Linux CLI/daemon | Strongest supported path. CI, package smoke, live backend acceptance, and release evidence exist. | Universal Linux desktop UX or every distro/service-manager combination. |
+| Linux mounted FUSE | Expanded lifecycle proof is archived in `docs/release/evidence/lazy-linux-20260508T170825Z/`: browse before hydration, exact `cat`, mounted write/readback, cache clear/rehydrate, recursive safe-unsync refusal/success. | Packaged mount/systemd first-use as continuously proven on every supported distro. |
+| K8s/on-prem backend | Live backend works; source-owned OpenTofu migration/cutover is planned and renderable. | That NATS/SeaweedFS are already source-owned or storage-mobile. |
+| CI/test coverage | PR #351 passed the full matrix: Rust build/lint/test, Docs, Nix CI, Nix Build, cargo-deny, Secret Scan, FileProvider staticlib, iOS typecheck. | Production Finder, iOS device, Kubernetes rollout, accessibility, or visible badge/progress UX. |
+| Fuzzing | Four cargo-fuzz targets exist under `fuzz/`. | Continuous fuzz execution in CI or `task check`; fuzz is present but not currently a release gate. |
+| macOS package/FileProvider | PZM testing-mode lane is green through enumerate, hydrate, evict, rehydrate, mutation upload/readback, CLI conflict state, and exact FileProvider content preservation. | Production Developer ID clean-host Finder lifecycle or visible Finder conflict/status UX. |
+| iOS | Host app, extension, generated bindings, and simulator type-check surface exist. | Active release target, TestFlight/App Store readiness, real-device Files.app behavior, or write support. |
+| Distribution | `v0.12.12` Homebrew/Nix, Linux `.deb`/`.rpm`, and amd64 container proof are archived. Release workflow is ready to publish arm64 container images on the next cut. | Native arm64 container proof for the current tag or production macOS `.pkg` clean-host proof. |
+| Signing | Semantic release tags now fail closed on Developer ID signing/profile inputs; PZM testing-mode uses Mac App Development signing material and managed lab policy. | That Mac App Development testing-mode evidence substitutes for production Developer ID distribution evidence. |
+| E2E/runners | PZM, `neo`, and `honey` have named roles in lab acceptance docs. GitHub-hosted macOS lanes need public storage endpoints. | That hosted macOS can replace a clean physical production Finder host. |
+| Helm/Kubernetes charts | `tcfs-stack` is an umbrella control-plane chart with external SeaweedFS credentials and endpoint; `tcfs-backend` is the direct worker chart. | Blank-cluster storage bootstrap or easy standalone chart install without KEDA/ServiceMonitor CRDs unless optional resources are disabled. |
+| Remote governance | `origin` is canonical. `tinyland` has a prune proposal. `yoga` is documentation-only retired. | Any remote branch deletion without explicit operator approval. |
+
+## Next Grounded Goals
+
+1. Decide `#312` Tranche A: approve or explicitly defer deletion of the 44
+   superseded fix/chore branches.
+2. Keep `#280` focused on native arm64 container proof on the next tag and
+   production macOS `.pkg` clean-host proof.
+3. Keep `#309` focused on production Developer ID Finder lifecycle, not more
+   PZM testing-mode proof unless the lab harness changes.
+4. Schedule `#327` only with a named downtime window, rollback owner, and
+   post-cut smoke owner.
+5. Leave `#298` blocked until the on-prem cutover decision is grounded.
+6. Keep `TIN-131`, `TIN-132`, and `TIN-133` as Linear mirrors; do not expand
+   Linear into a second source of truth for exact proof claims.
+
+## Related Docs
+
+- [Product Reality And Priority](product-reality-and-priority.md)
+- [TCFS Usage Reality Sprint Plan](usage-reality-sprint-plan-2026-05-06.md)
+- [Distribution Smoke Matrix](distribution-smoke-matrix.md)
+- [Lazy Hydration Demo Acceptance](lazy-hydration-demo.md)
+- [Apple Surface Status](apple-surface-status.md)
+- [macOS Finder and FileProvider Reality](macos-fileprovider-reality.md)
+- [iOS Surface Status](ios-surface-status.md)
+- [On-Prem Authority Recovery](onprem-authority-recovery.md)
+- [Remote Governance](remote-governance.md)
+- [Tinyland Branch Prune Proposal - 2026-05-09](tinyland-branch-prune-proposal-2026-05-09.md)

--- a/docs/tex/fileprovider.tex
+++ b/docs/tex/fileprovider.tex
@@ -355,8 +355,11 @@ variables or arbitrary config files. Credentials are stored via:
 
 \begin{description}
   \item[Keychain] S3 access and secret credentials stored in a shared Keychain
-    access group (\code{group.com.tummycrypt.tcfs}). The host app writes
-    credentials during setup; the extension reads them at runtime.
+    access group. The current app group is
+    \code{group.io.tinyland.tcfs}; the concrete Keychain group is the Apple
+    Team ID / App Identifier Prefix plus that group, for example
+    \code{QP994XQKNH.group.io.tinyland.tcfs}. The host app writes credentials
+    during setup; the extension reads them at runtime.
   \item[App Group UserDefaults] Configuration values (S3 endpoint, bucket,
     prefix, NATS URL) stored in shared UserDefaults.
   \item[App Group Container] Large config files or state caches stored in
@@ -478,11 +481,14 @@ tcfs-sync       & 100\% & 100\% & 100\% & 80\%  \\
   \item \textbf{Apple Developer enrollment}: Is Tinyland Inc enrolled in the
     Apple Developer Program (\$99/year)? If not, who initiates enrollment?
   \item \textbf{App Group identifier}: Proposed
-    \code{group.com.tummycrypt.tcfs} for shared Keychain and container access.
+    \code{group.io.tinyland.tcfs} for shared Keychain and container access.
   \item \textbf{Distribution}: \code{.dmg} with drag-to-install? Homebrew cask?
     Both?
   \item \textbf{Minimum macOS}: \code{NSFileProviderReplicatedExtension}
-    matured in macOS 13+. Recommend targeting macOS 13 (Ventura) as minimum.
+    matured in macOS 13+, but the current packaged FileProvider lane targets
+    macOS 15.0 in the build script and bundle plists. Treat macOS 13 as
+    historical design direction unless \code{MIN\_MACOS} and the plists are
+    lowered deliberately.
   \item \textbf{iOS timeline}: Shared crate enables iOS but requires Xcode
     project, TestFlight, and App Store submission. Defer to Phase 3+.
 \end{enumerate}

--- a/infra/k8s/charts/tcfs-backend/README.md
+++ b/infra/k8s/charts/tcfs-backend/README.md
@@ -36,6 +36,16 @@ With the default release name `tcfs-backend`, this chart creates:
 
 ## Usage
 
+This direct chart can render KEDA `ScaledObject` and Prometheus
+`ServiceMonitor` resources. Before using the defaults, confirm those CRDs are
+installed. For a plain backend-worker reconcile without those CRDs, disable the
+optional resources explicitly:
+
+```bash
+--set autoscaling.enabled=false \
+--set metrics.serviceMonitor.enabled=false
+```
+
 ```bash
 bash scripts/tcfs-backend-deploy.sh
 ```
@@ -47,6 +57,8 @@ helm upgrade --install tcfs-backend ./infra/k8s/charts/tcfs-backend \
   --namespace tcfs \
   --create-namespace \
   --set image.tag=v0.12.12 \
+  --set autoscaling.enabled=false \
+  --set metrics.serviceMonitor.enabled=false \
   --set config.natsUrl=nats://nats.tcfs.svc.cluster.local:4222
 ```
 

--- a/infra/k8s/charts/tcfs-stack/Chart.yaml
+++ b/infra/k8s/charts/tcfs-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tcfs-stack
-description: Umbrella Helm chart for tcfs backend workers, NATS, KEDA, and monitoring
+description: Umbrella Helm chart for tcfs backend workers, NATS, KEDA, and monitoring with external SeaweedFS
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/infra/k8s/charts/tcfs-stack/templates/seaweedfs-secret.yaml
+++ b/infra/k8s/charts/tcfs-stack/templates/seaweedfs-secret.yaml
@@ -12,9 +12,11 @@ type: Opaque
 data:
   {{- if .Values.seaweedfs.accessKeyId }}
   AWS_ACCESS_KEY_ID: {{ .Values.seaweedfs.accessKeyId | b64enc | quote }}
+  access_key_id: {{ .Values.seaweedfs.accessKeyId | b64enc | quote }}
   {{- end }}
   {{- if .Values.seaweedfs.secretAccessKey }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.seaweedfs.secretAccessKey | b64enc | quote }}
+  secret_access_key: {{ .Values.seaweedfs.secretAccessKey | b64enc | quote }}
   {{- end }}
 stringData:
   SEAWEEDFS_ENDPOINT: {{ .Values.global.seaweedfsEndpoint | quote }}

--- a/infra/k8s/charts/tcfs-stack/values.yaml
+++ b/infra/k8s/charts/tcfs-stack/values.yaml
@@ -27,7 +27,9 @@ global:
       cpu: "1"
       memory: 512Mi
 
-# -- Existing SeaweedFS S3 credentials (populate via --set or sealed-secrets)
+# -- Existing SeaweedFS S3 credentials (populate via --set or sealed-secrets).
+# -- The generated Secret includes both AWS-style keys and the key names that
+# -- tcfs-backend consumes directly.
 seaweedfs:
   # -- S3 access key ID
   accessKeyId: ""
@@ -42,7 +44,13 @@ createNamespace: true
 # -------------------------------------------------------
 # tcfs-backend (local sub-chart, always installed)
 # -------------------------------------------------------
-tcfs-backend: {}
+tcfs-backend:
+  credentialsSecret: tcfs-seaweedfs-secret
+  metrics:
+    serviceMonitor:
+      # kube-prometheus-stack is disabled by default, so do not render a
+      # ServiceMonitor unless an operator enables the monitoring CRDs.
+      enabled: false
 
 # -------------------------------------------------------
 # NATS (optional dependency)

--- a/scripts/tcfs-deploy.sh
+++ b/scripts/tcfs-deploy.sh
@@ -8,8 +8,9 @@
 #   ./scripts/tcfs-deploy.sh --dry-run          # template only, no install
 #   ./scripts/tcfs-deploy.sh --set global.imageTag=v0.12.12
 #
-# This is the blank-cluster umbrella path. For reconciling an already-existing
-# direct `tcfs-backend` Helm release, use `scripts/tcfs-backend-deploy.sh`.
+# This is the blank TCFS control-plane umbrella path with external SeaweedFS.
+# For reconciling an already-existing direct `tcfs-backend` Helm release, use
+# `scripts/tcfs-backend-deploy.sh`.
 # Set an explicit release tag for proof or production runs; mutable defaults are
 # convenience values only.
 #


### PR DESCRIPTION
## Summary
- add a dated TCFS workstream reality checkpoint covering GitHub, Linear, distribution, Apple, Linux, K8s, CI, signing, and remote governance fronts
- refresh stale tracker/docs reality after PR #351 and mark #313 as documentation-only retired
- fix low-risk repo hygiene: wire tcfs-stack SeaweedFS secret keys to tcfs-backend, make Windows install.ps1 fail honestly while Windows artifacts are disabled, document chart CRD prerequisites, and update stale FileProvider/fleet docs

## Validation
- git diff --check
- task docs:links
- task docs:pdf
- yq e '.' .github/workflows/release.yml
- yq e '.' infra/k8s/charts/tcfs-stack/values.yaml
- yq e '.' infra/k8s/charts/tcfs-stack/Chart.yaml
- yq e '.' infra/k8s/charts/tcfs-backend/values.yaml
- bash -n scripts/tcfs-deploy.sh
- helm template tcfs-backend infra/k8s/charts/tcfs-backend --namespace tcfs --set autoscaling.enabled=false --set metrics.serviceMonitor.enabled=false
- temp-dir helm dependency build + helm template for tcfs-stack, verifying SeaweedFS secret/backend key wiring and no ServiceMonitor rendered by default
- bash scripts/test-tcfs-onprem-migration-plan.sh
- bash scripts/test-tcfs-onprem-tofu-candidate-workloads.sh
- bash scripts/test-tcfs-onprem-preflight.sh

Refs #280
Refs #309
Refs #312
Refs #327
Refs #298