### PR TITLE
docs(release): v0.12.13 evidence matrix

### DIFF
--- a/docs/release/v0.12.13-evidence-matrix.md
+++ b/docs/release/v0.12.13-evidence-matrix.md
@@ -16,6 +16,8 @@ rather than re-describing release state in prose.
 - Release commit: `985e704` ([`985e704...`](https://github.com/Jesssullivan/tummycrypt/commit/985e704))
 - Release workflow run: [`actions/runs/26063349561`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561)
 - Release notes: [`releases/tag/v0.12.13-rc1`](https://github.com/Jesssullivan/tummycrypt/releases/tag/v0.12.13-rc1)
+- Published: 2026-05-18T23:40:42Z
+- Release workflow conclusion: success
 
 ## Headline change
 
@@ -34,31 +36,132 @@ Evidence packet:
 
 The canonical smoke matrix lists six surfaces. This matrix splits `.deb` into
 Ubuntu 24.04 and Debian 12 because their outcomes differ materially, so seven
-surfaces are tracked here. Outcomes filled in after the rc1 release pipeline
-completes; this skeleton lands first to make the link target stable.
+surfaces are tracked here.
 
 | # | Surface | Fresh install | Upgrade | Result | Evidence |
 |---|---------|---------------|---------|--------|----------|
-| 1 | Homebrew | TBD | TBD | TBD | _to fill after release pipeline_ |
-| 2 | macOS `.pkg` (production Dev ID FileProvider) | **proven on PZM** | TBD | ✅ for FileProvider; TBD for first-install on pristine | run [`26062554542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26062554542) |
-| 3 | `.deb` on Ubuntu 24.04 | TBD | TBD | TBD | _to fill_ |
+| 1 | Homebrew | formula published; install smoke pending | formula updated | ⚠️ artifact/formula pass | release job [`76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317) |
+| 2 | macOS `.pkg` (production Dev ID FileProvider) | **FileProvider proven on PZM**; pristine first-run pending | package build/notarization passed | ✅ for FileProvider; ⚠️ first-run UX gap | run [`26062554542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26062554542), release job [`76633468317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76633468317) |
+| 3 | `.deb` on Ubuntu 24.04 | packages published; install smoke pending | package upgrade smoke pending | ⚠️ artifact pass | release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
 | 4 | `.deb` on Debian 12 bookworm | known blocked (`libc6 >= 2.39` floor) | n/a | ❌ blocked | inherits from [`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor) |
-| 5 | `.rpm` on Fedora 42 | TBD | TBD | TBD | _to fill_ |
-| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1` | TBD | TBD | TBD | _to fill_ |
-| 7 | Nix flake install | TBD | TBD | TBD | _to fill (cache externality resolved per 2026-04-29 note on v0.12.2 matrix)_ |
+| 5 | `.rpm` on Fedora 42 | daemon-only package published; install smoke pending | sampled only | ⚠️ daemon-only artifact pass | release job [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870) |
+| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1` | multi-arch image built and signed; run smoke pending | sampled only | ✅ artifact/signature pass; ⚠️ runtime smoke pending | release job [`76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828) |
+| 7 | Nix flake install | Nix build + Attic push passed; external profile install pending | sampled only | ⚠️ build/cache pass | release job [`76628512831`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512831) |
 
-Rollup pending pipeline completion.
+Rollup: **1 product-surface pass · 5 artifact/build/formula passes with first-use
+smoke still pending · 1 blocked**.
 
 ## Per-Surface Evidence
 
-### Surfaces 1-7 — pending
+### Published release assets
 
-Each row will be filled with concrete artifact-level evidence once the release
-pipeline ([`run 26063349561`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561))
-completes. Per-surface evidence sections will mirror the v0.12.2 matrix
-([`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#per-surface-evidence))
-structure: host, command sequence, version assertion, signature posture, and
-any host-specific caveats.
+Release [`v0.12.13-rc1`](https://github.com/Jesssullivan/tummycrypt/releases/tag/v0.12.13-rc1)
+published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
+`SHA256SUMS.txt.pem`. The checksum file records:
+
+- `tcfs-0.12.13-rc1-macos-aarch64.pkg`:
+  `54a686c468e18514595756f4d1cf5a48f5d58a9141e39363ef8d9caf810355de`
+- `TCFSProvider-0.12.13-rc1-macos-aarch64.zip`:
+  `b93867c2503bfa6e04cb84af538fc946ed9ea47bbb7cfedf31538386dd393bf6`
+- `tcfs-0.12.13-rc1-linux-x86_64.tar.gz`:
+  `8f9c2a92390f5c7251a42e8f6603a99d176c0fd98f01fb20477ec5c32c94b9a5`
+- `tcfs-0.12.13-rc1-linux-aarch64.tar.gz`:
+  `672c1bb85d799c9da0cdd9f1e8e93ef109f9bc7141f7e99fe187fcf0ac32bdf9`
+- `tcfs-0.12.13-rc1-amd64.deb`:
+  `6ae3e3c3bf38c158cfdaab335876633d074ef3217abd88edc6d842a643c9e2af`
+- `tcfsd-0.12.13-rc1-amd64.deb`:
+  `87de2adac6d5d1a31454a8e9b9502c2611d7412f4c8f2ef407399af1997402d5`
+- `tcfs-0.12.13-rc1-arm64.deb`:
+  `fb48985db44c96ae3f7dfc4081d32499aaf950fcc0ff18bffee7fef81bf7046e`
+- `tcfsd-0.12.13-rc1-arm64.deb`:
+  `34bd1e9079059e1fd196996a549dfc2082f72c1da1127150ce4418a9f51496fe`
+- `tcfsd-0.12.13-rc1-x86_64.rpm`:
+  `0e3f991f93ca9b7c979ce11898ce85cb661efd4a76faa3c93e1337e0326c169e`
+
+### 1. Homebrew — formula publication pass; install smoke pending
+
+- Release job: `Update Homebrew formula` succeeded
+  ([job `76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317)).
+- The job downloaded `SHA256SUMS.txt`, generated `Formula/tcfs.rb` from the
+  release tarball hashes, and force-pushed the `homebrew-tap` branch.
+- Not proven in this rc1 packet: fresh `brew install` and upgrade smoke on a
+  host after the formula update. The v0.12.2 Homebrew proof remains the latest
+  install/upgrade smoke evidence.
+
+### 2. macOS `.pkg` — package publication pass; FileProvider product surface proven
+
+- Release job: `Build macOS installer (.pkg)` succeeded
+  ([job `76633468317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76633468317)).
+- The job downloaded the macOS CLI binaries and FileProvider app, imported the
+  Developer ID Installer certificate, built
+  `tcfs-0.12.13-rc1-macos-aarch64.pkg`, notarized it, ran the package-structure
+  smoke, and uploaded the `.pkg` artifact.
+- Published checksum:
+  `54a686c468e18514595756f4d1cf5a48f5d58a9141e39363ef8d9caf810355de`.
+- Product-surface proof: production Developer ID FileProvider hydrate,
+  evict/rehydrate, mutation, and conflict-status were proven on PZM in run
+  [`26062554542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26062554542).
+- Not proven in this rc1 packet: clean-host first-run UX from package install to
+  working `tcfs status [ok]`. That remains TIN-1425 scope.
+
+### 3. Debian/Ubuntu `.deb` on Ubuntu 24.04 — artifact publication pass
+
+- Release jobs: `Build linux-x86_64` and `Build linux-aarch64` succeeded
+  ([job `76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870),
+  [job `76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850)).
+- Published assets:
+  - `tcfs-0.12.13-rc1-amd64.deb`
+  - `tcfsd-0.12.13-rc1-amd64.deb`
+  - `tcfs-0.12.13-rc1-arm64.deb`
+  - `tcfsd-0.12.13-rc1-arm64.deb`
+- Important caveat: the release workflow still wraps `cargo deb` with
+  `|| echo "::warning::..."`, so the asset list is the proof that packages were
+  actually produced for this tag.
+- Not proven in this rc1 packet: install/upgrade smoke on Ubuntu 24.04 or Debian
+  13. That remains TIN-131 / TIN-1422 scope.
+
+### 4. Debian/Ubuntu `.deb` on Debian 12 bookworm — blocked
+
+Unchanged from v0.12.2. The released `.deb` assets still target a newer libc /
+OpenSSL floor than Debian 12 provides. Debian 12 remains excluded unless a
+bookworm-specific package or static build is added.
+
+### 5. Fedora/RHEL `.rpm` on Fedora 42 — daemon-only artifact publication pass
+
+- Release job: `Build linux-x86_64` succeeded
+  ([job `76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870)).
+- Published asset: `tcfsd-0.12.13-rc1-x86_64.rpm`.
+- Published checksum:
+  `0e3f991f93ca9b7c979ce11898ce85cb661efd4a76faa3c93e1337e0326c169e`.
+- Structural caveat unchanged: RPM ships `tcfsd` only today. There is no `tcfs`
+  CLI RPM asset.
+- Not proven in this rc1 packet: Fedora 42 install smoke with
+  `scripts/install-smoke.sh --skip-cli`.
+
+### 6. Container image — multi-arch build/signature pass
+
+- Release job: `Build container image` succeeded
+  ([job `76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828)).
+- The workflow built and pushed `ghcr.io/jesssullivan/tcfsd` for
+  `linux/amd64` and `linux/arm64/v8`.
+- Tags published by the job:
+  - `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1`
+  - `ghcr.io/jesssullivan/tcfsd:0.12.13-rc1`
+  - `ghcr.io/jesssullivan/tcfsd:latest`
+- The immutable digest was signed with Cosign keyless OIDC.
+- Not proven in this rc1 packet: `docker run`/`podman run` worker-mode runtime
+  smoke against the published image.
+
+### 7. Nix flake install — build/cache pass; external profile install pending
+
+- Release job: `Nix Build + Attic Push` succeeded
+  ([job `76628512831`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512831)).
+- The job built `tcfsd`, `tcfs-cli`, `tcfs-tui`, and `tcfs-mcp`, then pushed the
+  results to the configured Attic cache.
+- This confirms the release flake builds at the tag and the cache push path is
+  healthy.
+- Not proven in this rc1 packet: an external `nix profile install
+  github:Jesssullivan/tummycrypt?ref=v0.12.13-rc1#...` from a non-tinyland host.
 
 ### Production Dev ID FileProvider — proven on PZM (M10 acceptance)
 
@@ -99,13 +202,13 @@ in a sibling evidence dir once the release pipeline completes.
 
 Inherits blockers from the v0.12.2 matrix where still applicable.
 
-### Blocker A — Nix cache externality (resolved per 2026-04-29 note)
+### Blocker A — Nix external profile proof
 
 The v0.12.2 matrix flagged `nix-cache.fuzzy-dev.tinyland.dev` as not
 externally reachable. The 2026-04-29 update noted main moved to
-`nix-cache.tinyland.dev`. The rc1 Nix surface result confirms or refutes
-that this is now resolved end-to-end for tagged releases. Pending pipeline
-completion.
+`nix-cache.tinyland.dev`. The rc1 release job confirms Nix build and Attic push
+success at the tag, but does **not** prove a fresh external profile install from
+the published ref. Treat this as a reduced proof gap, not a fully closed surface.
 
 ### Blocker B — Debian 12 bookworm support floor
 
@@ -145,3 +248,6 @@ Same as v0.12.2:
 
 - 2026-05-18 — Skeleton created at rc1 cut. Per-surface outcomes filled in
   after release pipeline run `26063349561` completes.
+- 2026-05-18 — Release pipeline completed successfully and GitHub Release was
+  published. Filled artifact/formula/container/Nix outcomes; kept first-use
+  smoke gaps explicit.

--- a/docs/release/v0.12.13-evidence-matrix.md
+++ b/docs/release/v0.12.13-evidence-matrix.md
@@ -192,11 +192,11 @@ ad-hoc-built .pkg before the rc1 cut):
 Full evidence packet at
 [`docs/release/evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/`](evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/).
 
-The rc1 release will re-build the same .pkg from commit `985e704` (the tag's
-HEAD), which contains the same FileProvider extension code, so the production
-Dev ID FileProvider surface is expected to remain green for the v0.12.13
-artifact. A confirming PZM smoke run against the rc1 .pkg will be archived
-in a sibling evidence dir once the release pipeline completes.
+The rc1 release rebuilt the same `.pkg` surface from commit `985e704` (the tag's
+HEAD), which contains the same FileProvider extension code. The production
+Dev ID FileProvider lifecycle proof above therefore remains the acceptance
+evidence for this rc1 unless a confirming package-installed PZM smoke against
+the published release artifact finds a regression.
 
 ## Blockers And Unblock Paths
 

--- a/docs/release/v0.12.13-evidence-matrix.md
+++ b/docs/release/v0.12.13-evidence-matrix.md
@@ -1,0 +1,147 @@
+# v0.12.13 Release Surface Evidence Matrix
+
+Concrete proof table for `tcfs v0.12.13`, anchored against the tagged release and
+the [Distribution Smoke Matrix](../ops/distribution-smoke-matrix.md) runbook.
+
+This document is the per-tag evidence freeze that the `Tummycrypt — Daily Driver
+Track` initiative carries forward from the `v0.12.2` pattern. Use it as a link
+target from tracker comments and from
+[`product-reality-and-priority.md`](../ops/product-reality-and-priority.md)
+rather than re-describing release state in prose.
+
+## Release Metadata
+
+- Tag: `v0.12.13-rc1`
+- Tagged: 2026-05-18T22:08:50Z (rc1)
+- Release commit: `985e704` ([`985e704...`](https://github.com/Jesssullivan/tummycrypt/commit/985e704))
+- Release workflow run: [`actions/runs/26063349561`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561)
+- Release notes: [`releases/tag/v0.12.13-rc1`](https://github.com/Jesssullivan/tummycrypt/releases/tag/v0.12.13-rc1)
+
+## Headline change
+
+**First green end-to-end production Dev ID FileProvider acceptance** on the
+canonical PZM self-hosted runner. Smoke run
+[`26062554542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26062554542)
+proved hydrate + evict/rehydrate + mutation + conflict-status — the complete
+M10 TIN-133 acceptance bar — against a Developer ID notarized `.pkg` without
+requiring `fileprovider_testing_mode=true` (whose entitlement only ships on
+Mac App Development profiles).
+
+Evidence packet:
+[`docs/release/evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/`](evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/).
+
+## Summary Table
+
+The canonical smoke matrix lists six surfaces. This matrix splits `.deb` into
+Ubuntu 24.04 and Debian 12 because their outcomes differ materially, so seven
+surfaces are tracked here. Outcomes filled in after the rc1 release pipeline
+completes; this skeleton lands first to make the link target stable.
+
+| # | Surface | Fresh install | Upgrade | Result | Evidence |
+|---|---------|---------------|---------|--------|----------|
+| 1 | Homebrew | TBD | TBD | TBD | _to fill after release pipeline_ |
+| 2 | macOS `.pkg` (production Dev ID FileProvider) | **proven on PZM** | TBD | ✅ for FileProvider; TBD for first-install on pristine | run [`26062554542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26062554542) |
+| 3 | `.deb` on Ubuntu 24.04 | TBD | TBD | TBD | _to fill_ |
+| 4 | `.deb` on Debian 12 bookworm | known blocked (`libc6 >= 2.39` floor) | n/a | ❌ blocked | inherits from [`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor) |
+| 5 | `.rpm` on Fedora 42 | TBD | TBD | TBD | _to fill_ |
+| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1` | TBD | TBD | TBD | _to fill_ |
+| 7 | Nix flake install | TBD | TBD | TBD | _to fill (cache externality resolved per 2026-04-29 note on v0.12.2 matrix)_ |
+
+Rollup pending pipeline completion.
+
+## Per-Surface Evidence
+
+### Surfaces 1-7 — pending
+
+Each row will be filled with concrete artifact-level evidence once the release
+pipeline ([`run 26063349561`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561))
+completes. Per-surface evidence sections will mirror the v0.12.2 matrix
+([`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#per-surface-evidence))
+structure: host, command sequence, version assertion, signature posture, and
+any host-specific caveats.
+
+### Production Dev ID FileProvider — proven on PZM (M10 acceptance)
+
+Run [`26062554542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26062554542)
+on the `petting-zoo-mini-tcfs` self-hosted runner (macOS, ARM64, on tailnet)
+against an artifact built by the
+[notarization-proof workflow run 26057944325](https://github.com/Jesssullivan/tummycrypt/actions/runs/26057944325)
+from main commit `c08a0a4` (PR #370).
+
+Evidence in the harness directory of that run's
+`macos-postinstall-smoke-v0.12.12.zip` artifact (note: artifact name carries
+the prior tag because the smoke ran with `tag=v0.12.12` against the
+ad-hoc-built .pkg before the rc1 cut):
+
+- `expected-file-index.json`: `tcfs index inspect` returned
+  `status=visible`, `entry_state=committed`, `manifest_exists=true`,
+  `size=55`, `chunks=1`.
+- `hydrated-expected-file`: contained exact expected bytes
+  `"tcfs macOS post-install smoke v0.12.12 run 26062554542"`.
+- `hydrate-read-error.log`: empty.
+- `host-evict-launch.log`: `evict: ci-smoke/0.12.12/postinstall-1.txt: OK
+  nonce=tcfs-smoke-80676-29692-20774`.
+- `mutation-remote-pull.log`: 68-byte download with manifest hash
+  `0929fa9655...`.
+- `conflict-hydrated-file` matches `conflict-expected-content`; `tcfs
+  sync-status` reports `sync state: conflict`.
+
+Full evidence packet at
+[`docs/release/evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/`](evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/).
+
+The rc1 release will re-build the same .pkg from commit `985e704` (the tag's
+HEAD), which contains the same FileProvider extension code, so the production
+Dev ID FileProvider surface is expected to remain green for the v0.12.13
+artifact. A confirming PZM smoke run against the rc1 .pkg will be archived
+in a sibling evidence dir once the release pipeline completes.
+
+## Blockers And Unblock Paths
+
+Inherits blockers from the v0.12.2 matrix where still applicable.
+
+### Blocker A — Nix cache externality (resolved per 2026-04-29 note)
+
+The v0.12.2 matrix flagged `nix-cache.fuzzy-dev.tinyland.dev` as not
+externally reachable. The 2026-04-29 update noted main moved to
+`nix-cache.tinyland.dev`. The rc1 Nix surface result confirms or refutes
+that this is now resolved end-to-end for tagged releases. Pending pipeline
+completion.
+
+### Blocker B — Debian 12 bookworm support floor
+
+Unchanged from v0.12.2. `tcfsd` still links `libc6 >= 2.39`; bookworm ships
+`2.36`. Three named unblock paths (variant build, static musl build, or
+explicit support narrowing) remain documented in the
+[v0.12.2 matrix](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor).
+No decision change for v0.12.13.
+
+### Blocker C — macOS `.pkg` fresh-install on pristine host
+
+The v0.12.2 matrix flagged that the .pkg upgrade path was proven on `neo`
+but a fresh-install-on-pristine-host pass was not gathered. For v0.12.13
+the **production Dev ID FileProvider lifecycle is now proven** on
+`petting-zoo-mini-tcfs` (run 26062554542), which is a stronger statement
+than v0.12.2's upgrade-only proof. First-install-on-pristine-macOS-VM
+remains an open gap but is now of materially lower risk.
+
+## Relationship To Other Acceptance Lanes
+
+Same as v0.12.2:
+
+- Use this matrix as the **evidence freeze for a tagged release**
+- [Distribution Smoke Matrix](../ops/distribution-smoke-matrix.md) is the
+  **runbook**
+- [`product-reality-and-priority.md`](../ops/product-reality-and-priority.md)
+  is the **current-state summary**
+- [Lab Host Acceptance Matrix](../ops/lab-host-acceptance-matrix.md) is
+  **host-level acceptance**
+- [Neo-Honey Live Acceptance](../ops/neo-honey-acceptance.md) is **live
+  backend sync proof**
+- [`macos-fileprovider-reality.md`](../ops/macos-fileprovider-reality.md)
+  carries the FileProvider-surface running log (updated 2026-05-18 with
+  the PROVEN milestone)
+
+## Revision History
+
+- 2026-05-18 — Skeleton created at rc1 cut. Per-surface outcomes filled in
+  after release pipeline run `26063349561` completes.


### PR DESCRIPTION
## Summary

Fills `docs/release/v0.12.13-evidence-matrix.md` now that rc1 release pipeline [26063349561](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561) completed successfully and GitHub Release `v0.12.13-rc1` was published.

## Filled

- Release publication metadata + SHA256 evidence
- Homebrew formula update, `.pkg`, `.deb`, RPM, container, and Nix build/cache outcomes
- Explicit first-use smoke gaps for Homebrew, `.deb`, RPM, container, Nix, and macOS first-run UX
- Keeps Debian 12 blocked and Nix external profile proof as residual gaps

## Test plan

- [x] Release pipeline completed successfully
- [x] No `TBD` / pending placeholders remain in the matrix
- [ ] PR checks after this doc update

Draft until this post-fill CI pass is green.