### PR TITLE
Scaffold Linux post-install smoke harness (TIN-1422)

### DIFF
--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -1,0 +1,370 @@
+name: Linux Post-Install Smoke
+
+# TIN-1422 scaffold: this workflow mirrors macos-postinstall-smoke.yml for
+# the Linux .deb/.rpm path. It downloads a package artifact (either a
+# release asset or a workflow-run artifact), installs it, writes a live
+# config keyed on the smoke secrets, mounts FUSE, and runs
+# scripts/linux-postinstall-smoke.sh to gate hydration via
+# `tcfs index inspect`.
+#
+# Several steps are intentionally minimal compared to the macOS workflow:
+# Linux doesn't need FileProvider plumbing (host app, pluginkit, CloudStorage
+# discovery), and the smoke fixture path lives directly under the FUSE
+# mount. See TIN-1422 for follow-up items.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to validate (for example v0.13.0)"
+        required: true
+        type: string
+      package_url:
+        description: "Optional direct .deb/.rpm URL to install instead of the release asset for tag"
+        required: false
+        default: ""
+        type: string
+      package_artifact_run_id:
+        description: "Optional Actions run ID containing a package artifact to install instead of the release asset"
+        required: false
+        default: ""
+        type: string
+      package_artifact_name:
+        description: "Artifact name to download when package_artifact_run_id is set"
+        required: false
+        default: "dist-linux-x86_64"
+        type: string
+      runner_label:
+        description: "Runner label (default: ubuntu-24.04). Use a self-hosted Linux label for private endpoints."
+        required: false
+        default: "ubuntu-24.04"
+        type: string
+      exercise_evict_rehydrate:
+        description: "After initial hydration, exercise unsync + rehydrate"
+        required: false
+        default: false
+        type: boolean
+      exercise_mutation:
+        description: "Write a new file through the FUSE mount and verify by remote pull"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  package-postinstall:
+    name: Linux package post-install smoke
+    if: github.repository == 'Jesssullivan/tummycrypt'
+    runs-on: ${{ github.event.inputs.runner_label }}
+    timeout-minutes: 30
+    environment: tcfs-linux-smoke
+    env:
+      TCFS_SMOKE_S3_ENDPOINT: ${{ secrets.TCFS_SMOKE_S3_ENDPOINT }}
+      TCFS_SMOKE_S3_BUCKET: ${{ secrets.TCFS_SMOKE_S3_BUCKET }}
+      TCFS_SMOKE_S3_ACCESS_KEY_ID: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
+      TCFS_SMOKE_S3_SECRET_ACCESS_KEY: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
+      TCFS_SMOKE_MASTER_KEY_B64: ${{ secrets.TCFS_SMOKE_MASTER_KEY_B64 }}
+      TCFS_S3_ACCESS: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
+      TCFS_S3_SECRET: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Initialize log directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          LOG_DIR="$RUNNER_TEMP/tcfs-linux-postinstall"
+          mkdir -p "$LOG_DIR"
+          echo "LOG_DIR=$LOG_DIR" >> "$GITHUB_ENV"
+
+      - name: Validate release inputs and storage secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag }}"
+          PACKAGE_URL="${{ github.event.inputs.package_url }}"
+          PACKAGE_ARTIFACT_RUN_ID="${{ github.event.inputs.package_artifact_run_id }}"
+          [[ "$TAG" == v* ]] || {
+            echo "::error::tag must start with 'v' (got '$TAG')"
+            exit 1
+          }
+          if [[ -n "$PACKAGE_URL" && -n "$PACKAGE_ARTIFACT_RUN_ID" ]]; then
+            echo "::error::set only one of package_url or package_artifact_run_id"
+            exit 1
+          fi
+
+          missing=()
+          for name in \
+            TCFS_SMOKE_S3_ENDPOINT \
+            TCFS_SMOKE_S3_BUCKET \
+            TCFS_SMOKE_S3_ACCESS_KEY_ID \
+            TCFS_SMOKE_S3_SECRET_ACCESS_KEY \
+            TCFS_SMOKE_MASTER_KEY_B64
+          do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required tcfs-linux-smoke environment secrets: ${missing[*]}"
+            echo "Set the storage and E2EE smoke secrets before using this workflow."
+            exit 1
+          fi
+
+      - name: Derive run paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag }}"
+          VERSION="${TAG#v}"
+          LOG_DIR="${LOG_DIR:-$RUNNER_TEMP/tcfs-linux-postinstall}"
+          SYNC_ROOT="$RUNNER_TEMP/tcfs-sync-root"
+          MOUNT_POINT="$RUNNER_TEMP/tcfs-mount"
+          CONFIG_DIR="$RUNNER_TEMP/tcfs-config"
+          CONFIG_PATH="$CONFIG_DIR/config.toml"
+          MASTER_KEY_PATH="$RUNNER_TEMP/tcfs-master.key"
+          STATE_PATH="$RUNNER_TEMP/tcfs-state.json"
+          EXPECTED_CONTENT_FILE="$RUNNER_TEMP/expected-fixture-content"
+          MUTATION_CONTENT_FILE="$RUNNER_TEMP/mutation-fixture-content"
+          REMOTE_PREFIX="gha/linux-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          FIXTURE_REL="ci-smoke/${VERSION}/postinstall-${GITHUB_RUN_ATTEMPT}.txt"
+          MUTATION_REL="ci-smoke/${VERSION}/mutation-${GITHUB_RUN_ATTEMPT}.txt"
+
+          mkdir -p "$LOG_DIR" "$SYNC_ROOT" "$MOUNT_POINT" "$CONFIG_DIR"
+
+          {
+            echo "TAG=$TAG"
+            echo "VERSION=$VERSION"
+            echo "LOG_DIR=$LOG_DIR"
+            echo "SYNC_ROOT=$SYNC_ROOT"
+            echo "MOUNT_POINT=$MOUNT_POINT"
+            echo "CONFIG_DIR=$CONFIG_DIR"
+            echo "CONFIG_PATH=$CONFIG_PATH"
+            echo "MASTER_KEY_PATH=$MASTER_KEY_PATH"
+            echo "STATE_PATH=$STATE_PATH"
+            echo "EXPECTED_CONTENT_FILE=$EXPECTED_CONTENT_FILE"
+            echo "MUTATION_CONTENT_FILE=$MUTATION_CONTENT_FILE"
+            echo "REMOTE_PREFIX=$REMOTE_PREFIX"
+            echo "FIXTURE_REL=$FIXTURE_REL"
+            echo "MUTATION_REL=$MUTATION_REL"
+          } >> "$GITHUB_ENV"
+
+      - name: Install FUSE userspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          # TIN-1422: cargo-deb may not declare fuse3 as a dependency for the
+          # tcfs-cli package; install the userspace helper explicitly so
+          # `tcfs mount` can attach.
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fuse3 libfuse3-3
+
+      - name: Install E2EE master key
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - "$MASTER_KEY_PATH" <<'PY'
+          import base64
+          import binascii
+          import os
+          import sys
+
+          target = sys.argv[1]
+          encoded = os.environ.get("TCFS_SMOKE_MASTER_KEY_B64", "").strip()
+          try:
+              key = base64.b64decode(encoded, validate=True)
+          except binascii.Error as exc:
+              print(f"::error::TCFS_SMOKE_MASTER_KEY_B64 is not valid base64: {exc}")
+              raise SystemExit(1)
+
+          if len(key) != 32:
+              print(
+                  f"::error::TCFS_SMOKE_MASTER_KEY_B64 decoded to {len(key)} bytes; expected 32"
+              )
+              raise SystemExit(1)
+
+          with open(target, "wb") as fh:
+              fh.write(key)
+          PY
+          chmod 600 "$MASTER_KEY_PATH"
+
+      - name: Download package
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PACKAGE_URL="${{ github.event.inputs.package_url }}"
+          PACKAGE_ARTIFACT_RUN_ID="${{ github.event.inputs.package_artifact_run_id }}"
+          PACKAGE_ARTIFACT_NAME="${{ github.event.inputs.package_artifact_name }}"
+
+          if [[ -n "$PACKAGE_ARTIFACT_RUN_ID" ]]; then
+            artifact_dir="$RUNNER_TEMP/package-artifact"
+            artifact_json="$RUNNER_TEMP/package-artifacts.json"
+            artifact_zip="$RUNNER_TEMP/package-artifact.zip"
+            mkdir -p "$artifact_dir"
+            curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/runs/${PACKAGE_ARTIFACT_RUN_ID}/artifacts?per_page=100" \
+              -o "$artifact_json"
+            artifact_url="$(
+          python3 - "$artifact_json" "$PACKAGE_ARTIFACT_NAME" <<'PY'
+          import json
+          import sys
+
+          payload = json.load(open(sys.argv[1], encoding="utf-8"))
+          wanted = sys.argv[2]
+          for artifact in payload.get("artifacts", []):
+              if artifact.get("name") == wanted and not artifact.get("expired", False):
+                  print(artifact["archive_download_url"])
+                  raise SystemExit(0)
+          raise SystemExit(1)
+          PY
+            )" || {
+              echo "::error::non-expired artifact $PACKAGE_ARTIFACT_NAME not found on run $PACKAGE_ARTIFACT_RUN_ID"
+              cat "$artifact_json"
+              exit 1
+            }
+            curl -fL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -o "$artifact_zip" \
+              "$artifact_url"
+            python3 -m zipfile -e "$artifact_zip" "$artifact_dir"
+            artifact_pkg="$(find "$artifact_dir" -type f \( -name '*.deb' -o -name '*.rpm' \) -print -quit)"
+            if [[ -z "$artifact_pkg" ]]; then
+              echo "::error::artifact $PACKAGE_ARTIFACT_NAME from run $PACKAGE_ARTIFACT_RUN_ID did not contain a .deb or .rpm"
+              find "$artifact_dir" -type f -print
+              exit 1
+            fi
+            PACKAGE_PATH="$artifact_pkg"
+          elif [[ -n "$PACKAGE_URL" ]]; then
+            # Preserve the source extension; default to .deb for ubuntu runners.
+            case "$PACKAGE_URL" in
+              *.rpm) PACKAGE_PATH="$RUNNER_TEMP/tcfsd-${VERSION}.rpm" ;;
+              *)     PACKAGE_PATH="$RUNNER_TEMP/tcfsd-${VERSION}.deb" ;;
+            esac
+            curl -fL -o "$PACKAGE_PATH" "$PACKAGE_URL"
+          else
+            # Default to the amd64 .deb shipped from the release workflow.
+            PACKAGE_PATH="$RUNNER_TEMP/tcfsd-${VERSION}-amd64.deb"
+            curl -fL \
+              -o "$PACKAGE_PATH" \
+              "https://github.com/${{ github.repository }}/releases/download/${TAG}/tcfsd-${VERSION}-amd64.deb"
+          fi
+
+          echo "PACKAGE_PATH=$PACKAGE_PATH" >> "$GITHUB_ENV"
+
+      - name: Write live config
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${TCFS_SMOKE_S3_ENDPOINT}" == https://* ]]; then
+            STORAGE_ENFORCE_TLS=true
+          else
+            STORAGE_ENFORCE_TLS=false
+          fi
+          cat > "$CONFIG_PATH" <<EOF
+          [daemon]
+          socket = "/tmp/tcfsd-gha.sock"
+          metrics_addr = "127.0.0.1:19100"
+          log_format = "text"
+
+          [storage]
+          endpoint = "${TCFS_SMOKE_S3_ENDPOINT}"
+          region = "us-east-1"
+          bucket = "${TCFS_SMOKE_S3_BUCKET}"
+          remote_prefix = "${REMOTE_PREFIX}"
+          enforce_tls = ${STORAGE_ENFORCE_TLS}
+
+          [crypto]
+          enabled = true
+          master_key_file = "${MASTER_KEY_PATH}"
+
+          [auth]
+          require_session = false
+
+          [sync]
+          state_db = "${RUNNER_TEMP}/tcfs-state.db"
+          sync_root = "${SYNC_ROOT}"
+          device_name = "gha-linux-postinstall"
+          device_id = "gha-linux-postinstall"
+          EOF
+          chmod 600 "$CONFIG_PATH"
+
+      - name: Prepare expected fixture content
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf 'tcfs Linux post-install smoke %s run %s\n' "$TAG" "$GITHUB_RUN_ID" \
+            > "$EXPECTED_CONTENT_FILE"
+
+      - name: Run Linux post-install harness
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The harness installs the package, starts tcfsd, seeds the fixture
+          # via `tcfs push` (--seed-expected-file), mounts FUSE, and gates
+          # exact-content hydration on `tcfs index inspect` reporting
+          # status=visible — the same gate as the macOS harness.
+          args=(
+            --package-path "$PACKAGE_PATH"
+            --config "$CONFIG_PATH"
+            --expected-version "${VERSION}"
+            --expected-file "${FIXTURE_REL}"
+            --expected-content-file "$EXPECTED_CONTENT_FILE"
+            --seed-expected-file
+            --remote-prefix "$REMOTE_PREFIX"
+            --remote-spec "s3://${TCFS_SMOKE_S3_BUCKET}/${REMOTE_PREFIX}"
+            --mount-point "$MOUNT_POINT"
+            --log-dir "$LOG_DIR/harness"
+          )
+
+          if [[ "${{ github.event.inputs.exercise_evict_rehydrate }}" == "true" ]]; then
+            args+=(--exercise-evict-rehydrate)
+          fi
+
+          if [[ "${{ github.event.inputs.exercise_mutation }}" == "true" ]]; then
+            printf 'tcfs Linux mutation %s run %s attempt %s\n' \
+              "$TAG" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" > "$MUTATION_CONTENT_FILE"
+            args+=(
+              --exercise-mutation
+              --mutation-file "$MUTATION_REL"
+              --mutation-content-file "$MUTATION_CONTENT_FILE"
+            )
+          fi
+
+          bash scripts/linux-postinstall-smoke.sh "${args[@]}"
+
+      - name: Capture diagnostics
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if command -v systemctl >/dev/null 2>&1; then
+            systemctl status tcfsd.service > "$LOG_DIR/systemctl-status.log" 2>&1 || true
+            journalctl -u tcfsd.service --no-pager -n 200 \
+              > "$LOG_DIR/journalctl-tcfsd.log" 2>&1 || true
+          fi
+          dpkg -l | grep -E 'tcfs|tcfsd' > "$LOG_DIR/dpkg-list.log" 2>&1 || true
+          rpm -qa 2>/dev/null | grep -E 'tcfs|tcfsd' > "$LOG_DIR/rpm-list.log" 2>&1 || true
+          cat /proc/self/mountinfo > "$LOG_DIR/mountinfo.log" 2>&1 || true
+          dmesg | tail -200 > "$LOG_DIR/dmesg-tail.log" 2>&1 || true
+
+      - name: Upload smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-postinstall-smoke-${{ github.event.inputs.tag }}
+          path: ${{ env.LOG_DIR }}
+          if-no-files-found: ignore
+          retention-days: 7

