### PR TITLE
ops: add tcfs alpha gate preflight

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -130,6 +130,14 @@ fleet-check:
 neo-honey-smoke:
     bash scripts/neo-honey-smoke.sh
 
+# Read-only alpha productionization gate classifier
+alpha-gate-preflight *ARGS:
+    @bash scripts/tcfs-alpha-gate-preflight.sh {{ARGS}}
+
+# Regression test the alpha productionization gate classifier
+alpha-gate-preflight-test:
+    @bash scripts/test-tcfs-alpha-gate-preflight.sh
+
 # Installed-binary smoke for release surfaces that ship tcfsd (and optionally tcfs)
 install-smoke *ARGS:
     bash scripts/install-smoke.sh {{ARGS}}

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -89,6 +89,12 @@ allowed policy, for example:
 
 ## Dispatch
 
+Before dispatching, classify the full alpha gate state:
+
+```bash
+scripts/tcfs-alpha-gate-preflight.sh
+```
+
 Preferred helper:
 
 ```bash

--- a/docs/ops/tcfs-alpha-beta-qa-readiness-2026-05-19.md
+++ b/docs/ops/tcfs-alpha-beta-qa-readiness-2026-05-19.md
@@ -5,6 +5,9 @@ It is deliberately stricter than "the code path works": alpha and beta need
 repeatable evidence, bounded failure modes, and clear limits on what testers are
 allowed to trust.
 
+Current execution board:
+[TCFS Alpha Productionization Sprint - May 20, 2026](tcfs-alpha-productionization-sprint-2026-05-20.md).
+
 ## Current Posture
 
 TCFS is ready for focused productionization QA, not for broad primary-filesystem
@@ -104,6 +107,12 @@ has shipped and been proven end to end.
 | iOS | Proof-of-concept only | Files.app real-device/simulator acceptance, safe enrollment posture, TestFlight/provisioning decision | `TIN-1548`, `TIN-134` |
 
 ## This Week's Alpha Runway
+
+Start each pass with the read-only gate classifier:
+
+```bash
+scripts/tcfs-alpha-gate-preflight.sh
+```
 
 1. Archive the `v0.12.13-rc2` exact public `.pkg` smoke packet from run
    `26122478486`, and keep a main-ref/package rerun ready for the next rc or

--- a/docs/ops/tcfs-alpha-productionization-sprint-2026-05-20.md
+++ b/docs/ops/tcfs-alpha-productionization-sprint-2026-05-20.md
@@ -1,0 +1,100 @@
+# TCFS Alpha Productionization Sprint - May 20, 2026
+
+This is the execution board for the current alpha push. It turns the
+productionization plan into runnable gates and keeps the claim boundary strict:
+macOS production FileProvider exact hydration is green, while storage posture,
+Linux first-use, and fresh neo/honey evidence remain open until their packets
+exist.
+
+## Current Truth
+
+| Lane | Tracker | Current state | Next action |
+| --- | --- | --- | --- |
+| Production S3/storage posture | `TIN-1546` | Workflow, custom CA support, scoped denial proof, and dispatch helper are on `main`; `tcfs-storage-prod-smoke` has no secrets yet | Populate scoped HTTPS S3-compatible secrets, then run the storage canary dispatch helper |
+| Linux package first-use | `TIN-1540`, `TIN-1422`, `TIN-131`, `#280` | Linux workflow and harness are present; hosted Linux rejects the current private/plaintext endpoint by design; `tcfs-linux-smoke` has no secrets yet | Reuse the hosted-reachable HTTPS storage backend, then run Linux smoke with evict/rehydrate and mutation enabled |
+| Named fleet acceptance | `TIN-132` | CI Live Storage is green regression coverage, but no fresh named `neo`/`honey` transcript is archived for this sprint | Run `just neo-honey-smoke` from the operator environment and archive the transcript |
+| FileProvider post-M10 hardening | `TIN-1547` | Public `v0.12.13-rc2` `.pkg` passed signed HostApp root enumeration, exact hydrate, evict/rehydrate, mutation, and conflict/status; PR #412 landed rename/unsync safety | Add signed-package hardening proof for rename/unsync behavior, badge/progress/recovery capture, and a longer desktop soak |
+| Enrollment and beta security | `TIN-1424`, `TIN-1417` | Full invite payload signature coverage landed; self-enrollment remains unsafe as a production trust boundary | Implement single-use redemption and admin/session gating before exposing enrollment UX |
+
+## One-Command Preflight
+
+Run the read-only gate classifier before dispatching anything:
+
+```bash
+scripts/tcfs-alpha-gate-preflight.sh
+# or
+just alpha-gate-preflight
+```
+
+The expected blocked output today is:
+
+- `TIN-1546`: missing required secrets in `tcfs-storage-prod-smoke`
+- `TIN-1540/TIN-1422`: missing required secrets in `tcfs-linux-smoke`
+- `TIN-132`: operator-run-required because named neo/honey evidence cannot be
+  inferred from CI Live Storage
+
+Use strict mode when a release checklist should fail on blocked gates:
+
+```bash
+scripts/tcfs-alpha-gate-preflight.sh --strict
+# or
+just alpha-gate-preflight --strict
+```
+
+## Dispatch Commands After Secrets Exist
+
+Storage posture:
+
+```bash
+scripts/storage-posture-canary-dispatch.sh \
+  --environment tcfs-storage-prod-smoke \
+  --runner-label ubuntu-24.04
+```
+
+Linux package smoke:
+
+```bash
+gh workflow run linux-postinstall-smoke.yml \
+  -R Jesssullivan/tummycrypt \
+  --ref main \
+  -f tag=v0.12.13-rc2 \
+  -f runner_label=ubuntu-24.04 \
+  -f smoke_environment=tcfs-linux-smoke \
+  -f exercise_evict_rehydrate=true \
+  -f exercise_mutation=true
+```
+
+Named fleet acceptance, from the operator environment:
+
+```bash
+just neo-honey-smoke
+```
+
+## Close Criteria
+
+- `TIN-1546`: attach the `storage-posture-canary-<run_id>-<attempt>` artifact;
+  `storage-canary.json` must show `endpoint_tls=true`,
+  `enforce_tls=true`, delete verification, and denial-prefix
+  `PermissionDenied`.
+- `TIN-1540`: close only after the selected route is real: hosted-reachable
+  HTTPS secrets in `tcfs-linux-smoke`, or an online Linux self-hosted runner.
+- `TIN-1422`: close only after package install, config, FUSE mount,
+  seeded-index visibility, exact hydrate, evict/rehydrate, and mutation are
+  green from the Linux workflow.
+- `TIN-131/#280`: keep open until the distribution matrix records Linux
+  first-use and production storage posture, not just macOS/Homebrew/container
+  rows.
+- `TIN-132`: close only from a fresh named neo/honey transcript or an explicit
+  tracker decision to supersede that gate. The current decision is to keep the
+  fresh transcript as required.
+- `TIN-1547`: close the current hardening slice only after rename/unsync safety
+  is proven through a signed package and badge/progress/recovery or soak
+  evidence is archived.
+
+## Claim Boundary
+
+Alpha can claim trusted-operator QA on scoped roots after the storage, Linux,
+and fleet packets are green. It must not claim primary home-directory takeover,
+self-service enrollment, lost-device revocation, multitenant isolation, iOS
+production readiness, Windows Explorer readiness, or daily-driver broad
+directory ownership.

