### PR TITLE
test: wait for Linux postinstall daemon socket (TIN-1422)

### DIFF
--- a/scripts/linux-postinstall-smoke.sh
+++ b/scripts/linux-postinstall-smoke.sh
@@ -407,17 +407,57 @@ start_daemon_foreground() {
   DAEMON_PID="$!"
   echo "tcfsd pid: $DAEMON_PID (log: $log)"
 
-  # TODO(TIN-1422): poll for the daemon socket path. Today the unit socket
-  # lives at /run/tcfsd/tcfsd.sock for systemd; foreground mode follows the
-  # CLI's default XDG_STATE_HOME-derived path. The macOS harness relies on
-  # `tcfs status` to prove the daemon is reachable, so we lean on the same
-  # gate below in run_status.
-  short_pause
-  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
-    echo "tcfsd exited immediately; see $log" >&2
-    cat "$log" >&2 || true
-    exit 1
+  wait_for_foreground_daemon_socket "$log"
+}
+
+config_daemon_socket() {
+  python3 - "$CONFIG_PATH" <<'PY' 2>/dev/null || true
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+with open(sys.argv[1], "rb") as fh:
+    cfg = tomllib.load(fh)
+print(cfg.get("daemon", {}).get("socket", ""))
+PY
+}
+
+wait_for_foreground_daemon_socket() {
+  local log="$1"
+  local socket_path
+  local deadline
+
+  socket_path="$(config_daemon_socket)"
+  if [[ -z "$socket_path" ]]; then
+    echo "daemon socket not configured; falling back to process liveness check"
+    short_pause
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+      echo "tcfsd exited immediately; see $log" >&2
+      cat "$log" >&2 || true
+      exit 1
+    fi
+    return
   fi
+
+  deadline=$((SECONDS + TIMEOUT_SECS))
+  while (( SECONDS < deadline )); do
+    if [[ -S "$socket_path" ]]; then
+      echo "daemon socket ready: $socket_path"
+      return
+    fi
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+      echo "tcfsd exited before socket appeared: $socket_path; see $log" >&2
+      cat "$log" >&2 || true
+      exit 1
+    fi
+    short_pause
+  done
+
+  echo "timed out waiting for daemon socket: $socket_path" >&2
+  cat "$log" >&2 || true
+  exit 1
 }
 
 start_daemon() {

--- a/scripts/test-linux-postinstall-smoke.sh
+++ b/scripts/test-linux-postinstall-smoke.sh
@@ -56,6 +56,7 @@ MUTATION_REL="canary/mutation.txt"
 EXPECTED_CONTENT_FILE="${TMPDIR_BASE}/expected.txt"
 MUTATION_CONTENT_FILE="${TMPDIR_BASE}/mutation.txt"
 REMOTE_ROOT="${TMPDIR_BASE}/remote"
+DAEMON_SOCKET="${TMPDIR_BASE}/tcfsd.sock"
 
 mkdir -p \
   "$FAKE_BIN" \
@@ -65,6 +66,9 @@ mkdir -p \
   "$LOG_DIR"
 
 cat >"$CONFIG_PATH" <<EOF
+[daemon]
+socket = "${DAEMON_SOCKET}"
+
 [storage]
 endpoint = "http://example.invalid:8333"
 bucket = "tcfs"
@@ -189,9 +193,68 @@ cat >"$FAKE_BIN/tcfsd" <<'EOF'
 if [[ "${1:-}" == "--version" ]]; then
   printf 'tcfsd 0.13.0\n'
 else
-  # The harness foreground-mode call runs the daemon detached; just sleep so
-  # `kill -0 $pid` succeeds.
-  exec sleep 60
+  config=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --config)
+        config="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  socket_path=""
+  if [[ -n "$config" ]]; then
+    socket_path="$(python3 - "$config" <<'PY' 2>/dev/null || true
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+with open(sys.argv[1], "rb") as fh:
+    cfg = tomllib.load(fh)
+print(cfg.get("daemon", {}).get("socket", ""))
+PY
+)"
+  fi
+
+  if [[ -z "$socket_path" ]]; then
+    exec sleep 60
+  fi
+
+  mkdir -p "$(dirname "$socket_path")"
+  exec python3 - "$socket_path" <<'PY'
+import os
+import signal
+import socket
+import sys
+import time
+
+path = sys.argv[1]
+try:
+    os.unlink(path)
+except FileNotFoundError:
+    pass
+
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(path)
+server.listen(1)
+
+def stop(_signum, _frame):
+    server.close()
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+    raise SystemExit(0)
+
+signal.signal(signal.SIGTERM, stop)
+while True:
+    time.sleep(60)
+PY
 fi
 EOF
 
@@ -247,6 +310,7 @@ env PATH="$FAKE_BIN:$PATH" \
 
 assert_contains "$POSITIVE_OUT" "tcfsd version: tcfsd 0.13.0"
 assert_contains "$POSITIVE_OUT" "tcfs version: tcfs 0.13.0"
+assert_contains "$POSITIVE_OUT" "daemon socket ready: $DAEMON_SOCKET"
 assert_contains "$POSITIVE_OUT" "remote index status for expected file: visible"
 assert_contains "$POSITIVE_OUT" "FUSE mount ready"
 assert_contains "$POSITIVE_OUT" "hydrated file content matched expected content file"


### PR DESCRIPTION
## Summary

Small TIN-1422 follow-up on the merged Linux postinstall smoke scaffold.

- Replaces the foreground `tcfsd` blind pause with polling for `[daemon].socket` from the smoke config.
- Keeps the old process-liveness fallback when no socket is configured.
- Extends the fake `tcfsd` regression test double to bind a Unix socket and asserts the harness observes `daemon socket ready`.

## Test plan

- [x] `bash scripts/test-linux-postinstall-smoke.sh`
- [x] `git diff --check`

Draft because this is a narrow scaffold hardening slice; real package/FUSE execution still needs the next TIN-1422 runner pass.