### PR TITLE
[codex] Harden S3 upload telemetry for fresh-prefix canaries

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -6,6 +6,8 @@ exclude = [
   "^https://developer.apple.com/documentation/fskit$",
   "^https://developer.apple.com/documentation/fileprovider$",
   "^https://developer.apple.com/documentation/fileprovider/nsfileproviderreplicatedextension$",
+  # Debian package pages intermittently return 503 to GitHub-hosted link checks.
+  "^https://packages.debian.org/",
   "your-org",
   "localhost",
   "127\\.0\\.0\\.1",

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -69,6 +69,47 @@ fn upload_chunk_concurrency() -> usize {
     )
 }
 
+fn upload_assume_fresh_prefix_from_env_value(value: Option<&str>) -> bool {
+    matches!(value.map(str::trim), Some("1" | "true" | "yes" | "on"))
+}
+
+fn upload_assume_fresh_prefix() -> bool {
+    upload_assume_fresh_prefix_from_env_value(
+        std::env::var("TCFS_UPLOAD_ASSUME_FRESH_PREFIX")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn upload_progress_every_chunks_from_env_value(value: Option<&str>) -> usize {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0)
+}
+
+fn upload_progress_every_chunks() -> usize {
+    upload_progress_every_chunks_from_env_value(
+        std::env::var("TCFS_UPLOAD_PROGRESS_EVERY_CHUNKS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn should_record_chunk_upload_progress(
+    completed_chunks: usize,
+    num_chunks: usize,
+    every_chunks: usize,
+) -> bool {
+    if every_chunks == 0 {
+        return false;
+    }
+
+    completed_chunks % every_chunks == 0
+        || (completed_chunks == num_chunks && num_chunks >= every_chunks)
+}
+
 async fn retry_with_backoff<T, E, Action, ActionFuture, Sleep, SleepFuture, OnRetry>(
     max_attempts: u32,
     mut action: Action,
@@ -168,8 +209,9 @@ async fn maybe_upload_chunk(
     upload_data: Vec<u8>,
     chunk_idx: usize,
     logical_len: u64,
+    assume_fresh_prefix: bool,
 ) -> Result<u64> {
-    if !op.exists(&chunk_key).await.unwrap_or(false) {
+    if assume_fresh_prefix || !op.exists(&chunk_key).await.unwrap_or(false) {
         write_chunk_with_retry(&op, &chunk_key, upload_data, chunk_idx).await?;
         return Ok(logical_len);
     }
@@ -183,6 +225,28 @@ async fn await_next_chunk_upload(pending: &mut JoinSet<Result<u64>>) -> Result<u
         .await
         .context("chunk upload task set unexpectedly empty")?;
     joined.context("chunk upload task panicked or was cancelled")?
+}
+
+fn record_chunk_upload_progress(
+    local_path: &Path,
+    completed_chunks: usize,
+    num_chunks: usize,
+    uploaded_bytes: u64,
+    streaming: bool,
+    every_chunks: usize,
+) {
+    if !should_record_chunk_upload_progress(completed_chunks, num_chunks, every_chunks) {
+        return;
+    }
+
+    info!(
+        path = %local_path.display(),
+        completed_chunks,
+        chunks = num_chunks,
+        uploaded_bytes,
+        streaming,
+        "chunk upload progress"
+    );
 }
 
 /// Read a key from remote storage with exponential backoff retry.
@@ -714,10 +778,37 @@ pub async fn upload_file_with_device(
     let file_meta = std::fs::metadata(local_path)
         .with_context(|| format!("stat for chunking: {}", local_path.display()))?;
     let use_streaming = file_meta.len() >= tcfs_chunks::STREAMING_THRESHOLD;
+    let prepare_started = std::time::Instant::now();
+    debug!(
+        path = %local_path.display(),
+        bytes = file_meta.len(),
+        streaming = use_streaming,
+        "preparing upload snapshot"
+    );
     let snapshot = prepare_upload_snapshot(local_path, use_streaming)?;
+    let snapshot_chunks = match &snapshot.source {
+        UploadSourceSnapshot::InMemory(_) => 0,
+        UploadSourceSnapshot::Streaming(chunks) => chunks.len(),
+    };
+    debug!(
+        path = %local_path.display(),
+        bytes = snapshot.file_size,
+        streaming = use_streaming,
+        chunks = snapshot_chunks,
+        elapsed_ms = prepare_started.elapsed().as_millis(),
+        "prepared upload snapshot"
+    );
     let file_size = snapshot.file_size;
     let file_hash_hex = snapshot.file_hash_hex.clone();
+    let verify_started = std::time::Instant::now();
     ensure_source_matches_snapshot(local_path, &snapshot, "upload preparation")?;
+    debug!(
+        path = %local_path.display(),
+        bytes = file_size,
+        streaming = use_streaming,
+        elapsed_ms = verify_started.elapsed().as_millis(),
+        "verified upload snapshot"
+    );
 
     // Build remote manifest path (using the file's content hash)
     let remote_manifest = format!("{remote_prefix}/manifests/{file_hash_hex}");
@@ -916,6 +1007,8 @@ pub async fn upload_file_with_device(
     let mut bytes_uploaded = 0u64;
     let num_chunks;
     let chunk_upload_concurrency = upload_chunk_concurrency();
+    let assume_fresh_prefix = upload_assume_fresh_prefix();
+    let progress_every_chunks = upload_progress_every_chunks();
 
     // Generate per-file encryption key if encryption is enabled
     #[cfg(feature = "crypto")]
@@ -933,7 +1026,13 @@ pub async fn upload_file_with_device(
 
     if use_streaming {
         // ── Streaming path: prepared snapshot chunks ─────────
-        debug!(path = %local_path.display(), size = file_size, "using streaming chunker");
+        debug!(
+            path = %local_path.display(),
+            size = file_size,
+            chunk_upload_concurrency,
+            chunk_exists_check = !assume_fresh_prefix,
+            "using streaming chunker"
+        );
         let UploadSourceSnapshot::Streaming(streaming_chunks) = &snapshot.source else {
             unreachable!("streaming upload expected streaming snapshot")
         };
@@ -980,6 +1079,7 @@ pub async fn upload_file_with_device(
                 upload_data,
                 i,
                 chunk.length as u64,
+                assume_fresh_prefix,
             ));
 
             while pending_uploads.len() >= chunk_upload_concurrency {
@@ -992,6 +1092,14 @@ pub async fn upload_file_with_device(
                         &format!("chunk {completed_chunks}/{num_chunks}"),
                     );
                 }
+                record_chunk_upload_progress(
+                    local_path,
+                    completed_chunks,
+                    num_chunks,
+                    bytes_uploaded,
+                    true,
+                    progress_every_chunks,
+                );
             }
         }
 
@@ -1005,6 +1113,14 @@ pub async fn upload_file_with_device(
                     &format!("chunk {completed_chunks}/{num_chunks}"),
                 );
             }
+            record_chunk_upload_progress(
+                local_path,
+                completed_chunks,
+                num_chunks,
+                bytes_uploaded,
+                true,
+                progress_every_chunks,
+            );
         }
     } else {
         // ── In-memory path: prepared snapshot bytes ───────────────
@@ -1058,6 +1174,7 @@ pub async fn upload_file_with_device(
                 upload_data,
                 i,
                 chunk.length as u64,
+                assume_fresh_prefix,
             ));
 
             while pending_uploads.len() >= chunk_upload_concurrency {
@@ -1070,6 +1187,14 @@ pub async fn upload_file_with_device(
                         &format!("chunk {completed_chunks}/{num_chunks}"),
                     );
                 }
+                record_chunk_upload_progress(
+                    local_path,
+                    completed_chunks,
+                    num_chunks,
+                    bytes_uploaded,
+                    false,
+                    progress_every_chunks,
+                );
             }
         }
 
@@ -1083,6 +1208,14 @@ pub async fn upload_file_with_device(
                     &format!("chunk {completed_chunks}/{num_chunks}"),
                 );
             }
