### PR TITLE
storage: prove scoped credential denial in canary (TIN-1546)

### DIFF
--- a/.github/workflows/storage-posture-canary.yml
+++ b/.github/workflows/storage-posture-canary.yml
@@ -5,7 +5,9 @@ name: Storage Posture Canary
 # This workflow turns `tcfs storage canary --json` into an archived evidence
 # lane. It intentionally does not claim broad production S3 readiness by itself:
 # the run proves one scoped write/read/delete/delete-verify operation plus
-# endpoint TLS posture for the selected environment.
+# endpoint TLS posture for the selected environment. When scope_deny_prefix is
+# provided, it also proves the selected credentials cannot write outside the
+# intended prefix.
 
 on:
   workflow_dispatch:
@@ -22,6 +24,11 @@ on:
         type: string
       remote_prefix:
         description: "Remote prefix for the canary object; default is gha/storage-posture/<run>"
+        required: false
+        default: ""
+        type: string
+      scope_deny_prefix:
+        description: "Optional prefix that must reject canary writes, proving credential scope"
         required: false
         default: ""
         type: string
@@ -172,6 +179,9 @@ jobs:
           fi
           REMOTE_PREFIX="${REMOTE_PREFIX#/}"
           REMOTE_PREFIX="${REMOTE_PREFIX%/}"
