### PR TITLE
storage: require scoped denial for HTTPS canary

### DIFF
--- a/.github/workflows/storage-posture-canary.yml
+++ b/.github/workflows/storage-posture-canary.yml
@@ -93,6 +93,12 @@ jobs:
             exit 1
           fi
 
+          if [[ "${{ github.event.inputs.require_https }}" == "true" \
+                && -z "${{ github.event.inputs.scope_deny_prefix }}" ]]; then
+            echo "::error::require_https=true requires scope_deny_prefix so the production posture packet proves scoped-credential denial"
+            exit 1
+          fi
+
           case "${{ github.event.inputs.timeout_secs }}" in
             ''|*[!0-9]*)
               echo "::error::timeout_secs must be a positive integer"
@@ -266,14 +272,17 @@ jobs:
 
           assert report["deleted"] is True, "delete verification must pass"
           assert report["bytes"] > 0, "canary payload must be non-empty"
+          if require_https:
+              assert report["endpoint_tls"] is True, "endpoint_tls must be true"
+              assert report["enforce_tls"] is True, "enforce_tls must be true"
+              assert report.get("scope_deny") is not None, (
+                  "require_https production posture runs must include scope-deny proof"
+              )
           if scope_deny := report.get("scope_deny"):
               assert scope_deny["denied"] is True, "scope-deny probe must be denied"
               assert scope_deny["error_kind"] == "PermissionDenied", (
                   "scope-deny probe must fail with PermissionDenied"
               )
-          if require_https:
-              assert report["endpoint_tls"] is True, "endpoint_tls must be true"
-              assert report["enforce_tls"] is True, "enforce_tls must be true"
           print("storage canary report validated")
           PY
 

--- a/scripts/test-storage-posture-canary-dispatch.sh
+++ b/scripts/test-storage-posture-canary-dispatch.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/scripts/storage-posture-canary-dispatch.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/storage-posture-canary.yml"
 TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-storage-dispatch-test.XXXXXX")"
 trap 'rm -rf "$TMPDIR"' EXIT
 
@@ -81,6 +82,10 @@ export GH_FAKE_LOG="$TMPDIR/gh.log"
 : >"$GH_FAKE_LOG"
 
 bash -n "$SCRIPT"
+assert_contains "$WORKFLOW" "require_https=true requires scope_deny_prefix"
+assert_contains "$WORKFLOW" "production posture packet proves scoped-credential denial"
+assert_contains "$WORKFLOW" "require_https production posture runs must include scope-deny proof"
+assert_contains "$WORKFLOW" "scope-deny probe must fail with PermissionDenied"
 
 DRY_RUN="$TMPDIR/dry-run.out"
 bash "$SCRIPT" \


### PR DESCRIPTION
## Summary

Hardens the TIN-1546 storage posture canary so a production-style HTTPS run cannot go green without scoped-credential denial evidence.

- workflow input validation now rejects `require_https=true` when `scope_deny_prefix` is empty
- canary report validation now requires a `scope_deny` block for `require_https=true` runs
- existing dispatch regression test now asserts the workflow-side guardrails are present

## Why

The helper already defaulted to a denial prefix, but the workflow itself still allowed a direct manual dispatch that proved TLS without proving credential scope. This closes that gap for the production posture packet.

## Validation

- `bash -n scripts/test-storage-posture-canary-dispatch.sh scripts/storage-posture-canary-dispatch.sh`
- `bash scripts/test-storage-posture-canary-dispatch.sh`
- `shellcheck scripts/test-storage-posture-canary-dispatch.sh scripts/storage-posture-canary-dispatch.sh`
- `git diff --check`

Refs: TIN-1546
