### PR TITLE
ci: restore macOS system path in notarization proof

### DIFF
--- a/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
+++ b/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
@@ -34,6 +34,10 @@ jobs:
           LOG_DIR="$RUNNER_TEMP/tcfs-macos-fileprovider-pkg-notarization-proof"
           mkdir -p "$LOG_DIR"
           echo "LOG_DIR=$LOG_DIR" >> "$GITHUB_ENV"
+          for system_dir in /usr/bin /bin /usr/sbin /sbin; do
+            echo "$system_dir" >> "$GITHUB_PATH"
+          done
+          export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
           VERSION="$(python3 - <<'PY'
           import pathlib
@@ -410,7 +414,7 @@ jobs:
 
           {
             printf '[pkgutil --check-signature]\n'
-            pkgutil --check-signature "$PKG_PATH"
+            /usr/sbin/pkgutil --check-signature "$PKG_PATH"
           } 2>&1 | tee "$LOG_DIR/pkgutil-check-signature-before-notary.log"
           shasum -a 256 "$PKG_PATH" | tee "$LOG_DIR/pkg-sha256-before-notary.txt"
 
@@ -519,7 +523,7 @@ jobs:
           shasum -a 256 "$PKG_PATH" | tee "$LOG_DIR/pkg-sha256-after-staple.txt"
           {
             printf '[pkgutil --check-signature]\n'
-            pkgutil --check-signature "$PKG_PATH"
+            /usr/sbin/pkgutil --check-signature "$PKG_PATH"
           } 2>&1 | tee "$LOG_DIR/pkgutil-check-signature-after-staple.log"
 
       - name: Upload notarized package proof artifact


### PR DESCRIPTION
## Summary
- add standard macOS system directories to `GITHUB_PATH` for the package notarization proof
- use `/usr/sbin/pkgutil` explicitly for direct signature checks
- keeps PZM self-hosted runs from losing system tools after Homebrew path setup

## Verification
- `git diff --check`

## Tracking
- TIN-1547 diagnostic package build
- failed run 26115956483 reached signed package creation but stopped at `pkgutil: command not found`