### PR TITLE
auth: sign full enrollment invite payload (TIN-1424)

### DIFF
--- a/crates/tcfs-auth/src/enrollment.rs
+++ b/crates/tcfs-auth/src/enrollment.rs
@@ -11,6 +11,7 @@
 //! # Security Model
 //!
 //! - Invites are signed with the admin device's key (BLAKE3-HMAC)
+//! - The signature covers the full invite payload except the signature itself
 //! - Each invite has a single-use nonce and expiry
 //! - Invite can be scoped to specific permissions
 //! - Revocation is immediate (admin removes device from registry)
@@ -37,7 +38,7 @@ pub struct EnrollmentInvite {
     pub expires_at: DateTime<Utc>,
     /// Permissions granted to the enrolled device.
     pub permissions: DevicePermissions,
-    /// BLAKE3-HMAC signature of the invite fields (signed by admin's master key).
+    /// BLAKE3-HMAC signature of the invite payload (signed by admin's master key).
     pub signature: String,
     /// Optional: NATS server URL for the fleet.
     pub nats_url: Option<String>,
@@ -101,17 +102,16 @@ impl EnrollmentInvite {
         invite
     }
 
-    /// Compute BLAKE3-keyed-MAC of the invite fields.
+    /// Recompute the invite signature after mutating optional payload fields.
+    pub fn refresh_signature(&mut self, master_key: &[u8; 32]) {
+        self.signature = self.compute_signature(master_key);
+    }
+
+    /// Compute BLAKE3-keyed-MAC of the invite payload.
     fn compute_signature(&self, master_key: &[u8; 32]) -> String {
-        let payload = format!(
-            "{}:{}:{}:{}:{}",
-            self.invite_id,
-            self.nonce,
-            self.created_by,
-            self.created_at.timestamp(),
-            self.expires_at.timestamp(),
-        );
-        let mac = blake3::keyed_hash(master_key, payload.as_bytes());
+        let payload = serde_json::to_vec(&InviteSignaturePayload::from_invite(self))
+            .expect("serialize invite signature payload");
+        let mac = blake3::keyed_hash(master_key, &payload);
         mac.to_hex().to_string()
     }
 
@@ -204,6 +204,47 @@ impl EnrollmentInvite {
     }
 }
 
+#[derive(Serialize)]
+struct InviteSignaturePayload<'a> {
+    invite_id: &'a str,
+    nonce: &'a str,
+    created_by: &'a str,
+    created_at: i64,
+    expires_at: i64,
+    permissions: &'a DevicePermissions,
+    nats_url: Option<&'a str>,
+    storage_endpoint: Option<&'a str>,
+    storage_bucket: Option<&'a str>,
+    storage_access_key: Option<&'a str>,
+    storage_secret_key: Option<&'a str>,
+    remote_prefix: Option<&'a str>,
+    encryption_passphrase: Option<&'a str>,
+    encryption_salt: Option<&'a str>,
+    description: Option<&'a str>,
+}
+
+impl<'a> InviteSignaturePayload<'a> {
+    fn from_invite(invite: &'a EnrollmentInvite) -> Self {
+        Self {
+            invite_id: &invite.invite_id,
+            nonce: &invite.nonce,
+            created_by: &invite.created_by,
+            created_at: invite.created_at.timestamp(),
+            expires_at: invite.expires_at.timestamp(),
+            permissions: &invite.permissions,
+            nats_url: invite.nats_url.as_deref(),
+            storage_endpoint: invite.storage_endpoint.as_deref(),
+            storage_bucket: invite.storage_bucket.as_deref(),
+            storage_access_key: invite.storage_access_key.as_deref(),
+            storage_secret_key: invite.storage_secret_key.as_deref(),
+            remote_prefix: invite.remote_prefix.as_deref(),
+            encryption_passphrase: invite.encryption_passphrase.as_deref(),
+            encryption_salt: invite.encryption_salt.as_deref(),
+            description: invite.description.as_deref(),
+        }
+    }
+}
+
 /// Compact invite representation with short keys for QR-friendly encoding.
 ///
 /// Field mapping:
