### PR TITLE
ops: archive neo-honey smoke evidence packet

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -130,6 +130,10 @@ fleet-check:
 neo-honey-smoke:
     bash scripts/neo-honey-smoke.sh
 
+# Regression test the neo/honey evidence-packet wrapper without live services
+neo-honey-smoke-test:
+    bash scripts/test-neo-honey-smoke.sh
+
 # Read-only alpha productionization gate classifier
 alpha-gate-preflight *ARGS:
     @bash scripts/tcfs-alpha-gate-preflight.sh {{ARGS}}

--- a/scripts/neo-honey-smoke.sh
+++ b/scripts/neo-honey-smoke.sh
@@ -2,18 +2,155 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT"
+RUN_STAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
+LOG_DIR="${TCFS_NEO_HONEY_LOG_DIR:-}"
+RESULT_WRITTEN=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/neo-honey-smoke.sh [options]
+
+Run the named neo/honey live fleet acceptance lane and write an evidence packet.
+
+Options:
+  --log-dir <dir>  Evidence directory. Default:
+                   docs/release/evidence/neo-honey-smoke-<UTC timestamp>
+  -h, --help       Show this help text
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log-dir)
+      [[ $# -ge 2 ]] || {
+        echo "--log-dir requires a directory" >&2
+        exit 2
+      }
+      LOG_DIR="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$LOG_DIR" ]]; then
+  LOG_DIR="$ROOT/docs/release/evidence/neo-honey-smoke-${RUN_STAMP}"
+fi
+mkdir -p "$LOG_DIR"
+LOG_DIR="$(cd "$LOG_DIR" && pwd)"
+RESULT_ENV="$LOG_DIR/result.env"
+RUN_METADATA="$LOG_DIR/run-metadata.env"
+
+redact_url() {
+  local value="$1"
+  python3 - "$value" <<'PY'
+import sys
+import urllib.parse
+
+raw = sys.argv[1]
+parsed = urllib.parse.urlparse(raw)
+if not parsed.scheme:
+    print(raw)
+    raise SystemExit
+netloc = parsed.hostname or ""
+if parsed.port:
+    netloc = f"{netloc}:{parsed.port}"
+print(urllib.parse.urlunparse((parsed.scheme, netloc, parsed.path, "", "", "")))
+PY
+}
+
+write_result() {
+  local status="$1"
+  local proof="$2"
+  local failed_step="${3:-}"
+
+  {
+    echo "status=$status"
+    echo "proof=$proof"
+    echo "failed_step=$failed_step"
+    echo "started_at=$RUN_STAMP"
+    echo "completed_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "log_dir=$LOG_DIR"
+  } >"$RESULT_ENV"
+  RESULT_WRITTEN=1
+}
+
+write_metadata() {
+  local git_sha git_branch endpoint_redacted nats_redacted
+  git_sha="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || true)"
+  git_branch="$(git -C "$ROOT" branch --show-current 2>/dev/null || true)"
+  endpoint_redacted="$(redact_url "${TCFS_S3_ENDPOINT:-}")"
+  nats_redacted="$(redact_url "${TCFS_NATS_URL:-}")"
+
+  {
+    echo "run_stamp=$RUN_STAMP"
+    echo "repo=$ROOT"
+    echo "git_sha=$git_sha"
+    echo "git_branch=$git_branch"
+    echo "tcfs_e2e_live=${TCFS_E2E_LIVE:-}"
+    echo "s3_endpoint=$endpoint_redacted"
+    echo "s3_bucket=${TCFS_S3_BUCKET:-}"
+    echo "nats_url=$nats_redacted"
+    echo "log_dir=$LOG_DIR"
+  } >"$RUN_METADATA"
+}
+
+fail_with_result() {
+  local status="$1"
+  local proof="$2"
+  local failed_step="$3"
+  shift 3
+  echo "$*" >&2
+  write_metadata
+  write_result "$status" "$proof" "$failed_step"
+  exit "$status"
+}
 
 require_env() {
   local name="$1"
   if [[ -z "${!name:-}" ]]; then
-    echo "missing required env: $name" >&2
-    exit 1
+    fail_with_result 2 "blocked-missing-env" "env:$name" "missing required env: $name"
   fi
 }
 
