### PR TITLE
ci: reuse shared TCFS smoke secrets for Linux

### DIFF
--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -5,7 +5,10 @@ name: Linux Post-Install Smoke
 # release asset or a workflow-run artifact), installs it, writes a live
 # config keyed on the smoke secrets, mounts FUSE, and runs
 # scripts/linux-postinstall-smoke.sh to gate hydration via
-# `tcfs index inspect`.
+# `tcfs index inspect`. By default it reuses the already-populated
+# `tcfs-macos-smoke` environment because both smoke lanes need the same
+# TCFS_SMOKE_* storage secrets; callers can override the environment when a
+# dedicated Linux secret set exists.
 #
 # Several steps are intentionally minimal compared to the macOS workflow:
 # Linux doesn't need FileProvider plumbing (host app, pluginkit, CloudStorage
@@ -39,6 +42,11 @@ on:
         required: false
         default: "ubuntu-24.04"
         type: string
+      smoke_environment:
+        description: "GitHub environment containing TCFS_SMOKE_* secrets"
+        required: false
+        default: "tcfs-macos-smoke"
+        type: string
       exercise_evict_rehydrate:
         description: "After initial hydration, exercise unsync + rehydrate"
         required: false
@@ -60,7 +68,7 @@ jobs:
     if: github.repository == 'Jesssullivan/tummycrypt'
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 30
-    environment: tcfs-linux-smoke
+    environment: ${{ github.event.inputs.smoke_environment }}
     env:
       TCFS_SMOKE_S3_ENDPOINT: ${{ secrets.TCFS_SMOKE_S3_ENDPOINT }}
       TCFS_SMOKE_S3_BUCKET: ${{ secrets.TCFS_SMOKE_S3_BUCKET }}


### PR DESCRIPTION
## Summary
- add a `smoke_environment` workflow_dispatch input to the Linux post-install smoke workflow
- default it to the populated `tcfs-macos-smoke` environment, which already owns the shared `TCFS_SMOKE_*` storage secrets
- keep callers able to override to `tcfs-linux-smoke` once that environment has its own secrets

## Why
The first real TIN-1422 dispatch against `v0.12.13-rc1` failed before package install because `tcfs-linux-smoke` has no secrets. `tcfs-macos-smoke` has the same five required secret names and is already used by the production macOS smoke lane.

Failed run: https://github.com/Jesssullivan/tummycrypt/actions/runs/26071828210

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/linux-postinstall-smoke.yml"); puts "yaml ok"'`
- `git diff --check`

Refs TIN-1422.