### PR TITLE
docs: archive neo honey device2 proof

### DIFF
--- a/docs/release/evidence/neo-honey-device2-20260531T155450Z/README.md
+++ b/docs/release/evidence/neo-honey-device2-20260531T155450Z/README.md
@@ -1,0 +1,42 @@
+# Neo-Honey Device 2 Exact-Byte Proof
+
+Date: 2026-05-31
+
+This packet records a throwaway neo-to-honey TCFS round-trip proof after honey
+was enrolled as the second real device and switched to the repo-managed
+Home Manager build carrying the registry-sync CLI.
+
+## Result
+
+- Status: complete
+- Source: `neo.local`
+- Target: `honey`
+- Payload bytes: 76
+- Payload SHA-256: `9a510bd212f7d8ea515780e1262c79a04e9077ef135eb84db2f62a1968435e74`
+- Pulled SHA-256 on honey: `9a510bd212f7d8ea515780e1262c79a04e9077ef135eb84db2f62a1968435e74`
+- Manifest:
+  `data/proofs/neo-honey-20260531T155450Z/manifests/4930ea4f7b561c7ec3a551fdb008563fa7f872c32f1a1cc13fae1a0a8be5e694`
+
+## Commands
+
+Neo generated a temporary payload and pushed it:
+
+```sh
+tcfs push --prefix data/proofs/neo-honey-20260531T155450Z /tmp/tcfs-neo-honey-proof.psG1y2/payload.txt
+```
+
+Honey pulled the manifest and verified the bytes:
+
+```sh
+tcfs pull data/proofs/neo-honey-20260531T155450Z/manifests/4930ea4f7b561c7ec3a551fdb008563fa7f872c32f1a1cc13fae1a0a8be5e694 /tmp/tcfs-neo-honey-pull.nCb8YC/payload.txt
+sha256sum /tmp/tcfs-neo-honey-pull.nCb8YC/payload.txt
+wc -c /tmp/tcfs-neo-honey-pull.nCb8YC/payload.txt
+```
+
+## Caveats
+
+- This proves exact bytes through the storage-backed manifest/chunk path.
+- It does not prove a mounted-file edit/hydrate workflow for an enrolled
+  agent-state directory.
+- The lab storage and NATS paths still use plaintext transport and remain a
+  production hardening item before broad daily-driver enrollment.

--- a/docs/release/evidence/neo-honey-device2-20260531T155450Z/result.env
+++ b/docs/release/evidence/neo-honey-device2-20260531T155450Z/result.env
@@ -1,0 +1,14 @@
+status=complete
+timestamp_utc=2026-05-31T15:55:02Z
+source_device=neo.local
+source_device_id=03d8a0bd
+target_device=honey
+target_device_id=d1176e5d
+honey_tcfs_version=0.12.13
+payload_bytes=76
+payload_sha256=9a510bd212f7d8ea515780e1262c79a04e9077ef135eb84db2f62a1968435e74
+pulled_sha256=9a510bd212f7d8ea515780e1262c79a04e9077ef135eb84db2f62a1968435e74
+manifest=data/proofs/neo-honey-20260531T155450Z/manifests/4930ea4f7b561c7ec3a551fdb008563fa7f872c32f1a1cc13fae1a0a8be5e694
+proof=exact-byte-match
+caveat_transport=plaintext-http-storage-and-plaintext-nats-in-lab
+caveat_scope=storage-manifest-round-trip-not-mounted-agent-dir-hydration


### PR DESCRIPTION
## Summary

- Archives the 2026-05-31 neo-to-honey exact-byte TCFS proof.
- Records the manifest path, byte count, SHA-256 match, and transport caveats for TIN-1736.

## Validation

- `git diff --check`
- Neo pushed a 76-byte payload to `data/proofs/neo-honey-20260531T155450Z`.
- Honey pulled the manifest and produced matching SHA-256 `9a510bd212f7d8ea515780e1262c79a04e9077ef135eb84db2f62a1968435e74`.

## Linear

TIN-1736