### PR TITLE
docs: refresh tcfs rc2 readiness posture

### DIFF
--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -1,7 +1,7 @@
 # macOS Finder and FileProvider Reality
 
-As of May 18, 2026, the production Developer ID FileProvider lifecycle is
-proven on a clean install of the notarized `.pkg`. GitHub Actions run
+As of May 19, 2026, the production Developer ID FileProvider lifecycle is
+proven on PZM, with one important release-asset caveat. GitHub Actions run
 `26061402177` first proved installed strict preflight, storage `[ok]`,
 host-app domain add, CloudStorage enumeration, host-app `requestDownload`, and
 exact-content hydration of a 55-byte seeded fixture through the installed
@@ -22,8 +22,14 @@ badge/progress UI and long-running recovery UX. The remaining production gaps
 are first-run setup from installer to valid config/status, badge/progress
 assertions, recovery UX, and continuously exercised release-day viability.
 PR #389 branch run `26079830341` proves the exact published `v0.12.13-rc1`
-release `.pkg`; merged-workflow reruns still matter as an ongoing release-day
-regression signal.
+release `.pkg` as a historical release-freeze row. Later main-ref reruns exposed
+a CloudStorage root authority split: shell/raw-path enumeration can get EPERM
+while FileProvider control APIs still see a healthy root. PR #405 added a signed
+HostApp root/user-visible-URL probe, and diagnostic package run `26117175542`
+at `66ae92f` proved that the installed signed HostApp can enumerate the
+FileProvider user-visible root and complete exact hydrate, evict/rehydrate,
+mutation, and conflict/status. The next public-package closure step is the
+`v0.12.13-rc2` exact release asset smoke after release run `26117684515`.
 
 This document defines the actual workflow the repo supports today, separates
 what is proven from what remains experimental, and records the highest-value

--- a/docs/ops/tcfs-alpha-beta-qa-readiness-2026-05-19.md
+++ b/docs/ops/tcfs-alpha-beta-qa-readiness-2026-05-19.md
@@ -14,7 +14,11 @@ use.
   petting-zoo-mini by run `26062554542`: install, domain rebuild, enumerate,
   exact hydrate, host evict/rehydrate, remote mutation, and conflict/status.
   PR #389 branch run `26079830341` also proves the exact published
-  `v0.12.13-rc1` `.pkg`; product hardening remains open in `TIN-1547`.
+  `v0.12.13-rc1` `.pkg`. Later main-ref repeatability exposed a
+  CloudStorage root authority split, and diagnostic package run `26117175542`
+  proves the signed HostApp user-visible root path at `66ae92f`. `v0.12.13-rc2`
+  is the next exact published-asset proof target; product hardening remains open
+  in `TIN-1547`.
 - Linux remains the strongest runtime for CLI/daemon/FUSE work, but package
   first-use is not fully proven. `TIN-1422` is blocked on `TIN-1540` until the
   Linux smoke backend is reachable from CI or a private runner.
@@ -44,8 +48,9 @@ Alpha may exercise:
 
 - release artifacts and source builds on disposable or shadow sync roots
 - scoped project trees, repo canaries, and small daily-use folders
-- macOS FileProvider lifecycle after the `TIN-1547` release-asset smoke, with
-  main-ref reruns used as release-day regression evidence
+- macOS FileProvider lifecycle after the `TIN-1547` rc2 release-asset smoke,
+  with main-ref and diagnostic-artifact reruns used as release-day regression
+  evidence
 - Linux FUSE clean-name traversal and hydrate-on-open after `TIN-1422`
 - live fleet sync against named hosts after `TIN-132`
 - storage latency, object-count, retry, and failure-classification evidence
@@ -97,14 +102,15 @@ has shipped and been proven end to end.
 
 ## This Week's Alpha Runway
 
