### PR TITLE
ci: add hosted runner disk headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ env:
   RUST_BACKTRACE: 1
   RUST_TOOLCHAIN: 1.93.0
   GITLEAKS_VERSION: 8.30.1
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
   check:
@@ -28,6 +30,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-bin: false
+
+      - name: Free hosted runner disk
+        run: |
+          set -euo pipefail
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          df -h /
 
       - name: Install system dependencies
         run: |
@@ -58,6 +67,14 @@ jobs:
         run: |
           cargo test -p tcfs-e2e --test blacklist_wireup -- --nocapture
           cargo test -p tcfs-e2e --test reconcile_wireup -- --nocapture
+
+      - name: Trim incremental artifacts before final builds
+        run: |
+          set -euo pipefail
+          du -sh target || true
+          find target -type d -name incremental -prune -exec rm -rf {} +
+          du -sh target || true
+          df -h .
 
       - name: Build workspace (default features)
         run: cargo build --workspace


### PR DESCRIPTION
## Summary
- reduce Cargo dev/test debug artifacts in CI
- free unused hosted-runner SDK/toolcache space before the Ubuntu Build + Lint + Test job
- trim incremental Cargo artifacts before the final build-only steps and print disk telemetry

## Evidence
- `git diff --check`
- `ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'\"`

## Why
The last two post-merge `main` CI runs failed in `Build + Lint + Test` with hosted-runner disk exhaustion while compiling the final `tcfsd --features k8s-worker` build, after other jobs had passed. This keeps alpha-gate CI failures from being masked by runner ENOSPC.