### PR TITLE
linux: support custom CA in postinstall smoke

### DIFF
--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -74,6 +74,8 @@ jobs:
       TCFS_SMOKE_S3_BUCKET: ${{ secrets.TCFS_SMOKE_S3_BUCKET }}
       TCFS_SMOKE_S3_ACCESS_KEY_ID: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
       TCFS_SMOKE_S3_SECRET_ACCESS_KEY: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
+      TCFS_SMOKE_S3_REGION: ${{ secrets.TCFS_SMOKE_S3_REGION }}
+      TCFS_SMOKE_S3_CA_CERT_PEM: ${{ secrets.TCFS_SMOKE_S3_CA_CERT_PEM }}
       TCFS_SMOKE_MASTER_KEY_B64: ${{ secrets.TCFS_SMOKE_MASTER_KEY_B64 }}
       TCFS_S3_ACCESS: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
       TCFS_S3_SECRET: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
@@ -318,10 +320,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          REGION="${TCFS_SMOKE_S3_REGION:-us-east-1}"
           if [[ "${TCFS_SMOKE_S3_ENDPOINT}" == https://* ]]; then
             STORAGE_ENFORCE_TLS=true
           else
             STORAGE_ENFORCE_TLS=false
+          fi
+          CA_CERT_PATH=""
+          CA_CERT_CONFIG_LINE=""
+          if [[ -n "${TCFS_SMOKE_S3_CA_CERT_PEM:-}" ]]; then
+            CA_CERT_PATH="$RUNNER_TEMP/tcfs-linux-storage-ca.pem"
+            printf '%s\n' "$TCFS_SMOKE_S3_CA_CERT_PEM" > "$CA_CERT_PATH"
+            chmod 600 "$CA_CERT_PATH"
+            CA_CERT_CONFIG_LINE="ca_cert_path = \"${CA_CERT_PATH}\""
           fi
           cat > "$CONFIG_PATH" <<EOF
           [daemon]
@@ -331,10 +342,11 @@ jobs:
 
           [storage]
           endpoint = "${TCFS_SMOKE_S3_ENDPOINT}"
-          region = "us-east-1"
+          region = "${REGION}"
           bucket = "${TCFS_SMOKE_S3_BUCKET}"
           remote_prefix = "${REMOTE_PREFIX}"
           enforce_tls = ${STORAGE_ENFORCE_TLS}
+          ${CA_CERT_CONFIG_LINE}
 
           [crypto]
           enabled = true
@@ -350,6 +362,15 @@ jobs:
           device_id = "gha-linux-postinstall"
           EOF
           chmod 600 "$CONFIG_PATH"
+          {
+            echo "endpoint=$TCFS_SMOKE_S3_ENDPOINT"
+            echo "bucket=$TCFS_SMOKE_S3_BUCKET"
+            echo "region=$REGION"
+            echo "remote_prefix=$REMOTE_PREFIX"
+            echo "enforce_tls=$STORAGE_ENFORCE_TLS"
+            echo "ca_cert_path_supported=true"
+            echo "ca_cert_path_configured=$([[ -n "$CA_CERT_PATH" ]] && echo true || echo false)"
+          } > "$LOG_DIR/linux-storage.env"
 
       - name: Prepare expected fixture content
         shell: bash

--- a/Justfile
+++ b/Justfile
@@ -138,6 +138,10 @@ alpha-gate-preflight *ARGS:
 alpha-gate-preflight-test:
     @bash scripts/test-tcfs-alpha-gate-preflight.sh
 
+# Static regression test for the Linux package post-install smoke workflow
+linux-postinstall-workflow-test:
+    @bash scripts/test-linux-postinstall-workflow.sh
+
 # Installed-binary smoke for release surfaces that ship tcfsd (and optionally tcfs)
 install-smoke *ARGS:
     bash scripts/install-smoke.sh {{ARGS}}

--- a/scripts/test-linux-postinstall-workflow.sh
+++ b/scripts/test-linux-postinstall-workflow.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # Literal workflow expressions are what this test asserts.
+#
+# Static regression checks for the Linux post-install smoke workflow.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${REPO_ROOT}/.github/workflows/linux-postinstall-smoke.yml"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-linux-postinstall-workflow-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+
+  if grep -Fq -- "$unexpected" "$file"; then
+    printf 'expected not to find %s in %s\n' "$unexpected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+extract_step_from_workflow() {
+  local step_name="$1"
+  local output="$2"
+
+  ruby -ryaml -e '
+    workflow = YAML.load_file(ARGV[0])
+    steps = workflow.fetch("jobs").fetch("package-postinstall").fetch("steps")
+    step = steps.find { |item| item["name"] == ARGV[1] }
+    raise "missing workflow step #{ARGV[1]}" unless step
+    puts step.fetch("run")
+  ' "$WORKFLOW" "$step_name" >"$output"
+}
+
+check_secret_surface() {
+  assert_contains "$WORKFLOW" 'TCFS_SMOKE_S3_REGION: ${{ secrets.TCFS_SMOKE_S3_REGION }}'
+  assert_contains "$WORKFLOW" 'TCFS_SMOKE_S3_CA_CERT_PEM: ${{ secrets.TCFS_SMOKE_S3_CA_CERT_PEM }}'
+}
+
+check_live_config_ca_cert_shape() {
+  local step="$TMPDIR/write-live-config.sh"
+  extract_step_from_workflow "Write live config" "$step"
+
+  assert_contains "$step" 'REGION="${TCFS_SMOKE_S3_REGION:-us-east-1}"'
+  assert_contains "$step" 'CA_CERT_CONFIG_LINE="ca_cert_path = \"${CA_CERT_PATH}\""'
+  assert_contains "$step" 'ca_cert_path_supported=true'
+  assert_contains "$step" 'ca_cert_path_configured=$([[ -n "$CA_CERT_PATH" ]] && echo true || echo false)'
+  assert_not_contains "$step" "printf 'ca_cert_path = \"%s\"\\n' \"\$CA_CERT_PATH\" >> \"\$CONFIG_PATH\""
+
+  python3 - "$step" <<'PY'
+import pathlib
+import sys
+
+run = pathlib.Path(sys.argv[1]).read_text()
+storage = run.index("[storage]")
+ca_line = run.index("${CA_CERT_CONFIG_LINE}", storage)
+crypto = run.index("[crypto]", storage)
+sync = run.index("[sync]", storage)
+if not (storage < ca_line < crypto < sync):
+    raise SystemExit("CA cert config line must be emitted inside [storage]")
+PY
+}
+
+check_secret_surface
+check_live_config_ca_cert_shape
+
+printf 'Linux post-install smoke workflow tests passed\n'


### PR DESCRIPTION
## Summary
- thread optional `TCFS_SMOKE_S3_REGION` and `TCFS_SMOKE_S3_CA_CERT_PEM` into the Linux post-install smoke workflow
- write the custom CA path inside the `[storage]` stanza so HTTPS private endpoints can be tested with the same posture as the storage canary
- add a static workflow regression test plus `just linux-postinstall-workflow-test`

## Validation
- `bash -n scripts/test-linux-postinstall-workflow.sh scripts/test-linux-postinstall-smoke.sh scripts/linux-postinstall-smoke.sh`
- `bash scripts/test-linux-postinstall-workflow.sh`
- `just linux-postinstall-workflow-test`
- `shellcheck scripts/test-linux-postinstall-workflow.sh`
- `git diff --check`

## Not run
- `bash scripts/test-linux-postinstall-smoke.sh` on this macOS host: the existing harness uses `mapfile`, and `/bin/bash` here is Bash 3.2. The workflow target is Linux/GitHub Actions bash.
- live `linux-postinstall-smoke.yml`: still blocked until the GitHub smoke environment has reachable S3 endpoint/bucket/credentials and `TCFS_SMOKE_MASTER_KEY_B64`.

Refs TIN-1540, TIN-1422.