### PR TITLE
restore-proof: preflight restore disk headroom

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -646,6 +646,12 @@ tasks:
           if [[ "${REQUIRE_EMPTY_DIRS:-0}" == "1" ]]; then
             args+=(--require-empty-dirs)
           fi
+          if [[ "${RESTORE_REQUIRE_HEADROOM:-0}" == "1" ]]; then
+            args+=(--require-restore-headroom)
+          fi
+          if [[ -n "${RESTORE_HEADROOM_MARGIN_BYTES:-}" ]]; then
+            args+=(--restore-headroom-margin-bytes "$RESTORE_HEADROOM_MARGIN_BYTES")
+          fi
 
           scripts/git-repo-restore-proof.sh "${args[@]}"
           EOF

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -229,6 +229,13 @@ source. Remote read attempts for manifests and chunks are bounded by
 `TCFS_DOWNLOAD_READ_TIMEOUT_SECS` (default 300, cap 3600, `0` disables), so a
 wedged S3 read is classified as a timeout and retried instead of hanging the
 restore indefinitely.
+Large fresh-tree restore packets can require restore-host headroom before any
+reconcile action by setting `RESTORE_REQUIRE_HEADROOM=1` and an optional
+`RESTORE_HEADROOM_MARGIN_BYTES` value. The helper records free bytes, required
+bytes, shadow regular-file bytes, and the margin in `restore-proof.env`; if the
+preflight fails, it writes a blocked packet before any dry-run or execute log is
+created. Use this for the next `linux-xr-fast` candidate-package restore so host
+capacity is not misclassified as storage correctness or transient recovery.
 Fresh-prefix bulk proof can now opt in to
 `TCFS_UPLOAD_ASSUME_FRESH_PREFIX=1` to skip per-chunk remote existence checks,
 and `TCFS_UPLOAD_PROGRESS_EVERY_CHUNKS=N` records bounded chunk progress for

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -223,6 +223,21 @@ Use this companion for the next `linux-xr-fast` candidate-package restore so
 multi-GB Git pack recovery can be compared across release candidates without
 claiming broad home-directory ownership.
 
+Before running a large restore, require local disk headroom explicitly:
+
+```bash
+RESTORE_REQUIRE_HEADROOM=1 \
+RESTORE_HEADROOM_MARGIN_BYTES=$((2 * 1024 * 1024 * 1024)) \
+task lazy:git-repo-restore-proof
+```
+
+The guard compares free bytes on the restore root filesystem against the
+archived shadow regular-file byte total plus the requested margin and writes a
+blocked restore packet before any reconcile dry-run or execute step if the host
+cannot hold the restore. This matters for `linux-xr-fast`: the current neo
+workspace has only single-digit GiB free, below the honest restore size plus
+overhead.
+
 ## Failure Classification
 
 - Missing secrets: environment configuration blocker.
@@ -232,6 +247,8 @@ claiming broad home-directory ownership.
   index enumeration need the same permission.
 - Write/read/delete timeout: storage reliability blocker.
 - Delete verification failed: storage consistency blocker.
+- Restore headroom preflight failed: host-capacity blocker, not a storage
+  correctness failure.
 - S3 auth/access denied: credential-scope blocker unless the policy was
   intentionally read-only.
 

--- a/scripts/git-repo-restore-proof.sh
+++ b/scripts/git-repo-restore-proof.sh
@@ -22,6 +22,12 @@ Options:
   --reconcile-timeout-secs <n>
                          Bound each reconcile command. Default: 900; 0 disables timeout
   --require-empty-dirs   Fail if empty directories are not restored exactly
+  --require-restore-headroom
+                         Fail before reconcile unless the restore filesystem has
+                         enough free bytes for the shadow regular-file bytes plus margin
+  --restore-headroom-margin-bytes <n>
+                         Extra free-byte margin for --require-restore-headroom.
+                         Default: RESTORE_HEADROOM_MARGIN_BYTES or 0
   -h, --help             Show this help
 
 Environment mirrors:
@@ -33,6 +39,8 @@ Environment mirrors:
   TCFS_STATE_PATH
   RESTORE_RECONCILE_TIMEOUT_SECS
   REQUIRE_EMPTY_DIRS=1
+  RESTORE_REQUIRE_HEADROOM=1
+  RESTORE_HEADROOM_MARGIN_BYTES
 EOF
 }
 
@@ -49,6 +57,16 @@ bool_env() {
     1|true|yes|on) printf '1\n' ;;
     0|false|no|off|"") printf '0\n' ;;
     *) fail "$label must be 0/1, got: $value" ;;
+  esac
+}
+
+uint_env() {
+  local label="$1"
+  local value="$2"
+
+  case "$value" in
+    ""|*[!0-9]*) fail "$label must be a non-negative integer, got: $value" ;;
+    *) printf '%s\n' "$value" ;;
   esac
 }
 