--- a/scripts/tcfs-alpha-gate-preflight.sh
+++ b/scripts/tcfs-alpha-gate-preflight.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # Markdown backticks are literal in printf strings.
+set -euo pipefail
+
+REPO="Jesssullivan/tummycrypt"
+STORAGE_ENVIRONMENT="tcfs-storage-prod-smoke"
+LINUX_ENVIRONMENT="tcfs-linux-smoke"
+STORAGE_RUNNER_LABEL="ubuntu-24.04"
+LINUX_RUNNER_LABEL="ubuntu-24.04"
+TAG="v0.12.13-rc2"
+SCOPE_DENY_PREFIX="gha/storage-posture-denied/$(date -u +%Y%m%dT%H%M%SZ)"
+REMOTE_PREFIX=""
+STRICT=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/tcfs-alpha-gate-preflight.sh [options]
+
+Classify whether the TCFS alpha productionization gates are runnable from the
+current GitHub/runner state. This is intentionally read-only: it checks
+environment secret names and runner labels, then prints the next dispatch
+commands or the exact blocker.
+
+Options:
+  --repo OWNER/REPO                 GitHub repo (default: Jesssullivan/tummycrypt)
+  --storage-environment NAME        GitHub environment for TIN-1546 storage canary
+                                    (default: tcfs-storage-prod-smoke)
+  --linux-environment NAME          GitHub environment for TIN-1422 Linux smoke
+                                    (default: tcfs-linux-smoke)
+  --storage-runner-label LABEL      Runner label for storage posture canary
+                                    (default: ubuntu-24.04)
+  --linux-runner-label LABEL        Runner label for Linux postinstall smoke
+                                    (default: ubuntu-24.04)
+  --tag TAG                         Release tag for Linux package smoke
+                                    (default: v0.12.13-rc2)
+  --scope-deny-prefix PREFIX        Outside-policy prefix that storage canary
+                                    must reject
+  --remote-prefix PREFIX            Optional positive storage canary prefix
+  --strict                          Exit non-zero when any alpha gate is blocked
+  -h, --help                        Show this help
+
+Required storage secrets:
+  TCFS_SMOKE_S3_ENDPOINT
+  TCFS_SMOKE_S3_BUCKET
+  TCFS_SMOKE_S3_ACCESS_KEY_ID
+  TCFS_SMOKE_S3_SECRET_ACCESS_KEY
+
+Required Linux smoke secrets:
+  TCFS_SMOKE_S3_ENDPOINT
+  TCFS_SMOKE_S3_BUCKET
+  TCFS_SMOKE_S3_ACCESS_KEY_ID
+  TCFS_SMOKE_S3_SECRET_ACCESS_KEY
+  TCFS_SMOKE_MASTER_KEY_B64
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || die "$flag requires a value"
+}
+
+is_hosted_runner_label() {
+  case "$1" in
+    ubuntu-*|macos-*|windows-*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+quote_cmd() {
+  local quoted=()
+  local arg
+  for arg in "$@"; do
+    quoted+=("$(printf '%q' "$arg")")
+  done
+  printf '%s\n' "${quoted[*]}"
+}
+
+secret_names_for_environment() {
+  local environment="$1"
+  gh secret list -R "$REPO" --env "$environment" 2>/dev/null | awk '{print $1}'
+}
+
+missing_secret_names() {
+  local environment="$1"
+  shift
+  local secret_names
+  secret_names="$(secret_names_for_environment "$environment" || true)"
+
+  local missing=()
+  local name
+  for name in "$@"; do
+    if ! grep -qx "$name" <<<"$secret_names"; then
+      missing+=("$name")
+    fi
+  done
+
+  if (( ${#missing[@]} > 0 )); then
+    printf '%s\n' "${missing[@]}"
+  fi
+}
+
+self_hosted_runner_match() {
+  local label="$1"
+  gh api "repos/$REPO/actions/runners" --paginate \
+    --jq '.runners[] | [.name, .status, ([.labels[].name] | join(","))] | @tsv' \
+    | awk -F '\t' -v label="$label" '
+        $2 == "online" {
+          split($3, labels, ",")
+          for (i in labels) {
+            if (labels[i] == label) {
+              print $1
+              exit
+            }
+          }
+        }
+      '
+}
+
+runner_status_line() {
+  local label="$1"
+  if is_hosted_runner_label "$label"; then
+    printf 'hosted:%s\n' "$label"
+    return
+  fi
+
+  local match
+  match="$(self_hosted_runner_match "$label")"
+  if [[ -n "$match" ]]; then
+    printf 'online:%s\n' "$match"
+  else
+    printf 'missing:%s\n' "$label"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      require_value "$1" "${2:-}"
+      REPO="$2"
+      shift 2
+      ;;
+    --storage-environment)
+      require_value "$1" "${2:-}"
+      STORAGE_ENVIRONMENT="$2"
+      shift 2
+      ;;
+    --linux-environment)
+      require_value "$1" "${2:-}"
+      LINUX_ENVIRONMENT="$2"
+      shift 2
+      ;;
+    --storage-runner-label)
+      require_value "$1" "${2:-}"
+      STORAGE_RUNNER_LABEL="$2"
+      shift 2
+      ;;
+    --linux-runner-label)
+      require_value "$1" "${2:-}"
+      LINUX_RUNNER_LABEL="$2"
+      shift 2
+      ;;
+    --tag)
+      require_value "$1" "${2:-}"
+      TAG="$2"
+      shift 2
+      ;;
+    --scope-deny-prefix)
+      require_value "$1" "${2:-}"
+      SCOPE_DENY_PREFIX="${2#/}"
+      SCOPE_DENY_PREFIX="${SCOPE_DENY_PREFIX%/}"
+      shift 2
+      ;;
+    --remote-prefix)
+      require_value "$1" "${2:-}"
+      REMOTE_PREFIX="${2#/}"
+      REMOTE_PREFIX="${REMOTE_PREFIX%/}"
+      shift 2
+      ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$TAG" == v* ]] || die "--tag must start with v"
+[[ -n "$SCOPE_DENY_PREFIX" ]] || die "--scope-deny-prefix must not be empty"
+
+if ! command -v gh >/dev/null 2>&1; then
+  die "gh CLI is required"
+fi
+
+storage_required=(
+  TCFS_SMOKE_S3_ENDPOINT
+  TCFS_SMOKE_S3_BUCKET
+  TCFS_SMOKE_S3_ACCESS_KEY_ID
+  TCFS_SMOKE_S3_SECRET_ACCESS_KEY
+)
+linux_required=(
+  TCFS_SMOKE_S3_ENDPOINT
+  TCFS_SMOKE_S3_BUCKET
+  TCFS_SMOKE_S3_ACCESS_KEY_ID
+  TCFS_SMOKE_S3_SECRET_ACCESS_KEY
+  TCFS_SMOKE_MASTER_KEY_B64
+)
+
+mapfile -t storage_missing < <(missing_secret_names "$STORAGE_ENVIRONMENT" "${storage_required[@]}")
+mapfile -t linux_missing < <(missing_secret_names "$LINUX_ENVIRONMENT" "${linux_required[@]}")
+storage_runner_status="$(runner_status_line "$STORAGE_RUNNER_LABEL")"
+linux_runner_status="$(runner_status_line "$LINUX_RUNNER_LABEL")"
+
+blocked=0
+run_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '# TCFS Alpha Gate Preflight\n\n'
+printf -- '- generated_at: `%s`\n' "$run_date"
+printf -- '- repo: `%s`\n' "$REPO"
+printf -- '- tag: `%s`\n\n' "$TAG"
+
+printf '## TIN-1546 Storage Posture\n\n'
+printf -- '- environment: `%s`\n' "$STORAGE_ENVIRONMENT"
+printf -- '- runner: `%s` (%s)\n' "$STORAGE_RUNNER_LABEL" "$storage_runner_status"
+if [[ "$storage_runner_status" == missing:* ]]; then
+  printf -- '- status: `blocked`\n'
+  printf -- '- blocker: no online self-hosted runner advertises `%s`\n' "$STORAGE_RUNNER_LABEL"
+  blocked=1
+elif (( ${#storage_missing[@]} > 0 )); then
+  printf -- '- status: `blocked`\n'
+  printf -- '- missing_secrets: `%s`\n' "${storage_missing[*]}"
+  blocked=1
+else
+  printf -- '- status: `runnable`\n'
+  storage_cmd=(
+    scripts/storage-posture-canary-dispatch.sh
+    --repo "$REPO"
+    --environment "$STORAGE_ENVIRONMENT"
+    --runner-label "$STORAGE_RUNNER_LABEL"
+    --scope-deny-prefix "$SCOPE_DENY_PREFIX"
+  )
+  if [[ -n "$REMOTE_PREFIX" ]]; then
+    storage_cmd+=(--remote-prefix "$REMOTE_PREFIX")
+  fi
+  printf -- '- dispatch:\n\n'
+  printf '```bash\n%s\n```\n' "$(quote_cmd "${storage_cmd[@]}")"
+fi
+
+printf '\n## TIN-1540 / TIN-1422 Linux Package Smoke\n\n'
+printf -- '- environment: `%s`\n' "$LINUX_ENVIRONMENT"
+printf -- '- runner: `%s` (%s)\n' "$LINUX_RUNNER_LABEL" "$linux_runner_status"
+if [[ "$linux_runner_status" == missing:* ]]; then
+  printf -- '- status: `blocked`\n'
+  printf -- '- blocker: no online self-hosted runner advertises `%s`\n' "$LINUX_RUNNER_LABEL"
+  blocked=1
+elif (( ${#linux_missing[@]} > 0 )); then
+  printf -- '- status: `blocked`\n'
+  printf -- '- missing_secrets: `%s`\n' "${linux_missing[*]}"
+  blocked=1
+else
+  printf -- '- status: `runnable`\n'
+  linux_cmd=(
+    gh workflow run linux-postinstall-smoke.yml
+    -R "$REPO"
+    --ref main
+    -f "tag=$TAG"
+    -f "runner_label=$LINUX_RUNNER_LABEL"
+    -f "smoke_environment=$LINUX_ENVIRONMENT"
+    -f "exercise_evict_rehydrate=true"
+    -f "exercise_mutation=true"
+  )
+  printf -- '- dispatch:\n\n'
+  printf '```bash\n%s\n```\n' "$(quote_cmd "${linux_cmd[@]}")"
+fi
+
+printf '\n## TIN-132 Neo/Honey Fleet\n\n'
+printf -- '- status: `operator-run-required`\n'
+printf -- '- command:\n\n'
+printf '```bash\njust neo-honey-smoke\n```\n'
+printf '\n'
+printf 'Run this from the operator environment with `TCFS_E2E_LIVE=1`, live S3 credentials, and live NATS URL set. CI Live Storage remains regression coverage, not a replacement for the named neo/honey transcript.\n'
+
+printf '\n## Claim Boundary\n\n'
+printf 'Do not close `TIN-1546`, `TIN-1540`, `TIN-1422`, `TIN-131/#280`, or `TIN-132` from this preflight alone. Close only from the workflow/operator artifacts named above.\n'
+
+if (( STRICT == 1 && blocked == 1 )); then
+  exit 1
+fi

--- a/scripts/test-tcfs-alpha-gate-preflight.sh
+++ b/scripts/test-tcfs-alpha-gate-preflight.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/tcfs-alpha-gate-preflight.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-alpha-gate-preflight-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+
+  local out="$TMPDIR/failure.out"
+  if "$@" >"$out" 2>&1; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+  assert_contains "$out" "$expected"
+}
+
+cat >"$TMPDIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'gh %s\n' "$*" >> "${GH_FAKE_LOG:?}"
+
+if [[ "${1:-}" == "secret" && "${2:-}" == "list" ]]; then
+  env_name=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env)
+        env_name="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  case "$env_name" in
+    storage-good)
+      cat <<'SECRETS'
+TCFS_SMOKE_S3_ENDPOINT	2026-05-20T00:00:00Z
+TCFS_SMOKE_S3_BUCKET	2026-05-20T00:00:00Z
+TCFS_SMOKE_S3_ACCESS_KEY_ID	2026-05-20T00:00:00Z
+TCFS_SMOKE_S3_SECRET_ACCESS_KEY	2026-05-20T00:00:00Z
+SECRETS
+      ;;
+    linux-good)
+      cat <<'SECRETS'
+TCFS_SMOKE_S3_ENDPOINT	2026-05-20T00:00:00Z
+TCFS_SMOKE_S3_BUCKET	2026-05-20T00:00:00Z
+TCFS_SMOKE_S3_ACCESS_KEY_ID	2026-05-20T00:00:00Z
+TCFS_SMOKE_S3_SECRET_ACCESS_KEY	2026-05-20T00:00:00Z
+TCFS_SMOKE_MASTER_KEY_B64	2026-05-20T00:00:00Z
+SECRETS
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "api" ]]; then
+  printf 'linux-1\tonline\tself-hosted,linux-private\n'
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 99
+EOF
+chmod +x "$TMPDIR/gh"
+
+export PATH="$TMPDIR:$PATH"
+export GH_FAKE_LOG="$TMPDIR/gh.log"
+: >"$GH_FAKE_LOG"
+
+bash -n "$SCRIPT"
+
+READY="$TMPDIR/ready.out"
+bash "$SCRIPT" \
+  --repo owner/repo \
+  --storage-environment storage-good \
+  --linux-environment linux-good \
+  --tag v1.2.3 \
+  >"$READY"
+assert_contains "$READY" "# TCFS Alpha Gate Preflight"
+assert_contains "$READY" "- status: \`runnable\`"
+assert_contains "$READY" "scripts/storage-posture-canary-dispatch.sh"
+assert_contains "$READY" "gh workflow run linux-postinstall-smoke.yml"
+assert_contains "$READY" "-f tag=v1.2.3"
+assert_contains "$READY" "just neo-honey-smoke"
+
+BLOCKED="$TMPDIR/blocked.out"
+bash "$SCRIPT" \
+  --repo owner/repo \
+  --storage-environment storage-empty \
+  --linux-environment linux-empty \
+  >"$BLOCKED"
+assert_contains "$BLOCKED" "missing_secrets"
+assert_contains "$BLOCKED" "TCFS_SMOKE_MASTER_KEY_B64"
+
+SELF_HOSTED="$TMPDIR/self-hosted.out"
+bash "$SCRIPT" \
+  --repo owner/repo \
+  --storage-environment storage-good \
+  --linux-environment linux-good \
+  --linux-runner-label linux-private \
+  >"$SELF_HOSTED"
+assert_contains "$SELF_HOSTED" "runner: \`linux-private\` (online:linux-1)"
+
+assert_fails_contains \
+  "missing_secrets" \
+  bash "$SCRIPT" \
+    --strict \
+    --repo owner/repo \
+    --storage-environment storage-empty \
+    --linux-environment linux-empty
+
+printf 'tcfs alpha gate preflight tests passed\n'


