### PR TITLE
ci: probe FileProvider root from signed HostApp

### DIFF
--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -123,6 +123,7 @@ LOG_SHOW_TIMEOUT_SECS="${LOG_SHOW_TIMEOUT_SECS:-5}"
 LOG_DIR_OVERRIDE=""
 SKIP_STATUS=0
 LOG_DIR=""
+HOST_APP_ROOT_ENUMERATION=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -1494,6 +1495,7 @@ classify_cloud_root_enumeration_failure() {
     "$LOG_DIR/cloud-root-find.err" \
     "$LOG_DIR/cloud-root-coordinated-list.log" \
     "$LOG_DIR/cloud-root-coordinated-list-nudge.log" \
+    "$LOG_DIR/host-root-probe.log" \
     "$LOG_DIR/cloud-root-stat.log" \
     "$LOG_DIR/cloud-root-access.log" \
     "$LOG_DIR/cloud-root-xattr.log" \
@@ -1563,10 +1565,47 @@ run_coordinated_root_listing() {
   printf '%s\n' "$listing"
 }
 
+run_host_root_probe() {
+  local root="$1"
+  local app_binary
+  local action_nonce
+  local host_probe_pid
+  local status=0
+  local log_file="$LOG_DIR/host-root-probe.log"
+
+  app_binary="$(host_app_binary_path)"
+  [[ -x "$app_binary" ]] || return 2
+
+  echo "launching host app binary for root probe: $app_binary" >&2
+  action_nonce="$(new_fileprovider_action_nonce)"
+  TCFS_FILEPROVIDER_ACTION_NONCE="$action_nonce" \
+  TCFS_FILEPROVIDER_ROOT_PROBE=1 \
+  TCFS_FILEPROVIDER_ROOT_PROBE_PATH="$root" \
+  TCFS_FILEPROVIDER_HOST_STDERR_LOG=1 \
+  TCFS_FILEPROVIDER_HOST_ACTION_TIMEOUT_SECS="${TCFS_FILEPROVIDER_HOST_ACTION_TIMEOUT_SECS:-30}" \
+    "$app_binary" >"$log_file" 2>&1 &
+  host_probe_pid="$!"
+
+  wait_for_pid_with_timeout "$host_probe_pid" 20 "host app root probe helper" || status="$?"
+  [[ "$status" == "0" ]] || return "$status"
+
+  awk -v nonce="nonce=$action_nonce" '
+    index($0, "rootProbe:") && index($0, " entry: ") && index($0, nonce) {
+      line = $0
+      sub(/^.* entry: /, "", line)
+      sub(/[[:space:]]+nonce=.*$/, "", line)
+      print line
+      found = 1
+    }
+    END { exit found ? 0 : 1 }
+  ' "$log_file"
+}
+
 enumerate_root() {
   local root="$1"
   local listing
   local coordinated_listing
+  local host_probe_listing
   local attempt=0
   local system_log
 
@@ -1595,6 +1634,13 @@ enumerate_root() {
     short_pause
     attempt=$((attempt + 1))
   done
+
+  if host_probe_listing="$(run_host_root_probe "$root")"; then
+    echo "host app root probe sample:"
+    echo "$host_probe_listing"
+    HOST_APP_ROOT_ENUMERATION=1
+    return
+  fi
 
   system_log="$(collect_fileprovider_system_log)"
   printf '%s\n' "$system_log" >"$(fileprovider_system_log_path)"
@@ -2119,9 +2165,14 @@ if [[ -n "$EXPECTED_FILE_REL" ]]; then
   EXPECTED_PATH="$CLOUD_ROOT/$EXPECTED_FILE_REL"
   EXPECTED_PARENT="$(dirname "$EXPECTED_PATH")"
   require_expected_remote_index "$EXPECTED_FILE_REL"
+  if [[ "$HOST_APP_ROOT_ENUMERATION" == "1" ]]; then
+    request_expected_file_download "$EXPECTED_FILE_REL"
+  fi
   wait_for_expected_parent_chain "$EXPECTED_PARENT"
   wait_for_expected_file "$EXPECTED_PATH"
-  request_expected_file_download "$EXPECTED_FILE_REL"
+  if [[ "$HOST_APP_ROOT_ENUMERATION" != "1" ]]; then
+    request_expected_file_download "$EXPECTED_FILE_REL"
+  fi
   if [[ "$REQUIRE_KEYCHAIN_CONFIG" == "1" ]]; then
     check_keychain_config_log
   fi

--- a/scripts/test-macos-postinstall-smoke.sh
+++ b/scripts/test-macos-postinstall-smoke.sh
@@ -399,6 +399,9 @@ if [[ -n "${TCFS_FAKE_HOST_BINARY_LOG:-}" ]]; then
   if [[ -n "${TCFS_FILEPROVIDER_EVICT_IDENTIFIER:-}" ]]; then
     printf ' evict=%s' "$TCFS_FILEPROVIDER_EVICT_IDENTIFIER" >>"$TCFS_FAKE_HOST_BINARY_LOG"
   fi
+  if [[ "${TCFS_FILEPROVIDER_ROOT_PROBE:-0}" == "1" ]]; then
+    printf ' rootProbe=%s' "${TCFS_FILEPROVIDER_ROOT_PROBE_PATH:-}" >>"$TCFS_FAKE_HOST_BINARY_LOG"
+  fi
   if [[ -n "${TCFS_FILEPROVIDER_ACTION_NONCE:-}" ]]; then
     printf ' nonce=%s' "$TCFS_FILEPROVIDER_ACTION_NONCE" >>"$TCFS_FAKE_HOST_BINARY_LOG"
   fi
@@ -413,6 +416,27 @@ if [[ "${TCFS_FILEPROVIDER_HOST_STDERR_LOG:-0}" == "1" ]]; then
     printf 'evict: %s: OK' "$TCFS_FILEPROVIDER_EVICT_IDENTIFIER"
     [[ -z "${TCFS_FILEPROVIDER_ACTION_NONCE:-}" ]] || printf ' nonce=%s' "$TCFS_FILEPROVIDER_ACTION_NONCE"
     printf '\n'
+  elif [[ "${TCFS_FILEPROVIDER_ROOT_PROBE:-0}" == "1" ]]; then
+    entries="${TCFS_FAKE_HOST_ROOT_PROBE_ENTRIES:-}"
+    if [[ -n "$entries" ]]; then
+      count="$(printf '%s\n' "$entries" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+      printf 'rootProbe: direct path: %s' "${TCFS_FILEPROVIDER_ROOT_PROBE_PATH:-}"
+      [[ -z "${TCFS_FILEPROVIDER_ACTION_NONCE:-}" ]] || printf ' nonce=%s' "$TCFS_FILEPROVIDER_ACTION_NONCE"
+      printf '\n'
+      printf 'rootProbe: direct path entries: %s' "$count"
+      [[ -z "${TCFS_FILEPROVIDER_ACTION_NONCE:-}" ]] || printf ' nonce=%s' "$TCFS_FILEPROVIDER_ACTION_NONCE"
+      printf '\n'
+      while IFS= read -r entry; do
+        [[ -n "$entry" ]] || continue
+        printf 'rootProbe: direct path entry: %s' "$entry"
+        [[ -z "${TCFS_FILEPROVIDER_ACTION_NONCE:-}" ]] || printf ' nonce=%s' "$TCFS_FILEPROVIDER_ACTION_NONCE"
+        printf '\n'
+      done <<<"$entries"
+    else
+      printf 'rootProbe: direct path list failed: fixture disabled'
+      [[ -z "${TCFS_FILEPROVIDER_ACTION_NONCE:-}" ]] || printf ' nonce=%s' "$TCFS_FILEPROVIDER_ACTION_NONCE"
+      printf '\n'
+    fi
   else
     [[ "${TCFS_FILEPROVIDER_TESTING_MODE_ALWAYS_ENABLED:-0}" != "1" ]] || printf 'testingMode: requested alwaysEnabled for FileProvider domain\n'
     printf 'add: OK - domain available\n'
@@ -918,6 +942,28 @@ assert_not_contains "$COORDINATED_LIST_OUT" "classification: cloudstorage_root_p
 assert_contains "${TMPDIR}/coordinated-list-logs/cloud-root-find.err" "Operation not permitted"
 assert_contains "${TMPDIR}/coordinated-list-logs/cloud-root-coordinated-list.log" "$CLOUD_ROOT/Projects"
 assert_contains "${TMPDIR}/coordinated-list-logs/cloud-root-coordinated-list-nudge.log" "$CLOUD_ROOT/Projects"
+
+HOST_ROOT_PROBE_OUT="${TMPDIR}/host-root-probe.out"
+env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \
+  TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+  TCFS_FAKE_FIND_PERMISSION_TARGET="$CLOUD_ROOT" \
+  TCFS_FAKE_HOST_ROOT_PROBE_ENTRIES="$CLOUD_ROOT/Projects" \
+  LOG_SHOW_TIMEOUT_SECS=1 \
+  bash "$SCRIPT" \
+    --expected-version 0.12.2 \
+    --config "$CONFIG_PATH" \
+    --app-path "$APP_PATH" \
+    --cloud-root "$CLOUD_ROOT" \
+    --log-dir "${TMPDIR}/host-root-probe-logs" \
+    --timeout 2 \
+    >"$HOST_ROOT_PROBE_OUT" 2>&1
+assert_contains "$HOST_ROOT_PROBE_OUT" "host app root probe sample:"
+assert_contains "$HOST_ROOT_PROBE_OUT" "$CLOUD_ROOT/Projects"
+assert_contains "$HOST_ROOT_PROBE_OUT" "macOS post-install FileProvider smoke passed"
+assert_not_contains "$HOST_ROOT_PROBE_OUT" "classification: cloudstorage_root_permission_denied"
+assert_contains "${TMPDIR}/host-root-probe-logs/cloud-root-find.err" "Operation not permitted"
+assert_contains "${TMPDIR}/host-root-probe-logs/host-root-probe.log" "rootProbe: direct path entry: $CLOUD_ROOT/Projects"
+assert_contains "$HOST_BINARY_LOG" "rootProbe=$CLOUD_ROOT"
 
 SAME_PATH_DUPES_OUT="${TMPDIR}/same-path-dupes.out"
 SAME_PATH_DUPES_ERR="${TMPDIR}/same-path-dupes.err"

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -65,6 +65,7 @@ struct TCFSProviderApp {
                     hostEvent("signal workingSet: timed out")
                 }
 
+                probeRootIfRequested(manager)
                 requestDownloadIfRequested(manager)
                 evictIfRequested(manager)
             } else {
@@ -151,6 +152,110 @@ struct TCFSProviderApp {
         if evictSem.wait(timeout: .now() + 15.0) == .timedOut {
             hostEvent("evict: \(rawIdentifier): timed out\(nonceSuffix)")
         }
+    }
+
+    private static func probeRootIfRequested(_ manager: NSFileProviderManager) {
+        guard ProcessInfo.processInfo.environment["TCFS_FILEPROVIDER_ROOT_PROBE"] == "1" else {
+            return
+        }
+
+        let nonceSuffix = fileProviderActionNonceLogSuffix()
+        if let rawPath = ProcessInfo.processInfo.environment[
+            "TCFS_FILEPROVIDER_ROOT_PROBE_PATH"
+        ], !rawPath.isEmpty {
+            let rootURL = URL(fileURLWithPath: rawPath)
+            hostEvent("rootProbe: direct path: \(rootURL.path)\(nonceSuffix)")
+            probeDirectoryEntries(at: rootURL, label: "direct path", nonceSuffix: nonceSuffix)
+        }
+
+        let visibleSem = DispatchSemaphore(value: 0)
+        var visibleURL: URL?
+        var visibleError: Error?
+        manager.getUserVisibleURL(for: .rootContainer) { url, error in
+            visibleURL = url
+            visibleError = error
+            visibleSem.signal()
+        }
+
+        let timeoutSeconds = hostActionTimeoutSeconds()
+        if visibleSem.wait(timeout: .now() + .seconds(timeoutSeconds)) == .timedOut {
+            hostEvent("rootProbe: user-visible URL timed out after \(timeoutSeconds)s\(nonceSuffix)")
+            return
+        }
+        if let visibleError {
+            hostEvent("rootProbe: user-visible URL failed: \(describe(visibleError))\(nonceSuffix)")
+            return
+        }
+        guard let visibleURL else {
+            hostEvent("rootProbe: user-visible URL missing\(nonceSuffix)")
+            return
+        }
+
+        hostEvent("rootProbe: user-visible URL: \(visibleURL.path)\(nonceSuffix)")
+        probeDirectoryEntries(at: visibleURL, label: "user-visible", nonceSuffix: nonceSuffix)
+    }
+
+    private static func probeDirectoryEntries(at url: URL, label: String, nonceSuffix: String) {
+        let coordinator = NSFileCoordinator(filePresenter: nil)
+        var coordinationError: NSError?
+        var operationError: Error?
+        var entries: [String] = []
+
+        coordinator.coordinate(readingItemAt: url, options: [], error: &coordinationError) { coordinatedURL in
+            do {
+                let accessed = coordinatedURL.startAccessingSecurityScopedResource()
+                defer {
+                    if accessed {
+                        coordinatedURL.stopAccessingSecurityScopedResource()
+                    }
+                }
+
+                entries = try FileManager.default.contentsOfDirectory(
+                    at: coordinatedURL,
+                    includingPropertiesForKeys: nil,
+                    options: []
+                )
+                .map { $0.path }
+                .sorted()
+            } catch {
+                operationError = error
+            }
+        }
+
+        if let coordinationError {
+            hostEvent("rootProbe: \(label) coordination failed: \(describe(coordinationError))\(nonceSuffix)")
+            return
+        }
+        if let operationError {
+            hostEvent("rootProbe: \(label) list failed: \(describe(operationError))\(nonceSuffix)")
+            return
+        }
+        if entries.isEmpty {
+            hostEvent("rootProbe: \(label) entries: <empty>\(nonceSuffix)")
+            return
+        }
+
+        hostEvent("rootProbe: \(label) entries: \(entries.count)\(nonceSuffix)")
+        for entry in entries.prefix(20) {
+            hostEvent("rootProbe: \(label) entry: \(entry)\(nonceSuffix)")
+        }
+    }
+
+    private static func describe(_ error: Error) -> String {
+        let nsError = error as NSError
+        var details = "\(nsError.localizedDescription) [domain=\(nsError.domain) code=\(nsError.code)]"
+
+        if let path = nsError.userInfo[NSFilePathErrorKey] as? String {
+            details += " path=\(path)"
+        }
+        if let url = nsError.userInfo[NSURLErrorKey] as? URL {
+            details += " url=\(url.path)"
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+            details += " underlying=\(underlying.domain)(\(underlying.code)): \(underlying.localizedDescription)"
+        }
+
+        return details
     }
 
     private static func hostEvent(_ message: String) {


### PR DESCRIPTION
## Summary
- add a signed HostApp root probe gated by `TCFS_FILEPROVIDER_ROOT_PROBE=1`
- have the macOS postinstall smoke invoke that probe when shell/coordinated CloudStorage root enumeration fails
- if the signed HostApp can enumerate root entries, continue far enough to drive signed-host `requestDownload` before shell path checks

## Verification
- `bash -n scripts/macos-postinstall-smoke.sh scripts/test-macos-postinstall-smoke.sh`
- `git diff --check`
- `env -u DEVELOPER_DIR -u SDKROOT -u NIX_CFLAGS_COMPILE -u NIX_LDFLAGS -u NIX_CC /usr/bin/xcrun --sdk macosx swiftc -parse-as-library -typecheck swift/fileprovider/Sources/HostApp/HostApp.swift`
- `bash scripts/test-macos-postinstall-smoke.sh`

## Tracking
- TIN-1547
- GitHub #280