@@ -176,6 +194,12 @@ sum_regular_file_bytes() {
   printf '%s\n' "$total"
 }
 
+free_space_bytes() {
+  local path="$1"
+
+  df -Pk "$path" | awk 'NR == 2 { printf "%.0f\n", $4 * 1024; found=1 } END { exit found ? 0 : 1 }'
+}
+
 write_state_manifest() {
   local state_file="$1"
   local root="$2"
@@ -220,6 +244,8 @@ tcfs_bin="${TCFS_BIN:-}"
 state_path="${TCFS_STATE_PATH:-}"
 reconcile_timeout_secs="${RESTORE_RECONCILE_TIMEOUT_SECS:-900}"
 require_empty_dirs="$(bool_env REQUIRE_EMPTY_DIRS "${REQUIRE_EMPTY_DIRS:-0}")"
+require_restore_headroom="$(bool_env RESTORE_REQUIRE_HEADROOM "${RESTORE_REQUIRE_HEADROOM:-0}")"
+restore_headroom_margin_bytes="$(uint_env RESTORE_HEADROOM_MARGIN_BYTES "${RESTORE_HEADROOM_MARGIN_BYTES:-0}")"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -261,6 +287,15 @@ while [[ $# -gt 0 ]]; do
     --require-empty-dirs)
       require_empty_dirs=1
       shift
+      ;;
+    --require-restore-headroom)
+      require_restore_headroom=1
+      shift
+      ;;
+    --restore-headroom-margin-bytes)
+      [[ $# -ge 2 ]] || fail "--restore-headroom-margin-bytes requires a value"
+      restore_headroom_margin_bytes="$(uint_env --restore-headroom-margin-bytes "$2")"
+      shift 2
       ;;
     -h|--help)
       usage
@@ -365,6 +400,9 @@ execute_completed_at_utc=
 execute_elapsed_secs=
 partial_restored_regular_file_count=0
 partial_restored_regular_file_bytes=0
+restore_free_bytes=unmeasured
+restore_required_free_bytes=unmeasured
+shadow_regular_file_bytes_preflight=unmeasured
 
 write_blocked_result() {
   local phase="$1"
@@ -386,6 +424,11 @@ blocked_rc=$rc
 evidence_dir=$evidence_dir
 shadow_root=$shadow_root
 restore_root=$restore_root
+restore_require_headroom=$require_restore_headroom
+restore_free_bytes=$restore_free_bytes
+restore_required_free_bytes=$restore_required_free_bytes
+restore_headroom_margin_bytes=$restore_headroom_margin_bytes
+shadow_regular_file_bytes_preflight=$shadow_regular_file_bytes_preflight
 config_path=$config_path
 remote_prefix=$remote_prefix
 state_path=$state_path
@@ -423,6 +466,8 @@ Reason: $reason
 - Packet: \`$evidence_dir\`
 - Shadow: \`$shadow_root\`
 - Restore root: \`$restore_root\`
+- Restore free bytes: \`$restore_free_bytes\`
+- Restore required free bytes: \`$restore_required_free_bytes\`
 - Config: \`$config_path\`
 - Remote prefix: \`$remote_prefix\`
 - tcfs: \`$tcfs_bin\`
@@ -431,6 +476,21 @@ Reason: $reason
 Inspect \`reconcile-dry-run.log\` and \`reconcile-execute.log\` when present.
 EOF
 }
+
+if [[ "$require_restore_headroom" == "1" ]]; then
+  shadow_regular_file_bytes_preflight="$(sum_regular_file_bytes "$shadow_root")"
+  restore_free_bytes="$(free_space_bytes "$restore_root")" || fail "could not determine free space for restore root: $restore_root"
+  restore_required_free_bytes=$((shadow_regular_file_bytes_preflight + restore_headroom_margin_bytes))
+
+  if [[ "$restore_free_bytes" -lt "$restore_required_free_bytes" ]]; then
+    headroom_reason="insufficient restore filesystem headroom: free=${restore_free_bytes} required=${restore_required_free_bytes} shadow_regular_file_bytes=${shadow_regular_file_bytes_preflight} margin=${restore_headroom_margin_bytes}"
+    write_blocked_result headroom 73 "$headroom_reason"
+    printf 'restore proof evidence: %s\n' "$restore_dir"
+    printf 'restore proof status: failed\n'
+    printf 'restore proof reason: %s\n' "$headroom_reason"
+    exit 73
+  fi
+fi
 
 dry_run_rc=0
 run_with_timeout "$restore_dir/reconcile-dry-run.log" \
@@ -573,6 +633,11 @@ tcfs_version=$tcfs_version
 tcfs_sha256_status=$tcfs_sha256_status
 tcfs_sha256=$tcfs_sha256
 reconcile_timeout_secs=$reconcile_timeout_secs
+restore_require_headroom=$require_restore_headroom
+restore_free_bytes=$restore_free_bytes
+restore_required_free_bytes=$restore_required_free_bytes
+restore_headroom_margin_bytes=$restore_headroom_margin_bytes
+shadow_regular_file_bytes_preflight=$shadow_regular_file_bytes_preflight
 dry_run_started_at_utc=$dry_run_started_at_utc
 dry_run_completed_at_utc=$dry_run_completed_at_utc
 dry_run_elapsed_secs=$dry_run_elapsed_secs
@@ -612,6 +677,8 @@ SHA-256 hashes and symlink targets against the archived shadow tree.
 - Packet: \`$evidence_dir\`
 - Shadow: \`$shadow_root\`
 - Restore root: \`$restore_root\`
+- Restore free bytes: \`$restore_free_bytes\`
+- Restore required free bytes: \`$restore_required_free_bytes\`
 - Config: \`$config_path\`
 - Remote prefix: \`$remote_prefix\`
 - tcfs: \`$tcfs_bin\`

--- a/scripts/test-git-repo-restore-proof.sh
+++ b/scripts/test-git-repo-restore-proof.sh
@@ -154,6 +154,7 @@ assert_contains "$PACKET/restore-proof/restore-proof.env" "proof=fresh-tree-rest
 assert_contains "$PACKET/restore-proof/restore-proof.env" "regular_files_match=1"
 assert_contains "$PACKET/restore-proof/restore-proof.env" "dry_run_elapsed_secs="
 assert_contains "$PACKET/restore-proof/restore-proof.env" "execute_elapsed_secs="
+assert_contains "$PACKET/restore-proof/restore-proof.env" "restore_require_headroom=0"
 assert_contains "$PACKET/restore-proof/restore-proof.env" "shadow_regular_file_bytes=31"
 assert_contains "$PACKET/restore-proof/restore-proof.env" "restored_regular_file_bytes=31"
 assert_contains "$PACKET/restore-proof/restore-proof.env" "restored_regular_file_bytes_per_sec="
@@ -168,6 +169,23 @@ test -f "$PACKET/restore-proof/reconcile-dry-run.log"
 test -f "$PACKET/restore-proof/reconcile-execute.log"
 test -L "$RESTORE/readme-link"
 test -d "$RESTORE/empty-dir"
+
+HEADROOM_RESTORE="$TMPDIR/restored tree headroom"
+HEADROOM_RESTORE_DIR="$PACKET/restore-proof-headroom"
+assert_fails_contains \
+  "insufficient restore filesystem headroom" \
+  env FAKE_RESTORE_SOURCE="$SHADOW" RESTORE_REQUIRE_HEADROOM=1 RESTORE_HEADROOM_MARGIN_BYTES=999999999999999 bash "$SCRIPT" \
+    --evidence-dir "$PACKET" \
+    --restore-root "$HEADROOM_RESTORE" \
+    --restore-dir "$HEADROOM_RESTORE_DIR" \
+    --config "$CONFIG" \
+    --state "$TMPDIR/restore-state-headroom.json"
+assert_contains "$HEADROOM_RESTORE_DIR/restore-proof.env" "status=failed"
+assert_contains "$HEADROOM_RESTORE_DIR/restore-proof.env" "blocked_phase=headroom"
+assert_contains "$HEADROOM_RESTORE_DIR/restore-proof.env" "restore_require_headroom=1"
+assert_contains "$HEADROOM_RESTORE_DIR/restore-proof.env" "restore_required_free_bytes="
+test ! -f "$HEADROOM_RESTORE_DIR/reconcile-dry-run.log"
+test ! -f "$HEADROOM_RESTORE_DIR/reconcile-execute.log"
 
 CUSTOM_RESTORE="$TMPDIR/restored tree custom"
 CUSTOM_RESTORE_DIR="$PACKET/restore-proof-custom"


### PR DESCRIPTION
## Summary

- adds an opt-in `RESTORE_REQUIRE_HEADROOM=1` / `--require-restore-headroom` preflight to `scripts/git-repo-restore-proof.sh`
- records restore free bytes, required bytes, shadow regular-file bytes, and margin in `restore-proof.env`
- wires the guard through `task lazy:git-repo-restore-proof` and documents the TIN-1546 large-restore usage

## Why

The next `linux-xr-fast` candidate-package restore needs enough local capacity for the 8.7 GiB-class restore plus overhead. Current local truth on this workspace is only 6.8 GiB free, and the archived shadow root is not present locally, so an honest large restore cannot be run from here. This guard makes that host-capacity blocker explicit before reconcile dry-run/execute creates partial restore evidence.

## Checks

- `bash -n scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh`
- `task lazy:test-git-repo-restore-proof`
- `git diff --check`