### PR TITLE
storage posture: support HTTPS SeaweedFS remotes

### DIFF
--- a/scripts/home-canary-linux-xr-shadow.sh
+++ b/scripts/home-canary-linux-xr-shadow.sh
@@ -16,7 +16,9 @@ Options:
   --source <path>        Source project. Default: /Users/jess/git/linux-xr
   --shadow-root <path>   Shadow copy path. Default: ~/TCFS Pilot/real-canaries/linux-xr-shadow-<UTC>
   --evidence-dir <path>  Evidence dir. Default: docs/release/evidence/home-canary-linux-xr-shadow-<UTC>
-  --remote <url>         seaweedfs://host:port/bucket/prefix disposable remote
+  --remote <url>         Disposable remote. Use seaweedfs://host:port/bucket/prefix
+                          for historical HTTP, seaweedfs+http://... for
+                          explicit HTTP, or seaweedfs+https://... for TLS.
   --state-dir <path>     Local TCFS state/config dir. Default: <evidence-dir>/state
   --tcfs-bin <path>      tcfs binary. Default: TCFS_BIN, target/debug/tcfs, or cargo run
   --push                 Push the shadow to the disposable prefix
@@ -272,7 +274,6 @@ done
 if [[ "$push_remote" == "1" && "$resume_after_push" == "1" ]]; then
   fail "--push and --resume-after-push are mutually exclusive"
 fi