-1. Merge the production-readiness sweep PR so the docs, evidence packet, and
-   Linux smoke remote-spec fix are on main.
+1. Let the `v0.12.13-rc2` release run finish, then smoke the exact published
+   `.pkg` on PZM with rebuild-domain, production Dev ID mode, layered proof, and
+   conflict/status enabled.
 2. Clear `TIN-1540`, then rerun `TIN-1422` against a reachable backend using
    the corrected `seaweedfs://host:port/bucket/prefix` remote spec, with
    `seaweedfs+https://` preserved for production-like HTTPS smoke endpoints.
 3. Complete the `TIN-131` first-use matrix for the rc artifact set:
-   macOS `.pkg`, Homebrew, Linux `.deb`, container runtime, and Nix external
-   profile.
+   Linux `.deb`, Nix external profile, and any upgrade rows not covered by the
+   current Homebrew/container smokes.
 4. Continue the alpha slice of `TIN-1547`: main-ref release-day viability,
    rename/unsync risk classification, and minimum visible status/recovery
    notes.

--- a/docs/release/v0.12.13-evidence-matrix.md
+++ b/docs/release/v0.12.13-evidence-matrix.md
@@ -21,6 +21,19 @@ rather than re-describing release state in prose.
   release until the rc first-use gates pass.
 - Release workflow conclusion: success
 
