### PR TITLE
feat(sync): wire git-bundle mode so peer rehydrate keeps working git history

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1441,6 +1441,7 @@ async fn cmd_pull_with_operator(
 
     state.flush().context("flushing state cache")?;
     remove_adjacent_stub_after_pull(&result.local_path).await?;
+    restore_git_history_after_pull(&result.local_path).await?;
 
     pb.finish_with_message("done".to_string());
     println!();
@@ -1489,6 +1490,43 @@ async fn remove_adjacent_stub_after_pull(local_path: &Path) -> Result<()> {
             Err(err).with_context(|| format!("removing stale stub: {}", stub_path.display()))
         }
     }
+}
+
+/// If the pulled file is a TCFS git bundle (`.git-tcfs-bundle`), reconstruct
+/// the repo's `.git` metadata in place so the rehydrated working tree has
+/// working history (`git log` / `git status` / `git fetch`).
+///
+/// The bundle artifact is intentionally left in place: it is a synced object,
+/// so deleting it locally would propagate as a deletion to peers on the next
+/// reconcile. Artifact cleanup (gitignore / post-restore prune) is tracked as
+/// a follow-up.
+async fn restore_git_history_after_pull(local_path: &Path) -> Result<()> {
+    let is_bundle = local_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n == tcfs_sync::git_safety::GIT_BUNDLE_REL_PATH)
+        .unwrap_or(false);
+    if !is_bundle {
+        return Ok(());
+    }
+    let Some(repo_root) = local_path.parent().map(|p| p.to_path_buf()) else {
+        return Ok(());
+    };
+    let bundle = local_path.to_path_buf();
+    // git invokes blocking subprocesses; keep them off the async runtime.
+    tokio::task::spawn_blocking(move || {
+        tcfs_sync::git_safety::restore_git_bundle_into(&bundle, &repo_root)
+    })
+    .await
+    .context("joining git bundle restore task")?
+    .with_context(|| {
+        format!(
+            "restoring git history from bundle: {}",
+            local_path.display()
+        )
+    })?;
+    println!("  restored git history from bundle");
+    Ok(())
 }
 
 async fn cmd_pull(

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -2833,6 +2833,14 @@ pub fn collect_files(root: &Path, config: &CollectConfig) -> Result<CollectResul
         &blacklist,
         &mut visited,
     )?;
+
+    // Bundle mode: for every enrolled git repo, capture `.git` as a single
+    // `git bundle` and add the bundle to the upload set as a normal object.
+    // The raw `.git/*` internals were skipped by `collect_files_inner`.
+    if config.sync_git_dirs && config.git_sync_mode == "bundle" {
+        collect_git_bundles(root, &mut files);
+    }
+
     files.sort(); // deterministic order
     symlinks.sort();
     empty_dirs.sort();
@@ -3010,6 +3018,123 @@ fn collect_files_inner(
     }
 
     Ok(())
