### PR TITLE
docs: record Linux rc3 first-use smoke evidence (TIN-131)

### DIFF
--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -38,11 +38,19 @@ mutation, and conflict/status. A merged-workflow main-ref rerun is still useful
 for continuous release-day viability, but the release asset itself is no longer
 only an inferred proof.
 
-Remaining rc1 distribution proof is first-use heavy: Homebrew install/upgrade,
-Ubuntu 24.04+/Debian 13 `.deb` install/upgrade, Fedora daemon-only `.rpm`
-install, container runtime smoke, and external Nix profile install are still
-pending. Debian 12 remains blocked by the libc/OpenSSL floor unless a separate
-bookworm-targeted package exists. See
+2026-05-21 update: PR #429 fixed mixed `.deb`/`.rpm` artifact selection in the
+Linux postinstall workflow, and post-merge run `26204699596` proved the rc3
+`dist-linux-x86_64` release-workflow artifact on hosted Ubuntu: `.deb` install,
+daemon startup, HTTPS storage `[ok]`, FUSE mount, seeded index `visible`, exact
+hydrate, evict/rehydrate, and mutation remote pull. This upgrades the Ubuntu
+`.deb` path from artifact publication to package-backed first-use proof for the
+tested hosted-Ubuntu lane.
+
+Remaining distribution proof is now breadth and upgrade heavy: Homebrew
+install/upgrade, public release asset rerun for Ubuntu `.deb` if required,
+Debian 13 `.deb` install/upgrade, Fedora daemon-only `.rpm` install, container
+runtime smoke, and external Nix profile install. Debian 12 remains blocked by
+the libc/OpenSSL floor unless a separate bookworm-targeted package exists. See
 [`docs/release/v0.12.13-evidence-matrix.md`](../release/v0.12.13-evidence-matrix.md)
 for the frozen rc1 evidence table.
 

--- a/docs/release/v0.12.13-evidence-matrix.md
+++ b/docs/release/v0.12.13-evidence-matrix.md
@@ -37,6 +37,18 @@ proved the exact public GitHub Release asset
 `tcfs-0.12.13-rc2-macos-aarch64.pkg` through the signed HostApp root-probe path,
 exact hydrate, evict/rehydrate, mutation, and conflict/status.
 
