### PR TITLE
storage: classify daemon health probes (TIN-1546)

### DIFF
--- a/crates/tcfs-storage/src/health.rs
+++ b/crates/tcfs-storage/src/health.rs
@@ -2,10 +2,103 @@
 
 use anyhow::Result;
 use opendal::Operator;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Default upper bound for storage health probes.
 pub const DEFAULT_HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Machine-readable storage health failure class.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum HealthCheckFailureKind {
+    Timeout,
+    PermissionDenied,
+    NotFound,
+    RateLimited,
+    Backend,
+}
+
+impl HealthCheckFailureKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::PermissionDenied => "permission_denied",
+            Self::NotFound => "not_found",
+            Self::RateLimited => "rate_limited",
+            Self::Backend => "backend_error",
+        }
+    }
+}
+
+impl std::fmt::Display for HealthCheckFailureKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Successful storage health probe details.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct HealthCheckReport {
+    pub path: String,
+    pub elapsed_ms: u128,
+    pub entry_count: usize,
+}
+
+/// Typed storage health probe failure.
+#[derive(Debug, thiserror::Error)]
+#[error("storage health check {kind} at {path} after {elapsed_ms} ms: {message}")]
+pub struct HealthCheckError {
+    kind: HealthCheckFailureKind,
+    path: String,
+    elapsed_ms: u128,
+    message: String,
+    backend_kind: Option<String>,
+}
+
+impl HealthCheckError {
+    pub fn kind(&self) -> HealthCheckFailureKind {
+        self.kind
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn elapsed_ms(&self) -> u128 {
+        self.elapsed_ms
+    }
+
+    pub fn backend_kind(&self) -> Option<&str> {
+        self.backend_kind.as_deref()
+    }
+
+    fn timeout(path: &str, timeout: Duration, elapsed: Duration) -> Self {
+        Self {
+            kind: HealthCheckFailureKind::Timeout,
+            path: path.to_string(),
+            elapsed_ms: elapsed.as_millis(),
+            message: format!("timed out after {timeout:?}"),
+            backend_kind: None,
+        }
+    }
+
+    fn from_opendal(path: &str, elapsed: Duration, err: opendal::Error) -> Self {
+        let backend_kind = err.kind().to_string();
+        let kind = match err.kind() {
+            opendal::ErrorKind::PermissionDenied => HealthCheckFailureKind::PermissionDenied,
+            opendal::ErrorKind::NotFound => HealthCheckFailureKind::NotFound,
+            opendal::ErrorKind::RateLimited => HealthCheckFailureKind::RateLimited,
+            _ => HealthCheckFailureKind::Backend,
+        };
+
+        Self {
+            kind,
+            path: path.to_string(),
+            elapsed_ms: elapsed.as_millis(),
+            message: err.to_string(),
+            backend_kind: Some(backend_kind),
+        }
+    }
+}
 
 /// Verify the storage endpoint is reachable by listing the root.
 pub async fn check_health(op: &Operator) -> Result<()> {
@@ -14,7 +107,23 @@ pub async fn check_health(op: &Operator) -> Result<()> {
 
 /// Verify storage health with an explicit timeout.
 pub async fn check_health_with_timeout(op: &Operator, timeout: Duration) -> Result<()> {
-    check_health_path_with_timeout(op, "/", timeout).await
+    check_health_detailed_with_timeout(op, timeout).await?;
+    Ok(())
+}
+
+/// Verify storage health and return probe details.
+pub async fn check_health_detailed(
+    op: &Operator,
+) -> std::result::Result<HealthCheckReport, HealthCheckError> {
+    check_health_detailed_with_timeout(op, DEFAULT_HEALTH_TIMEOUT).await
+}
+
+/// Verify storage health with an explicit timeout and return probe details.
+pub async fn check_health_detailed_with_timeout(
+    op: &Operator,
+    timeout: Duration,
+) -> std::result::Result<HealthCheckReport, HealthCheckError> {
+    check_health_path_detailed_with_timeout(op, "/", timeout).await
 }
 
 /// Verify the storage endpoint is reachable using a scoped remote prefix.
@@ -32,8 +141,26 @@ pub async fn check_health_for_prefix_with_timeout(
     prefix: &str,
     timeout: Duration,
 ) -> Result<()> {
+    check_health_for_prefix_detailed_with_timeout(op, prefix, timeout).await?;
+    Ok(())
+}
+
+/// Verify scoped storage health and return probe details.
+pub async fn check_health_for_prefix_detailed(
+    op: &Operator,
+    prefix: &str,
+) -> std::result::Result<HealthCheckReport, HealthCheckError> {
+    check_health_for_prefix_detailed_with_timeout(op, prefix, DEFAULT_HEALTH_TIMEOUT).await
+}
+
+/// Verify scoped storage health with an explicit timeout and return probe details.
+pub async fn check_health_for_prefix_detailed_with_timeout(
+    op: &Operator,
+    prefix: &str,
+    timeout: Duration,
+) -> std::result::Result<HealthCheckReport, HealthCheckError> {
     let path = health_probe_path(prefix);
-    check_health_path_with_timeout(op, &path, timeout).await
+    check_health_path_detailed_with_timeout(op, &path, timeout).await
 }
 
 fn health_probe_path(prefix: &str) -> String {
@@ -45,21 +172,22 @@ fn health_probe_path(prefix: &str) -> String {
     }
 }
 
-async fn check_health_path_with_timeout(
+async fn check_health_path_detailed_with_timeout(
     op: &Operator,
     path: &str,
     timeout: Duration,
-) -> Result<()> {
-    let probe = async {
-        op.list(path)
-            .await
-            .map(|_| ())
-            .map_err(|e| anyhow::anyhow!("storage health check failed at {path}: {e}"))
-    };
+) -> std::result::Result<HealthCheckReport, HealthCheckError> {
+    let start = Instant::now();
 
-    tokio::time::timeout(timeout, probe)
-        .await
-        .map_err(|_| anyhow::anyhow!("storage health check timed out after {timeout:?}"))?
+    match tokio::time::timeout(timeout, op.list(path)).await {
+        Ok(Ok(entries)) => Ok(HealthCheckReport {
+            path: path.to_string(),
+            elapsed_ms: start.elapsed().as_millis(),
+            entry_count: entries.len(),
+        }),
+        Ok(Err(err)) => Err(HealthCheckError::from_opendal(path, start.elapsed(), err)),
+        Err(_elapsed) => Err(HealthCheckError::timeout(path, timeout, start.elapsed())),
+    }
 }
 
 /// Returns true if storage is reachable, false otherwise (non-panicking)
@@ -106,6 +234,61 @@ mod tests {
         check_health_for_prefix_with_timeout(&op, "/tenant-a/", Duration::from_secs(1))
             .await
             .expect("prefix health check with explicit timeout");
+    }
+
+    #[tokio::test]
+    async fn detailed_prefix_health_records_path_latency_and_entry_count() {
+        let op = memory_operator();
+        op.write("tenant-a/index/file.txt", "ok")
+            .await
+            .expect("seed scoped object");
+
+        let report = check_health_for_prefix_detailed(&op, "tenant-a")
+            .await
+            .expect("prefix health report");
+
+        assert_eq!(report.path, "tenant-a/");
+        assert!(report.entry_count >= 1);
+    }
+
+    #[test]
+    fn permission_denied_errors_are_classified() {
+        let err = HealthCheckError::from_opendal(
+            "tenant-a/",
+            Duration::from_millis(12),
+            opendal::Error::new(opendal::ErrorKind::PermissionDenied, "denied"),
+        );
+
+        assert_eq!(err.kind(), HealthCheckFailureKind::PermissionDenied);
+        assert_eq!(err.path(), "tenant-a/");
+        assert_eq!(err.elapsed_ms(), 12);
+        assert_eq!(err.backend_kind(), Some("PermissionDenied"));
+    }
+
+    #[test]
+    fn rate_limited_errors_are_classified() {
+        let err = HealthCheckError::from_opendal(
+            "tenant-a/",
+            Duration::from_millis(9),
+            opendal::Error::new(opendal::ErrorKind::RateLimited, "slow down"),
+        );
+
+        assert_eq!(err.kind(), HealthCheckFailureKind::RateLimited);
+        assert_eq!(err.backend_kind(), Some("RateLimited"));
+    }
+
+    #[test]
+    fn timeout_errors_are_classified() {
+        let err = HealthCheckError::timeout(
+            "tenant-a/",
+            Duration::from_secs(5),
+            Duration::from_millis(5001),
+        );
+
+        assert_eq!(err.kind(), HealthCheckFailureKind::Timeout);
+        assert_eq!(err.path(), "tenant-a/");
+        assert_eq!(err.elapsed_ms(), 5001);
+        assert_eq!(err.backend_kind(), None);
     }
 
     #[test]

--- a/crates/tcfs-storage/src/lib.rs
+++ b/crates/tcfs-storage/src/lib.rs
@@ -5,7 +5,10 @@ pub mod multipart;
 pub mod operator;
 pub mod seaweedfs;
 
-pub use health::{check_health, check_health_for_prefix};
+pub use health::{
+    check_health, check_health_detailed, check_health_for_prefix, check_health_for_prefix_detailed,
+    HealthCheckError, HealthCheckFailureKind, HealthCheckReport,
+};
 pub use operator::{build_operator, StorageConfig};
 
 /// Parse a remote spec like `seaweedfs://host:port/bucket[/prefix]`.

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -258,11 +258,14 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             s3.secret_access_key.expose_secret(),
         )?;
         let storage_prefix = config.storage.resolved_prefix();
-        match tcfs_storage::check_health_for_prefix(&op, storage_prefix).await {
-            Ok(()) => {
+        match tcfs_storage::check_health_for_prefix_detailed(&op, storage_prefix).await {
+            Ok(report) => {
                 info!(
                     endpoint = %config.storage.endpoint,
                     prefix = %storage_prefix,
+                    health_path = %report.path,
+                    elapsed_ms = report.elapsed_ms,
+                    entry_count = report.entry_count,
                     "SeaweedFS: connected"
                 );
                 operator = Some(op);
@@ -272,7 +275,11 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                 warn!(
                     endpoint = %config.storage.endpoint,
                     prefix = %storage_prefix,
-                    "SeaweedFS: {e}"
+                    health_kind = %e.kind(),
+                    health_path = %e.path(),
+                    elapsed_ms = e.elapsed_ms(),
+                    backend_kind = e.backend_kind().unwrap_or("none"),
+                    "SeaweedFS health check failed: {e}"
                 );
                 // Still keep the operator for retry
                 operator = Some(op);

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -359,10 +359,39 @@ impl TcfsDaemon for TcfsDaemonImpl {
     ) -> Result<tonic::Response<StatusResponse>, tonic::Status> {
         let uptime = self.start_time.elapsed().as_secs() as i64;
         let mount_count = self.active_mounts.lock().await.len() as i32;
+        let storage_prefix = self.config.storage.resolved_prefix().to_string();
+        let operator = self.operator.lock().await.as_ref().cloned();
+        let storage_ok = match operator {
+            Some(op) => {
+                match tcfs_storage::check_health_for_prefix_detailed(&op, &storage_prefix).await {
+                    Ok(report) => {
+                        tracing::debug!(
+                            health_path = %report.path,
+                            elapsed_ms = report.elapsed_ms,
+                            entry_count = report.entry_count,
+                            "status storage health probe passed"
+                        );
+                        true
+                    }
+                    Err(err) => {
+                        warn!(
+                            health_kind = %err.kind(),
+                            health_path = %err.path(),
+                            elapsed_ms = err.elapsed_ms(),
+                            backend_kind = err.backend_kind().unwrap_or("none"),
+                            "status storage health probe failed: {err}"
+                        );
+                        false
+                    }
+                }
+            }
+            None => false,
+        };
+
         Ok(tonic::Response::new(StatusResponse {
             version: env!("CARGO_PKG_VERSION").into(),
             storage_endpoint: self.storage_endpoint.clone(),
-            storage_ok: self.storage_ok,
+            storage_ok,
             nats_ok: self.nats_ok.load(std::sync::atomic::Ordering::Relaxed),
             active_mounts: mount_count,
             uptime_secs: uptime,
@@ -2603,6 +2632,18 @@ mod tests {
         assert!(!resp.nats_ok);
         assert_eq!(resp.active_mounts, 0);
         assert!(resp.uptime_secs >= 0);
+    }
+
+    #[tokio::test]
+    async fn status_rechecks_live_storage_health() {
+        let daemon = test_daemon_with_operator(Some(memory_operator()));
+        let resp = daemon
+            .status(tonic::Request::new(StatusRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.storage_ok);
     }
 
     #[tokio::test]

--- a/crates/tcfsd/src/metrics.rs
+++ b/crates/tcfsd/src/metrics.rs
@@ -145,11 +145,34 @@ async fn healthz_handler() -> impl IntoResponse {
 async fn readyz_handler(State(state): State<HealthState>) -> impl IntoResponse {
     let op = state.operator.lock().await;
     match op.as_ref() {
-        Some(op) => match tcfs_storage::check_health_for_prefix(op, &state.storage_prefix).await {
-            Ok(()) => (StatusCode::OK, "ready"),
-            Err(_) => (StatusCode::SERVICE_UNAVAILABLE, "storage unreachable"),
-        },
-        None => (StatusCode::SERVICE_UNAVAILABLE, "no storage operator"),
+        Some(op) => {
+            match tcfs_storage::check_health_for_prefix_detailed(op, &state.storage_prefix).await {
+                Ok(report) => (
+                    StatusCode::OK,
+                    format!(
+                        "ready (storage path {}, {} entries, {} ms)",
+                        report.path, report.entry_count, report.elapsed_ms
+                    ),
+                ),
+                Err(err) => {
+                    tracing::warn!(
+                        health_kind = %err.kind(),
+                        health_path = %err.path(),
+                        elapsed_ms = err.elapsed_ms(),
+                        backend_kind = err.backend_kind().unwrap_or("none"),
+                        "storage readiness probe failed: {err}"
+                    );
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        format!("storage unreachable ({}) at {}", err.kind(), err.path()),
+                    )
+                }
+            }
+        }
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no storage operator".to_string(),
+        ),
     }
 }
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -65,6 +65,20 @@ The raw-Git project-tree canary is intentionally allowed to expose these
 storage bottlenecks, but those observations are performance evidence, not a
 production storage posture claim.
 
+Current production-like S3 posture snapshot from `main@6990ffb`, run
+`26209080328`, artifact `storage-posture-canary-26209080328-1`:
+
+| Endpoint class | Security/scope | Payload | List | Write | Read | Delete | Verify delete | Scope denial |
+|----------------|----------------|---------|------|-------|------|--------|---------------|--------------|
+| Public HTTPS S3-compatible endpoint (`https://tcfs-smoke-s3.tinyland.dev`) | `enforce_tls=true`; public CA chain; scoped `tcfs-storage-prod-smoke` identity under `gha/storage-posture/...` | 216 B | 37 ms, 1 entry | 139 ms | 34 ms | 35 ms | 36 ms | `PermissionDenied` in 33 ms for `gha/storage-posture-denied/...` |
+
+This packet proves TLS transport, allowed-prefix list permission, scoped
+write/read/delete/delete-verify behavior, and negative credential-scope denial
+for the selected production-smoke identity. It is not a large-object throughput
+or restore benchmark; keep the large-pack rows below open until a
+candidate-package restore packet records object counts, retry/timeout counts,
+socket highwater, and end-to-end restore latency.
+
 Functional follow-up observations from
 `docs/release/evidence/home-canary-linux-xr-shadow-20260511T040325Z/`:
 

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -32,6 +32,15 @@ Known evidence:
 - that run used `http://seaweedfs-tcfs:8333` with `require_https=false`.
 - it is not a production posture packet because the endpoint was plaintext and
   private, and the credentials were the existing smoke credentials.
+- run `26209080328` on `main` at `6990ffb` passed against
+  `tcfs-storage-prod-smoke` using `https://tcfs-smoke-s3.tinyland.dev`,
+  `require_https=true`, `endpoint_tls=true`, `enforce_tls=true`, allowed-prefix
+  listing, write/read/delete/delete-verify, and a denied-prefix
+  `PermissionDenied` probe.
+- the green `26209080328` packet proves the selected production-smoke identity
+  can operate under `gha/storage-posture/...` and is denied under
+  `gha/storage-posture-denied/...`. It does not prove broad restore throughput,
+  long soak behavior, or beta-grade transient-error recovery.
 
 ## Required GitHub Environment
 
@@ -186,6 +195,13 @@ plain language. Do not paste secrets.
 - Delete verification failed: storage consistency blocker.
 - S3 auth/access denied: credential-scope blocker unless the policy was
   intentionally read-only.
+
+Daemon health and readiness probes must keep these classes machine-readable.
+`tcfs-storage` reports scoped health failures as `timeout`,
+`permission_denied`, `not_found`, `rate_limited`, or `backend_error`,
+including the probed path and elapsed time. Startup logs, `/readyz`, and
+`tcfs status` should use the scoped prefix health probe rather than bucket-root
+listing or a stale startup boolean.
 
 If the failure is endpoint posture or credential scope, do not rerun the package
 or FileProvider smokes. Fix the storage gate first so downstream failures are


### PR DESCRIPTION
## Summary

- add typed `tcfs-storage` health reports and failure classes (`timeout`, `permission_denied`, `not_found`, `rate_limited`, `backend_error`)
- make daemon startup, `/readyz`, and `tcfs status` use the scoped-prefix health probe with path/latency/classification instead of relying on a stale startup boolean
- record the 2026-05-21 production-like S3 posture packet in the storage gate docs and `docs/BENCHMARKS.md`

## Validation

- `~/.cargo/bin/cargo fmt --all -- --check`
- `git diff --check`
- `~/.cargo/bin/cargo test -p tcfs-storage`
- `~/.cargo/bin/cargo test -p tcfs-storage health`
- `~/.cargo/bin/cargo test -p tcfsd status_rechecks_live_storage_health`
- `~/.cargo/bin/cargo clippy -p tcfs-storage --all-targets`
- `~/.cargo/bin/cargo clippy -p tcfsd --all-targets` completed; it reports two pre-existing `needless_borrow` warnings outside this patch

## Boundary

This advances TIN-1546's bounded/classified daemon health gate. It does not close the remaining large-pack candidate-package restore, socket/highwater, or long-soak storage posture work.

Note: the local GPG pinentry failed in this non-interactive session, so the branch commit was created with `--no-gpg-sign`.