+run_cargo_test() {
+  local label="$1"
+  local test_name="$2"
+  local log_file="$LOG_DIR/${label}.log"
+
+  echo "==> proving ${label//-/ }"
+  if cargo test -p tcfs-e2e --test fleet_live "$test_name" -- --nocapture \
+    >"$log_file" 2>&1; then
+    cat "$log_file"
+  else
+    local status=$?
+    cat "$log_file" >&2 || true
+    write_result "$status" "failed" "$label"
+    exit "$status"
+  fi
+}
+
+on_exit() {
+  local rc=$?
+  if [[ "$rc" != "0" && "$RESULT_WRITTEN" == "0" ]]; then
+    write_result "$rc" "failed" "unexpected"
+  fi
+}
+trap on_exit EXIT
+
+cd "$ROOT"
+
 echo "==> neo-honey live acceptance smoke"
 echo "repo: $ROOT"
+echo "evidence: $LOG_DIR"
 
 require_env TCFS_E2E_LIVE
 require_env TCFS_S3_ENDPOINT
@@ -23,17 +160,15 @@ require_env AWS_SECRET_ACCESS_KEY
 require_env TCFS_NATS_URL
 
 if [[ "${TCFS_E2E_LIVE}" != "1" ]]; then
-  echo "TCFS_E2E_LIVE must be set to 1" >&2
-  exit 1
+  fail_with_result 2 "blocked-live-disabled" "env:TCFS_E2E_LIVE" "TCFS_E2E_LIVE must be set to 1"
 fi
 
-echo "==> proving SeaweedFS health"
-cargo test -p tcfs-e2e --test fleet_live seaweedfs_health_check -- --nocapture
+write_metadata
 
-echo "==> proving NATS JetStream connectivity"
-cargo test -p tcfs-e2e --test fleet_live nats_connect_and_jetstream -- --nocapture
+run_cargo_test "seaweedfs-health" "seaweedfs_health_check"
+run_cargo_test "nats-jetstream" "nats_connect_and_jetstream"
+run_cargo_test "neo-honey-two-device-sync" "neo_honey_two_device_sync_smoke"
 
-echo "==> proving named neo-honey two-device sync path"
-cargo test -p tcfs-e2e --test fleet_live neo_honey_two_device_sync_smoke -- --nocapture
-
+write_result 0 "neo-honey-live-fleet-acceptance" ""
 echo "==> neo-honey smoke passed"
+echo "result: $RESULT_ENV"

