### PR TITLE
crypto: add per-device file key wrap substrate (TIN-1417)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5242,6 +5242,7 @@ name = "tcfs-crypto"
 version = "0.12.13"
 dependencies = [
  "aes-siv",
+ "age",
  "anyhow",
  "argon2",
  "base64 0.22.1",

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -5724,6 +5724,7 @@ mod tests {
             rel_path: Some(rel_path.to_string()),
             mode: None,
             encrypted_file_key: Some(base64::engine::general_purpose::STANDARD.encode(wrapped)),
+            wrapped_file_keys: Vec::new(),
         }
     }
 

--- a/crates/tcfs-crypto/Cargo.toml
+++ b/crates/tcfs-crypto/Cargo.toml
@@ -20,6 +20,7 @@ zeroize = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+age = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tcfs-crypto/src/keys.rs
+++ b/crates/tcfs-crypto/src/keys.rs
@@ -6,11 +6,15 @@ use chacha20poly1305::{
 };
 use hkdf::Hkdf;
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use zeroize::Zeroize;
 
 use crate::kdf::MasterKey;
 use crate::{KEY_SIZE, NONCE_SIZE, TAG_SIZE};
+
+/// Algorithm marker for file keys wrapped to age X25519 device recipients.
+pub const AGE_X25519_FILE_KEY_ALGORITHM: &str = "age-x25519-v1";
 
 /// A per-file 256-bit encryption key. Zeroized on drop.
 #[derive(Clone)]
@@ -40,6 +44,28 @@ impl std::fmt::Debug for FileKey {
             .field("bytes", &"[REDACTED]")
             .finish()
     }
+}
+
+/// An active device recipient for per-device FileKey wrapping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgeFileKeyRecipient {
+    /// Stable TCFS device identifier.
+    pub device_id: String,
+    /// age X25519 public recipient string (`age1...`).
+    pub recipient: String,
+}
+
+/// One FileKey wrap addressed to one device recipient.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgeWrappedFileKey {
+    /// Stable TCFS device identifier this wrap is intended for.
+    pub recipient_device_id: String,
+    /// Public recipient used when wrapping, retained for audit/migration checks.
+    pub recipient: String,
+    /// Cryptographic wrap algorithm.
+    pub algorithm: String,
+    /// Armored age ciphertext containing the 32-byte FileKey.
+    pub wrapped_key: String,
 }
 
 /// Generate a random 256-bit file encryption key.
@@ -125,10 +151,115 @@ pub fn unwrap_key(master: &MasterKey, wrapped: &[u8]) -> anyhow::Result<FileKey>
     Ok(FileKey::from_bytes(key_bytes))
 }
 