+}
+
+/// Walk `root` for git working trees (directories containing a `.git`
+/// directory) and, for each one that is safe to snapshot, create a git bundle
+/// and append its path to `files` so it is uploaded as a normal TCFS object.
+///
+/// Repos with in-progress operations (rebase, merge, lockfiles) are skipped
+/// this cycle and will be retried on the next sync once the operation settles.
+/// Bundle staleness is handled implicitly: `git bundle create --all` always
+/// reflects current refs, and the resulting object only re-uploads chunks that
+/// actually changed (content-addressed dedup).
+fn collect_git_bundles(root: &Path, files: &mut Vec<PathBuf>) {
+    let mut repos = Vec::new();
+    find_git_repos(root, &mut repos);
+    for repo_root in repos {
+        let git_dir = repo_root.join(".git");
+        let safety = crate::git_safety::git_is_safe(&git_dir);
+        if !safety.blocking.is_empty() {
+            warn!(
+                repo = %repo_root.display(),
+                blocking = ?safety.blocking,
+                "skipping git bundle: active git operation in progress"
+            );
+            continue;
+        }
+        match crate::git_safety::snapshot_git_for_sync(&repo_root) {
+            Ok(bundle_path) => {
+                debug!(repo = %repo_root.display(), bundle = %bundle_path.display(), "captured git bundle");
+                files.push(bundle_path);
+            }
+            Err(e) => {
+                warn!(repo = %repo_root.display(), "git bundle failed: {e}");
+            }
+        }
+    }
+}
+
+/// Recursively find directories under `root` that contain a `.git` directory
+/// (i.e. git working-tree roots). Does not descend into `.git` itself.
+fn find_git_repos(dir: &Path, out: &mut Vec<PathBuf>) {
+    if dir.join(".git").is_dir() {
+        out.push(dir.to_path_buf());
+        // Still descend to catch nested submodule/worktree repos.
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name == ".git" {
+            continue;
+        }
+        find_git_repos(&path, out);
+    }
+}
+
+/// Restore git history from any TCFS bundles materialized under `root`.
+///
+/// Call this after a pull/rehydrate completes: for every
+/// `.git-tcfs-bundle` file found under `root`, restore the repo's `.git`
+/// metadata in place so `git log` / `git status` / `git fetch` work on the
+/// peer. The synced working-tree files are left untouched.
+///
+/// Returns the number of repos successfully restored.
+pub fn restore_git_bundles_under(root: &Path) -> usize {
+    let mut bundles = Vec::new();
+    find_git_bundles(root, &mut bundles);
+    let mut restored = 0usize;
+    for bundle in bundles {
+        let Some(repo_root) = bundle.parent() else {
+            continue;
+        };
+        match crate::git_safety::restore_git_bundle_into(&bundle, repo_root) {
+            Ok(()) => {
+                info!(repo = %repo_root.display(), "restored git history from bundle");
+                restored += 1;
+            }
+            Err(e) => {
+                warn!(repo = %repo_root.display(), "git bundle restore failed: {e}");
+            }
+        }
+    }
+    restored
+}
+
+/// Recursively find `.git-tcfs-bundle` files under `dir`.
+fn find_git_bundles(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else { continue };
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if name == crate::git_safety::GIT_BUNDLE_REL_PATH {
+                out.push(path.clone());
+            }
+        }
+        if ft.is_dir() {
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if name == ".git" {
+                continue;
+            }
+            find_git_bundles(&path, out);
+        }
+    }
 }
 
 /// Normalize a filesystem path into a stable S3 index key component.

--- a/crates/tcfs-sync/src/git_safety.rs
+++ b/crates/tcfs-sync/src/git_safety.rs
@@ -5,6 +5,13 @@
 
 use std::path::Path;
 
