### PR TITLE
docs: refresh alpha storage gate evidence

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -65,12 +65,12 @@ The raw-Git project-tree canary is intentionally allowed to expose these
 storage bottlenecks, but those observations are performance evidence, not a
 production storage posture claim.
 
-Current production-like S3 posture snapshot from `main@6990ffb`, run
-`26209080328`, artifact `storage-posture-canary-26209080328-1`:
+Current production-like S3 posture snapshot from `main@84c7389`, run
+`26220824445`, artifact `storage-posture-canary-26220824445-1`:
 
 | Endpoint class | Security/scope | Payload | List | Write | Read | Delete | Verify delete | Scope denial |
 |----------------|----------------|---------|------|-------|------|--------|---------------|--------------|
-| Public HTTPS S3-compatible endpoint (`https://tcfs-smoke-s3.tinyland.dev`) | `enforce_tls=true`; public CA chain; scoped `tcfs-storage-prod-smoke` identity under `gha/storage-posture/...` | 216 B | 37 ms, 1 entry | 139 ms | 34 ms | 35 ms | 36 ms | `PermissionDenied` in 33 ms for `gha/storage-posture-denied/...` |
+| Public HTTPS S3-compatible endpoint (`https://tcfs-smoke-s3.tinyland.dev`) | `enforce_tls=true`; public CA chain; scoped `tcfs-storage-prod-smoke` identity under `gha/storage-posture/...` | 242 B | 99 ms, 1 entry | 328 ms | 99 ms | 101 ms | 99 ms | `PermissionDenied` in 96 ms for `gha/storage-posture-denied/...` |
 
 This packet proves TLS transport, allowed-prefix list permission, scoped
 write/read/delete/delete-verify behavior, and negative credential-scope denial

--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -66,12 +66,17 @@ the package-facing public-asset smokes are green from `main@e9b9f82`:
   `linux/arm64/v8` with manifest digest
   `sha256:4b1f235be8a20715b8eb1bb2de38a81b3628a6f56675420cdc2320cce19c20b3`.
 
+Homebrew current-tap fresh install also passed after the rc4 release job updated
+`homebrew-tap@b5877df`: run `26221252765` installed
+`/opt/homebrew/Cellar/tcfs/0.12.13-rc4` and the binaries reported
+`tcfs 0.12.13` / `tcfsd 0.12.13`.
+
 Remaining distribution proof is now breadth and upgrade heavy: Homebrew
-install/upgrade, Debian 13 `.deb` install/upgrade, Fedora daemon-only `.rpm`
-install, external Nix profile install, and release-candidate package version
-semantics (`0.12.13-1` installed from rc4-named `.deb` assets). Debian 12
-remains blocked by the libc/OpenSSL floor unless a separate bookworm-targeted
-package exists. See
+upgrade, Debian 13 `.deb` install/upgrade, Fedora daemon-only `.rpm` install,
+external Nix profile install, and release-candidate package version semantics
+(`0.12.13-1` installed from rc4-named `.deb` assets). Debian 12 remains blocked
+by the libc/OpenSSL floor unless a separate bookworm-targeted package exists.
+See
 [`docs/release/v0.12.13-evidence-matrix.md`](../release/v0.12.13-evidence-matrix.md)
 for the frozen rc-series evidence table.
 

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -3,7 +3,7 @@
 As of May 19, 2026, `tummycrypt` is in a much better state operationally than
 its remaining gaps might suggest.
 
-The latest release candidate is `v0.12.13-rc1`, and most release-facing
+The latest release candidate is `v0.12.13-rc4`, and most release-facing
 surfaces now have explicit proof paths. The important distinction is that
 `buildable`, `packaged`, `product-surface proven`, and `actually ready for
 daily-driver use` are still different things.
@@ -21,8 +21,8 @@ Use this document as the short answer to:
 | Linux CLI + daemon | strongest and most routinely proven path; x86_64 FUSE lifecycle has current real-host evidence, while packaged systemd/mount first-use remains a separate gate | CI, release smoke, live host acceptance, archived Linux lifecycle evidence |
 | Fleet sync / backend path | materially exercised on real hosts; current live transcripts are archived in the fleet pilot packets | `neo-honey` live acceptance plus lab host matrix and `docs/release/evidence/fleet-pilot-extended-20260509T2152Z/` |
 | Lazy traversal / hydration | core code and harnesses exist; Linux FUSE proves browse-before-download, exact `cat` hydration, mounted write/readback, cache clear/rehydrate, and recursive safe-unsync refusal/success on real host evidence; the extended fleet packet carries that lifecycle proof as a honey companion next to isolated `Documents`/`git` traversal and live backend smoke; PZM now proves production Developer ID FileProvider enumerate, exact-content hydrate, evict/rehydrate, mutation upload/readback, and conflict-status preservation without `fileprovider_testing_mode=true` | `tcfs-vfs`/FUSE implementation, archived Linux and fleet evidence, PZM production Dev ID smoke, and the lazy hydration demo runbook |
