### PR TITLE
ci: classify macos CloudStorage permission failures (TIN-1547)

### DIFF
--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -1359,6 +1359,53 @@ collect_expected_file_diagnostics() {
   fi
 }
 
+classify_expected_file_read_failure() {
+  local path="$1"
+  local read_error="$2"
+  local classification_path="$LOG_DIR/failure-classification.txt"
+  local evidence_path="$LOG_DIR/failure-classification-input.log"
+  local file
+
+  : >"$evidence_path"
+  for file in \
+    "$read_error" \
+    "$LOG_DIR/cloud-root-ls.log" \
+    "$LOG_DIR/cloud-root-open.log" \
+    "$LOG_DIR/cloud-root-find.log" \
+    "$LOG_DIR/expected-parent-ls.log" \
+    "$LOG_DIR/expected-parent-open.log" \
+    "$LOG_DIR/expected-file-ls.log" \
+    "$LOG_DIR/expected-file-stat.log" \
+    "$LOG_DIR/expected-file-xattr.log" \
+    "$LOG_DIR/fileproviderctl-evaluate-expected-file.log" \
+    "$LOG_DIR/fileproviderctl-check-expected-file.log"
+  do
+    [[ -f "$file" ]] || continue
+    {
+      printf -- '--- %s ---\n' "$file"
+      cat "$file"
+      printf '\n'
+    } >>"$evidence_path" || true
+  done
+
+  if grep -Eiq \
+    'Operation not permitted|NSPOSIXErrorDomain\(1\)|NSCocoaErrorDomain code=257|permission to view|Permission denied|EPERM' \
+    "$evidence_path"; then
+    {
+      printf 'classification=cloudstorage_permission_denied\n'
+      printf 'path=%s\n' "$path"
+      printf 'reason=CloudStorage/FileProvider access returned EPERM or NSCocoaErrorDomain 257 after requestDownload\n'
+      printf 'evidence=%s\n' "$evidence_path"
+    } >"$classification_path"
+    echo "FileProvider CloudStorage permission denied for expected file: $path" >&2
+    echo "classification: cloudstorage_permission_denied" >&2
+    echo "classification log: $classification_path" >&2
+    return 0
+  fi
+
+  return 1
+}
+
 enumerate_root() {
   local root="$1"
   local listing
@@ -1585,6 +1632,7 @@ hydrate_expected_file() {
   if (( attempt >= TIMEOUT_SECS || SECONDS >= deadline )); then
     cat "$read_error" >&2 || true
     collect_expected_file_diagnostics "$path" "$EXPECTED_FILE_REL"
+    classify_expected_file_read_failure "$path" "$read_error" || true
     echo "failed to read expected file for hydration: $path" >&2
     exit 1
   fi

--- a/scripts/test-macos-postinstall-smoke.sh
+++ b/scripts/test-macos-postinstall-smoke.sh
@@ -438,6 +438,7 @@ destination="${3:-}"
 marker="${TCFS_FAKE_SWIFT_MARKER:-}"
 target="${TCFS_FAKE_SWIFT_TARGET:-}"
 hang_target="${TCFS_FAKE_SWIFT_HANG_TARGET:-}"
+permission_target="${TCFS_FAKE_SWIFT_PERMISSION_TARGET:-}"
 
 if [[ "$helper" != *"macos-fileprovider-coordinated-read.swift" || -z "$source" || -z "$destination" ]]; then
   printf 'unexpected swift invocation:'
@@ -448,6 +449,11 @@ fi
 
 if [[ -n "$hang_target" && "$source" == "$hang_target" ]]; then
   exec perl -e 'select undef, undef, undef, 60'
+fi
+
+if [[ -n "$permission_target" && "$source" == "$permission_target" ]]; then
+  printf 'coordinated read operation failed: The file “postinstall-1” couldn'\''t be opened because you don'\''t have permission to view it. [domain=NSCocoaErrorDomain code=257] path=%s underlying=NSPOSIXErrorDomain(1): Operation not permitted\n' "$source" >&2
+  exit 1
 fi
 
 if [[ -n "$marker" && -n "$target" && "$source" == "$target" && ! -e "$marker" ]]; then
@@ -752,6 +758,22 @@ assert_fails_contains \
       --cloud-root "$CLOUD_ROOT" \
       --log-dir "${TMPDIR}/hung-read-logs" \
       --timeout 2
+
+assert_fails_contains \
+  "classification: cloudstorage_permission_denied" \
+  env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_FAKE_SWIFT_PERMISSION_TARGET="$CLOUD_ROOT/$EXPECTED_REL" \
+    bash "$SCRIPT" \
+      --expected-version 0.12.2 \
+      --config "$CONFIG_PATH" \
+      --expected-file "$EXPECTED_REL" \
+      --expected-content-file "$EXPECTED_CONTENT_FILE" \
+      --app-path "$APP_PATH" \
+      --cloud-root "$CLOUD_ROOT" \
+      --log-dir "${TMPDIR}/permission-denied-logs" \
+      --timeout 2
+assert_contains "${TMPDIR}/permission-denied-logs/failure-classification.txt" "classification=cloudstorage_permission_denied"
+assert_contains "${TMPDIR}/permission-denied-logs/failure-classification-input.log" "NSCocoaErrorDomain code=257"
 
 BOUNDED_LS_OUT="${TMPDIR}/bounded-cloud-root-ls.out"
 env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \


### PR DESCRIPTION
## Summary

Adds an explicit failure classifier for the macOS postinstall smoke when CloudStorage/FileProvider reads fail with EPERM-style permission errors.

The new classifier writes:
- `harness/failure-classification.txt`
- `harness/failure-classification-input.log`

It recognizes the failure shape from main run 26084837640:
- `NSCocoaErrorDomain code=257`
- `NSPOSIXErrorDomain(1)`
- `Operation not permitted`
- permission-to-view / EPERM variants

## Why

After #395, the main-ref `v0.12.13-rc1` `.pkg` smoke no longer hangs unbounded at CloudStorage enumeration. It now fails in a narrower window after install/config/seed/storage/index/requestDownload pass. This PR makes that next failure packet machine-classified as `cloudstorage_permission_denied` instead of requiring manual correlation across `hydrate-read-error.log`, `cloud-root-ls.log`, `expected-file-xattr.log`, and `fileproviderctl` logs.

## Validation

- `bash -n scripts/macos-postinstall-smoke.sh scripts/test-macos-postinstall-smoke.sh`
- `bash scripts/test-macos-postinstall-smoke.sh`
- `git diff --check`

## Claim boundary

Harness classification only. This does not fix FileProvider hydration/permissions and does not make the main-ref macOS `.pkg` repeatability gate green.