### PR TITLE
ci: bound macos CloudStorage enumeration probes (TIN-1547)

### DIFF
--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -372,6 +372,28 @@ run_bounded_to_log() {
   return "$status"
 }
 
+run_bounded_append_to_log() {
+  local label="$1"
+  local timeout_secs="$2"
+  shift 2
+
+  local out
+  local tmp
+  local pid
+  local status=0
+
+  out="$LOG_DIR/${label}.log"
+  tmp="$(mktemp "$LOG_DIR/${label}.XXXXXX")"
+
+  "$@" >"$tmp" 2>&1 &
+  pid="$!"
+
+  wait_for_pid_with_timeout "$pid" "$timeout_secs" "$label" || status="$?"
+  cat "$tmp" >>"$out" 2>/dev/null || true
+  rm -f "$tmp"
+  return "$status"
+}
+
 wait_for_pid_with_timeout() {
   local pid="$1"
   local timeout_secs="$2"
@@ -1201,13 +1223,19 @@ nudge_cloud_root_enumeration() {
 
   echo "nudging CloudStorage enumeration"
 
-  ls -la "$root" >"$LOG_DIR/cloud-root-ls.log" 2>&1 || true
+  run_bounded_to_log \
+    "cloud-root-ls" \
+    "$LOG_SHOW_TIMEOUT_SECS" \
+    ls -la "$root" || true
 
   # A headed workstation usually triggers FileProvider enumeration through
   # Finder naturally. GitHub-hosted macOS runners can create the CloudStorage
   # root without launching the extension until something explicitly opens or
   # materializes it, so use bounded best-effort nudges before the hard wait.
-  open "$root" >/dev/null 2>&1 || true
+  run_bounded_to_log \
+    "cloud-root-open" \
+    "$LOG_SHOW_TIMEOUT_SECS" \
+    open "$root" || true
 
   if command -v fileproviderctl >/dev/null 2>&1; then
     fileproviderctl_help="$(fileproviderctl 2>&1 || true)"
@@ -1251,7 +1279,10 @@ nudge_expected_parent_enumeration() {
     "$LOG_SHOW_TIMEOUT_SECS" \
     ls -la "$parent" || true
 
-  open "$parent" >/dev/null 2>&1 || true
+  run_bounded_to_log \
+    "expected-parent-open" \
+    "$LOG_SHOW_TIMEOUT_SECS" \
+    open "$parent" || true
 
   if command -v fileproviderctl >/dev/null 2>&1; then
     fileproviderctl_help="$(fileproviderctl 2>&1 || true)"
@@ -1336,9 +1367,16 @@ enumerate_root() {
 
   while (( attempt < TIMEOUT_SECS )); do
     if (( attempt % 5 == 0 )); then
-      ls -la "$root" >>"$LOG_DIR/cloud-root-ls.log" 2>&1 || true
+      run_bounded_append_to_log \
+        "cloud-root-ls" \
+        "$LOG_SHOW_TIMEOUT_SECS" \
+        ls -la "$root" || true
     fi
-    listing="$(find "$root" -mindepth 1 -maxdepth 4 | head -n 10 || true)"
+    run_bounded_to_log \
+      "cloud-root-find" \
+      "$LOG_SHOW_TIMEOUT_SECS" \
+      sh -c 'find "$1" -mindepth 1 -maxdepth 4 | head -n 10' sh "$root" || true
+    listing="$(cat "$LOG_DIR/cloud-root-find.log" 2>/dev/null || true)"
     if [[ -n "$listing" ]]; then
       echo "enumeration sample:"
       echo "$listing"

--- a/scripts/test-macos-postinstall-smoke.sh
+++ b/scripts/test-macos-postinstall-smoke.sh
@@ -340,9 +340,34 @@ fi
 EOF
 cat >"$FAKE_BIN/open" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n "${TCFS_FAKE_OPEN_HANG_TARGET:-}" && "${1:-}" == "$TCFS_FAKE_OPEN_HANG_TARGET" ]]; then
+  exec perl -e 'select undef, undef, undef, 60'
+fi
 printf 'open' >>"$TCFS_FAKE_OPEN_LOG"
 printf ' %q' "$@" >>"$TCFS_FAKE_OPEN_LOG"
 printf '\n' >>"$TCFS_FAKE_OPEN_LOG"
+EOF
+cat >"$FAKE_BIN/ls" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${TCFS_FAKE_LS_HANG_TARGET:-}" ]]; then
+  for arg in "$@"; do
+    if [[ "$arg" == "$TCFS_FAKE_LS_HANG_TARGET" ]]; then
+      exec perl -e 'select undef, undef, undef, 60'
+    fi
+  done
+fi
+exec /bin/ls "$@"
+EOF
+cat >"$FAKE_BIN/find" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${TCFS_FAKE_FIND_HANG_TARGET:-}" ]]; then
+  for arg in "$@"; do
+    if [[ "$arg" == "$TCFS_FAKE_FIND_HANG_TARGET" ]]; then
+      exec perl -e 'select undef, undef, undef, 60'
+    fi
+  done
+fi
+exec /usr/bin/find "$@"
 EOF
 cat >"$APP_PATH/Contents/MacOS/TCFSProvider" <<'EOF'
 #!/usr/bin/env bash
@@ -544,6 +569,10 @@ assert_contains "$LOG_DIR/fileproviderctl-evaluate-root.log" "fileproviderctl ev
 assert_contains "$LOG_DIR/fileproviderctl-check-root.log" "fileproviderctl check -P -a"
 assert_contains "$LOG_DIR/fileproviderctl-evaluate-expected-parent.log" "fileproviderctl evaluate"
 assert_contains "$LOG_DIR/fileproviderctl-check-expected-parent.log" "fileproviderctl check -P -a"
+test -f "$LOG_DIR/cloud-root-ls.log"
+test -f "$LOG_DIR/cloud-root-open.log"
+test -f "$LOG_DIR/cloud-root-find.log"
+test -f "$LOG_DIR/expected-parent-open.log"
 cmp -s "$EXPECTED_CONTENT_FILE" "$LOG_DIR/hydrated-expected-file"
 cmp -s "$MUTATION_CONTENT_FILE" "$CLOUD_ROOT/$MUTATION_REL"
 cmp -s "$MUTATION_CONTENT_FILE" "$LOG_DIR/mutation-remote-pull"
@@ -723,6 +752,43 @@ assert_fails_contains \
       --cloud-root "$CLOUD_ROOT" \
       --log-dir "${TMPDIR}/hung-read-logs" \
       --timeout 2
+
+BOUNDED_LS_OUT="${TMPDIR}/bounded-cloud-root-ls.out"
+env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \
+  TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+  TCFS_FAKE_HOST_BINARY_LOG="$HOST_BINARY_LOG" \
+  TCFS_FAKE_SWIFT_LOG="$SWIFT_LOG" \
+  TCFS_FAKE_REMOTE_ROOT="$CLOUD_ROOT" \
+  TCFS_FAKE_LS_HANG_TARGET="$CLOUD_ROOT" \
+  LOG_SHOW_TIMEOUT_SECS=1 \
+  bash "$SCRIPT" \
+    --expected-version 0.12.2 \
+    --config "$CONFIG_PATH" \
+    --expected-file "$EXPECTED_REL" \
+    --expected-content-file "$EXPECTED_CONTENT_FILE" \
+    --app-path "$APP_PATH" \
+    --cloud-root "$CLOUD_ROOT" \
+    --log-dir "${TMPDIR}/bounded-cloud-root-ls-logs" \
+    --timeout 3 \
+    >"$BOUNDED_LS_OUT" 2>&1
+assert_contains "$BOUNDED_LS_OUT" "cloud-root-ls timed out after 1s"
+assert_contains "$BOUNDED_LS_OUT" "macOS post-install FileProvider smoke passed"
+test -f "${TMPDIR}/bounded-cloud-root-ls-logs/cloud-root-ls.log"
+
+assert_fails_contains \
+  "cloud-root-find timed out after 1s" \
+  env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \
+    TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_FAKE_FIND_HANG_TARGET="$CLOUD_ROOT" \
+    LOG_SHOW_TIMEOUT_SECS=1 \
+    bash "$SCRIPT" \
+      --expected-version 0.12.2 \
+      --config "$CONFIG_PATH" \
+      --app-path "$APP_PATH" \
+      --cloud-root "$CLOUD_ROOT" \
+      --log-dir "${TMPDIR}/bounded-cloud-root-find-logs" \
+      --timeout 2
+test -f "${TMPDIR}/bounded-cloud-root-find-logs/cloud-root-find.log"
 
 SAME_PATH_DUPES_OUT="${TMPDIR}/same-path-dupes.out"
 SAME_PATH_DUPES_ERR="${TMPDIR}/same-path-dupes.err"


### PR DESCRIPTION
## Summary
- Bound CloudStorage root `ls`, root `open`, expected-parent `open`, and root `find` probes in `macos-postinstall-smoke.sh` with the existing watchdog timeout.
- Preserve repeated root `ls` diagnostics by appending through a temp file instead of running unbounded shell redirection.
- Add fake-tool regression coverage for stuck CloudStorage `ls` and `find` probes, plus assertions that the new probe logs are archived.

## Claim boundary
This fixes the harness failure mode seen on main-ref macOS smoke run 26080188768, where the job was cancelled while `ls -la /Users/jsullivan2/Library/CloudStorage/TCFSProvider-TCFS` was stuck. It does not prove production Finder hydration is fixed; after this lands, rerun the main-ref postinstall smoke and classify the next FileProvider boundary from artifacts.

## Validation
- `bash scripts/test-macos-postinstall-smoke.sh`
- `bash -n scripts/macos-postinstall-smoke.sh scripts/test-macos-postinstall-smoke.sh`
- `git diff --check`

TIN-1547