+            record_chunk_upload_progress(
+                local_path,
+                completed_chunks,
+                num_chunks,
+                bytes_uploaded,
+                false,
+                progress_every_chunks,
+            );
         }
     }
 
@@ -1165,6 +1298,7 @@ pub async fn upload_file_with_device(
         uploaded_bytes = bytes_uploaded,
         streaming = use_streaming,
         chunk_upload_concurrency,
+        chunk_exists_check = !assume_fresh_prefix,
         "uploaded"
     );
 
@@ -2158,6 +2292,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn upload_assume_fresh_prefix_env_is_strictly_opt_in() {
+        assert!(!upload_assume_fresh_prefix_from_env_value(None));
+        assert!(!upload_assume_fresh_prefix_from_env_value(Some("")));
+        assert!(!upload_assume_fresh_prefix_from_env_value(Some("0")));
+        assert!(!upload_assume_fresh_prefix_from_env_value(Some("false")));
+        assert!(!upload_assume_fresh_prefix_from_env_value(Some("TRUE")));
+        assert!(upload_assume_fresh_prefix_from_env_value(Some("1")));
+        assert!(upload_assume_fresh_prefix_from_env_value(Some("true")));
+        assert!(upload_assume_fresh_prefix_from_env_value(Some(" yes ")));
+        assert!(upload_assume_fresh_prefix_from_env_value(Some("on")));
+    }
+
+    #[test]
+    fn upload_progress_every_chunks_env_defaults_to_disabled() {
+        assert_eq!(upload_progress_every_chunks_from_env_value(None), 0);
+        assert_eq!(upload_progress_every_chunks_from_env_value(Some("")), 0);
+        assert_eq!(
+            upload_progress_every_chunks_from_env_value(Some("not-a-number")),
+            0
+        );
+        assert_eq!(upload_progress_every_chunks_from_env_value(Some("0")), 0);
+        assert_eq!(
+            upload_progress_every_chunks_from_env_value(Some("5000")),
+            5000
+        );
+    }
+
+    #[test]
+    fn chunk_upload_progress_records_interval_and_large_final_rows() {
+        assert!(!should_record_chunk_upload_progress(1, 1, 0));
+        assert!(!should_record_chunk_upload_progress(1, 4999, 5000));
+        assert!(!should_record_chunk_upload_progress(4999, 4999, 5000));
+        assert!(should_record_chunk_upload_progress(5000, 10001, 5000));
+        assert!(should_record_chunk_upload_progress(10000, 10001, 5000));
+        assert!(should_record_chunk_upload_progress(10001, 10001, 5000));
+    }
+
     // ── collect_files (empty dir detection) ──────────────────────────────
     #[test]
     fn collect_finds_empty_dirs() {
@@ -2596,6 +2768,25 @@ mod tests {
             *delays.lock().unwrap(),
             vec![std::time::Duration::from_millis(100)]
         );
+    }
+
+    #[tokio::test]
+    async fn maybe_upload_chunk_assume_fresh_prefix_skips_exists_gate() {
+        let op = memory_op();
+        let key = "data/chunks/existing".to_string();
+        op.write(&key, b"old".to_vec()).await.unwrap();
+
+        let skipped = maybe_upload_chunk(op.clone(), key.clone(), b"new".to_vec(), 0, 3, false)
+            .await
+            .unwrap();
+        assert_eq!(skipped, 0);
+        assert_eq!(op.read(&key).await.unwrap().to_bytes(), b"old".as_slice());
+
+        let uploaded = maybe_upload_chunk(op.clone(), key.clone(), b"new".to_vec(), 0, 3, true)
+            .await
+            .unwrap();
+        assert_eq!(uploaded, 3);
+        assert_eq!(op.read(&key).await.unwrap().to_bytes(), b"new".as_slice());
     }
 
     #[tokio::test]

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -80,8 +80,14 @@ Pre-fix host observations from
 The follow-up work routes `.idx` files through the large-file profile, keeps
 streaming upload snapshots to chunk metadata plus whole-file hash, and adds
 bounded chunk-upload fanout via `TCFS_UPLOAD_CHUNK_CONCURRENCY` (default 4, cap
-64). These changes still need a fresh host rerun before any post-fix throughput,
-object-count, or memory claim is made.
+64). Fresh-prefix bulk proof can now opt in to
+`TCFS_UPLOAD_ASSUME_FRESH_PREFIX=1` to skip per-chunk remote existence checks,
+and `TCFS_UPLOAD_PROGRESS_EVERY_CHUNKS=N` records bounded chunk progress for
+objects, including a terminal progress row once the object reaches at least `N`
+chunks. The fresh-prefix shortcut is only valid for a new disposable prefix;
+evidence should preserve the `chunk_exists_check=false` upload log field when it
+is enabled. These changes still need a fresh release-build host rerun before any
+production throughput, object-count, or memory claim is made.
 
 ## Compression Ratios
 

