### PR TITLE
cli: render FileProvider config from active config (TIN-1425)

### DIFF
--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -57,6 +57,11 @@ on:
         required: false
         default: false
         type: boolean
+      require_cli_fileprovider_config:
+        description: "Fail unless the installed tcfs CLI renders the FileProvider JSON via `tcfs config fileprovider`"
+        required: false
+        default: false
+        type: boolean
       lab_gatekeeper_override:
         description: "PZM-only non-production lab: require a SystemPolicyRule profile for the installed testing-mode app"
         required: false
@@ -656,11 +661,31 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ github.event.inputs.fileprovider_testing_mode }}" == "true" ]]; then
-            TCFS_FILEPROVIDER_SKIP_APP_GROUP_COPY=1 \
-              bash swift/fileprovider/provision-config.sh "$CONFIG_PATH"
+          FILEPROVIDER_CONFIG_PATH="$HOME/.config/tcfs/fileprovider/config.json"
+          REQUIRE_CLI_FILEPROVIDER_CONFIG="${{ github.event.inputs.require_cli_fileprovider_config }}"
+
+          if tcfs --config "$CONFIG_PATH" config fileprovider --help >/dev/null 2>&1; then
+            tcfs --config "$CONFIG_PATH" config fileprovider \
+              --out "$FILEPROVIDER_CONFIG_PATH" \
+              --device-id "gha-macos-postinstall" \
+              --master-key-file "$MASTER_KEY_PATH" \
+              --force
+
+            if [[ "${{ github.event.inputs.fileprovider_testing_mode }}" != "true" && -d "$APP_GROUP_DIR" ]]; then
+              install -m 600 "$FILEPROVIDER_CONFIG_PATH" "$APP_GROUP_DIR/config.json"
+              echo "==> Also written to $APP_GROUP_DIR/config.json"
+            fi
+          elif [[ "$REQUIRE_CLI_FILEPROVIDER_CONFIG" == "true" ]]; then
+            echo "::error::Installed tcfs does not support 'config fileprovider'; cannot prove Rust-owned FileProvider JSON path."
+            exit 1
           else