--- a/scripts/test-neo-honey-smoke.sh
+++ b/scripts/test-neo-honey-smoke.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/neo-honey-smoke.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-neo-honey-smoke-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_file_exists() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    printf 'expected file to exist: %s\n' "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+
+  local out="$TMPDIR/failure.out"
+  if "$@" >"$out" 2>&1; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+  assert_contains "$out" "$expected"
+}
+
+FAKE_BIN="$TMPDIR/fake-bin"
+mkdir -p "$FAKE_BIN"
+
+cat >"$FAKE_BIN/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'cargo %s\n' "$*" >> "${TCFS_FAKE_CARGO_LOG:?}"
+
+test_name=""
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "--test" ]]; then
+    prev=""
+    continue
+  fi
+  if [[ "$arg" == "--test" ]]; then
+    prev="--test"
+    continue
+  fi
+  case "$arg" in
+    seaweedfs_health_check | nats_connect_and_jetstream | neo_honey_two_device_sync_smoke)
+      test_name="$arg"
+      ;;
+  esac
+done
+
+if [[ -n "${TCFS_FAKE_FAIL_TEST:-}" && "$test_name" == "$TCFS_FAKE_FAIL_TEST" ]]; then
+  printf 'fake cargo failure for %s\n' "$test_name" >&2
+  exit 42
+fi
+
+printf 'fake cargo success for %s\n' "$test_name"
+EOF
+chmod +x "$FAKE_BIN/cargo"
+
+export PATH="$FAKE_BIN:$PATH"
+export TCFS_FAKE_CARGO_LOG="$TMPDIR/cargo.log"
+: >"$TCFS_FAKE_CARGO_LOG"
+
+bash -n "$SCRIPT"
+
+POSITIVE_LOG_DIR="$TMPDIR/positive-evidence"
+POSITIVE_OUT="$TMPDIR/positive.out"
+env \
+  TCFS_E2E_LIVE=1 \
+  TCFS_S3_ENDPOINT="https://access:secret@example.invalid:8333/private" \
+  TCFS_S3_BUCKET=tcfs-smoke \
+  AWS_ACCESS_KEY_ID=test-access \
+  AWS_SECRET_ACCESS_KEY=test-secret \
+  TCFS_NATS_URL="nats://token@example.invalid:4222" \
+  bash "$SCRIPT" --log-dir "$POSITIVE_LOG_DIR" >"$POSITIVE_OUT" 2>&1
+
+assert_contains "$POSITIVE_OUT" "neo-honey smoke passed"
+assert_contains "$POSITIVE_LOG_DIR/result.env" "status=0"
+assert_contains "$POSITIVE_LOG_DIR/result.env" "proof=neo-honey-live-fleet-acceptance"
+assert_contains "$POSITIVE_LOG_DIR/run-metadata.env" "s3_endpoint=https://example.invalid:8333/private"
+assert_contains "$POSITIVE_LOG_DIR/run-metadata.env" "nats_url=nats://example.invalid:4222"
+assert_contains "$POSITIVE_LOG_DIR/run-metadata.env" "s3_bucket=tcfs-smoke"
+assert_file_exists "$POSITIVE_LOG_DIR/seaweedfs-health.log"
+assert_file_exists "$POSITIVE_LOG_DIR/nats-jetstream.log"
+assert_file_exists "$POSITIVE_LOG_DIR/neo-honey-two-device-sync.log"
+assert_contains "$TCFS_FAKE_CARGO_LOG" "seaweedfs_health_check"
+assert_contains "$TCFS_FAKE_CARGO_LOG" "nats_connect_and_jetstream"
+assert_contains "$TCFS_FAKE_CARGO_LOG" "neo_honey_two_device_sync_smoke"
+
+MISSING_LOG_DIR="$TMPDIR/missing-evidence"
+assert_fails_contains \
+  "missing required env: TCFS_E2E_LIVE" \
+  env bash "$SCRIPT" --log-dir "$MISSING_LOG_DIR"
+assert_contains "$MISSING_LOG_DIR/result.env" "status=2"
+assert_contains "$MISSING_LOG_DIR/result.env" "proof=blocked-missing-env"
+assert_contains "$MISSING_LOG_DIR/result.env" "failed_step=env:TCFS_E2E_LIVE"
+
+FAIL_LOG_DIR="$TMPDIR/fail-evidence"
+assert_fails_contains \
+  "fake cargo failure for nats_connect_and_jetstream" \
+  env \
+    TCFS_E2E_LIVE=1 \
+    TCFS_S3_ENDPOINT="https://example.invalid:8333/private" \
+    TCFS_S3_BUCKET=tcfs-smoke \
+    AWS_ACCESS_KEY_ID=test-access \
+    AWS_SECRET_ACCESS_KEY=test-secret \
+    TCFS_NATS_URL="nats://example.invalid:4222" \
+    TCFS_FAKE_FAIL_TEST=nats_connect_and_jetstream \
+    bash "$SCRIPT" --log-dir "$FAIL_LOG_DIR"
+assert_contains "$FAIL_LOG_DIR/result.env" "status=42"
+assert_contains "$FAIL_LOG_DIR/result.env" "proof=failed"
+assert_contains "$FAIL_LOG_DIR/result.env" "failed_step=nats-jetstream"
+
+printf 'neo-honey smoke tests passed\n'


### PR DESCRIPTION
## Summary
- make `scripts/neo-honey-smoke.sh` write a durable evidence packet with `run-metadata.env`, `result.env`, and per-step cargo transcripts
- add `--log-dir`/`TCFS_NEO_HONEY_LOG_DIR` so operator runs can archive TIN-132 evidence in a named directory
- redact credential material from endpoint/NATS metadata and add a fake-cargo regression test plus `just neo-honey-smoke-test`

## Validation
- `bash -n scripts/neo-honey-smoke.sh scripts/test-neo-honey-smoke.sh`
- `bash scripts/test-neo-honey-smoke.sh`
- `shellcheck scripts/neo-honey-smoke.sh scripts/test-neo-honey-smoke.sh`
- `just neo-honey-smoke-test`
- `git diff --check`

## Boundary
This improves evidence capture only. It does not run the live neo/honey acceptance lane from this workspace; TIN-132 still needs an operator environment run or an explicit supersede decision.

Refs TIN-132.