### PR TITLE
auth: wrap enrollment bootstrap for device invites (TIN-1424)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5529,6 +5529,7 @@ dependencies = [
  "anyhow",
  "async-nats",
  "axum",
+ "base64 0.22.1",
  "blake3",
  "chrono",
  "clap",

--- a/crates/tcfs-auth/src/enrollment.rs
+++ b/crates/tcfs-auth/src/enrollment.rs
@@ -387,6 +387,30 @@ pub struct EnrollmentResult {
     pub available_auth_methods: Vec<String>,
 }
 
+/// Secret bootstrap material returned to a joining device.
+///
+/// This payload must be encrypted to the joining device's public key before it
+/// crosses an enrollment boundary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnrollmentBootstrap {
+    /// NATS server URL (if fleet sync is enabled).
+    pub nats_url: Option<String>,
+    /// Storage endpoint URL.
+    pub storage_endpoint: Option<String>,
+    /// S3 bucket name.
+    pub storage_bucket: Option<String>,
+    /// S3 access key.
+    pub storage_access_key: Option<String>,
+    /// S3 secret key.
+    pub storage_secret_key: Option<String>,
+    /// Remote prefix for file sync.
+    pub remote_prefix: Option<String>,
+    /// Base64-encoded TCFS master key for the current shared-master fleet.
+    pub master_key_base64: Option<String>,
+    /// Encryption salt (if passphrase-based E2EE is enabled).
+    pub encryption_salt: Option<String>,
+}
+
 /// Audit record for an invite that has already been redeemed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InviteRedemption {

--- a/crates/tcfs-auth/src/lib.rs
+++ b/crates/tcfs-auth/src/lib.rs
@@ -38,8 +38,8 @@ pub mod certificate;
 
 // Re-exports
 pub use enrollment::{
-    EnrollmentInvite, EnrollmentRequest, EnrollmentResult, InviteRedemption, InviteRedemptionError,
-    InviteRedemptionStore,
+    EnrollmentBootstrap, EnrollmentInvite, EnrollmentRequest, EnrollmentResult, InviteRedemption,
+    InviteRedemptionError, InviteRedemptionStore,
 };
 pub use provider::{AuthChallenge, AuthProvider, AuthResponse, VerifyResult};
 pub use session::{DevicePermissions, RateLimitConfig, RateLimiter, Session, SessionStore};

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -4161,33 +4161,11 @@ async fn cmd_device_invite(
         DevicePermissions::default(),
     );
 
-    // Include storage credentials for credential brokering
+    // Include non-secret routing metadata. Secret bootstrap material is brokered
+    // by tcfsd during DeviceEnroll and wrapped to the joining device public key.
     invite.storage_endpoint = Some(config.storage.endpoint.clone());
     invite.storage_bucket = Some(config.storage.bucket.clone());
-    invite.remote_prefix = Some(String::from("default"));
-
-    // Load S3 credentials from environment (sops-nix populates these)
-    if let Ok(access_key) = std::env::var("AWS_ACCESS_KEY_ID").or_else(|_| {
-        std::env::var("TCFS_S3_ACCESS_KEY_FILE")
-            .and_then(|f| std::fs::read_to_string(f).map_err(|_| std::env::VarError::NotPresent))
-    }) {
-        invite.storage_access_key = Some(access_key);
-    }
-    if let Ok(secret_key) = std::env::var("AWS_SECRET_ACCESS_KEY").or_else(|_| {
-        std::env::var("TCFS_S3_SECRET_KEY_FILE")
-            .and_then(|f| std::fs::read_to_string(f).map_err(|_| std::env::VarError::NotPresent))
-    }) {
-        invite.storage_secret_key = Some(secret_key);
-    }
-
-    // Include encryption config if enabled
-    if config.crypto.enabled {
-        if let Ok(passphrase) = std::env::var("TCFS_ENCRYPTION_KEY_FILE")
-            .and_then(|f| std::fs::read_to_string(f).map_err(|_| std::env::VarError::NotPresent))
-        {
-            invite.encryption_passphrase = Some(passphrase);
-        }
-    }
+    invite.remote_prefix = Some(config.storage.resolved_prefix().to_string());
 
     invite.refresh_signature(&signing_key);
 