--- a/docs/ops/lazy-traversal-qa-permutation-matrix-2026-05-09.md
+++ b/docs/ops/lazy-traversal-qa-permutation-matrix-2026-05-09.md
@@ -89,7 +89,7 @@ queueing, retry, or endpoint problems that block production claims.
 | S1 | Large raw-Git index push | `.git/objects/pack/*.idx` uses a large-file chunk profile, records chunk count and push duration, and does not explode into tiny S3 objects | `20260510T201809Z` exposed the old small-profile behavior: a 395,849,892-byte `.idx` became 72,598 chunks. Code-level regression now routes `.idx` through the pack/binary profile, but host performance proof must be rerun with rebuilt binaries |
 | S2 | Large raw-Git pack push | Multi-GB `.pack` files push without unbounded memory growth, with archived chunk count, bytes uploaded, retry count, and wall-clock duration | `20260510T201809Z` captured pre-fix behavior: a 6,216,046,897-byte `.pack` produced 70,856 chunks and sampled about 6.1 GiB footprint during snapshot preparation. Streaming snapshot memory is fixed locally, but post-fix proof remains open |
 | S3 | Endpoint posture | Packet records endpoint class, TLS policy, credential source, bucket/prefix isolation, and whether public CI can reach it safely | Open. Existing packets use disposable prefixes, but production-like endpoint class and public-runner reachability remain separate proof rows |
