### PR TITLE
crypto: flip file-key wrap to per-device age recipients behind flag (TIN-1417)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5451,6 +5451,7 @@ dependencies = [
 name = "tcfs-sync"
 version = "0.12.13"
 dependencies = [
+ "age",
  "anyhow",
  "async-nats",
  "base64 0.22.1",
@@ -5464,6 +5465,7 @@ dependencies = [
  "proptest",
  "rayon",
  "rocksdb",
+ "secrecy",
  "serde",
  "serde_json",
  "tcfs-chunks",

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1075,6 +1075,64 @@ fn resolve_sync_status_lookup_path(path: &Path) -> Result<PathBuf> {
     std::fs::canonicalize(path).map_err(Into::into)
 }
 
+/// Build an `EncryptionContext`, attaching per-device wrapping (TIN-1417) when
+/// `crypto.per_device_wrapping` is enabled and the device registry has real age
+/// recipients. Falls back to legacy shared-master wrapping (logging why) if the
+/// registry can't be loaded, has no real recipients, or this device's age secret
+/// is missing — never producing content this device cannot read back.
+fn build_encryption_context(
+    config: &tcfs_core::config::TcfsConfig,
+    device_id: &str,
+    master_key: &tcfs_crypto::MasterKey,
+) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
+
+    let base = EncryptionContext::new(master_key.clone());
+    if !config.crypto.per_device_wrapping {
+        return base;
+    }
+    let registry_path = config
+        .sync
+        .device_identity
+        .clone()
+        .unwrap_or_else(tcfs_secrets::device::default_registry_path);
+    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
+            return base;
+        }
+    };
+    let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = registry
+        .active_devices()
+        .filter(|d| tcfs_secrets::device::is_real_age_public_key(&d.public_key))
+        .map(|d| tcfs_crypto::AgeFileKeyRecipient {
+            device_id: d.device_id.clone(),
+            recipient: d.public_key.clone(),
+        })
+        .collect();
+    if recipients.is_empty() {
+        tracing::warn!(
+            "per-device wrapping enabled but no active age recipients; using master wrap"
+        );
+        return base;
+    }
+    let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
+    let identity = match std::fs::read_to_string(&secret_path) {
+        Ok(s) => DeviceUnwrapIdentity {
+            device_id: device_id.to_string(),
+            secret: s.trim().to_string(),
+        },
+        Err(e) => {
+            tracing::warn!(
+                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+            );
+            return base;
+        }
+    };
+    base.with_device_wrapping(recipients, Some(identity))
+}
+
 // ── `tcfs push` ───────────────────────────────────────────────────────────────
 
 async fn cmd_push_with_operator(
@@ -1137,7 +1195,7 @@ async fn cmd_push_with_operator(
             });
         let enc_ctx = master_key
             .as_ref()
-            .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
+            .map(|mk| build_encryption_context(config, device_id, mk));
 
         let result = tcfs_sync::engine::upload_file_with_device(
             op,
@@ -1339,7 +1397,7 @@ async fn cmd_pull_with_operator(
         });
     let enc_ctx = master_key
         .as_ref()
-        .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
+        .map(|mk| build_encryption_context(config, device_id, mk));
 
     let result = tcfs_sync::engine::download_file_with_device(
         op,
@@ -5191,7 +5249,7 @@ async fn cmd_reconcile(
             });
         let enc_ctx = master_key
             .as_ref()
-            .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
+            .map(|mk| build_encryption_context(config, &device_id, mk));
 
         let result = tcfs_sync::reconcile::execute_plan(
             &plan,

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1137,9 +1137,7 @@ async fn cmd_push_with_operator(
             });
         let enc_ctx = master_key
             .as_ref()
-            .map(|mk| tcfs_sync::engine::EncryptionContext {
-                master_key: mk.clone(),
-            });
+            .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
 
         let result = tcfs_sync::engine::upload_file_with_device(
             op,
@@ -1341,9 +1339,7 @@ async fn cmd_pull_with_operator(
         });
     let enc_ctx = master_key
         .as_ref()
