### PR TITLE
ci: gate FileProvider package affordance metadata (TIN-1547)

### DIFF
--- a/scripts/macos-pkg-structure-smoke.sh
+++ b/scripts/macos-pkg-structure-smoke.sh
@@ -40,6 +40,7 @@ PKGUTIL_BIN="${TCFS_PKGUTIL:-}"
 SPCTL_BIN="${TCFS_SPCTL:-}"
 XCRUN_BIN="${TCFS_XCRUN:-}"
 UNAME_BIN="${TCFS_UNAME:-uname}"
+PYTHON_BIN="${TCFS_PYTHON:-python3}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -105,6 +106,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 payload_files="${tmp_dir}/payload-files.txt"
 normalized_payload="${tmp_dir}/payload-files-normalized.txt"
 expanded_dir="${tmp_dir}/expanded"
+expanded_full_dir="${tmp_dir}/expanded-full"
 
 "$PKGUTIL_BIN" --payload-files "$PKG_PATH" >"$payload_files"
 sed -E 's#^\./##' "$payload_files" >"$normalized_payload"
@@ -144,6 +146,77 @@ if ! cmp -s "$EXPECTED_POSTINSTALL" "$postinstall"; then
   fi
 fi
 
+"$PKGUTIL_BIN" --expand-full "$PKG_PATH" "$expanded_full_dir"
+fileprovider_info_plist="$(
+  find "$expanded_full_dir" \
+    -path '*/Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex/Contents/Info.plist' \
+    -type f \
+    | head -1
+)"
+[[ -n "$fileprovider_info_plist" ]] ||
+  fail "package full expansion did not contain TCFSFileProvider.appex/Contents/Info.plist"
+
+"$PYTHON_BIN" - "$fileprovider_info_plist" <<'PY'
+import plistlib
+import sys
+
+path = sys.argv[1]
+with open(path, "rb") as handle:
+    plist = plistlib.load(handle)
+
+extension = plist.get("NSExtension")
+if not isinstance(extension, dict):
+    raise SystemExit("FileProvider Info.plist missing NSExtension dictionary")
+
+point = extension.get("NSExtensionPointIdentifier")
+if point != "com.apple.fileprovider-nonui":
+    raise SystemExit(f"unexpected FileProvider extension point: {point!r}")
+
+if extension.get("NSExtensionFileProviderSupportsEnumeration") is not True:
+    raise SystemExit("FileProvider extension does not declare enumeration support")
+
+if extension.get("NSExtensionFileProviderSupportsDatalessFolders") is not True:
+    raise SystemExit("FileProvider extension does not declare dataless-folder support")
+
+decorations = extension.get("NSFileProviderDecorations")
+if not isinstance(decorations, list):
+    raise SystemExit("FileProvider extension missing NSFileProviderDecorations")
+
+decoration_ids = {
+    item.get("Identifier")
+    for item in decorations
+    if isinstance(item, dict)
+}
+required_decoration_ids = {
+    "io.tinyland.tcfs.fileprovider.decoration.conflict",
+    "io.tinyland.tcfs.fileprovider.decoration.locked",
+    "io.tinyland.tcfs.fileprovider.decoration.pinned",
+    "io.tinyland.tcfs.fileprovider.decoration.excluded",
+}
+missing_decorations = sorted(required_decoration_ids - decoration_ids)
+if missing_decorations:
+    raise SystemExit(
+        "missing FileProvider decorations: " + ", ".join(missing_decorations)
+    )
+
+actions = extension.get("NSExtensionFileProviderActions")
+if not isinstance(actions, list):
+    raise SystemExit("FileProvider extension missing NSExtensionFileProviderActions")
+
+action_ids = {
+    item.get("NSExtensionFileProviderActionIdentifier")
+    for item in actions
+    if isinstance(item, dict)
+}
+required_action_ids = {
+    "io.tinyland.tcfs.action.unsync",
+    "io.tinyland.tcfs.action.pin",
+}
+missing_actions = sorted(required_action_ids - action_ids)
+if missing_actions:
+    raise SystemExit("missing FileProvider actions: " + ", ".join(missing_actions))
+PY
+
 if [[ "$REQUIRE_SIGNATURE" == "1" ]]; then
   "$PKGUTIL_BIN" --check-signature "$PKG_PATH" >/dev/null
 fi
