### PR TITLE
ci: probe FileProvider user-visible root URL

### DIFF
--- a/scripts/macos-fileprovider-coordinated-list.swift
+++ b/scripts/macos-fileprovider-coordinated-list.swift
@@ -1,9 +1,14 @@
 #!/usr/bin/env swift
+import FileProvider
 import Foundation
 
 func fail(_ message: String) -> Never {
     FileHandle.standardError.write(Data((message + "\n").utf8))
     exit(1)
+}
+
+struct ProbeError: Error, CustomStringConvertible {
+    let description: String
 }
 
 func describe(_ error: Error) -> String {
@@ -23,46 +28,117 @@ func describe(_ error: Error) -> String {
     return details
 }
 
-guard CommandLine.arguments.count == 2 else {
-    fail("usage: macos-fileprovider-coordinated-list.swift <root-path>")
+guard CommandLine.arguments.count >= 2 && CommandLine.arguments.count <= 4 else {
+    fail("usage: macos-fileprovider-coordinated-list.swift <root-path> [domain-identifier] [display-name]")
 }
 
 let rootURL = URL(fileURLWithPath: CommandLine.arguments[1])
-let coordinator = NSFileCoordinator(filePresenter: nil)
-var coordinationError: NSError?
-var operationError: Error?
-var entries: [String] = []
+let domainIdentifier = CommandLine.arguments.count >= 3 ? CommandLine.arguments[2] : "io.tinyland.tcfs"
+let displayName = CommandLine.arguments.count >= 4 ? CommandLine.arguments[3] : "TCFS"
+var failures: [String] = []
 
-coordinator.coordinate(readingItemAt: rootURL, options: [], error: &coordinationError) { coordinatedURL in
-    do {
-        let accessed = coordinatedURL.startAccessingSecurityScopedResource()
-        defer {
-            if accessed {
-                coordinatedURL.stopAccessingSecurityScopedResource()
+func coordinatedDirectoryEntries(at url: URL) throws -> [String] {
+    let coordinator = NSFileCoordinator(filePresenter: nil)
+    var coordinationError: NSError?
+    var operationError: Error?
+    var entries: [String] = []
+
+    coordinator.coordinate(readingItemAt: url, options: [], error: &coordinationError) { coordinatedURL in
+        do {
+            let accessed = coordinatedURL.startAccessingSecurityScopedResource()
+            defer {
+                if accessed {
+                    coordinatedURL.stopAccessingSecurityScopedResource()
+                }
             }
+
+            let children = try FileManager.default.contentsOfDirectory(
+                at: coordinatedURL,
+                includingPropertiesForKeys: nil,
+                options: []
+            )
+            entries = children
+                .map { $0.path }
+                .sorted()
+        } catch {
+            operationError = error
         }
-
-        let children = try FileManager.default.contentsOfDirectory(
-            at: coordinatedURL,
-            includingPropertiesForKeys: nil,
-            options: []
-        )
-        entries = children
-            .map { $0.path }
-            .sorted()
-    } catch {
-        operationError = error
     }
+
+    if let coordinationError {
+        throw ProbeError(description: "coordinated list failed: \(describe(coordinationError))")
+    }
+
+    if let operationError {
+        throw ProbeError(description: "coordinated list operation failed: \(describe(operationError))")
+    }
+
+    return entries
 }
 
-if let coordinationError {
-    fail("coordinated list failed: \(describe(coordinationError))")
+func userVisibleRootURL(domainIdentifier: String, displayName: String) throws -> URL {
+    let domain = NSFileProviderDomain(
+        identifier: NSFileProviderDomainIdentifier(domainIdentifier),
+        displayName: displayName
+    )
+    guard let manager = NSFileProviderManager(for: domain) else {
+        throw ProbeError(description: "NSFileProviderManager unavailable for domain \(domainIdentifier)")
+    }
+
+    let sem = DispatchSemaphore(value: 0)
+    var resolvedURL: URL?
+    var resolvedError: Error?
+    manager.getUserVisibleURL(for: .rootContainer) { url, error in
+        resolvedURL = url
+        resolvedError = error
+        sem.signal()
+    }
+
+    if sem.wait(timeout: .now() + .seconds(10)) == .timedOut {
+        throw ProbeError(description: "getUserVisibleURL timed out for domain \(domainIdentifier)")
+    }
+
+    if let resolvedError {
+        throw ProbeError(description: "getUserVisibleURL failed: \(describe(resolvedError))")
+    }
+
+    guard let resolvedURL else {
+        throw ProbeError(description: "getUserVisibleURL returned no URL for domain \(domainIdentifier)")
+    }
+
+    return resolvedURL
 }
 
-if let operationError {
-    fail("coordinated list operation failed: \(describe(operationError))")
+func printEntries(_ entries: [String]) -> Bool {
+    guard !entries.isEmpty else {
+        return false
+    }
+    for entry in entries {
+        print(entry)
+    }
+    return true
 }
 
-for entry in entries {
-    print(entry)
+do {
+    if printEntries(try coordinatedDirectoryEntries(at: rootURL)) {
+        exit(0)
+    }
+    failures.append("direct coordinated list returned no entries for \(rootURL.path)")
+} catch {
+    failures.append("direct path: \(error)")
 }
+
+do {
+    let visibleURL = try userVisibleRootURL(
+        domainIdentifier: domainIdentifier,
+        displayName: displayName
+    )
+    if printEntries(try coordinatedDirectoryEntries(at: visibleURL)) {
+        exit(0)
+    }
+    failures.append("user-visible URL returned no entries for \(visibleURL.path)")
+} catch {
+    failures.append("user-visible URL: \(error)")
+}
+
+fail(failures.joined(separator: "\n"))


### PR DESCRIPTION
## Summary
- extend the coordinated CloudStorage root-list helper to ask `NSFileProviderManager.getUserVisibleURL(for: .rootContainer)` after raw-path coordination fails
- list the manager-provided URL with security-scoped access before classifying root enumeration as denied
- preserve the existing raw-path failure evidence when both paths fail

## Evidence
- `bash scripts/test-macos-postinstall-smoke.sh`
- `bash -n scripts/macos-postinstall-smoke.sh scripts/test-macos-postinstall-smoke.sh`
- `env -u DEVELOPER_DIR -u SDKROOT -u NIX_CFLAGS_COMPILE -u NIX_LDFLAGS -u NIX_CC /usr/bin/xcrun --sdk macosx swiftc -typecheck scripts/macos-fileprovider-coordinated-list.swift`
- `git diff --check`

## Production boundary
This is still TIN-1547 diagnostic work. Run `26092804190` proved raw-path `NSFileCoordinator` fails with NSCocoaErrorDomain 257; this PR tests whether manager-derived security-scoped root URLs are the missing production access path.