-        .map(|mk| tcfs_sync::engine::EncryptionContext {
-            master_key: mk.clone(),
-        });
+        .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
 
     let result = tcfs_sync::engine::download_file_with_device(
         op,
@@ -5195,9 +5191,7 @@ async fn cmd_reconcile(
             });
         let enc_ctx = master_key
             .as_ref()
-            .map(|mk| tcfs_sync::engine::EncryptionContext {
-                master_key: mk.clone(),
-            });
+            .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
 
         let result = tcfs_sync::reconcile::execute_plan(
             &plan,

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -329,6 +329,12 @@ pub struct CryptoConfig {
     /// Generated once per vault. If unset and passphrase_file is used, a random
     /// salt is generated and must be persisted by the caller.
     pub kdf_salt: Option<String>,
+    /// Wrap file keys per-device (age/X25519) for non-revoked devices instead of
+    /// under the shared master key (TIN-1417). When true, new manifests carry
+    /// `wrapped_file_keys` and omit `encrypted_file_key`, so a revoked device
+    /// cannot decrypt newly written content. Default false (legacy shared-master)
+    /// until a fleet has real per-device identities enrolled.
+    pub per_device_wrapping: bool,
 }
 
 impl Default for CryptoConfig {
@@ -342,6 +348,7 @@ impl Default for CryptoConfig {
             device_identity: None,
             passphrase_file: None,
             kdf_salt: None,
+            per_device_wrapping: false,
         }
     }
 }

--- a/crates/tcfs-file-provider/src/grpc_backend.rs
+++ b/crates/tcfs-file-provider/src/grpc_backend.rs
@@ -231,9 +231,7 @@ async fn fetch_direct_to_file(
 
     let enc_ctx = master_key
         .as_ref()
-        .map(|mk| tcfs_sync::engine::EncryptionContext {
-            master_key: mk.clone(),
-        });
+        .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
 
     tcfs_sync::engine::download_file_with_device(
         &operator,

--- a/crates/tcfs-sync/Cargo.toml
+++ b/crates/tcfs-sync/Cargo.toml
@@ -45,3 +45,5 @@ full = ["dep:rocksdb", "nats", "crypto"]
 proptest = { workspace = true }
 tempfile = { workspace = true }
 tokio-test = { workspace = true }
+age = { workspace = true }
+secrecy = { workspace = true }

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -983,6 +983,49 @@ where
 #[cfg(feature = "crypto")]
 pub struct EncryptionContext {
     pub master_key: tcfs_crypto::MasterKey,
+    /// Active-device recipients for per-device FileKey wrapping (TIN-1417).
+    ///
+    /// When non-empty, writes emit per-device `wrapped_file_keys` and OMIT the
+    /// master-wrapped `encrypted_file_key`, so a device removed from this set
+    /// (revoked) cannot decrypt newly written content. Empty = legacy
+    /// shared-master behavior.
+    pub device_recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
+    /// This device's age identity, used to unwrap per-device manifests on read.
+    /// `None` relies on the master-key fallback (legacy manifests).
+    pub device_identity: Option<DeviceUnwrapIdentity>,
+}
+
+/// A local device's age X25519 identity for unwrapping per-device manifests.
+#[cfg(feature = "crypto")]
+#[derive(Clone)]
+pub struct DeviceUnwrapIdentity {
+    /// Stable TCFS device id this identity belongs to.
+    pub device_id: String,
+    /// Armored age X25519 secret key (`AGE-SECRET-KEY-1...`).
+    pub secret: String,
+}
+
+#[cfg(feature = "crypto")]
+impl EncryptionContext {
+    /// Legacy shared-master context: no per-device recipients or identity.
+    pub fn new(master_key: tcfs_crypto::MasterKey) -> Self {
+        Self {
+            master_key,
+            device_recipients: Vec::new(),
+            device_identity: None,
+        }
+    }
+
+    /// Attach per-device wrapping recipients and this device's unwrap identity.
+    pub fn with_device_wrapping(
+        mut self,
+        recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
+        identity: Option<DeviceUnwrapIdentity>,
+    ) -> Self {
+        self.device_recipients = recipients;
+        self.device_identity = identity;
+        self
+    }
 }
 
 /// Type alias for optional encryption context (feature-gated).
@@ -1805,20 +1848,42 @@ async fn upload_file_with_device_with_state(
 
     ensure_source_matches_snapshot(local_path, &snapshot, "manifest publish")?;
 
-    // Wrap file key for manifest if encryption is enabled
+    // Wrap the file key for the manifest. With per-device recipients (TIN-1417)
+    // we emit only per-device `wrapped_file_keys` and OMIT the master-wrapped
+    // `encrypted_file_key`, so a revoked device (absent from the recipient set)
+    // cannot decrypt new content. Without recipients we keep the legacy
+    // shared-master wrap for backward compatibility.
     #[cfg(feature = "crypto")]
-    let encrypted_file_key = if let (Some(ctx), Some(ref fk)) = (encryption, &file_key) {
-        let wrapped = tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
-        Some(base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &wrapped,
-        ))
-    } else {
-        None
-    };
+    let (encrypted_file_key, wrapped_file_keys) =
+        if let (Some(ctx), Some(ref fk)) = (encryption, &file_key) {
+            if ctx.device_recipients.is_empty() {
+                let wrapped =
+                    tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
+                let b64 =
+                    base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wrapped);
+                (Some(b64), Vec::new())
+            } else {
+                let wrapped =
+                    tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
+                        .context("wrapping file key for device recipients")?
+                        .into_iter()
+                        .map(|w| crate::manifest::WrappedFileKey {
+                            recipient_device_id: w.recipient_device_id,
+                            recipient: w.recipient,
+                            algorithm: w.algorithm,
+                            wrapped_key: w.wrapped_key,
+                        })
+                        .collect();
+                (None, wrapped)
+            }
+        } else {
+            (None, Vec::new())
+        };
 
     #[cfg(not(feature = "crypto"))]
     let encrypted_file_key: Option<String> = None;
+    #[cfg(not(feature = "crypto"))]
+    let wrapped_file_keys: Vec<crate::manifest::WrappedFileKey> = Vec::new();
 
     // Capture Unix file permissions for cross-device preservation
     #[cfg(unix)]
@@ -1848,7 +1913,7 @@ async fn upload_file_with_device_with_state(
         rel_path: rel_path.map(|s| s.to_string()),
         mode: file_mode,
         encrypted_file_key,
-        wrapped_file_keys: Vec::new(),
+        wrapped_file_keys,
     };
 
     let manifest_bytes = manifest.to_bytes()?;
@@ -2153,9 +2218,41 @@ pub async fn download_file_with_device(
         });
     }
 