-            bash swift/fileprovider/provision-config.sh "$CONFIG_PATH"
+            echo "::warning::Installed tcfs lacks 'config fileprovider'; falling back to legacy provision-config.sh"
+            if [[ "${{ github.event.inputs.fileprovider_testing_mode }}" == "true" ]]; then
+              TCFS_FILEPROVIDER_SKIP_APP_GROUP_COPY=1 \
+                bash swift/fileprovider/provision-config.sh "$CONFIG_PATH"
+            else
+              bash swift/fileprovider/provision-config.sh "$CONFIG_PATH"
+            fi
           fi
 
       - name: Seed remote fixture

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -528,6 +528,21 @@ enum TrashAction {
 enum ConfigAction {
     /// Print the active configuration (merged defaults + config file)
     Show,
+    /// Render the macOS FileProvider bootstrap JSON from the active config
+    Fileprovider {
+        /// Path to write (default: ~/.config/tcfs/fileprovider/config.json)
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Device ID to place in the FileProvider bootstrap JSON
+        #[arg(long)]
+        device_id: Option<String>,
+        /// Master key file path to hand to the HostApp for Keychain enrichment
+        #[arg(long)]
+        master_key_file: Option<PathBuf>,
+        /// Overwrite an existing FileProvider config JSON
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -603,6 +618,24 @@ async fn main() -> Result<()> {
         Commands::Config {
             action: ConfigAction::Show,
         } => cmd_config_show(&config, &cli.config),
+        Commands::Config {
+            action:
+                ConfigAction::Fileprovider {
+                    out,
+                    device_id,
+                    master_key_file,
+                    force,
+                },
+        } => {
+            cmd_config_fileprovider(
+                &config,
+                out.as_deref(),
+                device_id.as_deref(),
+                master_key_file.as_deref(),
+                force,
+            )
+            .await
+        }
         Commands::Kdbx {
             action:
                 KdbxAction::Resolve {
@@ -2470,6 +2503,29 @@ fn cmd_config_show(config: &tcfs_core::config::TcfsConfig, config_path: &Path) -
     Ok(())
 }
 
+async fn cmd_config_fileprovider(
+    config: &tcfs_core::config::TcfsConfig,
+    out: Option<&Path>,
+    device_id: Option<&str>,
+    master_key_file: Option<&Path>,
+    force: bool,
+) -> Result<()> {
+    let config_path = out
+        .map(Path::to_path_buf)
+        .unwrap_or_else(default_fileprovider_config_path);
+    let device_id = resolve_fileprovider_device_id(config, device_id)?;
+    let master_key_path = resolve_fileprovider_master_key_path(config, master_key_file)?;
+
+    write_fileprovider_init_config(&config_path, config, &master_key_path, &device_id, force)
+        .await?;
+    println!("FileProvider config: {}", config_path.display());
+    Ok(())
+}
+
+fn default_fileprovider_config_path() -> PathBuf {
+    default_user_config_dir().join("fileprovider/config.json")
+}
+
 // ── `tcfs kdbx resolve` ───────────────────────────────────────────────────────
 
 fn cmd_kdbx_resolve(
@@ -3568,6 +3624,61 @@ fn build_init_config(
     config.sync.device_identity = Some(registry_path.to_path_buf());
     config.sync.device_name = Some(device_name.to_string());
     config
+}
+
+fn resolve_fileprovider_device_id(
+    config: &tcfs_core::config::TcfsConfig,
+    explicit: Option<&str>,
+) -> Result<String> {
+    if let Some(device_id) = explicit.map(str::trim).filter(|value| !value.is_empty()) {
+        return Ok(device_id.to_string());
+    }
+
+    if let Some(registry_path) = &config.sync.device_identity {
+        if let Ok(registry) = tcfs_secrets::device::DeviceRegistry::load(registry_path) {
+            let active_devices: Vec<_> = registry.active_devices().collect();
+            if let Some(device_name) = config.sync.device_name.as_deref() {
+                if let Some(device) = active_devices
+                    .iter()
+                    .copied()
+                    .find(|device| device.name == device_name)
+                {
+                    if !device.device_id.is_empty() {
+                        return Ok(device.device_id.clone());
+                    }
+                }
+            }
+            if active_devices.len() == 1 && !active_devices[0].device_id.is_empty() {
+                return Ok(active_devices[0].device_id.clone());
+            }
+        }
+    }
+
+    if let Some(device_name) = config
+        .sync
+        .device_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(device_name.to_string());
+    }
+
+    anyhow::bail!(
+        "FileProvider config requires a device id; pass --device-id or configure sync.device_name/device_identity"
+    )
+}
+
+fn resolve_fileprovider_master_key_path(
+    config: &tcfs_core::config::TcfsConfig,
+    explicit: Option<&Path>,
+) -> Result<PathBuf> {
+    explicit
+        .map(Path::to_path_buf)
+        .or_else(|| config.crypto.master_key_file.clone())
+        .context(
+            "FileProvider config requires a master key file; pass --master-key-file or configure crypto.master_key_file",
+        )
 }
 
 fn write_init_config(
@@ -5408,6 +5519,55 @@ mod tests {
             json["master_key_file"].as_str(),
             Some(master_key_path.to_string_lossy().as_ref())
         );
+    }
+
+    #[test]
+    fn resolve_fileprovider_device_id_prefers_explicit_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+
+        let resolved = resolve_fileprovider_device_id(&config, Some(" device-from-ci ")).unwrap();
+
+        assert_eq!(resolved, "device-from-ci");
+    }
+
+    #[test]
+    fn resolve_fileprovider_device_id_reads_registry_for_configured_device() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("devices.json");
+        let mut registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path).unwrap();
+        let (device_id, _device_key) = registry.enroll_local("macbook", None);
+        registry.save(&registry_path).unwrap();
+
+        let mut config = test_config(dir.path());
+        config.sync.device_identity = Some(registry_path);
+        config.sync.device_name = Some("macbook".into());
+
+        let resolved = resolve_fileprovider_device_id(&config, None).unwrap();
+
+        assert_eq!(resolved, device_id);
+    }
+
+    #[test]
+    fn resolve_fileprovider_device_id_falls_back_to_device_name_for_packaged_smoke() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.sync.device_name = Some("gha-macos-postinstall".into());
+
+        let resolved = resolve_fileprovider_device_id(&config, None).unwrap();
+
+        assert_eq!(resolved, "gha-macos-postinstall");
+    }
+
+    #[test]
+    fn resolve_fileprovider_master_key_path_prefers_explicit_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path());
+        let explicit = dir.path().join("explicit-master.key");
+
+        let resolved = resolve_fileprovider_master_key_path(&config, Some(&explicit)).unwrap();
+
+        assert_eq!(resolved, explicit);
     }
 
     #[test]

--- a/docs/ops/tcfs-daily-driver-productionization-todo-2026-05-24.md
+++ b/docs/ops/tcfs-daily-driver-productionization-todo-2026-05-24.md
@@ -280,12 +280,17 @@ files.
   writes the macOS HostApp/FileProvider bootstrap JSON from the same first-run
   state as `config.toml`, using the unified credential resolver and a `0600`
   temp file before atomic install.
+- [x] Add `tcfs config fileprovider --out <path>` so package smokes can render
+  the HostApp/FileProvider JSON from an existing config through installed Rust
+  code instead of the legacy shell/TOML parser.
 - [x] Extend the static FileProvider surface contract test so HostApp drift is
   caught if it stops reading `~/.config/tcfs/fileprovider/config.json` or stops
   enriching `master_key_file` into the Keychain `master_key_base64` payload.