-| Real project-tree canary / storage posture | scoped isolated `linux-xr` shadow parity is green, including symlink target preservation through honey-mounted traversal. The current release-binary storage-posture packet completed the 7.7 GB shadow, then reused that prefix for honey mounted `find -maxdepth 8`, exact `.clang-format` hydration, and all 85 mounted symlink target checks. The mounted warning follow-up is closed: the exact `.tc` filename fix rerun dropped S3 `NoSuchKey` warnings from 274 to 0 while preserving real ftrace `.tc` filenames. The lifecycle companion now reuses that same prefix and reports `scoped-project-tree-parity-evidence-complete`, including mounted write/readback, cache clear/rehydrate, dirty recursive safe-unsync refusal, and clean recursive safe-unsync success. The small real-repo dogfood surface is green for both source-built and explicit current Nix flake package binaries: `git-repo-canary-oauth-mux-sourcebin-fresh-20260515T014640Z/` and `git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/` both prove clean `oauth-mux` shadow push, 0 skipped symlinks, honey mounted traversal/hydration, 9 mounted symlink target checks, and Linux lifecycle. The original Nix restore timeout remains archived at `git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof/`; source-built `restore-proof-source-fix-empty-dirs-20260515T183805Z/` and rebuilt Nix package `restore-proof-nixpkg-current-empty-dirs-20260515T200359Z/` now prove fresh-tree restore for 4,601 regular files, 9 symlinks, synced state for all 4,610 restored paths, and all 12 empty directories with `--require-empty-dirs`. The larger `linux-xr-fast` source-built packet is green for shadow push, honey mounted traversal/hydration, and Linux lifecycle in `git-repo-canary-linux-xr-fast-sourcefix-index-20260516T045054Z/`: the clean shadow has 2,038 regular files, 0 symlinks, about 8.7 GB of file bytes, and the Git pack-index, temp-pack, and exact `.git/index` chunk-profile fixes are proven in one run. Fresh-tree restore remains blocked because 2 of 2,038 regular files did not restore; both are multi-GB raw Git pack files that failed after transient chunk read errors, while all 6 empty directories restored exactly. Homebrew remains the package-current blocker: `tcfs-symlink-package-probe-20260515T041947Z/` shows current-checkout Nix and source-built `tcfs 0.12.12` preserve symlinks, while installed Homebrew `tcfs 0.12.12` skips them; `tcfs-symlink-package-probe-20260515T051126Z/` proves neo current-checkout Nix can publish a symlink index that honey current source-built Linux can mount, read, and verify as `link.txt -> target.txt`; `tcfs-symlink-package-probe-20260515T060330Z/` proves current Nix flake packages on neo and honey pass the same tiny mounted parse/target check. Homebrew rebuild/publish, candidate package proof for the large repo, enough local free space for full restore, and package-backed fresh-tree restore/rollback proof remain open before live repo moves. Production storage posture remains open because the endpoint is plaintext tailnet HTTP, local restore disk margin was tight, socket highwater exceeded configured upload concurrency in prior storage proof, generated large source headers still create thousands of chunks, and the Git metadata fixes have not yet been proven from a selected package/binary | `docs/release/evidence/git-repo-canary-linux-xr-fast-sourcefix-index-20260516T045054Z/`, `docs/release/evidence/git-repo-canary-linux-xr-fast-sourcefix-tmppack-20260516T024810Z/`, `docs/release/evidence/git-repo-canary-linux-xr-fast-sourcefix-20260516T024122Z/`, `docs/release/evidence/git-repo-canary-linux-xr-fast-nixpkg-tuned-20260516T010911Z/`, `docs/release/evidence/git-repo-canary-linux-xr-fast-nixpkg-20260516T005236Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof-nixpkg-current-empty-dirs-20260515T200359Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof-source-fix-empty-dirs-20260515T183805Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof-source-fix-symlink-state-20260515T171712Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/`, `docs/release/evidence/tcfs-symlink-package-probe-20260515T060330Z/`, `docs/release/evidence/tcfs-symlink-package-probe-20260515T051126Z/`, `docs/release/evidence/tcfs-symlink-package-probe-20260515T041947Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-sourcebin-fresh-20260515T014640Z/`, `docs/release/evidence/home-canary-linux-xr-storage-posture-lifecycle-20260514T213826Z/`, `docs/release/evidence/home-canary-linux-xr-shadow-20260511T040325Z/`, `docs/release/evidence/tcfs-symlink-config-probe-20260515T005858Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-20260515T000411Z/`, `docs/ops/git-repo-canary-dogfood.md`, `docs/release/evidence/home-canary-linux-xr-storage-posture-tc-extfix-20260514T202343Z/`, `docs/release/evidence/home-canary-linux-xr-storage-posture-20260514T021513Z/`, `docs/release/evidence/home-canary-linux-xr-storage-posture-20260513T220442Z/`, PR `#367`, and blocker packet `docs/release/evidence/home-canary-linux-xr-storage-posture-20260513T174944Z/` |
-| macOS | experimental but real; `v0.12.13-rc2` ships a notarized production Developer ID `.pkg`, PZM run `26122478486` proves the exact public release asset through installed strict preflight, storage `[ok]`, domain rebuild, signed HostApp user-visible root enumeration, exact hydrate, evict/rehydrate, mutation upload/readback, and conflict-status preservation without `fileprovider_testing_mode=true`; PR #412 also landed copy-before-delete rename and unsync-vs-delete safety. Remaining macOS production gaps are first-run setup from installer to valid config/status, badge/progress assertions, recovery UX, longer desktop soak, and continuous release-day viability | build + packaging + PZM production Dev ID smoke + v0.12.13 evidence matrix + local desktop evidence |
+| Real project-tree canary / storage posture | scoped isolated `linux-xr` shadow parity is green, including symlink target preservation through honey-mounted traversal. The current release-binary storage-posture packet completed the 7.7 GB shadow, then reused that prefix for honey mounted `find -maxdepth 8`, exact `.clang-format` hydration, and all 85 mounted symlink target checks. The mounted warning follow-up is closed: the exact `.tc` filename fix rerun dropped S3 `NoSuchKey` warnings from 274 to 0 while preserving real ftrace `.tc` filenames. The lifecycle companion now reuses that same prefix and reports `scoped-project-tree-parity-evidence-complete`, including mounted write/readback, cache clear/rehydrate, dirty recursive safe-unsync refusal, and clean recursive safe-unsync success. The small real-repo dogfood surface is green for both source-built and explicit current Nix flake package binaries: `git-repo-canary-oauth-mux-sourcebin-fresh-20260515T014640Z/` and `git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/` both prove clean `oauth-mux` shadow push, 0 skipped symlinks, honey mounted traversal/hydration, 9 mounted symlink target checks, and Linux lifecycle. The original Nix restore timeout remains archived at `git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof/`; source-built `restore-proof-source-fix-empty-dirs-20260515T183805Z/` and rebuilt Nix package `restore-proof-nixpkg-current-empty-dirs-20260515T200359Z/` now prove fresh-tree restore for 4,601 regular files, 9 symlinks, synced state for all 4,610 restored paths, and all 12 empty directories with `--require-empty-dirs`. The larger `linux-xr-fast` source-built packet is green for shadow push, honey mounted traversal/hydration, and Linux lifecycle in `git-repo-canary-linux-xr-fast-sourcefix-index-20260516T045054Z/`: the clean shadow has 2,038 regular files, 0 symlinks, about 8.7 GB of file bytes, and the Git pack-index, temp-pack, and exact `.git/index` chunk-profile fixes are proven in one run. Fresh-tree restore remains blocked because 2 of 2,038 regular files did not restore; both are multi-GB raw Git pack files that failed after transient chunk read errors, while all 6 empty directories restored exactly. Homebrew current-tap install is now green for rc4, but Homebrew remains a package-backed real-repo blocker until the symlink/large-canary path is repeated with the current formula: `tcfs-symlink-package-probe-20260515T041947Z/` showed current-checkout Nix and source-built `tcfs 0.12.12` preserving symlinks while installed Homebrew `tcfs 0.12.12` skipped them; `tcfs-symlink-package-probe-20260515T051126Z/` proves neo current-checkout Nix can publish a symlink index that honey current source-built Linux can mount, read, and verify as `link.txt -> target.txt`; `tcfs-symlink-package-probe-20260515T060330Z/` proves current Nix flake packages on neo and honey pass the same tiny mounted parse/target check. The production storage posture gate now has a current scoped HTTPS canary: run `26220824445` on `main@84c7389` proved public HTTPS, `enforce_tls=true`, public CA trust, allowed-prefix list/write/read/delete/delete-verify, and denied-prefix `PermissionDenied`. Large-restore throughput, socket/highwater behavior, transient recovery classification, enough local free space for full restore, and package-backed fresh-tree restore/rollback proof remain open before live repo moves. | `docs/release/evidence/git-repo-canary-linux-xr-fast-sourcefix-index-20260516T045054Z/`, `docs/release/evidence/git-repo-canary-linux-xr-fast-sourcefix-tmppack-20260516T024810Z/`, `docs/release/evidence/git-repo-canary-linux-xr-fast-sourcefix-20260516T024122Z/`, `docs/release/evidence/git-repo-canary-linux-xr-fast-nixpkg-tuned-20260516T010911Z/`, `docs/release/evidence/git-repo-canary-linux-xr-fast-nixpkg-20260516T005236Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof-nixpkg-current-empty-dirs-20260515T200359Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof-source-fix-empty-dirs-20260515T183805Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof-source-fix-symlink-state-20260515T171712Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/restore-proof/`, `docs/release/evidence/git-repo-canary-oauth-mux-nixpkg-20260515T133843Z/`, `docs/release/evidence/tcfs-symlink-package-probe-20260515T060330Z/`, `docs/release/evidence/tcfs-symlink-package-probe-20260515T051126Z/`, `docs/release/evidence/tcfs-symlink-package-probe-20260515T041947Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-sourcebin-fresh-20260515T014640Z/`, `docs/release/evidence/home-canary-linux-xr-storage-posture-lifecycle-20260514T213826Z/`, `docs/release/evidence/home-canary-linux-xr-shadow-20260511T040325Z/`, `docs/release/evidence/tcfs-symlink-config-probe-20260515T005858Z/`, `docs/release/evidence/git-repo-canary-oauth-mux-20260515T000411Z/`, `docs/ops/git-repo-canary-dogfood.md`, `docs/release/evidence/home-canary-linux-xr-storage-posture-tc-extfix-20260514T202343Z/`, `docs/release/evidence/home-canary-linux-xr-storage-posture-20260514T021513Z/`, `docs/release/evidence/home-canary-linux-xr-storage-posture-20260513T220442Z/`, PR `#367`, and blocker packet `docs/release/evidence/home-canary-linux-xr-storage-posture-20260513T174944Z/` |
+| macOS | experimental but real; `v0.12.13-rc4` ships a notarized production Developer ID `.pkg`, PZM run `26218940950` proves the exact public release asset through installed strict preflight, storage `[ok]`, domain rebuild, signed HostApp user-visible root enumeration, exact hydrate, evict/rehydrate, mutation upload/readback, rename, and conflict-status preservation without `fileprovider_testing_mode=true`. Remaining macOS production gaps are first-run setup from installer to valid config/status, badge/progress assertions, recovery UX, longer desktop soak, and continuous release-day viability | build + packaging + PZM production Dev ID smoke + v0.12.13 evidence matrix + local desktop evidence |
 | iOS | proof-of-concept | Swift type-check and scaffold only |
 | Windows | planned / skeleton | code exists, but there is no release-grade CLI, daemon, or Explorer flow |
 