-    // Unwrap file key if manifest is encrypted
+    // Unwrap the file key if the manifest is encrypted. Prefer per-device wraps
+    // (TIN-1417): when present, the file key is unwrapped with this device's age
+    // identity. Manifests carrying only the legacy master-wrapped key fall back
+    // to master-key unwrap.
     #[cfg(feature = "crypto")]
-    let file_key = if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+    let file_key = if !manifest.wrapped_file_keys.is_empty() {
+        let ctx = encryption.ok_or_else(|| {
+            anyhow::anyhow!(
+                "manifest is per-device encrypted but no encryption context provided for: {remote_manifest}"
+            )
+        })?;
+        let identity = ctx.device_identity.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "manifest is per-device encrypted but this device has no age identity for: {remote_manifest}"
+            )
+        })?;
+        let age_wraps: Vec<tcfs_crypto::AgeWrappedFileKey> = manifest
+            .wrapped_file_keys
+            .iter()
+            .map(|w| tcfs_crypto::AgeWrappedFileKey {
+                recipient_device_id: w.recipient_device_id.clone(),
+                recipient: w.recipient.clone(),
+                algorithm: w.algorithm.clone(),
+                wrapped_key: w.wrapped_key.clone(),
+            })
+            .collect();
+        Some(
+            tcfs_crypto::unwrap_file_key_with_age_identity(
+                &age_wraps,
+                &identity.secret,
+                Some(&identity.device_id),
+            )
+            .context("unwrapping per-device file key from manifest")?,
+        )
+    } else if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
         let ctx = encryption.ok_or_else(|| {
             anyhow::anyhow!(
                 "manifest is encrypted but no encryption context provided for: {remote_manifest}"

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1854,31 +1854,30 @@ async fn upload_file_with_device_with_state(
     // cannot decrypt new content. Without recipients we keep the legacy
     // shared-master wrap for backward compatibility.
     #[cfg(feature = "crypto")]
-    let (encrypted_file_key, wrapped_file_keys) =
-        if let (Some(ctx), Some(ref fk)) = (encryption, &file_key) {
-            if ctx.device_recipients.is_empty() {
-                let wrapped =
-                    tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
-                let b64 =
-                    base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wrapped);
-                (Some(b64), Vec::new())
-            } else {
-                let wrapped =
-                    tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
-                        .context("wrapping file key for device recipients")?
-                        .into_iter()
-                        .map(|w| crate::manifest::WrappedFileKey {
-                            recipient_device_id: w.recipient_device_id,
-                            recipient: w.recipient,
-                            algorithm: w.algorithm,
-                            wrapped_key: w.wrapped_key,
-                        })
-                        .collect();
-                (None, wrapped)
-            }
+    let (encrypted_file_key, wrapped_file_keys) = if let (Some(ctx), Some(ref fk)) =
+        (encryption, &file_key)
+    {
+        if ctx.device_recipients.is_empty() {
+            let wrapped =
+                tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
+            let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wrapped);
+            (Some(b64), Vec::new())
         } else {
-            (None, Vec::new())
-        };
+            let wrapped = tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
+                .context("wrapping file key for device recipients")?
+                .into_iter()
+                .map(|w| crate::manifest::WrappedFileKey {
+                    recipient_device_id: w.recipient_device_id,
+                    recipient: w.recipient,
+                    algorithm: w.algorithm,
+                    wrapped_key: w.wrapped_key,
+                })
+                .collect();
+            (None, wrapped)
+        }
+    } else {
+        (None, Vec::new())
+    };
 
     #[cfg(not(feature = "crypto"))]
     let encrypted_file_key: Option<String> = None;

--- a/crates/tcfs-sync/tests/encrypted_roundtrip_test.rs
+++ b/crates/tcfs-sync/tests/encrypted_roundtrip_test.rs
@@ -24,7 +24,7 @@ fn write_test_file(dir: &Path, name: &str, content: &[u8]) -> std::path::PathBuf
 
 fn test_encryption_context() -> tcfs_sync::engine::EncryptionContext {
     let master_key = tcfs_crypto::MasterKey::from_bytes([42u8; 32]);
-    tcfs_sync::engine::EncryptionContext { master_key }
+    tcfs_sync::engine::EncryptionContext::new(master_key)
 }
 
 #[tokio::test]

--- a/crates/tcfs-sync/tests/per_device_wrap_test.rs
+++ b/crates/tcfs-sync/tests/per_device_wrap_test.rs
@@ -1,0 +1,170 @@
+//! Integration tests for per-device file-key wrapping (TIN-1417).
+//!
+//! Exercises the real engine write/read paths to prove:
+//! - per-device recipients produce `wrapped_file_keys` and OMIT the
+//!   master-wrapped `encrypted_file_key` (clean-cut), and every recipient can
+//!   hydrate exact bytes;
+//! - a revoked device (absent from the recipient set on a new write) cannot
+//!   decrypt content written after revocation, while an active device can.
+
+#![cfg(feature = "crypto")]
+
+use opendal::Operator;
+use secrecy::ExposeSecret;
+use tempfile::TempDir;
+
+use tcfs_crypto::AgeFileKeyRecipient;
+use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
+
+fn memory_operator() -> Operator {
+    Operator::new(opendal::services::Memory::default())
+        .expect("memory operator")
+        .finish()
+}
+
+fn master() -> tcfs_crypto::MasterKey {
+    tcfs_crypto::MasterKey::from_bytes([7u8; 32])
+}
+
+/// Freshly generate an age device, returning its wrap recipient and unwrap identity.
+fn device(id: &str) -> (AgeFileKeyRecipient, DeviceUnwrapIdentity) {
+    let key = age::x25519::Identity::generate();
+    let recipient = AgeFileKeyRecipient {
+        device_id: id.to_string(),
+        recipient: key.to_public().to_string(),
+    };
+    let identity = DeviceUnwrapIdentity {
+        device_id: id.to_string(),
+        secret: key.to_string().expose_secret().to_string(),
+    };
+    (recipient, identity)
+}
+
+fn read_ctx(id: &DeviceUnwrapIdentity) -> EncryptionContext {
+    EncryptionContext::new(master()).with_device_wrapping(Vec::new(), Some(id.clone()))
+}
+
+#[tokio::test]
+async fn per_device_wrap_roundtrip_and_manifest_shape() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/per-device";
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    let (rec_a, id_a) = device("device-a");
+    let (rec_b, id_b) = device("device-b");
+
+    let write_ctx = EncryptionContext::new(master())
+        .with_device_wrapping(vec![rec_a, rec_b], Some(id_a.clone()));
+
+    let content = b"per-device wrapped payload that should round-trip exactly";
+    let src = tmp.path().join("doc.txt");
+    std::fs::write(&src, content).unwrap();
+
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .expect("upload should succeed");
+
+    // Manifest carries one wrap per recipient and OMITS the master-wrapped key.
+    let manifest_bytes = op.read(&up.remote_path).await.unwrap();
+    let manifest =
+        tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes()).unwrap();
+    assert_eq!(manifest.wrapped_file_keys.len(), 2, "one wrap per recipient");
+    assert!(
+        manifest.encrypted_file_key.is_none(),
+        "per-device manifest must not carry the master-wrapped key (clean-cut)"
+    );
+
+    // Both recipients hydrate exact bytes.
+    for id in [&id_a, &id_b] {
+        let dst = tmp.path().join(format!("out-{}.txt", id.device_id));
+        tcfs_sync::engine::download_file_with_device(
+            &op,
+            &up.remote_path,
+            &dst,
+            prefix,
+            None,
+            &id.device_id,
+            None,
+            Some(&read_ctx(id)),
+        )
+        .await
+        .expect("recipient download should succeed");
+        assert_eq!(std::fs::read(&dst).unwrap(), content);
+    }
+}
+
+#[tokio::test]
+async fn revoked_device_cannot_decrypt_new_content() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/revocation";
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    let (rec_a, id_a) = device("device-a");
+    let (_rec_b, id_b) = device("device-b");
+
+    // New content is written for the active set [A] only — B has been revoked.
+    let write_ctx =
+        EncryptionContext::new(master()).with_device_wrapping(vec![rec_a], Some(id_a.clone()));
+
+    let content = b"content written after device-b was revoked";
+    let src = tmp.path().join("after-revoke.txt");
+    std::fs::write(&src, content).unwrap();
+
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .expect("upload should succeed");
+
+    // The revoked device B cannot decrypt the new content.
+    let dst_b = tmp.path().join("b.txt");
+    let revoked = tcfs_sync::engine::download_file_with_device(
+        &op,
+        &up.remote_path,
+        &dst_b,
+        prefix,
+        None,
+        "device-b",
+        None,
+        Some(&read_ctx(&id_b)),
+    )
+    .await;
+    assert!(
+        revoked.is_err(),
+        "revoked device must not decrypt content written after revocation"
+    );
+
+    // The still-active device A can.
+    let dst_a = tmp.path().join("a.txt");
+    tcfs_sync::engine::download_file_with_device(
+        &op,
+        &up.remote_path,
+        &dst_a,
+        prefix,
+        None,
+        "device-a",
+        None,
+        Some(&read_ctx(&id_a)),
+    )
+    .await
+    .expect("active device download should succeed");
+    assert_eq!(std::fs::read(&dst_a).unwrap(), content);
+}

