### PR TITLE
[codex] Ground checkpoint and RFC identifiers

### DIFF
--- a/docs/ops/workstream-reality-check-2026-05-09.md
+++ b/docs/ops/workstream-reality-check-2026-05-09.md
@@ -1,6 +1,6 @@
 # TCFS Workstream Reality Check - 2026-05-09
 
-This checkpoint records the repo, tracker, and proof state after PR #351 merged.
+This checkpoint records the repo, tracker, and proof state after PR #352 merged.
 It is meant to keep planning language grounded while the remaining M10 work
 continues.
 
@@ -9,8 +9,8 @@ continues.
 | Surface | Current state |
 | --- | --- |
 | Canonical repo | `Jesssullivan/tummycrypt` |
-| Current `main` | `26e9fab3e08d` |
-| Open PRs | none at audit time |
+| Checkpoint commit | PR #352 merge commit `57a60b892854` |
+| Open PRs | none immediately after PR #352 merged |
 | Current release | `v0.12.12` |
 | Primary milestone | GitHub milestone `#9 M10: Usage Reality & Product Parity` |
 
@@ -55,7 +55,7 @@ truth.
 | Linux CLI/daemon | Strongest supported path. CI, package smoke, live backend acceptance, and release evidence exist. | Universal Linux desktop UX or every distro/service-manager combination. |
 | Linux mounted FUSE | Expanded lifecycle proof is archived in `docs/release/evidence/lazy-linux-20260508T170825Z/`: browse before hydration, exact `cat`, mounted write/readback, cache clear/rehydrate, recursive safe-unsync refusal/success. | Packaged mount/systemd first-use as continuously proven on every supported distro. |
 | K8s/on-prem backend | Live backend works; source-owned OpenTofu migration/cutover is planned and renderable. | That NATS/SeaweedFS are already source-owned or storage-mobile. |
-| CI/test coverage | PR #351 passed the full matrix: Rust build/lint/test, Docs, Nix CI, Nix Build, cargo-deny, Secret Scan, FileProvider staticlib, iOS typecheck. | Production Finder, iOS device, Kubernetes rollout, accessibility, or visible badge/progress UX. |
+| CI/test coverage | PR #352 passed the full pre-merge matrix: Rust build/lint/test, Docs, Nix CI, Nix Build, cargo-deny, Secret Scan, FileProvider staticlib, iOS typecheck. | Production Finder, iOS device, Kubernetes rollout, accessibility, or visible badge/progress UX. |
 | Fuzzing | Four cargo-fuzz targets exist under `fuzz/`. | Continuous fuzz execution in CI or `task check`; fuzz is present but not currently a release gate. |
 | macOS package/FileProvider | PZM testing-mode lane is green through enumerate, hydrate, evict, rehydrate, mutation upload/readback, CLI conflict state, and exact FileProvider content preservation. | Production Developer ID clean-host Finder lifecycle or visible Finder conflict/status UX. |
 | iOS | Host app, extension, generated bindings, and simulator type-check surface exist. | Active release target, TestFlight/App Store readiness, real-device Files.app behavior, or write support. |

