### PR TITLE
linux-smoke: evict mounted cache by index

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -483,6 +483,17 @@ enum CacheAction {
     Stats,
     /// Clear all cached content
     Clear,
+    /// Evict one remote-backed file from the local hydrated-content cache
+    Evict {
+        /// Logical relative path under the remote prefix
+        rel_path: String,
+        /// Remote prefix override
+        #[arg(long, short = 'p')]
+        prefix: Option<String>,
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -583,6 +594,11 @@ async fn main() -> Result<()> {
         Commands::Cache { action } => match action {
             CacheAction::Stats => cmd_cache_stats(&config).await,
             CacheAction::Clear => cmd_cache_clear(&config).await,
+            CacheAction::Evict {
+                rel_path,
+                prefix,
+                json,
+            } => cmd_cache_evict(&config, &rel_path, prefix.as_deref(), json).await,
         },
         Commands::Mount {
             remote,
@@ -2370,6 +2386,15 @@ fn format_uptime(secs: i64) -> String {
 
 // ── `tcfs cache stats` / `tcfs cache clear` ──────────────────────────────────
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct CacheEvictReport {
+    rel_path: String,
+    remote_prefix: String,
+    manifest_hash: String,
+    bytes_freed: u64,
+    was_cached: bool,
+}
+
 async fn cmd_cache_stats(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
     let cache_dir = expand_tilde(&config.fuse.cache_dir);
     let cache_max = config.fuse.cache_max_mb * 1024 * 1024;
@@ -2413,6 +2438,74 @@ async fn cmd_cache_clear(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
     } else {
         println!("Cache directory does not exist: {}", cache_dir.display());
     }
+    Ok(())
+}
+
+async fn evict_cache_entry_with_operator(
+    config: &tcfs_core::config::TcfsConfig,
+    op: &opendal::Operator,
+    rel_path: &str,
+    remote_prefix: &str,
+) -> Result<CacheEvictReport> {
+    let report = inspect_index_entry_with_operator(op, rel_path, remote_prefix).await?;
+    let status = report.status.clone();
+    let visible = report.visible_entry.with_context(|| {
+        format!(
+            "cannot evict cache for {}: remote index status is {status}",
+            report.rel_path
+        )
+    })?;
+    anyhow::ensure!(
+        visible.manifest_exists,
+        "cannot evict cache for {}: manifest {} is missing",
+        report.rel_path,
+        visible.manifest_key
+    );
+
+    let cache_dir = expand_tilde(&config.fuse.cache_dir);
+    let cache_max = config.fuse.cache_max_mb * 1024 * 1024;
+    let cache = tcfs_vfs::DiskCache::new(cache_dir, cache_max);
+    let bytes_freed = cache.evict(&visible.manifest_hash).await?;
+
+    Ok(CacheEvictReport {
+        rel_path: report.rel_path,
+        remote_prefix: report.remote_prefix,
+        manifest_hash: visible.manifest_hash,
+        bytes_freed,
+        was_cached: bytes_freed > 0,
+    })
+}
+
+async fn cmd_cache_evict(
+    config: &tcfs_core::config::TcfsConfig,
+    rel_path: &str,
+    prefix: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let op = build_operator(config).await?;
+    let remote_prefix = prefix.unwrap_or_else(|| config.storage.resolved_prefix());
+    let report = evict_cache_entry_with_operator(config, &op, rel_path, remote_prefix).await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).context("serializing cache evict report")?
+        );
+    } else {
+        println!("Evicted cache entry: {}", report.rel_path);
+        println!("  remote prefix: {}", report.remote_prefix);
+        println!("  manifest:      {}", report.manifest_hash);
+        println!("  freed:         {}", fmt_bytes(report.bytes_freed));
+        println!(
+            "  result:        {}",
+            if report.was_cached {
+                "evicted"
+            } else {
+                "not cached"
+            }
+        );
+    }
+
     Ok(())
 }
 
@@ -4939,6 +5032,58 @@ enabled = false
         assert_eq!(visible.manifest_key, "data/manifests/hash123");
         assert!(visible.manifest_exists);
         assert_eq!(visible.size, 46);
+    }
+
+    #[tokio::test]
+    async fn cache_evict_uses_remote_index_manifest_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = dir.path().join("cache");
+        let mut config = test_config(dir.path());
+        config.fuse.cache_dir = cache_dir.clone();
+
+        let op = memory_op();
+        op.write("data/manifests/hash123", b"{}".to_vec())
+            .await
+            .unwrap();
+        tcfs_sync::index_entry::write_committed_index_entry(
+            &op,
+            "data/index/shared/alpha-test.txt",
+            &tcfs_sync::index_entry::RemoteIndexEntry::new("hash123", 46, 1),
+        )
+        .await
+        .unwrap();
+
+        let cache = tcfs_vfs::DiskCache::new(cache_dir, 1024 * 1024);
+        cache.put("hash123", b"hydrated bytes").await.unwrap();
+        assert!(cache.contains("hash123").await);
+
+        let report = evict_cache_entry_with_operator(&config, &op, "shared/alpha-test.txt", "data")
+            .await
+            .unwrap();
+
+        assert_eq!(report.rel_path, "shared/alpha-test.txt");
+        assert_eq!(report.manifest_hash, "hash123");
+        assert_eq!(report.bytes_freed, b"hydrated bytes".len() as u64);
+        assert!(report.was_cached);
+        assert!(!cache.contains("hash123").await);
+    }
+
+    #[tokio::test]
+    async fn cache_evict_rejects_missing_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.fuse.cache_dir = dir.path().join("cache");
+        let op = memory_op();
+
+        let err = evict_cache_entry_with_operator(&config, &op, "missing.txt", "data")
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("remote index status is missing_index"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/tcfs-cli/tests/cli_parsing_test.rs
+++ b/crates/tcfs-cli/tests/cli_parsing_test.rs
@@ -68,6 +68,10 @@ enum Commands {
     Unmount {
         mountpoint: PathBuf,
     },
+    Cache {
+        #[command(subcommand)]
+        action: CacheAction,
+    },
     Unsync {
         path: PathBuf,
         #[arg(long)]
@@ -91,6 +95,19 @@ enum ConfigAction {
 #[derive(clap::Subcommand, Debug)]
 enum IndexAction {
     Inspect {
+        rel_path: String,
+        #[arg(long, short = 'p')]
+        prefix: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum CacheAction {
+    Stats,
+    Clear,
+    Evict {
         rel_path: String,
         #[arg(long, short = 'p')]
         prefix: Option<String>,
@@ -280,6 +297,36 @@ fn parse_unmount() {
         assert_eq!(mountpoint, PathBuf::from("/mnt/tcfs"));
     } else {
         panic!("expected Unmount");
+    }
+}
+
+#[test]
+fn parse_cache_evict() {
+    let cli = Cli::try_parse_from([
+        "tcfs",
+        "cache",
+        "evict",
+        "Projects/tcfs-odrive-parity/honey-readme.txt",
+        "--prefix",
+        "data",
+        "--json",
+    ])
+    .expect("cache evict should parse");
+
+    if let Commands::Cache {
+        action:
+            CacheAction::Evict {
+                rel_path,
+                prefix,
+                json,
+            },
+    } = cli.command
+    {
+        assert_eq!(rel_path, "Projects/tcfs-odrive-parity/honey-readme.txt");
+        assert_eq!(prefix, Some("data".to_string()));
+        assert!(json);
+    } else {
+        panic!("expected Cache Evict");
     }
 }
 

--- a/scripts/linux-postinstall-smoke.sh
+++ b/scripts/linux-postinstall-smoke.sh
@@ -4,7 +4,7 @@
 # Verify the installed Linux package path after .deb/.rpm install:
 # package install, tcfsd reachable (systemd unit or fallback foreground),
 # FUSE mount, remote index gate via `tcfs index inspect`, exact-content
-# hydration through the mount, and optional evict/rehydrate and mutation
+# hydration through the mount, and optional cache-evict/rehydrate and mutation
 # exercises.
 #
 # This is the structural analog of scripts/macos-postinstall-smoke.sh.
@@ -24,7 +24,7 @@ Usage: scripts/linux-postinstall-smoke.sh [options]
 
 Verify the installed Linux package path after .deb/.rpm install:
 package layout, tcfsd reachable, FUSE mount, exact-content hydration,
-optional evict/rehydrate and mutation exercises.
+optional cache-evict/rehydrate and mutation exercises.
 
 This harness assumes a real operator config and a routable backend.
 It does not fabricate storage credentials.
@@ -44,8 +44,8 @@ Options:
                               File containing exact expected content
   --seed-expected-file        Create a timestamped fixture, push to remote, and
                               use it as the expected hydration target
-  --exercise-evict-rehydrate  After hydration, run `tcfs unsync` and re-read to
-                              verify rehydrate
+  --exercise-evict-rehydrate  After hydration, evict the hydrated cache entry
+                              and re-read to verify rehydrate
   --exercise-mutation         Write a new file through the mount and verify via
                               remote pull
   --mutation-file <relpath>   Relative mutation file path under the mount
@@ -671,8 +671,10 @@ resolve_remote_spec() {
     exit 2
   fi
   local remote_scheme authority bucket
-  local -a remote_parts
-  mapfile -t remote_parts < <(python3 - "$CONFIG_PATH" <<'PY' 2>/dev/null || true
+  local -a remote_parts=()
+  while IFS= read -r remote_part; do
+    remote_parts+=("$remote_part")
+  done < <(python3 - "$CONFIG_PATH" <<'PY' 2>/dev/null || true
 import sys
 import urllib.parse
 try:
@@ -800,27 +802,25 @@ hydrate_expected_file() {
   fi
 }
 
-# ── Evict / rehydrate via `tcfs unsync` ──────────────────────────────────────
+# ── Evict / rehydrate via mounted-content cache eviction ─────────────────────
 exercise_evict_rehydrate_cycle() {
   local rel="$1"
   local mount_path="$MOUNT_POINT/$rel"
-  local unsync_log="$LOG_DIR/unsync.log"
+  local evict_log="$LOG_DIR/cache-evict.log"
+  local -a args
 
-  # TODO(TIN-1422): on Linux the canonical "evict" path for the FUSE mount
-  # is `tcfs unsync <hydrated-copy>` applied to the sync_root copy (the
-  # FUSE mount itself is a read-through cache, not the eviction target).
-  # For the scaffold we drive `tcfs unsync` against the mounted path and
-  # rely on the CLI to convert it to a stub on disk — followup work needs
-  # to confirm the right semantics for FUSE-backed flows and may need to
-  # operate on a sync_root path instead.
-  echo "requesting unsync (evict): $mount_path"
-  "$TCFS_PATH" --config "$CONFIG_PATH" unsync "$mount_path" \
-    >"$unsync_log" 2>&1 || {
-    echo "tcfs unsync failed" >&2
-    cat "$unsync_log" >&2 || true
+  args=(--config "$CONFIG_PATH" cache evict "$rel")
+  if [[ -n "$REMOTE_PREFIX" ]]; then
+    args+=(--prefix "$REMOTE_PREFIX")
+  fi
+
+  echo "evicting hydrated cache entry: $rel"
+  "$TCFS_PATH" "${args[@]}" >"$evict_log" 2>&1 || {
+    echo "tcfs cache evict failed" >&2
+    cat "$evict_log" >&2 || true
     exit 1
   }
-  cat "$unsync_log"
+  cat "$evict_log"
 
   # Read again — should rehydrate.
   hydrate_expected_file "$mount_path"

--- a/scripts/test-linux-postinstall-smoke.sh
+++ b/scripts/test-linux-postinstall-smoke.sh
@@ -94,7 +94,7 @@ fi
 EOF
 
 # ── Fake tcfs CLI that supports status, index inspect, push, pull, mount,
-#    unsync ──────────────────────────────────────────────────────────────────
+#    and cache evict ─────────────────────────────────────────────────────────
 cat >"$FAKE_BIN/tcfs" <<'EOF'
 #!/usr/bin/env bash
 case "${1:-}" in
@@ -171,9 +171,21 @@ JSON
         : >"${TCFS_FAKE_MOUNT_MARKER:-/dev/null}"
         exec sleep 60
         ;;
+      cache)
+        [[ "${2:-}" == "evict" ]] || {
+          printf 'expected fake cache evict\n' >&2
+          exit 1
+        }
+        rel="${3:-}"
+        printf 'Evicted cache entry: %s\n' "$rel"
+        printf '  remote prefix: fake/prefix\n'
+        printf '  manifest:      fakehash\n'
+        printf '  freed:         27 B\n'
+        printf '  result:        evicted\n'
+        ;;
       unsync)
-        path="$2"
-        printf 'Unsynced: %s -> stub\n' "$path"
+        printf 'fake tcfs unsync should not be used for mounted cache eviction\n' >&2
+        exit 64
         ;;
       *)
         printf 'unexpected tcfs --config invocation:'
@@ -368,6 +380,8 @@ assert_contains "$POSITIVE_OUT" "remote index status for expected file: visible"
 assert_contains "$POSITIVE_OUT" "derived --remote-spec: seaweedfs+https://example.invalid:8333/tcfs/fake/prefix"
 assert_contains "$POSITIVE_OUT" "FUSE mount ready"
 assert_contains "$POSITIVE_OUT" "hydrated file content matched expected content file"
+assert_contains "$POSITIVE_OUT" "evicting hydrated cache entry: $EXPECTED_REL"
+assert_contains "$POSITIVE_OUT" "Evicted cache entry: $EXPECTED_REL"
 assert_contains "$POSITIVE_OUT" "Linux evict/rehydrate cycle passed"
 assert_contains "$POSITIVE_OUT" "Linux mutation local content matched"
 assert_contains "$POSITIVE_OUT" "remote mutation pull matched expected content"


### PR DESCRIPTION
## Summary
- add `tcfs cache evict <rel_path>` to evict a single hydrated-content cache entry by resolving its manifest hash through the remote index
- switch Linux post-install evict/rehydrate from mounted-path `tcfs unsync` to mounted-content cache eviction, which matches the FUSE cache model
- remove Bash 4-only `mapfile` from `scripts/linux-postinstall-smoke.sh` so the fake harness runs on macOS Bash 3 as advertised

## Validation
- `bash -n scripts/linux-postinstall-smoke.sh scripts/test-linux-postinstall-smoke.sh`
- `bash scripts/test-linux-postinstall-smoke.sh`
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test -p tcfs-cli cache_evict -- --nocapture`
- `shellcheck -e SC2024,SC2034 scripts/linux-postinstall-smoke.sh scripts/test-linux-postinstall-smoke.sh`
- `git diff --check`

## Boundary
This is source-owned TIN-1422 hardening. It does not by itself close the live Linux package smoke, which still needs the reachable S3 backend/secrets/runner path tracked by TIN-1540.

Refs TIN-1422, TIN-1540.