### PR TITLE
docs: record rc4 public asset proof

### DIFF
--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -46,13 +46,34 @@ hydrate, evict/rehydrate, and mutation remote pull. This upgrades the Ubuntu
 `.deb` path from artifact publication to package-backed first-use proof for the
 tested hosted-Ubuntu lane.
 
+Later 2026-05-21 update: `v0.12.13-rc4` public release assets are published and
+the package-facing public-asset smokes are green from `main@e9b9f82`:
+
+- Linux `.deb` run
+  [`26218940925`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940925)
+  installed `tcfs-0.12.13-rc4-amd64.deb` and proved daemon start, HTTPS storage
+  `[ok]`, FUSE mount, seeded index `visible`, exact hydrate, `tcfs cache evict`
+  plus rehydrate, and mutation remote pull against
+  `https://tcfs-smoke-s3.tinyland.dev`.
+- macOS `.pkg` run
+  [`26218940950`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940950)
+  installed `tcfs-0.12.13-rc4-macos-aarch64.pkg` and proved signed HostApp
+  root authority, exact signed-host hydrate, evict/rehydrate, FileProvider
+  mutation, rename, and conflict/status.
+- Container runtime run
+  [`26218940985`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940985)
+  proved `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc4` on `linux/amd64` and
+  `linux/arm64/v8` with manifest digest
+  `sha256:4b1f235be8a20715b8eb1bb2de38a81b3628a6f56675420cdc2320cce19c20b3`.
+
 Remaining distribution proof is now breadth and upgrade heavy: Homebrew
-install/upgrade, public release asset rerun for Ubuntu `.deb` if required,
-Debian 13 `.deb` install/upgrade, Fedora daemon-only `.rpm` install, container
-runtime smoke, and external Nix profile install. Debian 12 remains blocked by
-the libc/OpenSSL floor unless a separate bookworm-targeted package exists. See
+install/upgrade, Debian 13 `.deb` install/upgrade, Fedora daemon-only `.rpm`
+install, external Nix profile install, and release-candidate package version
+semantics (`0.12.13-1` installed from rc4-named `.deb` assets). Debian 12
+remains blocked by the libc/OpenSSL floor unless a separate bookworm-targeted
+package exists. See
 [`docs/release/v0.12.13-evidence-matrix.md`](../release/v0.12.13-evidence-matrix.md)
-for the frozen rc1 evidence table.
+for the frozen rc-series evidence table.
 
 ## Out-Of-Scope Published Helpers
 

--- a/docs/ops/macos-fileprovider-reality.md
+++ b/docs/ops/macos-fileprovider-reality.md
@@ -1,7 +1,7 @@
 # macOS Finder and FileProvider Reality
 
-As of May 19, 2026, the production Developer ID FileProvider lifecycle is
-proven on PZM, including the exact public `v0.12.13-rc2` GitHub Release
+As of May 21, 2026, the production Developer ID FileProvider lifecycle is
+proven on PZM, including the exact public `v0.12.13-rc4` GitHub Release
 `.pkg`. GitHub Actions run
 `26061402177` first proved installed strict preflight, storage `[ok]`,
 host-app domain add, CloudStorage enumeration, host-app `requestDownload`, and
@@ -30,8 +30,9 @@ HostApp root/user-visible-URL probe, and diagnostic package run `26117175542`
 at `66ae92f` proved that the installed signed HostApp can enumerate the
 FileProvider user-visible root and complete exact hydrate, evict/rehydrate,
 mutation, and conflict/status. Run `26122478486` then proved the same path
-against the exact public `v0.12.13-rc2` release asset:
-`tcfs-0.12.13-rc2-macos-aarch64.pkg`.
+against the exact public `v0.12.13-rc2` release asset, and run `26218940950`
+repeated that public-asset proof for `v0.12.13-rc4` with mutation, rename, and
+conflict/status enabled: `tcfs-0.12.13-rc4-macos-aarch64.pkg`.
 
 This document defines the actual workflow the repo supports today, separates
 what is proven from what remains experimental, and records the highest-value
@@ -1256,3 +1257,30 @@ This clears the original production `.pkg` exact-file hydration blocker for the
 published rc2 macOS arm64 asset. It does not close production storage posture:
 the run still uses the private/plaintext PZM smoke backend, so TIN-1546 remains
 open until an HTTPS/scoped-credential storage packet passes.