--- a/docs/rfc/0001-fleet-sync-integration.md
+++ b/docs/rfc/0001-fleet-sync-integration.md
@@ -242,8 +242,11 @@ All open questions have been resolved. See [Fleet Deployment Guide](../ops/fleet
    KDBX > config file. Rotation procedure documented. See [Fleet Deployment Guide, Section 2](../ops/fleet-deployment.md#2-credential-distribution).
 
 3. **Automatic daemon startup**: Resolved — **systemd** on Linux (NixOS module or manual unit),
-   **launchd** on macOS (plist at `dist/com.tummycrypt.tcfsd.plist`). Both configured for
-   auto-start on boot with restart-on-failure. See [Fleet Deployment Guide, Section 3](../ops/fleet-deployment.md#3-automatic-daemon-startup).
+   **launchd** on macOS. Current packaged installs write
+   `/Library/LaunchAgents/io.tinyland.tcfsd.plist`; the older
+   `dist/com.tummycrypt.tcfsd.plist` helper is historical/manual-only. Both
+   are configured for auto-start on boot with restart-on-failure. See
+   [Fleet Deployment Guide, Section 3](../ops/fleet-deployment.md#3-automatic-daemon-startup).
 
 ---
 

--- a/docs/rfc/0002-darwin-fuse-strategy.md
+++ b/docs/rfc/0002-darwin-fuse-strategy.md
@@ -32,6 +32,14 @@ Investigation of alternatives (FUSE-T, NFS loopback, FSKit) revealed fundamental
 limitations. FileProvider emerged as the Apple-sanctioned solution designed
 specifically for cloud storage with on-demand hydration.
 
+Current implementation note as of 2026-05-09: the product docs outrank this
+RFC for exact identifiers and signing posture. The active macOS lane uses
+`io.tinyland.tcfs`, `io.tinyland.tcfs.fileprovider`,
+`group.io.tinyland.tcfs`, and a Team-ID-prefixed Keychain access group such as
+`QP994XQKNH.group.io.tinyland.tcfs`. The packaged LaunchAgent is
+`/Library/LaunchAgents/io.tinyland.tcfsd.plist`; older `com.tummycrypt` and
+`dist/*.plist` examples below are historical design notes.
+
 ## Platform Integration Matrix
 
 | Platform | Integration Point | Framework | Crate | Status |
@@ -272,12 +280,11 @@ else:
 
 macOS daemon startup via launchd (for both FileProvider and FUSE modes):
 
-```
-dist/com.tummycrypt.tcfsd.plist
-  - RunAtLoad: true
-  - KeepAlive: true
-  - Logs: /tmp/tcfsd.stdout.log, /tmp/tcfsd.stderr.log
-```
+The active packaged postinstall writes
+`/Library/LaunchAgents/io.tinyland.tcfsd.plist` and starts `tcfsd` with the
+user config at `$HOME/.config/tcfs/config.toml`. The older
+`dist/com.tummycrypt.tcfsd.plist` file is a historical/manual helper, not the
+release proof path.
 
 See `docs/ops/fleet-deployment.md` for installation instructions.
 
@@ -411,8 +418,10 @@ frameworks through a Swift shim, Rust + cbindgen is the pragmatic choice.
 1. **Apple Developer enrollment**: Is Tinyland Inc already enrolled in the Apple
    Developer Program ($99/year)? If not, who initiates enrollment?
 
-2. **App Group identifier**: What App Group and Keychain access group should we
-   register? Proposed: `group.com.tummycrypt.tcfs`
+2. **App Group identifier**: resolved in the current implementation as
+   `group.io.tinyland.tcfs`; the concrete Keychain access group is prefixed by
+   the Apple Team ID / App Identifier Prefix, for example
+   `QP994XQKNH.group.io.tinyland.tcfs`.
 
 3. **Distribution format**: .dmg with drag-to-install? Homebrew cask? Both?
 

--- a/docs/rfc/0003-ios-file-provider.md
+++ b/docs/rfc/0003-ios-file-provider.md
@@ -272,8 +272,9 @@ Credentials must be stored in the iOS Keychain and accessed via
 ```swift
 let query: [String: Any] = [
     kSecClass: kSecClassGenericPassword,
-    kSecAttrService: "com.tummycrypt.tcfsd",
-    kSecAttrAccount: "s3_access_key",
+    kSecAttrService: "io.tinyland.tcfs.config",
+    kSecAttrAccount: "configJSON",
+    kSecAttrAccessGroup: "group.io.tinyland.tcfs",
     kSecReturnData: true,
 ]
 ```


### PR DESCRIPTION
## Summary
- update the 2026-05-09 workstream checkpoint to point at merged PR #352 and its merge commit
- mark old macOS launchd/App Group examples in RFC docs as historical and point to current io.tinyland identifiers
- refresh the iOS Keychain snippet to match the current shared config service/account/access group

## Validation
- git diff --check
- task docs:links