### PR TITLE
ci: add storage restore SLO budgets (TIN-1622)

### DIFF
--- a/.github/workflows/storage-large-restore-canary.yml
+++ b/.github/workflows/storage-large-restore-canary.yml
@@ -49,6 +49,46 @@ on:
         required: false
         default: "8"
         type: string
+      min_restore_throughput_bps:
+        description: "Fail if restore throughput is below this bytes/sec budget; 0 observes only"
+        required: false
+        default: "0"
+        type: string
+      max_restore_elapsed_secs:
+        description: "Fail if restore execute elapsed seconds exceed this budget; 0 observes only"
+        required: false
+        default: "0"
+        type: string
+      max_502_log_lines:
+        description: "Fail if restore logs contain more HTTP 502 lines than this budget; 0 observes only"
+        required: false
+        default: "0"
+        type: string
+      max_opendal_retry_rows:
+        description: "Fail if restore logs contain more OpenDAL retry rows than this budget; 0 observes only"
+        required: false
+        default: "0"
+        type: string
+      max_tcfs_chunk_retry_rows:
+        description: "Fail if restore logs contain more TCFS chunk retry rows than this budget; 0 observes only"
+        required: false
+        default: "0"
+        type: string
+      max_push_warn_rows:
+        description: "Fail if push summary has more warning rows than this budget; 0 observes only"
+        required: false
+        default: "0"
+        type: string
+      max_push_error_rows:
+        description: "Fail if push summary has more error rows than this budget; 0 observes only"
+        required: false
+        default: "0"
+        type: string
+      max_socket_highwater:
+        description: "Fail if sampled S3 socket highwater exceeds this budget; 0 observes only"
+        required: false
+        default: "0"
+        type: string
       tcfs_binary_source:
         description: "tcfs binary under test"
         required: false
@@ -127,7 +167,15 @@ jobs:
             "pack_size_mib:${{ github.event.inputs.pack_size_mib }}" \
             "restore_headroom_margin_mib:${{ github.event.inputs.restore_headroom_margin_mib }}" \
             "reconcile_timeout_secs:${{ github.event.inputs.reconcile_timeout_secs }}" \
-            "download_chunk_retries:${{ github.event.inputs.download_chunk_retries }}"
+            "download_chunk_retries:${{ github.event.inputs.download_chunk_retries }}" \
+            "min_restore_throughput_bps:${{ github.event.inputs.min_restore_throughput_bps }}" \
+            "max_restore_elapsed_secs:${{ github.event.inputs.max_restore_elapsed_secs }}" \
+            "max_502_log_lines:${{ github.event.inputs.max_502_log_lines }}" \
+            "max_opendal_retry_rows:${{ github.event.inputs.max_opendal_retry_rows }}" \
+            "max_tcfs_chunk_retry_rows:${{ github.event.inputs.max_tcfs_chunk_retry_rows }}" \
+            "max_push_warn_rows:${{ github.event.inputs.max_push_warn_rows }}" \
+            "max_push_error_rows:${{ github.event.inputs.max_push_error_rows }}" \
+            "max_socket_highwater:${{ github.event.inputs.max_socket_highwater }}"
           do
             name="${pair%%:*}"
             value="${pair#*:}"
@@ -454,6 +502,22 @@ jobs:
             --evidence-dir "$EVIDENCE_DIR" \
             --restore-root "$RESTORE_ROOT"
 
+      - name: Evaluate storage SLO budgets
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/evaluate-storage-large-restore-slo.sh \
+            --evidence-dir "$EVIDENCE_DIR" \
+            --min-restore-throughput-bps "${{ github.event.inputs.min_restore_throughput_bps }}" \
+            --max-restore-elapsed-secs "${{ github.event.inputs.max_restore_elapsed_secs }}" \
+            --max-502-log-lines "${{ github.event.inputs.max_502_log_lines }}" \
+            --max-opendal-retry-rows "${{ github.event.inputs.max_opendal_retry_rows }}" \
+            --max-tcfs-chunk-retry-rows "${{ github.event.inputs.max_tcfs_chunk_retry_rows }}" \
+            --max-push-warn-rows "${{ github.event.inputs.max_push_warn_rows }}" \
+            --max-push-error-rows "${{ github.event.inputs.max_push_error_rows }}" \
+            --max-socket-highwater "${{ github.event.inputs.max_socket_highwater }}"
+
       - name: Summarize large restore packet
         if: always()
         shell: bash