+
+## 2026-05-21 — Exact public rc4 package proof
+
+Run [`26218940950`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940950)
+of `macos-postinstall-smoke.yml` installed the exact public GitHub Release
+asset `tcfs-0.12.13-rc4-macos-aarch64.pkg` from
+[`v0.12.13-rc4`](https://github.com/Jesssullivan/tummycrypt/releases/tag/v0.12.13-rc4)
+and passed the production Dev ID postinstall harness from
+`main@e9b9f827724e88b451804f570a6ed0fe0b124a2e`.
+
+Evidence artifact `macos-postinstall-smoke-v0.12.13-rc4` records:
+
+- `expected-file-index.json`: `status: visible`, committed entry, manifest
+  present, size 59, chunks 1, remote prefix
+  `gha/storage-posture/macos-postinstall/v0.12.13-rc4/20260521T095553Z`.
+- `host-root-probe.log`: direct raw CloudStorage root traversal is still denied
+  by macOS sandbox permissions, but the signed HostApp
+  `getUserVisibleURL(.rootContainer)` path lists `.Trash` and `ci-smoke`.
+- `hydrated-expected-file`: exact 59-byte expected content captured after
+  signed-host `requestDownload`.
+- FileProvider mutation remote pull matched the expected rc4 mutation content.
+- FileProvider rename remote pull matched the expected rc4 rename content.
+- Conflict/status proof recorded `sync state: conflict`.
+
+This updates the current public package proof from rc2 to rc4. The remaining
+FileProvider hardening lane is now badge/progress assertions, recovery UX,
+longer desktop soak, and first-run setup from installer to valid config/status.

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -1,6 +1,7 @@
 # TCFS Production Storage Posture Gate
 
 Date: 2026-05-19
+Updated: 2026-05-21
 
 This is the operator handoff for `TIN-1546`. It defines the minimum storage
 packet required before TCFS can claim production-like S3 readiness for alpha QA.
@@ -47,6 +48,20 @@ Known evidence:
   verification, and denied-prefix `PermissionDenied` evidence under
   `gha/storage-posture-denied/...`. Treat this as the current-main storage
   posture packet for alpha QA, not as large-restore or soak proof.
+- downstream public-asset smokes on `main@e9b9f82` then used the same
+  production-smoke prefix family successfully:
+  - Linux `.deb` run `26218940925` used
+    `gha/storage-posture/linux-postinstall/v0.12.13-rc4/20260521T095553Z`
+    against `https://tcfs-smoke-s3.tinyland.dev` and proved package install,
+    storage `[ok]`, FUSE mount, exact hydrate, `tcfs cache evict` + rehydrate,
+    and mutation remote pull.
+  - macOS `.pkg` run `26218940950` used
+    `gha/storage-posture/macos-postinstall/v0.12.13-rc4/20260521T095553Z` and
+    proved exact signed-host hydrate, evict/rehydrate, mutation, rename, and
+    conflict/status through the public release package.
+  These runs prove the production-smoke storage posture is usable by package
+  first-use lanes; they still do not prove large-pack restore throughput,
+  socket/highwater behavior, long soak, or transient recovery classification.
 
 ## Required GitHub Environment
 

--- a/docs/release/v0.12.13-evidence-matrix.md
+++ b/docs/release/v0.12.13-evidence-matrix.md
@@ -45,9 +45,24 @@ run
 proved the rc3 `dist-linux-x86_64` release-workflow artifact on hosted Ubuntu:
 `.deb` install, daemon startup, HTTPS storage `[ok]`, FUSE mount, seeded index
 `visible`, exact 59-byte hydrate, evict/rehydrate, and mutation remote pull.
-Treat this as Ubuntu `.deb` first-use proof from the release workflow artifact;
-public release asset rerun, upgrade proof, and Debian/Fedora/RPM breadth remain
-under TIN-131 / #280.
+At that point, this was Ubuntu `.deb` first-use proof from the release workflow
+artifact; exact public-asset proof, upgrade proof, and Debian/Fedora/RPM breadth
+remained under TIN-131 / #280.
+
+Later 2026-05-21 follow-up: `v0.12.13-rc4` is published and the package-facing
+public asset smokes are green from
+`main@e9b9f827724e88b451804f570a6ed0fe0b124a2e` using the exact public release
+artifacts. Release run
+[`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287)
+published `v0.12.13-rc4`; Linux smoke run
+[`26218940925`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940925)
+proved `tcfs-0.12.13-rc4-amd64.deb`; macOS smoke run
+[`26218940950`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940950)
+proved `tcfs-0.12.13-rc4-macos-aarch64.pkg`; and container runtime smoke run
+[`26218940985`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940985)
+proved `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc4` on `linux/amd64` and
+`linux/arm64`. Treat rc4 as the current public-asset proof for macOS `.pkg`,
+Ubuntu `.deb`, and container runtime.
 
 ## Headline change
 
@@ -72,7 +87,8 @@ diagnostic package run `26117175542` proved that the installed signed HostApp
 can enumerate the root and drive exact hydrate, evict/rehydrate, mutation, and
 conflict/status, and published-release run `26122478486` proved the same path
 against the exact public `v0.12.13-rc2` `.pkg`. Treat rc1 as the historical
-release freeze and rc2 as the current exact published-asset proof.
+release freeze, rc2 as the first signed-HostApp exact public package proof, and
+rc4 as the current public release package proof.
 
 Evidence packet:
 [`docs/release/evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/`](evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/).
@@ -86,22 +102,29 @@ surfaces are tracked here.
 | # | Surface | Fresh install | Upgrade | Result | Evidence |
 |---|---------|---------------|---------|--------|----------|
 | 1 | Homebrew | install smoke green on `main` | formula updated | ✅ install smoke pass | smoke run [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508), release job [`76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317) |
-| 2 | macOS `.pkg` (production Dev ID FileProvider) | rc2 exact public release asset green; rc1 exact asset and `66ae92f` diagnostic artifact retained as historical proof | package build/notarization passed | ✅ published-asset smoke pass | rc2 exact asset smoke [`26122478486`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26122478486), rc2 release run [`26117684515`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515), diagnostic run [`26117175542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542), artifact source [`26116692781`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781), rc1 exact asset run [`26079830341`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26079830341) |
-| 3 | `.deb` on Ubuntu 24.04 | rc3 release-workflow artifact passed package-backed first-use smoke | package upgrade smoke pending | ✅ artifact first-use pass | post-merge smoke [`26204699596`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596), PR [`#429`](https://github.com/Jesssullivan/tummycrypt/pull/429), rc3 release run [`26204080480`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204080480), rc1 release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
+| 2 | macOS `.pkg` (production Dev ID FileProvider) | rc4 exact public release asset green; rc2 signed-HostApp exact asset, rc1 exact asset, and `66ae92f` diagnostic artifact retained as historical proof | package build/notarization passed | ✅ published-asset smoke pass | rc4 exact asset smoke [`26218940950`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940950), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc2 exact asset smoke [`26122478486`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26122478486), rc2 release run [`26117684515`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515), diagnostic run [`26117175542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542), artifact source [`26116692781`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781), rc1 exact asset run [`26079830341`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26079830341) |
+| 3 | `.deb` on Ubuntu 24.04 | rc4 exact public release asset passed package-backed first-use smoke | package upgrade smoke pending | ✅ public-asset first-use pass | rc4 public asset smoke [`26218940925`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940925), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc3 post-merge smoke [`26204699596`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596), PR [`#429`](https://github.com/Jesssullivan/tummycrypt/pull/429), rc3 release run [`26204080480`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204080480), rc1 release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
 | 4 | `.deb` on Debian 12 bookworm | known blocked (`libc6 >= 2.39` floor) | n/a | ❌ blocked | inherits from [`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor) |
 | 5 | `.rpm` on Fedora 42 | daemon-only package published; install smoke pending | sampled only | ⚠️ daemon-only artifact pass | release job [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870) |
-| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1` | multi-arch runtime smoke green | sampled only | ✅ runtime smoke pass | smoke run [`26083222949`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26083222949), release job [`76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828) |
+| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc4` | multi-arch runtime smoke green | sampled only | ✅ runtime smoke pass | rc4 runtime smoke [`26218940985`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940985), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc1 smoke run [`26083222949`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26083222949), rc1 release job [`76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828) |
 | 7 | Nix flake install | Nix build + Attic push passed; external profile install pending | sampled only | ⚠️ build/cache pass | release job [`76628512831`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512831) |
 
 Rollup: **4 current product-surface or first-use passes · 2 artifact/build
-passes with first-use smoke still pending · 1 blocked**. The macOS `.pkg` row
-has both diagnostic-artifact and exact public rc2 release-asset proof. The
-Ubuntu `.deb` row has rc3 release-workflow artifact first-use proof, but still
-owes public release asset and upgrade proof before #280 can fully close.
+passes with first-use smoke still pending · 1 blocked**. The macOS `.pkg`,
+Ubuntu `.deb`, and container rows now have exact public rc4 release-asset proof.
+Ubuntu `.deb` still owes upgrade proof and distro breadth before #280 can fully
+close.
 
 ## Per-Surface Evidence
 
 ### Published release assets
+
+Current public proof release
+[`v0.12.13-rc4`](https://github.com/Jesssullivan/tummycrypt/releases/tag/v0.12.13-rc4)
+published 16 assets on 2026-05-21, including `.pkg`, `.deb` amd64/arm64,
+daemon-only `.rpm`, tarballs, `TCFSProvider`, checksums, detached signature, and
+Sigstore certificate. The package-facing rc4 smokes used those public release
+assets, not release-workflow artifacts.
 
 Release [`v0.12.13-rc1`](https://github.com/Jesssullivan/tummycrypt/releases/tag/v0.12.13-rc1)
 published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
@@ -136,9 +159,10 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
   [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508)
   passed after PR #393 landed: generated tap install, installed-binary smoke,
   diagnostics, and artifact upload all completed.
-- Not proven in this rc1 packet: upgrade smoke from an older Homebrew install.
+- Not proven in this rc-series packet: upgrade smoke from an older Homebrew
+  install.
 
-### 2. macOS `.pkg` — exact rc2 public asset green
+### 2. macOS `.pkg` — exact rc4 public asset green
 
 - Release job: `Build macOS installer (.pkg)` succeeded
   ([job `76633468317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76633468317)).
@@ -184,10 +208,26 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
   hydrate, evict + rehydrate, FileProvider mutation with 72-byte remote pull,
   and conflict/status with `sync state: conflict` plus 80-byte conflict
   hydration.
-- Not proven in this rc1 packet: clean-host first-run UX from package install to
-  working `tcfs status [ok]`. That remains TIN-1425 scope.
+- Release run
+  [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287)
+  published `v0.12.13-rc4` with
+  `tcfs-0.12.13-rc4-macos-aarch64.pkg`.
+- Public-asset smoke run
+  [`26218940950`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940950)
+  installed that exact GitHub Release `.pkg` from `main@e9b9f82` and passed the
+  production Dev ID postinstall gate. Evidence artifact
+  `macos-postinstall-smoke-v0.12.13-rc4` records:
+  `tcfs index inspect` status `visible`, committed entry, manifest present,
+  59-byte exact signed-host hydrate, evict + rehydrate, FileProvider mutation
+  remote pull, rename remote pull, and conflict/status with
+  `sync state: conflict`.
+- Boundary retained: direct raw CloudStorage root traversal can still be denied
+  by macOS sandbox permissions; the signed HostApp
+  `getUserVisibleURL(.rootContainer)` path is the proven root authority.
+- Not proven in this rc-series packet: clean-host first-run UX from package
+  install to working `tcfs status [ok]`. That remains TIN-1425 scope.
 
-### 3. Debian/Ubuntu `.deb` on Ubuntu 24.04 — artifact first-use pass
+### 3. Debian/Ubuntu `.deb` on Ubuntu 24.04 — public asset first-use pass
 
 - Release jobs: `Build linux-x86_64` and `Build linux-aarch64` succeeded
   ([job `76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870),
@@ -212,8 +252,22 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
   daemon foreground fallback, socket readiness, HTTPS storage `[ok]`, FUSE
   mount, seeded `tcfs index inspect` status `visible`, exact 59-byte hydrate,
   evict/rehydrate, and mutation remote pull.
-- Still not proven: public release asset rerun, upgrade smoke, Debian 13 smoke,
-  and Debian 12 compatibility. Those remain TIN-131 / #280 scope.
+- Release run
+  [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287)
+  published `v0.12.13-rc4` with `tcfs-0.12.13-rc4-amd64.deb`.
+- Public-asset smoke run
+  [`26218940925`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940925)
+  installed the exact public `.deb` asset from `main@e9b9f82` against
+  `https://tcfs-smoke-s3.tinyland.dev` with remote prefix
+  `gha/storage-posture/linux-postinstall/v0.12.13-rc4/20260521T095553Z`. The
+  packet records storage `[ok]`, FUSE mount, `tcfs index inspect` status
+  `visible`, manifest present, exact 59-byte hydrate, `tcfs cache evict` +
+  rehydrate, and mutation remote pull.
+- Versioning caveat: the rc4-named `.deb` assets install package versions
+  `tcfs-cli 0.12.13-1` and `tcfsd 0.12.13-1`. Treat release-candidate package
+  version semantics as a remaining TIN-131/#280 risk.
+- Still not proven: upgrade smoke, Debian 13 smoke, Fedora/RPM breadth, and
+  Debian 12 compatibility. Those remain TIN-131 / #280 scope.
 
 ### 4. Debian/Ubuntu `.deb` on Debian 12 bookworm — blocked
 
@@ -230,7 +284,7 @@ bookworm-specific package or static build is added.
   `0e3f991f93ca9b7c979ce11898ce85cb661efd4a76faa3c93e1337e0326c169e`.
 - Structural caveat unchanged: RPM ships `tcfsd` only today. There is no `tcfs`
   CLI RPM asset.
-- Not proven in this rc1 packet: Fedora 42 install smoke with
+- Not proven in this rc-series packet: Fedora 42 install smoke with
   `scripts/install-smoke.sh --skip-cli`.
 
 ### 6. Container image — multi-arch runtime smoke pass
@@ -248,7 +302,18 @@ bookworm-specific package or static build is added.
   passed on `main` after PR #392 landed for `linux/amd64` and `linux/arm64/v8`:
   manifest inspect, platform pull, `tcfsd 0.12.13` version check, worker-mode
   startup, and artifact upload completed.
-- Not proven in this rc1 packet: full worker execution against live NATS/S3.
+- Release run
+  [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287)
+  published `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc4`.
+- Runtime smoke run
+  [`26218940985`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940985)
+  proved the exact rc4 image for `linux/amd64` and `linux/arm64/v8`: manifest
+  digest `sha256:4b1f235be8a20715b8eb1bb2de38a81b3628a6f56675420cdc2320cce19c20b3`,
+  platform pulls, `tcfsd 0.12.13` version checks, and worker-mode
+  startup/metrics listener. The expected local-NATS connection refusal remains
+  a test-config boundary, not a backend rollout proof.
+- Not proven in this rc-series packet: full worker execution against live
+  NATS/S3.
 
 ### 7. Nix flake install — build/cache pass; external profile install pending
 
@@ -258,8 +323,8 @@ bookworm-specific package or static build is added.
   results to the configured Attic cache.
 - This confirms the release flake builds at the tag and the cache push path is
   healthy.
-- Not proven in this rc1 packet: an external `nix profile install
-  github:Jesssullivan/tummycrypt?ref=v0.12.13-rc1#...` from a non-tinyland host.
+- Not proven in this rc-series packet: an external `nix profile install
+  github:Jesssullivan/tummycrypt?ref=v0.12.13-rc4#...` from a non-tinyland host.
 
 ### Production Dev ID FileProvider — proven on PZM (M10 acceptance)
 
@@ -295,7 +360,7 @@ HEAD). Run `26079830341` confirmed the exact published release asset after PR
 #389 fixed the prerelease asset-version vs Cargo binary-version smoke gate.
 Later main-ref reruns exposed the raw CloudStorage root authority split and led
 to the signed HostApp root-probe path in PR #405. The freshest evidence is the
-published `v0.12.13-rc2` exact-package pass in run `26122478486`.
+published `v0.12.13-rc4` exact-package pass in run `26218940950`.
 
 ## Blockers And Unblock Paths
 
@@ -359,3 +424,6 @@ Same as v0.12.2:
   `26122478486`, replacing the rc2-pending caveat for the macOS package row.
 - 2026-05-21 — Added Ubuntu `.deb` rc3 release-workflow artifact first-use proof
   from post-merge smoke run `26204699596` and PR #429.
+- 2026-05-21 — Added exact public `v0.12.13-rc4` package-facing proof: Linux
+  `.deb` run `26218940925`, macOS `.pkg` run `26218940950`, and container run
+  `26218940985`.


### PR DESCRIPTION
## Summary

- records `v0.12.13-rc4` as the current public-asset proof for macOS `.pkg`, Ubuntu `.deb`, and container runtime
- updates the distribution smoke matrix and FileProvider reality doc with exact run links and remaining boundaries
- updates the TIN-1546 storage posture gate with downstream package-smoke evidence while keeping large-restore/soak/transient gaps open

## Evidence

- Release: https://github.com/Jesssullivan/tummycrypt/releases/tag/v0.12.13-rc4
- Linux `.deb` public asset smoke: https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940925
- macOS `.pkg` public asset smoke: https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940950
- Container runtime smoke: https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940985
- #280 update: https://github.com/Jesssullivan/tummycrypt/issues/280#issuecomment-4507069881

## Checks

- `git diff --check`