@@ -34,11 +34,11 @@ This is the narrowest and most important truth for public release claims.
 
 | Surface | Status | Current reality |
 | --- | --- | --- |
-| Homebrew | rc1 install smoke pass | `v0.12.13-rc1` formula update passed in the release workflow, and main run `26082967508` proves fresh install plus installed-binary smoke. Upgrade smoke remains pending |
-| macOS `.pkg` | FileProvider release-asset pass; first-run UX gap | `v0.12.13-rc2` publishes a notarized production Developer ID `.pkg`; PZM run `26122478486` proves the exact public GitHub Release `.pkg` through hydrate, evict/rehydrate, mutation upload/readback, and conflict-status. First-run config UX remains pending |
-| `.deb` | rc1 artifact pass | Ubuntu 24.04+ / Debian 13+ are the truthful targets; packages are published, but install/upgrade smoke is still pending. Debian 12 remains excluded unless a bookworm-targeted package exists |
+| Homebrew | current tap fresh-install pass; upgrade gap | `homebrew-tap@b5877df` points at `v0.12.13-rc4`, and run `26221252765` proves fresh install plus installed `tcfs 0.12.13` / `tcfsd 0.12.13` smoke. Upgrade proof remains pending under TIN-131/#280 |
+| macOS `.pkg` | FileProvider release-asset pass; first-run UX gap | `v0.12.13-rc4` publishes a notarized production Developer ID `.pkg`; PZM run `26218940950` proves the exact public GitHub Release `.pkg` through hydrate, evict/rehydrate, mutation upload/readback, rename, and conflict/status. First-run config UX remains pending |
+| `.deb` | rc4 public-asset first-use pass | Ubuntu 24.04+ is proven by run `26218940925` through install, storage `[ok]`, FUSE mount, exact hydrate, `tcfs cache evict` + rehydrate, and mutation remote pull. Debian 13 and upgrade smoke remain pending |
 | `.rpm` | rc1 daemon-only artifact pass | Fedora/RHEL daemon package is published; install smoke remains pending and the CLI `.rpm` surface is still absent |
