### PR TITLE
storage: support custom CA for posture canary (TIN-1546)

### DIFF
--- a/.github/workflows/storage-posture-canary.yml
+++ b/.github/workflows/storage-posture-canary.yml
@@ -52,6 +52,7 @@ jobs:
       TCFS_SMOKE_S3_ACCESS_KEY_ID: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
       TCFS_SMOKE_S3_SECRET_ACCESS_KEY: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
       TCFS_SMOKE_S3_REGION: ${{ secrets.TCFS_SMOKE_S3_REGION }}
+      TCFS_SMOKE_S3_CA_CERT_PEM: ${{ secrets.TCFS_SMOKE_S3_CA_CERT_PEM }}
       AWS_ACCESS_KEY_ID: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
     steps:
@@ -178,6 +179,13 @@ jobs:
           fi
 
           CONFIG_PATH="$RUNNER_TEMP/tcfs-storage-canary.toml"
+          CA_CERT_PATH=""
+          if [[ -n "${TCFS_SMOKE_S3_CA_CERT_PEM:-}" ]]; then
+            CA_CERT_PATH="$RUNNER_TEMP/tcfs-storage-ca.pem"
+            printf '%s\n' "$TCFS_SMOKE_S3_CA_CERT_PEM" > "$CA_CERT_PATH"
+            chmod 600 "$CA_CERT_PATH"
+          fi
+
           cat > "$CONFIG_PATH" <<EOF
           [storage]
           endpoint = "$TCFS_SMOKE_S3_ENDPOINT"
@@ -190,11 +198,15 @@ jobs:
           s3_pool_max_idle_per_host = 8
           max_concurrent_ops = 4
           EOF
+          if [[ -n "$CA_CERT_PATH" ]]; then
+            printf 'ca_cert_path = "%s"\n' "$CA_CERT_PATH" >> "$CONFIG_PATH"
+          fi
 
           {
             echo "CONFIG_PATH=$CONFIG_PATH"
             echo "REMOTE_PREFIX=$REMOTE_PREFIX"
             echo "STORAGE_ENFORCE_TLS=$ENFORCE_TLS"
+            echo "CA_CERT_PATH=$CA_CERT_PATH"
           } >> "$GITHUB_ENV"
 
           {
@@ -207,7 +219,8 @@ jobs:
             echo "remote_prefix=$REMOTE_PREFIX"
             echo "enforce_tls=$ENFORCE_TLS"
             echo "require_https=${{ github.event.inputs.require_https }}"
-            echo "ca_cert_path_supported=false"
+            echo "ca_cert_path_supported=true"
+            echo "ca_cert_path_configured=$([[ -n "$CA_CERT_PATH" ]] && echo true || echo false)"
           } > "$LOG_DIR/storage-posture.env"
 
       - name: Run scoped storage canary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5439,6 +5439,7 @@ dependencies = [
  "reqwest",
  "serde",
  "tcfs-core",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -2395,6 +2395,7 @@ async fn cmd_mount(
         s3_pool_idle_timeout_secs: config.storage.s3_pool_idle_timeout_secs,
         s3_pool_max_idle_per_host: config.storage.s3_pool_max_idle_per_host,
         s3_http1_only: config.storage.s3_http1_only,
+        ca_cert_path: config.storage.ca_cert_path.clone(),
     };
     let op = tcfs_storage::operator::build_operator_with_limits(
         &storage_cfg,

--- a/crates/tcfs-storage/Cargo.toml
+++ b/crates/tcfs-storage/Cargo.toml
@@ -17,4 +17,5 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+tempfile = { workspace = true }
 tokio-test = { workspace = true }

--- a/crates/tcfs-storage/src/operator.rs
+++ b/crates/tcfs-storage/src/operator.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 use opendal::raw::HttpClient;
 use opendal::Operator;
+use std::path::PathBuf;
 use std::time::Duration;
 
 /// Minimal config needed to build an operator
@@ -18,6 +19,7 @@ pub struct StorageConfig {
     pub s3_pool_idle_timeout_secs: u64,
     pub s3_pool_max_idle_per_host: usize,
     pub s3_http1_only: bool,
+    pub ca_cert_path: Option<PathBuf>,
 }
 
 impl Default for StorageConfig {
@@ -32,6 +34,7 @@ impl Default for StorageConfig {
             s3_pool_idle_timeout_secs: 0,
             s3_pool_max_idle_per_host: 0,
             s3_http1_only: false,
+            ca_cert_path: None,
         }
     }
 }
@@ -95,13 +98,21 @@ fn build_s3_http_client(cfg: &StorageConfig) -> Result<Option<HttpClient>> {
     let custom_client_requested = cfg.s3_connect_timeout_secs > 0
         || cfg.s3_pool_idle_timeout_secs > 0
         || cfg.s3_pool_max_idle_per_host > 0
-        || cfg.s3_http1_only;
+        || cfg.s3_http1_only
+        || cfg.ca_cert_path.is_some();
 
     if !custom_client_requested {
         return Ok(None);
     }
 
     let mut builder = reqwest::Client::builder();
+    if let Some(path) = &cfg.ca_cert_path {
+        let pem = std::fs::read(path)
+            .with_context(|| format!("reading S3 CA certificate {}", path.display()))?;
+        let cert = reqwest::Certificate::from_pem(&pem)
+            .with_context(|| format!("parsing S3 CA certificate {}", path.display()))?;
+        builder = builder.add_root_certificate(cert);
+    }
     if cfg.s3_connect_timeout_secs > 0 {
         builder = builder.connect_timeout(Duration::from_secs(cfg.s3_connect_timeout_secs));
     }
@@ -121,6 +132,10 @@ fn build_s3_http_client(cfg: &StorageConfig) -> Result<Option<HttpClient>> {
         s3_pool_idle_timeout_secs = cfg.s3_pool_idle_timeout_secs,
         s3_pool_max_idle_per_host = cfg.s3_pool_max_idle_per_host,
         s3_http1_only = cfg.s3_http1_only,
+        ca_cert_path = cfg
+            .ca_cert_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
         "S3 HTTP client controls enabled"
     );
     Ok(Some(HttpClient::with(client)))
@@ -161,6 +176,7 @@ pub fn build_from_core_config(
             s3_pool_idle_timeout_secs: storage.s3_pool_idle_timeout_secs,
             s3_pool_max_idle_per_host: storage.s3_pool_max_idle_per_host,
             s3_http1_only: storage.s3_http1_only,
+            ca_cert_path: storage.ca_cert_path.clone(),
         },
         storage.max_concurrent_ops,
     )
@@ -196,6 +212,7 @@ mod tests {
             s3_pool_idle_timeout_secs: 15,
             s3_pool_max_idle_per_host: 4,
             s3_http1_only: true,
+            ca_cert_path: None,
         };
 
         assert!(
@@ -205,6 +222,28 @@ mod tests {
         assert!(
             build_operator_with_limits(&cfg, 4).is_ok(),
             "operator construction should succeed with S3 HTTP controls and concurrency limits"
+        );
+    }
+
+    #[test]
+    fn test_build_s3_http_client_reads_configured_ca_cert_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca_path = dir.path().join("missing-ca.pem");
+
+        let cfg = StorageConfig {
+            endpoint: "https://s3.example.com".to_string(),
+            region: "us-east-1".to_string(),
+            bucket: "test-bucket".to_string(),
+            access_key_id: "test-key".to_string(),
+            secret_access_key: "test-secret".to_string(),
+            ca_cert_path: Some(ca_path.clone()),
+            ..Default::default()
+        };
+
+        let err = build_s3_http_client(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("reading S3 CA certificate"),
+            "missing CA error should name the CA read failure: {err}"
         );
     }
 
@@ -246,5 +285,23 @@ mod tests {
         };
         let result = build_from_core_config(&storage, "key", "secret");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_build_from_core_config_uses_ca_cert_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca_path = dir.path().join("missing-ca.pem");
+        let storage = tcfs_core::config::StorageConfig {
+            endpoint: "https://s3.example.com:8333".into(),
+            enforce_tls: true,
+            ca_cert_path: Some(ca_path),
+            ..Default::default()
+        };
+
+        let err = build_from_core_config(&storage, "key", "secret").unwrap_err();
+        assert!(
+            err.to_string().contains("reading S3 CA certificate"),
+            "core config CA path should be passed to the operator: {err}"
+        );
     }
 }

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -41,11 +41,15 @@ Required secrets:
 Optional secret:
 
 - `TCFS_SMOKE_S3_REGION`
