### PR TITLE
device: generate real local age identities (TIN-1417)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -3292,8 +3292,9 @@ async fn cmd_init(
 
     // Step 6: Create device registry and enroll this device
     let mut registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path)?;
-    let public_key = format!("age1-device-{}", &blake3_short(&device_name));
-    let device_id = registry.enroll(&device_name, &public_key, None);
+    let (device_id, device_key) = registry.enroll_local(&device_name, None);
+    let device_key_path = tcfs_secrets::device::device_secret_key_path(&registry_path, &device_id);
+    tcfs_secrets::device::save_device_secret_key(&device_key_path, &device_key.secret_key, false)?;
     registry.save(&registry_path)?;
 
     if !skip_config {
@@ -3307,6 +3308,7 @@ async fn cmd_init(
     println!();
     println!("  Device name:  {}", device_name);
     println!("  Device ID:    {}", device_id);
+    println!("  Device key:   {}", device_key_path.display());
     println!("  Master key:   {}", master_key_path.display());
     println!("  Registry:     {}", registry_path.display());
     if !skip_config {
@@ -3399,6 +3401,51 @@ fn cmd_init_check(paths: &InitPaths) -> Result<()> {
             paths.registry_path.display()
         );
     }
+    let configured_device_name = std::fs::read_to_string(&paths.config_path)
+        .ok()
+        .and_then(|content| toml::from_str::<tcfs_core::config::TcfsConfig>(&content).ok())
+        .and_then(|config| config.sync.device_name);
+    let active_devices: Vec<_> = registry.active_devices().collect();
+    let local_device = configured_device_name
+        .as_deref()
+        .and_then(|name| {
+            active_devices
+                .iter()
+                .copied()
+                .find(|device| device.name == name)
+        })
+        .or_else(|| {
+            if active_devices.len() == 1 {
+                active_devices.first().copied()
+            } else {
+                None
+            }
+        })
+        .with_context(|| {
+            let expected = configured_device_name
+                .as_deref()
+                .unwrap_or("<unset; registry has multiple active devices>");
+            format!(
+                "tcfs is not initialized; local device '{expected}' was not found in {}",
+                paths.registry_path.display()
+            )
+        })?;
+
+    if !tcfs_secrets::device::is_real_age_public_key(&local_device.public_key) {
+        anyhow::bail!(
+            "tcfs is not initialized with a real device key; '{}' has a placeholder public key. Run 'tcfs init' with a fresh config or migrate the device registry.",
+            local_device.name
+        );
+    }
+    let key_path =
+        tcfs_secrets::device::device_secret_key_path(&paths.registry_path, &local_device.device_id);
+    if !key_path.exists() {
+        anyhow::bail!(
+            "tcfs is not initialized; missing device private key for '{}' ({}). Run 'tcfs init' with a fresh config or restore the device key backup.",
+            local_device.name,
+            key_path.display()
+        );
+    }
 
     println!("tcfs init check [ok]");
     println!("  Config:     {}", paths.config_path.display());
@@ -3456,11 +3503,6 @@ fn rand_salt() -> [u8; 16] {
     use rand::RngCore;
     rand::thread_rng().fill_bytes(&mut salt);
     salt
-}
-
-fn blake3_short(s: &str) -> String {
-    let hash = blake3::hash(s.as_bytes());
-    hash.to_hex().as_str()[..8].to_string()
 }
 
 // ── `tcfs device list` ───────────────────────────────────────────────────────
@@ -3521,16 +3563,16 @@ fn cmd_device_enroll(name: Option<String>) -> Result<()> {
         );
     }
 
-    let public_key = format!(
-        "age1-device-{}",
-        &blake3::hash(device_name.as_bytes()).to_hex().as_str()[..8]
-    );
-    let device_id = registry.enroll(&device_name, &public_key, None);
+    let (device_id, device_key) = registry.enroll_local(&device_name, None);
+    let device_key_path = tcfs_secrets::device::device_secret_key_path(&registry_path, &device_id);
+    tcfs_secrets::device::save_device_secret_key(&device_key_path, &device_key.secret_key, false)?;
     registry.save(&registry_path)?;
 
     println!("Device enrolled:");
     println!("  name:      {}", device_name);
     println!("  device_id: {}", device_id);
+    println!("  public_key: {}", device_key.public_key);
+    println!("  key:       {}", device_key_path.display());
     println!("  registry:  {}", registry_path.display());
     println!();
     println!("Next: configure sync in tcfs.toml and run 'tcfs push'");
@@ -5094,6 +5136,56 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn init_check_accepts_real_device_key_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let master_key_path = dir.path().join("master.key");
+        let registry_path = dir.path().join("devices.json");
+        std::fs::write(&config_path, "config = true\n").unwrap();
+        std::fs::write(&master_key_path, [7u8; tcfs_crypto::KEY_SIZE]).unwrap();
+
+        let mut registry = tcfs_secrets::device::DeviceRegistry::default();
+        let (device_id, key) = registry.enroll_local("laptop", None);
+        registry.save(&registry_path).unwrap();
+        let key_path = tcfs_secrets::device::device_secret_key_path(&registry_path, &device_id);
+        tcfs_secrets::device::save_device_secret_key(&key_path, &key.secret_key, false).unwrap();
+
+        let paths = InitPaths {
+            config_dir: dir.path().to_path_buf(),
+            config_path,
+            master_key_path,
+            registry_path,
+        };
+        cmd_init_check(&paths).unwrap();
+    }
+
+    #[test]
+    fn init_check_rejects_placeholder_device_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let master_key_path = dir.path().join("master.key");
+        let registry_path = dir.path().join("devices.json");
+        std::fs::write(&config_path, "config = true\n").unwrap();
+        std::fs::write(&master_key_path, [7u8; tcfs_crypto::KEY_SIZE]).unwrap();
+
+        let mut registry = tcfs_secrets::device::DeviceRegistry::default();
+        registry.enroll("legacy", "age1-device-deadbeef", None);
+        registry.save(&registry_path).unwrap();
+
+        let paths = InitPaths {
+            config_dir: dir.path().to_path_buf(),
+            config_path,
+            master_key_path,
+            registry_path,
+        };
+        let err = cmd_init_check(&paths).unwrap_err();
+        assert!(
+            err.to_string().contains("placeholder public key"),
+            "unexpected error: {err:#}"
+        );
     }
 
     fn make_encrypted_manifest(

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -4,8 +4,9 @@
 //! Device keys are stored in the platform keychain or an age-encrypted file.
 
 use anyhow::{Context, Result};
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// A registered device identity
@@ -38,6 +39,16 @@ pub struct DeviceIdentity {
 pub struct DeviceRegistry {
     /// List of enrolled devices
     pub devices: Vec<DeviceIdentity>,
+}
+
+/// Newly generated local device key material.
+///
+/// The secret half must be persisted outside `DeviceRegistry`; the registry is
+/// intended to be shareable metadata and should only contain public keys.
+#[derive(Clone)]
+pub struct LocalDeviceKey {
+    pub public_key: String,
+    pub secret_key: SecretString,
 }
 
 impl DeviceRegistry {
@@ -141,6 +152,21 @@ impl DeviceRegistry {
         device_id
     }
 
+    /// Enroll a local device with a real age X25519 keypair.
+    ///
+    /// Returns `(device_id, key_material)`. Callers must persist
+    /// `key_material.secret_key` with `save_device_secret_key` before exposing
+    /// the registry as usable.
+    pub fn enroll_local(
+        &mut self,
+        name: &str,
+        description: Option<String>,
+    ) -> (String, LocalDeviceKey) {
+        let key = generate_local_device_key();
+        let device_id = self.enroll(name, &key.public_key, description);
+        (device_id, key)
+    }
+
     /// Load device registry from S3 remote storage.
     pub async fn load_remote(op: &opendal::Operator, meta_prefix: &str) -> Result<Self> {
         let key = format!(
@@ -182,14 +208,71 @@ impl DeviceRegistry {
         name: &str,
         meta_prefix: &str,
     ) -> Result<(String, String)> {
-        let identity = age::x25519::Identity::generate();
-        let public_key = identity.to_public().to_string();
-        let secret_key = identity.to_string().expose_secret().to_string();
-
-        let device_id = self.enroll(name, &public_key, None);
+        let (device_id, key) = self.enroll_local(name, None);
         self.sync_to_remote(op, meta_prefix).await?;
-        Ok((device_id, secret_key))
+        Ok((device_id, key.secret_key.expose_secret().to_string()))
     }
+}
+
+/// Generate a real local age X25519 device identity.
+pub fn generate_local_device_key() -> LocalDeviceKey {
+    let identity = age::x25519::Identity::generate();
+    LocalDeviceKey {
+        public_key: identity.to_public().to_string(),
+        secret_key: SecretString::from(identity.to_string().expose_secret().to_string()),
+    }
+}
+
+/// Return the secret-key path associated with a registry path and device id.
+pub fn device_secret_key_path(registry_path: &Path, device_id: &str) -> PathBuf {
+    registry_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("device-{device_id}.age"))
+}
+
+/// Persist a local device identity secret key with owner-only permissions.
+pub fn save_device_secret_key(
+    path: &Path,
+    secret_key: &SecretString,
+    overwrite: bool,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating device key dir: {}", parent.display()))?;
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true);
+    if overwrite {
+        options.truncate(true);
+    } else {
+        options.create_new(true);
+    }
+
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("creating device secret key: {}", path.display()))?;
+    file.write_all(secret_key.expose_secret().as_bytes())
+        .with_context(|| format!("writing device secret key: {}", path.display()))?;
+    file.write_all(b"\n")
+        .with_context(|| format!("writing device secret key newline: {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("syncing device secret key: {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("chmod device secret key: {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+/// Return true when `public_key` is a parseable age X25519 recipient.
+pub fn is_real_age_public_key(public_key: &str) -> bool {
+    public_key.parse::<age::x25519::Recipient>().is_ok()
 }
 
 /// Get the default device registry path
@@ -220,6 +303,7 @@ pub fn default_device_name() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use secrecy::ExposeSecret;
 
     #[test]
     fn test_registry_add_and_find() {
@@ -291,6 +375,51 @@ mod tests {
         assert!(!id.is_empty());
         assert!(reg.find("yoga").is_some());
         assert_eq!(reg.find("yoga").unwrap().device_id, id);
+    }
+
+    #[test]
+    fn test_enroll_local_generates_real_age_keypair() {
+        let mut reg = DeviceRegistry::default();
+        let (id, key) = reg.enroll_local("neo", None);
+        let device = reg.find("neo").unwrap();
+
+        assert_eq!(device.device_id, id);
+        assert_eq!(device.public_key, key.public_key);
+        assert!(is_real_age_public_key(&device.public_key));
+        assert!(!device.public_key.starts_with("age1-device-"));
+
+        let identity: age::x25519::Identity = key
+            .secret_key
+            .expose_secret()
+            .parse()
+            .expect("age secret key");
+        assert_eq!(identity.to_public().to_string(), device.public_key);
+    }
+
+    #[test]
+    fn test_save_device_secret_key_uses_owner_only_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("device-test.age");
+        let key = generate_local_device_key();
+
+        save_device_secret_key(&path, &key.secret_key, false).unwrap();
+        let persisted = std::fs::read_to_string(&path).unwrap();
+        let identity: age::x25519::Identity =
+            persisted.trim().parse().expect("persisted age secret key");
+        assert_eq!(identity.to_public().to_string(), key.public_key);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+
+        let err = save_device_secret_key(&path, &key.secret_key, false).unwrap_err();
+        assert!(
+            err.to_string().contains("creating device secret key"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -111,28 +111,15 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             dev.device_id.clone()
         }
     } else {
-        let identity = age::x25519::Identity::generate();
-        let public_key = identity.to_public().to_string();
-        let secret_key = identity.to_string();
-
-        let id = registry.enroll(&device_name, &public_key, None);
-
-        // Persist the device secret key alongside the registry
-        let secret_key_path = registry_path
-            .parent()
-            .unwrap_or(std::path::Path::new("."))
-            .join(format!("device-{id}.age"));
-        if let Err(e) = std::fs::write(&secret_key_path, secret_key.expose_secret().as_bytes()) {
+        let (id, device_key) = registry.enroll_local(&device_name, None);
+        let secret_key_path = tcfs_secrets::device::device_secret_key_path(&registry_path, &id);
+        if let Err(e) = tcfs_secrets::device::save_device_secret_key(
+            &secret_key_path,
+            &device_key.secret_key,
+            false,
+        ) {
             warn!("failed to write device secret key: {e}");
         } else {
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(
-                    &secret_key_path,
-                    std::fs::Permissions::from_mode(0o600),
-                );
-            }
             info!(path = %secret_key_path.display(), "device secret key saved");
         }
 

--- a/docs/ops/per-device-crypto-identity-design-2026-05-18.md
+++ b/docs/ops/per-device-crypto-identity-design-2026-05-18.md
@@ -5,6 +5,12 @@ proposes the architecture; the user reviews and aligns before any code lands.
 
 Date: 2026-05-18.
 
+2026-05-25 implementation note: the Phase 0 local-key slice has now started.
+`tcfs init` and `tcfs device enroll` generate real age/X25519 device keys and
+persist the secret half in a `0600` `device-<device_id>.age` file beside the
+registry. Manifest wrapping, revoke semantics, pairing, and remote registry
+trust are still open.
+
 ## Problem Statement
 
 Today every "enrolled" device on a tcfs fleet holds the same shared master key
@@ -185,11 +191,11 @@ projected bytes-to-rewrite before the operator confirms.
 Existing fleets are on shared-master-key model with `encrypted_file_key:
 Option<String>` (one wrap). Phased rollout:
 
-1. **Phase 0 (this PR's follow-on, additive only)**: real keypair generation
-   inside `cmd_device_enroll`. Persist secret to keychain. Publish public key
-   to the remote registry via the existing `sync_to_remote` path. No manifest
-   format change yet. Existing fleets keep working unchanged because the new
-   per-device key is unused at the wrap layer.
+1. **Phase 0 (started 2026-05-25, additive only)**: real keypair generation
+   inside local `tcfs init` and `tcfs device enroll`. Persist the secret half in
+   a protected file fallback for now; the keychain-backed store remains a
+   follow-up. No manifest format change yet. Existing fleets keep working
+   unchanged because the new per-device key is unused at the wrap layer.
 2. **Phase 1 (manifest schema v3)**: add `wrapped_file_keys:
    Vec<WrappedFileKey>` alongside the legacy `encrypted_file_key`. Push paths
    write both. Pull paths prefer `wrapped_file_keys` and fall back to the

--- a/docs/ops/tcfs-daily-driver-productionization-todo-2026-05-24.md
+++ b/docs/ops/tcfs-daily-driver-productionization-todo-2026-05-24.md
@@ -214,12 +214,26 @@ files.
 Why second: real self-enrollment and revocation are not product boundaries
 until devices have real local private keys and per-device wrapped content keys.
 
-- [ ] Replace placeholder CLI enrollment public keys with real X25519 keys.
-- [ ] Persist device private keys in a platform-appropriate secret store or
-  explicitly protected fallback.
+- [x] Replace placeholder CLI enrollment public keys with real X25519 keys for
+  the local `tcfs init` and `tcfs device enroll` paths.
+- [x] Persist generated local device private keys in an explicitly protected
+  `0600` file fallback beside the device registry.
 - [ ] Add file-key wrapping per non-revoked device.
 - [ ] Prove a revoked device cannot decrypt new content.
 - [ ] Document migration from shared-master fleets.
+
+2026-05-25 Phase 0 cut:
+
+- [x] `tcfs-secrets::DeviceRegistry::enroll_local` generates a real
+  age/X25519 keypair and stores only the public `age1...` recipient in
+  `devices.json`.
+- [x] `tcfs init` writes `device-<device_id>.age` beside `devices.json` and
+  `tcfs init --check` rejects placeholder public keys or missing private-key
+  files.
+- [x] `tcfs device enroll` now uses the same local key-generation path instead
+  of `age1-device-<hash>` placeholders.
+- [ ] This does not yet change manifest wrapping, revoke semantics, pairing, or
+  remote registry trust. Those remain the actual beta security boundary.
 
 ### 7. `TIN-1424` Pairing/Admin-Gated Enrollment
 

--- a/docs/ops/tcfs-init-wizard-design-2026-05-18.md
+++ b/docs/ops/tcfs-init-wizard-design-2026-05-18.md
@@ -95,6 +95,9 @@ These calls resolve the open questions for the first implementation slice:
    for single-operator setup, but invite/join verification must stay blocked
    until TIN-1417/TIN-1424 provide real per-device public keys, full invite
    payload signatures, and no raw long-lived storage secrets in invites.
+   2026-05-25 update: the local `tcfs init` and `tcfs device enroll` paths now
+   generate real age/X25519 device keys; invite/join remains blocked on the
+   rest of TIN-1417/TIN-1424.
 3. **Use an inline macOS sheet, backed by Rust-owned state.** Do not shell out
    to Terminal for the primary Mac path. The Swift host app should render the
    form, but validators, config rendering, and final verification stay in the
@@ -187,11 +190,9 @@ own its own copy of the prompt sequence.
    "join existing fleet via invite", or do we split into `tcfs init` (new) and
    `tcfs enroll <invite>` (join)? The latter is easier to document and harder
    to misuse, but doubles the surface the postinstall hook has to nudge toward.
-2. **TIN-1417 ordering.** If per-device pubkey work (TIN-1417) has not landed
-   when TIN-1425 ships, do we fall back to the current
-   `format!("age1-device-{}", blake3_short(name))` placeholder
-   (`crates/tcfs-cli/src/main.rs:2872`) with a `TODO(TIN-1417)` comment, or
-   block the wizard's "verify" step until real pubkeys exist?
+2. **TIN-1417 ordering.** Local real device keys have landed for fresh setup.
+   The remaining ordering question is invite/join verification: keep that path
+   blocked until per-device wrapping and pairing/admin gates are in place.
 3. **macOS host-app inline vs. terminal hand-off.** Should the first-run sheet
    in `TCFSProviderApp` render the prompts itself (SwiftUI form, full control
    over UX) or shell out to `Terminal.app` running `tcfs init` (one source of


### PR DESCRIPTION
## Summary
- replace local placeholder device public keys with real age/X25519 keypair generation for `tcfs init` and `tcfs device enroll`
- persist local device private keys as owner-only `device-<device_id>.age` files beside `devices.json`
- make `tcfs init --check` reject placeholder public keys or missing local private-key files for the configured/single local device
- reuse the same helper in daemon auto-enrollment and document the Phase 0 boundary

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p tcfs-cli init`
- `cargo test -p tcfs-secrets device`
- `cargo test -p tcfsd`
- `cargo build -p tcfs-cli -p tcfsd`
- `bash scripts/install-smoke.sh --tcfs target/debug/tcfs --tcfsd target/debug/tcfsd --expected-version 0.12.13`
- `bash scripts/test-install-smoke.sh`
- real-key smoke: `tcfs init` wrote a parseable `age1...` public key and a `0600` `device-<uuid>.age` file
- `cargo clippy -p tcfs-secrets -p tcfs-cli -p tcfsd --all-targets` (passes with existing warnings in `cmd_init` arg count and two grpc needless borrows)

## Claim boundary
This is TIN-1417 Phase 0 only. It does not implement per-device manifest wrapping, revoke-denies-new-content semantics, pairing/admin-gated enrollment, remote registry signing, or migration from shared-master fleets.