-[[ "$remote" == seaweedfs://* ]] || fail "remote must start with seaweedfs://"
 [[ "$honey_smoke_max_depth" =~ ^[0-9]+$ ]] || fail "--honey-smoke-max-depth must be an integer"
 [[ "$honey_smoke_timeout_secs" =~ ^[0-9]+$ ]] || fail "--honey-smoke-timeout-secs must be an integer"
 [[ "$storage_max_concurrent_ops" =~ ^[0-9]+$ ]] || fail "TCFS_STORAGE_MAX_CONCURRENT_OPS must be an integer"
@@ -308,7 +309,20 @@ esac
 [[ "$source_canon" != "$home_canon" ]] || fail "refusing to canary full HOME"
 [[ "$source_canon" != "$git_canon" ]] || fail "refusing to canary full ~/git"
 
-remote_rest="${remote#seaweedfs://}"
+remote_transport_tls=false
+if [[ "$remote" == seaweedfs+https://* ]]; then
+  remote_rest="${remote#seaweedfs+https://}"
+  remote_endpoint_scheme=https
+  remote_transport_tls=true
+elif [[ "$remote" == seaweedfs+http://* ]]; then
+  remote_rest="${remote#seaweedfs+http://}"
+  remote_endpoint_scheme=http
+elif [[ "$remote" == seaweedfs://* ]]; then
+  remote_rest="${remote#seaweedfs://}"
+  remote_endpoint_scheme=http
+else
+  fail "remote must start with seaweedfs://, seaweedfs+http://, or seaweedfs+https://"
+fi
 remote_host="${remote_rest%%/*}"
 [[ "$remote_rest" != "$remote_host" ]] || fail "remote must include /bucket/prefix: $remote"
 remote_path="${remote_rest#*/}"
@@ -321,7 +335,7 @@ else
   prefix="${prefix%/}"
 fi
 [[ -n "$prefix" ]] || fail "remote must include a dedicated non-root prefix: $remote"
-endpoint="http://${remote_host}"
+endpoint="${remote_endpoint_scheme}://${remote_host}"
 region="${TCFS_S3_REGION:-us-east-1}"
 
 tcfs_cmd=()
@@ -469,7 +483,7 @@ endpoint = "$endpoint"
 region = "$region"
 bucket = "$bucket"
 remote_prefix = "$prefix"
-enforce_tls = false
+enforce_tls = $remote_transport_tls
 max_concurrent_ops = $storage_max_concurrent_ops
 s3_connect_timeout_secs = $storage_s3_connect_timeout_secs
 s3_pool_idle_timeout_secs = $storage_s3_pool_idle_timeout_secs

--- a/scripts/home-canary-linux-xr-storage-posture.sh
+++ b/scripts/home-canary-linux-xr-storage-posture.sh
@@ -16,7 +16,9 @@ Options:
   --source <path>        Source project. Default: /Users/jess/git/linux-xr
   --shadow-root <path>   Shadow copy path. Default: ~/TCFS Pilot/real-canaries/linux-xr-storage-posture-<UTC>
   --evidence-dir <path>  Evidence dir. Default: docs/release/evidence/home-canary-linux-xr-storage-posture-<UTC>
-  --remote <url>         seaweedfs://host:port/bucket/prefix disposable remote
+  --remote <url>         Disposable remote. Use seaweedfs://host:port/bucket/prefix
+                          for historical HTTP, seaweedfs+http://... for
+                          explicit HTTP, or seaweedfs+https://... for TLS.
   --state-dir <path>     Local TCFS state/config dir. Default: <evidence-dir>/state
   --tcfs-bin <path>      Release tcfs binary. Default: target/release/tcfs
   --push                 Push the shadow to the disposable prefix
@@ -385,8 +387,20 @@ if [[ "$allow_debug_binary" != "1" && "$tcfs_profile" == "debug" ]]; then
   fail "storage posture proof requires a release binary; pass --allow-debug-binary only for tests"
 fi
 
-remote_no_scheme="${remote#seaweedfs://}"
-[[ "$remote_no_scheme" != "$remote" ]] || fail "remote must use seaweedfs://"
+remote_transport_tls=false
+if [[ "$remote" == seaweedfs+https://* ]]; then
+  remote_no_scheme="${remote#seaweedfs+https://}"
+  remote_endpoint_scheme=https
+  remote_transport_tls=true
+elif [[ "$remote" == seaweedfs+http://* ]]; then
+  remote_no_scheme="${remote#seaweedfs+http://}"
+  remote_endpoint_scheme=http
+elif [[ "$remote" == seaweedfs://* ]]; then
+  remote_no_scheme="${remote#seaweedfs://}"
+  remote_endpoint_scheme=http
+else
+  fail "remote must use seaweedfs://, seaweedfs+http://, or seaweedfs+https://"
+fi
 remote_host="${remote_no_scheme%%/*}"
 [[ -n "$remote_host" ]] || fail "remote host is empty: $remote"
 remote_path="${remote_no_scheme#*/}"
@@ -447,8 +461,8 @@ shadow=$shadow_root
 remote=$remote
 bucket=$bucket
 remote_prefix=$prefix
-endpoint=http://$remote_host
-transport_tls=false
+endpoint=$remote_endpoint_scheme://$remote_host
+transport_tls=$remote_transport_tls
 credential_aws_access_key_id_present=$aws_access_key_id_present
 credential_aws_secret_access_key_present=$aws_secret_access_key_present
 credential_aws_session_token_present=$aws_session_token_present

--- a/scripts/test-home-canary-linux-xr-storage-posture.sh
+++ b/scripts/test-home-canary-linux-xr-storage-posture.sh
@@ -108,6 +108,8 @@ assert_contains "$OUT" "home canary evidence:"
 assert_contains "$EVIDENCE/storage-posture.env" "posture_claim=not-production-storage-posture"
 assert_contains "$EVIDENCE/storage-posture.env" "helper_status=0"
 assert_contains "$EVIDENCE/storage-posture.env" "remote_prefix=home-canary-linux-xr-storage-posture-test"
+assert_contains "$EVIDENCE/storage-posture.env" "endpoint=http://example.invalid"
+assert_contains "$EVIDENCE/storage-posture.env" "transport_tls=false"
 assert_contains "$EVIDENCE/storage-posture.env" "credential_source=unset_or_helper_default"
 assert_contains "$EVIDENCE/storage-posture.env" "credential_aws_secret_access_key_present=0"
 assert_contains "$EVIDENCE/storage-posture.env" "state_dir=$STATE"
@@ -139,6 +141,8 @@ assert_contains "$EVIDENCE/run-metadata.env" "push=0"
 assert_contains "$EVIDENCE/run-metadata.env" "storage_max_concurrent_ops=7"
 assert_contains "$EVIDENCE/tcfs-linux-xr-shadow.toml" "sync_symlinks = true"
 assert_contains "$EVIDENCE/tcfs-linux-xr-shadow.toml" "max_concurrent_ops = 7"
+assert_contains "$EVIDENCE/tcfs-linux-xr-shadow.toml" "endpoint = \"http://example.invalid\""
+assert_contains "$EVIDENCE/tcfs-linux-xr-shadow.toml" "enforce_tls = false"
 assert_contains "$EVIDENCE/tcfs-linux-xr-shadow.toml" "s3_connect_timeout_secs = 5"
 assert_contains "$EVIDENCE/tcfs-linux-xr-shadow.toml" "s3_pool_idle_timeout_secs = 13"
 assert_contains "$EVIDENCE/tcfs-linux-xr-shadow.toml" "s3_pool_max_idle_per_host = 7"
@@ -174,6 +178,20 @@ assert_contains "$PUSH_EVIDENCE/push-storage-summary.env" "max_upload_elapsed_ms
 assert_contains "$PUSH_EVIDENCE/push-storage-summary.env" "max_upload_bytes_per_sec=8192"
 assert_contains "$PUSH_EVIDENCE/push-storage-summary.env" "fresh_prefix_publish_true_rows=1"
 assert_contains "$PUSH_EVIDENCE/push-storage-summary.env" "remote_conflict_check_false_rows=1"
+
+HTTPS_EVIDENCE="$TMPDIR/https-evidence"
+"${RUN_ENV[@]}" bash "$SCRIPT" \
+  --source "$SOURCE" \
+  --shadow-root "$TMPDIR/https-shadow" \
+  --evidence-dir "$HTTPS_EVIDENCE" \
+  --state-dir "$TMPDIR/https-state" \
+  --remote seaweedfs+https://storage.example.invalid/tcfs/home-canary-linux-xr-storage-posture-https \
+  --tcfs-bin "$BIN_DIR/tcfs" \
+  >"$TMPDIR/https.out"
+assert_contains "$HTTPS_EVIDENCE/storage-posture.env" "endpoint=https://storage.example.invalid"
+assert_contains "$HTTPS_EVIDENCE/storage-posture.env" "transport_tls=true"
+assert_contains "$HTTPS_EVIDENCE/tcfs-linux-xr-shadow.toml" "endpoint = \"https://storage.example.invalid\""
+assert_contains "$HTTPS_EVIDENCE/tcfs-linux-xr-shadow.toml" "enforce_tls = true"
 
 gzip -f "$PUSH_EVIDENCE/push.log"
 rm -f "$PUSH_EVIDENCE/push-storage-summary.env" "$PUSH_EVIDENCE/push-storage-summary.md"


### PR DESCRIPTION
## Summary

- allow the linux-xr storage posture helper to accept `seaweedfs+https://` and explicit `seaweedfs+http://` remotes
- propagate HTTPS remotes through the delegated shadow helper as `endpoint = "https://..."` with `enforce_tls = true`
- record `endpoint=` and `transport_tls=` accurately in `storage-posture.env`

## Why

TIN-1546 needs a production-shaped storage evidence packet with live HTTPS/TLS posture. The existing posture helper rejected anything except historical `seaweedfs://` and hardcoded plaintext metadata, so it could not faithfully archive a future HTTPS run even if the endpoint and scoped credentials were ready.

This does not claim production storage readiness by itself; it removes the helper-level blocker so the live HTTPS/CA/scoped credential packet can be run and archived accurately.

## Validation

- `bash scripts/test-home-canary-linux-xr-storage-posture.sh`
- `bash scripts/test-home-canary-linux-xr-shadow.sh`
- `bash -n scripts/home-canary-linux-xr-storage-posture.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-storage-posture.sh`
- `git diff --check`