@@ -481,6 +545,11 @@ jobs:
               echo
               echo "## Restore"
               sed -n '1,120p' "$EVIDENCE_DIR/restore-proof/restore-proof.env"
+            fi
+            if [[ -f "$EVIDENCE_DIR/storage-slo-summary.env" ]]; then
+              echo
+              echo "## Storage SLO"
+              sed -n '1,120p' "$EVIDENCE_DIR/storage-slo-summary.env"
             fi
           } | tee "$EVIDENCE_DIR/large-restore-summary.md" >> "$GITHUB_STEP_SUMMARY"
 

--- a/Justfile
+++ b/Justfile
@@ -154,6 +154,10 @@ linux-package-container-workflow-test:
 storage-large-restore-workflow-test:
     @bash scripts/test-storage-large-restore-canary-workflow.sh
 
+# Regression test the storage large restore SLO evaluator
+storage-large-restore-slo-test:
+    @bash scripts/test-evaluate-storage-large-restore-slo.sh
+
 # Read-only inventory packet for a candidate large workdir
 large-workdir-inventory ROOT *ARGS:
     python3 scripts/large-workdir-inventory.py {{ROOT}} {{ARGS}}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -664,6 +664,49 @@ tasks:
     cmds:
       - bash scripts/test-git-repo-restore-proof.sh
 
+  lazy:storage-large-restore-slo:
+    desc: "Evaluate a storage large-restore packet against optional SLO budgets"
+    cmds:
+      - cmd: |
+          bash -euo pipefail <<'EOF'
+          args=()
+
+          if [[ -n "${EVIDENCE_DIR:-}" ]]; then
+            args+=(--evidence-dir "$EVIDENCE_DIR")
+          fi
+          if [[ -n "${MIN_RESTORE_THROUGHPUT_BPS:-}" ]]; then
+            args+=(--min-restore-throughput-bps "$MIN_RESTORE_THROUGHPUT_BPS")
+          fi
+          if [[ -n "${MAX_RESTORE_ELAPSED_SECS:-}" ]]; then
+            args+=(--max-restore-elapsed-secs "$MAX_RESTORE_ELAPSED_SECS")
+          fi
+          if [[ -n "${MAX_502_LOG_LINES:-}" ]]; then
+            args+=(--max-502-log-lines "$MAX_502_LOG_LINES")
+          fi
+          if [[ -n "${MAX_OPENDAL_RETRY_ROWS:-}" ]]; then
+            args+=(--max-opendal-retry-rows "$MAX_OPENDAL_RETRY_ROWS")
+          fi
+          if [[ -n "${MAX_TCFS_CHUNK_RETRY_ROWS:-}" ]]; then
+            args+=(--max-tcfs-chunk-retry-rows "$MAX_TCFS_CHUNK_RETRY_ROWS")
+          fi
+          if [[ -n "${MAX_PUSH_WARN_ROWS:-}" ]]; then
+            args+=(--max-push-warn-rows "$MAX_PUSH_WARN_ROWS")
+          fi
+          if [[ -n "${MAX_PUSH_ERROR_ROWS:-}" ]]; then
+            args+=(--max-push-error-rows "$MAX_PUSH_ERROR_ROWS")
+          fi
+          if [[ -n "${MAX_SOCKET_HIGHWATER:-}" ]]; then
+            args+=(--max-socket-highwater "$MAX_SOCKET_HIGHWATER")
+          fi
+
+          scripts/evaluate-storage-large-restore-slo.sh "${args[@]}"
+          EOF
+
+  lazy:test-storage-large-restore-slo:
+    desc: Regression-test the storage large-restore SLO evaluator
+    cmds:
+      - bash scripts/test-evaluate-storage-large-restore-slo.sh
+
   lazy:tcfs-symlink-package-probe:
     desc: "Probe candidate package/current tcfs binaries for sync_symlinks behavior"
     cmds:

