### PR TITLE
test: fail linux smoke on apt repair failure (TIN-1422)

### DIFF
--- a/scripts/linux-postinstall-smoke.sh
+++ b/scripts/linux-postinstall-smoke.sh
@@ -336,7 +336,11 @@ install_package() {
               cat "$install_log" >&2 || true
               exit 1
             }
-            sudo -n apt-get install -y -f >>"$install_log" 2>&1 || true
+            sudo -n apt-get install -y -f >>"$install_log" 2>&1 || {
+              echo "apt dependency repair failed after dpkg install; see $install_log" >&2
+              cat "$install_log" >&2 || true
+              exit 1
+            }
           }
       else
         dpkg -i "$PACKAGE_PATH" >"$install_log" 2>&1 || {

--- a/scripts/test-linux-postinstall-smoke.sh
+++ b/scripts/test-linux-postinstall-smoke.sh
@@ -268,6 +268,42 @@ cat >"$FAKE_BIN/systemctl" <<'EOF'
 exit 1
 EOF
 
+cat >"$FAKE_BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-n" ]]; then
+  shift
+fi
+exec "$@"
+EOF
+
+cat >"$FAKE_BIN/apt-get" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "install" && "${*: -1}" == *.deb ]]; then
+  printf 'fake apt direct install failure\n' >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "install" && "${*: -1}" == "-f" ]]; then
+  if [[ "${TCFS_FAKE_APT_FIX_FAIL:-0}" == "1" ]]; then
+    printf 'fake apt dependency repair failure\n' >&2
+    exit 23
+  fi
+  printf 'fake apt dependency repair success\n'
+  exit 0
+fi
+
+printf 'unexpected fake apt-get invocation:'
+printf ' %q' "$@"
+printf '\n' >&2
+exit 1
+EOF
+
+cat >"$FAKE_BIN/dpkg" <<'EOF'
+#!/usr/bin/env bash
+printf 'fake dpkg install success\n'
+exit 0
+EOF
+
 cat >"$FAKE_BIN/mountpoint" <<'EOF'
 #!/usr/bin/env bash
 # Treat the marker file as proof of mount.
@@ -378,5 +414,19 @@ assert_fails_contains "mutually exclusive" \
 # ── Negative: --exercise-evict-rehydrate without expected file ──────────────
 assert_fails_contains "--exercise-evict-rehydrate requires" \
   run_with_fakes --exercise-evict-rehydrate
+
+# ── Negative: .deb fallback must not mask apt dependency repair failure ─────
+FAKE_DEB="${TMPDIR_BASE}/fake-tcfsd.deb"
+: >"$FAKE_DEB"
+assert_fails_contains "apt dependency repair failed after dpkg install" \
+  env PATH="$FAKE_BIN:$PATH" \
+    HOME="$HOME_DIR" \
+    TCFS_FAKE_APT_FIX_FAIL=1 \
+    bash "$SCRIPT" \
+      --package-path "$FAKE_DEB" \
+      --config "$CONFIG_PATH" \
+      --no-systemd \
+      --timeout 1 \
+      --log-dir "${TMPDIR_BASE}/deb-failure-logs"
 
 echo "linux-postinstall-smoke tests passed"


### PR DESCRIPTION
## Summary

Hardens the Linux post-install smoke harness so the `.deb` fallback path fails immediately if `apt-get install -f` cannot repair dependencies after `dpkg -i`.

This keeps TIN-1422 package validation from silently continuing after a broken package dependency repair and surfacing later as a less useful daemon/binary failure.

## Validation

- `bash scripts/test-linux-postinstall-smoke.sh`
- `git diff --check`

## Notes

The fake-tool regression now stubs `sudo`, `apt-get`, and `dpkg` to force the direct apt install fallback and verify the repair failure is fatal.