+Late 2026-05-21 follow-up: PR
+[#429](https://github.com/Jesssullivan/tummycrypt/pull/429) fixed the Linux
+postinstall workflow's mixed `.deb`/`.rpm` artifact selection, and post-merge
+run
+[`26204699596`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596)
+proved the rc3 `dist-linux-x86_64` release-workflow artifact on hosted Ubuntu:
+`.deb` install, daemon startup, HTTPS storage `[ok]`, FUSE mount, seeded index
+`visible`, exact 59-byte hydrate, evict/rehydrate, and mutation remote pull.
+Treat this as Ubuntu `.deb` first-use proof from the release workflow artifact;
+public release asset rerun, upgrade proof, and Debian/Fedora/RPM breadth remain
+under TIN-131 / #280.
+
 ## Headline change
 
 **First green end-to-end production Dev ID FileProvider acceptance** on the
@@ -75,15 +87,17 @@ surfaces are tracked here.
 |---|---------|---------------|---------|--------|----------|
 | 1 | Homebrew | install smoke green on `main` | formula updated | ✅ install smoke pass | smoke run [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508), release job [`76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317) |
 | 2 | macOS `.pkg` (production Dev ID FileProvider) | rc2 exact public release asset green; rc1 exact asset and `66ae92f` diagnostic artifact retained as historical proof | package build/notarization passed | ✅ published-asset smoke pass | rc2 exact asset smoke [`26122478486`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26122478486), rc2 release run [`26117684515`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515), diagnostic run [`26117175542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542), artifact source [`26116692781`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781), rc1 exact asset run [`26079830341`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26079830341) |
-| 3 | `.deb` on Ubuntu 24.04 | packages published; install smoke pending | package upgrade smoke pending | ⚠️ artifact pass | release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
+| 3 | `.deb` on Ubuntu 24.04 | rc3 release-workflow artifact passed package-backed first-use smoke | package upgrade smoke pending | ✅ artifact first-use pass | post-merge smoke [`26204699596`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596), PR [`#429`](https://github.com/Jesssullivan/tummycrypt/pull/429), rc3 release run [`26204080480`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204080480), rc1 release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
 | 4 | `.deb` on Debian 12 bookworm | known blocked (`libc6 >= 2.39` floor) | n/a | ❌ blocked | inherits from [`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor) |
 | 5 | `.rpm` on Fedora 42 | daemon-only package published; install smoke pending | sampled only | ⚠️ daemon-only artifact pass | release job [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870) |
 | 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1` | multi-arch runtime smoke green | sampled only | ✅ runtime smoke pass | smoke run [`26083222949`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26083222949), release job [`76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828) |
 | 7 | Nix flake install | Nix build + Attic push passed; external profile install pending | sampled only | ⚠️ build/cache pass | release job [`76628512831`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512831) |
 
-Rollup: **3 current product-surface passes · 3 artifact/build passes with
-first-use smoke still pending · 1 blocked**. The macOS `.pkg` row now has both
-diagnostic-artifact and exact public rc2 release-asset proof.
+Rollup: **4 current product-surface or first-use passes · 2 artifact/build
+passes with first-use smoke still pending · 1 blocked**. The macOS `.pkg` row
+has both diagnostic-artifact and exact public rc2 release-asset proof. The
+Ubuntu `.deb` row has rc3 release-workflow artifact first-use proof, but still
+owes public release asset and upgrade proof before #280 can fully close.
 
 ## Per-Surface Evidence
 
@@ -173,7 +187,7 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
 - Not proven in this rc1 packet: clean-host first-run UX from package install to
   working `tcfs status [ok]`. That remains TIN-1425 scope.
 
-### 3. Debian/Ubuntu `.deb` on Ubuntu 24.04 — artifact publication pass
+### 3. Debian/Ubuntu `.deb` on Ubuntu 24.04 — artifact first-use pass
 
 - Release jobs: `Build linux-x86_64` and `Build linux-aarch64` succeeded
   ([job `76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870),
@@ -186,8 +200,20 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
 - Important caveat: the release workflow still wraps `cargo deb` with
   `|| echo "::warning::..."`, so the asset list is the proof that packages were
   actually produced for this tag.
-- Not proven in this rc1 packet: install/upgrade smoke on Ubuntu 24.04 or Debian
-  13. That remains TIN-131 / TIN-1422 scope.
+- PR [#429](https://github.com/Jesssullivan/tummycrypt/pull/429) fixed the
+  Linux postinstall workflow's mixed artifact selection so Ubuntu runners select
+  `.deb` packages from a release workflow artifact that also contains `.rpm`.
+- Post-merge smoke run
+  [`26204699596`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596)
+  on `main@44df23b` used rc3 release workflow artifact `dist-linux-x86_64` from
+  run
+  [`26204080480`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204080480)
+  and passed: `.deb` package install, installed CLI/daemon version `0.12.13`,
+  daemon foreground fallback, socket readiness, HTTPS storage `[ok]`, FUSE
+  mount, seeded `tcfs index inspect` status `visible`, exact 59-byte hydrate,
+  evict/rehydrate, and mutation remote pull.
+- Still not proven: public release asset rerun, upgrade smoke, Debian 13 smoke,
+  and Debian 12 compatibility. Those remain TIN-131 / #280 scope.
 
 ### 4. Debian/Ubuntu `.deb` on Debian 12 bookworm — blocked
 
@@ -331,3 +357,5 @@ Same as v0.12.2:
   signed HostApp user-visible root path.
 - 2026-05-19 — Added exact public `v0.12.13-rc2` macOS `.pkg` proof from run
   `26122478486`, replacing the rc2-pending caveat for the macOS package row.
+- 2026-05-21 — Added Ubuntu `.deb` rc3 release-workflow artifact first-use proof
+  from post-merge smoke run `26204699596` and PR #429.


### PR DESCRIPTION
## Summary
- update the v0.12.13 evidence matrix with the post-merge Linux package first-use smoke
- record PR #429 as the mixed-artifact package selection fix
- narrow TIN-131/#280 remaining scope to public release asset rerun, upgrades, Debian/Fedora/RPM breadth, and external Nix/Homebrew gaps

## Evidence
- PR #429 merged at `44df23b`
- Main smoke run: https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596
- Package source: rc3 release workflow artifact `dist-linux-x86_64` from run `26204080480`
- Gates: `.deb` install, daemon startup, HTTPS storage `[ok]`, FUSE mount, seeded index `visible`, exact hydrate, evict/rehydrate, mutation remote pull

## Verification
- `git diff --check`