-| S4 | Queue/concurrency behavior | Upload engine records whether file and chunk writes are sequential or bounded-parallel, and retries are visible in evidence | Code-level support now uses bounded per-file chunk fanout via `TCFS_UPLOAD_CHUNK_CONCURRENCY`, with upload logs carrying `chunk_upload_concurrency`; host proof still needs a rerun with object counts, retries, and timings |
+| S4 | Queue/concurrency behavior | Upload engine records whether file and chunk writes are sequential or bounded-parallel, and retries are visible in evidence | Code-level support now uses bounded per-file chunk fanout via `TCFS_UPLOAD_CHUNK_CONCURRENCY`, optional disposable-prefix chunk writes via `TCFS_UPLOAD_ASSUME_FRESH_PREFIX=1` with `chunk_exists_check=false` in logs, and bounded progress rows via `TCFS_UPLOAD_PROGRESS_EVERY_CHUNKS`; host proof still needs a release-build rerun with object counts, retries, and timings |
 | S5 | Hydration latency on S3 | Cold list, first-byte hydrate, full hydrate, cache-hit read, and cache-clear/rehydrate timings are archived for representative small and large files | Open. Current traversal rows prove exact bytes, not latency SLOs |
 
 ## QA Evidence Minimums
@@ -148,3 +148,19 @@ behavior into user-facing claims:
    large `.idx`/`.pack` paths with the rebuilt chunk-profile, streaming-memory,
    and bounded chunk-upload fanout changes, then decide whether multipart or
    native SeaweedFS semantics are the next product change.
+
+## Next Mutation Detail
+
+These rows are the planning targets for the next QA packets and should not be
+reported as product claims until evidence lands:
+
+| ID | Mutation | Acceptance notes |
+| --- | --- | --- |
+| S6 | Post-fix release-binary raw-Git canary on a new disposable S3 prefix | Archive release build provenance, endpoint/TLS/credential posture, object counts, retries, memory peak, wall-clock timings, `chunk_exists_check` mode, progress rows, and hydration latency. Debug-binary evidence remains functional evidence only. |
+| P6 | Mounted symlink closure for `linux-xr` | Prove all inventoried symlinks rehydrate as symlinks with matching `readlink` targets from the honey mounted view, then run the Linux lifecycle companion against the same prefix. Shadow inventory alone is not enough. |
+| M8-A | Delete/rename while peer-unsynced tombstone details | Add `sync-status` for stale `.tc` paths, repeated pull/open idempotence, mounted old-path behavior, delete-then-recreate same relative path, and rename same-hash versus different-hash cases. Keep product tombstone semantics open until accepted. |
+| M5-D2 | Daemon-backed conflict resolve closure | Assert the RPC returns, winning bytes remain at the original path, losing bytes land at the daemon conflict-copy path, final state is synced, a second resolve is idempotent, and timeout paths leave no partial files. |
+| K1 | Keep-synced / pin acceptance | Define the product surface before testing: status wording, local storage guarantee, eviction refusal or allowance, watcher/reconcile behavior, peer delete/edit behavior, and conflict behavior. |
+| R1 | Mounted remount and stale-index behavior | Mutate the remote while a local physical root is stub-only, restart/remount the daemon, and prove clean-name reads pick up the latest index without stale negative-cache behavior. This is Linux mounted VFS evidence, not neo/macOS M4 closure. |
+| F8 | Finder PZM peer-update/evict smoke | Under the PZM/testing-mode label only, mirror M3/M6 with FileProvider evict/dehydrate, peer update, requestDownload, exact latest bytes, and CLI status/log evidence. Production Finder remains blocked by Developer ID package proof. |
+| M7-A | Three-machine/offline descendant matrix | Add a third device with one offline subtree, one conflicted child, one independent delete/rename sibling, and exact proof that unrelated descendants continue syncing while local conflicted content is preserved. |


### PR DESCRIPTION
## Summary
- add an explicit TCFS_UPLOAD_ASSUME_FRESH_PREFIX opt-in for disposable-prefix bulk upload proof runs
- add optional chunk upload progress telemetry with a terminal row for large objects
- document S3 proof boundaries and the next QA mutation rows for linux-xr, M8, conflict resolve, keep-synced, remount, Finder PZM, and N>2 descendants

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p tcfs-sync upload_
- task docs:links
- task lazy:check

## Notes
The live linux-xr canary packet remains untracked and separate from this PR. This PR adds the knobs needed for a follow-up release-binary fresh-prefix run; it does not claim production S3 posture or full linux-xr parity.