@@ -179,6 +252,7 @@ printf 'payload: usr/local/bin/tcfs present\n'
 printf 'payload: usr/local/bin/tcfsd present\n'
 printf 'payload: TCFSProvider.app present\n'
 printf 'payload: TCFSFileProvider.appex present\n'
+printf 'payload: FileProvider status decorations/actions present\n'
 printf 'postinstall: %s\n' "$postinstall_status"
 if [[ "$REQUIRE_SIGNATURE" == "1" ]]; then
   printf 'signature: valid\n'

--- a/scripts/test-macos-pkg-structure-smoke.sh
+++ b/scripts/test-macos-pkg-structure-smoke.sh
@@ -60,6 +60,10 @@ case "${1:-}" in
     mkdir -p "$3/Scripts"
     cp "$2.postinstall" "$3/Scripts/postinstall"
     ;;
+  --expand-full)
+    mkdir -p "$3/Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex/Contents"
+    cp "$2.info.plist" "$3/Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex/Contents/Info.plist"
+    ;;
   --check-signature)
     if [[ "${TCFS_FAKE_SIGNATURE_STATUS:-0}" != "0" ]]; then
       printf 'signature rejected\n' >&2
@@ -109,10 +113,12 @@ write_pkg_fixture() {
   local pkg="$1"
   local payload="$2"
   local postinstall="$3"
+  local info_plist="${4:-$GOOD_INFO_PLIST}"
 
   : >"$pkg"
   printf '%s\n' "$payload" >"$pkg.payload"
   cp "$postinstall" "$pkg.postinstall"
+  cp "$info_plist" "$pkg.info.plist"
 }
 
 GOOD_PAYLOAD='.
@@ -127,6 +133,56 @@ GOOD_PAYLOAD='.
 ./Applications/TCFSProvider.app/Contents/Extensions
 ./Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex'
 
+GOOD_INFO_PLIST="${TMPDIR}/Extension-Info.plist"
+cat >"$GOOD_INFO_PLIST" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.fileprovider-nonui</string>
+    <key>NSExtensionFileProviderSupportsEnumeration</key>
+    <true/>
+    <key>NSExtensionFileProviderSupportsDatalessFolders</key>
+    <true/>
+    <key>NSFileProviderDecorations</key>
+    <array>
+      <dict>
+        <key>Identifier</key>
+        <string>io.tinyland.tcfs.fileprovider.decoration.conflict</string>
+      </dict>
+      <dict>
+        <key>Identifier</key>
+        <string>io.tinyland.tcfs.fileprovider.decoration.locked</string>
+      </dict>
+      <dict>
+        <key>Identifier</key>
+        <string>io.tinyland.tcfs.fileprovider.decoration.pinned</string>
+      </dict>
+      <dict>
+        <key>Identifier</key>
+        <string>io.tinyland.tcfs.fileprovider.decoration.excluded</string>
+      </dict>
+    </array>
+    <key>NSExtensionFileProviderActions</key>
+    <array>
+      <dict>
+        <key>NSExtensionFileProviderActionIdentifier</key>
+        <string>io.tinyland.tcfs.action.unsync</string>
+      </dict>
+      <dict>
+        <key>NSExtensionFileProviderActionIdentifier</key>
+        <string>io.tinyland.tcfs.action.pin</string>
+      </dict>
+    </array>
+  </dict>
+</dict>
+</plist>
+EOF
+
 GOOD_PKG="${TMPDIR}/tcfs-good.pkg"
 write_pkg_fixture "$GOOD_PKG" "$GOOD_PAYLOAD" "$POSTINSTALL"
 
