### PR TITLE
ci: fix macOS rc package smoke version gate (TIN-1547)

### DIFF
--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -247,6 +247,10 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event.inputs.tag }}"
           VERSION="${TAG#v}"
+          # Release-candidate asset names keep the prerelease suffix
+          # (`0.12.13-rc1`), but the Rust binaries report the Cargo package
+          # version (`0.12.13`).
+          BINARY_EXPECTED_VERSION="${VERSION%%-*}"
           LOG_DIR="${LOG_DIR:-$RUNNER_TEMP/tcfs-macos-postinstall}"
           SYNC_ROOT="$RUNNER_TEMP/tcfs-sync-root"
           CONFIG_DIR="$RUNNER_TEMP/tcfs-config"
@@ -270,6 +274,7 @@ jobs:
           {
             echo "TAG=$TAG"
             echo "VERSION=$VERSION"
+            echo "BINARY_EXPECTED_VERSION=$BINARY_EXPECTED_VERSION"
             echo "LOG_DIR=$LOG_DIR"
             echo "SYNC_ROOT=$SYNC_ROOT"
             echo "CONFIG_DIR=$CONFIG_DIR"
@@ -450,7 +455,7 @@ jobs:
             -u TCFS_S3_SECRET \
             -u AWS_ACCESS_KEY_ID \
             -u AWS_SECRET_ACCESS_KEY \
-            bash scripts/install-smoke.sh --expected-version "${VERSION}"
+            bash scripts/install-smoke.sh --expected-version "${BINARY_EXPECTED_VERSION}"
 
       - name: Verify PZM lab Gatekeeper profile
         if: ${{ github.event.inputs.lab_gatekeeper_override == 'true' }}
@@ -802,7 +807,7 @@ jobs:
         run: |
           set -euo pipefail
           args=(
-            --expected-version "${VERSION}" \
+            --expected-version "${BINARY_EXPECTED_VERSION}" \
             --config "$CONFIG_PATH" \
             --expected-file "${FIXTURE_REL}" \
             --expected-content-file "$EXPECTED_CONTENT_FILE" \


### PR DESCRIPTION
## Summary
- Fix the macOS post-install smoke workflow to validate installed `tcfs`/`tcfsd` binaries against the Cargo package version for prerelease tags.
- Keep the full prerelease version string for release asset names, remote prefixes, and fixture paths.

## Why
The exact published `v0.12.13-rc1` `.pkg` smoke reached package download, structure verification, install, and FileProvider signing, then failed before live FileProvider proof because installed binaries report `0.12.13` while the release asset/tag is `0.12.13-rc1`.

Failed run: https://github.com/Jesssullivan/tummycrypt/actions/runs/26079672380

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/macos-postinstall-smoke.yml"); puts "yaml ok"'`
- `git diff --check`

`actionlint` is not installed in this workspace.