+/// Wrap a FileKey once per active age X25519 device recipient.
+///
+/// This is the additive TIN-1417 primitive for manifest schema v3. Existing
+/// master-key wraps remain supported during migration; callers should dual-write
+/// this recipient list before cutting over reads to per-device identities.
+pub fn wrap_file_key_for_age_recipients(
+    file_key: &FileKey,
+    recipients: &[AgeFileKeyRecipient],
+) -> anyhow::Result<Vec<AgeWrappedFileKey>> {
+    if recipients.is_empty() {
+        anyhow::bail!("at least one recipient is required to wrap a file key");
+    }
+
+    recipients
+        .iter()
+        .map(|recipient| {
+            let age_recipient: age::x25519::Recipient =
+                recipient.recipient.parse().map_err(|e| {
+                    anyhow::anyhow!("parsing age recipient for {}: {e}", recipient.device_id)
+                })?;
+            let wrapped_key =
+                age::encrypt_and_armor(&age_recipient, file_key.as_bytes()).map_err(|e| {
+                    anyhow::anyhow!("wrapping file key for {}: {e}", recipient.device_id)
+                })?;
+            Ok(AgeWrappedFileKey {
+                recipient_device_id: recipient.device_id.clone(),
+                recipient: recipient.recipient.clone(),
+                algorithm: AGE_X25519_FILE_KEY_ALGORITHM.to_string(),
+                wrapped_key,
+            })
+        })
+        .collect()
+}
+
+/// Unwrap a FileKey using a local age X25519 identity.
+///
+/// If `device_id` is provided, only wraps addressed to that device are tried.
+/// Otherwise every supported wrap is attempted. Non-matching wraps fail closed
+/// and do not produce corrupted keys.
+pub fn unwrap_file_key_with_age_identity(
+    wrapped_keys: &[AgeWrappedFileKey],
+    identity_secret: &str,
+    device_id: Option<&str>,
+) -> anyhow::Result<FileKey> {
+    use age::armor::ArmoredReader;
+    use std::io::Read;
+
+    let identity: age::x25519::Identity = identity_secret
+        .parse()
+        .map_err(|e| anyhow::anyhow!("parsing age identity: {e}"))?;
+    let mut saw_candidate = false;
+
+    for wrapped in wrapped_keys {
+        if wrapped.algorithm != AGE_X25519_FILE_KEY_ALGORITHM {
+            continue;
+        }
+        if device_id.is_some_and(|id| id != wrapped.recipient_device_id) {
+            continue;
+        }
+        saw_candidate = true;
+
+        let armored = ArmoredReader::new(wrapped.wrapped_key.as_bytes());
+        let decryptor = match age::Decryptor::new(armored) {
+            Ok(decryptor) => decryptor,
+            Err(_) => continue,
+        };
+        if decryptor.is_scrypt() {
+            continue;
+        }
+
+        let mut reader = match decryptor.decrypt(std::iter::once(&identity as &dyn age::Identity)) {
+            Ok(reader) => reader,
+            Err(_) => continue,
+        };
+        let mut plaintext = Vec::new();
+        if reader.read_to_end(&mut plaintext).is_err() {
+            plaintext.zeroize();
+            continue;
+        }
+
+        if plaintext.len() != KEY_SIZE {
+            plaintext.zeroize();
+            anyhow::bail!(
+                "age-wrapped file key for {} had wrong size: {} bytes",
+                wrapped.recipient_device_id,
+                plaintext.len()
+            );
+        }
+
+        let mut key_bytes = [0u8; KEY_SIZE];
+        key_bytes.copy_from_slice(&plaintext);
+        plaintext.zeroize();
+        return Ok(FileKey::from_bytes(key_bytes));
+    }
+
+    if saw_candidate {
+        anyhow::bail!("no decryptable age-wrapped file key for this identity");
+    }
+    if let Some(device_id) = device_id {
+        anyhow::bail!("manifest has no supported age-wrapped file key for device {device_id}");
+    }
+    anyhow::bail!("manifest has no supported age-wrapped file key entries")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::kdf::MasterKey;
+    use secrecy::ExposeSecret;
 
     fn test_master_key() -> MasterKey {
         MasterKey::from_bytes([42u8; KEY_SIZE])
@@ -184,5 +315,67 @@ mod tests {
 
         // nonce (24) + key (32) + tag (16) = 72
         assert_eq!(wrapped.len(), NONCE_SIZE + KEY_SIZE + TAG_SIZE);
+    }
+
+    #[test]
+    fn test_age_recipient_file_key_wrap_roundtrip() {
+        let device_a = age::x25519::Identity::generate();
+        let device_b = age::x25519::Identity::generate();
+        let outsider = age::x25519::Identity::generate();
+        let file_key = generate_file_key();
+
+        let wrapped = wrap_file_key_for_age_recipients(
+            &file_key,
+            &[
+                AgeFileKeyRecipient {
+                    device_id: "device-a".into(),
+                    recipient: device_a.to_public().to_string(),
+                },
+                AgeFileKeyRecipient {
+                    device_id: "device-b".into(),
+                    recipient: device_b.to_public().to_string(),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(wrapped.len(), 2);
+        assert!(wrapped
+            .iter()
+            .all(|wrap| wrap.algorithm == AGE_X25519_FILE_KEY_ALGORITHM));
+
+        let a = unwrap_file_key_with_age_identity(
+            &wrapped,
+            device_a.to_string().expose_secret(),
+            Some("device-a"),
+        )
+        .unwrap();
+        let b = unwrap_file_key_with_age_identity(
+            &wrapped,
+            device_b.to_string().expose_secret(),
+            Some("device-b"),
+        )
+        .unwrap();
+
+        assert_eq!(a.as_bytes(), file_key.as_bytes());
+        assert_eq!(b.as_bytes(), file_key.as_bytes());
+
+        let outsider_result =
+            unwrap_file_key_with_age_identity(&wrapped, outsider.to_string().expose_secret(), None);
+        assert!(outsider_result.is_err());
+    }
+
+    #[test]
+    fn test_age_wrap_rejects_bad_recipient() {
+        let file_key = generate_file_key();
+        let result = wrap_file_key_for_age_recipients(
+            &file_key,
+            &[AgeFileKeyRecipient {
+                device_id: "bad-device".into(),
+                recipient: "age1-not-a-real-recipient".into(),
+            }],
+        );
+
+        assert!(result.is_err());
     }
 }

--- a/crates/tcfs-crypto/src/lib.rs
+++ b/crates/tcfs-crypto/src/lib.rs
@@ -23,7 +23,9 @@ pub mod recovery;
 pub use chunk::{decrypt_chunk, encrypt_chunk};
 pub use kdf::{derive_master_key, MasterKey};
 pub use keys::{
-    derive_manifest_key, derive_name_key, generate_file_key, unwrap_key, wrap_key, FileKey,
+    derive_manifest_key, derive_name_key, generate_file_key, unwrap_file_key_with_age_identity,
+    unwrap_key, wrap_file_key_for_age_recipients, wrap_key, AgeFileKeyRecipient, AgeWrappedFileKey,
+    FileKey, AGE_X25519_FILE_KEY_ALGORITHM,
 };
 pub use manifest::{EncryptedManifest, ManifestEntry};
 pub use names::{decrypt_name, encrypt_name};

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -712,6 +712,7 @@ pub unsafe extern "C" fn tcfs_provider_upload(
                 rel_path: Some(remote_str.to_string()),
                 mode: None,
                 encrypted_file_key,
+                wrapped_file_keys: Vec::new(),
             };
 
             let manifest_json = serde_json::to_vec_pretty(&manifest)?;

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -569,6 +569,7 @@ impl TcfsProviderHandle {
                 rel_path: Some(remote_path.to_string()),
                 mode: None,
                 encrypted_file_key,
+                wrapped_file_keys: Vec::new(),
             };
 
             let manifest_json =

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1848,6 +1848,7 @@ async fn upload_file_with_device_with_state(
         rel_path: rel_path.map(|s| s.to_string()),
         mode: file_mode,
         encrypted_file_key,
+        wrapped_file_keys: Vec::new(),
     };
 
     let manifest_bytes = manifest.to_bytes()?;
@@ -3760,6 +3761,7 @@ mod tests {
             rel_path: Some("large.bin".into()),
             mode: None,
             encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
         };
         let manifest_path = format!("data/manifests/{file_hash}");
         op.write(&manifest_path, manifest.to_bytes().unwrap())

--- a/crates/tcfs-sync/src/manifest.rs
+++ b/crates/tcfs-sync/src/manifest.rs
@@ -7,6 +7,23 @@ use crate::conflict::VectorClock;
 use crate::index_entry::RemoteEntryKind;
 use serde::{Deserialize, Serialize};
 
+/// One per-device FileKey wrap carried by a regular-file manifest.
+///
+/// This is additive for TIN-1417 Phase 1. Existing manifests continue to use
+/// `encrypted_file_key`; upgraded writers can dual-write this field before the
+/// fleet cuts over to per-device unwrap.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WrappedFileKey {
+    /// Stable TCFS device identifier this wrap is intended for.
+    pub recipient_device_id: String,
+    /// Public age recipient used when producing this wrap.
+    pub recipient: String,
+    /// Cryptographic wrap algorithm, for example `age-x25519-v1`.
+    pub algorithm: String,
+    /// Wrapped FileKey payload.
+    pub wrapped_key: String,
+}
+
 /// A manifest describing a synced file's chunks and metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncManifest {
@@ -33,6 +50,9 @@ pub struct SyncManifest {
     /// Base64-encoded wrapped file key (present only when E2E encryption is enabled)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encrypted_file_key: Option<String>,
+    /// Per-device wrapped FileKeys for manifest schema v3 migration.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub wrapped_file_keys: Vec<WrappedFileKey>,
 }
 
 /// A manifest for a POSIX symbolic link.
@@ -134,6 +154,7 @@ impl SyncManifest {
             rel_path: None,
             mode: None,
             encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
         })
     }
 
@@ -173,6 +194,12 @@ mod tests {
             rel_path: Some("docs/readme.md".into()),
             mode: Some(0o644),
             encrypted_file_key: None,
+            wrapped_file_keys: vec![WrappedFileKey {
+                recipient_device_id: "device-a".into(),
+                recipient: "age1recipient".into(),
+                algorithm: "age-x25519-v1".into(),
+                wrapped_key: "AGE-ENCRYPTED-PAYLOAD".into(),
+            }],
         };
 
         let bytes = manifest.to_bytes().unwrap();
@@ -183,6 +210,8 @@ mod tests {
         assert_eq!(parsed.chunks.len(), 2);
         assert_eq!(parsed.vclock.get("yoga"), 1);
         assert_eq!(parsed.written_by, "yoga");
+        assert_eq!(parsed.wrapped_file_keys.len(), 1);
+        assert_eq!(parsed.wrapped_file_keys[0].recipient_device_id, "device-a");
     }
 
     #[test]
@@ -268,6 +297,7 @@ mod proptest_suite {
                 rel_path: None,
                 mode: None,
                 encrypted_file_key: None,
+                wrapped_file_keys: Vec::new(),
             };
 
             let bytes = manifest.to_bytes().unwrap();

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -1265,6 +1265,7 @@ mod tests {
             rel_path: Some("doc.txt".into()),
             mode: None,
             encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
         };
 
         op.write("data/manifests/file-hash", manifest.to_bytes().unwrap())
@@ -1294,6 +1295,7 @@ mod tests {
             rel_path: Some("doc.txt".into()),
             mode: None,
             encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
         };
 
         op.write("data/manifests/file-hash", manifest.to_bytes().unwrap())
@@ -1383,6 +1385,7 @@ mod tests {
             rel_path: Some("doc.txt".into()),
             mode: None,
             encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
         };
 
         op.write("data/manifests/file-hash", manifest.to_bytes().unwrap())

--- a/crates/tcfs-sync/tests/multi_machine_sim.rs
+++ b/crates/tcfs-sync/tests/multi_machine_sim.rs
@@ -180,6 +180,7 @@ fn execute_op(
                 rel_path: Some(path.clone()),
                 mode: None,
                 encrypted_file_key: None,
+                wrapped_file_keys: Vec::new(),
             };
 
             remote.manifests.insert(path.clone(), manifest);
@@ -916,6 +917,7 @@ fn test_manifest_serialization_in_sim() {
         rel_path: Some("src/main.rs".into()),
         mode: None,
         encrypted_file_key: None,
+        wrapped_file_keys: Vec::new(),
     };
 
     let bytes = manifest.to_bytes().unwrap();

--- a/crates/tcfs-vfs/src/driver.rs
+++ b/crates/tcfs-vfs/src/driver.rs
@@ -348,6 +348,7 @@ impl TcfsVfs {
             rel_path: Some(vpath.to_string()),
             mode: None,
             encrypted_file_key,
+            wrapped_file_keys: Vec::new(),
         };
         let manifest_key = format!("{}/manifests/{}", prefix, file_hash);
         self.op

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1483,6 +1483,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                     rel_path: Some(req.path.clone()),
                     mode: None,
                     encrypted_file_key: None,
+                    wrapped_file_keys: Vec::new(),
                 };
 
                 // Upload updated manifest