-| container image | rc1 runtime smoke pass | multi-arch `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc1` built and signed; main run `26083222949` proves manifest inspect, platform pull, version check, and worker startup for amd64 and arm64/v8 |
+| container image | rc4 runtime smoke pass | `v0.12.13-rc4` container runtime smoke run `26218940985` proves manifest inspect, platform pull, version check, and worker startup |
 | Nix install | rc1 build/cache pass | release Nix build and Attic push passed; an external profile install from a non-tinyland host remains pending |
 
 Canonical runbook: [Distribution Smoke Matrix](distribution-smoke-matrix.md).
@@ -46,7 +46,7 @@ Install-to-first-use bridge:
 [Packaged Install To First-Real-Use Acceptance](packaged-install-first-use.md).
 Historical per-release evidence freeze for `v0.12.2`:
 [v0.12.2 Evidence Matrix](../release/v0.12.2-evidence-matrix.md).
-Current release-surface evidence for `v0.12.13-rc1`:
+Current release-surface evidence for `v0.12.13-rc4`:
 [v0.12.13 Evidence Matrix](../release/v0.12.13-evidence-matrix.md).
 Current evidence index with GitHub Actions run links:
 [Release Evidence Index](../release/evidence/README.md).
@@ -115,7 +115,7 @@ Still useful as non-production PZM lab evidence:
 
 Now proven on the production Dev ID PZM lane:
 
-- `v0.12.13-rc1` release publication includes a notarized production
+- `v0.12.13-rc4` release publication includes a notarized production
   Developer ID macOS `.pkg`.
 - production Dev ID smoke run `26061402177` first proved installed strict
   preflight, storage `[ok]`, domain add, CloudStorage enumeration,
@@ -125,6 +125,9 @@ Now proven on the production Dev ID PZM lane:
   conflict-status preservation without `fileprovider_testing_mode=true`.
 - key artifacts from that follow-up are archived under
   `docs/release/evidence/macos-postinstall-prod-devid-hydration-20260518T212705Z/run-26062554542/`.
+- public asset smoke run `26218940950` repeated the signed HostApp path against
+  `tcfs-0.12.13-rc4-macos-aarch64.pkg` with exact hydrate, evict/rehydrate,
+  mutation, rename, and conflict/status enabled.
 - the older PZM testing-mode lane remains useful as a lab signal, but it is no
   longer the strongest FileProvider lifecycle evidence.
 
@@ -169,8 +172,11 @@ Functional isolated project-tree behavior is green in
 `docs/release/evidence/home-canary-linux-xr-shadow-20260511T040325Z/`: the
 shadowed `linux-xr` tree could be pushed, traversed from honey, hydrate selected
 content, preserve all 85 symlink targets through the mounted view, and pass the
-Linux lifecycle companion. Production storage posture is not green, but the
-storage lane has narrowed: `20260513T220442Z` reduced the dominant
+Linux lifecycle companion. Scoped HTTPS storage posture is now green for the
+small canary gate: run `26220824445` at `main@84c7389` proved public HTTPS,
+`enforce_tls=true`, public CA trust, allowed-prefix list/write/read/delete,
+delete verification, and denied-prefix `PermissionDenied`. The larger storage
+lane remains open for throughput and recovery: `20260513T220442Z` reduced the dominant
 6.2 GB raw Git `.pack` from 70,856 chunks to 1,211 chunks, and
 `docs/release/evidence/home-canary-linux-xr-storage-posture-20260514T021513Z/`
 reduced the adjacent 45.6 MB `.rev` from 8,405 chunks to 8 chunks while
@@ -179,10 +185,11 @@ that same prefix also passed honey mounted `find -maxdepth 8`, all 85 mounted
 symlink target checks, and exact `.clang-format` hydration. The lifecycle
 companion `home-canary-linux-xr-storage-posture-lifecycle-20260514T213826Z/`
 closes the same-prefix mounted write/readback, cache clear/rehydrate, and
