### PR TITLE
ci: install split Linux smoke packages

### DIFF
--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -132,6 +132,7 @@ jobs:
           STATE_PATH="$RUNNER_TEMP/tcfs-state.json"
           EXPECTED_CONTENT_FILE="$RUNNER_TEMP/expected-fixture-content"
           MUTATION_CONTENT_FILE="$RUNNER_TEMP/mutation-fixture-content"
+          PACKAGE_PATHS_FILE="$RUNNER_TEMP/tcfs-package-paths.txt"
           REMOTE_PREFIX="gha/linux-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           FIXTURE_REL="ci-smoke/${VERSION}/postinstall-${GITHUB_RUN_ATTEMPT}.txt"
           MUTATION_REL="ci-smoke/${VERSION}/mutation-${GITHUB_RUN_ATTEMPT}.txt"
@@ -150,6 +151,7 @@ jobs:
             echo "STATE_PATH=$STATE_PATH"
             echo "EXPECTED_CONTENT_FILE=$EXPECTED_CONTENT_FILE"
             echo "MUTATION_CONTENT_FILE=$MUTATION_CONTENT_FILE"
+            echo "PACKAGE_PATHS_FILE=$PACKAGE_PATHS_FILE"
             echo "REMOTE_PREFIX=$REMOTE_PREFIX"
             echo "FIXTURE_REL=$FIXTURE_REL"
             echo "MUTATION_REL=$MUTATION_REL"
@@ -203,6 +205,7 @@ jobs:
           PACKAGE_URL="${{ github.event.inputs.package_url }}"
           PACKAGE_ARTIFACT_RUN_ID="${{ github.event.inputs.package_artifact_run_id }}"
           PACKAGE_ARTIFACT_NAME="${{ github.event.inputs.package_artifact_name }}"
+          : > "$PACKAGE_PATHS_FILE"
 
           if [[ -n "$PACKAGE_ARTIFACT_RUN_ID" ]]; then
             artifact_dir="$RUNNER_TEMP/package-artifact"
@@ -240,13 +243,13 @@ jobs:
               -o "$artifact_zip" \
               "$artifact_url"
             python3 -m zipfile -e "$artifact_zip" "$artifact_dir"
