### PR TITLE
auth: make enrollment invites single-use (TIN-1424)

### DIFF
--- a/crates/tcfs-auth/src/enrollment.rs
+++ b/crates/tcfs-auth/src/enrollment.rs
@@ -18,6 +18,10 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::RwLock;
 
 use crate::session::DevicePermissions;
 
@@ -383,6 +387,112 @@ pub struct EnrollmentResult {
     pub available_auth_methods: Vec<String>,
 }
 
+/// Audit record for an invite that has already been redeemed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InviteRedemption {
+    /// Redeemed invite ID.
+    pub invite_id: String,
+    /// Redeemed invite nonce.
+    pub nonce: String,
+    /// UTC timestamp when the daemon accepted the redemption.
+    pub redeemed_at: DateTime<Utc>,
+    /// Device name requested during redemption.
+    pub device_name: String,
+    /// Device public key presented during redemption.
+    pub public_key: String,
+    /// Device platform presented during redemption.
+    pub platform: String,
+}
+
+#[derive(Debug, Error)]
+pub enum InviteRedemptionError {
+    #[error("invite {invite_id} has already been redeemed")]
+    AlreadyRedeemed { invite_id: String },
+}
+
+/// Thread-safe single-use invite redemption ledger.
+///
+/// The key is `(invite_id, nonce)` so a malicious client cannot replay an
+/// otherwise valid invite payload after the first successful enrollment.
+#[derive(Clone, Default)]
+pub struct InviteRedemptionStore {
+    redemptions: Arc<RwLock<HashMap<String, InviteRedemption>>>,
+}
+
+impl InviteRedemptionStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn key(invite_id: &str, nonce: &str) -> String {
+        format!("{invite_id}:{nonce}")
+    }
+
+    /// Claim an invite nonce. Returns an error if it has already been used.
+    pub async fn claim(
+        &self,
+        invite_id: &str,
+        nonce: &str,
+        device_name: &str,
+        public_key: &str,
+        platform: &str,
+    ) -> Result<InviteRedemption, InviteRedemptionError> {
+        let key = Self::key(invite_id, nonce);
+        let mut redemptions = self.redemptions.write().await;
+        if redemptions.contains_key(&key) {
+            return Err(InviteRedemptionError::AlreadyRedeemed {
+                invite_id: invite_id.to_string(),
+            });
+        }
+
+        let redemption = InviteRedemption {
+            invite_id: invite_id.to_string(),
+            nonce: nonce.to_string(),
+            redeemed_at: Utc::now(),
+            device_name: device_name.to_string(),
+            public_key: public_key.to_string(),
+            platform: platform.to_string(),
+        };
+        redemptions.insert(key, redemption.clone());
+        Ok(redemption)
+    }
+
+    pub async fn is_redeemed(&self, invite_id: &str, nonce: &str) -> bool {
+        self.redemptions
+            .read()
+            .await
+            .contains_key(&Self::key(invite_id, nonce))
+    }
+
+    pub async fn count(&self) -> usize {
+        self.redemptions.read().await.len()
+    }
+
+    pub async fn save_to_file(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        let redemptions = self.redemptions.read().await;
+        let data = serde_json::to_string_pretty(&*redemptions)?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(path, data).await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(())
+    }
+
+    pub async fn load_from_file(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        let data = tokio::fs::read_to_string(path).await?;
+        let loaded: HashMap<String, InviteRedemption> = serde_json::from_str(&data)?;
+        let mut redemptions = self.redemptions.write().await;
+        redemptions.clear();
+        redemptions.extend(loaded);
+        Ok(())
+    }
+}
+
 // Need hex for nonce encoding
 mod hex {
     pub fn encode(bytes: impl AsRef<[u8]>) -> String {
@@ -562,5 +672,75 @@ mod tests {
         let mut tampered_permissions = invite.clone();
         tampered_permissions.permissions.can_admin = false;
         assert!(!tampered_permissions.verify_signature(&master_key));
+    }
+
+    #[tokio::test]
+    async fn test_invite_redemption_store_rejects_reuse() {
+        let master_key = [42u8; 32];
+        let invite = EnrollmentInvite::new(
+            "admin-device",
+            &master_key,
+            24,
+            DevicePermissions::default(),
+        );
+        let store = InviteRedemptionStore::new();
+
+        let first = store
+            .claim(
+                &invite.invite_id,
+                &invite.nonce,
+                "laptop",
+                "age1test",
+                "linux-x86_64",
+            )
+            .await;
+        assert!(first.is_ok());
+        assert!(store.is_redeemed(&invite.invite_id, &invite.nonce).await);
+
+        let second = store
+            .claim(
+                &invite.invite_id,
+                &invite.nonce,
+                "tablet",
+                "age1other",
+                "ios",
+            )
+            .await;
+        assert!(matches!(
+            second,
+            Err(InviteRedemptionError::AlreadyRedeemed { .. })
+        ));
+        assert_eq!(store.count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_invite_redemption_store_save_load_roundtrip() {
+        let master_key = [42u8; 32];
+        let invite = EnrollmentInvite::new(
+            "admin-device",
+            &master_key,
+            24,
+            DevicePermissions::default(),
+        );
+        let store = InviteRedemptionStore::new();
+        store
+            .claim(
+                &invite.invite_id,
+                &invite.nonce,
+                "laptop",
+                "age1test",
+                "linux-x86_64",
+            )
+            .await
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("invite-redemptions.json");
+        store.save_to_file(&path).await.unwrap();
+
+        let loaded = InviteRedemptionStore::new();
+        loaded.load_from_file(&path).await.unwrap();
+        assert!(loaded.is_redeemed(&invite.invite_id, &invite.nonce).await);
+        assert_eq!(loaded.count().await, 1);
     }
 }

--- a/crates/tcfs-auth/src/lib.rs
+++ b/crates/tcfs-auth/src/lib.rs
@@ -37,6 +37,9 @@ pub mod pam;
 pub mod certificate;
 
 // Re-exports
-pub use enrollment::{EnrollmentInvite, EnrollmentRequest, EnrollmentResult};
+pub use enrollment::{
+    EnrollmentInvite, EnrollmentRequest, EnrollmentResult, InviteRedemption, InviteRedemptionError,
+    InviteRedemptionStore,
+};
 pub use provider::{AuthChallenge, AuthProvider, AuthResponse, VerifyResult};
 pub use session::{DevicePermissions, RateLimitConfig, RateLimiter, Session, SessionStore};

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -919,6 +919,12 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             warn!("failed to load sessions: {e}");
         }
     }
+    let invite_redemption_path = data_dir.join("invite-redemptions.json");
+    if invite_redemption_path.exists() {
+        if let Err(e) = impl_.load_invite_redemptions(&invite_redemption_path).await {
+            warn!("failed to load invite redemptions: {e}");
+        }
+    }
 
     // Connect to NATS for fleet state sync (non-blocking, best-effort)
     let nats_url = &config.sync.nats_url;

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -34,12 +34,14 @@ pub struct TcfsDaemonImpl {
     nats: Arc<TokioMutex<Option<tcfs_sync::NatsClient>>>,
     active_mounts: Arc<TokioMutex<std::collections::HashMap<String, tokio::process::Child>>>,
     path_locks: tcfs_sync::state::PathLocks,
+    data_dir: std::path::PathBuf,
     /// VFS handle from active FUSE mount — used to invalidate negative cache
     /// on NATS events so remote files appear in readdir immediately.
     pub vfs_handle: tokio::sync::watch::Receiver<Option<std::sync::Arc<tcfs_vfs::TcfsVfs>>>,
     vfs_tx: tokio::sync::watch::Sender<Option<std::sync::Arc<tcfs_vfs::TcfsVfs>>>,
     // Auth infrastructure
     session_store: tcfs_auth::SessionStore,
+    invite_redemptions: tcfs_auth::InviteRedemptionStore,
     totp_provider: Arc<tcfs_auth::totp::TotpProvider>,
     webauthn_provider: Arc<tcfs_auth::webauthn::WebAuthnProvider>,
     rate_limiter: tcfs_auth::RateLimiter,
@@ -172,6 +174,8 @@ impl TcfsDaemonImpl {
             backoff_multiplier: config.auth.rate_limit.backoff_multiplier,
         });
 
+        let data_dir = dirs::data_dir().unwrap_or_default().join("tcfsd");
+
         Self {
             cred_store,
             config,
@@ -182,6 +186,7 @@ impl TcfsDaemonImpl {
             operator,
             device_id,
             device_name,
+            data_dir,
             master_key: Arc::new(TokioMutex::new(master_key)),
             nats_ok: std::sync::atomic::AtomicBool::new(false),
             nats: Arc::new(TokioMutex::new(None)),
@@ -190,6 +195,7 @@ impl TcfsDaemonImpl {
             vfs_handle: vfs_rx,
             vfs_tx,
             session_store: tcfs_auth::SessionStore::new(),
+            invite_redemptions: tcfs_auth::InviteRedemptionStore::new(),
             totp_provider,
             webauthn_provider,
             rate_limiter,
@@ -199,6 +205,12 @@ impl TcfsDaemonImpl {
     /// Get a clone of the session store (for background tasks).
     pub fn session_store(&self) -> tcfs_auth::SessionStore {
         self.session_store.clone()
+    }
+
+    #[cfg(test)]
+    fn with_data_dir(mut self, data_dir: std::path::PathBuf) -> Self {
+        self.data_dir = data_dir;
+        self
     }
 
     /// Load persisted TOTP credentials from disk.
@@ -211,14 +223,23 @@ impl TcfsDaemonImpl {
         self.session_store.load_from_file(path).await
     }
 
+    /// Load persisted invite redemptions from disk.
+    pub async fn load_invite_redemptions(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        self.invite_redemptions.load_from_file(path).await
+    }
+
     /// Save sessions to disk (called after session changes).
     async fn persist_sessions(&self) {
-        let path = dirs::data_dir()
-            .unwrap_or_default()
-            .join("tcfsd/sessions.json");
+        let path = self.data_dir.join("sessions.json");
         if let Err(e) = self.session_store.save_to_file(&path).await {
             tracing::warn!("failed to persist sessions: {e}");
         }
+    }
+
+    /// Save invite redemptions to disk (called after successful invite use).
+    async fn persist_invite_redemptions(&self) -> anyhow::Result<()> {
+        let path = self.data_dir.join("invite-redemptions.json");
+        self.invite_redemptions.save_to_file(&path).await
     }
 
     /// Validate a session token from gRPC request metadata.
@@ -2287,7 +2308,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
         info!(device_name = %req.device_name, platform = %req.platform, "device enroll requested");
 
         // Decode and validate the enrollment invite
-        let invite = tcfs_auth::EnrollmentInvite::decode(&req.invite_data)
+        let invite = tcfs_auth::EnrollmentInvite::decode_any(&req.invite_data)
             .map_err(|e| tonic::Status::invalid_argument(format!("invalid invite: {e}")))?;
 
         if invite.is_expired() {
@@ -2313,6 +2334,34 @@ impl TcfsDaemon for TcfsDaemonImpl {
             return Err(tonic::Status::failed_precondition(
                 "daemon master key not loaded — cannot verify invite signature",
             ));
+        }
+
+        match self
+            .invite_redemptions
+            .claim(
+                &invite.invite_id,
+                &invite.nonce,
+                &req.device_name,
+                &req.public_key,
+                &req.platform,
+            )
+            .await
+        {
+            Ok(_) => {
+                if let Err(e) = self.persist_invite_redemptions().await {
+                    tracing::warn!(error = %e, invite_id = %invite.invite_id, "failed to persist invite redemption");
+                    return Err(tonic::Status::internal(
+                        "failed to persist invite redemption state",
+                    ));
+                }
+            }
+            Err(tcfs_auth::InviteRedemptionError::AlreadyRedeemed { .. }) => {
+                return Ok(tonic::Response::new(DeviceEnrollResponse {
+                    success: false,
+                    error: "invite has already been redeemed".into(),
+                    ..Default::default()
+                }));
+            }
         }
 
         // Enroll device in the local registry
@@ -2506,7 +2555,10 @@ mod tests {
     use tower::service_fn;
 
     /// Build a TcfsDaemonImpl with in-memory components for testing.
-    fn test_daemon_with_operator(operator_value: Option<Operator>) -> TcfsDaemonImpl {
+    fn test_daemon_with_operator_and_master(
+        operator_value: Option<Operator>,
+        master_key: Option<tcfs_crypto::MasterKey>,
+    ) -> TcfsDaemonImpl {
         let mut config = TcfsConfig::default();
         config.auth.require_session = false;
         config.storage.bucket = "data".into();
@@ -2530,8 +2582,12 @@ mod tests {
             tcfs_sync::state::PathLocks::new(),
             "test-device-id".into(),
             "test-device".into(),
-            None,
+            master_key,
         )
+    }
+
+    fn test_daemon_with_operator(operator_value: Option<Operator>) -> TcfsDaemonImpl {
+        test_daemon_with_operator_and_master(operator_value, None)
     }
 
     fn test_daemon() -> TcfsDaemonImpl {
@@ -2727,6 +2783,52 @@ mod tests {
 
         assert!(!resp.success);
         assert!(resp.error.contains("must be"));
+    }
+
+    #[tokio::test]
+    async fn device_enroll_rejects_reused_invite() {
+        let key_bytes = [0xA5; tcfs_crypto::KEY_SIZE];
+        let signing_key: [u8; 32] = *blake3::hash(&key_bytes).as_bytes();
+        let temp = tempfile::tempdir().unwrap();
+        let daemon = test_daemon_with_operator_and_master(
+            None,
+            Some(tcfs_crypto::MasterKey::from_bytes(key_bytes)),
+        )
+        .with_data_dir(temp.path().join("tcfsd"));
+
+        let mut invite = tcfs_auth::EnrollmentInvite::new(
+            "admin-device",
+            &signing_key,
+            24,
+            tcfs_auth::DevicePermissions::default(),
+        );
+        invite.storage_endpoint = Some("https://s3.example.invalid".into());
+        invite.storage_bucket = Some("tcfs".into());
+        invite.refresh_signature(&signing_key);
+        let invite_data = invite.encode_compact().unwrap();
+
+        let req = DeviceEnrollRequest {
+            invite_data: invite_data.clone(),
+            device_name: "new-laptop".into(),
+            public_key: "age1testdevice".into(),
+            platform: "linux-x86_64".into(),
+        };
+
+        let first = daemon
+            .device_enroll(tonic::Request::new(req.clone()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(first.success, "first enrollment failed: {}", first.error);
+        assert!(temp.path().join("tcfsd/invite-redemptions.json").exists());
+
+        let second = daemon
+            .device_enroll(tonic::Request::new(req))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!second.success);
+        assert!(second.error.contains("already been redeemed"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add a persisted `InviteRedemptionStore` in `tcfs-auth`
- load and persist `invite-redemptions.json` from `tcfsd`
- reject replayed `device_enroll` invites before returning brokered credentials
- accept compact invite payloads in the daemon enrollment RPC path

## Evidence
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p tcfs-auth`
- `cargo test -p tcfsd device_enroll_rejects_reused_invite`
- `cargo clippy -p tcfs-auth -p tcfsd --all-targets` passes with the two known pre-existing `tcfsd` needless-borrow warnings

## Boundary
This is TIN-1424 Phase 1 only: invite replay is now blocked by daemon-local persisted redemption state. It does not yet remove raw brokered storage credentials from invite payloads, implement admin session approval, wrap bootstrap material to the recipient device key, or make revocation deny new content.