--- a/docs/ops/per-device-crypto-identity-design-2026-05-18.md
+++ b/docs/ops/per-device-crypto-identity-design-2026-05-18.md
@@ -11,6 +11,14 @@ persist the secret half in a `0600` `device-<device_id>.age` file beside the
 registry. Manifest wrapping, revoke semantics, pairing, and remote registry
 trust are still open.
 
+2026-05-25 follow-up implementation note: the first Phase 1 substrate slice now
+adds age/X25519 per-recipient FileKey wrap helpers in `tcfs-crypto` and the
+additive `wrapped_file_keys` manifest field in `tcfs-sync`. This does not yet
+change push/pull behavior: writers still emit the legacy `encrypted_file_key`
+only, and readers still unwrap through the shared master key until recipient-set
+resolution and device-secret loading are wired through the sync, VFS, and
+FileProvider paths.
+
 ## Problem Statement
 
 Today every "enrolled" device on a tcfs fleet holds the same shared master key


### PR DESCRIPTION
## Summary

- Adds additive age/X25519 FileKey wrap helpers in `tcfs-crypto` for wrapping one FileKey to multiple device recipients.
- Adds the `wrapped_file_keys` manifest field in `tcfs-sync` while preserving the legacy `encrypted_file_key` path.
- Wires current manifest construction sites to emit an empty recipient list for now and updates the TIN-1417 design note with the exact boundary.

## Validation

- `~/.cargo/bin/cargo test -p tcfs-crypto keys::tests::test_age -- --nocapture`
- `~/.cargo/bin/cargo test -p tcfs-sync manifest -- --nocapture`
- `~/.cargo/bin/cargo check -p tcfs-vfs -p tcfs-file-provider`
- `~/.cargo/bin/cargo check --workspace --locked`
- `~/.cargo/bin/cargo fmt --all -- --check`
- `git diff --check`

## Claim boundary

Substrate only. This does not change push/pull encryption behavior yet: writers still emit legacy `encrypted_file_key`, readers still unwrap through the shared master key, and revocation is not meaningful until recipient-set resolution plus device-secret loading are wired through sync, VFS, and FileProvider.