--- a/scripts/linux-postinstall-smoke.sh
+++ b/scripts/linux-postinstall-smoke.sh
@@ -1,0 +1,888 @@
+#!/usr/bin/env bash
+# Linux post-install smoke harness (TIN-1422 scaffold).
+#
+# Verify the installed Linux package path after .deb/.rpm install:
+# package install, tcfsd reachable (systemd unit or fallback foreground),
+# FUSE mount, remote index gate via `tcfs index inspect`, exact-content
+# hydration through the mount, and optional evict/rehydrate and mutation
+# exercises.
+#
+# This is the structural analog of scripts/macos-postinstall-smoke.sh.
+# Some sections are explicit TODO stubs — see the comments and the PR body
+# for TIN-1422 follow-up. The goal of this commit is to lock in the shape,
+# argument surface, log-dir layout, and the require_expected_remote_index
+# gate so future commits can fill out coverage without renegotiating the
+# harness contract.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/linux-postinstall-smoke.sh [options]
+
+Verify the installed Linux package path after .deb/.rpm install:
+package layout, tcfsd reachable, FUSE mount, exact-content hydration,
+optional evict/rehydrate and mutation exercises.
+
+This harness assumes a real operator config and a routable backend.
+It does not fabricate storage credentials.
+
+Options:
+  --package-path <path>       .deb or .rpm artifact to install. If omitted
+                              the harness assumes tcfsd/tcfs are already on
+                              PATH (useful when packages were installed by
+                              the workflow before this script runs).
+  --config <path>             tcfs config (default: ~/.config/tcfs/config.toml)
+  --expected-version <ver>    Require tcfs/tcfsd --version output to include this
+  --expected-file <relpath>   Relative path under the mount to enumerate + hydrate
+  --expected-content <text>   Exact content expected from --expected-file
+  --expected-content-file <path>
+                              File containing exact expected content
+  --seed-expected-file        Create a timestamped fixture, push to remote, and
+                              use it as the expected hydration target
+  --exercise-evict-rehydrate  After hydration, run `tcfs unsync` and re-read to
+                              verify rehydrate
+  --exercise-mutation         Write a new file through the mount and verify via
+                              remote pull
+  --mutation-file <relpath>   Relative mutation file path under the mount
+  --mutation-content <text>   Exact content for the mutation file
+  --mutation-content-file <path>
+                              File containing exact mutation content
+  --remote-prefix <prefix>    Remote prefix used for index inspect + push/pull
+  --mount-point <path>        FUSE mount point (default: temp dir under LOG_DIR)
+  --remote-spec <spec>        Remote spec for `tcfs mount` (default:
+                              s3://<bucket>/<prefix>; required for direct mount)
+  --tcfs <path-or-name>       CLI binary (default: tcfs)
+  --tcfsd <path-or-name>      Daemon binary (default: tcfsd)
+  --timeout <seconds>         Wait timeout for async steps (default: 45)
+  --log-dir <path>            Persist logs instead of using a temp dir
+  --skip-status               Skip `tcfs status` checks
+  --skip-package-install      Skip dpkg/rpm install (binaries already present)
+  --systemd-unit <name>       systemd unit to start (default: tcfsd.service)
+  --no-systemd                Always run tcfsd in foreground, don't try systemd
+  -h, --help                  Show this help
+EOF
+}
+
+EXPECTED_VERSION=""
+CONFIG_PATH="${TCFS_CONFIG:-$HOME/.config/tcfs/config.toml}"
+EXPECTED_FILE_REL=""
+EXPECTED_CONTENT=""
+EXPECTED_CONTENT_FILE=""
+SEED_EXPECTED_FILE="${TCFS_SEED_EXPECTED_FILE:-0}"
+EXERCISE_EVICT_REHYDRATE="${TCFS_EXERCISE_EVICT_REHYDRATE:-0}"
+EXERCISE_MUTATION="${TCFS_EXERCISE_MUTATION:-0}"
+MUTATION_FILE_REL="${TCFS_MUTATION_FILE_REL:-}"
+MUTATION_CONTENT="${TCFS_MUTATION_CONTENT:-}"
+MUTATION_CONTENT_FILE="${TCFS_MUTATION_CONTENT_FILE:-}"
+REMOTE_PREFIX="${TCFS_REMOTE_PREFIX:-}"
+REMOTE_SPEC="${TCFS_REMOTE_SPEC:-}"
+MOUNT_POINT="${TCFS_MOUNT_POINT:-}"
+PACKAGE_PATH=""
+SKIP_PACKAGE_INSTALL="${TCFS_SKIP_PACKAGE_INSTALL:-0}"
+SYSTEMD_UNIT="${TCFS_SYSTEMD_UNIT:-tcfsd.service}"
+USE_SYSTEMD="${TCFS_USE_SYSTEMD:-1}"
+TCFS_BIN="${TCFS_BIN:-tcfs}"
+TCFSD_BIN="${TCFSD_BIN:-tcfsd}"
+TIMEOUT_SECS="${TIMEOUT_SECS:-45}"
+LOG_DIR_OVERRIDE=""
+SKIP_STATUS=0
+LOG_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --package-path)
+      PACKAGE_PATH="$2"
+      shift 2
+      ;;
+    --config)
+      CONFIG_PATH="$2"
+      shift 2
+      ;;
+    --expected-version)
+      EXPECTED_VERSION="$2"
+      shift 2
+      ;;
+    --expected-file)
+      EXPECTED_FILE_REL="$2"
+      shift 2
+      ;;
+    --expected-content)
+      EXPECTED_CONTENT="$2"
+      shift 2
+      ;;
+    --expected-content-file)
+      EXPECTED_CONTENT_FILE="$2"
+      shift 2
+      ;;
+    --seed-expected-file)
+      SEED_EXPECTED_FILE=1
+      shift
+      ;;
+    --exercise-evict-rehydrate)
+      EXERCISE_EVICT_REHYDRATE=1
+      shift
+      ;;
+    --exercise-mutation)
+      EXERCISE_MUTATION=1
+      shift
+      ;;
+    --mutation-file)
+      MUTATION_FILE_REL="$2"
+      shift 2
+      ;;
+    --mutation-content)
+      MUTATION_CONTENT="$2"
+      shift 2
+      ;;
+    --mutation-content-file)
+      MUTATION_CONTENT_FILE="$2"
+      shift 2
+      ;;
+    --remote-prefix)
+      REMOTE_PREFIX="$2"
+      shift 2
+      ;;
+    --remote-spec)
+      REMOTE_SPEC="$2"
+      shift 2
+      ;;
+    --mount-point)
+      MOUNT_POINT="$2"
+      shift 2
+      ;;
+    --tcfs)
+      TCFS_BIN="$2"
+      shift 2
+      ;;
+    --tcfsd)
+      TCFSD_BIN="$2"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT_SECS="$2"
+      shift 2
+      ;;
+    --log-dir)
+      LOG_DIR_OVERRIDE="$2"
+      shift 2
+      ;;
+    --skip-status)
+      SKIP_STATUS=1
+      shift
+      ;;
+    --skip-package-install)
+      SKIP_PACKAGE_INSTALL=1
+      shift
+      ;;
+    --systemd-unit)
+      SYSTEMD_UNIT="$2"
+      shift 2
+      ;;
+    --no-systemd)
+      USE_SYSTEMD=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "scripts/linux-postinstall-smoke.sh only runs on Linux" >&2
+  exit 1
+fi
+
+if [[ -n "$EXPECTED_CONTENT" && -n "$EXPECTED_CONTENT_FILE" ]]; then
+  echo "--expected-content and --expected-content-file are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ -n "$MUTATION_CONTENT" && -n "$MUTATION_CONTENT_FILE" ]]; then
+  echo "--mutation-content and --mutation-content-file are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ "$EXERCISE_EVICT_REHYDRATE" == "1" && -z "$EXPECTED_FILE_REL" && "$SEED_EXPECTED_FILE" != "1" ]]; then
+  echo "--exercise-evict-rehydrate requires --expected-file or --seed-expected-file" >&2
+  exit 2
+fi
+
+if [[ "$EXERCISE_EVICT_REHYDRATE" == "1" && "$SEED_EXPECTED_FILE" != "1" && -z "$EXPECTED_CONTENT" && -z "$EXPECTED_CONTENT_FILE" ]]; then
+  echo "--exercise-evict-rehydrate requires --expected-content, --expected-content-file, or --seed-expected-file" >&2
+  exit 2
+fi
+
+if [[ "$EXERCISE_MUTATION" == "1" && -z "$REMOTE_PREFIX" ]]; then
+  echo "--exercise-mutation requires --remote-prefix" >&2
+  exit 2
+fi
+
+short_pause() {
+  if command -v perl >/dev/null 2>&1; then
+    perl -e 'select undef, undef, undef, 1.0'
+  else
+    python3 -c 'import select; select.select([], [], [], 1.0)'
+  fi
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "$path" ]] || {
+    echo "required file not found: $path" >&2
+    exit 1
+  }
+}
+
+require_dir() {
+  local path="$1"
+  [[ -d "$path" ]] || {
+    echo "required directory not found: $path" >&2
+    exit 1
+  }
+}
+
+if [[ -n "$EXPECTED_CONTENT_FILE" ]]; then
+  require_file "$EXPECTED_CONTENT_FILE"
+fi
+
+if [[ -n "$MUTATION_CONTENT_FILE" ]]; then
+  require_file "$MUTATION_CONTENT_FILE"
+fi
+
+resolve_bin() {
+  local candidate="$1"
+  if [[ "$candidate" == */* ]]; then
+    [[ -x "$candidate" ]] || {
+      echo "binary is not executable: $candidate" >&2
+      exit 1
+    }
+    printf '%s\n' "$candidate"
+    return
+  fi
+
+  command -v "$candidate" >/dev/null 2>&1 || {
+    echo "command not found: $candidate" >&2
+    exit 1
+  }
+  command -v "$candidate"
+}
+
+assert_version() {
+  local label="$1"
+  local bin="$2"
+  local output
+
+  output="$("$bin" --version)"
+  echo "$label binary: $bin"
+  echo "$label version: $output"
+
+  if [[ -n "$EXPECTED_VERSION" && "$output" != *"$EXPECTED_VERSION"* ]]; then
+    echo "$label version mismatch: expected output containing '$EXPECTED_VERSION'" >&2
+    exit 1
+  fi
+}
+
+validate_relative_file_path() {
+  local path="$1"
+
+  if [[ -z "$path" || "$path" == /* || "$path" == */ ]]; then
+    echo "expected relative file path, got: $path" >&2
+    exit 2
+  fi
+
+  local component
+  local -a components=()
+  IFS='/' read -r -a components <<<"$path"
+  for component in "${components[@]}"; do
+    if [[ -z "$component" || "$component" == "." || "$component" == ".." ]]; then
+      echo "expected normalized relative file path, got: $path" >&2
+      exit 2
+    fi
+  done
+}
+
+# ── Package install ──────────────────────────────────────────────────────────
+install_package() {
+  [[ "$SKIP_PACKAGE_INSTALL" == "1" ]] && {
+    echo "package install skipped (--skip-package-install)"
+    return 0
+  }
+  [[ -n "$PACKAGE_PATH" ]] || {
+    echo "no --package-path provided and --skip-package-install not set" >&2
+    exit 2
+  }
+  require_file "$PACKAGE_PATH"
+
+  local install_log="$LOG_DIR/package-install.log"
+  case "$PACKAGE_PATH" in
+    *.deb)
+      echo "installing .deb: $PACKAGE_PATH"
+      if command -v sudo >/dev/null 2>&1; then
+        sudo -n apt-get install -y --no-install-recommends "$PACKAGE_PATH" \
+          >"$install_log" 2>&1 || {
+            # apt-get install on a path needs ./prefix or absolute; fall back to dpkg
+            sudo -n dpkg -i "$PACKAGE_PATH" >>"$install_log" 2>&1 || {
+              echo "dpkg install failed; see $install_log" >&2
+              cat "$install_log" >&2 || true
+              exit 1
+            }
+            sudo -n apt-get install -y -f >>"$install_log" 2>&1 || true
+          }
+      else
+        dpkg -i "$PACKAGE_PATH" >"$install_log" 2>&1 || {
+          echo "dpkg install failed (no sudo); see $install_log" >&2
+          cat "$install_log" >&2 || true
+          exit 1
+        }
+      fi
+      ;;
+    *.rpm)
+      echo "installing .rpm: $PACKAGE_PATH"
+      if command -v sudo >/dev/null 2>&1; then
+        sudo -n rpm -i --replacepkgs "$PACKAGE_PATH" >"$install_log" 2>&1 || {
+          echo "rpm install failed; see $install_log" >&2
+          cat "$install_log" >&2 || true
+          exit 1
+        }
+      else
+        rpm -i --replacepkgs "$PACKAGE_PATH" >"$install_log" 2>&1 || {
+          echo "rpm install failed (no sudo); see $install_log" >&2
+          cat "$install_log" >&2 || true
+          exit 1
+        }
+      fi
+      ;;
+    *)
+      echo "unsupported package extension (expected .deb or .rpm): $PACKAGE_PATH" >&2
+      exit 2
+      ;;
+  esac
+  echo "package install log: $install_log"
+}
+
+# ── Daemon control ───────────────────────────────────────────────────────────
+DAEMON_PID=""
+
+start_daemon_systemd() {
+  command -v systemctl >/dev/null 2>&1 || return 2
+
+  echo "starting tcfsd via systemd unit: $SYSTEMD_UNIT"
+  if command -v sudo >/dev/null 2>&1; then
+    sudo -n systemctl start "$SYSTEMD_UNIT" >"$LOG_DIR/systemctl-start.log" 2>&1 || return 1
+  else
+    systemctl start "$SYSTEMD_UNIT" >"$LOG_DIR/systemctl-start.log" 2>&1 || return 1
+  fi
+
+  # Wait until unit reports active. systemctl is-active prints "active" on
+  # success and non-zero exit on failure, so quote defensively.
+  local deadline=$((SECONDS + TIMEOUT_SECS))
+  local state="unknown"
+  while (( SECONDS < deadline )); do
+    state="$(systemctl is-active "$SYSTEMD_UNIT" 2>/dev/null || true)"
+    if [[ "$state" == "active" ]]; then
+      echo "systemd unit active: $SYSTEMD_UNIT"
+      return 0
+    fi
+    short_pause
+  done
+
+  echo "systemd unit did not become active in time: $SYSTEMD_UNIT (last state: $state)" >&2
+  return 1
+}
+
+start_daemon_foreground() {
+  local log="$LOG_DIR/tcfsd.log"
+  echo "starting tcfsd in foreground: $TCFSD_PATH --config $CONFIG_PATH"
+  "$TCFSD_PATH" --config "$CONFIG_PATH" --log-format text >"$log" 2>&1 &
+  DAEMON_PID="$!"
+  echo "tcfsd pid: $DAEMON_PID (log: $log)"
+
+  # TODO(TIN-1422): poll for the daemon socket path. Today the unit socket
+  # lives at /run/tcfsd/tcfsd.sock for systemd; foreground mode follows the
+  # CLI's default XDG_STATE_HOME-derived path. The macOS harness relies on
+  # `tcfs status` to prove the daemon is reachable, so we lean on the same
+  # gate below in run_status.
+  short_pause
+  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    echo "tcfsd exited immediately; see $log" >&2
+    cat "$log" >&2 || true
+    exit 1
+  fi
+}
+
+start_daemon() {
+  if [[ "$USE_SYSTEMD" == "1" ]]; then
+    if start_daemon_systemd; then
+      return 0
+    fi
+    echo "systemd start failed or unavailable; falling back to foreground" >&2
+  fi
+  start_daemon_foreground
+}
+
+stop_daemon() {
+  if [[ -n "$DAEMON_PID" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  if [[ "$USE_SYSTEMD" == "1" ]] && command -v systemctl >/dev/null 2>&1; then
+    if systemctl is-active --quiet "$SYSTEMD_UNIT" 2>/dev/null; then
+      if command -v sudo >/dev/null 2>&1; then
+        sudo -n systemctl stop "$SYSTEMD_UNIT" >/dev/null 2>&1 || true
+      else
+        systemctl stop "$SYSTEMD_UNIT" >/dev/null 2>&1 || true
+      fi
+    fi
+  fi
+}
+
+# ── Status + index gate (same shape as macOS harness) ────────────────────────
+status_log() {
+  local label="$1"
+  printf '%s/%s-status.log\n' "$LOG_DIR" "$label"
+}
+
+run_status() {
+  local label="$1"
+  local log_path
+
+  if [[ "$SKIP_STATUS" -eq 1 ]]; then
+    echo "status check skipped ($label)"
+    return
+  fi
+
+  require_file "$CONFIG_PATH"
+
+  log_path="$(status_log "$label")"
+  "$TCFS_PATH" --config "$CONFIG_PATH" status >"$log_path" 2>&1 || {
+    echo "tcfs status failed during $label" >&2
+    cat "$log_path" >&2 || true
+    exit 1
+  }
+
+  grep -q "tcfsd v" "$log_path" || {
+    echo "tcfs status output did not include daemon version during $label" >&2
+    cat "$log_path" >&2 || true
+    exit 1
+  }
+
+  grep -Eq 'storage:.*\[ok\]' "$log_path" || {
+    echo "tcfs status did not report storage [ok] during $label" >&2
+    cat "$log_path" >&2 || true
+    exit 1
+  }
+
+  echo "tcfs status ($label):"
+  cat "$log_path"
+}
+
+run_tcfs_index_inspect() {
+  local rel="$1"
+  local out="$2"
+  local err="${out}.err"
+  local -a args
+
+  [[ -n "$TCFS_PATH" ]] || return 2
+
+  args=(--config "$CONFIG_PATH" index inspect "$rel" --json)
+  if [[ -n "$REMOTE_PREFIX" ]]; then
+    args+=(--prefix "$REMOTE_PREFIX")
+  fi
+
+  "$TCFS_PATH" "${args[@]}" >"$out" 2>"$err"
+}
+
+extract_index_status() {
+  local report="$1"
+
+  python3 - "$report" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    report = json.load(fh)
+print(report.get("status", "unknown"))
+PY
+}
+
+require_expected_remote_index() {
+  local rel="$1"
+  local report="$LOG_DIR/expected-file-index.json"
+  local status
+
+  run_tcfs_index_inspect "$rel" "$report" || {
+    echo "tcfs index inspect failed for expected file: $rel" >&2
+    cat "${report}.err" >&2 2>/dev/null || true
+    exit 1
+  }
+
+  status="$(extract_index_status "$report")"
+  echo "remote index status for expected file: $status"
+  if [[ "$status" != "visible" ]]; then
+    echo "expected file is not backed by a visible remote index entry: $rel" >&2
+    cat "$report" >&2 || true
+    exit 1
+  fi
+}
+
+# ── Seed (push timestamped fixture, then use it as the expected file) ────────
+prepare_seed_content_file() {
+  local target="$1"
+
+  if [[ -n "$EXPECTED_CONTENT_FILE" ]]; then
+    cp "$EXPECTED_CONTENT_FILE" "$target"
+  elif [[ -n "$EXPECTED_CONTENT" ]]; then
+    printf '%s' "$EXPECTED_CONTENT" >"$target"
+  else
+    printf 'tcfs Linux seeded fixture %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$target"
+  fi
+}
+
+seed_expected_file_if_requested() {
+  [[ "$SEED_EXPECTED_FILE" == "1" ]] || return 0
+
+  local seed_stamp
+  local seed_root="$LOG_DIR/seed-expected-root"
+  local seed_content="$LOG_DIR/seed-expected-content"
+  local push_log="$LOG_DIR/seed-expected-file-push.log"
+  local push_state="$LOG_DIR/seed-expected-state.json"
+  local -a args
+
+  [[ -n "$TCFS_PATH" ]] || {
+    echo "--seed-expected-file requires tcfs CLI status checks; remove --skip-status" >&2
+    exit 2
+  }
+
+  if [[ -z "$EXPECTED_FILE_REL" ]]; then
+    seed_stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+    EXPECTED_FILE_REL="linux-smoke-${seed_stamp}/fixture.txt"
+  fi
+  validate_relative_file_path "$EXPECTED_FILE_REL"
+
+  mkdir -p "$seed_root/$(dirname "$EXPECTED_FILE_REL")"
+  prepare_seed_content_file "$seed_content"
+  cp "$seed_content" "$seed_root/$EXPECTED_FILE_REL"
+  EXPECTED_CONTENT_FILE="$seed_content"
+
+  echo "seeding expected fixture: $EXPECTED_FILE_REL"
+  args=(--config "$CONFIG_PATH" push "$seed_root" --state "$push_state")
+  if [[ -n "$REMOTE_PREFIX" ]]; then
+    args+=(--prefix "$REMOTE_PREFIX")
+  fi
+
+  "$TCFS_PATH" "${args[@]}" >"$push_log" 2>&1 || {
+    echo "failed to seed expected fixture" >&2
+    cat "$push_log" >&2 || true
+    exit 1
+  }
+}
+
+# ── FUSE mount ───────────────────────────────────────────────────────────────
+MOUNT_PID=""
+MOUNT_LOG=""
+
+resolve_mount_point() {
+  if [[ -z "$MOUNT_POINT" ]]; then
+    MOUNT_POINT="$LOG_DIR/mount"
+  fi
+  mkdir -p "$MOUNT_POINT"
+}
+
+resolve_remote_spec() {
+  if [[ -n "$REMOTE_SPEC" ]]; then
+    return 0
+  fi
+  # Derive a default s3://<bucket>/<prefix> spec from the config when the
+  # caller did not pass one explicitly.
+  if [[ -z "$REMOTE_PREFIX" ]]; then
+    echo "--remote-spec is required when --remote-prefix is not provided" >&2
+    exit 2
+  fi
+  local bucket
+  bucket="$(python3 - "$CONFIG_PATH" <<'PY' 2>/dev/null || true
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+with open(sys.argv[1], "rb") as fh:
+    cfg = tomllib.load(fh)
+print(cfg.get("storage", {}).get("bucket", ""))
+PY
+)"
+  if [[ -z "$bucket" ]]; then
+    echo "could not derive bucket from $CONFIG_PATH; pass --remote-spec" >&2
+    exit 2
+  fi
+  REMOTE_SPEC="s3://${bucket}/${REMOTE_PREFIX}"
+  echo "derived --remote-spec: $REMOTE_SPEC"
+}
+
+mount_fuse() {
+  resolve_mount_point
+  resolve_remote_spec
+
+  MOUNT_LOG="$LOG_DIR/tcfs-mount.log"
+  echo "mounting FUSE: $REMOTE_SPEC -> $MOUNT_POINT"
+  "$TCFS_PATH" --config "$CONFIG_PATH" mount "$REMOTE_SPEC" "$MOUNT_POINT" \
+    >"$MOUNT_LOG" 2>&1 &
+  MOUNT_PID="$!"
+
+  # Wait for the kernel to reflect the mount. mountpoint(1) is the most
+  # reliable signal; fall back to scanning /proc/self/mountinfo.
+  local deadline=$((SECONDS + TIMEOUT_SECS))
+  while (( SECONDS < deadline )); do
+    if command -v mountpoint >/dev/null 2>&1; then
+      if mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+        echo "FUSE mount ready: $MOUNT_POINT"
+        return 0
+      fi
+    elif grep -q " $MOUNT_POINT " /proc/self/mountinfo 2>/dev/null; then
+      echo "FUSE mount ready (mountinfo): $MOUNT_POINT"
+      return 0
+    fi
+    if ! kill -0 "$MOUNT_PID" 2>/dev/null; then
+      echo "tcfs mount exited before mount appeared; see $MOUNT_LOG" >&2
+      cat "$MOUNT_LOG" >&2 || true
+      exit 1
+    fi
+    short_pause
+  done
+
+  echo "timed out waiting for FUSE mount at $MOUNT_POINT" >&2
+  cat "$MOUNT_LOG" >&2 || true
+  exit 1
+}
+
+unmount_fuse() {
+  [[ -n "$MOUNT_POINT" ]] || return 0
+  if command -v fusermount3 >/dev/null 2>&1; then
+    fusermount3 -u "$MOUNT_POINT" >/dev/null 2>&1 || true
+  elif command -v fusermount >/dev/null 2>&1; then
+    fusermount -u "$MOUNT_POINT" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$MOUNT_PID" ]] && kill -0 "$MOUNT_PID" 2>/dev/null; then
+    kill "$MOUNT_PID" 2>/dev/null || true
+    wait "$MOUNT_PID" 2>/dev/null || true
+  fi
+}
+
+# ── Hydration ────────────────────────────────────────────────────────────────
+wait_for_expected_file() {
+  local path="$1"
+  local attempt=0
+  while (( attempt < TIMEOUT_SECS )); do
+    if [[ -e "$path" ]]; then
+      return
+    fi
+    short_pause
+    attempt=$((attempt + 1))
+  done
+  echo "timed out waiting for expected file: $path" >&2
+  exit 1
+}
+
+hydrate_expected_file() {
+  local path="$1"
+  local hydrated_copy="$LOG_DIR/hydrated-expected-file"
+  local expected_copy="$LOG_DIR/expected-content"
+
+  # On Linux the tcfs FUSE mount exposes files under their real names — no
+  # .tc stub semantics — so a plain `cat` triggers hydration through the
+  # driver's read path.
+  if ! cat "$path" >"$hydrated_copy" 2>"$LOG_DIR/hydrate-read-error.log"; then
+    echo "failed to read expected file: $path" >&2
+    cat "$LOG_DIR/hydrate-read-error.log" >&2 || true
+    exit 1
+  fi
+  echo "hydrated file: $path ($(wc -c <"$hydrated_copy" | tr -d '[:space:]') bytes)"
+
+  if [[ -n "$EXPECTED_CONTENT_FILE" ]]; then
+    if ! cmp -s "$EXPECTED_CONTENT_FILE" "$hydrated_copy"; then
+      echo "hydrated file content mismatch against $EXPECTED_CONTENT_FILE" >&2
+      exit 1
+    fi
+    echo "hydrated file content matched expected content file"
+  elif [[ -n "$EXPECTED_CONTENT" ]]; then
+    printf '%s' "$EXPECTED_CONTENT" >"$expected_copy"
+    if ! cmp -s "$expected_copy" "$hydrated_copy"; then
+      echo "hydrated file content mismatch against --expected-content" >&2
+      exit 1
+    fi
+    echo "hydrated file content matched expected content"
+  fi
+}
+
+# ── Evict / rehydrate via `tcfs unsync` ──────────────────────────────────────
+exercise_evict_rehydrate_cycle() {
+  local rel="$1"
+  local mount_path="$MOUNT_POINT/$rel"
+  local unsync_log="$LOG_DIR/unsync.log"
+
+  # TODO(TIN-1422): on Linux the canonical "evict" path for the FUSE mount
+  # is `tcfs unsync <hydrated-copy>` applied to the sync_root copy (the
+  # FUSE mount itself is a read-through cache, not the eviction target).
+  # For the scaffold we drive `tcfs unsync` against the mounted path and
+  # rely on the CLI to convert it to a stub on disk — followup work needs
+  # to confirm the right semantics for FUSE-backed flows and may need to
+  # operate on a sync_root path instead.
+  echo "requesting unsync (evict): $mount_path"
+  "$TCFS_PATH" --config "$CONFIG_PATH" unsync "$mount_path" \
+    >"$unsync_log" 2>&1 || {
+    echo "tcfs unsync failed" >&2
+    cat "$unsync_log" >&2 || true
+    exit 1
+  }
+  cat "$unsync_log"
+
+  # Read again — should rehydrate.
+  hydrate_expected_file "$mount_path"
+  echo "Linux evict/rehydrate cycle passed"
+}
+
+# ── Mutation ─────────────────────────────────────────────────────────────────
+prepare_mutation_content_file() {
+  local target="$1"
+
+  if [[ -n "$MUTATION_CONTENT_FILE" ]]; then
+    cp "$MUTATION_CONTENT_FILE" "$target"
+  elif [[ -n "$MUTATION_CONTENT" ]]; then
+    printf '%s' "$MUTATION_CONTENT" >"$target"
+  else
+    printf 'tcfs Linux mutation smoke %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$target"
+  fi
+}
+
+pull_mutation_from_remote() {
+  local rel="$1"
+  local expected_file="$2"
+  local pulled_copy="$LOG_DIR/mutation-remote-pull"
+  local attempt=0
+
+  rm -f "$pulled_copy"
+  while (( attempt < TIMEOUT_SECS )); do
+    if "$TCFS_PATH" --config "$CONFIG_PATH" pull "$rel" "$pulled_copy" \
+      --prefix "$REMOTE_PREFIX" >"$LOG_DIR/mutation-remote-pull.log" 2>&1; then
+      if cmp -s "$expected_file" "$pulled_copy"; then
+        echo "remote mutation pull matched expected content"
+        return
+      fi
+      echo "remote mutation content mismatch for $rel" >&2
+      exit 1
+    fi
+    short_pause
+    attempt=$((attempt + 1))
+  done
+
+  echo "timed out waiting for mutation to appear in remote index: $rel" >&2
+  cat "$LOG_DIR/mutation-remote-pull.log" >&2 || true
+  exit 1
+}
+
+exercise_mutation() {
+  local rel="$MUTATION_FILE_REL"
+  local expected_file="$LOG_DIR/mutation-expected-content"
+
+  if [[ -z "$rel" ]]; then
+    rel="tcfs-linux-mutation-${USER:-user}-$$-${RANDOM:-0}.txt"
+  fi
+  validate_relative_file_path "$rel"
+
+  local path="$MOUNT_POINT/$rel"
+  local parent
+  parent="$(dirname "$path")"
+  mkdir -p "$parent"
+  prepare_mutation_content_file "$expected_file"
+
+  echo "writing Linux mutation fixture: $rel"
+  if ! cp "$expected_file" "$path" 2>"$LOG_DIR/mutation-write.log"; then
+    echo "Linux mutation write failed: $path" >&2
+    cat "$LOG_DIR/mutation-write.log" >&2 || true
+    exit 1
+  fi
+
+  wait_for_expected_file "$path"
+  if ! cmp -s "$expected_file" "$path"; then
+    echo "Linux mutation local content mismatch: $path" >&2
+    exit 1
+  fi
+  echo "Linux mutation local content matched"
+
+  # TODO(TIN-1422): the FUSE write path may not push to remote synchronously.
+  # The macOS harness relies on the FileProvider extension queueing the push.
+  # On Linux today the operator typically runs `tcfs push <sync_root>` to
+  # publish mutations. Until the daemon's write-back path is wired in, the
+  # caller may need to invoke `tcfs push` explicitly before this verification.
+  pull_mutation_from_remote "$rel" "$expected_file"
+  run_status "post-mutation"
+}
+
+# ── Entry sequencing ─────────────────────────────────────────────────────────
+if [[ -n "$LOG_DIR_OVERRIDE" ]]; then
+  LOG_DIR="$LOG_DIR_OVERRIDE"
+  mkdir -p "$LOG_DIR"
+else
+  LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-linux-postinstall.XXXXXX")"
+  trap 'rm -rf "$LOG_DIR"' EXIT
+fi
+echo "status logs: $LOG_DIR"
+
+CLEANUP_REGISTERED=1
+cleanup() {
+  unmount_fuse
+  stop_daemon
+}
+trap 'cleanup; [[ -n "$LOG_DIR_OVERRIDE" ]] || rm -rf "$LOG_DIR"' EXIT
+
+install_package
+
+TCFSD_PATH="$(resolve_bin "$TCFSD_BIN")"
+assert_version "tcfsd" "$TCFSD_PATH"
+
+if [[ "$SKIP_STATUS" -eq 0 ]]; then
+  TCFS_PATH="$(resolve_bin "$TCFS_BIN")"
+  assert_version "tcfs" "$TCFS_PATH"
+else
+  if [[ -n "$EXPECTED_FILE_REL" || "$SEED_EXPECTED_FILE" == "1" || "$EXERCISE_MUTATION" == "1" ]]; then
+    TCFS_PATH="$(resolve_bin "$TCFS_BIN")"
+  else
+    TCFS_PATH=""
+  fi
+fi
+
+start_daemon
+run_status "preflight"
+
+seed_expected_file_if_requested
+
+mount_fuse
+
+if [[ -n "$EXPECTED_FILE_REL" ]]; then
+  EXPECTED_PATH="$MOUNT_POINT/$EXPECTED_FILE_REL"
+  require_expected_remote_index "$EXPECTED_FILE_REL"
+  wait_for_expected_file "$EXPECTED_PATH"
+  hydrate_expected_file "$EXPECTED_PATH"
+  if [[ "$EXERCISE_EVICT_REHYDRATE" == "1" ]]; then
+    exercise_evict_rehydrate_cycle "$EXPECTED_FILE_REL"
+  fi
+else
+  echo "warning: --expected-file not provided; hydration was not exercised" >&2
+fi
+
+if [[ "$EXERCISE_MUTATION" == "1" ]]; then
+  exercise_mutation
+fi
+
+run_status "post-hydrate"
+
+echo "Linux post-install smoke passed"

--- a/scripts/test-linux-postinstall-smoke.sh
+++ b/scripts/test-linux-postinstall-smoke.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+#
+# Regression tests for linux-postinstall-smoke.sh using fake tools.
+#
+# These tests do NOT mount a real FUSE filesystem. They stub `tcfs`,
+# `tcfsd`, `mountpoint`, and `fusermount3` so the harness's argument
+# parsing, the `tcfs index inspect` gate, and the seed/hydrate/mutation
+# control flow can be exercised on any Linux runner (and even on macOS by
+# bypassing the `uname` guard).
+#
+# TIN-1422 scaffold: only the most load-bearing behaviors are asserted
+# today — the harness itself contains explicit TODOs for the rest.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/linux-postinstall-smoke.sh"
+TMPDIR_BASE="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-linux-postinstall-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+
+  local out="${TMPDIR_BASE}/failure.out"
+  local err="${TMPDIR_BASE}/failure.err"
+
+  if "$@" >"$out" 2>"$err"; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+
+  cat "$out" "$err" >"${TMPDIR_BASE}/failure.combined"
+  assert_contains "${TMPDIR_BASE}/failure.combined" "$expected"
+}
+
+FAKE_BIN="${TMPDIR_BASE}/fake-bin"
+HOME_DIR="${TMPDIR_BASE}/home"
+LOG_DIR="${TMPDIR_BASE}/logs"
+MOUNT_POINT="${TMPDIR_BASE}/mount"
+CONFIG_PATH="${HOME_DIR}/.config/tcfs/config.toml"
+EXPECTED_REL="canary/fixture.txt"
+MUTATION_REL="canary/mutation.txt"
+EXPECTED_CONTENT_FILE="${TMPDIR_BASE}/expected.txt"
+MUTATION_CONTENT_FILE="${TMPDIR_BASE}/mutation.txt"
+REMOTE_ROOT="${TMPDIR_BASE}/remote"
+
+mkdir -p \
+  "$FAKE_BIN" \
+  "$(dirname "$CONFIG_PATH")" \
+  "$MOUNT_POINT/$(dirname "$EXPECTED_REL")" \
+  "$REMOTE_ROOT/$(dirname "$EXPECTED_REL")" \
+  "$LOG_DIR"
+
+cat >"$CONFIG_PATH" <<EOF
+[storage]
+endpoint = "http://example.invalid:8333"
+bucket = "tcfs"
+
+[sync]
+state_db = "${TMPDIR_BASE}/tcfs-state.db"
+sync_root = "${TMPDIR_BASE}/sync-root"
+EOF
+
+printf 'TCFS Linux hydration fixture\n' >"$EXPECTED_CONTENT_FILE"
+printf 'TCFS Linux mutation fixture\n' >"$MUTATION_CONTENT_FILE"
+cp "$EXPECTED_CONTENT_FILE" "$MOUNT_POINT/$EXPECTED_REL"
+cp "$EXPECTED_CONTENT_FILE" "$REMOTE_ROOT/$EXPECTED_REL"
+
+# ── Fake uname so the script runs on the test host too ──────────────────────
+cat >"$FAKE_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-s" ]]; then
+  printf 'Linux\n'
+else
+  printf 'Linux\n'
+fi
+EOF
+
+# ── Fake tcfs CLI that supports status, index inspect, push, pull, mount,
+#    unsync ──────────────────────────────────────────────────────────────────
+cat >"$FAKE_BIN/tcfs" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version)
+    printf 'tcfs 0.13.0\n'
+    ;;
+  --config)
+    config="$2"
+    shift 2
+    case "${1:-status}" in
+      status)
+        printf 'tcfsd v0.13.0\nstorage: [ok]\n'
+        ;;
+      index)
+        [[ "${2:-}" == "inspect" ]] || {
+          printf 'expected fake index inspect\n' >&2
+          exit 1
+        }
+        rel="${3:-}"
+        status="${TCFS_FAKE_INDEX_STATUS:-visible}"
+        cat <<JSON
+{
+  "rel_path": "$rel",
+  "remote_prefix": "data",
+  "index_key": "data/index/$rel",
+  "index_exists": true,
+  "status": "$status",
+  "parse_error": null,
+  "entry_state": "committed",
+  "visible_entry": {
+    "manifest_hash": "fakehash",
+    "manifest_key": "data/manifests/fakehash",
+    "manifest_exists": true,
+    "size": 27,
+    "chunks": 1,
+    "kind": "regular_file",
+    "symlink_target": null
+  },
+  "pending_entry": null
+}
+JSON
+        ;;
+      push)
+        root="$2"
+        [[ -n "${TCFS_FAKE_REMOTE_ROOT:-}" ]] || {
+          printf 'TCFS_FAKE_REMOTE_ROOT missing for fake push\n' >&2
+          exit 1
+        }
+        mkdir -p "$TCFS_FAKE_REMOTE_ROOT"
+        cp -R "$root"/. "$TCFS_FAKE_REMOTE_ROOT"/
+        printf 'Push complete:\n  uploaded: 1 files\n'
+        ;;
+      pull)
+        rel="$2"
+        dest="$3"
+        src="${TCFS_FAKE_REMOTE_ROOT:?}/$rel"
+        if [[ ! -f "$src" ]]; then
+          printf 'fake pull: missing %s\n' "$src" >&2
+          exit 1
+        fi
+        /bin/cat "$src" >"$dest"
+        printf 'Pulling %s -> %s using %s\n' "$rel" "$dest" "$config"
+        ;;
+      mount)
+        # tcfs mount is normally long-running; for the test we sleep until killed.
+        spec="$2"
+        point="$3"
+        printf 'fake mount: %s -> %s\n' "$spec" "$point"
+        # Touch a marker so the harness can use mountpoint(1) to detect.
+        : >"${TCFS_FAKE_MOUNT_MARKER:-/dev/null}"
+        exec sleep 60
+        ;;
+      unsync)
+        path="$2"
+        printf 'Unsynced: %s -> stub\n' "$path"
+        ;;
+      *)
+        printf 'unexpected tcfs --config invocation:'
+        printf ' %q' "$@"
+        printf '\n'
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    printf 'unexpected tcfs invocation:'
+    printf ' %q' "$@"
+    printf '\n'
+    exit 1
+    ;;
+esac
+EOF
+
+cat >"$FAKE_BIN/tcfsd" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'tcfsd 0.13.0\n'
+else
+  # The harness foreground-mode call runs the daemon detached; just sleep so
+  # `kill -0 $pid` succeeds.
+  exec sleep 60
+fi
+EOF
+
+cat >"$FAKE_BIN/systemctl" <<'EOF'
+#!/usr/bin/env bash
+# Always report "no systemd" so the harness falls back to foreground.
+exit 1
+EOF
+
+cat >"$FAKE_BIN/mountpoint" <<'EOF'
+#!/usr/bin/env bash
+# Treat the marker file as proof of mount.
+if [[ "${1:-}" == "-q" && -n "${2:-}" ]]; then
+  if [[ -f "${TCFS_FAKE_MOUNT_MARKER:-}" ]]; then
+    exit 0
+  fi
+  exit 1
+fi
+exit 1
+EOF
+
+cat >"$FAKE_BIN/fusermount3" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "$FAKE_BIN"/*
+
+POSITIVE_OUT="${TMPDIR_BASE}/positive.out"
+MOUNT_MARKER="${TMPDIR_BASE}/mount-marker"
+
+env PATH="$FAKE_BIN:$PATH" \
+  HOME="$HOME_DIR" \
+  TCFS_FAKE_REMOTE_ROOT="$REMOTE_ROOT" \
+  TCFS_FAKE_MOUNT_MARKER="$MOUNT_MARKER" \
+  bash "$SCRIPT" \
+    --expected-version 0.13.0 \
+    --config "$CONFIG_PATH" \
+    --expected-file "$EXPECTED_REL" \
+    --expected-content-file "$EXPECTED_CONTENT_FILE" \
+    --remote-prefix "fake/prefix" \
+    --remote-spec "s3://tcfs/fake/prefix" \
+    --mount-point "$MOUNT_POINT" \
+    --skip-package-install \
+    --no-systemd \
+    --timeout 10 \
+    --log-dir "$LOG_DIR" \
+    >"$POSITIVE_OUT" 2>&1 || {
+  echo "positive run failed; output:" >&2
+  cat "$POSITIVE_OUT" >&2 || true
+  exit 1
+}
+
+assert_contains "$POSITIVE_OUT" "tcfsd version: tcfsd 0.13.0"
+assert_contains "$POSITIVE_OUT" "tcfs version: tcfs 0.13.0"
+assert_contains "$POSITIVE_OUT" "remote index status for expected file: visible"
+assert_contains "$POSITIVE_OUT" "FUSE mount ready"
+assert_contains "$POSITIVE_OUT" "hydrated file content matched expected content file"
+assert_contains "$POSITIVE_OUT" "Linux post-install smoke passed"
+assert_contains "$LOG_DIR/expected-file-index.json" '"status": "visible"'
+
+# ── Negative: index inspect status != visible blocks hydration ──────────────
+NEG_OUT="${TMPDIR_BASE}/negative.out"
+NEG_MOUNT_MARKER="${TMPDIR_BASE}/neg-mount-marker"
+NEG_MOUNT_POINT="${TMPDIR_BASE}/neg-mount"
+mkdir -p "$NEG_MOUNT_POINT/$(dirname "$EXPECTED_REL")"
+cp "$EXPECTED_CONTENT_FILE" "$NEG_MOUNT_POINT/$EXPECTED_REL"
+
+env PATH="$FAKE_BIN:$PATH" \
+  HOME="$HOME_DIR" \
+  TCFS_FAKE_REMOTE_ROOT="$REMOTE_ROOT" \
+  TCFS_FAKE_MOUNT_MARKER="$NEG_MOUNT_MARKER" \
+  TCFS_FAKE_INDEX_STATUS="missing" \
+  bash "$SCRIPT" \
+    --expected-version 0.13.0 \
+    --config "$CONFIG_PATH" \
+    --expected-file "$EXPECTED_REL" \
+    --expected-content-file "$EXPECTED_CONTENT_FILE" \
+    --remote-prefix "fake/prefix" \
+    --remote-spec "s3://tcfs/fake/prefix" \
+    --mount-point "$NEG_MOUNT_POINT" \
+    --skip-package-install \
+    --no-systemd \
+    --timeout 10 \
+    --log-dir "${TMPDIR_BASE}/neg-logs" \
+    >"$NEG_OUT" 2>&1 && {
+  echo "expected negative run to fail when index status != visible" >&2
+  cat "$NEG_OUT" >&2 || true
+  exit 1
+}
+assert_contains "$NEG_OUT" "expected file is not backed by a visible remote index entry"
+
+# Helpers for negative arg-parsing checks. These need the fake `uname` on PATH
+# so the harness's Linux guard does not preempt arg validation.
+run_with_fakes() {
+  env PATH="$FAKE_BIN:$PATH" bash "$SCRIPT" "$@"
+}
+
+# ── Negative: --exercise-mutation requires --remote-prefix ──────────────────
+assert_fails_contains "--exercise-mutation requires --remote-prefix" \
+  run_with_fakes --exercise-mutation
+
+# ── Negative: --expected-content and --expected-content-file are mutually exclusive
+assert_fails_contains "mutually exclusive" \
+  run_with_fakes --expected-content foo --expected-content-file /etc/hostname
+
+# ── Negative: --exercise-evict-rehydrate without expected file ──────────────
+assert_fails_contains "--exercise-evict-rehydrate requires" \
+  run_with_fakes --exercise-evict-rehydrate
+
+echo "linux-postinstall-smoke tests passed"


### PR DESCRIPTION
## Summary

First concrete step on TIN-1422 (Linux post-install smoke parity with macOS).
Lands the **shape and gate**, not 100% feature parity. Three new files,
all additive:

1. **`scripts/linux-postinstall-smoke.sh`** — Linux analog of
   `scripts/macos-postinstall-smoke.sh`. Installs a .deb/.rpm, starts
   tcfsd via systemd (with foreground fallback), mounts FUSE, gates
   exact-content hydration on `tcfs index inspect` reporting
   `status=visible` (same `require_expected_remote_index` shape as the
   macOS harness), and optionally exercises evict/rehydrate and mutation.
2. **`scripts/test-linux-postinstall-smoke.sh`** — fake-tools regression
   suite mirroring `scripts/test-macos-postinstall-smoke.sh`. Stubs
   tcfs, tcfsd, mountpoint, fusermount3, systemctl, uname so the
   harness's arg parsing, the index-inspect gate (positive + negative),
   and the hydration flow run on any host.
3. **`.github/workflows/linux-postinstall-smoke.yml`** — workflow
   dispatch mirroring `macos-postinstall-smoke.yml`. Same secret shape
   (`TCFS_SMOKE_S3_ENDPOINT`, `TCFS_SMOKE_S3_BUCKET`,
   `TCFS_SMOKE_S3_ACCESS_KEY_ID`, `TCFS_SMOKE_S3_SECRET_ACCESS_KEY`,
   `TCFS_SMOKE_MASTER_KEY_B64`), same input surface
   (`tag`, `package_url`, `package_artifact_run_id`,
   `package_artifact_name`, `runner_label`, `exercise_evict_rehydrate`,
   `exercise_mutation`). Defaults to `ubuntu-24.04`. Derives
   `storage.enforce_tls` from the endpoint scheme the same way the macOS
   workflow does (after 0b1dc0c).

## Design decisions

- **Clean-name VFS**: Linux FUSE exposes files under their real names
  (no `.tc` stub semantics in the mount surface), so the harness uses
  plain `cat` to trigger hydration through the driver's read path —
  no fileproviderctl-style requestDownload nudges needed.
- **systemd-first**: prefers the unit shipped in the .deb
  (`tcfsd.service`), falls back to foreground `tcfsd --config ...` when
  systemd is unavailable or the unit fails to activate (covers
  containerised runners).
- **Harness installs the package**: keeps the workflow lean. The
  workflow only handles secret wiring, fixture prep, config render, and
  artifact download.
- **Seed via `--seed-expected-file`**: the workflow uses the harness's
  built-in seed flow rather than a separate `tcfs push` step, so the CLI
  used to seed is the same one being smoke-tested.

## Explicit TODOs (TIN-1422 follow-up)

- [ ] **Evict/rehydrate semantics on FUSE**: today the scaffold runs
  `tcfs unsync` against the mount path. The right semantics for FUSE
  flows may need to operate on a sync_root path or coordinate with the
  daemon's eviction queue — flagged inline.
- [ ] **Mutation write-back**: the macOS harness relies on
  FileProvider's queued push. On Linux the operator typically runs
  `tcfs push <sync_root>` to publish mutations; this scaffold assumes
  the FUSE write path queues to remote (may need an explicit push step).
- [ ] **Daemon socket polling**: the scaffold leans on `tcfs status` to
  prove the daemon is reachable rather than polling for a specific
  socket path. Add a socket-path poll once the systemd unit's runtime
  directory layout is canonical.
- [ ] **`.rpm` path coverage in CI**: the default workflow downloads the
  amd64 `.deb`. Add an rpm-on-fedora matrix entry once the release flow
  ships a routable RPM artifact.
- [ ] **Conflict-status fixture**: macOS has `--exercise-conflict-status`
  driven through FileProvider enumerator logs; the Linux scaffold does
  not yet have an analog because there's no equivalent enumerator log
  surface. Needs design.

## Test plan

- [x] `bash scripts/test-linux-postinstall-smoke.sh` passes on macOS
  (the fake `uname` lets the harness's Linux guard pass).
- [x] `bash -n scripts/linux-postinstall-smoke.sh` clean.
- [x] `yq` accepts the workflow YAML.
- [ ] Dispatch `Linux Post-Install Smoke` against a real `.deb` artifact
  on a Linux runner once the workflow merges and the
  `tcfs-linux-smoke` environment + secrets are configured.

Refs: TIN-1422.