### PR TITLE
ios: default FileProvider capabilities to read-only (TIN-1548)

### DIFF
--- a/docs/ops/ios-surface-status.md
+++ b/docs/ops/ios-surface-status.md
@@ -32,6 +32,8 @@ It does not prove:
 - Maintain browsing, enumeration, and hydration as the documented intent
 - Do not advertise upload, modify, delete, background sync, or conflict UX as
   supported iOS features, even though experimental hooks exist in code
+- FileProvider item capabilities should expose only read/enumerate affordances
+  until write/delete acceptance exists.
 
 ## Why Read-Only Remains The Posture
 
@@ -46,9 +48,9 @@ It does not prove:
 - The current entitlement files declare the App Group, but shared Keychain
   behavior still needs real-device proof before claiming credentials work
   across the host app and extension.
-- The FileProvider item capabilities can expose write affordances in Files.app;
-  those affordances are unsupported until create/modify/delete flows have
-  device-backed acceptance.
+- The FileProvider item capabilities now expose read/enumerate affordances by
+  default; create/modify/delete hooks remain experimental implementation
+  scaffolding until device-backed acceptance proves them.
 
 ## Maintenance Expectation
 

--- a/swift/ios/Extension/FileProviderItem.swift
+++ b/swift/ios/Extension/FileProviderItem.swift
@@ -67,9 +67,9 @@ class TCFSFileProviderItem: NSObject, NSFileProviderItem {
 
     var capabilities: NSFileProviderItemCapabilities {
         if contentType == .folder {
-            return [.allowsReading, .allowsContentEnumerating, .allowsAddingSubItems, .allowsDeleting]
+            return [.allowsReading, .allowsContentEnumerating]
         }
-        return [.allowsReading, .allowsWriting, .allowsDeleting]
+        return [.allowsReading]
     }
 
     var contentPolicy: NSFileProviderContentPolicy {


### PR DESCRIPTION
## Summary
- Align iOS FileProvider item capabilities with the documented read-only posture.
- Folders now advertise read/enumerate only; files advertise read only.
- Update `docs/ops/ios-surface-status.md` so write/delete hooks are explicitly experimental scaffolding until device-backed acceptance proves them.

## Claim boundary
This prevents Files.app from seeing write/delete affordances by default. It does not prove iOS Files.app acceptance, real-device Keychain/App Group behavior, TestFlight, or write support.

## Validation
- `bash -n swift/ios/Scripts/build-ios.sh`
- `git diff --check`

Local blocker:
- `bash swift/ios/Scripts/build-ios.sh --simulator` could not run here because `xcrun --sdk iphonesimulator --show-sdk-path` reports `unable to find sdk: 'iphonesimulator'`. The GitHub iOS FileProvider typecheck must be the compile gate for this PR.

TIN-1548