### PR TITLE
TIN-1758 fix daemon control-plane startup hangs

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -37,6 +37,13 @@ use tcfs_core::proto::{tcfs_daemon_client::TcfsDaemonClient, Empty, StatusReques
 type DaemonClient = TcfsDaemonClient<InterceptedService<Channel, SessionTokenInterceptor>>;
 
 #[cfg(unix)]
+const DAEMON_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(unix)]
+const DAEMON_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(unix)]
+const SESSION_TOKEN_LOOKUP_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[cfg(unix)]
 #[derive(Clone, Debug)]
 struct SessionTokenInterceptor {
     token: Option<String>,
@@ -2326,21 +2333,27 @@ async fn cmd_status(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
         std::process::exit(1);
     }
 
-    let mut client = connect_daemon(socket).await?;
+    let mut client = connect_daemon_without_session(socket).await?;
 
     // Daemon status
-    let status = client
-        .status(tonic::Request::new(StatusRequest {}))
-        .await
-        .context("status RPC failed")?
-        .into_inner();
+    let status = tokio::time::timeout(
+        DAEMON_RPC_TIMEOUT,
+        client.status(tonic::Request::new(StatusRequest {})),
+    )
+    .await
+    .context("status RPC timed out")?
+    .context("status RPC failed")?
+    .into_inner();
 
     // Credential status
-    let creds = client
-        .credential_status(tonic::Request::new(Empty {}))
-        .await
-        .context("credential_status RPC failed")?
-        .into_inner();
+    let creds = tokio::time::timeout(
+        DAEMON_RPC_TIMEOUT,
+        client.credential_status(tonic::Request::new(Empty {})),
+    )
+    .await
+    .context("credential_status RPC timed out")?
+    .context("credential_status RPC failed")?
+    .into_inner();
 
     let uptime = format_uptime(status.uptime_secs);
 
@@ -2515,7 +2528,7 @@ fn print_update_notice(current: &str, latest: &str) {
 // ── gRPC connection ───────────────────────────────────────────────────────────
 
 #[cfg(unix)]
-fn load_session_token() -> Option<String> {
+async fn load_session_token() -> Option<String> {
     if let Ok(token) = std::env::var("TCFS_SESSION_TOKEN") {
         let trimmed = token.trim();
         if !trimmed.is_empty() {
@@ -2523,11 +2536,25 @@ fn load_session_token() -> Option<String> {
         }
     }
 
-    match tcfs_secrets::keychain::get_secret(tcfs_secrets::keychain::keys::SESSION_TOKEN) {
-        Ok(Some(secret)) => Some(secret.expose_secret().to_string()),
-        Ok(None) => None,
-        Err(err) => {
-            tracing::debug!("failed to read TCFS session token from keychain: {err}");
+    let lookup = tokio::task::spawn_blocking(|| {
+        match tcfs_secrets::keychain::get_secret(tcfs_secrets::keychain::keys::SESSION_TOKEN) {
+            Ok(Some(secret)) => Some(secret.expose_secret().to_string()),
+            Ok(None) => None,
+            Err(err) => {
+                tracing::debug!("failed to read TCFS session token from keychain: {err}");
+                None
+            }
+        }
+    });
+
+    match tokio::time::timeout(SESSION_TOKEN_LOOKUP_TIMEOUT, lookup).await {
+        Ok(Ok(token)) => token,
+        Ok(Err(err)) => {
+            tracing::debug!("TCFS session token keychain lookup task failed: {err}");
+            None
+        }
+        Err(_) => {
+            tracing::debug!("TCFS session token keychain lookup timed out");
             None
         }
     }
@@ -2546,19 +2573,45 @@ fn store_session_token(token: &str) -> Result<()> {
 
 #[cfg(unix)]
 async fn connect_daemon(socket_path: &Path) -> Result<DaemonClient> {
+    let token = load_session_token().await;
+    connect_daemon_with_token(socket_path, token).await
+}
+
+#[cfg(unix)]
+async fn connect_daemon_without_session(socket_path: &Path) -> Result<DaemonClient> {
+    connect_daemon_with_token(socket_path, None).await
+}
+
+#[cfg(unix)]
+async fn connect_daemon_with_token(
+    socket_path: &Path,
+    token: Option<String>,
+) -> Result<DaemonClient> {
     let path = socket_path.to_path_buf();
-    let token = load_session_token();
 
     // tonic over Unix domain socket: use a tower service_fn connector
-    let channel = Endpoint::from_static("http://[::]:0")
-        .connect_with_connector(service_fn(move |_: Uri| {
-            let path = path.clone();
-            async move {
-                let stream = tokio::net::UnixStream::connect(&path).await?;
-                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
-            }
-        }))
+    let endpoint = Endpoint::from_static("http://[::]:0");
+    let connect = endpoint.connect_with_connector(service_fn(move |_: Uri| {
+        let path = path.clone();
+        async move {
+            let stream = tokio::time::timeout(
+                DAEMON_CONNECT_TIMEOUT,
+                tokio::net::UnixStream::connect(&path),
+            )
+            .await
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "timed out connecting to tcfsd",
+                )
+            })??;
+            Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+        }
+    }));
+
+    let channel = tokio::time::timeout(DAEMON_CONNECT_TIMEOUT, connect)
         .await
+        .with_context(|| format!("timed out connecting to tcfsd at {}", socket_path.display()))?
         .with_context(|| format!("connecting to tcfsd at {}", socket_path.display()))?;
 
     Ok(TcfsDaemonClient::with_interceptor(
@@ -4288,14 +4341,17 @@ async fn cmd_auth_unlock(
     };
 
     // Send to daemon via gRPC
-    let mut client = connect_daemon(&config.daemon.socket).await?;
-    let resp = client
-        .auth_unlock(tcfs_core::proto::AuthUnlockRequest {
+    let mut client = connect_daemon_without_session(&config.daemon.socket).await?;
+    let resp = tokio::time::timeout(
+        DAEMON_RPC_TIMEOUT,
+        client.auth_unlock(tcfs_core::proto::AuthUnlockRequest {
             master_key: key_bytes,
-        })
-        .await
-        .context("auth_unlock RPC failed")?
-        .into_inner();
+        }),
+    )
+    .await
+    .context("auth_unlock RPC timed out")?
+    .context("auth_unlock RPC failed")?
+    .into_inner();
 
     if resp.success {
         println!("Encryption unlocked. Master key loaded into daemon.");
@@ -4310,12 +4366,15 @@ async fn cmd_auth_unlock(
 #[cfg(unix)]
 async fn cmd_auth_lock(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
     // Clear from daemon
-    let mut client = connect_daemon(&config.daemon.socket).await?;
-    let resp = client
-        .auth_lock(tcfs_core::proto::Empty {})
-        .await
-        .context("auth_lock RPC failed")?
-        .into_inner();
+    let mut client = connect_daemon_without_session(&config.daemon.socket).await?;
+    let resp = tokio::time::timeout(
+        DAEMON_RPC_TIMEOUT,
+        client.auth_lock(tcfs_core::proto::Empty {}),
+    )
+    .await
+    .context("auth_lock RPC timed out")?
+    .context("auth_lock RPC failed")?
+    .into_inner();
 
     if !resp.success {
         anyhow::bail!("lock failed: {}", resp.error);
@@ -4331,12 +4390,15 @@ async fn cmd_auth_lock(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
 
 #[cfg(unix)]
 async fn cmd_auth_status(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
-    let mut client = connect_daemon(&config.daemon.socket).await?;
-    let resp = client
-        .auth_status(tcfs_core::proto::Empty {})
-        .await
-        .context("auth_status RPC failed")?
-        .into_inner();
+    let mut client = connect_daemon_without_session(&config.daemon.socket).await?;
+    let resp = tokio::time::timeout(
+        DAEMON_RPC_TIMEOUT,
+        client.auth_status(tcfs_core::proto::Empty {}),
+    )
+    .await
+    .context("auth_status RPC timed out")?
+    .context("auth_status RPC failed")?
+    .into_inner();
 
     if resp.crypto_enabled {
         if resp.unlocked {

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -2123,7 +2123,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
         _request: tonic::Request<Empty>,
     ) -> Result<tonic::Response<AuthStatusResponse>, tonic::Status> {
         use tcfs_auth::AuthProvider;
-        let guard = self.master_key.lock().await;
+        let unlocked = self.master_key.lock().await.is_some();
 
         // Build available methods dynamically
         let mut methods = vec!["master_key".into()];
@@ -2139,12 +2139,12 @@ impl TcfsDaemon for TcfsDaemonImpl {
         let active_sessions = self.session_store.active_count().await;
 
         Ok(tonic::Response::new(AuthStatusResponse {
-            unlocked: guard.is_some(),
+            unlocked,
             crypto_enabled: self.config.crypto.enabled,
             session_device_id: self.device_id.clone(),
             auth_method: if active_sessions > 0 {
                 "session".into()
-            } else if guard.is_some() {
+            } else if unlocked {
                 "master_key".into()
             } else {
                 String::new()
@@ -2652,16 +2652,39 @@ pub async fn serve(
     };
 
     // Spawn a second gRPC server on the FileProvider socket if configured.
-    // Uses a separate tokio task with a shared shutdown notify.
+    //
+    // This listener is optional. Keep its bind path off the startup critical
+    // path so a stale App Group socket cannot leave the primary daemon socket
+    // bound but unserved.
     let fp_handle = if let Some(fp_path) = fileprovider_socket {
-        let secondary = bind_uds(fp_path).await?;
-        info!(socket = %fp_path.display(), "gRPC FileProvider socket ready");
-
+        let fp_path = fp_path.to_path_buf();
         let fp_service = service.clone();
         let fp_shutdown = Arc::new(tokio::sync::Notify::new());
         let fp_shutdown_clone = fp_shutdown.clone();
 
         let handle = tokio::spawn(async move {
+            let bind_result =
+                tokio::time::timeout(std::time::Duration::from_secs(5), bind_uds(&fp_path)).await;
+
+            let secondary = match bind_result {
+                Ok(Ok(listener)) => listener,
+                Ok(Err(e)) => {
+                    warn!(
+                        socket = %fp_path.display(),
+                        "FileProvider gRPC socket bind failed; primary daemon socket remains active: {e}"
+                    );
+                    return;
+                }
+                Err(_) => {
+                    warn!(
+                        socket = %fp_path.display(),
+                        "FileProvider gRPC socket bind timed out; primary daemon socket remains active"
+                    );
+                    return;
+                }
+            };
+
+            info!(socket = %fp_path.display(), "gRPC FileProvider socket ready");
             if let Err(e) = Server::builder()
                 .add_service(fp_service)
                 .serve_with_incoming_shutdown(secondary, fp_shutdown_clone.notified())
@@ -2685,7 +2708,12 @@ pub async fn serve(
     // Stop the FileProvider server when the primary shuts down
     if let Some((handle, notify)) = fp_handle {
         notify.notify_one();
-        let _ = handle.await;
+        if tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .is_err()
+        {
+            warn!("FileProvider gRPC server did not stop within timeout");
+        }
     }
     if let Some((handle, notify)) = tcp_handle {
         notify.notify_one();
@@ -2898,6 +2926,45 @@ mod tests {
         assert!(!resp.nats_ok);
         assert_eq!(resp.active_mounts, 0);
         assert!(resp.uptime_secs >= 0);
+    }
+
+    #[tokio::test]
+    async fn primary_uds_serves_when_fileprovider_socket_bind_fails() {
+        let daemon = test_daemon();
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("tcfsd.sock");
+        let not_a_dir = dir.path().join("not-a-dir");
+        std::fs::write(&not_a_dir, b"not a directory").unwrap();
+        let fileprovider_socket = not_a_dir.join("tcfsd-fileprovider.sock");
+        let shutdown = Arc::new(tokio::sync::Notify::new());
+        let shutdown_for_server = shutdown.clone();
+
+        let socket_path_for_server = socket_path.clone();
+        let handle = tokio::spawn(async move {
+            serve(
+                &socket_path_for_server,
+                Some(&fileprovider_socket),
+                None,
+                daemon,
+                shutdown_for_server.notified(),
+            )
+            .await
+        });
+
+        let mut client = connect_test_client(&socket_path).await;
+        let resp = client
+            .status(tonic::Request::new(StatusRequest {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.device_id, "test-device-id");
+
+        shutdown.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+            .await
+            .expect("server shutdown timed out")
+            .unwrap()
+            .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- keeps the primary tcfsd gRPC control socket serving even when the optional FileProvider socket bind fails, stalls, or times out
- skips Keychain session-token lookup for unauthenticated control-plane probes (`tcfs status`, `tcfs auth status`, `tcfs auth unlock`, `tcfs auth lock`)
- adds bounded CLI connect/RPC timeouts so daemon probes fail clearly instead of hanging indefinitely
- drops the daemon `master_key` lock before auth-status session-store awaits
- adds a regression test proving the primary UDS still serves when FileProvider socket bind fails

## Validation

- `~/.cargo/bin/cargo fmt --all -- --check`
- `git diff --check`
- `~/.cargo/bin/cargo check -p tcfs-cli -p tcfsd`
- `~/.cargo/bin/cargo test -p tcfs-cli --no-run`
- `~/.cargo/bin/cargo test -p tcfsd --no-run`
- `~/.cargo/bin/cargo test -p tcfsd primary_uds_serves_when_fileprovider_socket_bind_fails -- --nocapture`