+/// Relative path (under the repo working root) where the TCFS git bundle is
+/// written and synced as a normal object. Keeping it inside the working tree
+/// (not under `.git/`) means it flows through the regular file collector and
+/// is visible to the peer pull as an ordinary path, while the raw `.git/*`
+/// internals are skipped by the collector in bundle mode.
+pub const GIT_BUNDLE_REL_PATH: &str = ".git-tcfs-bundle";
+
 /// Result of checking whether a .git directory is safe to sync.
 #[derive(Debug, Clone, Default)]
 pub struct GitSafetyCheck {
@@ -76,7 +83,7 @@ pub fn git_is_safe(git_dir: &Path) -> GitSafetyCheck {
 /// Runs `git bundle create --all` to create a single file containing
 /// all refs and objects, suitable for transporting a complete repository.
 pub fn snapshot_git_for_sync(repo_root: &Path) -> anyhow::Result<std::path::PathBuf> {
-    let bundle_path = repo_root.join(".git-tcfs-bundle");
+    let bundle_path = repo_root.join(GIT_BUNDLE_REL_PATH);
 
     let output = std::process::Command::new("git")
         .args(["bundle", "create", &bundle_path.to_string_lossy(), "--all"])
@@ -92,7 +99,67 @@ pub fn snapshot_git_for_sync(repo_root: &Path) -> anyhow::Result<std::path::Path
     Ok(bundle_path)
 }
 
-/// Restore a git repository from a bundle.
+/// Restore git history from a TCFS bundle into an existing working tree.
+///
+/// Unlike a fresh `git clone`, this is designed for the rehydrate path where
+/// the working-tree files have already been materialized by TCFS as normal
+/// objects: only the `.git` metadata (objects, refs, logs) is missing. It:
+///
+/// 1. `git init`s the repo in place if there is no `.git` directory yet.
+/// 2. `git fetch`es every ref from the bundle into the live object store
+///    (`+refs/*:refs/*`), which repopulates branches, tags, and history.
+/// 3. Restores `HEAD` to the bundle's default branch so `git log` / `git
+///    status` / `git fetch` work against a real ref.
+///
+/// The working-tree files are left untouched: after this runs, `git status`
+/// compares the freshly-restored index/HEAD against the already-synced files,
+/// so a faithfully-synced tree reports clean.
+pub fn restore_git_bundle_into(bundle: &Path, repo_root: &Path) -> anyhow::Result<()> {
+    if !bundle.exists() {
+        anyhow::bail!("git bundle not found: {}", bundle.display());
+    }
+
+    let git_dir = repo_root.join(".git");
+    if !git_dir.exists() {
+        run_git(repo_root, &["init", "--quiet"]).map_err(|e| anyhow::anyhow!("git init: {e}"))?;
+    }
+
+    // Park HEAD on a throwaway unborn branch before fetching. A fresh `git
+    // init` puts HEAD on `refs/heads/main` (or `master`); git then refuses
+    // `+refs/*:refs/*` because it would fetch into the currently checked-out
+    // branch. Pointing HEAD at a ref the bundle does not contain makes every
+    // real branch non-current, so the mirror fetch succeeds. We restore HEAD
+    // to the real branch immediately after.
+    run_git(
+        repo_root,
+        &["symbolic-ref", "HEAD", "refs/heads/__tcfs_bundle_restore"],
+    )
+    .map_err(|e| anyhow::anyhow!("parking HEAD before bundle fetch: {e}"))?;
+
+    // Pull every ref from the bundle into the live repo. `+refs/*:refs/*`
+    // mirrors heads, tags, and remotes so history is complete.
+    let bundle_str = bundle.to_string_lossy().to_string();
+    run_git(
+        repo_root,
+        &["fetch", "--quiet", &bundle_str, "+refs/*:refs/*"],
+    )
+    .map_err(|e| anyhow::anyhow!("git fetch from bundle: {e}"))?;
+
+    // Restore HEAD to the bundle's default branch. The bundle stores the
+    // symbolic HEAD target; resolve it so the peer lands on the same branch.
+    if let Some(branch) = bundle_head_branch(bundle) {
+        // Point HEAD at the branch without touching the working tree.
+        let _ = run_git(repo_root, &["symbolic-ref", "HEAD", &branch]);
+        // Make the index match HEAD without overwriting synced files.
+        let _ = run_git(repo_root, &["reset", "--mixed", "--quiet"]);
+    }
+
+    Ok(())
+}
+
+/// Backwards-compatible clone-based restore (creates a fresh checkout at
+/// `target`). Retained for callers that want a standalone clone rather than an
+/// in-place working-tree restore.
 pub fn restore_git_from_bundle(bundle: &Path, target: &Path) -> anyhow::Result<()> {
     let output = std::process::Command::new("git")
         .args([
@@ -109,6 +176,56 @@ pub fn restore_git_from_bundle(bundle: &Path, target: &Path) -> anyhow::Result<(
     }
 
     Ok(())
+}
+
+/// Run a git command in `cwd`, returning an error with captured stderr on
+/// non-zero exit.
+fn run_git(cwd: &Path, args: &[&str]) -> anyhow::Result<()> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| anyhow::anyhow!("running git {args:?}: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git {args:?} failed: {stderr}");
+    }
+    Ok(())
+}
+
+/// Resolve the bundle's default HEAD branch ref (e.g. `refs/heads/main`) by
+/// listing its refs. Returns `None` if HEAD cannot be determined.
+fn bundle_head_branch(bundle: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["bundle", "list-heads", &bundle.to_string_lossy()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let listing = String::from_utf8_lossy(&output.stdout);
+    // `git bundle list-heads` prints `<sha> HEAD` for the symbolic head and
+    // `<sha> refs/heads/<branch>` lines. Find the SHA that HEAD points at,
+    // then map it back to a concrete branch ref.
+    let mut head_sha: Option<String> = None;
+    for line in listing.lines() {
+        let mut parts = line.split_whitespace();
+        let sha = parts.next().unwrap_or_default();
+        let refname = parts.next().unwrap_or_default();
+        if refname == "HEAD" {
+            head_sha = Some(sha.to_string());
+        }
+    }
+    let head_sha = head_sha?;
+    for line in listing.lines() {
+        let mut parts = line.split_whitespace();
+        let sha = parts.next().unwrap_or_default();
+        let refname = parts.next().unwrap_or_default();
+        if sha == head_sha && refname.starts_with("refs/heads/") {
+            return Some(refname.to_string());
+        }
+    }
+    None
 }
 
 /// Acquire a cooperative lock on .git/tcfs.lock for raw sync mode.

--- a/crates/tcfs-sync/tests/git_bundle_roundtrip.rs
+++ b/crates/tcfs-sync/tests/git_bundle_roundtrip.rs
@@ -78,8 +78,7 @@ async fn git_bundle_mode_preserves_history_on_peer() {
     let op = memory_operator();
     let prefix = "test/git-bundle";
 
-    let mut state =
-        tcfs_sync::state::StateCache::open(&src_tmp.path().join("state.db")).unwrap();
+    let mut state = tcfs_sync::state::StateCache::open(&src_tmp.path().join("state.db")).unwrap();
 
     // Bundle mode: include .git, but capture it as a bundle (not raw walk).
     let config = tcfs_sync::engine::CollectConfig {
@@ -118,7 +117,10 @@ async fn git_bundle_mode_preserves_history_on_peer() {
     )
     .await
     .expect("push tree in bundle mode");
-    assert!(uploaded >= 3, "expected README, file2, bundle: got {uploaded}");
+    assert!(
+        uploaded >= 3,
+        "expected README, file2, bundle: got {uploaded}"
+    );
 
     // ── Peer rehydrate ───────────────────────────────────────────────────
     let peer_tmp = TempDir::new().unwrap();
@@ -130,10 +132,9 @@ async fn git_bundle_mode_preserves_history_on_peer() {
 
     // Pull every synced working-tree path (incl. the bundle) into the peer.
     for rel in &rels {
-        let manifest =
-            tcfs_sync::engine::resolve_manifest_path(&op, rel, prefix, Some(&repo))
-                .await
-                .unwrap_or_else(|e| panic!("resolve manifest for {rel}: {e}"));
+        let manifest = tcfs_sync::engine::resolve_manifest_path(&op, rel, prefix, Some(&repo))
+            .await
+            .unwrap_or_else(|e| panic!("resolve manifest for {rel}: {e}"));
         let dst = peer_repo.join(rel);
         std::fs::create_dir_all(dst.parent().unwrap()).unwrap();
         tcfs_sync::engine::download_file_with_device(

--- a/crates/tcfs-sync/tests/git_bundle_roundtrip.rs
+++ b/crates/tcfs-sync/tests/git_bundle_roundtrip.rs
@@ -1,0 +1,195 @@
+//! Integration test: git-bundle sync → peer rehydrate preserves history.
+//!
+//! Verifies the bundle-mode path end-to-end:
+//!   1. Create a temp git repo with >=2 commits.
+//!   2. Push the tree in bundle mode (sync_git_dirs=true, git_sync_mode=bundle).
+//!      The raw `.git/*` internals are NOT walked; instead a single
+//!      `.git-tcfs-bundle` object is synced.
+//!   3. Pull every synced object into a fresh peer directory.
+//!   4. Restore git history from the bundle on the peer.
+//!   5. Assert `git log` shows both commits and `git status` is clean.
+
+use opendal::Operator;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn memory_operator() -> Operator {
+    Operator::new(opendal::services::Memory::default())
+        .expect("memory operator")
+        .finish()
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("running git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_stdout(cwd: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("running git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn init_repo_with_two_commits(dir: &Path) {
+    git(dir, &["init", "--quiet", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@tcfs.local"]);
+    git(dir, &["config", "user.name", "TCFS Test"]);
+    git(dir, &["config", "commit.gpgsign", "false"]);
+
+    std::fs::write(dir.join("README.md"), b"first\n").unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "--quiet", "-m", "first commit"]);
+
+    std::fs::write(dir.join("file2.txt"), b"second\n").unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "--quiet", "-m", "second commit"]);
+}
+
+#[tokio::test]
+async fn git_bundle_mode_preserves_history_on_peer() {
+    // Skip gracefully if git is unavailable in the environment.
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available; skipping git_bundle_mode_preserves_history_on_peer");
+        return;
+    }
+
+    let src_tmp = TempDir::new().unwrap();
+    let repo = src_tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo_with_two_commits(&repo);
+
+    let op = memory_operator();
+    let prefix = "test/git-bundle";
+
+    let mut state =
+        tcfs_sync::state::StateCache::open(&src_tmp.path().join("state.db")).unwrap();
+
+    // Bundle mode: include .git, but capture it as a bundle (not raw walk).
+    let config = tcfs_sync::engine::CollectConfig {
+        sync_git_dirs: true,
+        git_sync_mode: "bundle".into(),
+        sync_empty_dirs: false,
+        ..Default::default()
+    };
+
+    // Sanity: the collector must NOT walk raw `.git/*` internals, but MUST
+    // include the synthesized bundle object.
+    let collected = tcfs_sync::engine::collect_files(&repo, &config).unwrap();
+    let rels: Vec<String> = collected
+        .files
+        .iter()
+        .map(|p| p.strip_prefix(&repo).unwrap().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        rels.iter().any(|r| r == ".git-tcfs-bundle"),
+        "bundle object should be in collected set: {rels:?}"
+    );
+    assert!(
+        !rels.iter().any(|r| r.starts_with(".git/")),
+        "raw .git internals must not be walked in bundle mode: {rels:?}"
+    );
+
+    let (uploaded, _skipped, _bytes) = tcfs_sync::engine::push_tree_with_device(
+        &op,
+        &repo,
+        prefix,
+        &mut state,
+        None,
+        "neo",
+        Some(&config),
+        None,
+    )
+    .await
+    .expect("push tree in bundle mode");
+    assert!(uploaded >= 3, "expected README, file2, bundle: got {uploaded}");
+
+    // ── Peer rehydrate ───────────────────────────────────────────────────
+    let peer_tmp = TempDir::new().unwrap();
+    let peer_repo = peer_tmp.path().join("repo");
+    std::fs::create_dir_all(&peer_repo).unwrap();
+
+    let mut restore_state =
+        tcfs_sync::state::StateCache::open(&peer_tmp.path().join("restore-state.db")).unwrap();
+
+    // Pull every synced working-tree path (incl. the bundle) into the peer.
+    for rel in &rels {
+        let manifest =
+            tcfs_sync::engine::resolve_manifest_path(&op, rel, prefix, Some(&repo))
+                .await
+                .unwrap_or_else(|e| panic!("resolve manifest for {rel}: {e}"));
+        let dst = peer_repo.join(rel);
+        std::fs::create_dir_all(dst.parent().unwrap()).unwrap();
+        tcfs_sync::engine::download_file_with_device(
+            &op,
+            &manifest,
+            &dst,
+            prefix,
+            None,
+            "honey",
+            Some(&mut restore_state),
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("download {rel}: {e}"));
+    }
+
+    // Before restore the peer has working-tree files but no `.git` history.
+    assert!(peer_repo.join("README.md").exists());
+    assert!(peer_repo.join("file2.txt").exists());
+    assert!(peer_repo.join(".git-tcfs-bundle").exists());
+    assert!(!peer_repo.join(".git").exists());
+
+    // Restore git history from the bundle.
+    let restored = tcfs_sync::engine::restore_git_bundles_under(peer_tmp.path());
+    assert_eq!(restored, 1, "exactly one repo should be restored");
+
+    // ── Assertions: history + clean status on the peer ─────────────────────
+    let log = git_stdout(&peer_repo, &["log", "--oneline"]);
+    assert!(
+        log.contains("first commit"),
+        "peer git log should include first commit: {log}"
+    );
+    assert!(
+        log.contains("second commit"),
+        "peer git log should include second commit: {log}"
+    );
+    let count = log.lines().filter(|l| !l.trim().is_empty()).count();
+    assert_eq!(count, 2, "peer should have exactly 2 commits: {log}");
+
+    // `git status` should be clean. The TCFS bundle artifact is the only
+    // untracked file; ignore it so the working tree is otherwise pristine.
+    let status = git_stdout(
+        &peer_repo,
+        &["status", "--porcelain", "--untracked-files=all"],
+    );
+    let dirty: Vec<&str> = status
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter(|l| !l.ends_with(".git-tcfs-bundle"))
+        .collect();
+    assert!(
+        dirty.is_empty(),
+        "peer working tree should be clean (excluding bundle artifact): {dirty:?}"
+    );
+
+    // HEAD should resolve to the same branch the source was on.
+    let branch = git_stdout(&peer_repo, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    assert_eq!(branch.trim(), "main", "peer HEAD should be on main");
+}


### PR DESCRIPTION
## What

Makes TCFS preserve working git history when a repo is rehydrated on a peer host, closing the structural dev-env parity gap where a rehydrated repo had working-tree files but no usable `.git` history.

This wires the previously dead `git_safety.rs` bundle path behind the existing `git_sync_mode = "bundle"` policy:

- Sync: `collect_files` captures each safe enrolled repo's `.git` as a single `.git-tcfs-bundle` object via `git bundle create --all`, and bundle mode skips raw `.git/*` internals.
- Rehydrate: CLI pull detects `.git-tcfs-bundle` and restores `.git` metadata in place using `restore_git_bundle_into`, so the peer gets real branches, tags, objects, and HEAD.
- Safety: repos with active git operations are skipped for that sync cycle.

## Recovery bug fixed

A fresh `git init` leaves HEAD on a checked-out branch, and git refuses `+refs/*:refs/*` into that current branch. The restore path now parks HEAD on a temporary unborn branch before mirror-fetching bundle refs, then restores HEAD to the bundle's default branch.

## Validation

- `cargo build -p tcfs-cli` passed during local validation.
- `crates/tcfs-sync/tests/git_bundle_roundtrip.rs` passes: bundle object synced, raw `.git/*` excluded, peer pulls objects, `.git` restored, both commits visible in `git log`, `git status` clean except the synced bundle artifact, HEAD on `main`.
- GitHub checks are green: Build + Lint + Test, fleet_live, Flake Check, Nix Build, Linux/macOS builds, FileProvider staticlib, iOS typecheck, cargo-deny, Secret Scan.

## Follow-ups intentionally deferred

- `.git-tcfs-bundle` remains as a synced artifact after restore. Deleting it locally would currently propagate deletion to peers, so cleanup/gitignore policy should be a separate decision.
- `git bundle create --all` can be expensive for very large repos; add change-detection before using bundle mode on stress targets like `linux-xr`.