-            artifact_pkg="$(find "$artifact_dir" -type f \( -name '*.deb' -o -name '*.rpm' \) -print -quit)"
-            if [[ -z "$artifact_pkg" ]]; then
+            mapfile -t artifact_pkgs < <(find "$artifact_dir" -type f \( -name '*.deb' -o -name '*.rpm' \) -print | sort)
+            if (( ${#artifact_pkgs[@]} == 0 )); then
               echo "::error::artifact $PACKAGE_ARTIFACT_NAME from run $PACKAGE_ARTIFACT_RUN_ID did not contain a .deb or .rpm"
               find "$artifact_dir" -type f -print
               exit 1
             fi
-            PACKAGE_PATH="$artifact_pkg"
+            printf '%s\n' "${artifact_pkgs[@]}" > "$PACKAGE_PATHS_FILE"
           elif [[ -n "$PACKAGE_URL" ]]; then
             # Preserve the source extension; default to .deb for ubuntu runners.
             case "$PACKAGE_URL" in
@@ -254,15 +257,24 @@ jobs:
               *)     PACKAGE_PATH="$RUNNER_TEMP/tcfsd-${VERSION}.deb" ;;
             esac
             curl -fL -o "$PACKAGE_PATH" "$PACKAGE_URL"
+            printf '%s\n' "$PACKAGE_PATH" > "$PACKAGE_PATHS_FILE"
           else
-            # Default to the amd64 .deb shipped from the release workflow.
-            PACKAGE_PATH="$RUNNER_TEMP/tcfsd-${VERSION}-amd64.deb"
+            # Default to both amd64 .debs shipped from the release workflow:
+            # tcfs-cli owns /usr/bin/tcfs, tcfsd owns /usr/bin/tcfsd and the
+            # systemd unit. The smoke exercises both installed surfaces.
+            CLI_PACKAGE_PATH="$RUNNER_TEMP/tcfs-${VERSION}-amd64.deb"
+            DAEMON_PACKAGE_PATH="$RUNNER_TEMP/tcfsd-${VERSION}-amd64.deb"
             curl -fL \
-              -o "$PACKAGE_PATH" \
+              -o "$CLI_PACKAGE_PATH" \
+              "https://github.com/${{ github.repository }}/releases/download/${TAG}/tcfs-${VERSION}-amd64.deb"
+            curl -fL \
+              -o "$DAEMON_PACKAGE_PATH" \
               "https://github.com/${{ github.repository }}/releases/download/${TAG}/tcfsd-${VERSION}-amd64.deb"
+            printf '%s\n' "$CLI_PACKAGE_PATH" "$DAEMON_PACKAGE_PATH" > "$PACKAGE_PATHS_FILE"
           fi
 
-          echo "PACKAGE_PATH=$PACKAGE_PATH" >> "$GITHUB_ENV"
+          echo "package paths:"
+          sed 's/^/  - /' "$PACKAGE_PATHS_FILE"
 
       - name: Write live config
         shell: bash
@@ -317,7 +329,6 @@ jobs:
           # exact-content hydration on `tcfs index inspect` reporting
           # status=visible — the same gate as the macOS harness.
           args=(
-            --package-path "$PACKAGE_PATH"
             --config "$CONFIG_PATH"
             --expected-version "${VERSION}"
             --expected-file "${FIXTURE_REL}"
@@ -328,6 +339,15 @@ jobs:
             --mount-point "$MOUNT_POINT"
             --log-dir "$LOG_DIR/harness"
           )
+
+          if [[ ! -s "$PACKAGE_PATHS_FILE" ]]; then
+            echo "::error::package download did not record any package paths"
+            exit 1
+          fi
+          while IFS= read -r package_path; do
+            [[ -n "$package_path" ]] || continue
+            args+=(--package-path "$package_path")
+          done < "$PACKAGE_PATHS_FILE"
 
           if [[ "${{ github.event.inputs.exercise_evict_rehydrate }}" == "true" ]]; then
             args+=(--exercise-evict-rehydrate)

--- a/scripts/linux-postinstall-smoke.sh
+++ b/scripts/linux-postinstall-smoke.sh
@@ -30,10 +30,12 @@ This harness assumes a real operator config and a routable backend.
 It does not fabricate storage credentials.
 
 Options:
-  --package-path <path>       .deb or .rpm artifact to install. If omitted
-                              the harness assumes tcfsd/tcfs are already on
-                              PATH (useful when packages were installed by
-                              the workflow before this script runs).
+  --package-path <path>       .deb or .rpm artifact to install. May be
+                              repeated for split CLI/daemon packages. If
+                              omitted, the harness assumes tcfsd/tcfs are
+                              already on PATH (useful when packages were
+                              installed by the workflow before this script
+                              runs).
   --config <path>             tcfs config (default: ~/.config/tcfs/config.toml)
   --expected-version <ver>    Require tcfs/tcfsd --version output to include this
   --expected-file <relpath>   Relative path under the mount to enumerate + hydrate
@@ -80,7 +82,7 @@ MUTATION_CONTENT_FILE="${TCFS_MUTATION_CONTENT_FILE:-}"
 REMOTE_PREFIX="${TCFS_REMOTE_PREFIX:-}"
 REMOTE_SPEC="${TCFS_REMOTE_SPEC:-}"
 MOUNT_POINT="${TCFS_MOUNT_POINT:-}"
-PACKAGE_PATH=""
+PACKAGE_PATHS=()
 SKIP_PACKAGE_INSTALL="${TCFS_SKIP_PACKAGE_INSTALL:-0}"
 SYSTEMD_UNIT="${TCFS_SYSTEMD_UNIT:-tcfsd.service}"
 USE_SYSTEMD="${TCFS_USE_SYSTEMD:-1}"
@@ -94,7 +96,7 @@ LOG_DIR=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --package-path)
-      PACKAGE_PATH="$2"
+      PACKAGE_PATHS+=("$2")
       shift 2
       ;;
     --config)