-recursive safe-unsync row. Do not claim production S3 posture or broad
-home-directory readiness until endpoint/TLS posture, socket accounting,
+recursive safe-unsync row. Do not claim broad home-directory readiness or
+large-object production storage maturity until socket accounting,
 candidate-package proof of the Git metadata profile fixes, large-pack restore
-reliability, and generated-large-file policy are closed.
+reliability, transient-recovery classification, and generated-large-file policy
+are closed.
 
 The next generic git-repo dogfood lane is narrower and currently blocked at
 Homebrew package truth plus larger/restore proof, not source or current Nix
@@ -334,17 +341,17 @@ As of May 19, 2026, the narrow GitHub backlog snapshot is below. Verify live
 GitHub state before acting on exact issue or milestone status.
 
 - M10 release-proof tranche
-  - `#280`: distribution install and upgrade proof umbrella. `v0.12.13-rc1`
-    release artifacts and formula updates are published, but first-use smokes
-    remain pending for Homebrew, Linux packages, container runtime, and Nix
-    external profile install. Debian 12 remains excluded by the libc/OpenSSL
-    floor unless a separate bookworm package is produced.
+  - `#280`: distribution install and upgrade proof umbrella. `v0.12.13-rc4`
+    public Linux `.deb`, macOS `.pkg`, and container runtime smokes are green,
+    but Homebrew upgrade, Debian 13, Fedora/RPM, Nix external
+    profile/NixOS, and package-upgrade semantics remain pending. Debian 12
+    remains excluded by the libc/OpenSSL floor unless a separate bookworm
+    package is produced.
   - `#309`: macOS `.pkg` clean-host and FileProvider acceptance lane. PZM
     production Dev ID smoke run `26062554542` proves hydrate,
     evict/rehydrate, mutation upload/readback, and conflict-status. Remaining
-    Apple follow-ups are exact published-release-asset post-cut smoke,
-    first-run setup UX, badge/progress/recovery assertions, and long-running
-    daily-use proof.
+    Apple follow-ups are first-run setup UX, badge/progress/recovery
+    assertions, and long-running daily-use proof.
 - Adjacent non-M10 lanes
   - `#298`: residual Civo TCFS PVC retirement after on-prem recovery
   - `#327`: TCFS on-prem OpenTofu migration and cutover
@@ -398,24 +405,24 @@ freshest truth source for `tummycrypt`.
 
 - `TIN-133`, `TIN-1414`, and `TIN-1415` are Done for the M10 production
   FileProvider hydration/lifecycle proof.
-- `TIN-131` and `TIN-132` are In Progress under `Tummycrypt M10: Usage
-  Reality & Product Parity`; they remain the distribution and live-fleet
-  acceptance lanes.
+- `TIN-131` is In Progress under `Tummycrypt M10: Usage Reality & Product
+  Parity` for the remaining distribution breadth and upgrade lanes. `TIN-132`
+  is Done with a fresh named neo/honey packet, but release-day acceptance should
+  keep that transcript current or explicitly supersede the named-lane
+  requirement.
 - `TIN-1421` is Done for the real-storage CI lane.
-- `TIN-1422` is In Progress for Linux postinstall parity and is blocked by
-  `TIN-1540`, which must provide either a reachable hosted Linux smoke backend
-  or a private Linux runner that can resolve the tailnet endpoint.
+- `TIN-1422` and `TIN-1540` are Done for the reachable Linux package-smoke
+  backend and hosted Linux first-use lane.
 - `TIN-1417`, `TIN-1424`, and `TIN-1418` are the enrollment/security and
   multitenancy chain: per-device identity must land before self-enrollment or
   multitenant trust-boundary claims are product-real.
-- `TIN-1546` is the production S3/storage posture gate: TLS/CA posture,
-  bounded health/read attempts, transient-error classification, large-pack
-  restore, and storage latency/object-count evidence. PR #390 landed bounded
-  remote manifest/index/chunk read attempts; production-like TLS/CA and live
+- `TIN-1546` is the production S3/storage posture gate: scoped HTTPS canary
+  evidence is green on current `main`, while transient-error classification,
+  large-pack restore, socket/highwater evidence, and storage latency/object-count
   evidence remain open.
 - `TIN-1547` is the post-M10 FileProvider product-hardening gate: exact release
-  asset smoke, rename/unsync semantics, badges/progress, recovery UX, and
-  longer desktop soak.
+  asset smoke and rename/conflict paths are green; badges/progress, recovery UX,
+  first-run setup, and longer desktop soak remain open.
 - `TIN-1548` keeps iOS as a proof-of-concept until there is a real-device or
   simulator Files.app acceptance lane with safe enrollment posture.
 - `TIN-1549` is the beta desktop status/progress/conflict recovery UX gate

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -48,6 +48,16 @@ Known evidence:
   verification, and denied-prefix `PermissionDenied` evidence under
   `gha/storage-posture-denied/...`. Treat this as the current-main storage
   posture packet for alpha QA, not as large-restore or soak proof.
+- run `26220824445` refreshed the packet on `main` at `84c7389` after PRs `#437`
+  and `#438` merged. It used
+  `gha/storage-posture/current-main/20260521T103646Z`, public HTTPS endpoint
+  `https://tcfs-smoke-s3.tinyland.dev`, `require_https=true`,
+  `endpoint_tls=true`, `enforce_tls=true`, public CA trust
+  (`ca_cert_path_configured=false`), 242-byte write/read/delete/delete-verify,
+  allowed-prefix listing, and denied-prefix `PermissionDenied` under
+  `gha/storage-posture-denied/current-main/20260521T103646Z`. Treat this as the
+  current-main storage posture packet for alpha QA, not as large-restore,
+  socket/highwater, transient-recovery, or soak proof.
 - downstream public-asset smokes on `main@e9b9f82` then used the same
   production-smoke prefix family successfully:
   - Linux `.deb` run `26218940925` used