+- `TCFS_SMOKE_S3_CA_CERT_PEM` — PEM-encoded custom root CA for private HTTPS
+  endpoints that are not signed by a public trust root
 
 The endpoint must be reachable from the selected runner. For GitHub-hosted
 Linux, it must be public HTTPS. For a private self-hosted runner, it may be
 private, but `require_https=true` still requires the endpoint URL to start with
-`https://`.
+`https://`. If the endpoint uses a private CA, set `TCFS_SMOKE_S3_CA_CERT_PEM`;
+the workflow writes it to a run-scoped file and passes it as
+`storage.ca_cert_path`.
 
 ## Credential Bar
 
@@ -118,7 +122,8 @@ The workflow run must complete successfully and upload its evidence artifact.
 - remote prefix
 - `require_https=true`
 - `enforce_tls=true`
-- whether custom CA support was required
+- `ca_cert_path_supported=true`
+- whether a custom CA was configured for the run
 
 The Linear/GitHub closeout comment should also include the credential scope in
 plain language. Do not paste secrets.


### PR DESCRIPTION
## Summary
- wire `storage.ca_cert_path` through `tcfs-storage` reqwest/OpenDAL operator construction
- pass custom CA config through the direct CLI mount operator path
- let `storage-posture-canary.yml` consume optional `TCFS_SMOKE_S3_CA_CERT_PEM` and record CA support/configuration in the evidence packet
- update the TIN-1546 production storage posture handoff with the custom CA secret

## Validation
- `~/.cargo/bin/cargo test -p tcfs-storage`
- `~/.cargo/bin/cargo check -p tcfs-cli --no-default-features`
- `git diff --check`

## Boundary
This makes the HTTPS/private-CA storage packet runnable once scoped secrets exist. It does not provide the live TIN-1546 evidence by itself.