@@ -312,26 +314,21 @@ validate_relative_file_path() {
 }
 
 # ── Package install ──────────────────────────────────────────────────────────
-install_package() {
-  [[ "$SKIP_PACKAGE_INSTALL" == "1" ]] && {
-    echo "package install skipped (--skip-package-install)"
-    return 0
-  }
-  [[ -n "$PACKAGE_PATH" ]] || {
-    echo "no --package-path provided and --skip-package-install not set" >&2
-    exit 2
-  }
-  require_file "$PACKAGE_PATH"
+install_package_path() {
+  local package_path="$1"
+  local package_index="$2"
+  local install_log="$LOG_DIR/package-install-${package_index}.log"
 
-  local install_log="$LOG_DIR/package-install.log"
-  case "$PACKAGE_PATH" in
+  require_file "$package_path"
+
+  case "$package_path" in
     *.deb)
-      echo "installing .deb: $PACKAGE_PATH"
+      echo "installing .deb: $package_path"
       if command -v sudo >/dev/null 2>&1; then
-        sudo -n apt-get install -y --no-install-recommends "$PACKAGE_PATH" \
+        sudo -n apt-get install -y --no-install-recommends "$package_path" \
           >"$install_log" 2>&1 || {
             # apt-get install on a path needs ./prefix or absolute; fall back to dpkg
-            sudo -n dpkg -i "$PACKAGE_PATH" >>"$install_log" 2>&1 || {
+            sudo -n dpkg -i "$package_path" >>"$install_log" 2>&1 || {
               echo "dpkg install failed; see $install_log" >&2
               cat "$install_log" >&2 || true
               exit 1
@@ -343,7 +340,7 @@ install_package() {
             }
           }
       else
-        dpkg -i "$PACKAGE_PATH" >"$install_log" 2>&1 || {
+        dpkg -i "$package_path" >"$install_log" 2>&1 || {
           echo "dpkg install failed (no sudo); see $install_log" >&2
           cat "$install_log" >&2 || true
           exit 1
@@ -351,15 +348,15 @@ install_package() {
       fi
       ;;
     *.rpm)
-      echo "installing .rpm: $PACKAGE_PATH"
+      echo "installing .rpm: $package_path"
       if command -v sudo >/dev/null 2>&1; then
-        sudo -n rpm -i --replacepkgs "$PACKAGE_PATH" >"$install_log" 2>&1 || {
+        sudo -n rpm -i --replacepkgs "$package_path" >"$install_log" 2>&1 || {
           echo "rpm install failed; see $install_log" >&2
           cat "$install_log" >&2 || true
           exit 1
         }
       else
-        rpm -i --replacepkgs "$PACKAGE_PATH" >"$install_log" 2>&1 || {
+        rpm -i --replacepkgs "$package_path" >"$install_log" 2>&1 || {
           echo "rpm install failed (no sudo); see $install_log" >&2
           cat "$install_log" >&2 || true
           exit 1
@@ -367,11 +364,29 @@ install_package() {
       fi
       ;;
     *)
-      echo "unsupported package extension (expected .deb or .rpm): $PACKAGE_PATH" >&2
+      echo "unsupported package extension (expected .deb or .rpm): $package_path" >&2
       exit 2
       ;;
   esac
   echo "package install log: $install_log"
+}
+
+install_packages() {
+  [[ "$SKIP_PACKAGE_INSTALL" == "1" ]] && {
+    echo "package install skipped (--skip-package-install)"
+    return 0
+  }
+  (( ${#PACKAGE_PATHS[@]} > 0 )) || {
+    echo "no --package-path provided and --skip-package-install not set" >&2
+    exit 2
+  }
+
+  local package_index=1
+  local package_path
+  for package_path in "${PACKAGE_PATHS[@]}"; do
+    install_package_path "$package_path" "$package_index"
+    package_index=$((package_index + 1))
+  done
 }
 
 # ── Daemon control ───────────────────────────────────────────────────────────
@@ -888,7 +903,7 @@ cleanup() {
 }
 trap 'cleanup; [[ -n "$LOG_DIR_OVERRIDE" ]] || rm -rf "$LOG_DIR"' EXIT
 
-install_package
+install_packages
 
 TCFSD_PATH="$(resolve_bin "$TCFSD_BIN")"
 assert_version "tcfsd" "$TCFSD_PATH"

--- a/scripts/test-linux-postinstall-smoke.sh
+++ b/scripts/test-linux-postinstall-smoke.sh
@@ -325,6 +325,10 @@ chmod +x "$FAKE_BIN"/*
 
 POSITIVE_OUT="${TMPDIR_BASE}/positive.out"
 MOUNT_MARKER="${TMPDIR_BASE}/mount-marker"
+FAKE_CLI_DEB="${TMPDIR_BASE}/tcfs-0.13.0-amd64.deb"
+FAKE_DAEMON_DEB="${TMPDIR_BASE}/tcfsd-0.13.0-amd64.deb"
+: >"$FAKE_CLI_DEB"
+: >"$FAKE_DAEMON_DEB"
 
 env PATH="$FAKE_BIN:$PATH" \
   HOME="$HOME_DIR" \
@@ -332,6 +336,8 @@ env PATH="$FAKE_BIN:$PATH" \
   TCFS_FAKE_MOUNT_ROOT="$MOUNT_POINT" \
   TCFS_FAKE_MOUNT_MARKER="$MOUNT_MARKER" \
   bash "$SCRIPT" \
+    --package-path "$FAKE_CLI_DEB" \
+    --package-path "$FAKE_DAEMON_DEB" \
     --expected-version 0.13.0 \
     --config "$CONFIG_PATH" \
     --expected-file "$EXPECTED_REL" \
@@ -343,7 +349,6 @@ env PATH="$FAKE_BIN:$PATH" \
     --exercise-mutation \
     --mutation-file "$MUTATION_REL" \
     --mutation-content-file "$MUTATION_CONTENT_FILE" \
-    --skip-package-install \
     --no-systemd \
     --timeout 10 \
     --log-dir "$LOG_DIR" \
@@ -353,6 +358,10 @@ env PATH="$FAKE_BIN:$PATH" \
   exit 1
 }
 
+assert_contains "$POSITIVE_OUT" "installing .deb: $FAKE_CLI_DEB"
+assert_contains "$POSITIVE_OUT" "installing .deb: $FAKE_DAEMON_DEB"
+assert_contains "$POSITIVE_OUT" "package-install-1.log"
+assert_contains "$POSITIVE_OUT" "package-install-2.log"
 assert_contains "$POSITIVE_OUT" "tcfsd version: tcfsd 0.13.0"
 assert_contains "$POSITIVE_OUT" "tcfs version: tcfs 0.13.0"
 assert_contains "$POSITIVE_OUT" "daemon socket ready: $DAEMON_SOCKET"


### PR DESCRIPTION
## Summary
- teach `scripts/linux-postinstall-smoke.sh` to accept repeated `--package-path` arguments for split CLI/daemon packages
- update the Linux post-install workflow to download both `tcfs-...amd64.deb` and `tcfsd-...amd64.deb` by default
- cover the split-package install path in the fake-tool smoke regression

## Why
TIN-1422's release-asset default installed only the daemon .deb, but the harness exercises both `tcfsd` and the `tcfs` CLI. The release pipeline emits those as separate packages, so the Linux smoke proof needs to install both before it can prove first use.

## Validation
- `bash -n scripts/linux-postinstall-smoke.sh scripts/test-linux-postinstall-smoke.sh`
- `bash scripts/test-linux-postinstall-smoke.sh`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/linux-postinstall-smoke.yml"); puts "yaml ok"'`

Refs TIN-1422.