--- a/docs/ops/tcfs-alpha-productionization-sprint-2026-05-20.md
+++ b/docs/ops/tcfs-alpha-productionization-sprint-2026-05-20.md
@@ -2,18 +2,20 @@
 
 This is the execution board for the current alpha push. It turns the
 productionization plan into runnable gates and keeps the claim boundary strict:
-macOS production FileProvider exact hydration is green, while storage posture,
-Linux first-use, and fresh neo/honey evidence remain open until their packets
-exist.
+macOS production FileProvider exact hydration, Linux package first-use, and
+scoped HTTPS storage posture are green for the rc4/public-asset path. The
+remaining alpha-to-beta work is large-restore throughput/recovery evidence,
+package breadth/upgrade proof, FileProvider UX hardening, and keeping the named
+neo/honey transcript current.
 
 ## Current Truth
 
 | Lane | Tracker | Current state | Next action |
 | --- | --- | --- | --- |
-| Production S3/storage posture | `TIN-1546` | Workflow, custom CA support, scoped denial proof, and dispatch helper are on `main`; `tcfs-storage-prod-smoke` has no secrets yet | Populate scoped HTTPS S3-compatible secrets, then run the storage canary dispatch helper |
-| Linux package first-use | `TIN-1540`, `TIN-1422`, `TIN-131`, `#280` | Linux workflow and harness are present; hosted Linux rejects the current private/plaintext endpoint by design; `tcfs-linux-smoke` has no secrets yet | Reuse the hosted-reachable HTTPS storage backend, then run Linux smoke with evict/rehydrate and mutation enabled |
-| Named fleet acceptance | `TIN-132` | CI Live Storage is green regression coverage, but no fresh named `neo`/`honey` transcript is archived for this sprint | Run `just neo-honey-smoke` from the operator environment and archive the transcript |
-| FileProvider post-M10 hardening | `TIN-1547` | Public `v0.12.13-rc2` `.pkg` passed signed HostApp root enumeration, exact hydrate, evict/rehydrate, mutation, and conflict/status; PR #412 landed rename/unsync safety | Add signed-package hardening proof for rename/unsync behavior, badge/progress/recovery capture, and a longer desktop soak |
+| Production S3/storage posture | `TIN-1546` | Current `main@84c7389` run `26220824445` proves public HTTPS, `enforce_tls=true`, public CA trust, allowed-prefix list/write/read/delete/delete-verify, and denied-prefix `PermissionDenied` for `tcfs-storage-prod-smoke` | Run the large-restore companion on a host with the archived shadow root and disk headroom; record socket/highwater, transient recovery, and soak evidence |
+| Linux package first-use | `TIN-1540`, `TIN-1422`, `TIN-131`, `#280` | Public rc4 `.deb` smoke run `26218940925` passed install, storage `[ok]`, FUSE mount, exact hydrate, `tcfs cache evict` + rehydrate, and mutation remote pull against the hosted-reachable HTTPS backend. Homebrew current tap fresh-install smoke run `26221252765` passed against `homebrew-tap@b5877df` (`v0.12.13-rc4`) | Finish package breadth: Homebrew upgrade, Debian 13, Fedora/RPM, Nix external profile/NixOS, and upgrade semantics |
+| Named fleet acceptance | `TIN-132` | Fresh named transcript is archived at `docs/release/evidence/neo-honey-smoke-20260521T032725Z/`; CI Live Storage remains regression coverage, not a replacement for the named operator lane | Keep the transcript current for release-day acceptance or explicitly supersede the named-lane requirement in Linear |
+| FileProvider post-M10 hardening | `TIN-1547` | Public `v0.12.13-rc4` `.pkg` run `26218940950` passed signed HostApp root enumeration, exact hydrate, evict/rehydrate, mutation, rename, and conflict/status | Add badge/progress/recovery capture, first-run setup proof, and a longer desktop soak |
 | Enrollment and beta security | `TIN-1424`, `TIN-1417` | Full invite payload signature coverage landed; self-enrollment remains unsafe as a production trust boundary | Implement single-use redemption and admin/session gating before exposing enrollment UX |
 
 ## One-Command Preflight
