### PR TITLE
fileprovider: harden rename and unsync semantics (TIN-1547)

### DIFF
--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -807,6 +807,29 @@ pub unsafe extern "C" fn tcfs_provider_delete(
     result.unwrap_or(TcfsError::TcfsErrorInternal)
 }
 
+/// Mark an item as unsynced without deleting remote storage.
+///
+/// The direct backend has no daemon-local materialization state to evict, so
+/// this is intentionally a no-op. Swift uses this separate entry point for the
+/// FileProvider "Free Up Space" action so the action cannot accidentally share
+/// the destructive remote-delete path.
+///
+/// # Safety
+///
+/// - `provider` must be a valid pointer from `tcfs_provider_new`.
+/// - `item_id` must be a valid null-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn tcfs_provider_unsync(
+    provider: *mut TcfsProvider,
+    item_id: *const c_char,
+) -> TcfsError {
+    if provider.is_null() || item_id.is_null() {
+        return TcfsError::TcfsErrorInvalidArg;
+    }
+
+    TcfsError::TcfsErrorNone
+}
+
 /// Create a directory under the given parent path.
 ///
 /// # Safety

--- a/crates/tcfs-file-provider/src/grpc_backend.rs
+++ b/crates/tcfs-file-provider/src/grpc_backend.rs
@@ -249,6 +249,31 @@ async fn fetch_direct_to_file(
     .map(|_| ())
 }
 
+async fn delete_remote_entry(
+    operator: &opendal::Operator,
+    remote_prefix: &str,
+    item_id: &str,
+) -> anyhow::Result<()> {
+    let index_key = format!(
+        "{}/index/{}",
+        remote_prefix.trim_end_matches('/'),
+        item_id.trim_start_matches('/')
+    );
+    let index_data = operator.read(&index_key).await;
+    if let Ok(data) = index_data {
+        let bytes = data.to_bytes();
+        let manifest_prefix = format!("{}/manifests", remote_prefix.trim_end_matches('/'));
+        if let Ok(entry) = tcfs_sync::index_entry::parse_index_entry_record(&bytes) {
+            for manifest_path in entry.referenced_object_keys(&manifest_prefix) {
+                let _ = operator.delete(&manifest_path).await;
+            }
+        }
+    }
+
+    operator.delete(&index_key).await?;
+    Ok(())
+}
+
 /// Create a new provider from a JSON configuration string.
 ///
 /// The JSON should contain:
@@ -866,7 +891,7 @@ pub unsafe extern "C" fn tcfs_provider_upload(
     result.unwrap_or(TcfsError::TcfsErrorInternal)
 }
 
-/// Delete a file via the daemon (unsync then delete remote).
+/// Delete a file from remote storage.
 ///
 /// # Safety
 ///
@@ -888,8 +913,66 @@ pub unsafe extern "C" fn tcfs_provider_delete(
             Ok(s) => s,
             Err(_) => return TcfsError::TcfsErrorInvalidArg,
         };
