### PR TITLE
ci: add Linux package container smoke

### DIFF
--- a/.github/workflows/linux-package-container-smoke.yml
+++ b/.github/workflows/linux-package-container-smoke.yml
@@ -1,0 +1,295 @@
+name: Linux Package Container Smoke
+
+# TIN-131 / #280: prove distro package breadth without requiring a privileged
+# FUSE runner. This workflow pulls exact public release assets, verifies them
+# against SHA256SUMS.txt, installs them in clean Debian/Fedora containers, and
+# runs scripts/install-smoke.sh. It intentionally does not claim live storage,
+# systemd, FUSE mount, or first-real-use behavior.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/linux-package-container-smoke.yml"
+      - "scripts/install-smoke.sh"
+      - "scripts/test-linux-package-container-smoke-workflow.sh"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to validate, for example v0.12.13-rc4"
+        required: true
+        default: "v0.12.13-rc4"
+        type: string
+      binary_expected_version:
+        description: "Version printed by installed binaries, without rc suffix"
+        required: true
+        default: "0.12.13"
+        type: string
+      previous_tag:
+        description: "Prior release tag for upgrade smoke"
+        required: true
+        default: "v0.12.12"
+        type: string
+      previous_binary_expected_version:
+        description: "Version printed by prior binaries in upgrade smoke"
+        required: true
+        default: "0.12.12"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linux-package-container-smoke-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  package-container-smoke:
+    name: ${{ matrix.surface }}
+    if: github.repository == 'Jesssullivan/tummycrypt'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - surface: Debian 13 amd64 .deb install smoke
+            artifact_suffix: debian13-amd64
+            image: debian:13
+            platform: linux/amd64
+            package_family: deb
+            smoke_mode: fresh-install
+            skip_cli: "false"
+          - surface: Debian 13 amd64 .deb upgrade smoke
+            artifact_suffix: debian13-amd64-upgrade
+            image: debian:13
+            platform: linux/amd64
+            package_family: deb
+            smoke_mode: upgrade
+            skip_cli: "false"
+          - surface: Ubuntu 24.04 amd64 .deb upgrade smoke
+            artifact_suffix: ubuntu2404-amd64-upgrade
+            image: ubuntu:24.04
+            platform: linux/amd64
+            package_family: deb
+            smoke_mode: upgrade
+            skip_cli: "false"
+          - surface: Fedora 42 x86_64 daemon-only .rpm install smoke
+            artifact_suffix: fedora42-x86_64
+            image: fedora:42
+            platform: linux/amd64
+            package_family: rpm
+            smoke_mode: fresh-install
+            skip_cli: "true"
+          - surface: Fedora 42 x86_64 daemon-only .rpm upgrade smoke
+            artifact_suffix: fedora42-x86_64-upgrade
+            image: fedora:42
+            platform: linux/amd64
+            package_family: rpm
+            smoke_mode: upgrade
+            skip_cli: "true"
+
+    env:
+      TAG: ${{ github.event.inputs.tag || 'v0.12.13-rc4' }}
+      BINARY_EXPECTED_VERSION: ${{ github.event.inputs.binary_expected_version || '0.12.13' }}
+      PREVIOUS_TAG: ${{ github.event.inputs.previous_tag || 'v0.12.12' }}
+      PREVIOUS_BINARY_EXPECTED_VERSION: ${{ github.event.inputs.previous_binary_expected_version || '0.12.12' }}
+      PACKAGE_FAMILY: ${{ matrix.package_family }}
+      SMOKE_MODE: ${{ matrix.smoke_mode }}
+      SKIP_CLI: ${{ matrix.skip_cli }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Download and verify public package assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$TAG" == v* ]] || {
+            echo "::error::tag must start with 'v' (got '$TAG')"
+            exit 1
+          }
+          [[ "$PREVIOUS_TAG" == v* ]] || {
+            echo "::error::previous_tag must start with 'v' (got '$PREVIOUS_TAG')"
+            exit 1
+          }
+
+          VERSION="${TAG#v}"
+          PREVIOUS_VERSION="${PREVIOUS_TAG#v}"
+          PACKAGE_DIR="$RUNNER_TEMP/tcfs-linux-package-container/${{ matrix.artifact_suffix }}/packages"
+          LOG_DIR="$RUNNER_TEMP/tcfs-linux-package-container/${{ matrix.artifact_suffix }}/logs"
+          mkdir -p "$PACKAGE_DIR" "$LOG_DIR"
+
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "PREVIOUS_VERSION=$PREVIOUS_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_DIR=$PACKAGE_DIR" >> "$GITHUB_ENV"
+          echo "LOG_DIR=$LOG_DIR" >> "$GITHUB_ENV"
+
+          release_assets() {
+            local version="$1"
+            case "$PACKAGE_FAMILY" in
+              deb)
+                printf '%s\n' \
+                  "tcfs-${version}-amd64.deb" \
+                  "tcfsd-${version}-amd64.deb"
+                ;;
+              rpm)
+                printf '%s\n' "tcfsd-${version}-x86_64.rpm"
+                ;;
+              *)
+                echo "::error::unknown package family: $PACKAGE_FAMILY" >&2
+                return 2
+                ;;
+            esac
+          }
+
+          download_release_assets() {
+            local tag="$1"
+            local version="$2"
+            local label="$3"
+            local target_dir="$PACKAGE_DIR/$label"
+            local base_url="https://github.com/${{ github.repository }}/releases/download/${tag}"
+            local assets=()
+            local asset
+            mkdir -p "$target_dir"
+            mapfile -t assets < <(release_assets "$version")
+            curl -fsSLo "$target_dir/SHA256SUMS.txt" "$base_url/SHA256SUMS.txt"
+            : > "$target_dir/SHA256SUMS-selected.txt"
+
+            for asset in "${assets[@]}"; do
+              curl -fsSLo "$target_dir/$asset" "$base_url/$asset"
+              grep -F "  $asset" "$target_dir/SHA256SUMS.txt" \
+                >> "$target_dir/SHA256SUMS-selected.txt"
+            done
+
+            (
+              cd "$target_dir"
+              sha256sum -c SHA256SUMS-selected.txt
+            ) | tee "$LOG_DIR/sha256-check-${label}.log"
+          }
+
+          download_release_assets "$TAG" "$VERSION" current
+          if [[ "$SMOKE_MODE" == "upgrade" ]]; then
+            download_release_assets "$PREVIOUS_TAG" "$PREVIOUS_VERSION" previous
+          fi
+
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "binary_expected_version=$BINARY_EXPECTED_VERSION"
+            echo "previous_tag=$PREVIOUS_TAG"
+            echo "previous_version=$PREVIOUS_VERSION"
+            echo "previous_binary_expected_version=$PREVIOUS_BINARY_EXPECTED_VERSION"
+            echo "image=${{ matrix.image }}"
+            echo "platform=${{ matrix.platform }}"
+            echo "package_family=$PACKAGE_FAMILY"
+            echo "smoke_mode=$SMOKE_MODE"
+            echo "skip_cli=$SKIP_CLI"
+          } > "$LOG_DIR/run-metadata.env"
+
+      - name: Run package install smoke in container
+        shell: bash
+        run: |
+          set -euo pipefail
+          container_script="$RUNNER_TEMP/tcfs-container-install-smoke-${{ matrix.artifact_suffix }}.sh"
+          cat > "$container_script" <<'EOF'
+          set -euo pipefail
+
+          install_packages_from() {
+            local package_dir="$1"
+            local mode="${2:-install}"
+            case "$PACKAGE_FAMILY" in
+              deb)
+                export DEBIAN_FRONTEND=noninteractive
+                apt-get install -y --no-install-recommends "$package_dir"/tcfs-*.deb "$package_dir"/tcfsd-*.deb
+                dpkg -l | grep -E 'tcfs|tcfsd' | tee "/logs/package-list-${mode}.log"
+                ;;
+              rpm)
+                if [[ "$mode" == "upgrade" ]]; then
+                  dnf upgrade -y "$package_dir"/tcfsd-*.rpm
+                else
+                  dnf install -y "$package_dir"/tcfsd-*.rpm
+                fi
+                rpm -qa | grep -E 'tcfs|tcfsd' | tee "/logs/package-list-${mode}.log"
+                ;;
+              *)
+                echo "unknown package family: $PACKAGE_FAMILY" >&2
+                exit 2
+                ;;
+            esac
+          }
+
+          run_install_smoke() {
+            local expected_version="$1"
+            local log_path="$2"
+            command -v tcfsd | tee /logs/tcfsd-path.log
+            tcfsd --version | tee /logs/tcfsd-version.log
+
+            if [[ "$SKIP_CLI" == "true" ]]; then
+              bash /work/scripts/install-smoke.sh \
+                --expected-version "$expected_version" \
+                --skip-cli \
+                2>&1 | tee "$log_path"
+            else
+              command -v tcfs | tee /logs/tcfs-path.log
+              tcfs --version | tee /logs/tcfs-version.log
+              bash /work/scripts/install-smoke.sh \
+                --expected-version "$expected_version" \
+                2>&1 | tee "$log_path"
+            fi
+          }
+
+          case "$PACKAGE_FAMILY" in
+            deb)
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y --no-install-recommends ca-certificates
+              ;;
+            rpm)
+              dnf install -y ca-certificates
+              ;;
+            *)
+              echo "unknown package family: $PACKAGE_FAMILY" >&2
+              exit 2
+              ;;
+          esac
+
+          if [[ "$SMOKE_MODE" == "upgrade" ]]; then
+            install_packages_from /packages/previous install
+            run_install_smoke "$PREVIOUS_BINARY_EXPECTED_VERSION" /logs/install-smoke-before-upgrade.log
+            install_packages_from /packages/current upgrade
+            run_install_smoke "$BINARY_EXPECTED_VERSION" /logs/install-smoke.log
+          else
+            install_packages_from /packages/current install
+            run_install_smoke "$BINARY_EXPECTED_VERSION" /logs/install-smoke.log
+          fi
+          EOF
+
+          set +e
+          docker run --rm -i \
+            --platform "${{ matrix.platform }}" \
+            -e BINARY_EXPECTED_VERSION="$BINARY_EXPECTED_VERSION" \
+            -e PREVIOUS_BINARY_EXPECTED_VERSION="$PREVIOUS_BINARY_EXPECTED_VERSION" \
+            -e PACKAGE_FAMILY="$PACKAGE_FAMILY" \
+            -e SMOKE_MODE="$SMOKE_MODE" \
+            -e SKIP_CLI="$SKIP_CLI" \
+            -v "$PWD:/work:ro" \
+            -v "$PACKAGE_DIR:/packages:ro" \
+            -v "$LOG_DIR:/logs" \
+            "${{ matrix.image }}" \
+            bash -s < "$container_script" \
+            2>&1 | tee "$LOG_DIR/container-smoke.log"
+          status="${PIPESTATUS[0]}"
+          set -e
+
+          exit "$status"
+
+      - name: Upload smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-package-container-smoke-${{ github.event.inputs.tag || 'v0.12.13-rc4' }}-${{ matrix.artifact_suffix }}
+          path: ${{ env.LOG_DIR }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/nix-profile-install-smoke.yml
+++ b/.github/workflows/nix-profile-install-smoke.yml
@@ -100,7 +100,7 @@ jobs:
           mkdir -p "$LOG_DIR"
           {
             nix --version
-            nix config show substituters trusted-public-keys
+            nix config show | grep -E '^(substituters|trusted-public-keys) = ' || true
             if [[ -n "${TCFS_NIX_PROFILE:-}" ]]; then
               find "$TCFS_NIX_PROFILE" -maxdepth 3 -type f -o -type l
             fi

--- a/Justfile
+++ b/Justfile
@@ -146,6 +146,10 @@ alpha-gate-preflight-test:
 linux-postinstall-workflow-test:
     @bash scripts/test-linux-postinstall-workflow.sh
 
+# Static regression test for the Linux package container smoke workflow
+linux-package-container-workflow-test:
+    @bash scripts/test-linux-package-container-smoke-workflow.sh
+
 # Installed-binary smoke for release surfaces that ship tcfsd (and optionally tcfs)
 install-smoke *ARGS:
     bash scripts/install-smoke.sh {{ARGS}}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -137,6 +137,7 @@ tasks:
       - task: lazy:test-fileprovider-provision
       - task: lazy:test-release-workflow-fileprovider
       - task: lazy:test-release-workflow-container
+      - task: lazy:test-linux-package-container-workflow
       - task: lazy:test-smoke-endpoint-preflight
       - cargo test -p tcfs-cli cli_unsync
       - cargo test -p tcfs-cli cli_pull_after_unsync_hydrates_latest_remote_and_removes_stub
@@ -1058,6 +1059,11 @@ tasks:
     desc: Regression-test release workflow container platform publication
     cmds:
       - bash scripts/test-release-workflow-container.sh
+
+  lazy:test-linux-package-container-workflow:
+    desc: Regression-test Linux package container smoke workflow
+    cmds:
+      - bash scripts/test-linux-package-container-smoke-workflow.sh
 
   lazy:test-smoke-endpoint-preflight:
     desc: Regression-test CI smoke endpoint posture preflight

--- a/docs/ops/distribution-smoke-matrix.md
+++ b/docs/ops/distribution-smoke-matrix.md
@@ -69,13 +69,31 @@ the package-facing public-asset smokes are green from `main@e9b9f82`:
 Homebrew current-tap fresh install also passed after the rc4 release job updated
 `homebrew-tap@b5877df`: run `26221252765` installed
 `/opt/homebrew/Cellar/tcfs/0.12.13-rc4` and the binaries reported
+`tcfs 0.12.13` / `tcfsd 0.12.13`. Upgrade mode then passed in run
+`26221711601`, upgrading from tap ref `07dc9949f57921366c60a36728924f560a6d819a`
+(`v0.12.12`) to `homebrew-tap` (`v0.12.13-rc4`) and ending with
 `tcfs 0.12.13` / `tcfsd 0.12.13`.
 
-Remaining distribution proof is now breadth and upgrade heavy: Homebrew
-upgrade, Debian 13 `.deb` install/upgrade, Fedora daemon-only `.rpm` install,
-external Nix profile install, and release-candidate package version semantics
-(`0.12.13-1` installed from rc4-named `.deb` assets). Debian 12 remains blocked
-by the libc/OpenSSL floor unless a separate bookworm-targeted package exists.
+PR #442 added the hosted containerized breadth lane, and run `26243913292`
+proved the exact rc4 public Linux packages on Debian 13 amd64, Ubuntu 24.04
+amd64, and Fedora 42 x86_64. The lane verifies checksums, package install,
+binary versions, daemon socket readiness, and CLI status where the CLI package
+exists. It also proves sampled upgrade semantics: Debian 13 and Ubuntu 24.04
+upgrade from public `v0.12.12` `.deb` packages to public `v0.12.13-rc4` `.deb`
+packages, while Fedora 42 upgrades daemon-only `tcfsd` from the public
+`v0.12.12` RPM to the public `v0.12.13-rc4` RPM. It does not claim FUSE,
+systemd, live storage, or first-real-use behavior.
+
+Nix profile install smoke also passed in run `26242122899` on hosted
+Ubuntu 24.04: `nix profile install` from `github:Jesssullivan/tummycrypt/v0.12.13-rc4`
+installed `packages.x86_64-linux.tcfs-cli` and `packages.x86_64-linux.tcfsd`,
+the profile binaries reported `tcfs 0.12.13` / `tcfsd 0.12.13`, and
+`scripts/install-smoke.sh` ended with `install smoke passed`.
+
+Remaining distribution proof is now narrower: NixOS host proof and
+release-candidate package version semantics (`0.12.13-1` installed from
+rc4-named `.deb` / `.rpm` assets). Debian 12 remains blocked by the
+libc/OpenSSL floor unless a separate bookworm-targeted package exists.
 See
 [`docs/release/v0.12.13-evidence-matrix.md`](../release/v0.12.13-evidence-matrix.md)
 for the frozen rc-series evidence table.
@@ -142,7 +160,7 @@ installed-binary smoke to the first truthful user action, use
 | Ubuntu 24.04+ / Debian 13+ `.deb` | Yes | Yes | `scripts/install-smoke.sh` | Install both `tcfsd` and `tcfs` packages |
 | Fedora/RHEL `.rpm` | Yes | Sampled | `scripts/install-smoke.sh --skip-cli` | Fedora 42 x86_64 is currently proven; RHEL/Rocky remain target surfaces pending smoke |
 | Container image | Yes | Sampled | worker-image startup check | prove amd64 and arm64 pulls + entrypoint/startup, not CLI status or cluster rollout |
-| Nix | Yes | Sampled | `scripts/install-smoke.sh` | Current `v0.12.12` proof is Darwin profile install; Linux/NixOS host proof is separate |
+| Nix | Yes | Sampled | `scripts/install-smoke.sh` | rc4 Linux profile install is proven; NixOS host proof is separate |
 
 ## Surface Procedures
 
@@ -311,8 +329,8 @@ bash scripts/install-smoke.sh --expected-version "${BINARY_EXPECTED_VERSION}"
 
 ### Fedora `.rpm`
 
-The current `v0.12.12` proof covers Fedora 42 x86_64 daemon-only. RHEL/Rocky
-remain target surfaces pending smoke.
+Current `v0.12.13-rc4` proof covers Fedora 42 x86_64 daemon-only install
+smoke. RHEL/Rocky remain target surfaces pending smoke.
 
 Fresh install:
 
@@ -397,9 +415,9 @@ nix profile install \
 bash scripts/install-smoke.sh --expected-version "${BINARY_EXPECTED_VERSION}"
 ```
 
-Record the host platform in evidence. The current `v0.12.12` packet proves a
-Darwin temporary profile install; Linux Nix profile and NixOS module host proof
-remain separate acceptance lanes.
+Record the host platform in evidence. The current rc4 packet proves Linux
+temporary profile install on hosted Ubuntu 24.04; NixOS module host proof
+remains a separate acceptance lane.
 
 Upgrade is sampled unless the flake packaging path or install story changes
 materially between releases.

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -34,12 +34,12 @@ This is the narrowest and most important truth for public release claims.
 
 | Surface | Status | Current reality |
 | --- | --- | --- |
-| Homebrew | current tap fresh-install pass; upgrade gap | `homebrew-tap@b5877df` points at `v0.12.13-rc4`, and run `26221252765` proves fresh install plus installed `tcfs 0.12.13` / `tcfsd 0.12.13` smoke. Upgrade proof remains pending under TIN-131/#280 |
+| Homebrew | current tap fresh-install and upgrade pass | `homebrew-tap@b5877df` points at `v0.12.13-rc4`; run `26221252765` proves fresh install and run `26221711601` proves upgrade from the prior `v0.12.12` tap ref to rc4 with installed `tcfs 0.12.13` / `tcfsd 0.12.13` smoke |
 | macOS `.pkg` | FileProvider release-asset pass; first-run UX gap | `v0.12.13-rc4` publishes a notarized production Developer ID `.pkg`; PZM run `26218940950` proves the exact public GitHub Release `.pkg` through hydrate, evict/rehydrate, mutation upload/readback, rename, and conflict/status. First-run config UX remains pending |
-| `.deb` | rc4 public-asset first-use pass | Ubuntu 24.04+ is proven by run `26218940925` through install, storage `[ok]`, FUSE mount, exact hydrate, `tcfs cache evict` + rehydrate, and mutation remote pull. Debian 13 and upgrade smoke remain pending |
-| `.rpm` | rc1 daemon-only artifact pass | Fedora/RHEL daemon package is published; install smoke remains pending and the CLI `.rpm` surface is still absent |
+| `.deb` | rc4 public-asset first-use pass plus Debian/Ubuntu install-upgrade smoke | Ubuntu 24.04+ is proven by run `26218940925` through install, storage `[ok]`, FUSE mount, exact hydrate, `tcfs cache evict` + rehydrate, and mutation remote pull. PR #442 run `26243913292` proves public `v0.12.12` to public `v0.12.13-rc4` package upgrade smoke on Debian 13 and Ubuntu 24.04, plus Debian 13 fresh install smoke |
+| `.rpm` | rc4 Fedora 42 daemon-only install and sampled upgrade smoke pass | Fedora 42 x86_64 daemon-only installed-binary smoke and public `v0.12.12` to public `v0.12.13-rc4` RPM upgrade smoke passed in run `26243913292`; the CLI `.rpm` surface is still absent |
 | container image | rc4 runtime smoke pass | `v0.12.13-rc4` container runtime smoke run `26218940985` proves manifest inspect, platform pull, version check, and worker startup |
-| Nix install | rc1 build/cache pass | release Nix build and Attic push passed; an external profile install from a non-tinyland host remains pending |
+| Nix install | rc4 external profile install pass | run `26242122899` installed `tcfs-cli` and `tcfsd` from `github:Jesssullivan/tummycrypt/v0.12.13-rc4` into a temporary Nix profile on hosted Ubuntu 24.04; binaries reported `tcfs 0.12.13` / `tcfsd 0.12.13` and installed-binary smoke passed |
 
 Canonical runbook: [Distribution Smoke Matrix](distribution-smoke-matrix.md).
 Install-to-first-use bridge:
@@ -342,11 +342,12 @@ GitHub state before acting on exact issue or milestone status.
 
 - M10 release-proof tranche
   - `#280`: distribution install and upgrade proof umbrella. `v0.12.13-rc4`
-    public Linux `.deb`, macOS `.pkg`, and container runtime smokes are green,
-    but Homebrew upgrade, Debian 13, Fedora/RPM, Nix external
-    profile/NixOS, and package-upgrade semantics remain pending. Debian 12
-    remains excluded by the libc/OpenSSL floor unless a separate bookworm
-    package is produced.
+    public Linux `.deb`, macOS `.pkg`, Homebrew, Debian 13 install/upgrade,
+    Ubuntu 24.04 package upgrade, Fedora 42 daemon-only RPM install/upgrade,
+    Nix external profile install, and container runtime smokes are green.
+    NixOS host proof and rc package version semantics remain pending.
+    Debian 12 remains excluded by the libc/OpenSSL floor unless a separate
+    bookworm package is produced.
   - `#309`: macOS `.pkg` clean-host and FileProvider acceptance lane. PZM
     production Dev ID smoke run `26062554542` proves hydrate,
     evict/rehydrate, mutation upload/readback, and conflict-status. Remaining

--- a/docs/ops/tcfs-alpha-productionization-sprint-2026-05-20.md
+++ b/docs/ops/tcfs-alpha-productionization-sprint-2026-05-20.md
@@ -13,7 +13,7 @@ neo/honey transcript current.
 | Lane | Tracker | Current state | Next action |
 | --- | --- | --- | --- |
 | Production S3/storage posture | `TIN-1546` | Current `main@84c7389` run `26220824445` proves public HTTPS, `enforce_tls=true`, public CA trust, allowed-prefix list/write/read/delete/delete-verify, and denied-prefix `PermissionDenied` for `tcfs-storage-prod-smoke` | Run the large-restore companion on a host with the archived shadow root and disk headroom; record socket/highwater, transient recovery, and soak evidence |
-| Linux package first-use | `TIN-1540`, `TIN-1422`, `TIN-131`, `#280` | Public rc4 `.deb` smoke run `26218940925` passed install, storage `[ok]`, FUSE mount, exact hydrate, `tcfs cache evict` + rehydrate, and mutation remote pull against the hosted-reachable HTTPS backend. Homebrew current tap fresh-install smoke run `26221252765` passed against `homebrew-tap@b5877df` (`v0.12.13-rc4`) | Finish package breadth: Homebrew upgrade, Debian 13, Fedora/RPM, Nix external profile/NixOS, and upgrade semantics |
+| Linux package first-use | `TIN-1540`, `TIN-1422`, `TIN-131`, `#280` | Public rc4 `.deb` smoke run `26218940925` passed install, storage `[ok]`, FUSE mount, exact hydrate, `tcfs cache evict` + rehydrate, and mutation remote pull against the hosted-reachable HTTPS backend. Homebrew current tap fresh-install smoke run `26221252765` and upgrade smoke run `26221711601` passed against `homebrew-tap@b5877df` (`v0.12.13-rc4`). PR #442 run `26243913292` passed Debian 13 fresh install, Debian 13 upgrade, Ubuntu 24.04 upgrade, Fedora 42 daemon-only fresh install, and Fedora 42 daemon-only sampled upgrade smokes. Nix profile install smoke passed in run `26242122899` | Finish remaining package proof: NixOS host proof and rc package version semantics |
 | Named fleet acceptance | `TIN-132` | Fresh named transcript is archived at `docs/release/evidence/neo-honey-smoke-20260521T032725Z/`; CI Live Storage remains regression coverage, not a replacement for the named operator lane | Keep the transcript current for release-day acceptance or explicitly supersede the named-lane requirement in Linear |
 | FileProvider post-M10 hardening | `TIN-1547` | Public `v0.12.13-rc4` `.pkg` run `26218940950` passed signed HostApp root enumeration, exact hydrate, evict/rehydrate, mutation, rename, and conflict/status | Add badge/progress/recovery capture, first-run setup proof, and a longer desktop soak |
 | Enrollment and beta security | `TIN-1424`, `TIN-1417` | Full invite payload signature coverage landed; self-enrollment remains unsafe as a production trust boundary | Implement single-use redemption and admin/session gating before exposing enrollment UX |
@@ -78,9 +78,10 @@ just neo-honey-smoke
   socket/highwater, transient-recovery, and soak evidence.
 - `TIN-1540` / `TIN-1422`: the hosted HTTPS backend and Linux first-use route
   are closed. Re-run them on release-day if the release candidate changes.
-- `TIN-131/#280`: keep open for Homebrew upgrade, Debian 13,
-  Fedora/RPM, Nix external profile/NixOS, package-upgrade semantics, and rc
-  package version semantics.
+- `TIN-131/#280`: keep open for NixOS host proof and rc package version
+  semantics. Debian 13, Ubuntu 24.04, Fedora 42, and Nix profile install now
+  have installed-binary or profile smoke, but the hosted container package lane
+  does not prove live-storage/FUSE/systemd behavior.
 - `TIN-132`: fresh named neo/honey transcript exists; keep it current for
   release-day acceptance or record an explicit supersede decision.
 - `TIN-1547`: keep open until badge/progress/recovery, first-run setup, and a

--- a/docs/release/v0.12.13-evidence-matrix.md
+++ b/docs/release/v0.12.13-evidence-matrix.md
@@ -64,6 +64,14 @@ proved `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc4` on `linux/amd64` and
 `linux/arm64`. Treat rc4 as the current public-asset proof for macOS `.pkg`,
 Ubuntu `.deb`, and container runtime.
 
+PR [#442](https://github.com/Jesssullivan/tummycrypt/pull/442) then added the
+hosted package-container breadth lane. Run
+[`26243913292`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26243913292)
+proves exact public rc4 package install on Debian 13 and Fedora 42, plus public
+`v0.12.12` to public `v0.12.13-rc4` package upgrade smoke on Debian 13,
+Ubuntu 24.04, and Fedora 42 daemon-only RPM. This is installed-binary smoke,
+not FUSE/systemd/live-storage/first-real-use proof.
+
 ## Headline change
 
 **First green end-to-end production Dev ID FileProvider acceptance** on the
@@ -96,24 +104,26 @@ Evidence packet:
 ## Summary Table
 
 The canonical smoke matrix lists six surfaces. This matrix splits `.deb` into
-Ubuntu 24.04 and Debian 12 because their outcomes differ materially, so seven
-surfaces are tracked here.
+Ubuntu 24.04, Debian 13, and Debian 12 because their outcomes differ
+materially, so eight surfaces are tracked here.
 
 | # | Surface | Fresh install | Upgrade | Result | Evidence |
 |---|---------|---------------|---------|--------|----------|
-| 1 | Homebrew | rc4 current-tap fresh install green on `main` | upgrade smoke pending | ✅ install smoke pass | rc4 current-tap smoke [`26221252765`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26221252765), rc4 formula job [`77139820909`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287/job/77139820909), earlier smoke [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508) |
+| 1 | Homebrew | rc4 current-tap fresh install green on `main` | rc4 upgrade smoke green | ✅ install + upgrade smoke pass | rc4 upgrade smoke [`26221711601`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26221711601), rc4 current-tap smoke [`26221252765`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26221252765), rc4 formula job [`77139820909`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287/job/77139820909), earlier smoke [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508), PR [`#440`](https://github.com/Jesssullivan/tummycrypt/pull/440) |
 | 2 | macOS `.pkg` (production Dev ID FileProvider) | rc4 exact public release asset green; rc2 signed-HostApp exact asset, rc1 exact asset, and `66ae92f` diagnostic artifact retained as historical proof | package build/notarization passed | ✅ published-asset smoke pass | rc4 exact asset smoke [`26218940950`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940950), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc2 exact asset smoke [`26122478486`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26122478486), rc2 release run [`26117684515`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117684515), diagnostic run [`26117175542`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26117175542), artifact source [`26116692781`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26116692781), rc1 exact asset run [`26079830341`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26079830341) |
-| 3 | `.deb` on Ubuntu 24.04 | rc4 exact public release asset passed package-backed first-use smoke | package upgrade smoke pending | ✅ public-asset first-use pass | rc4 public asset smoke [`26218940925`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940925), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc3 post-merge smoke [`26204699596`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596), PR [`#429`](https://github.com/Jesssullivan/tummycrypt/pull/429), rc3 release run [`26204080480`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204080480), rc1 release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
-| 4 | `.deb` on Debian 12 bookworm | known blocked (`libc6 >= 2.39` floor) | n/a | ❌ blocked | inherits from [`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor) |
-| 5 | `.rpm` on Fedora 42 | daemon-only package published; install smoke pending | sampled only | ⚠️ daemon-only artifact pass | release job [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870) |
-| 6 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc4` | multi-arch runtime smoke green | sampled only | ✅ runtime smoke pass | rc4 runtime smoke [`26218940985`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940985), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc1 smoke run [`26083222949`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26083222949), rc1 release job [`76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828) |
-| 7 | Nix flake install | Nix build + Attic push passed; external profile install pending | sampled only | ⚠️ build/cache pass | release job [`76628512831`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512831) |
+| 3 | `.deb` on Ubuntu 24.04 | rc4 exact public release asset passed package-backed first-use smoke | package upgrade smoke green | ✅ public-asset first-use + upgrade smoke pass | rc4 public asset smoke [`26218940925`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940925), package-container upgrade smoke [`26243913292`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26243913292), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc3 post-merge smoke [`26204699596`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204699596), PRs [`#429`](https://github.com/Jesssullivan/tummycrypt/pull/429), [`#442`](https://github.com/Jesssullivan/tummycrypt/pull/442), rc3 release run [`26204080480`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26204080480), rc1 release jobs [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870), [`76628512850`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512850) |
+| 4 | `.deb` on Debian 13 trixie | rc4 exact public release assets passed installed-binary smoke | package upgrade smoke green | ✅ install + upgrade smoke pass | PR #442 package-container smoke [`26243913292`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26243913292) |
+| 5 | `.deb` on Debian 12 bookworm | known blocked (`libc6 >= 2.39` floor) | n/a | ❌ blocked | inherits from [`v0.12.2-evidence-matrix.md`](v0.12.2-evidence-matrix.md#blocker-b--debian-12-bookworm-support-floor) |
+| 6 | `.rpm` on Fedora 42 | rc4 exact public daemon-only RPM passed installed-binary smoke | sampled upgrade smoke green | ✅ daemon-only install + sampled upgrade smoke pass | PR #442 package-container smoke [`26243913292`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26243913292), release job [`76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870) |
+| 7 | Container image `ghcr.io/jesssullivan/tcfsd:v0.12.13-rc4` | multi-arch runtime smoke green | sampled only | ✅ runtime smoke pass | rc4 runtime smoke [`26218940985`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26218940985), rc4 release run [`26212215287`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287), rc1 smoke run [`26083222949`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26083222949), rc1 release job [`76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828) |
+| 8 | Nix flake install | rc4 external profile install green on hosted Ubuntu 24.04 | sampled only | ✅ profile install smoke pass | Nix profile smoke [`26242122899`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26242122899), release job [`76628512831`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512831) |
 
-Rollup: **4 current product-surface or first-use passes · 2 artifact/build
-passes with first-use smoke still pending · 1 blocked**. The macOS `.pkg`,
-Ubuntu `.deb`, Homebrew fresh install, and container rows now have exact public
-rc4/current-tap proof. Ubuntu `.deb` and Homebrew still owe upgrade proof, and
-the matrix still owes distro breadth before #280 can fully close.
+Rollup: **7 current product-surface, first-use, installed-binary, or profile
+install smoke passes · 1 blocked**. The macOS `.pkg`, Ubuntu `.deb`, Homebrew,
+Debian 13 `.deb`, Fedora 42 daemon-only `.rpm`, container, and Nix profile rows
+now have exact public rc4/current-tap proof. Ubuntu/Debian package upgrade
+semantics are now proven at installed-binary smoke level. NixOS host proof and
+rc package version semantics remain before #280 can fully close.
 
 ## Per-Surface Evidence
 
@@ -149,7 +159,7 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
 - `tcfsd-0.12.13-rc1-x86_64.rpm`:
   `0e3f991f93ca9b7c979ce11898ce85cb661efd4a76faa3c93e1337e0326c169e`
 
-### 1. Homebrew — current-tap install smoke pass
+### 1. Homebrew — current-tap install and upgrade smoke pass
 
 - Release job `Update Homebrew formula` succeeded for rc4
   ([job `77139820909`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26212215287/job/77139820909)).
@@ -160,11 +170,15 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
   passed on `main@84c7389`: `brew install Jesssullivan/tummycrypt/tcfs`
   installed `/opt/homebrew/Cellar/tcfs/0.12.13-rc4`, and installed binaries
   reported `tcfs 0.12.13` / `tcfsd 0.12.13`.
+- Upgrade smoke run
+  [`26221711601`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26221711601)
+  installed the prior tap ref
+  `07dc9949f57921366c60a36728924f560a6d819a` (`v0.12.12`), verified
+  `tcfs 0.12.12`, upgraded to `homebrew-tap@b5877df` (`v0.12.13-rc4`), and
+  ended with `tcfs 0.12.13` / `tcfsd 0.12.13`.
 - Earlier mainline install smoke run
   [`26082967508`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26082967508)
   remains historical proof for the earlier rc-series tap after PR #393 landed.
-- Not proven in this rc-series packet: upgrade smoke from an older Homebrew
-  install.
 
 ### 2. macOS `.pkg` — exact rc4 public asset green
 
@@ -267,31 +281,65 @@ published 16 assets, including `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, and
   packet records storage `[ok]`, FUSE mount, `tcfs index inspect` status
   `visible`, manifest present, exact 59-byte hydrate, `tcfs cache evict` +
   rehydrate, and mutation remote pull.
+- Package-container upgrade smoke run
+  [`26243913292`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26243913292)
+  installed public `v0.12.12` `.deb` packages inside `ubuntu:24.04`, verified
+  `tcfs 0.12.12` / `tcfsd 0.12.12` and `install smoke passed`, then installed
+  the public `v0.12.13-rc4` `.deb` packages over them and verified
+  `tcfs 0.12.13` / `tcfsd 0.12.13` plus `install smoke passed`.
 - Versioning caveat: the rc4-named `.deb` assets install package versions
   `tcfs-cli 0.12.13-1` and `tcfsd 0.12.13-1`. Treat release-candidate package
   version semantics as a remaining TIN-131/#280 risk.
-- Still not proven: upgrade smoke, Debian 13 smoke, Fedora/RPM breadth, and
-  Debian 12 compatibility. Those remain TIN-131 / #280 scope.
+- Still not proven: Debian 12 compatibility. That remains TIN-131 / #280 scope.
 
-### 4. Debian/Ubuntu `.deb` on Debian 12 bookworm — blocked
+### 4. Debian/Ubuntu `.deb` on Debian 13 trixie — install/upgrade smoke pass
+
+- PR [#442](https://github.com/Jesssullivan/tummycrypt/pull/442) added the
+  hosted containerized package smoke lane for distro breadth without pretending
+  a privileged FUSE runner exists.
+- Container smoke run
+  [`26243913292`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26243913292)
+  installed exact public rc4 assets `tcfs-0.12.13-rc4-amd64.deb` and
+  `tcfsd-0.12.13-rc4-amd64.deb` inside `debian:13` on `linux/amd64`.
+- The artifact records checksum verification against `SHA256SUMS.txt`, package
+  versions `tcfs-cli 0.12.13-1` and `tcfsd 0.12.13-1`, installed binary output
+  `tcfs 0.12.13` / `tcfsd 0.12.13`, daemon socket readiness, `tcfs status`,
+  and `install smoke passed`.
+- The same run proves package upgrade smoke inside `debian:13`: public
+  `v0.12.12` `.deb` packages install and pass binary smoke first, then public
+  `v0.12.13-rc4` `.deb` packages install over them and pass binary smoke.
+- Boundary: this is installed-binary package breadth. It does not prove FUSE
+  mount, systemd service management, live storage, or first-real-use behavior.
+
+### 5. Debian/Ubuntu `.deb` on Debian 12 bookworm — blocked
 
 Unchanged from v0.12.2. The released `.deb` assets still target a newer libc /
 OpenSSL floor than Debian 12 provides. Debian 12 remains excluded unless a
 bookworm-specific package or static build is added.
 
-### 5. Fedora/RHEL `.rpm` on Fedora 42 — daemon-only artifact publication pass
+### 6. Fedora/RHEL `.rpm` on Fedora 42 — daemon-only install/upgrade smoke pass
 
 - Release job: `Build linux-x86_64` succeeded
   ([job `76628512870`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512870)).
-- Published asset: `tcfsd-0.12.13-rc1-x86_64.rpm`.
+- Current published asset: `tcfsd-0.12.13-rc4-x86_64.rpm`.
 - Published checksum:
-  `0e3f991f93ca9b7c979ce11898ce85cb661efd4a76faa3c93e1337e0326c169e`.
+  `36d0298859c357034c59718434b92f3a72edb9de4a60df4f769e3ee2bf0119ff`.
+- Container smoke run
+  [`26243913292`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26243913292)
+  installed the exact public rc4 RPM inside `fedora:42` on `linux/amd64`.
+- The artifact records checksum verification against `SHA256SUMS.txt`, package
+  version `tcfsd-0.12.13-1.x86_64`, installed binary output `tcfsd 0.12.13`,
+  daemon socket readiness, and `CLI smoke skipped`.
+- The same run proves sampled daemon-only RPM upgrade smoke: public `v0.12.12`
+  `tcfsd` RPM installs and starts, `dnf upgrade` installs the public
+  `v0.12.13-rc4` RPM, and `tcfsd 0.12.13` starts afterward.
 - Structural caveat unchanged: RPM ships `tcfsd` only today. There is no `tcfs`
   CLI RPM asset.
-- Not proven in this rc-series packet: Fedora 42 install smoke with
-  `scripts/install-smoke.sh --skip-cli`.
+- Boundary: this is daemon-only installed-binary package breadth. It does not
+  prove live storage, systemd service management, worker execution, or a CLI RPM
+  surface.
 
-### 6. Container image — multi-arch runtime smoke pass
+### 7. Container image — multi-arch runtime smoke pass
 
 - Release job: `Build container image` succeeded
   ([job `76628512828`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512828)).
@@ -319,7 +367,7 @@ bookworm-specific package or static build is added.
 - Not proven in this rc-series packet: full worker execution against live
   NATS/S3.
 
-### 7. Nix flake install — build/cache pass; external profile install pending
+### 8. Nix flake install — external profile install pass
 
 - Release job: `Nix Build + Attic Push` succeeded
   ([job `76628512831`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26063349561/job/76628512831)).
@@ -327,8 +375,18 @@ bookworm-specific package or static build is added.
   results to the configured Attic cache.
 - This confirms the release flake builds at the tag and the cache push path is
   healthy.
-- Not proven in this rc-series packet: an external `nix profile install
-  github:Jesssullivan/tummycrypt?ref=v0.12.13-rc4#...` from a non-tinyland host.
+- Nix profile smoke run
+  [`26242122899`](https://github.com/Jesssullivan/tummycrypt/actions/runs/26242122899)
+  installed `packages.x86_64-linux.tcfs-cli` and
+  `packages.x86_64-linux.tcfsd` from
+  `github:Jesssullivan/tummycrypt/v0.12.13-rc4` into a temporary profile on
+  hosted Ubuntu 24.04.
+- The artifact records locked flake commit
+  `f89096aa1289fcf11c7bb134da9e69df56c74028`, store paths
+  `tcfs-cli-0.12.13` and `tcfsd-0.12.13`, profile size `84.1 MiB`, binaries
+  reporting `tcfs 0.12.13` / `tcfsd 0.12.13`, daemon socket readiness, and
+  `install smoke passed`.
+- Not proven in this rc-series packet: NixOS module host proof.
 
 ### Production Dev ID FileProvider — proven on PZM (M10 acceptance)
 
@@ -431,3 +489,7 @@ Same as v0.12.2:
 - 2026-05-21 — Added exact public `v0.12.13-rc4` package-facing proof: Linux
   `.deb` run `26218940925`, macOS `.pkg` run `26218940950`, and container run
   `26218940985`.
+- 2026-05-21 — Added Homebrew upgrade proof from run `26221711601` and PR #440,
+  plus Debian 13 `.deb` / Ubuntu 24.04 `.deb` / Fedora 42 daemon-only `.rpm`
+  installed-binary install-upgrade proof from PR #442 run `26243913292`.
+- 2026-05-21 — Added external Nix profile install proof from run `26242122899`.

--- a/scripts/test-linux-package-container-smoke-workflow.sh
+++ b/scripts/test-linux-package-container-smoke-workflow.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # Literal workflow expressions are what this test asserts.
+#
+# Static regression checks for the Linux package container smoke workflow.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${REPO_ROOT}/.github/workflows/linux-package-container-smoke.yml"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-linux-package-container-workflow-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+extract_step_from_workflow() {
+  local step_name="$1"
+  local output="$2"
+
+  ruby -ryaml -e '
+    workflow = YAML.load_file(ARGV[0])
+    steps = workflow.fetch("jobs").fetch("package-container-smoke").fetch("steps")
+    step = steps.find { |item| item["name"] == ARGV[1] }
+    raise "missing workflow step #{ARGV[1]}" unless step
+    puts step.fetch("run")
+  ' "$WORKFLOW" "$step_name" >"$output"
+}
+
+check_matrix_surfaces() {
+  assert_contains "$WORKFLOW" "pull_request:"
+  assert_contains "$WORKFLOW" ".github/workflows/linux-package-container-smoke.yml"
+  assert_contains "$WORKFLOW" "Debian 13 amd64 .deb install smoke"
+  assert_contains "$WORKFLOW" "image: debian:13"
+  assert_contains "$WORKFLOW" "package_family: deb"
+  assert_contains "$WORKFLOW" "smoke_mode: fresh-install"
+  assert_contains "$WORKFLOW" "skip_cli: \"false\""
+  assert_contains "$WORKFLOW" "Debian 13 amd64 .deb upgrade smoke"
+  assert_contains "$WORKFLOW" "Ubuntu 24.04 amd64 .deb upgrade smoke"
+  assert_contains "$WORKFLOW" "smoke_mode: upgrade"
+
+  assert_contains "$WORKFLOW" "Fedora 42 x86_64 daemon-only .rpm install smoke"
+  assert_contains "$WORKFLOW" "Fedora 42 x86_64 daemon-only .rpm upgrade smoke"
+  assert_contains "$WORKFLOW" "image: fedora:42"
+  assert_contains "$WORKFLOW" "package_family: rpm"
+  assert_contains "$WORKFLOW" "skip_cli: \"true\""
+}
+
+check_release_asset_selection() {
+  local step="$TMPDIR/download-and-verify.sh"
+  extract_step_from_workflow "Download and verify public package assets" "$step"
+
+  assert_contains "$step" 'VERSION="${TAG#v}"'
+  assert_contains "$step" 'PREVIOUS_VERSION="${PREVIOUS_TAG#v}"'
+  assert_contains "$step" '"tcfs-${version}-amd64.deb"'
+  assert_contains "$step" '"tcfsd-${version}-amd64.deb"'
+  assert_contains "$step" '"tcfsd-${version}-x86_64.rpm"'
+  assert_contains "$step" 'download_release_assets "$TAG" "$VERSION" current'
+  assert_contains "$step" 'download_release_assets "$PREVIOUS_TAG" "$PREVIOUS_VERSION" previous'
+  assert_contains "$step" 'releases/download/${tag}'
+  assert_contains "$step" 'SHA256SUMS.txt'
+  assert_contains "$step" 'sha256sum -c SHA256SUMS-selected.txt'
+}
+
+check_container_smoke() {
+  local step="$TMPDIR/container-smoke.sh"
+  extract_step_from_workflow "Run package install smoke in container" "$step"
+
+  assert_contains "$step" 'install_packages_from()'
+  assert_contains "$step" 'run_install_smoke()'
+  assert_contains "$step" 'apt-get install -y --no-install-recommends "$package_dir"/tcfs-*.deb "$package_dir"/tcfsd-*.deb'
+  assert_contains "$step" 'dnf upgrade -y "$package_dir"/tcfsd-*.rpm'
+  assert_contains "$step" 'install_packages_from /packages/previous install'
+  assert_contains "$step" 'run_install_smoke "$PREVIOUS_BINARY_EXPECTED_VERSION" /logs/install-smoke-before-upgrade.log'
+  assert_contains "$step" 'install_packages_from /packages/current upgrade'
+  assert_contains "$step" 'bash /work/scripts/install-smoke.sh'
+  assert_contains "$step" '--skip-cli'
+  assert_contains "$step" 'docker run --rm -i'
+  assert_contains "$step" '-e PREVIOUS_BINARY_EXPECTED_VERSION="$PREVIOUS_BINARY_EXPECTED_VERSION"'
+  assert_contains "$step" '-e SMOKE_MODE="$SMOKE_MODE"'
+  assert_contains "$step" '--platform "${{ matrix.platform }}"'
+  assert_contains "$step" '2>&1 | tee "$LOG_DIR/container-smoke.log"'
+  assert_contains "$step" 'status="${PIPESTATUS[0]}"'
+}
+
+check_artifact_retention() {
+  assert_contains "$WORKFLOW" "github.event.inputs.tag || 'v0.12.13-rc4'"
+  assert_contains "$WORKFLOW" "github.event.inputs.binary_expected_version || '0.12.13'"
+  assert_contains "$WORKFLOW" "github.event.inputs.previous_tag || 'v0.12.12'"
+  assert_contains "$WORKFLOW" "github.event.inputs.previous_binary_expected_version || '0.12.12'"
+  assert_contains "$WORKFLOW" "github.event.inputs.tag || github.ref"
+  assert_contains "$WORKFLOW" "linux-package-container-smoke-\${{ github.event.inputs.tag || 'v0.12.13-rc4' }}-\${{ matrix.artifact_suffix }}"
+  assert_contains "$WORKFLOW" "retention-days: 14"
+}
+
+check_matrix_surfaces
+check_release_asset_selection
+check_container_smoke
+check_artifact_retention
+
+printf 'Linux package container smoke workflow tests passed\n'


### PR DESCRIPTION
## Summary

Adds a Linux package container smoke lane for TIN-131 / #280 distro breadth and package-upgrade semantics, fixes the Nix profile smoke diagnostics capture, and refreshes the release/distribution docs with the rc4 proof state.

## What changed

- Adds `.github/workflows/linux-package-container-smoke.yml`.
- Verifies exact public release assets against `SHA256SUMS.txt` before install.
- Installs `tcfs` + `tcfsd` `.deb` packages in `debian:13` and runs the full installed-binary smoke.
- Upgrades Debian 13 and Ubuntu 24.04 from public `v0.12.12` `.deb` packages to public `v0.12.13-rc4` `.deb` packages.
- Installs the daemon-only `.rpm` in `fedora:42` and runs `scripts/install-smoke.sh --skip-cli`.
- Samples Fedora 42 daemon-only RPM upgrade from public `v0.12.12` to public `v0.12.13-rc4`.
- Adds a static regression test and wires it into `just` / `task lazy:check`.
- Cleans up `nix-profile-install-smoke.yml` diagnostics so successful artifacts no longer carry a `nix config show` argument error.
- Updates the distribution matrix, v0.12.13 evidence matrix, product reality doc, and alpha productionization board.

## Evidence

Package container run `26244154425` passed all five jobs on PR head `8ab3b66`:

- Debian 13 amd64 fresh install: exact public `v0.12.13-rc4` `.deb` assets checksum verified, installed as `tcfs-cli 0.12.13-1` / `tcfsd 0.12.13-1`, binaries reported `tcfs 0.12.13` and `tcfsd 0.12.13`, daemon socket became ready, and `install smoke passed`.
- Debian 13 amd64 upgrade: public `v0.12.12` `.deb` packages installed and passed smoke first; public `v0.12.13-rc4` `.deb` packages then installed over them and passed smoke with `tcfs 0.12.13` / `tcfsd 0.12.13`.
- Ubuntu 24.04 amd64 upgrade: same public `v0.12.12` to public `v0.12.13-rc4` `.deb` upgrade path passed with daemon socket readiness and `install smoke passed` before and after upgrade.
- Fedora 42 x86_64 fresh install: exact public `tcfsd-0.12.13-rc4-x86_64.rpm` checksum verified, installed as `tcfsd-0.12.13-1.x86_64`, binary reported `tcfsd 0.12.13`, daemon socket became ready, and CLI smoke was intentionally skipped because the RPM is daemon-only.
- Fedora 42 x86_64 upgrade: public `tcfsd-0.12.12-x86_64.rpm` installed and passed daemon-only smoke, then `dnf upgrade` installed public `tcfsd-0.12.13-rc4-x86_64.rpm` and daemon-only smoke passed again with `tcfsd 0.12.13`.

Nix profile run `26242122899` passed on `main@93e4bd4`:

- `nix profile install` from `github:Jesssullivan/tummycrypt/v0.12.13-rc4` installed `packages.x86_64-linux.tcfs-cli` and `packages.x86_64-linux.tcfsd` into a temporary profile on hosted Ubuntu 24.04.
- Artifacts record locked commit `f89096aa1289fcf11c7bb134da9e69df56c74028`, store paths `tcfs-cli-0.12.13` and `tcfsd-0.12.13`, profile size `84.1 MiB`, binaries reporting `tcfs 0.12.13` / `tcfsd 0.12.13`, daemon socket readiness, and `install smoke passed`.

## Boundary

This closes hosted package install-smoke breadth for Debian 13/Fedora 42, hosted package-upgrade smoke for Debian 13/Ubuntu 24.04/Fedora 42 daemon-only RPM, and external Nix profile install proof. It does not claim FUSE, systemd service management, live storage, NixOS module host behavior, Debian 12 compatibility, CLI RPM availability, or Linux first-real-use beyond the existing Ubuntu live postinstall lane.

## Validation

- `bash scripts/test-linux-package-container-smoke-workflow.sh`
- `bash scripts/test-linux-postinstall-workflow.sh`
- `task lazy:test-linux-package-container-workflow`
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/linux-package-container-smoke.yml"); YAML.load_file(".github/workflows/nix-profile-install-smoke.yml"); puts "workflow yaml ok"'`
- `git diff --check`
