### PR TITLE
ci: coordinate CloudStorage root enumeration

### DIFF
--- a/scripts/macos-fileprovider-coordinated-list.swift
+++ b/scripts/macos-fileprovider-coordinated-list.swift
@@ -1,0 +1,68 @@
+#!/usr/bin/env swift
+import Foundation
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+    exit(1)
+}
+
+func describe(_ error: Error) -> String {
+    let nsError = error as NSError
+    var details = "\(nsError.localizedDescription) [domain=\(nsError.domain) code=\(nsError.code)]"
+
+    if let path = nsError.userInfo[NSFilePathErrorKey] as? String {
+        details += " path=\(path)"
+    }
+    if let url = nsError.userInfo[NSURLErrorKey] as? URL {
+        details += " url=\(url.path)"
+    }
+    if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+        details += " underlying=\(underlying.domain)(\(underlying.code)): \(underlying.localizedDescription)"
+    }
+
+    return details
+}
+
+guard CommandLine.arguments.count == 2 else {
+    fail("usage: macos-fileprovider-coordinated-list.swift <root-path>")
+}
+
+let rootURL = URL(fileURLWithPath: CommandLine.arguments[1])
+let coordinator = NSFileCoordinator(filePresenter: nil)
+var coordinationError: NSError?
+var operationError: Error?
+var entries: [String] = []
+
+coordinator.coordinate(readingItemAt: rootURL, options: [], error: &coordinationError) { coordinatedURL in
+    do {
+        let accessed = coordinatedURL.startAccessingSecurityScopedResource()
+        defer {
+            if accessed {
+                coordinatedURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let children = try FileManager.default.contentsOfDirectory(
+            at: coordinatedURL,
+            includingPropertiesForKeys: nil,
+            options: []
+        )
+        entries = children
+            .map { $0.path }
+            .sorted()
+    } catch {
+        operationError = error
+    }
+}
+
+if let coordinationError {
+    fail("coordinated list failed: \(describe(coordinationError))")
+}
+
+if let operationError {
+    fail("coordinated list operation failed: \(describe(operationError))")
+}
+
+for entry in entries {
+    print(entry)
+}

--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -1264,6 +1264,8 @@ nudge_cloud_root_enumeration() {
         fileproviderctl check -P -a "$root" || true
     fi
   fi
+
+  run_coordinated_root_listing "$root" "cloud-root-coordinated-list-nudge" >/dev/null || true
 }
 
 nudge_expected_parent_enumeration() {
@@ -1490,6 +1492,8 @@ classify_cloud_root_enumeration_failure() {
     "$LOG_DIR/cloud-root-open.log" \
     "$LOG_DIR/cloud-root-find.log" \
     "$LOG_DIR/cloud-root-find.err" \
+    "$LOG_DIR/cloud-root-coordinated-list.log" \
+    "$LOG_DIR/cloud-root-coordinated-list-nudge.log" \
     "$LOG_DIR/cloud-root-stat.log" \
     "$LOG_DIR/cloud-root-access.log" \
     "$LOG_DIR/cloud-root-xattr.log" \
@@ -1539,9 +1543,30 @@ classify_cloud_root_enumeration_failure() {
   return 1
 }
 
+run_coordinated_root_listing() {
+  local root="$1"
+  local label="$2"
+  local helper="$REPO_ROOT/scripts/macos-fileprovider-coordinated-list.swift"
+  local listing
+
+  [[ "$COORDINATED_READ" != "0" ]] || return 2
+  [[ -f "$helper" ]] || return 2
+  command -v swift >/dev/null 2>&1 || return 2
+
+  run_bounded_to_log \
+    "$label" \
+    "$LOG_SHOW_TIMEOUT_SECS" \
+    swift "$helper" "$root" || return "$?"
+
+  listing="$(cat "$LOG_DIR/${label}.log" 2>/dev/null || true)"
+  [[ -n "$listing" ]] || return 1
+  printf '%s\n' "$listing"
+}
+
 enumerate_root() {
   local root="$1"
   local listing
+  local coordinated_listing
   local attempt=0
   local system_log
 
@@ -1560,6 +1585,11 @@ enumerate_root() {
     if [[ -n "$listing" ]]; then
       echo "enumeration sample:"
       echo "$listing"
+      return
+    fi
+    if coordinated_listing="$(run_coordinated_root_listing "$root" "cloud-root-coordinated-list")"; then
+      echo "coordinated enumeration sample:"
+      echo "$coordinated_listing"
       return
     fi
     short_pause

--- a/scripts/test-macos-postinstall-smoke.sh
+++ b/scripts/test-macos-postinstall-smoke.sh
@@ -459,6 +459,35 @@ marker="${TCFS_FAKE_SWIFT_MARKER:-}"
 target="${TCFS_FAKE_SWIFT_TARGET:-}"
 hang_target="${TCFS_FAKE_SWIFT_HANG_TARGET:-}"
 permission_target="${TCFS_FAKE_SWIFT_PERMISSION_TARGET:-}"
+list_target="${TCFS_FAKE_SWIFT_LIST_TARGET:-}"
+list_permission_target="${TCFS_FAKE_SWIFT_LIST_PERMISSION_TARGET:-}"
+list_output="${TCFS_FAKE_SWIFT_LIST_OUTPUT:-}"
+
+if [[ "$helper" == *"macos-fileprovider-coordinated-list.swift" ]]; then
+  if [[ -z "$source" || -n "$destination" ]]; then
+    printf 'unexpected coordinated list invocation:'
+    printf ' %q' "$@"
+    printf '\n'
+    exit 1
+  fi
+
+  if [[ -n "$list_permission_target" && "$source" == "$list_permission_target" ]]; then
+    printf 'coordinated list operation failed: The folder “TCFS” couldn'\''t be opened because you don'\''t have permission to view it. [domain=NSCocoaErrorDomain code=257] path=%s underlying=NSPOSIXErrorDomain(1): Operation not permitted\n' "$source" >&2
+    exit 1
+  fi
+
+  if [[ -n "$list_target" && "$source" == "$list_target" ]]; then
+    if [[ -n "$list_output" ]]; then
+      printf '%s\n' "$list_output"
+    else
+      printf '%s\n' "$source/Projects"
+    fi
+    exit 0
+  fi
+
+  printf 'coordinated list fixture disabled for %s\n' "$source" >&2
+  exit 1
+fi
 
 if [[ "$helper" != *"macos-fileprovider-coordinated-read.swift" || -z "$source" || -z "$destination" ]]; then
   printf 'unexpected swift invocation:'
@@ -866,6 +895,29 @@ test -f "${TMPDIR}/find-permission-logs/cloud-root-stat.log"
 test -f "${TMPDIR}/find-permission-logs/cloud-root-access.log"
 test -f "${TMPDIR}/find-permission-logs/cloud-root-xattr.log"
 test -f "${TMPDIR}/find-permission-logs/fileproviderctl-domain-list.log"
+
+COORDINATED_LIST_OUT="${TMPDIR}/coordinated-list.out"
+env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \
+  TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+  TCFS_FAKE_SWIFT_LOG="$SWIFT_LOG" \
+  TCFS_FAKE_FIND_PERMISSION_TARGET="$CLOUD_ROOT" \
+  TCFS_FAKE_SWIFT_LIST_TARGET="$CLOUD_ROOT" \
+  LOG_SHOW_TIMEOUT_SECS=1 \
+  bash "$SCRIPT" \
+    --expected-version 0.12.2 \
+    --config "$CONFIG_PATH" \
+    --app-path "$APP_PATH" \
+    --cloud-root "$CLOUD_ROOT" \
+    --log-dir "${TMPDIR}/coordinated-list-logs" \
+    --timeout 2 \
+    >"$COORDINATED_LIST_OUT" 2>&1
+assert_contains "$COORDINATED_LIST_OUT" "coordinated enumeration sample:"
+assert_contains "$COORDINATED_LIST_OUT" "$CLOUD_ROOT/Projects"
+assert_contains "$COORDINATED_LIST_OUT" "macOS post-install FileProvider smoke passed"
+assert_not_contains "$COORDINATED_LIST_OUT" "classification: cloudstorage_root_permission_denied"
+assert_contains "${TMPDIR}/coordinated-list-logs/cloud-root-find.err" "Operation not permitted"
+assert_contains "${TMPDIR}/coordinated-list-logs/cloud-root-coordinated-list.log" "$CLOUD_ROOT/Projects"
+assert_contains "${TMPDIR}/coordinated-list-logs/cloud-root-coordinated-list-nudge.log" "$CLOUD_ROOT/Projects"
 
 SAME_PATH_DUPES_OUT="${TMPDIR}/same-path-dupes.out"
 SAME_PATH_DUPES_ERR="${TMPDIR}/same-path-dupes.err"


### PR DESCRIPTION
## Summary
- add a Swift NSFileCoordinator helper that lists FileProvider CloudStorage roots through coordinated access
- let the macOS postinstall smoke proceed when POSIX find is denied but coordinated root listing returns entries
- keep root EPERM diagnostics in the failure classifier when both POSIX and coordinated enumeration fail

## Evidence
- bash scripts/test-macos-postinstall-smoke.sh
- bash -n scripts/macos-postinstall-smoke.sh scripts/test-macos-postinstall-smoke.sh
- swiftc -parse scripts/macos-fileprovider-coordinated-list.swift
- git diff --check

## Production boundary
This does not claim Finder hydration is fixed yet. It narrows TIN-1547 by testing whether production FileProvider roots require coordinated directory access before the exact-file requestDownload/read gate.