+          SCOPE_DENY_PREFIX="${{ github.event.inputs.scope_deny_prefix }}"
+          SCOPE_DENY_PREFIX="${SCOPE_DENY_PREFIX#/}"
+          SCOPE_DENY_PREFIX="${SCOPE_DENY_PREFIX%/}"
           ENFORCE_TLS=false
           if [[ "${{ github.event.inputs.require_https }}" == "true" \
                 || "$TCFS_SMOKE_S3_ENDPOINT" == https://* ]]; then
@@ -205,6 +215,7 @@ jobs:
           {
             echo "CONFIG_PATH=$CONFIG_PATH"
             echo "REMOTE_PREFIX=$REMOTE_PREFIX"
+            echo "SCOPE_DENY_PREFIX=$SCOPE_DENY_PREFIX"
             echo "STORAGE_ENFORCE_TLS=$ENFORCE_TLS"
             echo "CA_CERT_PATH=$CA_CERT_PATH"
           } >> "$GITHUB_ENV"
@@ -217,6 +228,7 @@ jobs:
             echo "endpoint=$TCFS_SMOKE_S3_ENDPOINT"
             echo "bucket=$TCFS_SMOKE_S3_BUCKET"
             echo "remote_prefix=$REMOTE_PREFIX"
+            echo "scope_deny_prefix=$SCOPE_DENY_PREFIX"
             echo "enforce_tls=$ENFORCE_TLS"
             echo "require_https=${{ github.event.inputs.require_https }}"
             echo "ca_cert_path_supported=true"
@@ -227,12 +239,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cargo run -p tcfs-cli --no-default-features -- \
+          args=(
             --config "$CONFIG_PATH" \
             storage canary \
             --prefix "$REMOTE_PREFIX" \
             --timeout-secs "${{ github.event.inputs.timeout_secs }}" \
-            --json \
+            --json
+          )
+          if [[ -n "${SCOPE_DENY_PREFIX:-}" ]]; then
+            args+=(--expect-deny-prefix "$SCOPE_DENY_PREFIX")
+          fi
+          cargo run -p tcfs-cli --no-default-features -- "${args[@]}" \
             | tee "$LOG_DIR/storage-canary.json"
 
       - name: Validate canary report
@@ -249,6 +266,11 @@ jobs:
 
           assert report["deleted"] is True, "delete verification must pass"
           assert report["bytes"] > 0, "canary payload must be non-empty"
+          if scope_deny := report.get("scope_deny"):
+              assert scope_deny["denied"] is True, "scope-deny probe must be denied"
+              assert scope_deny["error_kind"] == "PermissionDenied", (
+                  "scope-deny probe must fail with PermissionDenied"
+              )
           if require_https:
               assert report["endpoint_tls"] is True, "endpoint_tls must be true"
               assert report["enforce_tls"] is True, "enforce_tls must be true"

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -327,6 +327,9 @@ enum StorageAction {
         /// Remote prefix override (default: storage.remote_prefix or bucket)
         #[arg(long, short = 'p')]
         prefix: Option<String>,
+        /// Prefix that must reject canary writes with PermissionDenied
+        #[arg(long, value_name = "PREFIX")]
+        expect_deny_prefix: Option<String>,
         /// Per-operation timeout in seconds
         #[arg(long, default_value = "5")]
         timeout_secs: u64,
@@ -342,6 +345,8 @@ struct StorageCanaryReport {
     bucket: String,
     prefix: String,
     key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope_deny: Option<StorageCanaryScopeDenyReport>,
     bytes: usize,
     write_ms: u128,
     read_ms: u128,
@@ -350,6 +355,15 @@ struct StorageCanaryReport {
     deleted: bool,
     endpoint_tls: bool,
     enforce_tls: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct StorageCanaryScopeDenyReport {
+    prefix: String,
+    key: String,
+    write_ms: u128,
+    error_kind: String,
+    denied: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -1594,6 +1608,7 @@ async fn cmd_storage(config: &tcfs_core::config::TcfsConfig, action: StorageActi
     match action {
         StorageAction::Canary {
             prefix,
+            expect_deny_prefix,
             timeout_secs,
             json,
         } => {
@@ -1607,11 +1622,20 @@ async fn cmd_storage(config: &tcfs_core::config::TcfsConfig, action: StorageActi
                         .trim_matches('/')
                         .to_string()
                 });
+            let expect_deny_prefix = expect_deny_prefix
+                .map(|s| s.trim_matches('/').to_string())
+                .filter(|s| !s.is_empty());
             let timeout = Duration::from_secs(timeout_secs.max(1));
             let nonce = new_storage_canary_nonce();
-            let report =
-                run_storage_canary_with_operator(config, &op, &remote_prefix, &nonce, timeout)
-                    .await?;
+            let report = run_storage_canary_with_operator(
+                config,
+                &op,
+                &remote_prefix,
+                expect_deny_prefix.as_deref(),
+                &nonce,
+                timeout,
+            )
+            .await?;
 
             if json {
                 println!("{}", serde_json::to_string_pretty(&report)?);
@@ -1626,6 +1650,12 @@ async fn cmd_storage(config: &tcfs_core::config::TcfsConfig, action: StorageActi
                 println!("  read:     {} ms", report.read_ms);
                 println!("  delete:   {} ms", report.delete_ms);
                 println!("  verify:   {} ms", report.verify_delete_ms);
+                if let Some(scope_deny) = &report.scope_deny {
+                    println!(
+                        "  scope:    deny write to {} ({}, {} ms)",
+                        scope_deny.key, scope_deny.error_kind, scope_deny.write_ms
+                    );
+                }
                 println!(
                     "  tls:      endpoint={}, enforce_tls={}",
                     report.endpoint_tls, report.enforce_tls
@@ -1657,6 +1687,7 @@ async fn run_storage_canary_with_operator(
     config: &tcfs_core::config::TcfsConfig,
     op: &opendal::Operator,
     prefix: &str,
+    expect_deny_prefix: Option<&str>,
     nonce: &str,
     timeout: Duration,
 ) -> Result<StorageCanaryReport> {
@@ -1708,11 +1739,18 @@ async fn run_storage_canary_with_operator(
         "storage canary delete verification failed; object still exists: {key}"
     );
 
+    let scope_deny = if let Some(deny_prefix) = expect_deny_prefix {
+        Some(run_storage_canary_scope_deny_probe(op, prefix, deny_prefix, nonce, timeout).await?)
+    } else {
+        None
+    };
+
     Ok(StorageCanaryReport {
         endpoint: config.storage.endpoint.clone(),
         bucket: config.storage.bucket.clone(),
         prefix: prefix.to_string(),
         key,
+        scope_deny,
         bytes: payload.len(),
         write_ms,
         read_ms,
@@ -1722,6 +1760,54 @@ async fn run_storage_canary_with_operator(
         endpoint_tls: config.storage.endpoint.starts_with("https://"),
         enforce_tls: config.storage.enforce_tls,
     })
+}
+
+async fn run_storage_canary_scope_deny_probe(
+    op: &opendal::Operator,
+    allowed_prefix: &str,
+    deny_prefix: &str,
+    nonce: &str,
+    timeout: Duration,
+) -> Result<StorageCanaryScopeDenyReport> {
+    let key = storage_canary_key(deny_prefix, nonce);
+    anyhow::ensure!(
+        key != storage_canary_key(allowed_prefix, nonce),
+        "--expect-deny-prefix resolves to the same canary key as --prefix: {key}"
+    );
+
+    let payload = format!(
+        "tcfs storage canary forbidden-scope probe\nallowed_prefix={allowed_prefix}\ndeny_prefix={deny_prefix}\nkey={key}\nnonce={nonce}\n",
+    )
+    .into_bytes();
+
+    let write_start = std::time::Instant::now();
+    let write_result = tokio::time::timeout(timeout, op.write(&key, payload)).await;
+    let write_ms = write_start.elapsed().as_millis();
+
+    match write_result {
+        Err(_) => {
+            anyhow::bail!("storage canary deny-scope write timed out after {timeout:?}: {key}")
+        }
+        Ok(Err(err)) if err.kind() == opendal::ErrorKind::PermissionDenied => {
+            Ok(StorageCanaryScopeDenyReport {
+                prefix: deny_prefix.to_string(),
+                key,
+                write_ms,
+                error_kind: err.kind().to_string(),
+                denied: true,
+            })
+        }
+        Ok(Err(err)) => anyhow::bail!(
+            "storage canary deny-scope write failed with {}, expected PermissionDenied: {key}",
+            err.kind()
+        ),
+        Ok(Ok(_)) => {
+            let _ = tokio::time::timeout(timeout, op.delete(&key)).await;
+            anyhow::bail!(
+                "storage canary deny-scope write unexpectedly succeeded; credentials are not scoped away from {key}"
+            )
+        }
+    }
 }
 
 // ── `tcfs migrate-prefix` ────────────────────────────────────────────────────
@@ -4877,6 +4963,7 @@ enabled = false
             &config,
             &op,
             "data",
+            None,
             "test-nonce",
             Duration::from_secs(1),
         )
@@ -4885,7 +4972,57 @@ enabled = false
 
         assert_eq!(report.key, "data/.tcfs-canary/test-nonce.txt");
         assert!(report.deleted);
+        assert!(report.scope_deny.is_none());
         assert!(!op.exists(&report.key).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn storage_canary_rejects_same_scope_deny_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let op = memory_op();
+
+        let err = run_storage_canary_with_operator(
+            &config,
+            &op,
+            "data",
+            Some("/data/"),
+            "test-nonce",
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("same canary key"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn storage_canary_fails_when_deny_prefix_is_writable() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let op = memory_op();
+
+        let err = run_storage_canary_with_operator(
+            &config,
+            &op,
+            "data",
+            Some("outside"),
+            "test-nonce",
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("unexpectedly succeeded"),
+            "unexpected error: {err}"
+        );
+        assert!(!op
+            .exists("outside/.tcfs-canary/test-nonce.txt")
+            .await
+            .unwrap());
     }
 
     #[tokio::test]

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -10,6 +10,12 @@ one scoped write/read/delete/delete-verify path, endpoint TLS posture, and the
 credential scope used for the run. It does not prove broad directory ownership,
 multitenancy, lost-device recovery, or long soak behavior.
 
+For the production posture packet, the canary should also include a negative
+scope probe by setting `scope_deny_prefix` to a prefix outside the credential
+policy. The workflow passes that to `tcfs storage canary
+--expect-deny-prefix`; the run fails unless the write is rejected with
+`PermissionDenied`.
+
 ## Current State
 
 `main` has a dispatchable workflow:
@@ -74,6 +80,13 @@ release prefixes. If the backing S3 provider cannot express that exact policy,
 record the closest available policy in the evidence packet and keep `TIN-1546`
 open.
 
+To make that scope claim machine-checkable, choose a denial prefix outside the
+allowed policy, for example:
+
+- allowed parent prefix: `gha/storage-posture/`
+- canary write prefix: `gha/storage-posture/<run_id>-<attempt>`
+- denial prefix: `gha/storage-posture-denied/<run_id>-<attempt>`
+
 ## Dispatch
 
 Hosted Linux runner against a public HTTPS endpoint:
@@ -84,6 +97,7 @@ gh workflow run storage-posture-canary.yml \
   -f runner_label=ubuntu-24.04 \
   -f smoke_environment=tcfs-storage-prod-smoke \
   -f require_https=true \
+  -f scope_deny_prefix=gha/storage-posture-denied/$(date -u +%Y%m%dT%H%M%SZ) \
   -f timeout_secs=10
 ```
 
@@ -95,6 +109,7 @@ gh workflow run storage-posture-canary.yml \
   -f runner_label=<private-runner-label> \
   -f smoke_environment=tcfs-storage-prod-smoke \
   -f require_https=true \
+  -f scope_deny_prefix=gha/storage-posture-denied/$(date -u +%Y%m%dT%H%M%SZ) \
   -f timeout_secs=10
 ```
 
@@ -111,6 +126,8 @@ The workflow run must complete successfully and upload its evidence artifact.
 - `bytes > 0`
 - `endpoint_tls: true`
 - `enforce_tls: true`
+- if `scope_deny_prefix` was set: `scope_deny.denied: true` and
+  `scope_deny.error_kind: PermissionDenied`
 - non-empty `endpoint`, `bucket`, `prefix`, `key`, and operation timings
 
 `storage-posture.env` must record:
@@ -120,6 +137,7 @@ The workflow run must complete successfully and upload its evidence artifact.
 - endpoint
 - bucket
 - remote prefix
+- scope-deny prefix, if configured
 - `require_https=true`
 - `enforce_tls=true`
 - `ca_cert_path_supported=true`


### PR DESCRIPTION
## Summary

TIN-1546 follow-up after #414. This adds an optional negative credential-scope probe to the storage posture canary.

- adds `tcfs storage canary --expect-deny-prefix <prefix>`
- requires the denied-prefix write to fail with OpenDAL `PermissionDenied`
- treats a successful outside-prefix write as a hard failure and best-effort deletes the probe object
- archives `scope_deny_prefix` in `storage-posture.env`
- validates `scope_deny.denied=true` and `scope_deny.error_kind=PermissionDenied` when the probe is configured
- updates the production storage posture runbook with the denial-prefix packet shape

## Validation

- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test -p tcfs-cli storage_canary -- --nocapture`
- `~/.cargo/bin/cargo check -p tcfs-cli --no-default-features`
- `git diff --check`

## Boundary

This still does not close TIN-1546. It makes the scoped-credential claim machine-checkable. Closure still requires populating `tcfs-storage-prod-smoke` with scoped HTTPS credentials and running `storage-posture-canary.yml` with `require_https=true` and a denial prefix outside the credential policy.
