### PR TITLE
ci: find Homebrew in macOS notarization proof

### DIFF
--- a/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
+++ b/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
@@ -126,6 +126,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if command -v protoc >/dev/null 2>&1; then
+            protoc --version
+            exit 0
+          fi
+
+          if ! command -v brew >/dev/null 2>&1; then
+            for brew_bin in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+              if [[ -x "$brew_bin" ]]; then
+                brew_dir="$(dirname "$brew_bin")"
+                echo "$brew_dir" >> "$GITHUB_PATH"
+                export PATH="$brew_dir:$PATH"
+                break
+              fi
+            done
+          fi
+
+          if ! command -v brew >/dev/null 2>&1; then
+            echo "::error::Homebrew is required to install protobuf, and protoc is not already available"
+            exit 1
+          fi
+
           brew install protobuf
 
       - name: Import Developer ID Application certificate


### PR DESCRIPTION
## Summary
- make the macOS FileProvider package notarization proof tolerate self-hosted runners where Homebrew is installed but not on PATH
- skip Homebrew install when `protoc` is already available
- emit a hard error only when neither `protoc` nor Homebrew can be found

## Verification
- `git diff --check`

## Tracking
- TIN-1547 diagnostic package build for #405
- failed run 26114644177 stopped at `brew: command not found` on PZM