### PR TITLE
cli: sync device registry during enrollment

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -426,6 +426,12 @@ enum DeviceAction {
         /// Device name (default: hostname)
         #[arg(long)]
         name: Option<String>,
+        /// Replace an existing placeholder/legacy public key with a real age key
+        #[arg(long)]
+        repair_placeholder: bool,
+        /// Merge the local registry with the storage-backed fleet registry
+        #[arg(long)]
+        sync_remote: bool,
     },
     /// List enrolled devices
     List,
@@ -721,7 +727,11 @@ async fn main() -> Result<()> {
             .await
         }
         Commands::Device { action } => match action {
-            DeviceAction::Enroll { name } => cmd_device_enroll(name),
+            DeviceAction::Enroll {
+                name,
+                repair_placeholder,
+                sync_remote,
+            } => cmd_device_enroll(&config, name, repair_placeholder, sync_remote).await,
             DeviceAction::List => cmd_device_list(),
             DeviceAction::Revoke { name } => cmd_device_revoke(&name),
             DeviceAction::Status => cmd_device_status(),
@@ -3995,33 +4005,199 @@ fn cmd_device_revoke(name: &str) -> Result<()> {
 
 // ── `tcfs device enroll` ──────────────────────────────────────────────────────
 
-fn cmd_device_enroll(name: Option<String>) -> Result<()> {
+async fn cmd_device_enroll(
+    config: &tcfs_core::config::TcfsConfig,
+    name: Option<String>,
+    repair_placeholder: bool,
+    sync_remote: bool,
+) -> Result<()> {
     let device_name = name.unwrap_or_else(tcfs_secrets::device::default_device_name);
     let registry_path = tcfs_secrets::device::default_registry_path();
     let mut registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path)?;
 
-    if registry.find(&device_name).is_some() {
+    let mut enrolled_or_repaired = false;
+    let device_id: String;
+    let public_key: String;
+    let mut device_key_path: Option<PathBuf> = None;
+
+    if let Some(device) = registry.find(&device_name) {
+        if !tcfs_secrets::device::is_real_age_public_key(&device.public_key) {
+            if !repair_placeholder {
+                anyhow::bail!(
+                    "Device '{}' is already enrolled with a placeholder/legacy public key. Re-run with --repair-placeholder to generate a real age device key.",
+                    device_name
+                );
+            }
+            let key_path =
+                repair_placeholder_device_key(&mut registry, &registry_path, &device_name)?;
+            device_key_path = Some(key_path);
+            enrolled_or_repaired = true;
+        } else if !sync_remote {
+            anyhow::bail!(
+                "Device '{}' is already enrolled. Use 'tcfs device list' to see devices.",
+                device_name
+            );
+        }
+        let device = registry.find(&device_name).with_context(|| {
+            format!(
+                "device '{}' disappeared while preparing enrollment output",
+                device_name
+            )
+        })?;
+        device_id = device.device_id.clone();
+        public_key = device.public_key.clone();
+    } else {
+        let (new_device_id, device_key) = registry.enroll_local(&device_name, None);
+        let key_path = tcfs_secrets::device::device_secret_key_path(&registry_path, &new_device_id);
+        tcfs_secrets::device::save_device_secret_key(&key_path, &device_key.secret_key, false)?;
+        device_id = new_device_id;
+        public_key = device_key.public_key;
+        device_key_path = Some(key_path);
+        enrolled_or_repaired = true;
+    }
+
+    registry.save(&registry_path)?;
+
+    if sync_remote {
+        let op = build_operator(config).await?;
+        let meta_prefix = config.storage.resolved_prefix();
+        let remote = tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?;
+        merge_device_registry(&mut registry, &remote)?;
+        tcfs_secrets::device::DeviceRegistry::sync_to_remote(&registry, &op, meta_prefix).await?;
+        registry.save(&registry_path)?;
+    }
+
+    if enrolled_or_repaired {
+        println!("Device enrolled:");
+    } else {
+        println!("Device already enrolled:");
+    }
+    println!("  name:      {}", device_name);
+    println!("  device_id: {}", device_id);
+    println!("  public_key: {}", public_key);
+    if let Some(path) = device_key_path {
+        println!("  key:       {}", path.display());
+    }
+    println!("  registry:  {}", registry_path.display());
+    if sync_remote {
+        println!(
+            "  remote:    {}/tcfs-meta/devices.json",
+            config.storage.resolved_prefix().trim_end_matches('/')
+        );
+    }
+    println!();
+    if sync_remote {
+        println!("Next: run the same command on peer devices to pull the merged registry.");
+    } else {
+        println!("Next: configure sync in tcfs.toml and run 'tcfs push'");
+    }
+
+    Ok(())
+}
+
+fn repair_placeholder_device_key(
+    registry: &mut tcfs_secrets::device::DeviceRegistry,
+    registry_path: &Path,
+    device_name: &str,
+) -> Result<PathBuf> {
+    let needs_device_id = registry
+        .find(device_name)
+        .map(|device| device.device_id.is_empty())
+        .unwrap_or(false);
+    if needs_device_id {
+        registry.backfill_device_id(device_name);
+    }
+
+    let device = registry
+        .devices
+        .iter_mut()
+        .find(|device| device.name == device_name)
+        .with_context(|| format!("device '{device_name}' not found in registry"))?;
+
+    if tcfs_secrets::device::is_real_age_public_key(&device.public_key) {
+        anyhow::bail!("device '{device_name}' already has a real age public key");
+    }
+
+    let key = tcfs_secrets::device::generate_local_device_key();
+    device.public_key = key.public_key.clone();
+    device.signing_key_hash =
+        blake3::hash(device.public_key.as_bytes()).to_hex().as_str()[..16].to_string();
+    device.revoked = false;
+
+    let key_path = tcfs_secrets::device::device_secret_key_path(registry_path, &device.device_id);
+    tcfs_secrets::device::save_device_secret_key(&key_path, &key.secret_key, false)?;
+    Ok(key_path)
+}
+
+fn merge_device_registry(
+    local: &mut tcfs_secrets::device::DeviceRegistry,
+    incoming: &tcfs_secrets::device::DeviceRegistry,
+) -> Result<usize> {
+    let mut changed = 0usize;
+    for incoming_device in &incoming.devices {
+        let existing = local.devices.iter_mut().find(|device| {
+            (!device.device_id.is_empty() && device.device_id == incoming_device.device_id)
+                || device.name == incoming_device.name
+        });
+
+        if let Some(existing_device) = existing {
+            if merge_device_entry(existing_device, incoming_device)? {
+                changed += 1;
+            }
+        } else {
+            local.devices.push(incoming_device.clone());
+            changed += 1;
+        }
+    }
+    Ok(changed)
+}
+
+fn merge_device_entry(
+    existing: &mut tcfs_secrets::device::DeviceIdentity,
+    incoming: &tcfs_secrets::device::DeviceIdentity,
+) -> Result<bool> {
+    let existing_real = tcfs_secrets::device::is_real_age_public_key(&existing.public_key);
+    let incoming_real = tcfs_secrets::device::is_real_age_public_key(&incoming.public_key);
+
+    if existing_real
+        && incoming_real
+        && existing.public_key != incoming.public_key
+        && (existing.device_id == incoming.device_id || existing.name == incoming.name)
+    {
         anyhow::bail!(
-            "Device '{}' is already enrolled. Use 'tcfs device list' to see devices.",
-            device_name
+            "registry conflict for device '{}' ({}): two real public keys differ",
+            existing.name,
+            existing.device_id
         );
     }
 
-    let (device_id, device_key) = registry.enroll_local(&device_name, None);
-    let device_key_path = tcfs_secrets::device::device_secret_key_path(&registry_path, &device_id);
-    tcfs_secrets::device::save_device_secret_key(&device_key_path, &device_key.secret_key, false)?;
-    registry.save(&registry_path)?;
+    if incoming_real && !existing_real {
+        *existing = incoming.clone();
+        return Ok(true);
+    }
 
-    println!("Device enrolled:");
-    println!("  name:      {}", device_name);
-    println!("  device_id: {}", device_id);
-    println!("  public_key: {}", device_key.public_key);
-    println!("  key:       {}", device_key_path.display());
-    println!("  registry:  {}", registry_path.display());
-    println!();
-    println!("Next: configure sync in tcfs.toml and run 'tcfs push'");
-
-    Ok(())
+    let mut changed = false;
+    if existing.device_id.is_empty() && !incoming.device_id.is_empty() {
+        existing.device_id = incoming.device_id.clone();
+        changed = true;
+    }
+    if existing.signing_key_hash.is_empty() && !incoming.signing_key_hash.is_empty() {
+        existing.signing_key_hash = incoming.signing_key_hash.clone();
+        changed = true;
+    }
+    if existing.description.is_none() && incoming.description.is_some() {
+        existing.description = incoming.description.clone();
+        changed = true;
+    }
+    if existing.revoked != incoming.revoked && incoming.revoked {
+        existing.revoked = true;
+        changed = true;
+    }
+    if incoming.last_nats_seq > existing.last_nats_seq {
+        existing.last_nats_seq = incoming.last_nats_seq;
+        changed = true;
+    }
+    Ok(changed)
 }
 
 // ── `tcfs device status` ─────────────────────────────────────────────────────
@@ -5765,6 +5941,63 @@ mod tests {
         let err = cmd_init_check(&paths).unwrap_err();
         assert!(
             err.to_string().contains("placeholder public key"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn repair_placeholder_device_key_preserves_device_id_and_writes_secret() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("devices.json");
+        let mut registry = tcfs_secrets::device::DeviceRegistry::default();
+        let device_id = registry.enroll("honey", "age1-device-6b746182", None);
+
+        let key_path =
+            repair_placeholder_device_key(&mut registry, &registry_path, "honey").unwrap();
+        let repaired = registry.find("honey").unwrap();
+
+        assert_eq!(repaired.device_id, device_id);
+        assert!(tcfs_secrets::device::is_real_age_public_key(
+            &repaired.public_key
+        ));
+        assert_eq!(
+            key_path,
+            tcfs_secrets::device::device_secret_key_path(&registry_path, &device_id)
+        );
+        assert!(key_path.exists());
+    }
+
+    #[test]
+    fn merge_device_registry_prefers_real_key_over_placeholder() {
+        let mut local = tcfs_secrets::device::DeviceRegistry::default();
+        let device_id = local.enroll("honey", "age1-device-6b746182", None);
+        let mut incoming = tcfs_secrets::device::DeviceRegistry::default();
+        let (_incoming_id, key) = incoming.enroll_local("honey", None);
+        incoming.devices[0].device_id = device_id.clone();
+
+        let changed = merge_device_registry(&mut local, &incoming).unwrap();
+
+        assert_eq!(changed, 1);
+        let merged = local.find("honey").unwrap();
+        assert_eq!(merged.device_id, device_id);
+        assert_eq!(merged.public_key, key.public_key);
+        assert!(tcfs_secrets::device::is_real_age_public_key(
+            &merged.public_key
+        ));
+    }
+
+    #[test]
+    fn merge_device_registry_rejects_conflicting_real_keys_for_same_device_id() {
+        let mut local = tcfs_secrets::device::DeviceRegistry::default();
+        let (device_id, _local_key) = local.enroll_local("honey", None);
+        let mut incoming = tcfs_secrets::device::DeviceRegistry::default();
+        incoming.enroll_local("honey", None);
+        incoming.devices[0].device_id = device_id;
+
+        let err = merge_device_registry(&mut local, &incoming).unwrap_err();
+
+        assert!(
+            err.to_string().contains("two real public keys differ"),
             "unexpected error: {err:#}"
         );
     }

--- a/docs/ops/fleet-deployment.md
+++ b/docs/ops/fleet-deployment.md
@@ -15,7 +15,10 @@ tracked in [On-Prem Authority Recovery](onprem-authority-recovery.md).
 
 - tcfs v0.3.0+ installed on all machines
 - SeaweedFS S3 reachable from all machines (verified: `dees-appu-bearts:8333`)
-- Each machine enrolled: `tcfs device enroll --name $(hostname)`
+- Each machine enrolled with a real age key and storage-backed registry merge:
+  `tcfs device enroll --name $(hostname) --sync-remote`
+  - If a host already has a legacy `age1-device-*` placeholder entry, repair it
+    explicitly with `--repair-placeholder --sync-remote`.
 - All fleet machines on the same Tailscale tailnet
 
 ---

--- a/docs/ops/tcfs-daily-driver-productionization-todo-2026-05-24.md
+++ b/docs/ops/tcfs-daily-driver-productionization-todo-2026-05-24.md
@@ -335,6 +335,10 @@ until devices have real local private keys and per-device wrapped content keys.
   files.
 - [x] `tcfs device enroll` now uses the same local key-generation path instead
   of `age1-device-<hash>` placeholders.
+- [x] `tcfs device enroll --repair-placeholder --sync-remote` repairs an
+  existing legacy placeholder in place, preserves the device id, writes the
+  device private key beside `devices.json`, and merges the local registry with
+  `{remote_prefix}/tcfs-meta/devices.json`.
 - [ ] This does not yet change manifest wrapping, revoke semantics, pairing, or
   remote registry trust. Those remain the actual beta security boundary.
 
@@ -382,8 +386,9 @@ Target window: 2026-06-15 through 2026-06-30.
 > workstreams. Operator ordering: crypto-first (`TIN-1417` / G1) → honey as
 > device #2 (`TIN-1736` / G2+G3) → agent-dir beachhead `~/.claude/projects`
 > (`TIN-1738` / G4), with guardrail hardening (`TIN-1737` / G0) as a step-zero
-> blocker. `neo` currently reports `nats_ok:false`; that backbone fix (G2) is
-> the keystone that unblocks the stalled shadow pilot and every cross-host goal.
+> blocker. Follow-up 2026-05-31: honey generation 384 activated
+> `nats_tls=false`; neo and honey now both report storage OK and NATS connected,
+> so the remaining honey blocker is G3 registry/enrollment convergence.
 > Follow-up 2026-05-31: `TIN-1740` adds the prepare-only mirror lane for
 > agentic-flow pickup on honey/server+1. The lane prepares manifests and
 > snapshot rules only; no honey transfer occurs before G1/G2/G3.

--- a/docs/rfc/0001-fleet-sync-integration.md
+++ b/docs/rfc/0001-fleet-sync-integration.md
@@ -163,7 +163,9 @@ from the unchecked historical task list below.
 1. Deploy updated Home Manager config to all 3 machines
 2. On each machine:
    ```bash
-   tcfs device enroll --name $(hostname)
+   tcfs device enroll --name $(hostname) --sync-remote
+   # If migrating a legacy placeholder:
+   tcfs device enroll --name $(hostname) --repair-placeholder --sync-remote
    tcfs device list  # verify all 3 visible
    ```
 3. Verify S3 registry at `tcfs-meta/devices.json` shows 3 devices


### PR DESCRIPTION
## Summary

- Adds a storage-backed registry merge path to `tcfs device enroll` via `--sync-remote`.
- Adds explicit `--repair-placeholder` handling for legacy `age1-device-*` entries so honey can preserve its existing device id while replacing the placeholder with a real age key.
- Updates fleet docs/runbooks to use registry sync for enrollment and to record the current G2-green/G3-blocked honey state.

## Changes

- `tcfs device enroll --name <host> --sync-remote` now merges local `devices.json` with `{remote_prefix}/tcfs-meta/devices.json` and uploads the merged registry.
- `--repair-placeholder` generates and stores a real age private key beside `devices.json`, updates the existing device entry in place, and refuses silent repair unless the flag is present.
- Registry merge prefers real keys over placeholders and fails on conflicting real keys for the same device identity.

## Test plan

- [ ] `task test` passes locally
- [ ] `task lint` passes locally
- [x] Verified affected functionality manually: `~/.cargo/bin/cargo fmt --all -- --check`
- [x] Verified affected functionality manually: `~/.cargo/bin/cargo check -p tcfs-cli`
- [x] Verified affected functionality manually: `~/.cargo/bin/cargo test -p tcfs-cli --bin tcfs repair_placeholder_device_key -- --nocapture`
- [x] Verified affected functionality manually: `~/.cargo/bin/cargo test -p tcfs-cli --bin tcfs merge_device_registry -- --nocapture`

## Checklist

- [x] Docs updated (if user-facing behavior changed)
- [ ] CHANGELOG.md updated (if applicable)
- [x] No secrets or credentials in diff