@@ -136,6 +192,7 @@ assert_contains "$GOOD_OUT" "payload: usr/local/bin/tcfs present"
 assert_contains "$GOOD_OUT" "payload: usr/local/bin/tcfsd present"
 assert_contains "$GOOD_OUT" "payload: TCFSProvider.app present"
 assert_contains "$GOOD_OUT" "payload: TCFSFileProvider.appex present"
+assert_contains "$GOOD_OUT" "payload: FileProvider status decorations/actions present"
 assert_contains "$GOOD_OUT" "postinstall: matches $POSTINSTALL"
 assert_contains "$GOOD_OUT" "macOS package structure smoke passed"
 
@@ -180,6 +237,29 @@ write_pkg_fixture "$MISSING_DAEMON_PKG" "$MISSING_DAEMON_PAYLOAD" "$POSTINSTALL"
 assert_fails_contains \
   "package payload missing usr/local/bin/tcfsd" \
   env PATH="$FAKE_BIN:$PATH" bash "$SCRIPT" --pkg "$MISSING_DAEMON_PKG"
+
+MISSING_ACTION_INFO_PLIST="${TMPDIR}/missing-action-Extension-Info.plist"
+python3 - "$GOOD_INFO_PLIST" "$MISSING_ACTION_INFO_PLIST" <<'PY'
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    plist = plistlib.load(handle)
+
+actions = plist["NSExtension"]["NSExtensionFileProviderActions"]
+plist["NSExtension"]["NSExtensionFileProviderActions"] = [
+    action for action in actions
+    if action.get("NSExtensionFileProviderActionIdentifier") != "io.tinyland.tcfs.action.pin"
+]
+
+with open(sys.argv[2], "wb") as handle:
+    plistlib.dump(plist, handle)
+PY
+MISSING_ACTION_PKG="${TMPDIR}/missing-action.pkg"
+write_pkg_fixture "$MISSING_ACTION_PKG" "$GOOD_PAYLOAD" "$POSTINSTALL" "$MISSING_ACTION_INFO_PLIST"
+assert_fails_contains \
+  "missing FileProvider actions: io.tinyland.tcfs.action.pin" \
+  env PATH="$FAKE_BIN:$PATH" bash "$SCRIPT" --pkg "$MISSING_ACTION_PKG"
 
 BAD_POSTINSTALL="${TMPDIR}/bad-postinstall.sh"
 printf '#!/bin/sh\nexit 0\n' >"$BAD_POSTINSTALL"


### PR DESCRIPTION
## Summary

Adds a macOS package-structure gate for the FileProvider extension metadata that backs the post-M10 UX affordances:

- requires the packaged `TCFSFileProvider.appex` `Info.plist` to declare the FileProvider extension point, enumeration support, and dataless-folder support
- requires the conflict/locked/pinned/excluded FileProvider decorations to be present in the shipped package
- requires the unsync and pin FileProvider custom actions to be present in the shipped package
- extends the fake `pkgutil --expand-full` regression test path and adds a missing-action failure case

## Why

TIN-1547 is past the destructive-rename fix, but the alpha/beta package proof should also verify that the shipped `.pkg` still carries the Finder/FileProvider status and recovery affordance metadata. This is a packaging gate only; it does not claim the badges render visually on every host.

## Validation

- `bash -n scripts/macos-pkg-structure-smoke.sh && bash -n scripts/test-macos-pkg-structure-smoke.sh`
- `bash scripts/test-macos-pkg-structure-smoke.sh`
- `bash scripts/test-release-workflow-fileprovider.sh`
- `bash scripts/test-macos-build-pkg.sh`
- `git diff --check`

## Boundary

This advances TIN-1547 package evidence. It does not close TIN-1547; public rc3 release-asset smoke and any runtime visual badge/progress/recovery proof remain separate.