### PR TITLE
smoke: seed storage-backed first-run config (TIN-1425)

### DIFF
--- a/.github/workflows/nix-profile-install-smoke.yml
+++ b/.github/workflows/nix-profile-install-smoke.yml
@@ -21,6 +21,21 @@ on:
         required: true
         default: "ubuntu-24.04"
         type: string
+      require_storage_ok:
+        description: "Require installed tcfs status to report storage [ok]"
+        required: true
+        default: false
+        type: boolean
+      smoke_environment:
+        description: "Environment containing TCFS_SMOKE_* storage secrets"
+        required: true
+        default: "tcfs-storage-prod-smoke"
+        type: string
+      remote_prefix:
+        description: "Optional storage prefix override for --require-storage-ok"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -34,10 +49,62 @@ jobs:
     name: Nix profile install smoke
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 60
+    environment: ${{ github.event.inputs.smoke_environment }}
+    env:
+      TCFS_SMOKE_S3_ENDPOINT: ${{ secrets.TCFS_SMOKE_S3_ENDPOINT }}
+      TCFS_SMOKE_S3_BUCKET: ${{ secrets.TCFS_SMOKE_S3_BUCKET }}
+      TCFS_SMOKE_S3_ACCESS_KEY_ID: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
+      TCFS_SMOKE_S3_SECRET_ACCESS_KEY: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
+      TCFS_SMOKE_S3_REGION: ${{ secrets.TCFS_SMOKE_S3_REGION }}
+      TCFS_SMOKE_S3_CA_CERT_PEM: ${{ secrets.TCFS_SMOKE_S3_CA_CERT_PEM }}
+      TCFS_S3_ACCESS: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
+      TCFS_S3_SECRET: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TCFS_SMOKE_S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TCFS_SMOKE_S3_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+
+      - name: Prepare smoke metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          REF="${{ github.event.inputs.ref }}"
+          RUNNER_LABEL="${{ github.event.inputs.runner_label }}"
+          SAFE_REF="$(printf '%s' "$REF" | tr -c 'A-Za-z0-9._-' '-')"
+          SAFE_RUNNER_LABEL="$(printf '%s' "$RUNNER_LABEL" | tr -c 'A-Za-z0-9._-' '-')"
+          echo "TCFS_NIX_SMOKE_ARTIFACT_NAME=nix-profile-install-smoke-${SAFE_REF}-${SAFE_RUNNER_LABEL}" >> "$GITHUB_ENV"
+
+      - name: Validate storage smoke inputs
+        if: ${{ github.event.inputs.require_storage_ok == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            TCFS_SMOKE_S3_ENDPOINT \
+            TCFS_SMOKE_S3_BUCKET \
+            TCFS_SMOKE_S3_ACCESS_KEY_ID \
+            TCFS_SMOKE_S3_SECRET_ACCESS_KEY
+          do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required storage smoke secrets: ${missing[*]}"
+            exit 1
+          fi
+
+          REMOTE_PREFIX="${{ github.event.inputs.remote_prefix }}"
+          if [[ -z "$REMOTE_PREFIX" ]]; then
+            REMOTE_PREFIX="gha/storage-posture/nix-profile/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          fi
+          if [[ "$REMOTE_PREFIX" != gha/storage-posture/* ]]; then
+            echo "::error::remote_prefix must stay under gha/storage-posture/ for scoped production-smoke credentials"
+            exit 1
+          fi
+
+          echo "TCFS_SMOKE_REMOTE_PREFIX=$REMOTE_PREFIX" >> "$GITHUB_ENV"
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -84,11 +151,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          args=(
+            --expected-version "${{ github.event.inputs.binary_expected_version }}"
+            --tcfs "$TCFS_NIX_PROFILE/bin/tcfs"
+            --tcfsd "$TCFS_NIX_PROFILE/bin/tcfsd"
+          )
+          if [[ "${{ github.event.inputs.require_storage_ok }}" == "true" ]]; then
+            args+=(--require-storage-ok)
+          fi
           env PATH="$TCFS_NIX_PROFILE/bin:$PATH" \
-            bash scripts/install-smoke.sh \
-              --expected-version "${{ github.event.inputs.binary_expected_version }}" \
-              --tcfs "$TCFS_NIX_PROFILE/bin/tcfs" \
-              --tcfsd "$TCFS_NIX_PROFILE/bin/tcfsd" \
+            bash scripts/install-smoke.sh "${args[@]}" \
             2>&1 | tee "$TCFS_NIX_SMOKE_LOG_DIR/install-smoke.log"
 
       - name: Capture diagnostics
@@ -110,6 +182,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nix-profile-install-smoke-${{ github.event.inputs.ref }}-${{ github.event.inputs.runner_label }}
+          name: ${{ env.TCFS_NIX_SMOKE_ARTIFACT_NAME }}
           path: ${{ runner.temp }}/nix-profile-install-smoke
           if-no-files-found: warn

--- a/scripts/install-smoke.sh
+++ b/scripts/install-smoke.sh
@@ -93,6 +93,11 @@ assert_version() {
 }
 
 write_daemon_only_config() {
+  if [[ "$REQUIRE_STORAGE_OK" -eq 1 ]]; then
+    write_storage_backed_config "$CONFIG_PATH" false
+    return
+  fi
+
   cat >"$CONFIG_PATH" <<EOF
 [daemon]
 socket = "$SOCKET_PATH"
@@ -109,6 +114,92 @@ state_db = "$STATE_DIR/tcfsd/state.db"
 enabled = false
 EOF
   chmod 600 "$CONFIG_PATH" 2>/dev/null || true
+}
+
+storage_env() {
+  local install_var="TCFS_INSTALL_SMOKE_$1"
+  local smoke_var="TCFS_SMOKE_$1"
+  local tcfs_var="TCFS_$1"
+  local default="${2:-}"
+
+  if [[ -n "${!install_var:-}" ]]; then
+    printf '%s\n' "${!install_var}"
+  elif [[ -n "${!smoke_var:-}" ]]; then
+    printf '%s\n' "${!smoke_var}"
+  elif [[ -n "${!tcfs_var:-}" ]]; then
+    printf '%s\n' "${!tcfs_var}"
+  else
+    printf '%s\n' "$default"
+  fi
+}
+
+toml_string() {
+  python3 - "$1" <<'PY'
+import sys
+print('"' + sys.argv[1].replace('\\', '\\\\').replace('"', '\\"') + '"')
+PY
+}
+
+write_storage_backed_config() {
+  local output_path="$1"
+  local crypto_enabled="$2"
+  local endpoint bucket region remote_prefix enforce_tls ca_cert_path ca_cert_pem
+
+  endpoint="$(storage_env S3_ENDPOINT "http://localhost:8333")"
+  bucket="$(storage_env S3_BUCKET "tcfs")"
+  region="$(storage_env S3_REGION "us-east-1")"
+  remote_prefix="$(storage_env REMOTE_PREFIX "")"
+  if [[ -z "$remote_prefix" ]]; then
+    remote_prefix="$(storage_env S3_REMOTE_PREFIX "")"
+  fi
+  ca_cert_path="$(storage_env S3_CA_CERT_PATH "")"
+  ca_cert_pem="$(storage_env S3_CA_CERT_PEM "")"
+  enforce_tls="$(storage_env S3_ENFORCE_TLS "")"
+
+  if [[ -z "$ca_cert_path" && -n "$ca_cert_pem" ]]; then
+    ca_cert_path="$TMP_DIR/storage-ca.pem"
+    printf '%s\n' "$ca_cert_pem" >"$ca_cert_path"
+    chmod 600 "$ca_cert_path" 2>/dev/null || true
+  fi
+
+  if [[ -z "$enforce_tls" ]]; then
+    case "$endpoint" in
+      https://*) enforce_tls="true" ;;
+      *) enforce_tls="false" ;;
+    esac
+  else
+    enforce_tls="$(printf '%s\n' "$enforce_tls" | tr '[:upper:]' '[:lower:]')"
+    case "$enforce_tls" in
+      true|1|yes) enforce_tls="true" ;;
+      false|0|no) enforce_tls="false" ;;
+      *)
+        echo "invalid storage TLS flag for install smoke: $enforce_tls" >&2
+        exit 2
+        ;;
+    esac
+  fi
+
+  {
+    printf '[daemon]\n'
+    printf 'socket = %s\n\n' "$(toml_string "$SOCKET_PATH")"
+    printf '[storage]\n'
+    printf 'endpoint = %s\n' "$(toml_string "$endpoint")"
+    printf 'region = %s\n' "$(toml_string "$region")"
+    printf 'bucket = %s\n' "$(toml_string "$bucket")"
+    printf 'enforce_tls = %s\n' "$enforce_tls"
+    if [[ -n "$remote_prefix" ]]; then
+      printf 'remote_prefix = %s\n' "$(toml_string "$remote_prefix")"
+    fi
+    if [[ -n "$ca_cert_path" ]]; then
+      printf 'ca_cert_path = %s\n' "$(toml_string "$ca_cert_path")"
+    fi
+    printf '\n[sync]\n'
+    printf 'state_db = %s\n\n' "$(toml_string "$STATE_DIR/tcfsd/state.db")"
+    printf '[crypto]\n'
+    printf 'enabled = %s\n' "$crypto_enabled"
+  } >"$output_path"
+
+  chmod 600 "$output_path" 2>/dev/null || true
 }
 
 tcfs_supports_init_config_out() {
@@ -207,6 +298,10 @@ if [[ "$SKIP_CLI" -eq 0 ]]; then
   TCFS_PATH="$(resolve_bin "$TCFS_BIN")"
   assert_version "tcfs" "$TCFS_PATH"
   if tcfs_supports_init_config_out; then
+    if [[ "$REQUIRE_STORAGE_OK" -eq 1 ]]; then
+      echo "writing storage-backed init base config: $INIT_BASE_CONFIG"
+      write_storage_backed_config "$INIT_BASE_CONFIG" true
+    fi
     echo "initializing first-run config: $CONFIG_PATH"
     TCFS_MASTER_PASSWORD="tcfs-install-smoke-passphrase" \
       "$TCFS_PATH" --config "$INIT_BASE_CONFIG" init \

--- a/scripts/test-install-smoke.sh
+++ b/scripts/test-install-smoke.sh
@@ -46,7 +46,10 @@ if [[ "${1:-}" == "--version" ]]; then
   exit 0
 fi
 
+base_config=""
 if [[ "${1:-}" == "--config" ]]; then
+  base_config="$2"
+  printf 'tcfs base-config:%s\n' "$base_config" >>"$log"
   shift 2
 fi
 
@@ -95,6 +98,11 @@ case "${1:-}" in
       exit 0
     fi
     mkdir -p "$config_dir"
+    if [[ -n "$base_config" && -f "$base_config" ]]; then
+      printf 'tcfs base-config-content-begin\n' >>"$log"
+      cat "$base_config" >>"$log"
+      printf '\ntcfs base-config-content-end\n' >>"$log"
+    fi
     printf '0123456789abcdef0123456789abcdef' >"$config_dir/master.key"
     printf '{"devices":[{"name":"install-smoke"}]}\n' >"$config_dir/devices.json"
     cat >"$config_out" <<CONFIG
@@ -112,7 +120,7 @@ CONFIG
     echo "tcfs initialized successfully."
     ;;
   status)
-    if [[ -n "${AWS_ACCESS_KEY_ID:-}${AWS_SECRET_ACCESS_KEY:-}${TCFS_S3_ACCESS:-}${TCFS_S3_SECRET:-}${SEAWEED_ACCESS_KEY:-}${SEAWEED_SECRET_KEY:-}" ]]; then
+    if [[ -z "${FAKE_ALLOW_STORAGE_ENV:-}" && -n "${AWS_ACCESS_KEY_ID:-}${AWS_SECRET_ACCESS_KEY:-}${TCFS_S3_ACCESS:-}${TCFS_S3_SECRET:-}${SEAWEED_ACCESS_KEY:-}${SEAWEED_SECRET_KEY:-}" ]]; then
       printf 'ambient credentials leaked into tcfs status\n' >>"$env_log"
     fi
     echo "tcfsd v0.12.13"
@@ -139,7 +147,7 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 
 env_log="${FAKE_TCFSD_ENV_LOG:?set FAKE_TCFSD_ENV_LOG}"
-if [[ -n "${AWS_ACCESS_KEY_ID:-}${AWS_SECRET_ACCESS_KEY:-}${TCFS_S3_ACCESS:-}${TCFS_S3_SECRET:-}${SEAWEED_ACCESS_KEY:-}${SEAWEED_SECRET_KEY:-}" ]]; then
+if [[ -z "${FAKE_ALLOW_STORAGE_ENV:-}" && -n "${AWS_ACCESS_KEY_ID:-}${AWS_SECRET_ACCESS_KEY:-}${TCFS_S3_ACCESS:-}${TCFS_S3_SECRET:-}${SEAWEED_ACCESS_KEY:-}${SEAWEED_SECRET_KEY:-}" ]]; then
   printf 'ambient credentials leaked into tcfsd\n' >>"$env_log"
 fi
 
@@ -239,6 +247,37 @@ assert_contains "$FAKE_TCFS_LOG" " init --check --config-out "
 assert_not_contains "$FAKE_TCFS_ENV_LOG" "ambient credentials leaked"
 assert_not_contains "$FAKE_TCFSD_ENV_LOG" "ambient credentials leaked"
 assert_not_contains "$CLI_OUT" "missing-config.toml"
+
+STORAGE_OUT="$TMPDIR/storage.out"
+: >"$FAKE_TCFSD_ENV_LOG"
+: >"$FAKE_TCFS_ENV_LOG"
+: >"$FAKE_TCFS_LOG"
+FAKE_ALLOW_STORAGE_ENV=1 \
+TCFS_SMOKE_S3_ENDPOINT="https://storage.example.invalid" \
+TCFS_SMOKE_S3_BUCKET="tcfs-smoke" \
+TCFS_SMOKE_S3_REGION="us-west-2" \
+TCFS_SMOKE_REMOTE_PREFIX="gha/install-smoke/test" \
+TCFS_SMOKE_S3_CA_CERT_PEM="-----BEGIN CERTIFICATE-----
+fake-ca
+-----END CERTIFICATE-----" \
+bash "$SCRIPT" \
+  --tcfs "$FAKE_TCFS" \
+  --tcfsd "$FAKE_TCFSD" \
+  --expected-version 0.12.13 \
+  --require-storage-ok \
+  >"$STORAGE_OUT" 2>&1
+
+assert_contains "$STORAGE_OUT" "writing storage-backed init base config:"
+assert_contains "$STORAGE_OUT" "initializing first-run config:"
+assert_contains "$STORAGE_OUT" "storage: [ok]"
+assert_contains "$FAKE_TCFS_LOG" "tcfs base-config-content-begin"
+assert_contains "$FAKE_TCFS_LOG" 'endpoint = "https://storage.example.invalid"'
+assert_contains "$FAKE_TCFS_LOG" 'bucket = "tcfs-smoke"'
+assert_contains "$FAKE_TCFS_LOG" 'remote_prefix = "gha/install-smoke/test"'
+assert_contains "$FAKE_TCFS_LOG" "enforce_tls = true"
+assert_contains "$FAKE_TCFS_LOG" "ca_cert_path = "
+assert_not_contains "$FAKE_TCFS_ENV_LOG" "ambient credentials leaked"
+assert_not_contains "$FAKE_TCFSD_ENV_LOG" "ambient credentials leaked"
 
 LEGACY_OUT="$TMPDIR/legacy.out"
 FAKE_TCFS_INIT_CONFIG_OUT=0 bash "$SCRIPT" \


### PR DESCRIPTION
## Summary
- teach `scripts/install-smoke.sh --require-storage-ok` to seed `tcfs init` from live storage env instead of a missing base config
- render endpoint, bucket, region, remote prefix, TLS enforcement, and optional CA PEM/path into the init base config
- keep the default install smoke credential-scrubbed; storage env is only preserved for `--require-storage-ok`
- extend `scripts/test-install-smoke.sh` with a fake installed-binary proof for storage-backed first-run config
- add Nix profile workflow dispatch inputs for `require_storage_ok`, scoped storage environment, and guarded remote prefix so this can produce a live first-run packet

## Evidence
- `bash scripts/test-install-smoke.sh`
- `bash -n scripts/install-smoke.sh`
- `bash -n scripts/test-install-smoke.sh`
- `ruby -ryaml -e 'YAML.load_file(ARGV.fetch(0)); puts "ok"' .github/workflows/nix-profile-install-smoke.yml`
- `git diff --check`

## Boundary
This enables package/profile smoke lanes to prove storage-backed first-run without hand-writing config. It does not itself dispatch a live Homebrew/Nix/package storage smoke, and it does not close the full first-run wizard UX for GUI, invite join, or systemd/LaunchAgent handoff.