+        prov.clear_last_error();
 
         let delete_result = prov.runtime.block_on(async {
+            let operator = prov.direct_operator.clone().ok_or_else(|| {
+                anyhow::anyhow!("remote delete requires direct storage credentials")
+            })?;
+            delete_remote_entry(&operator, &prov.remote_prefix, item_str).await?;
+
+            // Best-effort local eviction after the authoritative remote delete.
+            let _ = prov
+                .client
+                .unsync(tonic::Request::new(tcfs_core::proto::UnsyncRequest {
+                    path: item_str.to_string(),
+                    force: true,
+                }))
+                .await;
+
+            Ok::<(), anyhow::Error>(())
+        });
+
+        match delete_result {
+            Ok(()) => TcfsError::TcfsErrorNone,
+            Err(e) => {
+                let message = format!("{e:#}");
+                tracing::error!("delete failed: {message}");
+                prov.set_last_error(message);
+                prov.try_reconnect();
+                TcfsError::TcfsErrorStorage
+            }
+        }
+    }));
+
+    result.unwrap_or(TcfsError::TcfsErrorInternal)
+}
+
+/// Evict local materialization without deleting remote storage.
+///
+/// # Safety
+///
+/// - `provider` must be a valid pointer from `tcfs_provider_new`.
+/// - `item_id` must be a valid null-terminated UTF-8 C string.
+#[no_mangle]
+pub unsafe extern "C" fn tcfs_provider_unsync(
+    provider: *mut TcfsProvider,
+    item_id: *const c_char,
+) -> TcfsError {
+    if provider.is_null() || item_id.is_null() {
+        return TcfsError::TcfsErrorInvalidArg;
+    }
+
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let prov = unsafe { &mut *provider };
+        let c_item = unsafe { CStr::from_ptr(item_id) };
+        let item_str = match c_item.to_str() {
+            Ok(s) => s,
+            Err(_) => return TcfsError::TcfsErrorInvalidArg,
+        };
+        prov.clear_last_error();
+
+        let unsync_result = prov.runtime.block_on(async {
             let resp = prov
                 .client
                 .unsync(tonic::Request::new(tcfs_core::proto::UnsyncRequest {
@@ -906,10 +989,12 @@ pub unsafe extern "C" fn tcfs_provider_delete(
             Ok::<(), tonic::Status>(())
         });
 
-        match delete_result {
+        match unsync_result {
             Ok(()) => TcfsError::TcfsErrorNone,
             Err(e) => {
-                tracing::error!("delete failed: {}, attempting reconnect", e);
+                let message = format!("{e:#}");
+                tracing::error!("unsync failed: {message}");
+                prov.set_last_error(message);
                 prov.try_reconnect();
                 TcfsError::TcfsErrorStorage
             }

--- a/crates/tcfs-file-provider/tests/ffi_safety_test.rs
+++ b/crates/tcfs-file-provider/tests/ffi_safety_test.rs
@@ -227,6 +227,17 @@ fn delete_null_provider_returns_invalid_arg() {
     }
 }
 
+// ── tcfs_provider_unsync null safety ─────────────────────────────────────
+
+#[test]
+fn unsync_null_provider_returns_invalid_arg() {
+    let item = CString::new("test").unwrap();
+    unsafe {
+        let err = tcfs_provider_unsync(ptr::null_mut(), item.as_ptr());
+        assert!(matches!(err, TcfsError::TcfsErrorInvalidArg));
+    }
+}
+
 // ── tcfs_provider_create_dir null safety ─────────────────────────────────
 
 #[test]

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -347,6 +347,96 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         }
 
         DispatchQueue.global(qos: .userInitiated).async {
+            if changedFields.contains(.filename) {
+                let oldPath = item.itemIdentifier.rawValue
+                let parentPath = Self.logicalParentPath(item.parentItemIdentifier)
+                let newRemotePath = parentPath.isEmpty ? item.filename : "\(parentPath)/\(item.filename)"
+
+                if oldPath == newRemotePath {
+                    progress.completedUnitCount = 100
+                    completionHandler(item, [], false, nil)
+                    return
+                }
+
+                if item.contentType == .folder {
+                    logger.error("rename unsupported for directory \(oldPath, privacy: .public)")
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, NSFileProviderError(.serverUnreachable))
+                    return
+                }
+
+                var sourceURL: URL
+                var tempURL: URL?
+                var accessedSecurityScope = false
+
+                if changedFields.contains(.contents), let contentsURL = newContents {
+                    sourceURL = contentsURL
+                    accessedSecurityScope = contentsURL.startAccessingSecurityScopedResource()
+                } else {
+                    let fetchedURL = FileManager.default.temporaryDirectory
+                        .appendingPathComponent(UUID().uuidString)
+                    let fetchResult = oldPath.withCString { oldPtr in
+                        fetchedURL.path.withCString { destPtr in
+                            tcfs_provider_fetch(prov, oldPtr, destPtr)
+                        }
+                    }
+                    if fetchResult != TCFS_ERROR_TCFS_ERROR_NONE {
+                        progress.completedUnitCount = 100
+                        completionHandler(nil, [], false, Self.mapError(fetchResult))
+                        return
+                    }
+                    sourceURL = fetchedURL
+                    tempURL = fetchedURL
+                }
+
+                defer {
+                    if accessedSecurityScope {
+                        sourceURL.stopAccessingSecurityScopedResource()
+                    }
+                    if let tempURL {
+                        try? FileManager.default.removeItem(at: tempURL)
+                    }
+                }
+
+                let uploadResult = sourceURL.path.withCString { localPtr in
+                    newRemotePath.withCString { remotePtr in
+                        tcfs_provider_upload(prov, localPtr, remotePtr)
+                    }
+                }
+                if uploadResult != TCFS_ERROR_TCFS_ERROR_NONE {
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(uploadResult))
+                    return
+                }
+
+                let deleteResult = oldPath.withCString { oldPtr in
+                    tcfs_provider_delete(prov, oldPtr)
+                }
+                if deleteResult != TCFS_ERROR_TCFS_ERROR_NONE {
+                    logger.error(
+                        "rename copied \(oldPath, privacy: .public) to \(newRemotePath, privacy: .public), but old path delete failed: \(deleteResult.rawValue)"
+                    )
+                    progress.completedUnitCount = 100
+                    completionHandler(nil, [], false, Self.mapError(deleteResult))
+                    return
+                }
+
+                let fileSize = (try? FileManager.default.attributesOfItem(atPath: sourceURL.path)[.size] as? UInt64) ?? 0
+                let renamedItem = TCFSFileProviderItem(
+                    identifier: NSFileProviderItemIdentifier(newRemotePath),
+                    parentIdentifier: item.parentItemIdentifier,
+                    filename: item.filename,
+                    isDirectory: false,
+                    fileSize: fileSize,
+                    downloaded: true,
+                    uploaded: true
+                )
+                progress.completedUnitCount = 100
+                self.signalEnumeratorUpdate(for: item.parentItemIdentifier)
+                completionHandler(renamedItem, [], false, nil)
+                return
+            }
+
             // Handle content modification (re-upload)
             if changedFields.contains(.contents), let contentsURL = newContents {
                 let accessed = contentsURL.startAccessingSecurityScopedResource()
@@ -377,32 +467,6 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     progress.completedUnitCount = 100
                     completionHandler(nil, [], false, Self.mapError(result))
                 }
-            } else if changedFields.contains(.filename) {
-                // Rename: delete old index entry, re-upload to new path
-                let oldPath = item.itemIdentifier.rawValue
-                let parentPath = Self.logicalParentPath(item.parentItemIdentifier)
-                let newRemotePath = parentPath.isEmpty ? item.filename : "\(parentPath)/\(item.filename)"
-
-                // Delete old entry
-                let deleteResult = oldPath.withCString { idPtr in
-                    tcfs_provider_delete(prov, idPtr)
-                }
-                if deleteResult != TCFS_ERROR_TCFS_ERROR_NONE {
-                    progress.completedUnitCount = 100
-                    completionHandler(nil, [], false, Self.mapError(deleteResult))
-                    return
-                }
-
-                let renamedItem = TCFSFileProviderItem(
-                    identifier: NSFileProviderItemIdentifier(newRemotePath),
-                    parentIdentifier: item.parentItemIdentifier,
-                    filename: item.filename,
-                    isDirectory: item.contentType == .folder,
-                    fileSize: (item.documentSize as? UInt64) ?? 0
-                )
-                progress.completedUnitCount = 100
-                self.signalEnumeratorUpdate(for: item.parentItemIdentifier)
-                completionHandler(renamedItem, [], false, nil)
             } else {
                 // No content or filename change — return item as-is
                 progress.completedUnitCount = 100
@@ -661,10 +725,10 @@ extension TCFSFileProviderExtension: NSFileProviderCustomAction {
 
                 switch actionIdentifier.rawValue {
                 case "io.tinyland.tcfs.action.unsync":
-                    // Dehydrate: call daemon's Unsync/Delete RPC to free disk space
+                    // Dehydrate without deleting remote storage.
                     logger.info("action.unsync: \(itemPath)")
                     let result = itemPath.withCString { pathPtr in
-                        tcfs_provider_delete(prov, pathPtr)
+                        tcfs_provider_unsync(prov, pathPtr)
                     }
                     if result != TCFS_ERROR_TCFS_ERROR_NONE {
                         logger.error("action.unsync failed for \(itemPath): \(result.rawValue)")


### PR DESCRIPTION
## Summary

- handles FileProvider file renames as copy/upload-before-delete instead of deleting the old remote path first
- rejects directory rename explicitly for now rather than pretending the operation succeeded
- splits the FileProvider `Free Up Space` action onto a new `tcfs_provider_unsync` FFI entry point so local eviction cannot share the destructive remote-delete path
- makes the gRPC backend's `tcfs_provider_delete` perform actual remote index/manifest deletion when direct storage credentials are available, then best-effort local eviction

## Why

TIN-1547 is blocked on production FileProvider hardening after M10. The existing rename path could acknowledge a rename after deleting the old path without proving new content was present at the target. The custom unsync action also reused the destructive delete entry point, which is the wrong safety boundary for alpha/beta Finder usage.

## Validation

- `~/.cargo/bin/cargo test -p tcfs-file-provider unsync_null_provider_returns_invalid_arg`
- `~/.cargo/bin/cargo build -p tcfs-file-provider --release -j 4`
- `TCFS_EMBED_FILEPROVIDER_CONFIG=0 swift/fileprovider/build.sh target/release <generated header> /tmp/tcfs-fileprovider-build-check/output -`
- `~/.cargo/bin/cargo test -p tcfs-file-provider`
- `git diff --check`

## Boundaries

- This does not prove exact-file hydration on the signed production `.pkg`; that still needs the rc2 postinstall smoke against the published asset.
- Directory rename remains unsupported and returns an error.
- Direct backend `tcfs_provider_unsync` is intentionally a no-op because that backend has no daemon-local materialization state to evict.
- gRPC remote delete requires direct storage credentials; without them it fails closed instead of silently doing only local unsync.
