### PR TITLE
storage: add posture canary dispatch helper

### DIFF
--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -89,6 +89,19 @@ allowed policy, for example:
 
 ## Dispatch
 
+Preferred helper:
+
+```bash
+scripts/storage-posture-canary-dispatch.sh \
+  --environment tcfs-storage-prod-smoke \
+  --runner-label ubuntu-24.04
+```
+
+The helper checks that the GitHub environment exposes the required secret
+names before dispatch. It also requires a non-empty denial prefix by default,
+because production closure needs a machine-checkable scoped-credential denial
+probe.
+
 Hosted Linux runner against a public HTTPS endpoint:
 
 ```bash

--- a/scripts/storage-posture-canary-dispatch.sh
+++ b/scripts/storage-posture-canary-dispatch.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="Jesssullivan/tummycrypt"
+REF="main"
+RUNNER_LABEL="ubuntu-24.04"
+SMOKE_ENVIRONMENT="tcfs-storage-prod-smoke"
+REMOTE_PREFIX=""
+SCOPE_DENY_PREFIX="gha/storage-posture-denied/$(date -u +%Y%m%dT%H%M%SZ)"
+TIMEOUT_SECS="10"
+REQUIRE_HTTPS="true"
+DRY_RUN=0
+SKIP_SECRET_CHECK=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/storage-posture-canary-dispatch.sh [options]
+
+Dispatch the TIN-1546 production storage posture canary with the expected
+HTTPS + scoped-credential denial inputs.
+
+Options:
+  --repo OWNER/REPO             GitHub repo (default: Jesssullivan/tummycrypt)
+  --ref REF                     Git ref to dispatch (default: main)
+  --runner-label LABEL          Runner label (default: ubuntu-24.04)
+  --environment NAME            GitHub environment (default: tcfs-storage-prod-smoke)
+  --remote-prefix PREFIX        Optional positive canary prefix; otherwise workflow default is used
+  --scope-deny-prefix PREFIX    Outside-policy prefix that must be denied
+  --timeout-secs SECONDS        Per-operation canary timeout (default: 10)
+  --require-https true|false    Require HTTPS in workflow input (default: true)
+  --skip-secret-check           Do not verify required environment secret names before dispatch
+  --dry-run                     Print the gh command without dispatching
+  -h, --help                    Show this help
+
+Required environment secrets:
+  TCFS_SMOKE_S3_ENDPOINT
+  TCFS_SMOKE_S3_BUCKET
+  TCFS_SMOKE_S3_ACCESS_KEY_ID
+  TCFS_SMOKE_S3_SECRET_ACCESS_KEY
+
+Optional environment secrets:
+  TCFS_SMOKE_S3_REGION
+  TCFS_SMOKE_S3_CA_CERT_PEM
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+quote_cmd() {
+  local quoted=()
+  local arg
+  for arg in "$@"; do
+    quoted+=("$(printf '%q' "$arg")")
+  done
+  printf '%s\n' "${quoted[*]}"
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || die "$flag requires a value"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      require_value "$1" "${2:-}"
+      REPO="$2"
+      shift 2
+      ;;
+    --ref)
+      require_value "$1" "${2:-}"
+      REF="$2"
+      shift 2
+      ;;
+    --runner-label)
+      require_value "$1" "${2:-}"
+      RUNNER_LABEL="$2"
+      shift 2
+      ;;
+    --environment)
+      require_value "$1" "${2:-}"
+      SMOKE_ENVIRONMENT="$2"
+      shift 2
+      ;;
+    --remote-prefix)
+      require_value "$1" "${2:-}"
+      REMOTE_PREFIX="${2#/}"
+      REMOTE_PREFIX="${REMOTE_PREFIX%/}"
+      shift 2
+      ;;
+    --scope-deny-prefix)
+      require_value "$1" "${2:-}"
+      SCOPE_DENY_PREFIX="${2#/}"
+      SCOPE_DENY_PREFIX="${SCOPE_DENY_PREFIX%/}"
+      shift 2
+      ;;
+    --timeout-secs)
+      require_value "$1" "${2:-}"
+      TIMEOUT_SECS="$2"
+      shift 2
+      ;;
+    --require-https)
+      require_value "$1" "${2:-}"
+      REQUIRE_HTTPS="$2"
+      shift 2
+      ;;
+    --skip-secret-check)
+      SKIP_SECRET_CHECK=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$TIMEOUT_SECS" =~ ^[1-9][0-9]*$ ]] || die "--timeout-secs must be a positive integer"
+case "$REQUIRE_HTTPS" in
+  true|false) ;;
+  *) die "--require-https must be true or false" ;;
+esac
+[[ -n "$SCOPE_DENY_PREFIX" ]] || die "--scope-deny-prefix must not be empty for the production posture gate"
+
+if ! command -v gh >/dev/null 2>&1; then
+  die "gh CLI is required"
+fi
+
+if [[ "$SKIP_SECRET_CHECK" != "1" ]]; then
+  secret_names="$(gh secret list -R "$REPO" --env "$SMOKE_ENVIRONMENT" 2>/dev/null | awk '{print $1}')"
+  required=(
+    TCFS_SMOKE_S3_ENDPOINT
+    TCFS_SMOKE_S3_BUCKET
+    TCFS_SMOKE_S3_ACCESS_KEY_ID
+    TCFS_SMOKE_S3_SECRET_ACCESS_KEY
+  )
+  missing=()
+  for required_name in "${required[@]}"; do
+    if ! grep -qx "$required_name" <<<"$secret_names"; then
+      missing+=("$required_name")
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    die "GitHub environment '$SMOKE_ENVIRONMENT' is missing required secrets: ${missing[*]}"
+  fi
+fi
+
+case "$RUNNER_LABEL" in
+  ubuntu-*|macos-*|windows-*)
+    ;;
+  *)
+    runner_match="$(
+      gh api "repos/$REPO/actions/runners" --paginate \
+        --jq '.runners[] | [.name, .status, ([.labels[].name] | join(","))] | @tsv' \
+        | awk -F '\t' -v label="$RUNNER_LABEL" '
+            $2 == "online" {
+              split($3, labels, ",")
+              for (i in labels) {
+                if (labels[i] == label) {
+                  print $1
+                  exit
+                }
+              }
+            }
+          '
+    )"
+    [[ -n "$runner_match" ]] || die "no online self-hosted runner currently advertises label '$RUNNER_LABEL'"
+    log "runner label '$RUNNER_LABEL' is currently online on runner '$runner_match'"
+    ;;
+esac
+
+cmd=(
+  gh workflow run storage-posture-canary.yml
+  -R "$REPO"
+  --ref "$REF"
+  -f "runner_label=$RUNNER_LABEL"
+  -f "smoke_environment=$SMOKE_ENVIRONMENT"
+  -f "scope_deny_prefix=$SCOPE_DENY_PREFIX"
+  -f "timeout_secs=$TIMEOUT_SECS"
+  -f "require_https=$REQUIRE_HTTPS"
+)
+
+if [[ -n "$REMOTE_PREFIX" ]]; then
+  cmd+=(-f "remote_prefix=$REMOTE_PREFIX")
+fi
+
+log "dispatching storage posture canary:"
+log "  repo: $REPO"
+log "  ref: $REF"
+log "  runner: $RUNNER_LABEL"
+log "  environment: $SMOKE_ENVIRONMENT"
+log "  require_https: $REQUIRE_HTTPS"
+log "  scope_deny_prefix: $SCOPE_DENY_PREFIX"
+if [[ -n "$REMOTE_PREFIX" ]]; then
+  log "  remote_prefix: $REMOTE_PREFIX"
+else
+  log "  remote_prefix: <workflow default>"
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  quote_cmd "${cmd[@]}"
+  exit 0
+fi
+
+"${cmd[@]}"
+log "dispatch requested; inspect the latest workflow_dispatch run with:"
+log "  gh run list -R $REPO --workflow storage-posture-canary.yml --event workflow_dispatch --limit 5"

--- a/scripts/test-storage-posture-canary-dispatch.sh
+++ b/scripts/test-storage-posture-canary-dispatch.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/storage-posture-canary-dispatch.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-storage-dispatch-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+
+  local out="$TMPDIR/failure.out"
+  if "$@" >"$out" 2>&1; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+  assert_contains "$out" "$expected"
+}
+
+cat >"$TMPDIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'gh %s\n' "$*" >> "${GH_FAKE_LOG:?}"
+
+if [[ "${1:-}" == "secret" && "${2:-}" == "list" ]]; then
+  env_name=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env)
+        env_name="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  if [[ "$env_name" == "good-env" ]]; then
+    cat <<'SECRETS'
+TCFS_SMOKE_S3_ENDPOINT	2026-05-19T00:00:00Z
+TCFS_SMOKE_S3_BUCKET	2026-05-19T00:00:00Z
+TCFS_SMOKE_S3_ACCESS_KEY_ID	2026-05-19T00:00:00Z
+TCFS_SMOKE_S3_SECRET_ACCESS_KEY	2026-05-19T00:00:00Z
+SECRETS
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "api" ]]; then
+  printf 'linux-1\tonline\tself-hosted,private-linux\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "workflow" && "${2:-}" == "run" ]]; then
+  printf 'dispatch-ok\n'
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 99
+EOF
+chmod +x "$TMPDIR/gh"
+
+export PATH="$TMPDIR:$PATH"
+export GH_FAKE_LOG="$TMPDIR/gh.log"
+: >"$GH_FAKE_LOG"
+
+bash -n "$SCRIPT"
+
+DRY_RUN="$TMPDIR/dry-run.out"
+bash "$SCRIPT" \
+  --dry-run \
+  --repo owner/repo \
+  --environment good-env \
+  --scope-deny-prefix gha/storage-posture-denied/test \
+  --remote-prefix gha/storage-posture/test \
+  >"$DRY_RUN" 2>&1
+assert_contains "$DRY_RUN" "gh workflow run storage-posture-canary.yml"
+assert_contains "$DRY_RUN" "-R owner/repo"
+assert_contains "$DRY_RUN" "-f runner_label=ubuntu-24.04"
+assert_contains "$DRY_RUN" "-f smoke_environment=good-env"
+assert_contains "$DRY_RUN" "-f scope_deny_prefix=gha/storage-posture-denied/test"
+assert_contains "$DRY_RUN" "-f remote_prefix=gha/storage-posture/test"
+assert_contains "$DRY_RUN" "-f require_https=true"
+
+assert_fails_contains \
+  "GitHub environment 'missing-env' is missing required secrets" \
+  bash "$SCRIPT" \
+    --dry-run \
+    --repo owner/repo \
+    --environment missing-env
+
+PRIVATE_RUNNER="$TMPDIR/private-runner.out"
+bash "$SCRIPT" \
+  --dry-run \
+  --repo owner/repo \
+  --environment good-env \
+  --runner-label private-linux \
+  >"$PRIVATE_RUNNER" 2>&1
+assert_contains "$PRIVATE_RUNNER" "runner label 'private-linux' is currently online on runner 'linux-1'"
+assert_contains "$PRIVATE_RUNNER" "-f runner_label=private-linux"
+
+DISPATCH="$TMPDIR/dispatch.out"
+bash "$SCRIPT" \
+  --repo owner/repo \
+  --environment good-env \
+  --scope-deny-prefix gha/storage-posture-denied/test \
+  >"$DISPATCH" 2>&1
+assert_contains "$DISPATCH" "dispatch-ok"
+assert_contains "$DISPATCH" "gh run list -R owner/repo --workflow storage-posture-canary.yml"
+
+printf 'storage posture canary dispatch tests passed\n'


### PR DESCRIPTION
## Summary
- add `scripts/storage-posture-canary-dispatch.sh` for the TIN-1546 production storage packet
- preflight required GitHub environment secret names before dispatch
- keep the scoped-credential denial prefix mandatory by default
- document the helper in the storage posture gate runbook
- add a fake-`gh` regression test for dry-run, missing-secret, private-runner, and dispatch paths

## Evidence
- `bash -n scripts/storage-posture-canary-dispatch.sh scripts/test-storage-posture-canary-dispatch.sh`
- `bash scripts/test-storage-posture-canary-dispatch.sh`
- `git diff --check`

## Boundary
This does not close TIN-1546 by itself. It makes the live HTTPS/CA/scoped-credential packet repeatable once `tcfs-storage-prod-smoke` is populated with scoped storage secrets.