### PR TITLE
cli: emit FileProvider init config (TIN-1425)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -17,6 +17,7 @@ use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use secrecy::ExposeSecret;
 use serde::Serialize;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
@@ -179,6 +180,9 @@ enum Commands {
         /// Config path to write/check (default: ~/.config/tcfs/config.toml)
         #[arg(long)]
         config_out: Option<PathBuf>,
+        /// Optional FileProvider bootstrap JSON path to write for macOS HostApp provisioning
+        #[arg(long)]
+        fileprovider_config_out: Option<PathBuf>,
         /// Non-interactive mode (use with --password)
         #[arg(long)]
         non_interactive: bool,
@@ -631,18 +635,22 @@ async fn main() -> Result<()> {
             skip_config,
             force_config,
             config_out,
+            fileprovider_config_out,
             non_interactive,
             password,
         } => {
             cmd_init(
                 &config,
-                device_name,
-                check,
-                skip_config,
-                force_config,
-                config_out.as_deref(),
-                non_interactive,
-                password,
+                InitOptions {
+                    device_name,
+                    check,
+                    skip_config,
+                    force_config,
+                    config_out: config_out.as_deref(),
+                    fileprovider_config_out: fileprovider_config_out.as_deref(),
+                    non_interactive,
+                    password,
+                },
             )
             .await
         }
@@ -3187,16 +3195,30 @@ fn print_dirty_unsync_paths(root: &std::path::Path, dirty: &[DirtyUnsyncPath]) {
 
 // ── `tcfs init` ──────────────────────────────────────────────────────────────
 
-async fn cmd_init(
-    config: &tcfs_core::config::TcfsConfig,
+#[derive(Debug)]
+struct InitOptions<'a> {
     device_name: Option<String>,
     check: bool,
     skip_config: bool,
     force_config: bool,
-    config_out: Option<&Path>,
+    config_out: Option<&'a Path>,
+    fileprovider_config_out: Option<&'a Path>,
     non_interactive: bool,
     password: Option<String>,
-) -> Result<()> {
+}
+
+async fn cmd_init(config: &tcfs_core::config::TcfsConfig, options: InitOptions<'_>) -> Result<()> {
+    let InitOptions {
+        device_name,
+        check,
+        skip_config,
+        force_config,
+        config_out,
+        fileprovider_config_out,
+        non_interactive,
+        password,
+    } = options;
+
     let device_name = device_name.unwrap_or_else(tcfs_secrets::device::default_device_name);
     let init_paths = InitPaths::resolve(config_out);
     let config_path = init_paths.config_path.clone();
@@ -3297,9 +3319,19 @@ async fn cmd_init(
     tcfs_secrets::device::save_device_secret_key(&device_key_path, &device_key.secret_key, false)?;
     registry.save(&registry_path)?;
 
+    let init_config = build_init_config(config, &master_key_path, &registry_path, &device_name);
     if !skip_config {
-        let init_config = build_init_config(config, &master_key_path, &registry_path, &device_name);
         write_init_config(&config_path, &init_config, force_config)?;
+    }
+    if let Some(fileprovider_config_path) = fileprovider_config_out {
+        write_fileprovider_init_config(
+            fileprovider_config_path,
+            &init_config,
+            &master_key_path,
+            &device_id,
+            force_config,
+        )
+        .await?;
     }
 
     // Step 7: Print success message
@@ -3313,6 +3345,9 @@ async fn cmd_init(
     println!("  Registry:     {}", registry_path.display());
     if !skip_config {
         println!("  Config:       {}", config_path.display());
+    }
+    if let Some(fileprovider_config_path) = fileprovider_config_out {
+        println!("  FileProvider: {}", fileprovider_config_path.display());
     }
     println!();
     println!("Next steps:");
@@ -3495,6 +3530,166 @@ fn write_init_config(
         std::fs::set_permissions(config_path, std::fs::Permissions::from_mode(0o600))
             .with_context(|| format!("setting permissions on: {}", config_path.display()))?;
     }
+    Ok(())
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct FileProviderInitConfig {
+    s3_endpoint: String,
+    s3_bucket: String,
+    s3_access: String,
+    s3_secret: String,
+    remote_prefix: String,
+    device_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    daemon_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    daemon_socket: Option<String>,
+    master_key_file: String,
+}
+
+fn build_fileprovider_init_config(
+    config: &tcfs_core::config::TcfsConfig,
+    s3: &tcfs_secrets::S3Credentials,
+    master_key_path: &Path,
+    device_id: &str,
+) -> FileProviderInitConfig {
+    FileProviderInitConfig {
+        s3_endpoint: config.storage.endpoint.clone(),
+        s3_bucket: config.storage.bucket.clone(),
+        s3_access: s3.access_key_id.clone(),
+        s3_secret: s3.secret_access_key.expose_secret().to_string(),
+        remote_prefix: config.storage.resolved_prefix().to_string(),
+        device_id: device_id.to_string(),
+        daemon_endpoint: config.daemon.fileprovider_endpoint.clone(),
+        daemon_socket: config
+            .daemon
+            .fileprovider_socket
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned()),
+        master_key_file: master_key_path.to_string_lossy().into_owned(),
+    }
+}
+
+async fn write_fileprovider_init_config(
+    config_path: &Path,
+    config: &tcfs_core::config::TcfsConfig,
+    master_key_path: &Path,
+    device_id: &str,
+    force: bool,
+) -> Result<()> {
+    if config_path.exists() && !force {
+        anyhow::bail!(
+            "FileProvider config already exists: {}. Pass --force-config to overwrite it.",
+            config_path.display()
+        );
+    }
+    let cred_store = tcfs_secrets::CredStore::load(&config.secrets, &config.storage)
+        .await
+        .context("credential discovery failed for FileProvider init config")?;
+    let s3 = cred_store.s3.context(
+        "S3 credentials not found for FileProvider init config.\n\
+         Set TCFS_S3_ACCESS and TCFS_S3_SECRET environment variables,\n\
+         or configure storage.credentials_file in tcfs.toml,\n\
+         or use ~/.aws/credentials file.",
+    )?;
+    tracing::info!(source = %cred_store.source, "FileProvider init credentials loaded");
+
+    let rendered = serde_json::to_string_pretty(&build_fileprovider_init_config(
+        config,
+        &s3,
+        master_key_path,
+        device_id,
+    ))
+    .context("serializing FileProvider init config to JSON")?;
+    write_fileprovider_config_file(config_path, &rendered, force)
+}
+
+fn write_fileprovider_config_file(config_path: &Path, rendered: &str, force: bool) -> Result<()> {
+    if config_path.exists() && !force {
+        anyhow::bail!(
+            "FileProvider config already exists: {}. Pass --force-config to overwrite it.",
+            config_path.display()
+        );
+    }
+    if let Some(parent) = config_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating FileProvider config dir: {}", parent.display()))?;
+    }
+
+    let parent = config_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let filename = config_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config.json");
+    let temp_path = parent.join(format!(".{filename}.{}.tmp", std::process::id()));
+    let write_result = (|| -> Result<()> {
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        let mut file = options.open(&temp_path).with_context(|| {
+            format!(
+                "creating FileProvider config temp file: {}",
+                temp_path.display()
+            )
+        })?;
+        file.write_all(rendered.as_bytes()).with_context(|| {
+            format!(
+                "writing FileProvider config temp file: {}",
+                temp_path.display()
+            )
+        })?;
+        file.sync_all().with_context(|| {
+            format!(
+                "syncing FileProvider config temp file: {}",
+                temp_path.display()
+            )
+        })?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(error);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&temp_path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("setting permissions on: {}", temp_path.display()))?;
+    }
+    if config_path.exists() && !force {
+        let _ = std::fs::remove_file(&temp_path);
+        anyhow::bail!(
+            "FileProvider config already exists: {}. Pass --force-config to overwrite it.",
+            config_path.display()
+        );
+    }
+
+    #[cfg(windows)]
+    if force && config_path.exists() {
+        std::fs::remove_file(config_path)
+            .with_context(|| format!("replacing FileProvider config: {}", config_path.display()))?;
+    }
+
+    if let Err(error) = std::fs::rename(&temp_path, config_path)
+        .with_context(|| format!("installing FileProvider config: {}", config_path.display()))
+    {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(error);
+    }
+
     Ok(())
 }
 
@@ -5119,6 +5314,68 @@ mod tests {
         assert_eq!(reparsed.storage.bucket, config.storage.bucket);
     }
 
+    #[test]
+    fn build_fileprovider_init_config_emits_hostapp_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.storage.endpoint = "https://s3.example.test".into();
+        config.storage.bucket = "tcfs-smoke".into();
+        config.storage.remote_prefix = Some("devices/neo".into());
+        config.daemon.fileprovider_endpoint = Some("http://127.0.0.1:19101".into());
+        config.daemon.fileprovider_socket = Some(dir.path().join("tcfsd-fileprovider.sock"));
+
+        let s3 = tcfs_secrets::S3Credentials {
+            access_key_id: "access-key".into(),
+            secret_access_key: secrecy::SecretString::from("secret-key".to_string()),
+            endpoint: config.storage.endpoint.clone(),
+            region: config.storage.region.clone(),
+        };
+        let master_key_path = dir.path().join("master.key");
+        let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
+
+        assert_eq!(rendered.s3_endpoint, "https://s3.example.test");
+        assert_eq!(rendered.s3_bucket, "tcfs-smoke");
+        assert_eq!(rendered.s3_access, "access-key");
+        assert_eq!(rendered.s3_secret, "secret-key");
+        assert_eq!(rendered.remote_prefix, "devices/neo");
+        assert_eq!(rendered.device_id, "device-1");
+        assert_eq!(
+            rendered.daemon_endpoint.as_deref(),
+            Some("http://127.0.0.1:19101")
+        );
+        assert_eq!(
+            rendered.daemon_socket.as_deref(),
+            Some(dir.path().join("tcfsd-fileprovider.sock").to_str().unwrap())
+        );
+        assert_eq!(rendered.master_key_file, master_key_path.to_string_lossy());
+
+        let json = serde_json::to_value(&rendered).unwrap();
+        assert_eq!(json["s3_secret"], "secret-key");
+        assert_eq!(
+            json["master_key_file"].as_str(),
+            Some(master_key_path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn write_fileprovider_config_file_refuses_existing_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("fileprovider/config.json");
+        std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        std::fs::write(&config_path, "{}").unwrap();
+
+        let err = write_fileprovider_config_file(&config_path, "{\"ok\":true}", false).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("FileProvider config already exists"));
+
+        write_fileprovider_config_file(&config_path, "{\"ok\":true}", true).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&config_path).unwrap(),
+            "{\"ok\":true}"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn write_init_config_sets_owner_only_mode() {
@@ -5129,6 +5386,24 @@ mod tests {
         let config = tcfs_core::config::TcfsConfig::default();
 
         write_init_config(&config_path, &config, false).unwrap();
+
+        let mode = std::fs::metadata(&config_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_fileprovider_config_file_sets_owner_only_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("fileprovider/config.json");
+
+        write_fileprovider_config_file(&config_path, "{\"ok\":true}", false).unwrap();
 
         let mode = std::fs::metadata(&config_path)
             .unwrap()

--- a/crates/tcfs-cli/tests/cli_parsing_test.rs
+++ b/crates/tcfs-cli/tests/cli_parsing_test.rs
@@ -81,6 +81,16 @@ enum Commands {
         #[arg(long)]
         device_name: Option<String>,
         #[arg(long)]
+        check: bool,
+        #[arg(long)]
+        skip_config: bool,
+        #[arg(long)]
+        force_config: bool,
+        #[arg(long)]
+        config_out: Option<PathBuf>,
+        #[arg(long)]
+        fileprovider_config_out: Option<PathBuf>,
+        #[arg(long)]
         non_interactive: bool,
         #[arg(long, env = "TCFS_MASTER_PASSWORD", hide_env_values = true)]
         password: Option<String>,
@@ -357,12 +367,59 @@ fn parse_init() {
         .expect("init");
     if let Commands::Init {
         device_name,
+        check,
+        skip_config,
+        force_config,
+        config_out,
+        fileprovider_config_out,
         non_interactive,
         ..
     } = cli.command
     {
         assert_eq!(device_name, Some("neo".to_string()));
+        assert!(!check);
+        assert!(!skip_config);
+        assert!(!force_config);
+        assert!(config_out.is_none());
+        assert!(fileprovider_config_out.is_none());
         assert!(non_interactive);
+    } else {
+        panic!("expected Init");
+    }
+}
+
+#[test]
+fn parse_init_first_run_config_paths() {
+    let cli = Cli::try_parse_from([
+        "tcfs",
+        "init",
+        "--check",
+        "--skip-config",
+        "--force-config",
+        "--config-out",
+        "/tmp/tcfs/config.toml",
+        "--fileprovider-config-out",
+        "/tmp/tcfs/fileprovider/config.json",
+    ])
+    .expect("init config paths");
+
+    if let Commands::Init {
+        check,
+        skip_config,
+        force_config,
+        config_out,
+        fileprovider_config_out,
+        ..
+    } = cli.command
+    {
+        assert!(check);
+        assert!(skip_config);
+        assert!(force_config);
+        assert_eq!(config_out, Some(PathBuf::from("/tmp/tcfs/config.toml")));
+        assert_eq!(
+            fileprovider_config_out,
+            Some(PathBuf::from("/tmp/tcfs/fileprovider/config.json"))
+        );
     } else {
         panic!("expected Init");
     }

--- a/docs/ops/tcfs-daily-driver-productionization-todo-2026-05-24.md
+++ b/docs/ops/tcfs-daily-driver-productionization-todo-2026-05-24.md
@@ -1,6 +1,6 @@
 # TCFS Daily Driver Productionization Todo - 2026-05-24
 
-Status timestamp: 2026-05-25T03:15:00Z
+Status timestamp: 2026-05-25T05:40:00Z
 
 This is the current execution checklist for moving TCFS from an
 evidence-backed alpha surface toward a robust daily-driver filesystem product.
@@ -10,10 +10,11 @@ security, and user-visible control paths are also proven.
 
 ## Current State
 
-- `main` is clean at `1917a44d12d41d4eb112ac02e98597e6fc84a93e` after
-  PR `#450` merged the first TIN-1425 implementation slice for explicit
-  daemon missing-config behavior and installed-binary local first-run smoke.
-- No open GitHub PRs before this evidence-sync update.
+- `main` is at `3c220d2ba41bb3b89cc03ecf6a8bca16a110da76` after PR
+  `#456` merged the TIN-1424 admin-gated enrollment/revocation control RPC
+  slice.
+- Active PR: `#458` (`dd5b74d7358b31ba9692347d4ae00614faad5f5a`) adds
+  `tcfs init --fileprovider-config-out` and is waiting on remote checks.
 - Latest prerelease: `v0.12.13-rc4`.
 - Public `Latest` release remains `v0.12.12`.
 - Post-merge CI/Docs/Nix runs on `40b4514` are green:
@@ -222,6 +223,13 @@ files.
   `tcfs init --config-out` path. The run passed, but `nix profile install`
   took 27 minutes before the smoke ran; keep profile-install latency visible in
   future release evidence.
+- [x] Add an explicit `tcfs init --fileprovider-config-out <path>` path that
+  writes the macOS HostApp/FileProvider bootstrap JSON from the same first-run
+  state as `config.toml`, using the unified credential resolver and a `0600`
+  temp file before atomic install.
+- [ ] Prove the packaged macOS HostApp consumes that Rust-owned FileProvider
+  JSON path and provisions shared Keychain config without a hand-authored
+  `~/.config/tcfs/fileprovider/config.json`.
 - [ ] Keep fleet join out of `tcfs init` until `TIN-1417` and `TIN-1424` land;
   `tcfs init` should mean fresh local setup, while invite/pairing belongs to a
   later safe enrollment path.
@@ -257,7 +265,7 @@ until devices have real local private keys and per-device wrapped content keys.
 Why third: pairing depends on `TIN-1417`.
 
 - [x] Add single-use invite redemption state.
-- [ ] Require admin/session gates for enrollment and revocation RPCs.
+- [x] Require admin/session gates for enrollment and revocation control RPCs.
 - [ ] Stop treating QR payloads with raw S3 credentials as a production path.
 - [ ] Wrap bootstrap material to the new device public key.
 - [ ] Keep iOS fail-closed until real device enrollment proof exists.
@@ -270,9 +278,13 @@ Why third: pairing depends on `TIN-1417`.
 - [x] Replay now returns `success=false` with
   `invite has already been redeemed`.
 - [x] Redemption persistence failures fail closed.
-- [ ] This does not yet add admin/session approval, remove raw long-lived
-  storage secrets from invite payloads, wrap bootstrap material to the
-  recipient device key, or make desktop/iOS join product-safe.
+- [x] PR `#456` added admin/session gates for enrollment and revocation control
+  RPCs and merged at
+  `3c220d2ba41bb3b89cc03ecf6a8bca16a110da76` after green CI, live-storage,
+  Nix, FileProvider staticlib, iOS typecheck, cargo-deny, and Secret Scan.
+- [ ] This does not yet remove raw long-lived storage secrets from invite
+  payloads, wrap bootstrap material to the recipient device key, or make
+  desktop/iOS join product-safe.
 
 ## Then: Daily-Driver Primitives
 


### PR DESCRIPTION
## Summary
- add `tcfs init --fileprovider-config-out <path>` so first-run setup can emit the macOS HostApp/FileProvider bootstrap JSON alongside `config.toml`
- use the unified TCFS credential discovery chain instead of duplicating shell parsing
- write the FileProvider JSON through a `0600` temp file before atomic install, preserving the existing `--force-config` overwrite guard
- update parser/unit coverage and the daily-driver TIN-1425 checklist

## Validation
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test -p tcfs-cli write_fileprovider_config_file`
- `~/.cargo/bin/cargo test -p tcfs-cli build_fileprovider_init_config_emits_hostapp_fields`
- `~/.cargo/bin/cargo clippy -p tcfs-cli --all-targets`
- `git diff --check`
- local smoke: `tcfs init --config-out <tmp>/config.toml --fileprovider-config-out <tmp>/fileprovider/config.json` with fake TCFS S3 credentials, verified JSON fields and mode `0600`

## Claim boundary
This removes one hand-authored macOS first-run file. It does not prove GUI wizard flow, invite join, safe public self-enrollment, per-device wrapping/revocation, or packaged HostApp consumption yet.