@@ -26,12 +28,9 @@ scripts/tcfs-alpha-gate-preflight.sh
 just alpha-gate-preflight
 ```
 
-The expected blocked output today is:
-
-- `TIN-1546`: missing required secrets in `tcfs-storage-prod-smoke`
-- `TIN-1540/TIN-1422`: missing required secrets in `tcfs-linux-smoke`
-- `TIN-132`: operator-run-required because named neo/honey evidence cannot be
-  inferred from CI Live Storage
+The expected output today should show TIN-1546 and the Linux package smoke as
+`runnable`. The printed Linux package tag defaults to the newest GitHub Release
+tag unless `--tag` is provided explicitly.
 
 Use strict mode when a release checklist should fail on blocked gates:
 
@@ -57,7 +56,7 @@ Linux package smoke:
 gh workflow run linux-postinstall-smoke.yml \
   -R Jesssullivan/tummycrypt \
   --ref main \
-  -f tag=v0.12.13-rc2 \
+  -f tag=<current-release-tag> \
   -f runner_label=ubuntu-24.04 \
   -f smoke_environment=tcfs-linux-smoke \
   -f exercise_evict_rehydrate=true \
@@ -75,21 +74,17 @@ just neo-honey-smoke
 - `TIN-1546`: attach the `storage-posture-canary-<run_id>-<attempt>` artifact;
   `storage-canary.json` must show `endpoint_tls=true`,
   `enforce_tls=true`, delete verification, and denial-prefix
-  `PermissionDenied`.
-- `TIN-1540`: close only after the selected route is real: hosted-reachable
-  HTTPS secrets in `tcfs-linux-smoke`, or an online Linux self-hosted runner.
-- `TIN-1422`: close only after package install, config, FUSE mount,
-  seeded-index visibility, exact hydrate, evict/rehydrate, and mutation are
-  green from the Linux workflow.
-- `TIN-131/#280`: keep open until the distribution matrix records Linux
-  first-use and production storage posture, not just macOS/Homebrew/container
-  rows.
-- `TIN-132`: close only from a fresh named neo/honey transcript or an explicit
-  tracker decision to supersede that gate. The current decision is to keep the
-  fresh transcript as required.
-- `TIN-1547`: close the current hardening slice only after rename/unsync safety
-  is proven through a signed package and badge/progress/recovery or soak
-  evidence is archived.
+  `PermissionDenied`. Keep the larger TIN-1546 lane open for restore,
+  socket/highwater, transient-recovery, and soak evidence.
+- `TIN-1540` / `TIN-1422`: the hosted HTTPS backend and Linux first-use route
+  are closed. Re-run them on release-day if the release candidate changes.
+- `TIN-131/#280`: keep open for Homebrew upgrade, Debian 13,
+  Fedora/RPM, Nix external profile/NixOS, package-upgrade semantics, and rc
+  package version semantics.
+- `TIN-132`: fresh named neo/honey transcript exists; keep it current for
+  release-day acceptance or record an explicit supersede decision.
+- `TIN-1547`: keep open until badge/progress/recovery, first-run setup, and a
+  longer desktop soak are archived.
 
 ## Claim Boundary
 

--- a/docs/release/v0.12.13-evidence-matrix.md
+++ b/docs/release/v0.12.13-evidence-matrix.md
@@ -101,7 +101,7 @@ surfaces are tracked here.
 
 | # | Surface | Fresh install | Upgrade | Result | Evidence |
 |---|---------|---------------|---------|--------|----------|