+Late 2026-05-19 follow-up: `v0.12.13-rc2` is now the public-asset closure path
+for the macOS `.pkg` row. The original rc1 package had an earlier green exact
+asset proof, but later main-ref repeatability exposed a CloudStorage root
+authority split: shell/raw-path enumeration can get EPERM while the signed
+HostApp can resolve the FileProvider user-visible root. Diagnostic package run
+[`26117175542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542)
+passed at main `66ae92f` using notarized package artifact run
+[`26116692781`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781).
+Release run
+[`26117684515`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515)
+was dispatched for `v0.12.13-rc2` so the exact published release asset can carry
+that signed HostApp root-probe path.
+
 ## Headline change
 
 **First green end-to-end production Dev ID FileProvider acceptance** on the
@@ -36,8 +49,14 @@ Post-cut validation then proved the exact published GitHub Release asset
 [`26079830341`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26079830341):
 install, signing, binary smoke, live config, E2EE fixture seed, storage `[ok]`,
 exact hydrate, evict/rehydrate, mutation round trip, and conflict/status.
-The merged-workflow main-ref confirmation run is tracked separately from this
-release evidence row.
+
+Later PZM repeatability runs on `main` found the runner/harness could lose raw
+CloudStorage root access even though FileProvider control APIs still saw a
+healthy root. PR #405 added a signed HostApp root/user-visible-URL probe, and
+diagnostic package run `26117175542` proved that the installed signed HostApp
+can enumerate the root and drive exact hydrate, evict/rehydrate, mutation, and
+conflict/status. Treat rc1 as the historical release freeze and rc2 as the next
+exact published-asset proof target.
 
 Evidence packet:
 [`docs/release/evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/`](evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/).
@@ -50,15 +69,16 @@ surfaces are tracked here.
 
 | # | Surface | Fresh install | Upgrade | Result | Evidence |
 |---|---------|---------------|---------|--------|----------|
-| 1 | Homebrew | formula published; install smoke pending | formula updated | ⚠️ artifact/formula pass | release job [`76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317) |
-| 2 | macOS `.pkg` (production Dev ID FileProvider) | **Exact release `.pkg` FileProvider proven on PZM**; pristine first-run pending | package build/notarization passed | ✅ for FileProvider release asset; ⚠️ first-run UX gap | exact asset run [`26079830341`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26079830341), lifecycle run [`26062554542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26062554542), release job [`76633468317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76633468317) |
+| 1 | Homebrew | install smoke green on `main` | formula updated | ✅ install smoke pass | smoke run [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508), release job [`76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317) |
+| 2 | macOS `.pkg` (production Dev ID FileProvider) | rc1 exact asset had green branch proof; `66ae92f` diagnostic artifact green; rc2 exact asset pending | package build/notarization passed | ✅ diagnostic artifact pass; ⚠️ rc2 published-asset smoke pending | diagnostic run [`26117175542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542), artifact source [`26116692781`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781), rc2 release run [`26117684515`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515), rc1 exact asset run [`26079830341`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26079830341) |
 | 3 | `.deb` on Ubuntu 24.04 | packages published; install smoke pending | package upgrade smoke pending | ⚠️ artifact pass | release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
 | 4 | `.deb` on Debian 12 bookworm | known blocked (`libc6 >= 2.39` floor) | n/a | ❌ blocked | inherits from [`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor) |
 | 5 | `.rpm` on Fedora 42 | daemon-only package published; install smoke pending | sampled only | ⚠️ daemon-only artifact pass | release job [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870) |
-| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1` | multi-arch image built and signed; run smoke pending | sampled only | ✅ artifact/signature pass; ⚠️ runtime smoke pending | release job [`76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828) |
+| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1` | multi-arch runtime smoke green | sampled only | ✅ runtime smoke pass | smoke run [`26083222949`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26083222949), release job [`76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828) |
 | 7 | Nix flake install | Nix build + Attic push passed; external profile install pending | sampled only | ⚠️ build/cache pass | release job [`76628512831`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512831) |
 
-Rollup: **1 product-surface pass · 5 artifact/build/formula passes with first-use
+Rollup: **2 current product-surface passes · 1 macOS diagnostic-artifact pass
+awaiting exact rc2 release-asset proof · 3 artifact/build passes with first-use
 smoke still pending · 1 blocked**.
 
 ## Per-Surface Evidence
@@ -88,17 +108,19 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
 - `tcfsd-0.12.13-rc1-x86_64.rpm`:
   `0e3f991f93ca9b7c979ce11898ce85cb661efd4a76faa3c93e1337e0326c169e`
 
-### 1. Homebrew — formula publication pass; install smoke pending
+### 1. Homebrew — install smoke pass
 
 - Release job: `Update Homebrew formula` succeeded
   ([job `76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317)).
 - The job downloaded `SHA256SUMS.txt`, generated `Formula/tcfs.rb` from the
   release tarball hashes, and force-pushed the `homebrew-tap` branch.
-- Not proven in this rc1 packet: fresh `brew install` and upgrade smoke on a
-  host after the formula update. The v0.12.2 Homebrew proof remains the latest
-  install/upgrade smoke evidence.
+- Mainline install smoke run
+  [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508)
+  passed after PR #393 landed: generated tap install, installed-binary smoke,
+  diagnostics, and artifact upload all completed.
+- Not proven in this rc1 packet: upgrade smoke from an older Homebrew install.
 
-### 2. macOS `.pkg` — exact release package FileProvider surface proven
+### 2. macOS `.pkg` — diagnostic artifact green; rc2 exact asset pending
 
 - Release job: `Build macOS installer (.pkg)` succeeded
   ([job `76633468317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76633468317)).
@@ -119,6 +141,22 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
   provisioning, remote fixture seed, E2EE negative/positive pull, daemon
   storage `[ok]`, FileProvider exact hydrate, host evict/rehydrate, mutation
   round trip, and conflict/status fixture checks.
+- Later main-ref repeatability exposed a narrower CloudStorage root authority
+  split: shell/raw-path root enumeration can fail with
+  `NSCocoaErrorDomain code=257` / `NSPOSIXErrorDomain(1)` while FileProvider
+  control APIs see a healthy root.
+- Diagnostic package run
+  [`26117175542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542)
+  against notarized package artifact run
+  [`26116692781`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781)
+  from `66ae92f` passed: the installed signed HostApp resolved
+  `getUserVisibleURL(.rootContainer)`, enumerated `.Trash` and `ci-smoke`, then
+  passed exact hydrate, evict/rehydrate, mutation, and conflict/status. No
+  `failure-classification.txt` was produced.
+- Release run
+  [`26117684515`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515)
+  was dispatched for `v0.12.13-rc2`; the row is not complete until the exact
+  published rc2 `.pkg` passes the same PZM postinstall smoke.
 - Not proven in this rc1 packet: clean-host first-run UX from package install to
   working `tcfs status [ok]`. That remains TIN-1425 scope.
 
@@ -156,7 +194,7 @@ bookworm-specific package or static build is added.
 - Not proven in this rc1 packet: Fedora 42 install smoke with
   `scripts/install-smoke.sh --skip-cli`.
 
-### 6. Container image — multi-arch build/signature pass
+### 6. Container image — multi-arch runtime smoke pass
 
 - Release job: `Build container image` succeeded
   ([job `76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828)).
@@ -165,10 +203,13 @@ bookworm-specific package or static build is added.
 - Tags published by the job:
   - `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1`
   - `ghcr.io/jesssullivan/tcfsd:0.12.13-rc1`
-  - `ghcr.io/jesssullivan/tcfsd:latest`
 - The immutable digest was signed with Cosign keyless OIDC.
-- Not proven in this rc1 packet: `docker run`/`podman run` worker-mode runtime
-  smoke against the published image.
+- Runtime smoke run
+  [`26083222949`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26083222949)
+  passed on `main` after PR #392 landed for `linux/amd64` and `linux/arm64/v8`:
+  manifest inspect, platform pull, `tcfsd 0.12.13` version check, worker-mode
+  startup, and artifact upload completed.
+- Not proven in this rc1 packet: full worker execution against live NATS/S3.
 
 ### 7. Nix flake install — build/cache pass; external profile install pending
 
@@ -211,11 +252,12 @@ Full evidence packet at
 [`docs/release/evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/`](evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/).
 
 The rc1 release rebuilt the same `.pkg` surface from commit `985e704` (the tag's
-HEAD), which contains the same FileProvider extension code. Run `26079830341`
-then confirmed the exact published release asset after PR #389 fixed the
-prerelease asset-version vs Cargo binary-version smoke gate. A separate
-main-ref rerun is useful for continuous release-day viability, but the release
-asset itself is no longer only an inferred proof.
+HEAD). Run `26079830341` confirmed the exact published release asset after PR
+#389 fixed the prerelease asset-version vs Cargo binary-version smoke gate.
+Later main-ref reruns exposed the raw CloudStorage root authority split and led
+to the signed HostApp root-probe path in PR #405. The freshest evidence is the
+`66ae92f` diagnostic package pass in run `26117175542`; the next public-release
+closure step is the rc2 exact-asset smoke after run `26117684515` publishes.
 
 ## Blockers And Unblock Paths
 
@@ -272,3 +314,7 @@ Same as v0.12.2:
   smoke gaps explicit.
 - 2026-05-19 — Added post-cut exact macOS release `.pkg` proof from run
   `26079830341` and documented the remaining first-run UX gap separately.
+- 2026-05-19 — Added late-day posture update: Homebrew and container runtime
+  smokes are green; macOS diagnostic package at `66ae92f` passed through the
+  signed HostApp user-visible root path; `v0.12.13-rc2` is running to turn that
+  diagnostic pass into an exact published package proof.


### PR DESCRIPTION
## Summary
- refresh the v0.12.13 evidence matrix with the late May 19 posture: Homebrew/container smokes are green, macOS diagnostic artifact `66ae92f` is green, and rc2 is the exact published-asset closure path
- update the alpha/beta readiness doc so alpha macOS wording waits for the rc2 release-asset smoke instead of over-reading rc1
- update the FileProvider reality summary with the signed HostApp user-visible root finding from run `26117175542`

## Evidence
- macOS diagnostic package smoke: https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542
- notarized package artifact source: https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781
- rc2 release workflow in flight: https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515
- Homebrew install smoke: https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508
- container runtime smoke: https://github.com/Jesssullivan/tummycrypt/actions/runs/26083222949

## Validation
- `git diff --check`

## Claim Boundary
This is documentation/tracker truthing only. It does not claim the exact published `v0.12.13-rc2` package has passed yet; that remains the next smoke after the release assets publish.