@@ -4205,11 +4183,7 @@ async fn cmd_device_invite(
         "Storage: {} (bucket: {})",
         config.storage.endpoint, config.storage.bucket
     );
-    if invite.storage_access_key.is_some() {
-        println!("Credentials: included (S3 access key brokered)");
-    } else {
-        println!("Credentials: NOT included (set AWS_ACCESS_KEY_ID or TCFS_S3_ACCESS_KEY_FILE)");
-    }
+    println!("Credentials: not embedded in invite; daemon wraps bootstrap during enrollment");
     println!(
         "Payload: {} bytes compact, {} bytes full",
         compact.len(),

--- a/crates/tcfs-core/src/proto/tcfs.proto
+++ b/crates/tcfs-core/src/proto/tcfs.proto
@@ -277,6 +277,10 @@ message DeviceEnrollResponse {
   string remote_prefix = 10;
   string encryption_passphrase = 11;
   string encryption_salt = 12;
+  // ASCII-armored age ciphertext containing EnrollmentBootstrap JSON encrypted
+  // to DeviceEnrollRequest.public_key. New clients must prefer this over the
+  // legacy plaintext broker fields above.
+  string wrapped_bootstrap_age = 13;
 }
 
 // ── Diagnostics ──────────────────────────────────────────────────────────

--- a/crates/tcfs-secrets/src/age.rs
+++ b/crates/tcfs-secrets/src/age.rs
@@ -3,6 +3,15 @@
 use crate::identity::IdentityProvider;
 use anyhow::{Context, Result};
 
+/// Encrypt plaintext to an age X25519 public recipient and return ASCII armor.
+pub fn encrypt_for_recipient(public_key: &str, plaintext: &[u8]) -> Result<String> {
+    let recipient: age::x25519::Recipient = public_key
+        .parse()
+        .map_err(|e| anyhow::anyhow!("parsing age recipient public key {public_key}: {e}"))?;
+
+    age::encrypt_and_armor(&recipient, plaintext).context("encrypting age bootstrap payload")
+}
+
 /// Decrypt age-encrypted data using an identity
 ///
 /// `encrypted_data` should be the armored age ciphertext (PEM-like format)
@@ -45,8 +54,21 @@ pub fn decrypt_with_identity(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+
     #[test]
-    fn placeholder() {
-        // Round-trip test added in Phase 5 (requires age key generation)
+    fn encrypt_for_recipient_roundtrips_with_identity() {
+        let identity = age::x25519::Identity::generate();
+        let public_key = identity.to_public().to_string();
+        let ciphertext = encrypt_for_recipient(&public_key, b"bootstrap-secret").unwrap();
+        assert!(ciphertext.contains("BEGIN AGE ENCRYPTED FILE"));
+
+        let provider = IdentityProvider {
+            key_data: identity.to_string().expose_secret().to_string(),
+            source: "test".into(),
+        };
+        let plaintext = decrypt_with_identity(&provider, ciphertext.as_bytes()).unwrap();
+        assert_eq!(plaintext, b"bootstrap-secret");
     }
 }

--- a/crates/tcfsd/Cargo.toml
+++ b/crates/tcfsd/Cargo.toml
@@ -45,6 +45,7 @@ tempfile = { workspace = true }
 blake3 = { workspace = true }
 chrono = { workspace = true }
 age = { workspace = true }
+base64 = { workspace = true }
 uuid = { workspace = true }
 dirs = "6"
 openssl = { workspace = true, optional = true }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -11,6 +11,8 @@ use tracing::{info, warn};
 
 use crate::cred_store::SharedCredStore;
 
+use base64::Engine;
+use secrecy::ExposeSecret;
 use tcfs_core::config::TcfsConfig;
 use tcfs_core::proto::{
     tcfs_daemon_server::{TcfsDaemon, TcfsDaemonServer},
@@ -200,6 +202,78 @@ impl TcfsDaemonImpl {
             webauthn_provider,
             rate_limiter,
         }
+    }
+
+    async fn enrollment_bootstrap_for_invite(
+        &self,
+        invite: &tcfs_auth::EnrollmentInvite,
+    ) -> Result<tcfs_auth::EnrollmentBootstrap, tonic::Status> {
+        let (storage_access_key, storage_secret_key) =
+            self.enrollment_storage_credentials(invite).await;
+        if storage_access_key.is_none() || storage_secret_key.is_none() {
+            return Err(tonic::Status::failed_precondition(
+                "storage credentials unavailable for enrollment bootstrap",
+            ));
+        }
+
+        let master_key_base64 = {
+            let master = self.master_key.lock().await;
+            let master = master.as_ref().ok_or_else(|| {
+                tonic::Status::failed_precondition(
+                    "daemon master key not loaded — cannot wrap enrollment bootstrap",
+                )
+            })?;
+            base64::engine::general_purpose::STANDARD.encode(master.as_bytes())
+        };
+
+        Ok(tcfs_auth::EnrollmentBootstrap {
+            nats_url: invite
+                .nats_url
+                .clone()
+                .or_else(|| Some(self.config.sync.nats_url.clone()).filter(|url| !url.is_empty())),
+            storage_endpoint: invite.storage_endpoint.clone().or_else(|| {
+                Some(self.config.storage.endpoint.clone()).filter(|url| !url.is_empty())
+            }),
+            storage_bucket: invite.storage_bucket.clone().or_else(|| {
+                Some(self.config.storage.bucket.clone()).filter(|bucket| !bucket.is_empty())
+            }),
+            storage_access_key,
+            storage_secret_key,
+            remote_prefix: invite
+                .remote_prefix
+                .clone()
+                .or_else(|| Some(self.config.storage.resolved_prefix().to_string())),
+            master_key_base64: Some(master_key_base64),
+            encryption_salt: invite
+                .encryption_salt
+                .clone()
+                .or_else(|| self.config.crypto.kdf_salt.clone()),
+        })
+    }
+
+    async fn enrollment_storage_credentials(
+        &self,
+        invite: &tcfs_auth::EnrollmentInvite,
+    ) -> (Option<String>, Option<String>) {
+        if invite.storage_access_key.is_some() && invite.storage_secret_key.is_some() {
+            return (
+                invite.storage_access_key.clone(),
+                invite.storage_secret_key.clone(),
+            );
+        }
+
+        let store = self.cred_store.read().await;
+        if let Some(s3) = store.as_ref().and_then(|store| store.s3.as_ref()) {
+            return (
+                Some(s3.access_key_id.clone()),
+                Some(s3.secret_access_key.expose_secret().to_string()),
+            );
+        }
+
+        (
+            invite.storage_access_key.clone(),
+            invite.storage_secret_key.clone(),
+        )
     }
 
     /// Get a clone of the session store (for background tasks).
@@ -2326,6 +2400,14 @@ impl TcfsDaemon for TcfsDaemonImpl {
             }));
         }
 