### PR DESCRIPTION
## Summary

Adds a read-only alpha productionization gate classifier for TCFS and wires it into the ops runbooks.

- adds `scripts/tcfs-alpha-gate-preflight.sh` to classify whether the TIN-1546 storage posture, TIN-1540/TIN-1422 Linux smoke, and TIN-132 neo/honey fleet gates are runnable
- adds fake-`gh` regression coverage plus `just alpha-gate-preflight` and `just alpha-gate-preflight-test`
- adds the May 20 alpha productionization sprint board with tracker mapping, dispatch commands, close criteria, and claim boundaries
- links the classifier from the storage posture and alpha/beta QA readiness docs

## Claim boundary

This PR does not close the live blockers by itself. The current live preflight still reports:

- TIN-1546 blocked on missing `tcfs-storage-prod-smoke` secrets
- TIN-1540/TIN-1422 blocked on missing `tcfs-linux-smoke` secrets, including `TCFS_SMOKE_MASTER_KEY_B64`
- TIN-132 still requiring a fresh operator-run `neo`/`honey` transcript

## Validation

- `bash -n scripts/tcfs-alpha-gate-preflight.sh scripts/test-tcfs-alpha-gate-preflight.sh`
- `bash scripts/test-tcfs-alpha-gate-preflight.sh`
- `just alpha-gate-preflight-test`
- `shellcheck scripts/tcfs-alpha-gate-preflight.sh scripts/test-tcfs-alpha-gate-preflight.sh`
- `git diff --check`
- `just alpha-gate-preflight` against live GitHub repo state

Refs: TIN-1546, TIN-1540, TIN-1422, TIN-132, TIN-131, #280
