### PR TITLE
storage: make daemon health prefix scoped

### DIFF
--- a/crates/tcfs-storage/src/health.rs
+++ b/crates/tcfs-storage/src/health.rs
@@ -14,11 +14,47 @@ pub async fn check_health(op: &Operator) -> Result<()> {
 
 /// Verify storage health with an explicit timeout.
 pub async fn check_health_with_timeout(op: &Operator, timeout: Duration) -> Result<()> {
+    check_health_path_with_timeout(op, "/", timeout).await
+}
+
+/// Verify the storage endpoint is reachable using a scoped remote prefix.
+///
+/// Production credentials may be limited to a tenant or run prefix. In that
+/// case bucket-root `ListBucket` can be denied even though the configured tcfs
+/// prefix is fully usable.
+pub async fn check_health_for_prefix(op: &Operator, prefix: &str) -> Result<()> {
+    check_health_for_prefix_with_timeout(op, prefix, DEFAULT_HEALTH_TIMEOUT).await
+}
+
+/// Verify storage health for a scoped remote prefix with an explicit timeout.
+pub async fn check_health_for_prefix_with_timeout(
+    op: &Operator,
+    prefix: &str,
+    timeout: Duration,
+) -> Result<()> {
+    let path = health_probe_path(prefix);
+    check_health_path_with_timeout(op, &path, timeout).await
+}
+
+fn health_probe_path(prefix: &str) -> String {
+    let prefix = prefix.trim_matches('/');
+    if prefix.is_empty() {
+        "/".to_string()
+    } else {
+        format!("{prefix}/")
+    }
+}
+
+async fn check_health_path_with_timeout(
+    op: &Operator,
+    path: &str,
+    timeout: Duration,
+) -> Result<()> {
     let probe = async {
-        op.list("/")
+        op.list(path)
             .await
             .map(|_| ())
-            .map_err(|e| anyhow::anyhow!("storage health check failed: {e}"))
+            .map_err(|e| anyhow::anyhow!("storage health check failed at {path}: {e}"))
     };
 
     tokio::time::timeout(timeout, probe)
@@ -55,5 +91,28 @@ mod tests {
         check_health_with_timeout(&op, Duration::from_secs(1))
             .await
             .expect("memory health check with explicit timeout");
+    }
+
+    #[tokio::test]
+    async fn prefix_health_check_lists_scoped_prefix() {
+        let op = memory_operator();
+        op.write("tenant-a/index/file.txt", "ok")
+            .await
+            .expect("seed scoped object");
+
+        check_health_for_prefix(&op, "tenant-a")
+            .await
+            .expect("prefix health check");
+        check_health_for_prefix_with_timeout(&op, "/tenant-a/", Duration::from_secs(1))
+            .await
+            .expect("prefix health check with explicit timeout");
+    }
+
+    #[test]
+    fn health_probe_path_normalizes_prefixes() {
+        assert_eq!(health_probe_path(""), "/");
+        assert_eq!(health_probe_path("/"), "/");
+        assert_eq!(health_probe_path("tenant-a"), "tenant-a/");
+        assert_eq!(health_probe_path("/tenant-a/nested/"), "tenant-a/nested/");
     }
 }

--- a/crates/tcfs-storage/src/lib.rs
+++ b/crates/tcfs-storage/src/lib.rs
@@ -5,7 +5,7 @@ pub mod multipart;
 pub mod operator;
 pub mod seaweedfs;
 
-pub use health::check_health;
+pub use health::{check_health, check_health_for_prefix};
 pub use operator::{build_operator, StorageConfig};
 
 /// Parse a remote spec like `seaweedfs://host:port/bucket[/prefix]`.

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -257,14 +257,23 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             &s3.access_key_id,
             s3.secret_access_key.expose_secret(),
         )?;
-        match tcfs_storage::check_health(&op).await {
+        let storage_prefix = config.storage.resolved_prefix();
+        match tcfs_storage::check_health_for_prefix(&op, storage_prefix).await {
             Ok(()) => {
-                info!(endpoint = %config.storage.endpoint, "SeaweedFS: connected");
+                info!(
+                    endpoint = %config.storage.endpoint,
+                    prefix = %storage_prefix,
+                    "SeaweedFS: connected"
+                );
                 operator = Some(op);
                 true
             }
             Err(e) => {
-                warn!(endpoint = %config.storage.endpoint, "SeaweedFS: {e}");
+                warn!(
+                    endpoint = %config.storage.endpoint,
+                    prefix = %storage_prefix,
+                    "SeaweedFS: {e}"
+                );
                 // Still keep the operator for retry
                 operator = Some(op);
                 false
@@ -375,6 +384,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         let health_state = crate::metrics::HealthState {
             registry: metrics_registry.clone(),
             operator: operator.clone(),
+            storage_prefix: config.storage.resolved_prefix().to_string(),
             sync_root: config.sync.sync_root.clone(),
         };
         tokio::spawn(async move {

--- a/crates/tcfsd/src/metrics.rs
+++ b/crates/tcfsd/src/metrics.rs
@@ -91,6 +91,8 @@ impl DaemonMetrics {
 pub struct HealthState {
     pub registry: Arc<Registry>,
     pub operator: Arc<TokioMutex<Option<opendal::Operator>>>,
+    /// Remote storage prefix used for permission-aware readiness probing.
+    pub storage_prefix: String,
     /// Sync root path for FUSE mount liveness probing
     pub sync_root: Option<PathBuf>,
 }
@@ -143,7 +145,7 @@ async fn healthz_handler() -> impl IntoResponse {
 async fn readyz_handler(State(state): State<HealthState>) -> impl IntoResponse {
     let op = state.operator.lock().await;
     match op.as_ref() {
-        Some(op) => match tcfs_storage::check_health(op).await {
+        Some(op) => match tcfs_storage::check_health_for_prefix(op, &state.storage_prefix).await {
             Ok(()) => (StatusCode::OK, "ready"),
             Err(_) => (StatusCode::SERVICE_UNAVAILABLE, "storage unreachable"),
         },


### PR DESCRIPTION
## Summary
- classify the Linux postinstall smoke failure from run 26177991284 as a bucket-root health probe mismatch with scoped S3 credentials
- add `tcfs_storage::check_health_for_prefix` so production credentials can deny root `ListBucket` while allowing the configured `storage.remote_prefix`
- use prefix-scoped health in daemon startup and `/readyz`, keeping the old root health API for unscoped callers

## Evidence
- failed Linux smoke: https://github.com/Jesssullivan/tummycrypt/actions/runs/26177991284, job 77013090239, artifact `linux-postinstall-smoke-v0.12.13-rc2`
- artifact daemon log showed `AccessDenied` for `GET /tcfs?delimiter=/&list-type=2` while the daemon later listed the configured run prefix successfully
- `~/.cargo/bin/cargo test -p tcfs-storage`
- `~/.cargo/bin/cargo test -p tcfsd metrics`
- `~/.cargo/bin/cargo fmt --all -- --check`
- live source probe on 2026-05-21: patched `tcfsd` against `https://tcfs-smoke-s3.tinyland.dev` with the scoped Linux smoke credential reported `storage: [ok]` and `/readyz` returned HTTP 200

## Boundary
This fixes the source-side health check. The already-published `v0.12.13-rc2` packages still contain the root-list health behavior, so TIN-1540/TIN-1422 need a branch package artifact or next RC before the full Linux postinstall smoke can go green.

Linear: TIN-1540, TIN-1422