+        if !tcfs_secrets::device::is_real_age_public_key(&req.public_key) {
+            return Ok(tonic::Response::new(DeviceEnrollResponse {
+                success: false,
+                error: "invalid device public key; expected age X25519 recipient".into(),
+                ..Default::default()
+            }));
+        }
+
         // Validate invite signature against master key
         if let Some(mk) = self.master_key.lock().await.as_ref() {
             let signing_key: [u8; 32] = *blake3::hash(mk.as_bytes()).as_bytes();
@@ -2342,6 +2424,15 @@ impl TcfsDaemon for TcfsDaemonImpl {
                 "daemon master key not loaded — cannot verify invite signature",
             ));
         }
+
+        let bootstrap = self.enrollment_bootstrap_for_invite(&invite).await?;
+        let bootstrap_json = serde_json::to_vec(&bootstrap).map_err(|e| {
+            tonic::Status::internal(format!("serializing enrollment bootstrap: {e}"))
+        })?;
+        let wrapped_bootstrap_age =
+            tcfs_secrets::age::encrypt_for_recipient(&req.public_key, &bootstrap_json).map_err(
+                |e| tonic::Status::invalid_argument(format!("wrapping enrollment bootstrap: {e}")),
+            )?;
 
         match self
             .invite_redemptions
