### PR TITLE
fleet: fix tcfs pull local-path + add natsTls option (default false)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1302,14 +1302,23 @@ async fn cmd_pull_with_operator(
             .await
             .with_context(|| format!("resolving manifest for: {manifest_path}"))?;
 
-    // Default local path: current dir + manifest hash (last path component)
-    let hash_basename = resolved_manifest
-        .split('/')
-        .next_back()
-        .unwrap_or("downloaded");
-    let local_path = local
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from(hash_basename));
+    // Default local destination:
+    // - an explicit `local` always wins;
+    // - if the user pulled by file path, write back to that path (not a
+    //   hash-named file in the current directory);
+    // - otherwise (a remote manifest reference) fall back to the manifest hash
+    //   basename in the current directory.
+    let local_path = match local {
+        Some(p) => p.to_path_buf(),
+        None if is_file_path => PathBuf::from(manifest_path),
+        None => {
+            let hash_basename = resolved_manifest
+                .split('/')
+                .next_back()
+                .unwrap_or("downloaded");
+            PathBuf::from(hash_basename)
+        }
+    };
 
     println!("Pulling {} → {}", manifest_path, local_path.display(),);
 
@@ -5893,6 +5902,44 @@ enabled = false
         .unwrap();
 
         assert_eq!(std::fs::read(&pulled).unwrap(), b"hello from tcfs");
+    }
+
+    #[tokio::test]
+    async fn cli_pull_by_file_path_without_dest_writes_to_file_path() {
+        // Regression: `tcfs pull <file-path>` with no explicit destination must
+        // write back to that file path, not to a hash-named file in the cwd.
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("sync");
+        std::fs::create_dir_all(sync_root.join("docs")).unwrap();
+        let source = sync_root.join("docs/readme.txt");
+        std::fs::write(&source, b"hello from tcfs").unwrap();
+
+        let op = memory_op();
+        let state_path = dir.path().join("state.json");
+        let config = test_config(&sync_root);
+
+        cmd_push_with_operator(&config, &op, &source, None, &state_path, "test-device")
+            .await
+            .unwrap();
+
+        // Locally drift the file, then pull by file path with NO explicit dest.
+        // (Keep the file present so manifest resolution by path still works.)
+        std::fs::write(&source, b"locally drifted content").unwrap();
+        cmd_pull_with_operator(
+            &config,
+            &op,
+            &source.to_string_lossy(),
+            None,
+            None,
+            &state_path,
+            "test-device",
+        )
+        .await
+        .unwrap();
+
+        // The fix: pull wrote back to the file path (not a hash-named cwd file),
+        // restoring the exact pushed bytes.
+        assert_eq!(std::fs::read(&source).unwrap(), b"hello from tcfs");
     }
 
     #[tokio::test]

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -316,8 +316,18 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             .sync_root
             .as_deref()
             .unwrap_or(std::path::Path::new("/tmp/tcfs"));
-        match tcfs_sync::reconcile::list_remote_index(op, resolved_prefix).await {
-            Ok(remote_index) => {
+        // Bound startup remote-index discovery so a slow/unreachable S3
+        // endpoint cannot block the gRPC socket bind that happens later in
+        // run(). On timeout, log non-fatally and continue — the socket still
+        // binds and periodic reconcile retries. Prevents the "daemon running
+        // but no socket" startup hang.
+        let discovery = tokio::time::timeout(
+            std::time::Duration::from_secs(60),
+            tcfs_sync::reconcile::list_remote_index(op, resolved_prefix),
+        )
+        .await;
+        match discovery {
+            Ok(Ok(remote_index)) => {
                 let mut discovered = 0usize;
                 for (rel_path, entry) in &remote_index {
                     let local_key = std::path::PathBuf::from(sync_root).join(rel_path);
@@ -357,8 +367,14 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                     );
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!("remote index discovery failed (non-fatal): {e}");
+            }
+            Err(_elapsed) => {
+                warn!(
+                    "remote index discovery timed out after 60s (non-fatal); \
+                     binding socket anyway, periodic reconcile will retry"
+                );
             }
         }
     }

--- a/nix/modules/tcfs-user.nix
+++ b/nix/modules/tcfs-user.nix
@@ -109,6 +109,18 @@ in {
       description = "NATS server URL for real-time state sync";
     };
 
+    natsTls = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether the daemon connects to NATS over TLS. Defaults to false: the lab
+        NATS endpoints are plaintext and already transport-encrypted over the
+        tailnet (WireGuard). The Rust config default is true ("for security"),
+        so this must be emitted explicitly to connect to a plaintext server.
+        Set true only when the NATS server actually serves TLS.
+      '';
+    };
+
     excludePatterns = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [];
@@ -157,6 +169,9 @@ in {
       lib.recursiveUpdate {
         daemon.socket = "%t/tcfsd/tcfsd.sock";
         secrets.age_identity = cfg.identity;
+        # Emit nats_tls explicitly — the Rust default is true, but lab NATS is
+        # plaintext (tailnet-encrypted). Consumer `settings` can override.
+        sync.nats_tls = cfg.natsTls;
       } (lib.recursiveUpdate
         (lib.optionalAttrs (cfg.syncRoot != null) {
           sync.sync_root = cfg.syncRoot;


### PR DESCRIPTION
## Summary

Three small "fleet correctness/resilience" fixes surfaced during the 2026-05-31 neo↔honey bring-up.

### 1. `tcfs pull <file-path>` writes back to the file path (tcfs-cli)
Pulling **by file path** with no explicit destination defaulted the local path to the **manifest hash basename in the cwd** instead of the file path. Observed on honey: `tcfs pull /home/jess/tcfs/foo.txt` wrote correct bytes to `~/46db…`. Fixed; remote-manifest-reference pulls keep the hash-basename default. Regression test `cli_pull_by_file_path_without_dest_writes_to_file_path`.

### 2. `natsTls` option in the home-manager module (nix/modules/tcfs-user.nix)
`SyncConfig::nats_tls` defaults to **true** in Rust ("for security"), but the lab NATS endpoints are **plaintext** (WireGuard-encrypted over the tailnet). With no override the daemon upgraded `nats://`→`tls://` and failed the handshake → `nats_ok:false` on neo and honey. Adds a `natsTls` option (default `false`) emitting `sync.nats_tls`; consumer `settings` can override. Proven live on neo (nats_tls=false → connected, JetStream streams verified).

### 3. Bound startup remote-index discovery with a 60s timeout (tcfsd)
`list_remote_index` ran **before** the gRPC socket bind, so a slow/unreachable S3 endpoint blocked the socket from ever binding — the "daemon running but no socket" hang seen on neo. Now wrapped in a 60s timeout: on timeout/error it logs non-fatally and continues, so the socket binds and periodic reconcile retries. Converts a silent startup hang into a logged, recoverable degraded start.

## Validation
- `cargo test -p tcfs-cli pull` — 6/6 incl. new regression.
- `cargo clippy -p tcfs-cli -p tcfsd` clean for changed code (2 pre-existing `needless_borrow` warnings in untouched grpc.rs remain).
- `cargo fmt` clean; `nix-instantiate --parse nix/modules/tcfs-user.nix` OK (CI Flake/Nix validate fully).

## Deploy note
The nats fix takes effect on `home-manager switch` (neo+honey) + tcfsd restart; it does not change running daemons on merge. The startup-timeout makes future restarts fail-safe (logged degraded start instead of a silent hang).

Trackers: TIN-1736 (nats_tls G2 fix + launch-env/startup hardening), CLI pull-path UX.