-- [ ] Prove the packaged macOS HostApp consumes that Rust-owned FileProvider
-  JSON path and provisions shared Keychain config without a hand-authored
-  `~/.config/tcfs/fileprovider/config.json`.
+- [ ] Dispatch the macOS postinstall smoke with
+  `require_cli_fileprovider_config=true` on a package that includes
+  `tcfs config fileprovider`, then prove the packaged HostApp consumes that
+  Rust-owned JSON path and provisions shared Keychain config without a
+  hand-authored `~/.config/tcfs/fileprovider/config.json`.
 - [ ] Keep fleet join out of `tcfs init` until the remaining `TIN-1417` and
   `TIN-1424` product slices are complete; `tcfs init` should mean fresh local
   setup, while invite/pairing belongs to a separate safe enrollment path.

--- a/docs/ops/tcfs-init-wizard-design-2026-05-18.md
+++ b/docs/ops/tcfs-init-wizard-design-2026-05-18.md
@@ -154,6 +154,13 @@ own its own copy of the prompt sequence.
     `scripts/install-smoke.sh --tcfs target/debug/tcfs --tcfsd target/debug/tcfsd`,
     `cargo test -p tcfsd`, and `cargo test -p tcfs-cli init`. This does not
     close storage-backed first-use or the macOS inline wizard.
+- **macOS FileProvider bootstrap JSON**: `tcfs init --fileprovider-config-out`
+  handles fresh local setup, while `tcfs config fileprovider --out` renders the
+  same HostApp/FileProvider JSON from an existing config for package smokes and
+  operator repros. The macOS postinstall workflow should set
+  `require_cli_fileprovider_config=true` when validating a package new enough to
+  include this command; older tags may still fall back to
+  `swift/fileprovider/provision-config.sh`.
 - **macOS host app** (`swift/fileprovider/Sources/HostApp/HostApp.swift`):
   when `provisionConfig()` (`:194-204`) finds no config, instead of silently
   logging and continuing, launch the first-run wizard inline (sheet) before

--- a/scripts/test-release-workflow-fileprovider.sh
+++ b/scripts/test-release-workflow-fileprovider.sh
@@ -790,6 +790,12 @@ extract_step_from_workflow \
   "Provision FileProvider config" \
   "$PROVISION_FILEPROVIDER_CONFIG_STEP"
 bash -n "$PROVISION_FILEPROVIDER_CONFIG_STEP"
+assert_contains "$POSTINSTALL_WORKFLOW" "require_cli_fileprovider_config"
+assert_contains "$PROVISION_FILEPROVIDER_CONFIG_STEP" "tcfs --config \"\$CONFIG_PATH\" config fileprovider"
+assert_contains "$PROVISION_FILEPROVIDER_CONFIG_STEP" "--out \"\$FILEPROVIDER_CONFIG_PATH\""
+assert_contains "$PROVISION_FILEPROVIDER_CONFIG_STEP" "--device-id \"gha-macos-postinstall\""
+assert_contains "$PROVISION_FILEPROVIDER_CONFIG_STEP" "--master-key-file \"\$MASTER_KEY_PATH\""
+assert_contains "$PROVISION_FILEPROVIDER_CONFIG_STEP" "Installed tcfs does not support 'config fileprovider'"
 assert_contains "$PROVISION_FILEPROVIDER_CONFIG_STEP" "TCFS_FILEPROVIDER_SKIP_APP_GROUP_COPY=1"
 assert_contains "$PROVISION_FILEPROVIDER_CONFIG_STEP" "swift/fileprovider/provision-config.sh \"\$CONFIG_PATH\""
 


### PR DESCRIPTION
## Summary

- add `tcfs config fileprovider` to render the macOS HostApp/FileProvider bootstrap JSON from the active config using the Rust credential resolver
- wire the macOS postinstall workflow to prefer the installed CLI renderer, with an explicit `require_cli_fileprovider_config` gate for new package proofs and a legacy fallback for older release tags
- update the FileProvider workflow contract test and first-run docs so the next packaged HostApp proof can require the Rust-owned JSON path

## Claim boundary

This does not close first-run UX or self-service enrollment. It removes one shell/TOML-parser dependency from the macOS package smoke path and creates a dispatchable gate for packages that include the new CLI command.

## Validation

- `~/.cargo/bin/cargo fmt --all -- --check`
- `~/.cargo/bin/cargo test -p tcfs-cli fileprovider`
- runtime smoke: `target/debug/tcfs --config <tmp>/config.toml config fileprovider --out <tmp>/fileprovider/config.json --device-id device-from-runtime --force` + `jq` field validation
- `bash scripts/test-release-workflow-fileprovider.sh`
- `~/.cargo/bin/cargo clippy -p tcfs-cli --all-targets`
- `git diff --check`