@@ -2384,16 +2475,17 @@ impl TcfsDaemon for TcfsDaemonImpl {
         Ok(tonic::Response::new(DeviceEnrollResponse {
             success: true,
             device_id,
-            nats_url: invite.nats_url.unwrap_or_default(),
-            storage_endpoint: invite.storage_endpoint.unwrap_or_default(),
+            nats_url: bootstrap.nats_url.unwrap_or_default(),
+            storage_endpoint: bootstrap.storage_endpoint.unwrap_or_default(),
             available_auth_methods: vec!["totp".into()],
             error: String::new(),
-            storage_bucket: invite.storage_bucket.unwrap_or_default(),
-            storage_access_key: invite.storage_access_key.unwrap_or_default(),
-            storage_secret: invite.storage_secret_key.unwrap_or_default(),
-            remote_prefix: invite.remote_prefix.unwrap_or_default(),
-            encryption_passphrase: invite.encryption_passphrase.unwrap_or_default(),
-            encryption_salt: invite.encryption_salt.unwrap_or_default(),
+            storage_bucket: bootstrap.storage_bucket.unwrap_or_default(),
+            storage_access_key: String::new(),
+            storage_secret: String::new(),
+            remote_prefix: bootstrap.remote_prefix.unwrap_or_default(),
+            encryption_passphrase: String::new(),
+            encryption_salt: bootstrap.encryption_salt.unwrap_or_default(),
+            wrapped_bootstrap_age,
         }))
     }
 
