### PR TITLE
storage: preserve HTTPS remote specs (TIN-1546)

### DIFF
--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -201,7 +201,7 @@ jobs:
           MUTATION_CONTENT_FILE="$RUNNER_TEMP/mutation-fixture-content"
           PACKAGE_PATHS_FILE="$RUNNER_TEMP/tcfs-package-paths.txt"
           REMOTE_PREFIX="gha/linux-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          REMOTE_AUTHORITY="$(python3 - <<'PY'
+          readarray -t REMOTE_SPEC_PARTS < <(python3 - <<'PY'
           import os
           import urllib.parse
 
@@ -209,10 +209,13 @@ jobs:
           parsed = urllib.parse.urlparse(endpoint)
           if not parsed.netloc:
               raise SystemExit(f"storage endpoint has no authority: {endpoint}")
+          print("seaweedfs+https" if parsed.scheme == "https" else "seaweedfs")
           print(parsed.netloc)
           PY
-          )"
-          REMOTE_SPEC="seaweedfs://${REMOTE_AUTHORITY}/${TCFS_SMOKE_S3_BUCKET}/${REMOTE_PREFIX}"
+          )
+          REMOTE_SCHEME="${REMOTE_SPEC_PARTS[0]}"
+          REMOTE_AUTHORITY="${REMOTE_SPEC_PARTS[1]}"
+          REMOTE_SPEC="${REMOTE_SCHEME}://${REMOTE_AUTHORITY}/${TCFS_SMOKE_S3_BUCKET}/${REMOTE_PREFIX}"
           FIXTURE_REL="ci-smoke/${VERSION}/postinstall-${GITHUB_RUN_ATTEMPT}.txt"
           MUTATION_REL="ci-smoke/${VERSION}/mutation-${GITHUB_RUN_ATTEMPT}.txt"
 

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -119,7 +119,7 @@ enum Commands {
     // ── Phase 3: mount + stub management ──────────────────────────────────────
     /// Mount a remote as a local directory
     Mount {
-        /// Remote spec (e.g. seaweedfs://host/bucket[/prefix])
+        /// Remote spec (e.g. seaweedfs://host/bucket[/prefix] or seaweedfs+https://host/bucket[/prefix])
         remote: String,
         /// Local mountpoint
         mountpoint: PathBuf,

--- a/crates/tcfs-storage/src/lib.rs
+++ b/crates/tcfs-storage/src/lib.rs
@@ -8,16 +8,28 @@ pub mod seaweedfs;
 pub use health::check_health;
 pub use operator::{build_operator, StorageConfig};
 
-/// Parse a remote spec like `seaweedfs://host:port/bucket[/prefix]`
+/// Parse a remote spec like `seaweedfs://host:port/bucket[/prefix]`.
+///
+/// `seaweedfs://` is retained as the historical HTTP form for local/dev
+/// endpoints. Use `seaweedfs+https://` for production-like TLS endpoints.
 ///
 /// Returns `(endpoint, bucket, prefix)` where:
-/// - endpoint: `http://host:port`
+/// - endpoint: `http://host:port` or `https://host:port`
 /// - bucket: first path component
 /// - prefix: remaining path (may be empty)
 pub fn parse_remote_spec(spec: &str) -> anyhow::Result<(String, String, String)> {
-    let rest = spec.strip_prefix("seaweedfs://").ok_or_else(|| {
-        anyhow::anyhow!("remote spec must start with seaweedfs:// — got: {}", spec)
-    })?;
+    let (endpoint_scheme, rest) = if let Some(rest) = spec.strip_prefix("seaweedfs+https://") {
+        ("https", rest)
+    } else if let Some(rest) = spec.strip_prefix("seaweedfs+http://") {
+        ("http", rest)
+    } else if let Some(rest) = spec.strip_prefix("seaweedfs://") {
+        ("http", rest)
+    } else {
+        anyhow::bail!(
+            "remote spec must start with seaweedfs://, seaweedfs+http://, or seaweedfs+https:// — got: {}",
+            spec
+        );
+    };
 
     // Split host:port from /bucket[/prefix]
     let slash = rest
@@ -29,9 +41,12 @@ pub fn parse_remote_spec(spec: &str) -> anyhow::Result<(String, String, String)>
 
     // First path component = bucket, remainder = prefix
     let (bucket, prefix) = path.split_once('/').unwrap_or((path, ""));
+    if bucket.is_empty() {
+        anyhow::bail!("remote spec must include a bucket — got: {}", spec);
+    }
 
     Ok((
-        format!("http://{}", host),
+        format!("{}://{}", endpoint_scheme, host),
         bucket.to_string(),
         prefix.trim_end_matches('/').to_string(),
     ))
@@ -47,6 +62,24 @@ mod tests {
         assert_eq!(ep, "http://host:8333");
         assert_eq!(bucket, "mybucket");
         assert_eq!(prefix, "");
+    }
+
+    #[test]
+    fn test_parse_remote_spec_explicit_http() {
+        let (ep, bucket, prefix) =
+            parse_remote_spec("seaweedfs+http://host:8333/mybucket/data").unwrap();
+        assert_eq!(ep, "http://host:8333");
+        assert_eq!(bucket, "mybucket");
+        assert_eq!(prefix, "data");
+    }
+
+    #[test]
+    fn test_parse_remote_spec_https() {
+        let (ep, bucket, prefix) =
+            parse_remote_spec("seaweedfs+https://storage.example.com/mybucket/data").unwrap();
+        assert_eq!(ep, "https://storage.example.com");
+        assert_eq!(bucket, "mybucket");
+        assert_eq!(prefix, "data");
     }
 
     #[test]
@@ -78,5 +111,10 @@ mod tests {
     #[test]
     fn test_parse_remote_spec_no_bucket() {
         assert!(parse_remote_spec("seaweedfs://host").is_err());
+    }
+
+    #[test]
+    fn test_parse_remote_spec_empty_bucket() {
+        assert!(parse_remote_spec("seaweedfs://host:8333/").is_err());
     }
 }

--- a/docs/ops/tcfs-alpha-beta-qa-readiness-2026-05-19.md
+++ b/docs/ops/tcfs-alpha-beta-qa-readiness-2026-05-19.md
@@ -95,7 +95,8 @@ has shipped and been proven end to end.
 1. Merge the production-readiness sweep PR so the docs, evidence packet, and
    Linux smoke remote-spec fix are on main.
 2. Clear `TIN-1540`, then rerun `TIN-1422` against a reachable backend using
-   the corrected `seaweedfs://host:port/bucket/prefix` remote spec.
+   the corrected `seaweedfs://host:port/bucket/prefix` remote spec, with
+   `seaweedfs+https://` preserved for production-like HTTPS smoke endpoints.
 3. Complete the `TIN-131` first-use matrix for the rc artifact set:
    macOS `.pkg`, Homebrew, Linux `.deb`, container runtime, and Nix external
    profile.

--- a/scripts/linux-postinstall-smoke.sh
+++ b/scripts/linux-postinstall-smoke.sh
@@ -55,7 +55,8 @@ Options:
   --remote-prefix <prefix>    Remote prefix used for index inspect + push/pull
   --mount-point <path>        FUSE mount point (default: temp dir under LOG_DIR)
   --remote-spec <spec>        Remote spec for `tcfs mount` (default:
-                              seaweedfs://<host>:<port>/<bucket>/<prefix>;
+                              seaweedfs://<host>:<port>/<bucket>/<prefix> for HTTP
+                              or seaweedfs+https://<host>/<bucket>/<prefix> for HTTPS;
                               required for direct mount)
   --tcfs <path-or-name>       CLI binary (default: tcfs)
   --tcfsd <path-or-name>      Daemon binary (default: tcfsd)
@@ -662,14 +663,14 @@ resolve_remote_spec() {
   if [[ -n "$REMOTE_SPEC" ]]; then
     return 0
   fi
-  # Derive a default seaweedfs://<host>:<port>/<bucket>/<prefix> spec from the
-  # config when the caller did not pass one explicitly. `tcfs mount` uses the
-  # shared remote-spec parser, which intentionally does not accept s3://.
+  # Derive a default SeaweedFS mount spec from the config when the caller did
+  # not pass one explicitly. Preserve HTTPS endpoints as seaweedfs+https:// so
+  # the direct mount path cannot silently downgrade a production-like smoke.
   if [[ -z "$REMOTE_PREFIX" ]]; then
     echo "--remote-spec is required when --remote-prefix is not provided" >&2
     exit 2
   fi
-  local authority bucket
+  local remote_scheme authority bucket
   local -a remote_parts
   mapfile -t remote_parts < <(python3 - "$CONFIG_PATH" <<'PY' 2>/dev/null || true
 import sys
@@ -684,12 +685,14 @@ storage = cfg.get("storage", {})
 endpoint = str(storage.get("endpoint", "")).strip()
 bucket = str(storage.get("bucket", "")).strip()
 parsed = urllib.parse.urlparse(endpoint)
+print("seaweedfs+https" if parsed.scheme == "https" else "seaweedfs")
 print(parsed.netloc)
 print(bucket)
 PY
 )
-  authority="${remote_parts[0]:-}"
-  bucket="${remote_parts[1]:-}"
+  remote_scheme="${remote_parts[0]:-}"
+  authority="${remote_parts[1]:-}"
+  bucket="${remote_parts[2]:-}"
   if [[ -z "$authority" ]]; then
     echo "could not derive endpoint authority from $CONFIG_PATH; pass --remote-spec" >&2
     exit 2
@@ -698,7 +701,7 @@ PY
     echo "could not derive bucket from $CONFIG_PATH; pass --remote-spec" >&2
     exit 2
   fi
-  REMOTE_SPEC="seaweedfs://${authority}/${bucket}/${REMOTE_PREFIX}"
+  REMOTE_SPEC="${remote_scheme}://${authority}/${bucket}/${REMOTE_PREFIX}"
   echo "derived --remote-spec: $REMOTE_SPEC"
 }
 

--- a/scripts/test-linux-postinstall-smoke.sh
+++ b/scripts/test-linux-postinstall-smoke.sh
@@ -70,7 +70,7 @@ cat >"$CONFIG_PATH" <<EOF
 socket = "${DAEMON_SOCKET}"
 
 [storage]
-endpoint = "http://example.invalid:8333"
+endpoint = "https://example.invalid:8333"
 bucket = "tcfs"
 
 [sync]
@@ -365,7 +365,7 @@ assert_contains "$POSITIVE_OUT" "tcfsd version: tcfsd 0.13.0"
 assert_contains "$POSITIVE_OUT" "tcfs version: tcfs 0.13.0"
 assert_contains "$POSITIVE_OUT" "daemon socket ready: $DAEMON_SOCKET"
 assert_contains "$POSITIVE_OUT" "remote index status for expected file: visible"
-assert_contains "$POSITIVE_OUT" "derived --remote-spec: seaweedfs://example.invalid:8333/tcfs/fake/prefix"
+assert_contains "$POSITIVE_OUT" "derived --remote-spec: seaweedfs+https://example.invalid:8333/tcfs/fake/prefix"
 assert_contains "$POSITIVE_OUT" "FUSE mount ready"
 assert_contains "$POSITIVE_OUT" "hydrated file content matched expected content file"
 assert_contains "$POSITIVE_OUT" "Linux evict/rehydrate cycle passed"


### PR DESCRIPTION
## Summary

- Adds explicit `seaweedfs+https://` and `seaweedfs+http://` support to the shared mount remote-spec parser while keeping historical `seaweedfs://` as HTTP.
- Preserves HTTPS smoke endpoints when Linux postinstall derives a direct `tcfs mount` remote spec.
- Updates the Linux smoke harness regression test so production-like HTTPS config derives `seaweedfs+https://...` instead of silently downgrading to HTTP.

## Validation

- `~/.cargo/bin/cargo test -p tcfs-storage parse_remote_spec`
- `bash -n scripts/linux-postinstall-smoke.sh scripts/test-linux-postinstall-smoke.sh`
- `bash scripts/test-linux-postinstall-smoke.sh`
- `~/.cargo/bin/cargo fmt --all -- --check`
- `git diff --check`
- stacked pre-retarget CI: `fleet_live tests against compose-managed SeaweedFS + NATS` passed in 5m12s