@@ -211,10 +252,10 @@ impl EnrollmentInvite {
 /// - `c` = created_at (unix ts), `x` = expires_at (unix ts)
 /// - `p` = permissions (bitfield: mount=1, push=2, pull=4, admin=8)
 /// - `g` = signature
-/// - `e` = storage_endpoint, `k` = storage_bucket
+/// - `u` = nats_url, `e` = storage_endpoint, `k` = storage_bucket
 /// - `a` = storage_access_key, `s` = storage_secret_key
 /// - `r` = remote_prefix, `w` = encryption_passphrase
-/// - `t` = encryption_salt
+/// - `t` = encryption_salt, `d` = description
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CompactInvite {
     i: String,
@@ -224,6 +265,8 @@ struct CompactInvite {
     x: i64,
     p: u8,
     g: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    u: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     e: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -238,6 +281,8 @@ struct CompactInvite {
     w: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     t: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    d: Option<String>,
 }
 
 impl CompactInvite {
@@ -254,6 +299,7 @@ impl CompactInvite {
             x: inv.expires_at.timestamp(),
             p: perms,
             g: inv.signature.clone(),
+            u: inv.nats_url.clone(),
             e: inv.storage_endpoint.clone(),
             k: inv.storage_bucket.clone(),
             a: inv.storage_access_key.clone(),
@@ -261,6 +307,7 @@ impl CompactInvite {
             r: inv.remote_prefix.clone(),
             w: inv.encryption_passphrase.clone(),
             t: inv.encryption_salt.clone(),
+            d: inv.description.clone(),
         }
     }
 
@@ -279,7 +326,7 @@ impl CompactInvite {
                 allowed_prefixes: vec![],
             },
             signature: self.g.clone(),
-            nats_url: None,
+            nats_url: self.u.clone(),
             storage_endpoint: self.e.clone(),
             storage_bucket: self.k.clone(),
             storage_access_key: self.a.clone(),
@@ -287,7 +334,7 @@ impl CompactInvite {
             remote_prefix: self.r.clone(),
             encryption_passphrase: self.w.clone(),
             encryption_salt: self.t.clone(),
-            description: None,
+            description: self.d.clone(),
         }
     }
 }
@@ -424,6 +471,9 @@ mod tests {
         invite.storage_access_key = Some("AKIAIOSFODNN7EXAMPLE".into());
         invite.storage_secret_key = Some("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into());
         invite.remote_prefix = Some("default".into());
+        invite.nats_url = Some("nats://nats.example.com:4222".into());
+        invite.description = Some("test invite".into());
+        invite.refresh_signature(&master_key);
 
         let compact = invite.encode_compact().unwrap();
         let full = invite.encode().unwrap();
@@ -441,6 +491,8 @@ mod tests {
         assert_eq!(invite.invite_id, decoded.invite_id);
         assert_eq!(invite.storage_endpoint, decoded.storage_endpoint);
         assert_eq!(invite.storage_access_key, decoded.storage_access_key);
+        assert_eq!(invite.nats_url, decoded.nats_url);
+        assert_eq!(invite.description, decoded.description);
         assert!(decoded.verify_signature(&master_key));
 
         // Roundtrip via decode_any (auto-detect compact)
@@ -465,6 +517,7 @@ mod tests {
         invite.storage_bucket = Some("tcfs".into());
         invite.storage_access_key = Some("TESTKEY123".into());
         invite.storage_secret_key = Some("TESTSECRET456".into());
+        invite.refresh_signature(&master_key);
 
         let link = invite.to_compact_deep_link().unwrap();
         assert!(link.starts_with("tcfs://enroll?data="));
@@ -481,5 +534,33 @@ mod tests {
             "compact payload {} bytes, should be under 500 for QR",
             data.len()
         );
+    }
+
+    #[test]
+    fn test_signature_covers_brokered_payload_fields() {
+        let master_key = [42u8; 32];
+        let mut invite =
+            EnrollmentInvite::new("admin-device", &master_key, 24, DevicePermissions::admin());
+        invite.storage_endpoint = Some("https://s3.example.com".into());
+        invite.storage_bucket = Some("tcfs".into());
+        invite.storage_access_key = Some("AKIAIOSFODNN7EXAMPLE".into());
+        invite.storage_secret_key = Some("secret-before".into());
+        invite.remote_prefix = Some("tenant/a".into());
+        invite.encryption_passphrase = Some("passphrase-before".into());
+        invite.refresh_signature(&master_key);
+
+        assert!(invite.verify_signature(&master_key));
+
+        let mut tampered_secret = invite.clone();
+        tampered_secret.storage_secret_key = Some("secret-after".into());
+        assert!(!tampered_secret.verify_signature(&master_key));
+
+        let mut tampered_prefix = invite.clone();
+        tampered_prefix.remote_prefix = Some("tenant/b".into());
+        assert!(!tampered_prefix.verify_signature(&master_key));
+
+        let mut tampered_permissions = invite.clone();
+        tampered_permissions.permissions.can_admin = false;
+        assert!(!tampered_permissions.verify_signature(&master_key));
     }
 }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -3611,11 +3611,10 @@ async fn cmd_device_invite(
         }
         *blake3::hash(&key_bytes).as_bytes()
     } else {
-        eprintln!(
-            "Warning: master key not found at {}, using placeholder signing key",
-            key_path.display()
+        anyhow::bail!(
+            "cannot create a device invite without a master key at {}; run tcfs init or configure crypto.master_key_file",
+            key_path.display(),
         );
-        *blake3::hash(b"tcfs-fleet-invite-key").as_bytes()
     };
 
     let mut invite = EnrollmentInvite::new(
@@ -3652,6 +3651,8 @@ async fn cmd_device_invite(
             invite.encryption_passphrase = Some(passphrase);
         }
     }
+
+    invite.refresh_signature(&signing_key);
 
     // Use compact encoding (short keys + zstd) for QR-friendly payloads
     let compact = invite


### PR DESCRIPTION
## Summary

TIN-1424 fail-closed invite-signature hardening cut.

- signs the full `EnrollmentInvite` payload, not just id/nonce/creator/timestamps
- covers permissions, NATS URL, storage endpoint/bucket/access/secret, remote prefix, encryption bootstrap fields, salt, and description
- adds `refresh_signature()` for the controlled mutation flow used by `tcfs device invite`
- preserves `nats_url` and `description` in compact invite encoding so compact QR payloads remain verifiable
- fails closed when `tcfs device invite` cannot find a real master key, instead of signing with a placeholder key
- adds tamper tests for storage secret, remote prefix, and permissions

## Validation

- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test -p tcfs-auth invite -- --nocapture`
- `~/.cargo/bin/cargo test -p tcfs-auth enrollment::tests -- --nocapture`
- `~/.cargo/bin/cargo check -p tcfs-cli --no-default-features`
- `git diff --check`

## Boundary

This is not full pairing-based self-enrollment. It closes the current signature coverage gap and placeholder signing-key footgun so invite payloads are not mutable after issuance.