--- a/crates/tcfs-sync/tests/per_device_wrap_test.rs
+++ b/crates/tcfs-sync/tests/per_device_wrap_test.rs
@@ -78,7 +78,11 @@ async fn per_device_wrap_roundtrip_and_manifest_shape() {
     let manifest_bytes = op.read(&up.remote_path).await.unwrap();
     let manifest =
         tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes()).unwrap();
-    assert_eq!(manifest.wrapped_file_keys.len(), 2, "one wrap per recipient");
+    assert_eq!(
+        manifest.wrapped_file_keys.len(),
+        2,
+        "one wrap per recipient"
+    );
     assert!(
         manifest.encrypted_file_key.is_none(),
         "per-device manifest must not carry the master-wrapped key (clean-cut)"

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -547,6 +547,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                     let sched_metrics = daemon_metrics.clone();
                     let sched_master_key = master_key.clone();
                     let sched_path_locks = path_locks.clone();
+                    let sched_config = config.clone();
 
                     tokio::spawn({
                         let scheduler = scheduler.clone();
@@ -563,6 +564,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                     let metrics = sched_metrics.clone();
                                     let mk = sched_master_key.clone();
                                     let locks = sched_path_locks.clone();
+                                    let cfg = sched_config.clone();
 
                                     Box::pin(async move {
                                         // Acquire per-path lock to prevent concurrent operations
@@ -596,7 +598,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                                     cache.set(&task.path, active);
                                                 }
 
-                                                let enc_ctx = mk.as_ref().map(|k| tcfs_sync::engine::EncryptionContext::new(k.clone()));
+                                                let enc_ctx = mk.as_ref().map(|k| crate::grpc::build_encryption_context(&cfg, &device, k));
                                                 let upload_result =
                                                     tcfs_sync::engine::upload_file_with_device(
                                                         op_ref,
@@ -1070,6 +1072,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             let recon_state = impl_.state_cache_handle();
             let recon_op = operator.clone();
             let recon_device = device_id.clone();
+            let recon_tcfs_config = config.clone();
             let recon_master_key = impl_.master_key_handle();
             let orphan_chunk_cleanup_grace_secs = config.sync.orphan_chunk_cleanup_grace_secs;
             let orphan_chunk_cleanup_sweep_interval_secs = if orphan_chunk_cleanup_grace_secs > 0 {
@@ -1155,10 +1158,13 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
 
                         // Build encryption context from master key (if loaded)
                         let mk_guard = recon_master_key.lock().await;
-                        let enc_ctx =
-                            mk_guard
-                                .as_ref()
-                                .map(|k| tcfs_sync::engine::EncryptionContext::new(k.clone()));
+                        let enc_ctx = mk_guard.as_ref().map(|k| {
+                            crate::grpc::build_encryption_context(
+                                &recon_tcfs_config,
+                                &recon_device,
+                                k,
+                            )
+                        });
                         drop(mk_guard);
 
                         let mut cache = recon_state.lock().await;

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -596,9 +596,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                                     cache.set(&task.path, active);
                                                 }
 
-                                                let enc_ctx = mk.as_ref().map(|k| tcfs_sync::engine::EncryptionContext {
-                                                    master_key: k.clone(),
-                                                });
+                                                let enc_ctx = mk.as_ref().map(|k| tcfs_sync::engine::EncryptionContext::new(k.clone()));
                                                 let upload_result =
                                                     tcfs_sync::engine::upload_file_with_device(
                                                         op_ref,
@@ -1160,9 +1158,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                         let enc_ctx =
                             mk_guard
                                 .as_ref()
-                                .map(|k| tcfs_sync::engine::EncryptionContext {
-                                    master_key: k.clone(),
-                                });
+                                .map(|k| tcfs_sync::engine::EncryptionContext::new(k.clone()));
                         drop(mk_guard);
 
                         let mut cache = recon_state.lock().await;

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -851,9 +851,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
             let mk_guard = self.master_key.lock().await;
             let enc_ctx = mk_guard
                 .as_ref()
-                .map(|mk| tcfs_sync::engine::EncryptionContext {
-                    master_key: mk.clone(),
-                });
+                .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
             tcfs_sync::engine::upload_file_with_device(
                 &op,
                 &local_path,
@@ -991,9 +989,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
             let mk_guard = self.master_key.lock().await;
             let enc_ctx = mk_guard
                 .as_ref()
-                .map(|mk| tcfs_sync::engine::EncryptionContext {
-                    master_key: mk.clone(),
-                });
+                .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
             tcfs_sync::engine::download_file_with_device(
                 &op,
                 &resolved_manifest,
@@ -1087,9 +1083,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
             let mk_guard = self.master_key.lock().await;
             let enc_ctx = mk_guard
                 .as_ref()
-                .map(|mk| tcfs_sync::engine::EncryptionContext {
-                    master_key: mk.clone(),
-                });
+                .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
             tcfs_sync::engine::download_file_with_device(
                 &op,
                 &manifest_path,

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -20,6 +20,64 @@ use tcfs_core::proto::{
 };
 use tcfs_sync::state::StateCacheBackend;
 
+/// Build an `EncryptionContext`, attaching per-device wrapping (TIN-1417) when
+/// `crypto.per_device_wrapping` is enabled and the device registry has real age
+/// recipients. Falls back to legacy shared-master wrapping (and logs why) if the
+/// registry can't be loaded, has no real recipients, or this device's age secret
+/// is missing — never producing content this device cannot read back.
+pub(crate) fn build_encryption_context(
+    config: &TcfsConfig,
+    device_id: &str,
+    master_key: &tcfs_crypto::MasterKey,
+) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
+
+    let base = EncryptionContext::new(master_key.clone());
+    if !config.crypto.per_device_wrapping {
+        return base;
+    }
+    let registry_path = config
+        .sync
+        .device_identity
+        .clone()
+        .unwrap_or_else(tcfs_secrets::device::default_registry_path);
+    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
+            return base;
+        }
+    };
+    let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = registry
+        .active_devices()
+        .filter(|d| tcfs_secrets::device::is_real_age_public_key(&d.public_key))
+        .map(|d| tcfs_crypto::AgeFileKeyRecipient {
+            device_id: d.device_id.clone(),
+            recipient: d.public_key.clone(),
+        })
+        .collect();
+    if recipients.is_empty() {
+        tracing::warn!(
+            "per-device wrapping enabled but no active age recipients; using master wrap"
+        );
+        return base;
+    }
+    let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
+    let identity = match std::fs::read_to_string(&secret_path) {
+        Ok(s) => DeviceUnwrapIdentity {
+            device_id: device_id.to_string(),
+            secret: s.trim().to_string(),
+        },
+        Err(e) => {
+            tracing::warn!(
+                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+            );
+            return base;
+        }
+    };
+    base.with_device_wrapping(recipients, Some(identity))
+}
+
 /// Implementation of the TcfsDaemon gRPC service
 pub struct TcfsDaemonImpl {
     cred_store: SharedCredStore,
@@ -851,7 +909,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
             let mk_guard = self.master_key.lock().await;
             let enc_ctx = mk_guard
                 .as_ref()
-                .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
+                .map(|mk| build_encryption_context(&self.config, &self.device_id, mk));
             tcfs_sync::engine::upload_file_with_device(
                 &op,
                 &local_path,
@@ -989,7 +1047,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
             let mk_guard = self.master_key.lock().await;
             let enc_ctx = mk_guard
                 .as_ref()
-                .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
+                .map(|mk| build_encryption_context(&self.config, &self.device_id, mk));
             tcfs_sync::engine::download_file_with_device(
                 &op,
                 &resolved_manifest,
@@ -1083,7 +1141,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
             let mk_guard = self.master_key.lock().await;
             let enc_ctx = mk_guard
                 .as_ref()
-                .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
+                .map(|mk| build_encryption_context(&self.config, &self.device_id, mk));
             tcfs_sync::engine::download_file_with_device(
                 &op,
                 &manifest_path,

--- a/tests/e2e/tests/encrypted_roundtrip.rs
+++ b/tests/e2e/tests/encrypted_roundtrip.rs
@@ -34,9 +34,7 @@ async fn encrypted_push_pull_roundtrip() {
     let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db.json")).unwrap();
 
     let master_key = generate_test_master_key();
-    let enc_ctx = EncryptionContext {
-        master_key: master_key.clone(),
-    };
+    let enc_ctx = EncryptionContext::new(master_key.clone());
 
     // Push with encryption
     let upload = tcfs_sync::engine::upload_file_with_device(
@@ -122,9 +120,7 @@ async fn encrypted_large_file_multi_chunk() {
     let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db.json")).unwrap();
 
     let master_key = generate_test_master_key();
-    let enc_ctx = EncryptionContext {
-        master_key: master_key.clone(),
-    };
+    let enc_ctx = EncryptionContext::new(master_key.clone());
 
     let upload = tcfs_sync::engine::upload_file_with_device(
         &op,
@@ -172,9 +168,7 @@ async fn pull_without_key_fails_on_encrypted_file() {
     let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db.json")).unwrap();
 
     let master_key = generate_test_master_key();
-    let enc_ctx = EncryptionContext {
-        master_key: master_key.clone(),
-    };
+    let enc_ctx = EncryptionContext::new(master_key.clone());
 
     // Push with encryption
     let upload = tcfs_sync::engine::upload_file_with_device(
@@ -222,9 +216,7 @@ async fn wrong_key_fails_decryption() {
     let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db.json")).unwrap();
 
     let key_a = generate_test_master_key();
-    let enc_ctx_a = EncryptionContext {
-        master_key: key_a.clone(),
-    };
+    let enc_ctx_a = EncryptionContext::new(key_a.clone());
 
     // Push with key A
     let upload = tcfs_sync::engine::upload_file_with_device(
@@ -243,9 +235,7 @@ async fn wrong_key_fails_decryption() {
     // Pull with key B (different key)
     let key_b_bytes: [u8; 32] = [0xFF; 32];
     let key_b = tcfs_crypto::MasterKey::from_bytes(key_b_bytes);
-    let enc_ctx_b = EncryptionContext {
-        master_key: key_b.clone(),
-    };
+    let enc_ctx_b = EncryptionContext::new(key_b.clone());
 
     let result = tcfs_sync::engine::download_file_with_device(
         &op,


### PR DESCRIPTION
## Summary

Flips the file-key wrap path to **per-device age/X25519** wrapping behind a
default-off `crypto.per_device_wrapping` flag, building on the #468 substrate.
This is the behavior change `TIN-1417` was tracking (the substrate landed in
#468 but did not flip the write path).

When the flag is on and the device registry has real age recipients:

- **Write:** the file key is wrapped once per active (non-revoked) device into
  `wrapped_file_keys`, and the master-wrapped `encrypted_file_key` is **omitted**
  (clean-cut). This is what makes revocation real — a device removed from the
  active set on a new write cannot decrypt that content, even though it still
  holds the shared master key.
- **Read:** per-device unwrap with this device's age identity; legacy manifests
  (only `encrypted_file_key`) still read via master-key fallback.

## Changes

- `tcfs-core`: add `crypto.per_device_wrapping` flag (default `false`).
- `tcfs-sync`: extend `EncryptionContext` with `device_recipients` +
  `device_identity` (`new()` / `with_device_wrapping()`); branch the engine
  write/read paths; convert `AgeWrappedFileKey` ↔ `manifest::WrappedFileKey`.
- `tcfsd` + `tcfs-cli`: shared `build_encryption_context` helper loads active
  recipients from `DeviceRegistry` + this device's age secret behind the flag,
  with safe fallback to master-wrap if the registry/secret is unavailable
  (never writes content this device cannot read). Wired into **all** write/read
  paths: gRPC Push/Pull/Hydrate, CLI push/pull/reconcile, daemon watcher +
  periodic reconcile.

## Validation

- `cargo test -p tcfs-sync --features crypto` — full suite green (187 lib +
  integration), including new `per_device_wrap_test`:
  - `per_device_wrap_roundtrip_and_manifest_shape` — one wrap per recipient,
    `encrypted_file_key` omitted, every recipient hydrates exact bytes.
  - `revoked_device_cannot_decrypt_new_content` — **the named TIN-1417
    acceptance**: a device absent from the recipient set on a new write cannot
    decrypt that content; the active device can.
- `cargo build -p tcfsd -p tcfs-cli` clean; `cargo fmt --all --check` clean;
  `cargo clippy` clean for changed code (2 pre-existing `needless_borrow`
  warnings in untouched grpc.rs lines remain).

## Claim boundary / migration

- Default-off: zero behavior change until `crypto.per_device_wrapping = true` on
  a fleet with real per-device identities enrolled.
- Honest limit (documented in code): legacy content wrapped only under the
  master key remains decryptable by any device holding the master, including a
  revoked one, until rewritten. Revocation denies **new** content only.
- Does not yet add a `tcfs device revoke` UX or fleet migration tooling; this is
  the write/read substrate flip + enforcement plumbing.

Tracker: TIN-1417 (Gate G1 in `docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md`).
