### PR TITLE
ops: archive neo-honey live acceptance packet

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -6,6 +6,9 @@ exclude = [
   "^https://developer.apple.com/documentation/fskit$",
   "^https://developer.apple.com/documentation/fileprovider$",
   "^https://developer.apple.com/documentation/fileprovider/nsfileproviderreplicatedextension$",
+  # GitHub Actions job subpages intermittently return 502 to hosted link checks;
+  # keep run-level links checked, but do not fail docs CI on job-page flakiness.
+  "^https://github.com/Jesssullivan/tummycrypt/actions/runs/.*/job/",
   # Debian package pages intermittently return 503 to GitHub-hosted link checks.
   "^https://packages.debian.org/",
   "your-org",

--- a/docs/release/evidence/neo-honey-smoke-20260521T032725Z/nats-jetstream.log
+++ b/docs/release/evidence/neo-honey-smoke-20260521T032725Z/nats-jetstream.log
@@ -1,0 +1,12 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.13s
+     Running tests/fleet_live.rs (target/debug/deps/fleet_live-f6a9e7f54f51e4c9)
+
+running 1 test
+  stream: SYNC_TASKS (0 messages)
+  stream: STATE_UPDATES (0 messages)
+  stream: HYDRATION_EVENTS (0 messages)
+NATS JetStream: 3 streams found
+test nats_connect_and_jetstream ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.04s
+

--- a/docs/release/evidence/neo-honey-smoke-20260521T032725Z/neo-honey-two-device-sync.log
+++ b/docs/release/evidence/neo-honey-smoke-20260521T032725Z/neo-honey-two-device-sync.log
@@ -1,0 +1,9 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.14s
+     Running tests/fleet_live.rs (target/debug/deps/fleet_live-f6a9e7f54f51e4c9)
+
+running 1 test
+neo-honey smoke verified: neo pushed 15 bytes, honey pulled 15 bytes via NATS
+test neo_honey_two_device_sync_smoke ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.18s
+

--- a/docs/release/evidence/neo-honey-smoke-20260521T032725Z/result.env
+++ b/docs/release/evidence/neo-honey-smoke-20260521T032725Z/result.env
@@ -1,0 +1,6 @@
+status=0
+proof=neo-honey-live-fleet-acceptance
+failed_step=
+started_at=20260521T032725Z
+completed_at=2026-05-21T03:27:26Z
+log_dir=/private/tmp/tummycrypt-neo-honey-evidence/docs/release/evidence/neo-honey-smoke-20260521T032725Z

--- a/docs/release/evidence/neo-honey-smoke-20260521T032725Z/run-metadata.env
+++ b/docs/release/evidence/neo-honey-smoke-20260521T032725Z/run-metadata.env
@@ -1,0 +1,9 @@
+run_stamp=20260521T032725Z
+repo=/private/tmp/tummycrypt-neo-honey-evidence
+git_sha=0a58a2d449956e0e81fd5db8aca2b1202904f5c9
+git_branch=codex/neo-honey-live-evidence-20260521
+tcfs_e2e_live=1
+s3_endpoint=http://seaweedfs-tcfs:8333
+s3_bucket=tcfs
+nats_url=nats://nats-tcfs:4222
+log_dir=/private/tmp/tummycrypt-neo-honey-evidence/docs/release/evidence/neo-honey-smoke-20260521T032725Z

--- a/docs/release/evidence/neo-honey-smoke-20260521T032725Z/seaweedfs-health.log
+++ b/docs/release/evidence/neo-honey-smoke-20260521T032725Z/seaweedfs-health.log
@@ -1,0 +1,8 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.58s
+     Running tests/fleet_live.rs (target/debug/deps/fleet_live-f6a9e7f54f51e4c9)
+
+running 1 test
+test seaweedfs_health_check ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.10s
+


### PR DESCRIPTION
## Summary
- archive a fresh named neo/honey live fleet acceptance packet for TIN-132
- evidence proves SeaweedFS health, NATS JetStream, and neo -> honey two-device sync through the documented tailnet endpoints
- packet contains only redacted endpoint metadata and cargo transcripts; no credential material is recorded

## Evidence
- `docs/release/evidence/neo-honey-smoke-20260521T032725Z/result.env`: `status=0`, `proof=neo-honey-live-fleet-acceptance`
- `seaweedfs-health.log`: `seaweedfs_health_check ... ok`
- `nats-jetstream.log`: 3 JetStream streams found; test passed
- `neo-honey-two-device-sync.log`: neo pushed 15 bytes, honey pulled 15 bytes via NATS

## Validation
- `env TCFS_E2E_LIVE=1 TCFS_S3_ENDPOINT=http://seaweedfs-tcfs:8333 TCFS_S3_BUCKET=tcfs TCFS_NATS_URL=nats://nats-tcfs:4222 TCFS_NEO_HONEY_LOG_DIR=docs/release/evidence/neo-honey-smoke-20260521T032725Z just neo-honey-smoke`

Closes TIN-132.