-| 1 | Homebrew | install smoke green on `main` | formula updated | ✅ install smoke pass | smoke run [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508), release job [`76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317) |
+| 1 | Homebrew | rc4 current-tap fresh install green on `main` | upgrade smoke pending | ✅ install smoke pass | rc4 current-tap smoke [`26221252765`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26221252765), rc4 formula job [`77139820909`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287/job/77139820909), earlier smoke [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508) |
 | 2 | macOS `.pkg` (production Dev ID FileProvider) | rc4 exact public release asset green; rc2 signed-HostApp exact asset, rc1 exact asset, and `66ae92f` diagnostic artifact retained as historical proof | package build/notarization passed | ✅ published-asset smoke pass | rc4 exact asset smoke [`26218940950`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940950), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc2 exact asset smoke [`26122478486`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26122478486), rc2 release run [`26117684515`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515), diagnostic run [`26117175542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542), artifact source [`26116692781`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781), rc1 exact asset run [`26079830341`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26079830341) |
 | 3 | `.deb` on Ubuntu 24.04 | rc4 exact public release asset passed package-backed first-use smoke | package upgrade smoke pending | ✅ public-asset first-use pass | rc4 public asset smoke [`26218940925`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940925), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc3 post-merge smoke [`26204699596`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596), PR [`#429`](https://github.com/Jesssullivan/tummycrypt/pull/429), rc3 release run [`26204080480`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204080480), rc1 release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
 | 4 | `.deb` on Debian 12 bookworm | known blocked (`libc6 >= 2.39` floor) | n/a | ❌ blocked | inherits from [`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor) |
@@ -111,9 +111,9 @@ surfaces are tracked here.
 
 Rollup: **4 current product-surface or first-use passes · 2 artifact/build
 passes with first-use smoke still pending · 1 blocked**. The macOS `.pkg`,
-Ubuntu `.deb`, and container rows now have exact public rc4 release-asset proof.
-Ubuntu `.deb` still owes upgrade proof and distro breadth before #280 can fully
-close.
+Ubuntu `.deb`, Homebrew fresh install, and container rows now have exact public
+rc4/current-tap proof. Ubuntu `.deb` and Homebrew still owe upgrade proof, and
+the matrix still owes distro breadth before #280 can fully close.
 
 ## Per-Surface Evidence
 
@@ -149,16 +149,20 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
 - `tcfsd-0.12.13-rc1-x86_64.rpm`:
   `0e3f991f93ca9b7c979ce11898ce85cb661efd4a76faa3c93e1337e0326c169e`
 
-### 1. Homebrew — install smoke pass
+### 1. Homebrew — current-tap install smoke pass
 
-- Release job: `Update Homebrew formula` succeeded
-  ([job `76639631317`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76639631317)).
-- The job downloaded `SHA256SUMS.txt`, generated `Formula/tcfs.rb` from the
-  release tarball hashes, and force-pushed the `homebrew-tap` branch.
-- Mainline install smoke run
+- Release job `Update Homebrew formula` succeeded for rc4
+  ([job `77139820909`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287/job/77139820909)).
+- The job downloaded `SHA256SUMS.txt`, generated `Formula/tcfs.rb` from the rc4
+  release tarball hashes, and force-pushed `homebrew-tap@b5877df`.
+- Current-tap install smoke run
+  [`26221252765`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26221252765)
+  passed on `main@84c7389`: `brew install Jesssullivan/tummycrypt/tcfs`
+  installed `/opt/homebrew/Cellar/tcfs/0.12.13-rc4`, and installed binaries
+  reported `tcfs 0.12.13` / `tcfsd 0.12.13`.
+- Earlier mainline install smoke run
   [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508)
-  passed after PR #393 landed: generated tap install, installed-binary smoke,
-  diagnostics, and artifact upload all completed.
+  remains historical proof for the earlier rc-series tap after PR #393 landed.
 - Not proven in this rc-series packet: upgrade smoke from an older Homebrew
   install.
 

--- a/scripts/tcfs-alpha-gate-preflight.sh
+++ b/scripts/tcfs-alpha-gate-preflight.sh
@@ -7,7 +7,7 @@ STORAGE_ENVIRONMENT="tcfs-storage-prod-smoke"
 LINUX_ENVIRONMENT="tcfs-linux-smoke"
 STORAGE_RUNNER_LABEL="ubuntu-24.04"
 LINUX_RUNNER_LABEL="ubuntu-24.04"
-TAG="v0.12.13-rc2"
+TAG=""
 SCOPE_DENY_PREFIX="gha/storage-posture-denied/$(date -u +%Y%m%dT%H%M%SZ)"
 REMOTE_PREFIX=""
 LINUX_REMOTE_PREFIX=""
@@ -33,7 +33,7 @@ Options:
   --linux-runner-label LABEL        Runner label for Linux postinstall smoke
                                     (default: ubuntu-24.04)
   --tag TAG                         Release tag for Linux package smoke
-                                    (default: v0.12.13-rc2)
+                                    (default: newest GitHub Release tag)
   --scope-deny-prefix PREFIX        Outside-policy prefix that storage canary
                                     must reject
   --remote-prefix PREFIX            Optional positive storage canary prefix
@@ -124,6 +124,10 @@ self_hosted_runner_match() {
       '
 }
 
+latest_release_tag() {
+  gh api "repos/$REPO/releases?per_page=1" --jq '.[0].tag_name // empty'
+}
+
 runner_status_line() {
   local label="$1"
   if is_hosted_runner_label "$label"; then
@@ -204,12 +208,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ "$TAG" == v* ]] || die "--tag must start with v"
 [[ -n "$SCOPE_DENY_PREFIX" ]] || die "--scope-deny-prefix must not be empty"
 
 if ! command -v gh >/dev/null 2>&1; then
   die "gh CLI is required"
 fi
+
+if [[ -z "$TAG" ]]; then
+  TAG="$(latest_release_tag || true)"
+  [[ -n "$TAG" ]] || die "could not resolve the newest GitHub Release tag for $REPO; pass --tag explicitly"
+fi
+[[ "$TAG" == v* ]] || die "--tag must start with v"
 
 storage_required=(
   TCFS_SMOKE_S3_ENDPOINT

--- a/scripts/test-tcfs-alpha-gate-preflight.sh
+++ b/scripts/test-tcfs-alpha-gate-preflight.sh
@@ -72,6 +72,11 @@ SECRETS
   exit 0
 fi
 
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/owner/repo/releases?per_page=1" ]]; then
+  printf 'v9.9.9\n'
+  exit 0
+fi
+
 if [[ "${1:-}" == "api" ]]; then
   printf 'linux-1\tonline\tself-hosted,linux-private\n'
   exit 0
@@ -138,6 +143,15 @@ bash "$SCRIPT" \
   --linux-runner-label linux-private \
   >"$SELF_HOSTED"
 assert_contains "$SELF_HOSTED" "runner: \`linux-private\` (online:linux-1)"
+
+DEFAULT_TAG="$TMPDIR/default-tag.out"
+bash "$SCRIPT" \
+  --repo owner/repo \
+  --storage-environment storage-good \
+  --linux-environment linux-good \
+  >"$DEFAULT_TAG"
+assert_contains "$DEFAULT_TAG" "- tag: \`v9.9.9\`"
+assert_contains "$DEFAULT_TAG" "-f tag=v9.9.9"
 
 assert_fails_contains \
   "missing_secrets" \


### PR DESCRIPTION
## Summary
- make `scripts/tcfs-alpha-gate-preflight.sh` resolve the newest GitHub Release tag instead of carrying a stale rc default
- record fresh TIN-1546 storage posture canary run `26220824445` from `main@84c7389`
- record Homebrew current-tap fresh install run `26221252765` against `homebrew-tap@b5877df` / `v0.12.13-rc4`
- refresh alpha sprint/product reality/distribution docs so scoped HTTPS storage posture and current Homebrew install are green while large-restore, socket/highwater, transient recovery, soak, package upgrade/breadth, and FileProvider UX hardening remain open

## Evidence
- Storage Posture Canary: https://github.com/Jesssullivan/tummycrypt/actions/runs/26220824445
- Artifact: `storage-posture-canary-26220824445-1`
- `storage-canary.json`: public HTTPS endpoint, `endpoint_tls=true`, `enforce_tls=true`, 242-byte write/read/delete-delete-verify, allowed-prefix list, denied-prefix `PermissionDenied`
- Homebrew Install Smoke: https://github.com/Jesssullivan/tummycrypt/actions/runs/26221252765
- Artifact: `homebrew-install-smoke-0.12.13`; diagnostics show `/opt/homebrew/Cellar/tcfs/0.12.13-rc4`, `tcfs 0.12.13`, and `tcfsd 0.12.13`

## Validation
- `bash -n scripts/tcfs-alpha-gate-preflight.sh scripts/test-tcfs-alpha-gate-preflight.sh`
- `bash scripts/test-tcfs-alpha-gate-preflight.sh`
- `scripts/tcfs-alpha-gate-preflight.sh` now prints `tag: v0.12.13-rc4`
- `git diff --check`