### PR TITLE
ci: ignore CloudStorage find stderr as enumeration (TIN-1547)

### DIFF
--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -1372,6 +1372,7 @@ classify_expected_file_read_failure() {
     "$LOG_DIR/cloud-root-ls.log" \
     "$LOG_DIR/cloud-root-open.log" \
     "$LOG_DIR/cloud-root-find.log" \
+    "$LOG_DIR/cloud-root-find.err" \
     "$LOG_DIR/expected-parent-ls.log" \
     "$LOG_DIR/expected-parent-open.log" \
     "$LOG_DIR/expected-file-ls.log" \
@@ -1422,7 +1423,7 @@ enumerate_root() {
     run_bounded_to_log \
       "cloud-root-find" \
       "$LOG_SHOW_TIMEOUT_SECS" \
-      sh -c 'find "$1" -mindepth 1 -maxdepth 4 | head -n 10' sh "$root" || true
+      sh -c 'find "$1" -mindepth 1 -maxdepth 4 2>"$2" | head -n 10' sh "$root" "$LOG_DIR/cloud-root-find.err" || true
     listing="$(cat "$LOG_DIR/cloud-root-find.log" 2>/dev/null || true)"
     if [[ -n "$listing" ]]; then
       echo "enumeration sample:"

--- a/scripts/test-macos-postinstall-smoke.sh
+++ b/scripts/test-macos-postinstall-smoke.sh
@@ -21,6 +21,18 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+
+  if grep -Fq -- "$unexpected" "$file"; then
+    printf 'expected not to find %s in %s\n' "$unexpected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
 assert_fails_contains() {
   local expected="$1"
   shift
@@ -360,6 +372,14 @@ exec /bin/ls "$@"
 EOF
 cat >"$FAKE_BIN/find" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n "${TCFS_FAKE_FIND_PERMISSION_TARGET:-}" ]]; then
+  for arg in "$@"; do
+    if [[ "$arg" == "$TCFS_FAKE_FIND_PERMISSION_TARGET" ]]; then
+      printf 'find: %s: Operation not permitted\n' "$arg" >&2
+      exit 1
+    fi
+  done
+fi
 if [[ -n "${TCFS_FAKE_FIND_HANG_TARGET:-}" ]]; then
   for arg in "$@"; do
     if [[ "$arg" == "$TCFS_FAKE_FIND_HANG_TARGET" ]]; then
@@ -811,6 +831,31 @@ assert_fails_contains \
       --log-dir "${TMPDIR}/bounded-cloud-root-find-logs" \
       --timeout 2
 test -f "${TMPDIR}/bounded-cloud-root-find-logs/cloud-root-find.log"
+
+FIND_PERMISSION_OUT="${TMPDIR}/find-permission.out"
+FIND_PERMISSION_ERR="${TMPDIR}/find-permission.err"
+if env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \
+  TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+  TCFS_FAKE_FIND_PERMISSION_TARGET="$CLOUD_ROOT" \
+  LOG_SHOW_TIMEOUT_SECS=1 \
+  bash "$SCRIPT" \
+    --expected-version 0.12.2 \
+    --config "$CONFIG_PATH" \
+    --app-path "$APP_PATH" \
+    --cloud-root "$CLOUD_ROOT" \
+    --log-dir "${TMPDIR}/find-permission-logs" \
+    --timeout 2 \
+    >"$FIND_PERMISSION_OUT" \
+    2>"$FIND_PERMISSION_ERR"; then
+  printf 'expected CloudStorage find permission denial to fail enumeration\n' >&2
+  exit 1
+fi
+cat "$FIND_PERMISSION_OUT" "$FIND_PERMISSION_ERR" >"${TMPDIR}/find-permission.combined"
+assert_contains "${TMPDIR}/find-permission.combined" "enumeration found no entries under $CLOUD_ROOT"
+assert_not_contains "${TMPDIR}/find-permission.combined" "macOS post-install FileProvider smoke passed"
+assert_not_contains "${TMPDIR}/find-permission.combined" "enumeration sample:"
+assert_contains "${TMPDIR}/find-permission-logs/cloud-root-find.err" "Operation not permitted"
+test -f "${TMPDIR}/find-permission-logs/cloud-root-find.log"
 
 SAME_PATH_DUPES_OUT="${TMPDIR}/same-path-dupes.out"
 SAME_PATH_DUPES_ERR="${TMPDIR}/same-path-dupes.err"


### PR DESCRIPTION
## Summary
- stop treating `find: ... Operation not permitted` stderr as a successful CloudStorage enumeration sample
- preserve CloudStorage `find` stderr in `cloud-root-find.err` for diagnostics and failure classification
- add a regression test that simulates CloudStorage `find` returning EPERM on a populated root and requires the harness to fail instead of passing

## Evidence
- `bash scripts/test-macos-postinstall-smoke.sh`
- `git diff --check`
- `python3 scripts/test-tcfs-smoke-endpoint-preflight.py`

## Claim boundary
This does not prove production FileProvider hydration. It fixes the TIN-1547 harness false-positive exposed by main run 26089472294; the next proof is a rerun of macOS Post-Install Smoke on `main` after merge.