### PR TITLE
release.yml: accept pre-release tag suffix (-rc1, -beta.2, etc.)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,8 @@ jobs:
           else
             TAG="${{ github.event.inputs.tag }}"
           fi
-          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release tag must look like vX.Y.Z, got ${TAG}"
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Release tag must look like vX.Y.Z or vX.Y.Z-PRERELEASE (e.g. v0.12.13, v0.12.13-rc1, v1.0.0-beta.2), got ${TAG}"
             exit 1
           fi
           VERSION="${TAG#v}"  # strip leading v


### PR DESCRIPTION
## Summary

Plan release validation rejected `v0.12.13-rc1` because the regex was strict `^v[0-9]+\.[0-9]+\.[0-9]+$`. Loosen to `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$` so optional SemVer pre-release suffixes (-rc1, -rc.1, -beta.2, -alpha, etc.) drive the same release pipeline as full releases.

## Why

v0.12.13-rc1 cut was blocked: tag pushed and triggered release.yml, but Plan release step exited 1 at the regex check ([failed run](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063228113)). Per the Mon-Fri sprint plan, M10 acceptance is proven and we want the rc to verify the full release pipeline before a clean v0.12.13 cut.

## Behavior

- `v0.12.13` (release) → accepted (unchanged)
- `v0.12.13-rc1` → now accepted
- `v0.12.13-rc.1` → now accepted (cargo-style)
- `v1.0.0-beta.2` → now accepted
- `v0.12.13rc1` (no dash) → still rejected (correctly)
- `v0.12` (missing patch) → still rejected (unchanged)

## Test plan

- [x] Regex tested locally against representative tag strings
- [ ] CI green on this PR
- [ ] Merge → re-tag `v0.12.13-rc1` → full release pipeline runs end-to-end