@@ -2555,8 +2647,10 @@ pub async fn serve(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine;
     use opendal::services::Memory;
     use opendal::Operator;
+    use secrecy::{ExposeSecret, SecretString};
     use tcfs_core::proto::tcfs_daemon_client::TcfsDaemonClient;
     use tonic::transport::{Channel, Endpoint, Uri};
     use tower::service_fn;
@@ -2615,6 +2709,30 @@ mod tests {
 
     fn memory_operator() -> Operator {
         Operator::new(Memory::default()).unwrap().finish()
+    }
+
+    fn test_device_keypair() -> tcfs_secrets::device::LocalDeviceKey {
+        tcfs_secrets::device::generate_local_device_key()
+    }
+
+    async fn insert_test_s3_credentials(
+        daemon: &TcfsDaemonImpl,
+        access_key: &str,
+        secret_key: &str,
+    ) {
+        daemon
+            .cred_store
+            .write()
+            .await
+            .replace(tcfs_secrets::CredStore {
+                s3: Some(tcfs_secrets::S3Credentials {
+                    access_key_id: access_key.into(),
+                    secret_access_key: SecretString::from(secret_key.to_string()),
+                    endpoint: daemon.config.storage.endpoint.clone(),
+                    region: daemon.config.storage.region.clone(),
+                }),
+                source: "test".into(),
+            });
     }
 
     fn request_with_bearer<T>(message: T, token: &str) -> tonic::Request<T> {
@@ -2975,13 +3093,16 @@ mod tests {
         );
         invite.storage_endpoint = Some("https://s3.example.invalid".into());
         invite.storage_bucket = Some("tcfs".into());
+        invite.storage_access_key = Some("test-access".into());
+        invite.storage_secret_key = Some("test-secret".into());
         invite.refresh_signature(&signing_key);
         let invite_data = invite.encode_compact().unwrap();
+        let keypair = test_device_keypair();
 
         let req = DeviceEnrollRequest {
             invite_data: invite_data.clone(),
             device_name: "new-laptop".into(),
-            public_key: "age1testdevice".into(),
+            public_key: keypair.public_key.clone(),
             platform: "linux-x86_64".into(),
         };
 
@@ -3000,6 +3121,134 @@ mod tests {
             .into_inner();
         assert!(!second.success);
         assert!(second.error.contains("already been redeemed"));
+    }
+
+    #[tokio::test]
+    async fn device_enroll_rejects_invalid_public_key_before_claiming_invite() {
+        let key_bytes = [0xC7; tcfs_crypto::KEY_SIZE];
+        let signing_key: [u8; 32] = *blake3::hash(&key_bytes).as_bytes();
+        let temp = tempfile::tempdir().unwrap();
+        let daemon = test_daemon_with_operator_and_master(
+            None,
+            Some(tcfs_crypto::MasterKey::from_bytes(key_bytes)),
+        )
+        .with_data_dir(temp.path().join("tcfsd"));
+
+        let mut invite = tcfs_auth::EnrollmentInvite::new(
+            "admin-device",
+            &signing_key,
+            24,
+            tcfs_auth::DevicePermissions::default(),
+        );
+        invite.storage_endpoint = Some("https://s3.example.invalid".into());
+        invite.storage_bucket = Some("tcfs".into());
+        invite.storage_access_key = Some("test-access".into());
+        invite.storage_secret_key = Some("test-secret".into());
+        invite.refresh_signature(&signing_key);
+        let invite_data = invite.encode_compact().unwrap();
+
+        let rejected = daemon
+            .device_enroll(tonic::Request::new(DeviceEnrollRequest {
+                invite_data: invite_data.clone(),
+                device_name: "new-laptop".into(),
+                public_key: "not-an-age-recipient".into(),
+                platform: "linux-x86_64".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!rejected.success);
+        assert!(rejected.error.contains("invalid device public key"));
+        assert!(!temp.path().join("tcfsd/invite-redemptions.json").exists());
+
+        let keypair = test_device_keypair();
+        let accepted = daemon
+            .device_enroll(tonic::Request::new(DeviceEnrollRequest {
+                invite_data,
+                device_name: "new-laptop".into(),
+                public_key: keypair.public_key.clone(),
+                platform: "linux-x86_64".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(accepted.success, "retry failed: {}", accepted.error);
+    }
+
+    #[tokio::test]
+    async fn device_enroll_wraps_bootstrap_to_joining_device_key() {
+        let key_bytes = [0xB6; tcfs_crypto::KEY_SIZE];
+        let signing_key: [u8; 32] = *blake3::hash(&key_bytes).as_bytes();
+        let temp = tempfile::tempdir().unwrap();
+        let daemon = test_daemon_with_operator_and_master(
+            None,
+            Some(tcfs_crypto::MasterKey::from_bytes(key_bytes)),
+        )
+        .with_data_dir(temp.path().join("tcfsd"));
+        insert_test_s3_credentials(&daemon, "daemon-access", "daemon-secret").await;
+
+        let mut invite = tcfs_auth::EnrollmentInvite::new(
+            "admin-device",
+            &signing_key,
+            24,
+            tcfs_auth::DevicePermissions::default(),
+        );
+        invite.storage_endpoint = Some("https://s3.example.invalid".into());
+        invite.storage_bucket = Some("tcfs".into());
+        invite.remote_prefix = Some("tenant/a".into());
+        invite.refresh_signature(&signing_key);
+        let invite_data = invite.encode_compact().unwrap();
+        let keypair = test_device_keypair();
+
+        let resp = daemon
+            .device_enroll(tonic::Request::new(DeviceEnrollRequest {
+                invite_data,
+                device_name: "new-laptop".into(),
+                public_key: keypair.public_key.clone(),
+                platform: "linux-x86_64".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.success, "enrollment failed: {}", resp.error);
+        assert!(resp.storage_access_key.is_empty());
+        assert!(resp.storage_secret.is_empty());
+        assert!(resp.encryption_passphrase.is_empty());
+        assert!(resp
+            .wrapped_bootstrap_age
+            .contains("BEGIN AGE ENCRYPTED FILE"));
+
+        let identity = tcfs_secrets::IdentityProvider {
+            key_data: keypair.secret_key.expose_secret().to_string(),
+            source: "test".into(),
+        };
+        let plaintext = tcfs_secrets::age::decrypt_with_identity(
+            &identity,
+            resp.wrapped_bootstrap_age.as_bytes(),
+        )
+        .unwrap();
+        let bootstrap: tcfs_auth::EnrollmentBootstrap = serde_json::from_slice(&plaintext).unwrap();
+
+        assert_eq!(
+            bootstrap.storage_endpoint.as_deref(),
+            Some("https://s3.example.invalid")
+        );
+        assert_eq!(bootstrap.storage_bucket.as_deref(), Some("tcfs"));
+        assert_eq!(
+            bootstrap.storage_access_key.as_deref(),
+            Some("daemon-access")
+        );
+        assert_eq!(
+            bootstrap.storage_secret_key.as_deref(),
+            Some("daemon-secret")
+        );
+        assert_eq!(bootstrap.remote_prefix.as_deref(), Some("tenant/a"));
+        let expected_master_key = base64::engine::general_purpose::STANDARD.encode(key_bytes);
+        assert_eq!(
+            bootstrap.master_key_base64.as_deref(),
+            Some(expected_master_key.as_str())
+        );
     }
 
     #[tokio::test]

--- a/docs/ops/tcfs-alpha-beta-qa-readiness-2026-05-19.md
+++ b/docs/ops/tcfs-alpha-beta-qa-readiness-2026-05-19.md
@@ -28,10 +28,13 @@ use.
   remains `TIN-132`; CI does not replace named host evidence.
 - Enrollment and invite flows are not a production trust boundary. `TIN-1417`
   Phase 0 has landed real local age/X25519 device keys, and `TIN-1424`
-  Phase 1 has landed single-use invite redemption. That is not enough for
-  production self-enrollment or lost-device revocation: TIN-1417 still needs
-  per-device content-key wrapping, and TIN-1424 still needs admin/session
-  approval, no raw long-lived invite secrets, and recipient-wrapped bootstrap.
+  now has single-use invite redemption plus admin-gated control RPCs. The current
+  TIN-1424 recipient-bootstrap cut moves new invite responses to an age-wrapped
+  `EnrollmentBootstrap` payload and keeps new CLI invites from embedding raw S3
+  secrets by default. That still is not enough for production self-enrollment or
+  lost-device revocation: TIN-1417 still needs per-device content-key wrapping,
+  and TIN-1424 still needs productized pairing approval, safe bootstrap
+  persistence on clients, and revocation evidence.
 - Production S3/storage posture remains `TIN-1546`. Alpha HTTPS/scoped
   credential posture is green on current-main storage canary evidence, but the
   beta-grade gate still needs large restore/load, socket/highwater behavior,
@@ -97,7 +100,7 @@ has shipped and been proven end to end.
 | Linux package smoke | `.deb`/`.rpm` install and upgrade package smoke is green for the current alpha boundary | Scheduled package smoke on a stable runner with archived transcripts and broader FUSE/systemd/live-storage first-use | `TIN-1422`, `TIN-1540` |
 | Live fleet | Neo/honey acceptance is current, repeatable, and archived | Scheduled fleet acceptance with failure classification and dashboard history | `TIN-132`, `TIN-1421` |
 | S3/storage posture | TLS/CA posture documented, health/read paths bounded, transient errors separated from missing objects, large-pack restore evidence captured | Production-like S3 endpoint, scoped credentials, latency/object-count budgets, rollback/restore evidence | `TIN-1546`, `TIN-720`, `#327` |
-| Enrollment/security | Admin/operator-provisioned only; real local device keys and single-use invite redemption exist, but self-enrollment remains disabled for untrusted users | Per-device content-key wrapping, complete invite signature/MAC coverage, admin/session gating, safe bootstrap persistence, revocation evidence | `TIN-1417`, `TIN-1424` |
+| Enrollment/security | Admin/operator-provisioned only; real local device keys, single-use invite redemption, admin-gated control RPCs, and recipient-wrapped enrollment bootstrap exist, but self-enrollment remains disabled for untrusted users | Per-device content-key wrapping, productized pairing approval, safe bootstrap persistence, revocation evidence | `TIN-1417`, `TIN-1424` |
 | Daily-driver primitives | Scoped roots only; no broad home ownership claim | Stable root identity, pin-as-hydrated, subscription selective sync, streaming large-file IO, xattrs, conflict UX, home-dir blacklist | `TIN-1416`, `TIN-1419`, `TIN-1420`, `TIN-1423`, `TIN-1556` |
 | Desktop status and recovery | CLI/log-based inspection is acceptable for trusted operators | Cross-surface sync-state vocabulary, visible progress/errors/conflicts, and clean user-driven recovery | `TIN-1549` |
 | Multitenancy | Out of scope | Tenant/vault identity, namespaced storage/NATS/authz/audit/metrics, migration story | `TIN-1418` |


### PR DESCRIPTION
## Summary
- add an ASCII-armored age-wrapped `wrapped_bootstrap_age` field to `DeviceEnrollResponse`
- introduce `EnrollmentBootstrap` and a tcfs-secrets age encryption helper, with round-trip coverage
- have `device_enroll` require a real age recipient public key, wrap S3/bootstrap/master-key material to that key, reject malformed public keys before invite claim, and stop returning raw access key / secret / encryption passphrase fields
- stop `tcfs device invite` from embedding raw S3 credentials in new QR/deep-link payloads by default; the daemon brokers encrypted bootstrap material during enrollment
- update alpha/beta readiness docs with the narrowed claim boundary

## Validation
- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test -p tcfs-secrets encrypt_for_recipient`
- `~/.cargo/bin/cargo test -p tcfsd device_enroll`
- `~/.cargo/bin/cargo test -p tcfs-auth`
- `~/.cargo/bin/cargo test -p tcfs-cli --no-run`
- `~/.cargo/bin/cargo clippy -p tcfs-secrets -p tcfs-auth -p tcfsd -p tcfs-cli --all-targets` (passes with existing tcfs-cli too_many_arguments and tcfsd needless_borrow warnings)
- `~/.cargo/bin/cargo clippy -p tcfsd --all-targets` after the final invalid-key regression (same existing warnings)
- `git diff --check`

## Post-rebase validation
Rebased onto merged main after #458 landed at `97eb84c8baeb2e2d1b0ab13a6b4b0f2476127ec4`; refreshed PR head is `4426eaa1f3591881756988a93371dd8bfd7a6458`.

- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test -p tcfsd device_enroll`
- `~/.cargo/bin/cargo test -p tcfs-cli --no-run`
- `~/.cargo/bin/cargo clippy -p tcfsd -p tcfs-cli --all-targets` (same existing tcfsd needless_borrow warnings)
- `git diff --check`

## Claim boundary
This improves the invite/bootstrap trust boundary, but it is still not production self-enrollment. Remaining TIN-1424/TIN-1417 work: productized pairing approval, safe client-side bootstrap persistence, per-device content-key wrapping, real revocation denial for new content, and iOS/Desktop join acceptance.
