### PR TITLE
ci: keep large restore canary inside scoped storage prefix

### DIFF
--- a/.github/workflows/storage-large-restore-canary.yml
+++ b/.github/workflows/storage-large-restore-canary.yml
@@ -23,7 +23,7 @@ on:
         default: "tcfs-storage-prod-smoke"
         type: string
       remote_prefix:
-        description: "Remote prefix; default is gha/storage-posture-large/<run>"
+        description: "Remote prefix; default is gha/storage-posture/large/<run>"
         required: false
         default: ""
         type: string
@@ -207,12 +207,12 @@ jobs:
           set -euo pipefail
           REMOTE_PREFIX="${{ github.event.inputs.remote_prefix }}"
           if [[ -z "$REMOTE_PREFIX" ]]; then
-            REMOTE_PREFIX="gha/storage-posture-large/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            REMOTE_PREFIX="gha/storage-posture/large/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           fi
           REMOTE_PREFIX="${REMOTE_PREFIX#/}"
           REMOTE_PREFIX="${REMOTE_PREFIX%/}"
-          if [[ "$REMOTE_PREFIX" != *storage-posture* ]]; then
-            echo "::error::remote_prefix must contain storage-posture so the storage posture guard stays explicit"
+          if [[ "$REMOTE_PREFIX" != gha/storage-posture/* ]]; then
+            echo "::error::refusing to run restore against an untrusted prefix: remote_prefix must stay under gha/storage-posture/ for the scoped production-smoke credentials"
             exit 1
           fi
 
@@ -292,6 +292,60 @@ jobs:
             --chunk-timeout-secs 300 \
             --progress-heartbeat-secs 60 \
             --socket-sample-interval-secs 5
+
+      - name: Validate large canary push evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          SUMMARY="$EVIDENCE_DIR/push-storage-summary.env"
+          PUSH_LOG="$EVIDENCE_DIR/push.log"
+
+          if [[ ! -s "$SUMMARY" ]]; then
+            echo "::error::missing push summary at $SUMMARY"
+            exit 1
+          fi
+          if [[ ! -s "$PUSH_LOG" ]]; then
+            echo "::error::missing push log at $PUSH_LOG"
+            exit 1
+          fi
+
+          kv() {
+            awk -F= -v key="$1" '
+              $1 == key {
+                print substr($0, length($1) + 2)
+                found = 1
+              }
+              END { exit found ? 0 : 1 }
+            ' "$SUMMARY"
+          }
+
+          require_gt_zero() {
+            local key="$1"
+            local value
+            if ! value="$(kv "$key")"; then
+              echo "::error::missing $key in $SUMMARY"
+              exit 1
+            fi
+            if [[ -z "$value" || "$value" == *[!0-9]* ]]; then
+              echo "::error::$key must be a positive integer, got '$value'"
+              exit 1
+            fi
+            if (( value <= 0 )); then
+              echo "::error::$key must be greater than zero, got $value"
+              exit 1
+            fi
+          }
+
+          require_gt_zero upload_rows
+          require_gt_zero total_file_bytes
+          require_gt_zero pack_rows
+          require_gt_zero pack_file_bytes
+
+          if grep -E -i 'PermissionDenied|AccessDenied|upload failed|failed to write|Error:' "$PUSH_LOG" > "$RUNNER_TEMP/tcfs-push-failures.txt"; then
+            echo "::error::push log contains storage/write failures; refusing to run restore"
+            tail -40 "$RUNNER_TEMP/tcfs-push-failures.txt"
+            exit 1
+          fi
 
       - name: Restore large canary
         shell: bash

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -1,7 +1,7 @@
 # TCFS Production Storage Posture Gate
 
 Date: 2026-05-19
-Updated: 2026-05-24
+Updated: 2026-05-25
 
 This is the operator handoff for `TIN-1546`. It defines the minimum storage
 packet required before TCFS can claim production-like S3 readiness for alpha QA.
@@ -66,6 +66,16 @@ Known evidence:
   HTTPS storage posture packet. It still does not prove large-restore
   throughput, socket/highwater behavior, long soak, or transient recovery
   classification.
+- run `26376987029` attempted the large-restore companion on merged `main` at
+  `592d119` with the same public HTTPS production-smoke environment. It failed
+  before restore because the workflow defaulted to
+  `gha/storage-posture-large/...`, outside the scoped credential policy for
+  `gha/storage-posture/...`. The failure confirmed that out-of-scope writes and
+  index listing return `PermissionDenied`/`AccessDenied`, but it did not test
+  large-restore throughput, socket/highwater behavior, or transient recovery.
+  The workflow must rerun under `gha/storage-posture/large/...` and fail
+  immediately if the push evidence shows zero uploaded rows or storage access
+  denials.
 - downstream public-asset smokes on `main@e9b9f82` then used the same
   production-smoke prefix family successfully:
   - Linux `.deb` run `26218940925` used

--- a/scripts/test-storage-large-restore-canary-workflow.sh
+++ b/scripts/test-storage-large-restore-canary-workflow.sh
@@ -41,7 +41,8 @@ assert_contains "$WORKFLOW" "name: Storage Large Restore Canary"
 assert_contains "$WORKFLOW" "environment: \${{ github.event.inputs.smoke_environment }}"
 assert_contains "$WORKFLOW" "TCFS_SMOKE_S3_ENDPOINT: \${{ secrets.TCFS_SMOKE_S3_ENDPOINT }}"
 assert_contains "$WORKFLOW" "AWS_ACCESS_KEY_ID: \${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}"
-assert_contains "$WORKFLOW" "gha/storage-posture-large/"
+assert_contains "$WORKFLOW" "gha/storage-posture/large/"
+assert_contains "$WORKFLOW" "refusing to run restore against an untrusted prefix"
 assert_contains "$WORKFLOW" "actions/upload-artifact@v4"
 assert_contains "$WORKFLOW" 'TCFS_S3_REGION=$REGION'
 assert_contains "$WORKFLOW" 'TCFS_STORAGE_S3_CA_CERT_PATH=$CA_CERT_PATH'
@@ -64,6 +65,16 @@ assert_contains "$PUSH_STEP" "scripts/home-canary-linux-xr-storage-posture.sh"
 assert_contains "$PUSH_STEP" '--remote "$REMOTE"'
 assert_contains "$PUSH_STEP" "--push"
 assert_contains "$PUSH_STEP" "--socket-sample-interval-secs 5"
+
+VALIDATE_PUSH_STEP="$TMPDIR/validate-push-step.sh"
+extract_step_from_workflow "Validate large canary push evidence" "$VALIDATE_PUSH_STEP"
+assert_contains "$VALIDATE_PUSH_STEP" "push-storage-summary.env"
+assert_contains "$VALIDATE_PUSH_STEP" "push.log"
+assert_contains "$VALIDATE_PUSH_STEP" "require_gt_zero upload_rows"
+assert_contains "$VALIDATE_PUSH_STEP" "require_gt_zero total_file_bytes"
+assert_contains "$VALIDATE_PUSH_STEP" "require_gt_zero pack_rows"
+assert_contains "$VALIDATE_PUSH_STEP" "require_gt_zero pack_file_bytes"
+assert_contains "$VALIDATE_PUSH_STEP" "PermissionDenied|AccessDenied|upload failed|failed to write|Error:"
 
 RESTORE_STEP="$TMPDIR/restore-step.sh"
 extract_step_from_workflow "Restore large canary" "$RESTORE_STEP"


### PR DESCRIPTION
## Summary
- keep the TIN-1546 large-restore canary default under `gha/storage-posture/large/...`, matching the scoped production-smoke credential policy
- reject dispatch prefixes outside `gha/storage-posture/` before any storage writes
- add a push-evidence gate so restore does not run when uploads write zero rows or the push log contains storage access failures
- document failed run `26376987029` as credential-scope evidence, not large-restore evidence

## Validation
- `bash scripts/test-storage-large-restore-canary-workflow.sh`
- `git diff --check`

## Boundary
This does not close TIN-1546 by itself. It fixes the workflow bug exposed by run `26376987029`; the large-restore canary still needs a fresh green run from `main` after this lands.