--- a/scripts/evaluate-storage-large-restore-slo.sh
+++ b/scripts/evaluate-storage-large-restore-slo.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+#
+# Evaluate the storage large-restore packet against optional beta SLO budgets.
+#
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/evaluate-storage-large-restore-slo.sh --evidence-dir <path> [budgets]
+
+Reads a storage-large-restore evidence packet and writes:
+
+  storage-slo-summary.env
+  storage-slo-summary.md
+
+Budgets default to 0, which means "observe only" for that metric. A non-zero
+max budget fails when the observed value is greater than the budget. A non-zero
+min budget fails when the observed value is lower than the budget.
+
+Options:
+  --evidence-dir <path>
+  --min-restore-throughput-bps <n>
+  --max-restore-elapsed-secs <n>
+  --max-502-log-lines <n>
+  --max-opendal-retry-rows <n>
+  --max-tcfs-chunk-retry-rows <n>
+  --max-push-warn-rows <n>
+  --max-push-error-rows <n>
+  --max-socket-highwater <n>
+  -h, --help
+
+Environment mirrors:
+  EVIDENCE_DIR
+  MIN_RESTORE_THROUGHPUT_BPS
+  MAX_RESTORE_ELAPSED_SECS
+  MAX_502_LOG_LINES
+  MAX_OPENDAL_RETRY_ROWS
+  MAX_TCFS_CHUNK_RETRY_ROWS
+  MAX_PUSH_WARN_ROWS
+  MAX_PUSH_ERROR_ROWS
+  MAX_SOCKET_HIGHWATER
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+uint_value() {
+  local label="$1"
+  local value="$2"
+
+  case "$value" in
+    ""|*[!0-9]*) fail "$label must be a non-negative integer, got: $value" ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+}
+
+read_kv() {
+  local file="$1"
+  local key="$2"
+
+  [[ -f "$file" ]] || return 1
+  awk -F= -v key="$key" '
+    $1 == key {
+      print substr($0, length($1) + 2)
+      found = 1
+      exit
+    }
+    END { exit found ? 0 : 1 }
+  ' "$file"
+}
+
+read_uint_kv_or_zero() {
+  local file="$1"
+  local key="$2"
+  local value
+
+  value="$(read_kv "$file" "$key" || true)"
+  if [[ -z "$value" || "$value" == *[!0-9]* ]]; then
+    printf '0\n'
+  else
+    printf '%s\n' "$value"
+  fi
+}
+
+count_log_rows() {
+  local file="$1"
+  local pattern="$2"
+
+  if [[ ! -f "$file" ]]; then
+    printf '0\n'
+    return
+  fi
+
+  grep -Eci -- "$pattern" "$file" || true
+}
+
+check_max_budget() {
+  local label="$1"
+  local observed="$2"
+  local budget="$3"
+
+  if (( budget > 0 && observed > budget )); then
+    budget_failures+=("${label}: observed ${observed} > budget ${budget}")
+  fi
+}
+
+check_min_budget() {
+  local label="$1"
+  local observed="$2"
+  local budget="$3"
+
+  if (( budget > 0 && observed < budget )); then
+    budget_failures+=("${label}: observed ${observed} < budget ${budget}")
+  fi
+}
+
+evidence_dir="${EVIDENCE_DIR:-}"
+min_restore_throughput_bps="${MIN_RESTORE_THROUGHPUT_BPS:-0}"
+max_restore_elapsed_secs="${MAX_RESTORE_ELAPSED_SECS:-0}"
+max_502_log_lines="${MAX_502_LOG_LINES:-0}"
+max_opendal_retry_rows="${MAX_OPENDAL_RETRY_ROWS:-0}"
+max_tcfs_chunk_retry_rows="${MAX_TCFS_CHUNK_RETRY_ROWS:-0}"
+max_push_warn_rows="${MAX_PUSH_WARN_ROWS:-0}"
+max_push_error_rows="${MAX_PUSH_ERROR_ROWS:-0}"
+max_socket_highwater="${MAX_SOCKET_HIGHWATER:-0}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --evidence-dir)
+      [[ $# -ge 2 ]] || fail "--evidence-dir requires a value"
+      evidence_dir="$2"
+      shift 2
+      ;;
+    --min-restore-throughput-bps)
+      [[ $# -ge 2 ]] || fail "--min-restore-throughput-bps requires a value"
+      min_restore_throughput_bps="$2"
+      shift 2
+      ;;
+    --max-restore-elapsed-secs)
+      [[ $# -ge 2 ]] || fail "--max-restore-elapsed-secs requires a value"
+      max_restore_elapsed_secs="$2"
+      shift 2
+      ;;
+    --max-502-log-lines)
+      [[ $# -ge 2 ]] || fail "--max-502-log-lines requires a value"
+      max_502_log_lines="$2"
+      shift 2
+      ;;
+    --max-opendal-retry-rows)
+      [[ $# -ge 2 ]] || fail "--max-opendal-retry-rows requires a value"
+      max_opendal_retry_rows="$2"
+      shift 2
+      ;;
+    --max-tcfs-chunk-retry-rows)
+      [[ $# -ge 2 ]] || fail "--max-tcfs-chunk-retry-rows requires a value"
+      max_tcfs_chunk_retry_rows="$2"
+      shift 2
+      ;;
+    --max-push-warn-rows)
+      [[ $# -ge 2 ]] || fail "--max-push-warn-rows requires a value"
+      max_push_warn_rows="$2"
+      shift 2
+      ;;
+    --max-push-error-rows)
+      [[ $# -ge 2 ]] || fail "--max-push-error-rows requires a value"
+      max_push_error_rows="$2"
+      shift 2
+      ;;
+    --max-socket-highwater)
+      [[ $# -ge 2 ]] || fail "--max-socket-highwater requires a value"
+      max_socket_highwater="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$evidence_dir" ]] || fail "--evidence-dir is required"
+[[ -d "$evidence_dir" ]] || fail "evidence dir does not exist: $evidence_dir"
+
+min_restore_throughput_bps="$(uint_value min_restore_throughput_bps "$min_restore_throughput_bps")"
+max_restore_elapsed_secs="$(uint_value max_restore_elapsed_secs "$max_restore_elapsed_secs")"
+max_502_log_lines="$(uint_value max_502_log_lines "$max_502_log_lines")"
+max_opendal_retry_rows="$(uint_value max_opendal_retry_rows "$max_opendal_retry_rows")"
+max_tcfs_chunk_retry_rows="$(uint_value max_tcfs_chunk_retry_rows "$max_tcfs_chunk_retry_rows")"
+max_push_warn_rows="$(uint_value max_push_warn_rows "$max_push_warn_rows")"
+max_push_error_rows="$(uint_value max_push_error_rows "$max_push_error_rows")"
+max_socket_highwater="$(uint_value max_socket_highwater "$max_socket_highwater")"
+
+restore_env="$evidence_dir/restore-proof/restore-proof.env"
+restore_log="$evidence_dir/restore-proof/reconcile-execute.log"
+push_summary="$evidence_dir/push-storage-summary.env"
+socket_summary="$evidence_dir/s3-socket-summary.env"
+slo_env="$evidence_dir/storage-slo-summary.env"
+slo_md="$evidence_dir/storage-slo-summary.md"
+
+[[ -s "$restore_env" ]] || fail "missing restore proof env: $restore_env"
+
+restore_status="$(read_kv "$restore_env" status || true)"
+restore_reason="$(read_kv "$restore_env" reason || true)"
+execute_elapsed_secs="$(read_uint_kv_or_zero "$restore_env" execute_elapsed_secs)"
+restored_regular_file_bytes="$(read_uint_kv_or_zero "$restore_env" restored_regular_file_bytes)"
+restored_regular_file_bytes_per_sec="$(read_uint_kv_or_zero "$restore_env" restored_regular_file_bytes_per_sec)"
+download_chunk_retries="$(read_kv "$restore_env" download_chunk_retries || true)"
+
+push_warn_rows="$(read_uint_kv_or_zero "$push_summary" warn_rows)"
+push_retry_warning_rows="$(read_uint_kv_or_zero "$push_summary" retry_warning_rows)"
+push_error_rows="$(read_uint_kv_or_zero "$push_summary" error_rows)"
+socket_highwater="$(read_uint_kv_or_zero "$socket_summary" socket_highwater)"
+
+http_502_log_lines="$(count_log_rows "$restore_log" 'error code:[[:space:]]*502|(^|[^0-9])502([^0-9]|$)')"
+opendal_retry_rows="$(count_log_rows "$restore_log" 'opendal.*retry|Retryable|retrying after|backoff')"
+tcfs_chunk_retry_rows="$(count_log_rows "$restore_log" 'chunk download (failed|timed out|integrity mismatch), retrying')"
+
+budget_failures=()
+if [[ "$restore_status" != "passed" ]]; then
+  budget_failures+=("restore status: ${restore_status:-missing} (${restore_reason:-no reason})")
+fi
+
+check_min_budget "restore throughput bytes/sec" "$restored_regular_file_bytes_per_sec" "$min_restore_throughput_bps"
+check_max_budget "restore elapsed seconds" "$execute_elapsed_secs" "$max_restore_elapsed_secs"
+check_max_budget "HTTP 502 log lines" "$http_502_log_lines" "$max_502_log_lines"
+check_max_budget "OpenDAL retry rows" "$opendal_retry_rows" "$max_opendal_retry_rows"
+check_max_budget "TCFS chunk retry rows" "$tcfs_chunk_retry_rows" "$max_tcfs_chunk_retry_rows"
+check_max_budget "push warning rows" "$push_warn_rows" "$max_push_warn_rows"
+check_max_budget "push error rows" "$push_error_rows" "$max_push_error_rows"
+check_max_budget "S3 socket highwater" "$socket_highwater" "$max_socket_highwater"
+
+slo_status=passed
+if (( ${#budget_failures[@]} > 0 )); then
+  slo_status=failed
+fi
+
+{
+  printf 'created_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'status=%s\n' "$slo_status"
+  printf 'restore_status=%s\n' "${restore_status:-missing}"
+  printf 'restore_reason=%s\n' "$restore_reason"
+  printf 'restored_regular_file_bytes=%s\n' "$restored_regular_file_bytes"
+  printf 'execute_elapsed_secs=%s\n' "$execute_elapsed_secs"
+  printf 'restored_regular_file_bytes_per_sec=%s\n' "$restored_regular_file_bytes_per_sec"
+  printf 'download_chunk_retries=%s\n' "$download_chunk_retries"
+  printf 'http_502_log_lines=%s\n' "$http_502_log_lines"
+  printf 'opendal_retry_rows=%s\n' "$opendal_retry_rows"
+  printf 'tcfs_chunk_retry_rows=%s\n' "$tcfs_chunk_retry_rows"
+  printf 'push_warn_rows=%s\n' "$push_warn_rows"
+  printf 'push_retry_warning_rows=%s\n' "$push_retry_warning_rows"
+  printf 'push_error_rows=%s\n' "$push_error_rows"
+  printf 'socket_highwater=%s\n' "$socket_highwater"
+  printf 'min_restore_throughput_bps=%s\n' "$min_restore_throughput_bps"
+  printf 'max_restore_elapsed_secs=%s\n' "$max_restore_elapsed_secs"
+  printf 'max_502_log_lines=%s\n' "$max_502_log_lines"
+  printf 'max_opendal_retry_rows=%s\n' "$max_opendal_retry_rows"
+  printf 'max_tcfs_chunk_retry_rows=%s\n' "$max_tcfs_chunk_retry_rows"
+  printf 'max_push_warn_rows=%s\n' "$max_push_warn_rows"
+  printf 'max_push_error_rows=%s\n' "$max_push_error_rows"
+  printf 'max_socket_highwater=%s\n' "$max_socket_highwater"
+  printf 'budget_failure_count=%s\n' "${#budget_failures[@]}"
+  if (( ${#budget_failures[@]} > 0 )); then
+    printf 'budget_failures=%s\n' "$(IFS='; '; printf '%s' "${budget_failures[*]}")"
+  else
+    printf 'budget_failures=\n'
+  fi
+} >"$slo_env"
+
+{
+  echo "# Storage Large Restore SLO Evaluation"
+  echo
+  echo "- Status: \`$slo_status\`"
+  echo "- Restore status: \`${restore_status:-missing}\`"
+  echo "- Restore reason: \`$restore_reason\`"
+  echo "- Restored bytes: \`$restored_regular_file_bytes\`"
+  echo "- Restore elapsed seconds: \`$execute_elapsed_secs\`"
+  echo "- Restore throughput: \`${restored_regular_file_bytes_per_sec} bytes/s\`"
+  echo "- HTTP 502 log lines: \`$http_502_log_lines\`"
+  echo "- OpenDAL retry rows: \`$opendal_retry_rows\`"
+  echo "- TCFS chunk retry rows: \`$tcfs_chunk_retry_rows\`"
+  echo "- Push warning rows: \`$push_warn_rows\`"
+  echo "- Push retry warning rows: \`$push_retry_warning_rows\`"
+  echo "- Push error rows: \`$push_error_rows\`"
+  echo "- S3 socket highwater: \`$socket_highwater\`"
+  echo
+  echo "## Budgets"
+  echo
+  echo "- Minimum restore throughput: \`${min_restore_throughput_bps} bytes/s\`"
+  echo "- Maximum restore elapsed: \`${max_restore_elapsed_secs}s\`"
+  echo "- Maximum HTTP 502 log lines: \`$max_502_log_lines\`"
+  echo "- Maximum OpenDAL retry rows: \`$max_opendal_retry_rows\`"
+  echo "- Maximum TCFS chunk retry rows: \`$max_tcfs_chunk_retry_rows\`"
+  echo "- Maximum push warning rows: \`$max_push_warn_rows\`"
+  echo "- Maximum push error rows: \`$max_push_error_rows\`"
+  echo "- Maximum S3 socket highwater: \`$max_socket_highwater\`"
+  if (( ${#budget_failures[@]} > 0 )); then
+    echo
+    echo "## Failures"
+    echo
+    for failure in "${budget_failures[@]}"; do
+      echo "- $failure"
+    done
+  fi
+} >"$slo_md"
+
+printf 'storage SLO evidence: %s\n' "$slo_env"
+printf 'storage SLO status: %s\n' "$slo_status"
+
+if [[ "$slo_status" != "passed" ]]; then
+  exit 1
+fi

--- a/scripts/test-evaluate-storage-large-restore-slo.sh
+++ b/scripts/test-evaluate-storage-large-restore-slo.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Regression tests for storage large-restore SLO evaluation.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/evaluate-storage-large-restore-slo.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-storage-slo-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+make_packet() {
+  local dir="$1"
+
+  mkdir -p "$dir/restore-proof"
+  cat >"$dir/restore-proof/restore-proof.env" <<'EOF'
+status=passed
+reason=regular files restored exactly
+download_chunk_retries=8
+execute_elapsed_secs=120
+restored_regular_file_bytes=1048576000
+restored_regular_file_bytes_per_sec=8738133
+EOF
+  cat >"$dir/push-storage-summary.env" <<'EOF'
+warn_rows=2
+retry_warning_rows=1
+error_rows=0
+EOF
+  cat >"$dir/s3-socket-summary.env" <<'EOF'
+socket_highwater=4
+EOF
+  cat >"$dir/restore-proof/reconcile-execute.log" <<'EOF'
+2026-05-25T00:00:00Z WARN opendal::services: read failed Unexpected at read => error code: 502
+2026-05-25T00:00:01Z WARN tcfs_sync::engine: chunk download failed, retrying key=tcfs/chunks/a attempt=1 max=8
+2026-05-25T00:00:02Z WARN opendal::layers::retry: retrying after temporary storage error
+EOF
+}
+
+bash -n "$SCRIPT"
+
+packet="$TMPDIR/packet"
+make_packet "$packet"
+
+"$SCRIPT" --evidence-dir "$packet"
+assert_contains "$packet/storage-slo-summary.env" "status=passed"
+assert_contains "$packet/storage-slo-summary.env" "http_502_log_lines=1"
+assert_contains "$packet/storage-slo-summary.env" "tcfs_chunk_retry_rows=1"
+
+"$SCRIPT" \
+  --evidence-dir "$packet" \
+  --min-restore-throughput-bps 1000000 \
+  --max-restore-elapsed-secs 300 \
+  --max-502-log-lines 2 \
+  --max-opendal-retry-rows 3 \
+  --max-tcfs-chunk-retry-rows 1 \
+  --max-push-warn-rows 2 \
+  --max-push-error-rows 1 \
+  --max-socket-highwater 4
+assert_contains "$packet/storage-slo-summary.env" "status=passed"
+assert_contains "$packet/storage-slo-summary.env" "max_502_log_lines=2"
+
+if "$SCRIPT" --evidence-dir "$packet" --max-502-log-lines 0; then
+  :
+else
+  printf 'zero max budget should be observe-only, not failure\n' >&2
+  exit 1
+fi
+
+if "$SCRIPT" --evidence-dir "$packet" --max-502-log-lines 1; then
+  :
+else
+  printf 'expected max-502-log-lines=1 to pass at exactly one observed line\n' >&2
+  exit 1
+fi
+
+if "$SCRIPT" --evidence-dir "$packet" --max-502-log-lines 2; then
+  :
+else
+  printf 'expected max-502-log-lines=2 to pass\n' >&2
+  exit 1
+fi
+
+if "$SCRIPT" --evidence-dir "$packet" --max-tcfs-chunk-retry-rows 0; then
+  :
+else
+  printf 'zero chunk retry budget should be observe-only, not failure\n' >&2
+  exit 1
+fi
+
+if "$SCRIPT" --evidence-dir "$packet" --max-tcfs-chunk-retry-rows 1; then
+  :
+else
+  printf 'expected max-tcfs-chunk-retry-rows=1 to pass at exactly one observed line\n' >&2
+  exit 1
+fi
+
+if "$SCRIPT" --evidence-dir "$packet" --max-push-warn-rows 1 >"$TMPDIR/fail.log" 2>&1; then
+  printf 'expected push warning budget failure\n' >&2
+  exit 1
+fi
+assert_contains "$packet/storage-slo-summary.env" "status=failed"
+assert_contains "$packet/storage-slo-summary.env" "push warning rows: observed 2 > budget 1"
+
+if "$SCRIPT" --evidence-dir "$packet" --min-restore-throughput-bps 9000000 >"$TMPDIR/fail-throughput.log" 2>&1; then
+  printf 'expected restore throughput budget failure\n' >&2
+  exit 1
+fi
+assert_contains "$packet/storage-slo-summary.env" "restore throughput bytes/sec: observed 8738133 < budget 9000000"
+
+failed_packet="$TMPDIR/failed-packet"
+make_packet "$failed_packet"
+sed -i.bak 's/status=passed/status=failed/' "$failed_packet/restore-proof/restore-proof.env"
+if "$SCRIPT" --evidence-dir "$failed_packet" >"$TMPDIR/fail-status.log" 2>&1; then
+  printf 'expected failed restore status to fail SLO evaluation\n' >&2
+  exit 1
+fi
+assert_contains "$failed_packet/storage-slo-summary.env" "restore status: failed"
+
+printf 'storage large restore SLO tests passed\n'

--- a/scripts/test-storage-large-restore-canary-workflow.sh
+++ b/scripts/test-storage-large-restore-canary-workflow.sh
@@ -48,6 +48,15 @@ assert_contains "$WORKFLOW" "tcfs_binary_source:"
 assert_contains "$WORKFLOW" "default: \"nix-package\""
 assert_contains "$WORKFLOW" "download_chunk_retries:"
 assert_contains "$WORKFLOW" "TCFS_DOWNLOAD_CHUNK_RETRIES="
+assert_contains "$WORKFLOW" "min_restore_throughput_bps:"
+assert_contains "$WORKFLOW" "max_restore_elapsed_secs:"
+assert_contains "$WORKFLOW" "max_502_log_lines:"
+assert_contains "$WORKFLOW" "max_opendal_retry_rows:"
+assert_contains "$WORKFLOW" "max_tcfs_chunk_retry_rows:"
+assert_contains "$WORKFLOW" "max_push_warn_rows:"
+assert_contains "$WORKFLOW" "max_push_error_rows:"
+assert_contains "$WORKFLOW" "max_socket_highwater:"
+assert_contains "$WORKFLOW" "Evaluate storage SLO budgets"
 assert_contains "$WORKFLOW" "cachix/install-nix-action@v31"
 assert_contains "$WORKFLOW" 'TCFS_S3_REGION=$REGION'
 assert_contains "$WORKFLOW" 'TCFS_STORAGE_S3_CA_CERT_PATH=$CA_CERT_PATH'
@@ -102,5 +111,18 @@ assert_contains "$RESTORE_STEP" 'TCFS_DOWNLOAD_CHUNK_RETRIES="${{ github.event.i
 assert_contains "$RESTORE_STEP" 'TCFS_BIN="$TCFS_BIN_UNDER_TEST"'
 assert_contains "$RESTORE_STEP" "scripts/git-repo-restore-proof.sh"
 assert_contains "$RESTORE_STEP" '--restore-root "$RESTORE_ROOT"'
+
+SLO_STEP="$TMPDIR/slo-step.sh"
+extract_step_from_workflow "Evaluate storage SLO budgets" "$SLO_STEP"
+assert_contains "$SLO_STEP" "scripts/evaluate-storage-large-restore-slo.sh"
+assert_contains "$SLO_STEP" '--evidence-dir "$EVIDENCE_DIR"'
+assert_contains "$SLO_STEP" '--min-restore-throughput-bps "${{ github.event.inputs.min_restore_throughput_bps }}"'
+assert_contains "$SLO_STEP" '--max-restore-elapsed-secs "${{ github.event.inputs.max_restore_elapsed_secs }}"'
+assert_contains "$SLO_STEP" '--max-502-log-lines "${{ github.event.inputs.max_502_log_lines }}"'
+assert_contains "$SLO_STEP" '--max-opendal-retry-rows "${{ github.event.inputs.max_opendal_retry_rows }}"'
+assert_contains "$SLO_STEP" '--max-tcfs-chunk-retry-rows "${{ github.event.inputs.max_tcfs_chunk_retry_rows }}"'
+assert_contains "$SLO_STEP" '--max-push-warn-rows "${{ github.event.inputs.max_push_warn_rows }}"'
+assert_contains "$SLO_STEP" '--max-push-error-rows "${{ github.event.inputs.max_push_error_rows }}"'
+assert_contains "$SLO_STEP" '--max-socket-highwater "${{ github.event.inputs.max_socket_highwater }}"'
 
 printf 'storage large restore canary workflow tests passed\n'


### PR DESCRIPTION
## Summary
- add a storage large-restore SLO evaluator that writes `storage-slo-summary.env` / `.md` from existing restore artifacts
- add optional dispatch budgets to `storage-large-restore-canary.yml` for throughput, elapsed time, HTTP 502 noise, OpenDAL/TCFS retry rows, push warning/error rows, and S3 socket highwater
- wire local Task/Just entrypoints plus regression coverage for the evaluator and workflow step

## Validation
- `bash scripts/test-evaluate-storage-large-restore-slo.sh`
- `bash scripts/test-storage-large-restore-canary-workflow.sh`
- `bash -n scripts/evaluate-storage-large-restore-slo.sh scripts/test-evaluate-storage-large-restore-slo.sh`
- `shellcheck scripts/evaluate-storage-large-restore-slo.sh scripts/test-evaluate-storage-large-restore-slo.sh`
- `git diff --check`

## Claim Boundary
This does not make TIN-1546 beta-grade by itself. It adds the budget gate needed for TIN-1622 so future package-backed large-restore/soak runs can fail on excessive storage noise, low throughput, or socket growth instead of only recording the raw packet.