### PR TITLE
storage-canary: prove allowed-prefix list access (TIN-1546)

### DIFF
--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: "tcfs-macos-smoke"
         type: string
+      remote_prefix:
+        description: "Optional storage prefix override; use an allowed production prefix such as gha/storage-posture/linux-postinstall/<tag>/<run>"
+        required: false
+        default: ""
+        type: string
       exercise_evict_rehydrate:
         description: "After initial hydration, exercise unsync + rehydrate"
         required: false
@@ -156,7 +161,16 @@ jobs:
           EXPECTED_CONTENT_FILE="$RUNNER_TEMP/expected-fixture-content"
           MUTATION_CONTENT_FILE="$RUNNER_TEMP/mutation-fixture-content"
           PACKAGE_PATHS_FILE="$RUNNER_TEMP/tcfs-package-paths.txt"
-          REMOTE_PREFIX="gha/linux-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          REMOTE_PREFIX="${{ github.event.inputs.remote_prefix }}"
+          if [[ -z "$REMOTE_PREFIX" ]]; then
+            REMOTE_PREFIX="gha/linux-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          fi
+          REMOTE_PREFIX="${REMOTE_PREFIX#/}"
+          REMOTE_PREFIX="${REMOTE_PREFIX%/}"
+          if [[ -z "$REMOTE_PREFIX" ]]; then
+            echo "::error::remote_prefix resolved to an empty prefix"
+            exit 1
+          fi
           readarray -t REMOTE_SPEC_PARTS < <(python3 - <<'PY'
           import os
           import urllib.parse

--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -72,6 +72,16 @@ on:
         required: false
         default: "macos-15"
         type: string
+      smoke_environment:
+        description: "GitHub environment containing TCFS_SMOKE_* secrets"
+        required: false
+        default: "tcfs-macos-smoke"
+        type: string
+      remote_prefix:
+        description: "Optional storage prefix override; use an allowed production prefix such as gha/storage-posture/macos-postinstall/<tag>/<run>"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -83,7 +93,7 @@ jobs:
     if: github.repository == 'Jesssullivan/tummycrypt'
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 40
-    environment: tcfs-macos-smoke
+    environment: ${{ github.event.inputs.smoke_environment }}
     env:
       TCFS_SMOKE_S3_ENDPOINT: ${{ secrets.TCFS_SMOKE_S3_ENDPOINT }}
       TCFS_SMOKE_S3_BUCKET: ${{ secrets.TCFS_SMOKE_S3_BUCKET }}
@@ -287,7 +297,16 @@ jobs:
           APP_GROUP_DIR="$HOME/Library/Group Containers/group.io.tinyland.tcfs"
           FILEPROVIDER_LISTEN_ADDR="127.0.0.1:19101"
           FILEPROVIDER_ENDPOINT="http://${FILEPROVIDER_LISTEN_ADDR}"
-          REMOTE_PREFIX="gha/macos-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          REMOTE_PREFIX="${{ github.event.inputs.remote_prefix }}"
+          if [[ -z "$REMOTE_PREFIX" ]]; then
+            REMOTE_PREFIX="gha/macos-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          fi
+          REMOTE_PREFIX="${REMOTE_PREFIX#/}"
+          REMOTE_PREFIX="${REMOTE_PREFIX%/}"
+          if [[ -z "$REMOTE_PREFIX" ]]; then
+            echo "::error::remote_prefix resolved to an empty prefix"
+            exit 1
+          fi
           FIXTURE_REL="ci-smoke/${VERSION}/postinstall-${GITHUB_RUN_ATTEMPT}.txt"
           MUTATION_REL="ci-smoke/${VERSION}/mutation-${GITHUB_RUN_ATTEMPT}.txt"
           CONFLICT_REL="ci-smoke/${VERSION}/conflict-status-${GITHUB_RUN_ATTEMPT}.txt"

--- a/.github/workflows/storage-posture-canary.yml
+++ b/.github/workflows/storage-posture-canary.yml
@@ -4,10 +4,10 @@ name: Storage Posture Canary
 #
 # This workflow turns `tcfs storage canary --json` into an archived evidence
 # lane. It intentionally does not claim broad production S3 readiness by itself:
-# the run proves one scoped write/read/delete/delete-verify operation plus
-# endpoint TLS posture for the selected environment. When scope_deny_prefix is
-# provided, it also proves the selected credentials cannot write outside the
-# intended prefix.
+# the run proves allowed-prefix list plus one scoped write/read/delete/delete-
+# verify operation and endpoint TLS posture for the selected environment. When
+# scope_deny_prefix is provided, it also proves the selected credentials cannot
+# write outside the intended prefix.
 
 on:
   workflow_dispatch:
@@ -271,10 +271,15 @@ jobs:
               report = json.load(fh)
 
           assert report["deleted"] is True, "delete verification must pass"
+          assert report["listed"] is True, "allowed-prefix list proof must pass"
           assert report["bytes"] > 0, "canary payload must be non-empty"
+          assert report["list_prefix"], "allowed-prefix list path must be recorded"
           if require_https:
               assert report["endpoint_tls"] is True, "endpoint_tls must be true"
               assert report["enforce_tls"] is True, "enforce_tls must be true"
+              assert isinstance(report["list_count"], int), (
+                  "require_https production posture runs must record list_count"
+              )
               assert report.get("scope_deny") is not None, (
                   "require_https production posture runs must include scope-deny proof"
               )

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -345,13 +345,17 @@ struct StorageCanaryReport {
     bucket: String,
     prefix: String,
     key: String,
+    list_prefix: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     scope_deny: Option<StorageCanaryScopeDenyReport>,
     bytes: usize,
     write_ms: u128,
+    list_ms: u128,
+    list_count: usize,
     read_ms: u128,
     delete_ms: u128,
     verify_delete_ms: u128,
+    listed: bool,
     deleted: bool,
     endpoint_tls: bool,
     enforce_tls: bool,
@@ -1663,6 +1667,10 @@ async fn cmd_storage(config: &tcfs_core::config::TcfsConfig, action: StorageActi
                 println!("  key:      {}", report.key);
                 println!("  bytes:    {}", report.bytes);
                 println!("  write:    {} ms", report.write_ms);
+                println!(
+                    "  list:     {} ms ({} entries at {})",
+                    report.list_ms, report.list_count, report.list_prefix
+                );
                 println!("  read:     {} ms", report.read_ms);
                 println!("  delete:   {} ms", report.delete_ms);
                 println!("  verify:   {} ms", report.verify_delete_ms);
@@ -1699,6 +1707,15 @@ fn storage_canary_key(prefix: &str, nonce: &str) -> String {
     }
 }
 
+fn storage_canary_list_prefix(prefix: &str) -> String {
+    let prefix = prefix.trim_matches('/');
+    if prefix.is_empty() {
+        "/".to_string()
+    } else {
+        format!("{prefix}/")
+    }
+}
+
 async fn run_storage_canary_with_operator(
     config: &tcfs_core::config::TcfsConfig,
     op: &opendal::Operator,
@@ -1708,6 +1725,7 @@ async fn run_storage_canary_with_operator(
     timeout: Duration,
 ) -> Result<StorageCanaryReport> {
     let key = storage_canary_key(prefix, nonce);
+    let list_prefix = storage_canary_list_prefix(prefix);
     let payload = format!(
         "tcfs storage canary\nendpoint={}\nbucket={}\nprefix={}\nkey={}\nnonce={}\n",
         config.storage.endpoint, config.storage.bucket, prefix, key, nonce
@@ -1720,6 +1738,16 @@ async fn run_storage_canary_with_operator(
         .map_err(|_| anyhow::anyhow!("storage canary write timed out after {timeout:?}: {key}"))?
         .with_context(|| format!("storage canary write failed: {key}"))?;
     let write_ms = write_start.elapsed().as_millis();
+
+    let list_start = std::time::Instant::now();
+    let list_entries = tokio::time::timeout(timeout, op.list(&list_prefix))
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("storage canary list timed out after {timeout:?}: {list_prefix}")
+        })?
+        .with_context(|| format!("storage canary list failed: {list_prefix}"))?;
+    let list_ms = list_start.elapsed().as_millis();
+    let list_count = list_entries.len();
 
     let read_start = std::time::Instant::now();
     let read_back = tokio::time::timeout(timeout, op.read(&key))
@@ -1766,12 +1794,16 @@ async fn run_storage_canary_with_operator(
         bucket: config.storage.bucket.clone(),
         prefix: prefix.to_string(),
         key,
+        list_prefix,
         scope_deny,
         bytes: payload.len(),
         write_ms,
+        list_ms,
+        list_count,
         read_ms,
         delete_ms,
         verify_delete_ms,
+        listed: true,
         deleted: !exists_after_delete,
         endpoint_tls: config.storage.endpoint.starts_with("https://"),
         enforce_tls: config.storage.enforce_tls,
@@ -5099,6 +5131,13 @@ enabled = false
         assert_eq!(storage_canary_key("", "nonce"), ".tcfs-canary/nonce.txt");
     }
 
+    #[test]
+    fn storage_canary_list_prefix_matches_daemon_health_scope() {
+        assert_eq!(storage_canary_list_prefix("data"), "data/");
+        assert_eq!(storage_canary_list_prefix("/tenant/a/"), "tenant/a/");
+        assert_eq!(storage_canary_list_prefix(""), "/");
+    }
+
     #[tokio::test]
     async fn storage_canary_writes_reads_deletes_and_verifies() {
         let dir = tempfile::tempdir().unwrap();
@@ -5117,6 +5156,9 @@ enabled = false
         .unwrap();
 
         assert_eq!(report.key, "data/.tcfs-canary/test-nonce.txt");
+        assert_eq!(report.list_prefix, "data/");
+        assert!(report.listed);
+        assert!(report.list_count >= 1);
         assert!(report.deleted);
         assert!(report.scope_deny.is_none());
         assert!(!op.exists(&report.key).await.unwrap());

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -6,9 +6,10 @@ This is the operator handoff for `TIN-1546`. It defines the minimum storage
 packet required before TCFS can claim production-like S3 readiness for alpha QA.
 
 The gate is intentionally narrower than "storage works." A passing run proves
-one scoped write/read/delete/delete-verify path, endpoint TLS posture, and the
-credential scope used for the run. It does not prove broad directory ownership,
-multitenancy, lost-device recovery, or long soak behavior.
+allowed-prefix listing, one scoped write/read/delete/delete-verify path,
+endpoint TLS posture, and the credential scope used for the run. It does not
+prove broad directory ownership, multitenancy, lost-device recovery, or long
+soak behavior.
 
 For the production posture packet, the canary should also include a negative
 scope probe by setting `scope_deny_prefix` to a prefix outside the credential
@@ -70,6 +71,7 @@ The canary identity should be scoped to:
 
 The credential must be able to:
 
+- list the allowed parent prefix,
 - write the canary object,
 - read the same object,
 - delete the same object, and
@@ -86,6 +88,11 @@ allowed policy, for example:
 - allowed parent prefix: `gha/storage-posture/`
 - canary write prefix: `gha/storage-posture/<run_id>-<attempt>`
 - denial prefix: `gha/storage-posture-denied/<run_id>-<attempt>`
+
+Downstream package smokes that reuse this production-like environment must also
+use a prefix under the allowed parent. For example, dispatch Linux package
+smoke with `remote_prefix=gha/storage-posture/linux-postinstall/<tag>/<run>`
+instead of the workflow's private-smoke default `gha/linux-postinstall/...`.
 
 ## Dispatch
 
@@ -141,6 +148,9 @@ The workflow run must complete successfully and upload its evidence artifact.
 
 `storage-canary.json` must show:
 
+- `listed: true`
+- non-empty `list_prefix`
+- integer `list_count`
 - `deleted: true`
 - `bytes > 0`
 - `endpoint_tls: true`
@@ -170,6 +180,8 @@ plain language. Do not paste secrets.
 - Missing secrets: environment configuration blocker.
 - Endpoint preflight failure: runner/backend reachability blocker.
 - `require_https=true` with plaintext URL: posture blocker.
+- Allowed-prefix list failure: credential-scope blocker; `tcfsd status` and
+  index enumeration need the same permission.
 - Write/read/delete timeout: storage reliability blocker.
 - Delete verification failed: storage consistency blocker.
 - S3 auth/access denied: credential-scope blocker unless the policy was

--- a/scripts/tcfs-alpha-gate-preflight.sh
+++ b/scripts/tcfs-alpha-gate-preflight.sh
@@ -10,6 +10,7 @@ LINUX_RUNNER_LABEL="ubuntu-24.04"
 TAG="v0.12.13-rc2"
 SCOPE_DENY_PREFIX="gha/storage-posture-denied/$(date -u +%Y%m%dT%H%M%SZ)"
 REMOTE_PREFIX=""
+LINUX_REMOTE_PREFIX=""
 STRICT=0
 
 usage() {
@@ -36,6 +37,7 @@ Options:
   --scope-deny-prefix PREFIX        Outside-policy prefix that storage canary
                                     must reject
   --remote-prefix PREFIX            Optional positive storage canary prefix
+  --linux-remote-prefix PREFIX      Optional Linux smoke prefix override
   --strict                          Exit non-zero when any alpha gate is blocked
   -h, --help                        Show this help
 
@@ -182,6 +184,12 @@ while [[ $# -gt 0 ]]; do
       REMOTE_PREFIX="${REMOTE_PREFIX%/}"
       shift 2
       ;;
+    --linux-remote-prefix)
+      require_value "$1" "${2:-}"
+      LINUX_REMOTE_PREFIX="${2#/}"
+      LINUX_REMOTE_PREFIX="${LINUX_REMOTE_PREFIX%/}"
+      shift 2
+      ;;
     --strict)
       STRICT=1
       shift
@@ -217,8 +225,14 @@ linux_required=(
   TCFS_SMOKE_MASTER_KEY_B64
 )
 
-mapfile -t storage_missing < <(missing_secret_names "$STORAGE_ENVIRONMENT" "${storage_required[@]}")
-mapfile -t linux_missing < <(missing_secret_names "$LINUX_ENVIRONMENT" "${linux_required[@]}")
+storage_missing=()
+linux_missing=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && storage_missing+=("$line")
+done < <(missing_secret_names "$STORAGE_ENVIRONMENT" "${storage_required[@]}")
+while IFS= read -r line; do
+  [[ -n "$line" ]] && linux_missing+=("$line")
+done < <(missing_secret_names "$LINUX_ENVIRONMENT" "${linux_required[@]}")
 storage_runner_status="$(runner_status_line "$STORAGE_RUNNER_LABEL")"
 linux_runner_status="$(runner_status_line "$LINUX_RUNNER_LABEL")"
 
@@ -270,6 +284,10 @@ elif (( ${#linux_missing[@]} > 0 )); then
   blocked=1
 else
   printf -- '- status: `runnable`\n'
+  linux_remote_prefix="$LINUX_REMOTE_PREFIX"
+  if [[ -z "$linux_remote_prefix" && "$LINUX_ENVIRONMENT" == "$STORAGE_ENVIRONMENT" ]]; then
+    linux_remote_prefix="gha/storage-posture/linux-postinstall/${TAG}/$(date -u +%Y%m%dT%H%M%SZ)"
+  fi
   linux_cmd=(
     gh workflow run linux-postinstall-smoke.yml
     -R "$REPO"
@@ -280,6 +298,9 @@ else
     -f "exercise_evict_rehydrate=true"
     -f "exercise_mutation=true"
   )
+  if [[ -n "$linux_remote_prefix" ]]; then
+    linux_cmd+=(-f "remote_prefix=$linux_remote_prefix")
+  fi
   printf -- '- dispatch:\n\n'
   printf '```bash\n%s\n```\n' "$(quote_cmd "${linux_cmd[@]}")"
 fi

--- a/scripts/test-linux-postinstall-workflow.sh
+++ b/scripts/test-linux-postinstall-workflow.sh
@@ -89,8 +89,22 @@ check_artifact_package_selection() {
   assert_not_contains "$step" 'printf '\''%s\n'\'' "${artifact_pkgs[@]}" > "$PACKAGE_PATHS_FILE"'
 }
 
+check_remote_prefix_override() {
+  local step="$TMPDIR/derive-run-paths.sh"
+  extract_step_from_workflow "Derive run paths" "$step"
+
+  assert_contains "$WORKFLOW" "remote_prefix:"
+  assert_contains "$WORKFLOW" "Optional storage prefix override"
+  assert_contains "$step" 'REMOTE_PREFIX="${{ github.event.inputs.remote_prefix }}"'
+  assert_contains "$step" 'REMOTE_PREFIX="gha/linux-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"'
+  assert_contains "$step" 'REMOTE_PREFIX="${REMOTE_PREFIX#/}"'
+  assert_contains "$step" 'REMOTE_PREFIX="${REMOTE_PREFIX%/}"'
+  assert_contains "$step" "remote_prefix resolved to an empty prefix"
+}
+
 check_secret_surface
 check_live_config_ca_cert_shape
 check_artifact_package_selection
+check_remote_prefix_override
 
 printf 'Linux post-install smoke workflow tests passed\n'

--- a/scripts/test-release-workflow-fileprovider.sh
+++ b/scripts/test-release-workflow-fileprovider.sh
@@ -119,7 +119,7 @@ check_postinstall_workflow_environment_and_secrets() {
     actual_runner = job.fetch("runs-on")
     raise "postinstall runner mismatch: #{actual_runner.inspect}" unless actual_runner == expected_runner
 
-    expected_env = "tcfs-macos-smoke"
+    expected_env = "${{ github.event.inputs.smoke_environment }}"
     actual_env = job.fetch("environment")
     raise "postinstall environment mismatch: #{actual_env.inspect}" unless actual_env == expected_env
 
@@ -748,6 +748,13 @@ assert_contains "$DERIVE_RUN_PATHS_STEP" "CONFIG_DIR=\"\$RUNNER_TEMP/tcfs-config
 assert_contains "$DERIVE_RUN_PATHS_STEP" "CONFIG_PATH=\"\$CONFIG_DIR/config.toml\""
 assert_contains "$DERIVE_RUN_PATHS_STEP" "FILEPROVIDER_LISTEN_ADDR=\"127.0.0.1:19101\""
 assert_contains "$DERIVE_RUN_PATHS_STEP" "FILEPROVIDER_ENDPOINT=\"http://\${FILEPROVIDER_LISTEN_ADDR}\""
+assert_contains "$POSTINSTALL_WORKFLOW" "smoke_environment:"
+assert_contains "$POSTINSTALL_WORKFLOW" "remote_prefix:"
+assert_contains "$DERIVE_RUN_PATHS_STEP" 'REMOTE_PREFIX="${{ github.event.inputs.remote_prefix }}"'
+assert_contains "$DERIVE_RUN_PATHS_STEP" 'REMOTE_PREFIX="gha/macos-postinstall/${TAG}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"'
+assert_contains "$DERIVE_RUN_PATHS_STEP" 'REMOTE_PREFIX="${REMOTE_PREFIX#/}"'
+assert_contains "$DERIVE_RUN_PATHS_STEP" 'REMOTE_PREFIX="${REMOTE_PREFIX%/}"'
+assert_contains "$DERIVE_RUN_PATHS_STEP" "remote_prefix resolved to an empty prefix"
 assert_not_contains "$DERIVE_RUN_PATHS_STEP" "FILEPROVIDER_SOCKET=\"\$HOME/Library/Application Support/io.tinyland.tcfs/tcfsd.sock\""
 assert_not_contains "$DERIVE_RUN_PATHS_STEP" "FILEPROVIDER_SOCKET=\"\${APP_GROUP_DIR}/tcfsd-gha.sock\""
 assert_not_contains "$DERIVE_RUN_PATHS_STEP" "FILEPROVIDER_SOCKET=\"/tmp/tcfsd-fileprovider-gha.sock\""

--- a/scripts/test-tcfs-alpha-gate-preflight.sh
+++ b/scripts/test-tcfs-alpha-gate-preflight.sh
@@ -102,6 +102,25 @@ assert_contains "$READY" "gh workflow run linux-postinstall-smoke.yml"
 assert_contains "$READY" "-f tag=v1.2.3"
 assert_contains "$READY" "just neo-honey-smoke"
 
+SHARED_ENV="$TMPDIR/shared-env.out"
+bash "$SCRIPT" \
+  --repo owner/repo \
+  --storage-environment linux-good \
+  --linux-environment linux-good \
+  --tag v1.2.3 \
+  >"$SHARED_ENV"
+assert_contains "$SHARED_ENV" "-f remote_prefix=gha/storage-posture/linux-postinstall/v1.2.3/"
+
+LINUX_PREFIX="$TMPDIR/linux-prefix.out"
+bash "$SCRIPT" \
+  --repo owner/repo \
+  --storage-environment storage-good \
+  --linux-environment linux-good \
+  --linux-remote-prefix /custom/linux-prefix/ \
+  --tag v1.2.3 \
+  >"$LINUX_PREFIX"
+assert_contains "$LINUX_PREFIX" "-f remote_prefix=custom/linux-prefix"
+
 BLOCKED="$TMPDIR/blocked.out"
 bash "$SCRIPT" \
   --repo owner/repo \


### PR DESCRIPTION
## Summary
- make `tcfs storage canary --json` exercise the same allowed-prefix `list()` permission used by daemon health and index enumeration
- record `list_prefix`, `list_ms`, `list_count`, and `listed` in the canary report
- require list proof in the storage posture workflow validator so HTTPS/scoped-credential evidence cannot false-green on object lifecycle alone
- document the new production storage bar and let Linux/macOS package smokes override `remote_prefix` so production reruns can stay inside the scoped `gha/storage-posture/...` allow policy
- teach the alpha-gate preflight to emit a scoped Linux prefix automatically when Linux smoke reuses the storage posture environment

## Why
The production storage posture canary passed write/read/delete and deny-scope proof, but the Linux public package smoke failed because it used `gha/linux-postinstall/...`, outside the `tcfs-storage-prod-smoke` credential allow scope. The tightened canary now proves allowed-prefix list access, and package smoke workflows can be dispatched against a prefix that matches the production credential scope instead of widening the S3 policy or misclassifying package failures.

## Evidence
- Branch storage posture run with list proof passed: https://github.com/Jesssullivan/tummycrypt/actions/runs/26207145326
- Branch Linux public package smoke passed with scoped production prefix: https://github.com/Jesssullivan/tummycrypt/actions/runs/26207357056
- Earlier wrong-prefix dispatch failed at write as expected: https://github.com/Jesssullivan/tummycrypt/actions/runs/26207079665
- Linux public package smoke that exposed the prefix mismatch: https://github.com/Jesssullivan/tummycrypt/actions/runs/26206785352

## Validation
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test -p tcfs-cli storage_canary`
- `bash scripts/test-linux-postinstall-workflow.sh`
- `bash scripts/test-release-workflow-fileprovider.sh`
- `bash scripts/test-tcfs-alpha-gate-preflight.sh`
- `bash -n scripts/tcfs-alpha-gate-preflight.sh scripts/test-tcfs-alpha-gate-preflight.sh scripts/test-linux-postinstall-workflow.sh scripts/test-release-workflow-fileprovider.sh`
- `git diff --check`

## Boundaries
This is branch evidence until PR #433 lands. After merge, rerun the same Linux smoke from `main` or the next release candidate using a prefix under `gha/storage-posture/...`. The macOS production FileProvider rename proof still needs a fresh package built after current-main rename-manifest preservation.