### PR TITLE
linux-smoke: select runner-compatible artifact packages (TIN-1422)

### DIFF
--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -252,6 +252,35 @@ jobs:
             artifact_json="$RUNNER_TEMP/package-artifacts.json"
             artifact_zip="$RUNNER_TEMP/package-artifact.zip"
             mkdir -p "$artifact_dir"
+            select_compatible_packages() {
+              local package_ext=""
+              if command -v dpkg >/dev/null 2>&1 || command -v apt-get >/dev/null 2>&1; then
+                package_ext=".deb"
+              elif command -v rpm >/dev/null 2>&1 || command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+                package_ext=".rpm"
+              else
+                echo "::error::could not determine Linux package manager for artifact package selection"
+                return 1
+              fi
+
+              local selected=()
+              local package_path
+              for package_path in "$@"; do
+                case "$package_path" in
+                  *"$package_ext") selected+=("$package_path") ;;
+                esac
+              done
+
+              if (( ${#selected[@]} == 0 )); then
+                echo "::error::artifact $PACKAGE_ARTIFACT_NAME did not contain any $package_ext packages for this runner"
+                printf 'available packages:\n'
+                printf '  - %s\n' "$@"
+                return 1
+              fi
+
+              printf '%s\n' "${selected[@]}"
+            }
+
             curl -fsSL \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
@@ -289,7 +318,7 @@ jobs:
               find "$artifact_dir" -type f -print
               exit 1
             fi
-            printf '%s\n' "${artifact_pkgs[@]}" > "$PACKAGE_PATHS_FILE"
+            select_compatible_packages "${artifact_pkgs[@]}" > "$PACKAGE_PATHS_FILE"
           elif [[ -n "$PACKAGE_URL" ]]; then
             # Preserve the source extension; default to .deb for ubuntu runners.
             case "$PACKAGE_URL" in

--- a/scripts/test-linux-postinstall-workflow.sh
+++ b/scripts/test-linux-postinstall-workflow.sh
@@ -76,7 +76,21 @@ if not (storage < ca_line < crypto < sync):
 PY
 }
 
+check_artifact_package_selection() {
+  local step="$TMPDIR/download-package.sh"
+  extract_step_from_workflow "Download package" "$step"
+
+  assert_contains "$step" 'select_compatible_packages()'
+  assert_contains "$step" 'command -v dpkg'
+  assert_contains "$step" 'package_ext=".deb"'
+  assert_contains "$step" 'command -v rpm'
+  assert_contains "$step" 'package_ext=".rpm"'
+  assert_contains "$step" 'select_compatible_packages "${artifact_pkgs[@]}" > "$PACKAGE_PATHS_FILE"'
+  assert_not_contains "$step" 'printf '\''%s\n'\'' "${artifact_pkgs[@]}" > "$PACKAGE_PATHS_FILE"'
+}
+
 check_secret_surface
 check_live_config_ca_cert_shape
+check_artifact_package_selection
 
 printf 'Linux post-install smoke workflow tests passed\n'


### PR DESCRIPTION
## Summary
- filter mixed release workflow artifacts to runner-compatible package types before invoking the Linux postinstall harness
- keep Ubuntu hosted smokes on `.deb` packages and rpm-family runners on `.rpm` packages
- add a static workflow regression check so the mixed-artifact bug does not come back

## Root Cause
Run 26204503344 proved the `tcfs-linux-smoke` backend was reachable and installed both Ubuntu `.deb` packages, then failed because `dist-linux-x86_64` also contained the daemon `.rpm` and the Ubuntu harness attempted to install it with `rpm`.

## Verification
- `bash scripts/test-linux-postinstall-workflow.sh`
- `git diff --check`

## Tracker
TIN-1422 / TIN-1540 unblocker. After this workflow change lands, rerun Linux postinstall smoke against rc3 artifact `dist-linux-x86_64` from release run 26204080480.