### PR TITLE
scripts: stage TIN-1620 flipflop canary harness

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -107,14 +107,15 @@ tasks:
   lazy:check:
     desc: Run lazy hydration harness/static regression checks
     cmds:
-      - bash -n scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
-      - shellcheck scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
+      - bash -n scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/tin1620-flipflop-canary-harness.sh scripts/test-tin1620-flipflop-canary-harness.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
+      - shellcheck scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/tin1620-flipflop-canary-harness.sh scripts/test-tin1620-flipflop-canary-harness.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
       - python3 -m py_compile scripts/asc-fileprovider-lab-provision.py scripts/tcfs-smoke-endpoint-preflight.py scripts/test-tcfs-smoke-endpoint-preflight.py scripts/large-workdir-inventory.py scripts/test-large-workdir-inventory.py
       - task: lazy:test-linux-lifecycle-demo
       - task: lazy:test-mounted-smoke
       - task: lazy:test-desktop-honey
       - task: lazy:test-fleet-pilot
       - task: lazy:test-neo-honey-unsynced-rehydrate
+      - task: lazy:test-tin1620-flipflop-canary
       - task: lazy:test-neo-honey-reverse-unsynced-rehydrate
       - task: lazy:test-neo-mounted-reverse-read
       - task: lazy:test-neo-honey-delete-rename-unsynced
@@ -244,6 +245,76 @@ tasks:
     desc: Regression-test the neo/honey unsynced rehydrate helper
     cmds:
       - bash scripts/test-neo-honey-unsynced-rehydrate-demo.sh
+
+  lazy:tin1620-flipflop-canary-plan:
+    desc: "TIN-1620 canary: plan-only or execute neo unsync, honey edit, neo rehydrate"
+    cmds:
+      - cmd: |
+          bash -euo pipefail <<'EOF'
+          args=()
+
+          if [[ "${EXECUTE:-0}" == "1" ]]; then
+            args+=(--execute)
+          fi
+          if [[ "${SKIP_READINESS:-0}" == "1" ]]; then
+            args+=(--skip-readiness)
+          fi
+          if [[ -n "${REMOTE:-}" ]]; then
+            args+=(--remote "$REMOTE")
+          fi
+          if [[ -n "${CANARY_ROOT:-}" ]]; then
+            args+=(--canary-root "$CANARY_ROOT")
+          fi
+          if [[ -n "${EVIDENCE_DIR:-}" ]]; then
+            args+=(--evidence-dir "$EVIDENCE_DIR")
+          fi
+          if [[ -n "${STATE_DIR:-}" ]]; then
+            args+=(--state-dir "$STATE_DIR")
+          fi
+          if [[ -n "${TCFS_BIN:-}" ]]; then
+            args+=(--tcfs-bin "$TCFS_BIN")
+          fi
+          if [[ -n "${HONEY_HOST:-}" ]]; then
+            args+=(--honey-host "$HONEY_HOST")
+          fi
+          if [[ -n "${HONEY_MOUNT_ROOT:-}" ]]; then
+            args+=(--honey-mount-root "$HONEY_MOUNT_ROOT")
+          fi
+          if [[ -n "${HONEY_REMOTE_DIR:-}" ]]; then
+            args+=(--honey-remote-dir "$HONEY_REMOTE_DIR")
+          fi
+          if [[ -n "${HONEY_TCFS_BIN:-}" ]]; then
+            args+=(--honey-tcfs-bin "$HONEY_TCFS_BIN")
+          fi
+          if [[ "${HONEY_START_MOUNT:-0}" == "1" ]]; then
+            args+=(--honey-start-mount)
+          fi
+          if [[ "${HONEY_EXISTING_MOUNT:-0}" == "1" ]]; then
+            args+=(--honey-existing-mount)
+          fi
+          if [[ "${CREATE_BUCKET:-0}" == "1" ]]; then
+            args+=(--create-bucket)
+          fi
+          if [[ "${FORWARD_AWS_ENV:-0}" == "1" ]]; then
+            args+=(--forward-aws-env)
+          fi
+          if [[ -n "${MAX_LOAD:-}" ]]; then
+            args+=(--max-load "$MAX_LOAD")
+          fi
+          if [[ -n "${MIN_DAEMON_UPTIME_SECS:-}" ]]; then
+            args+=(--min-daemon-uptime-secs "$MIN_DAEMON_UPTIME_SECS")
+          fi
+          if [[ -n "${STATUS_TIMEOUT_SECS:-}" ]]; then
+            args+=(--status-timeout-secs "$STATUS_TIMEOUT_SECS")
+          fi
+
+          scripts/tin1620-flipflop-canary-harness.sh "${args[@]}"
+          EOF
+
+  lazy:test-tin1620-flipflop-canary:
+    desc: Regression-test the TIN-1620 flip-flop canary wrapper
+    cmds:
+      - bash scripts/test-tin1620-flipflop-canary-harness.sh
 
   lazy:neo-honey-reverse-unsynced-rehydrate-plan:
     desc: "Reverse same-fixture proof: honey unsyncs, neo mutates, honey rehydrates"

--- a/scripts/test-tin1620-flipflop-canary-harness.sh
+++ b/scripts/test-tin1620-flipflop-canary-harness.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Regression tests for tin1620-flipflop-canary-harness.sh.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/tin1620-flipflop-canary-harness.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-tin1620-harness-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+
+  local out="$TMPDIR/failure.out"
+  local err="$TMPDIR/failure.err"
+
+  if "$@" >"$out" 2>"$err"; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+
+  cat "$out" "$err" >"$TMPDIR/failure.combined"
+  assert_contains "$TMPDIR/failure.combined" "$expected"
+}
+
+HOME_OK="$TMPDIR/home-ok"
+EVIDENCE="$TMPDIR/evidence"
+OUT="$TMPDIR/plan.out"
+mkdir -p "$HOME_OK/git"
+CANARY_CANON="$(cd "$HOME_OK/git" && pwd -P)/tcfs-flipflop-canary"
+
+HOME="$HOME_OK" bash "$SCRIPT" \
+  --remote seaweedfs://example.invalid/tcfs/tin1620-plan-test \
+  --evidence-dir "$EVIDENCE" \
+  --honey-host honey-test \
+  --honey-existing-mount \
+  >"$OUT"
+
+assert_contains "$OUT" "plan-only: no TCFS or SSH commands were run"
+assert_contains "$OUT" "run later:"
+assert_contains "$EVIDENCE/result.env" "status=plan-only"
+assert_contains "$EVIDENCE/result.env" "canary_created=0"
+assert_contains "$EVIDENCE/run-metadata.env" "honey_host=honey-test"
+assert_contains "$EVIDENCE/run-metadata.env" "execute=0"
+assert_contains "$EVIDENCE/README.md" "no tcfs command is executed"
+assert_contains "$EVIDENCE/README.md" "storage ready and NATS connected"
+assert_contains "$EVIDENCE/run-when-ready.sh" "--execute"
+assert_contains "$EVIDENCE/run-when-ready.sh" "--honey-existing-mount"
+test ! -e "$HOME_OK/git/tcfs-flipflop-canary"
+
+FAKE_BIN="$TMPDIR/fake-bin"
+FAKE_DEMO="$FAKE_BIN/fake-demo.sh"
+FAKE_LOG="$TMPDIR/fake-demo.log"
+EXEC_EVIDENCE="$TMPDIR/execute-evidence"
+mkdir -p "$FAKE_BIN"
+
+cat >"$FAKE_DEMO" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'fake-demo' >>"$TCFS_FAKE_DEMO_LOG"
+printf ' %q' "$@" >>"$TCFS_FAKE_DEMO_LOG"
+printf '\n' >>"$TCFS_FAKE_DEMO_LOG"
+EOF
+chmod +x "$FAKE_DEMO"
+
+HOME="$HOME_OK" \
+TCFS_TIN1620_DEMO_SCRIPT="$FAKE_DEMO" \
+TCFS_FAKE_DEMO_LOG="$FAKE_LOG" \
+bash "$SCRIPT" \
+  --execute \
+  --skip-readiness \
+  --remote seaweedfs://example.invalid/tcfs/tin1620-execute-test \
+  --evidence-dir "$EXEC_EVIDENCE" \
+  --tcfs-bin /tmp/tcfs-current \
+  --honey-host honey-run \
+  --honey-existing-mount \
+  >"$TMPDIR/execute.out"
+
+assert_contains "$FAKE_LOG" "--neo-root"
+assert_contains "$FAKE_LOG" "$CANARY_CANON"
+assert_contains "$FAKE_LOG" "--push"
+assert_contains "$FAKE_LOG" "--run-honey"
+assert_contains "$FAKE_LOG" "--tcfs-bin /tmp/tcfs-current"
+assert_contains "$FAKE_LOG" "--honey-existing-mount"
+
+BLOCK_EVIDENCE="$TMPDIR/block-evidence"
+assert_fails_contains \
+  "host load too high" \
+  env HOME="$HOME_OK" \
+    TCFS_TIN1620_LOAD_1M=99.0 \
+    TCFS_TIN1620_DAEMON_UPTIME_SECS=999 \
+    TCFS_TIN1620_STATUS_CMD="printf 'storage: ok\nnats: connected\n'" \
+    TCFS_TIN1620_DEMO_SCRIPT="$FAKE_DEMO" \
+    TCFS_FAKE_DEMO_LOG="$FAKE_LOG.block" \
+    bash "$SCRIPT" \
+      --execute \
+      --remote seaweedfs://example.invalid/tcfs/tin1620-block-test \
+      --evidence-dir "$BLOCK_EVIDENCE" \
+      --max-load 1.0
+assert_contains "$BLOCK_EVIDENCE/result.env" "status=blocked-host-readiness"
+test ! -e "$FAKE_LOG.block"
+
+READY_EVIDENCE="$TMPDIR/ready-evidence"
+READY_LOG="$TMPDIR/ready-demo.log"
+HOME="$HOME_OK" \
+TCFS_TIN1620_LOAD_1M=0.1 \
+TCFS_TIN1620_DAEMON_UPTIME_SECS=999 \
+TCFS_TIN1620_STATUS_CMD="printf 'storage: ok\nnats: connected\n'" \
+TCFS_TIN1620_DEMO_SCRIPT="$FAKE_DEMO" \
+TCFS_FAKE_DEMO_LOG="$READY_LOG" \
+bash "$SCRIPT" \
+  --execute \
+  --remote seaweedfs://example.invalid/tcfs/tin1620-ready-test \
+  --evidence-dir "$READY_EVIDENCE" \
+  --honey-existing-mount \
+  >"$TMPDIR/ready.out"
+assert_contains "$READY_EVIDENCE/readiness/readiness.env" "load_ready=1"
+assert_contains "$READY_EVIDENCE/readiness/readiness.env" "daemon_ready=1"
+assert_contains "$READY_EVIDENCE/readiness/readiness.env" "storage_ready=1"
+assert_contains "$READY_EVIDENCE/readiness/readiness.env" "nats_ready=1"
+assert_contains "$READY_LOG" "--run-honey"
+
+assert_fails_contains \
+  "refusing to use HOME as canary root" \
+  env HOME="$HOME_OK" bash "$SCRIPT" \
+    --canary-root "$HOME_OK" \
+    --evidence-dir "$TMPDIR/bad-home"
+
+assert_fails_contains \
+  "refusing to use ~/git as canary root" \
+  env HOME="$HOME_OK" bash "$SCRIPT" \
+    --canary-root "$HOME_OK/git" \
+    --evidence-dir "$TMPDIR/bad-git"
+
+printf 'tin1620 flipflop canary harness tests passed\n'

--- a/scripts/tin1620-flipflop-canary-harness.sh
+++ b/scripts/tin1620-flipflop-canary-harness.sh
@@ -1,0 +1,622 @@
+#!/usr/bin/env bash
+#
+# Stage or run the TIN-1620 neo/honey flip-flop proof against a throwaway
+# ~/git canary. Default mode is plan-only and does not touch TCFS, SSH, or the
+# real canary path.
+#
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/tin1620-flipflop-canary-harness.sh [options]
+
+Create a ready-to-run evidence packet for the TIN-1620 daily-driver flip-flop:
+neo pushes a canary under ~/git, neo unsyncs it, honey mutates the same fixture,
+and neo rehydrates the exact honey bytes.
+
+By default this is plan-only: it writes an evidence packet and run-later script,
+but runs no tcfs, ssh, cargo, nix, or daemon commands.
+
+Options:
+  --execute
+      Run readiness gates, then execute the flip-flop proof.
+  --skip-readiness
+      With --execute, skip host readiness gates. Use only for controlled tests.
+  --remote <seaweedfs://host:port/bucket/prefix>
+      Remote prefix. Defaults to a timestamped localhost prefix.
+  --canary-root <path>
+      Canary sync root. Defaults to "$HOME/git/tcfs-flipflop-canary".
+  --evidence-dir <path>
+      Evidence output directory. Defaults to docs/release/evidence/<run-id>.
+  --state-dir <path>
+      Local TCFS helper state directory passed to the lower-level harness.
+  --tcfs-bin <path>
+      tcfs binary for the lower-level harness.
+  --honey-host <host>
+      SSH host label for honey. Default: honey.
+  --honey-mount-root <path>
+      Honey mountpoint. Default: /tmp/tcfs-<run-id>-honey/mount.
+  --honey-remote-dir <path>
+      Honey temp directory. Default: /tmp/tcfs-<run-id>-honey/run.
+  --honey-tcfs-bin <path>
+      Remote tcfs binary on honey. Default: tcfs.
+  --honey-start-mount
+      Ask honey to start a temporary mount during the proof.
+  --honey-existing-mount
+      Assume --honey-mount-root is already mounted on honey.
+  --create-bucket
+      Best-effort create the S3 bucket before pushing.
+  --forward-aws-env
+      Forward current AWS env to honey for a temporary mount.
+  --max-load <float>
+      Maximum acceptable local 1-minute load before executing. Default: 12.0.
+  --min-daemon-uptime-secs <int>
+      Minimum tcfsd process age before executing. Default: 120.
+  --status-timeout-secs <int>
+      Timeout for "tcfs status" readiness probe. Default: 10.
+  -h, --help
+      Show this help.
+
+Environment mirrors:
+  TCFS_TIN1620_EXECUTE=1
+  TCFS_TIN1620_SKIP_READINESS=1
+  TCFS_TIN1620_REMOTE
+  TCFS_TIN1620_CANARY_ROOT
+  TCFS_TIN1620_EVIDENCE_DIR
+  TCFS_TIN1620_STATE_DIR
+  TCFS_TIN1620_MAX_LOAD
+  TCFS_TIN1620_MIN_DAEMON_UPTIME_SECS
+  TCFS_TIN1620_STATUS_TIMEOUT_SECS
+  TCFS_TIN1620_STATUS_CMD
+  TCFS_TIN1620_DEMO_SCRIPT
+  TCFS_BIN
+  HONEY_HOST
+  HONEY_MOUNT_ROOT
+  HONEY_REMOTE_DIR
+  HONEY_TCFS_BIN
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+bool_env() {
+  local label="$1"
+  local value="$2"
+
+  case "$value" in
+    1|true|yes|on) printf '1\n' ;;
+    0|false|no|off|"") printf '0\n' ;;
+    *) fail "$label must be 0/1, got: $value" ;;
+  esac
+}
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+expand_home() {
+  local path="$1"
+
+  case "$path" in
+    ~) printf '%s\n' "$HOME" ;;
+    ~/*) printf '%s/%s\n' "$HOME" "${path#~/}" ;;
+    *) printf '%s\n' "$path" ;;
+  esac
+}
+
+canonical_future_path() {
+  local path="$1"
+  local parent
+  local base
+
+  if [[ -e "$path" ]]; then
+    (cd "$path" && pwd -P)
+    return
+  fi
+
+  parent="$(dirname "$path")"
+  base="$(basename "$path")"
+  if [[ -d "$parent" ]]; then
+    printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$base"
+    return
+  fi
+
+  printf '%s\n' "$path"
+}
+
+float_le() {
+  awk -v left="$1" -v right="$2" 'BEGIN { exit !(left <= right) }'
+}
+
+int_ge() {
+  awk -v left="$1" -v right="$2" 'BEGIN { exit !(left >= right) }'
+}
+
+read_current_load() {
+  if [[ -n "${TCFS_TIN1620_LOAD_1M:-}" ]]; then
+    printf '%s\n' "$TCFS_TIN1620_LOAD_1M"
+    return
+  fi
+
+  uptime | sed -E 's/.*load averages?:[[:space:]]*([0-9.]+).*/\1/'
+}
+
+read_daemon_uptime_secs() {
+  if [[ -n "${TCFS_TIN1620_DAEMON_UPTIME_SECS:-}" ]]; then
+    printf '%s\n' "$TCFS_TIN1620_DAEMON_UPTIME_SECS"
+    return
+  fi
+
+  if ! command -v pgrep >/dev/null 2>&1; then
+    printf '0\n'
+    return
+  fi
+
+  local pids
+  pids="$(pgrep -f 'tcfsd' 2>/dev/null || true)"
+  if [[ -z "$pids" ]]; then
+    printf '0\n'
+    return
+  fi
+
+  local max_age=0
+  local pid
+  local age
+  for pid in $pids; do
+    age="$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    if [[ "$age" =~ ^[0-9]+$ && "$age" -gt "$max_age" ]]; then
+      max_age="$age"
+    fi
+  done
+  printf '%s\n' "$max_age"
+}
+
+run_shell_with_timeout() {
+  local timeout_secs="$1"
+  local out_path="$2"
+  local err_path="$3"
+  local command="$4"
+
+  python3 - "$timeout_secs" "$out_path" "$err_path" "$command" <<'PY'
+import subprocess
+import sys
+
+timeout_secs = float(sys.argv[1])
+out_path = sys.argv[2]
+err_path = sys.argv[3]
+command = sys.argv[4]
+
+try:
+    result = subprocess.run(
+        command,
+        shell=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout_secs,
+    )
+    with open(out_path, "w", encoding="utf-8") as out_file:
+        out_file.write(result.stdout)
+    with open(err_path, "w", encoding="utf-8") as err_file:
+        err_file.write(result.stderr)
+    sys.exit(result.returncode)
+except subprocess.TimeoutExpired as exc:
+    stdout = exc.stdout or ""
+    stderr = exc.stderr or ""
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8", "replace")
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", "replace")
+    with open(out_path, "w", encoding="utf-8") as out_file:
+        out_file.write(stdout)
+    with open(err_path, "w", encoding="utf-8") as err_file:
+        err_file.write(stderr)
+        err_file.write(f"\ncommand timed out after {timeout_secs:g}s\n")
+    sys.exit(124)
+PY
+}
+
+status_has_storage_ready() {
+  grep -Eiq 'storage(_ok)?[^[:alnum:]]+(true|ok)|storage.*\[(ok|OK)\]' "$1"
+}
+
+status_has_nats_ready() {
+  grep -Eiq 'nats(_ok)?[^[:alnum:]]+(true|ok|connected)|nats.*connected|nats.*\[(ok|OK)\]' "$1"
+}
+
+write_readiness_result() {
+  local path="$1"
+  shift
+
+  {
+    printf 'created_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    for row in "$@"; do
+      printf '%s\n' "$row"
+    done
+  } >"$path"
+}
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+run_id="tin1620-flipflop-canary-${timestamp}-$$"
+
+execute="$(bool_env TCFS_TIN1620_EXECUTE "${TCFS_TIN1620_EXECUTE:-0}")"
+skip_readiness="$(bool_env TCFS_TIN1620_SKIP_READINESS "${TCFS_TIN1620_SKIP_READINESS:-0}")"
+remote="${TCFS_TIN1620_REMOTE:-seaweedfs://localhost:8333/tcfs/${run_id}}"
+canary_root="$(expand_home "${TCFS_TIN1620_CANARY_ROOT:-$HOME/git/tcfs-flipflop-canary}")"
+evidence_dir="${TCFS_TIN1620_EVIDENCE_DIR:-$REPO_ROOT/docs/release/evidence/${run_id}}"
+state_dir="${TCFS_TIN1620_STATE_DIR:-}"
+tcfs_bin="${TCFS_BIN:-}"
+honey_host="${HONEY_HOST:-honey}"
+honey_mount_root="${HONEY_MOUNT_ROOT:-/tmp/tcfs-${run_id}-honey/mount}"
+honey_remote_dir="${HONEY_REMOTE_DIR:-/tmp/tcfs-${run_id}-honey/run}"
+honey_tcfs_bin="${HONEY_TCFS_BIN:-tcfs}"
+honey_start_mount="$(bool_env HONEY_START_MOUNT "${HONEY_START_MOUNT:-0}")"
+honey_existing_mount="$(bool_env HONEY_EXISTING_MOUNT "${HONEY_EXISTING_MOUNT:-0}")"
+create_bucket="$(bool_env CREATE_BUCKET "${CREATE_BUCKET:-0}")"
+forward_aws_env="$(bool_env FORWARD_AWS_ENV "${FORWARD_AWS_ENV:-0}")"
+max_load="${TCFS_TIN1620_MAX_LOAD:-12.0}"
+min_daemon_uptime_secs="${TCFS_TIN1620_MIN_DAEMON_UPTIME_SECS:-120}"
+status_timeout_secs="${TCFS_TIN1620_STATUS_TIMEOUT_SECS:-10}"
+status_cmd="${TCFS_TIN1620_STATUS_CMD:-tcfs status}"
+demo_script="${TCFS_TIN1620_DEMO_SCRIPT:-$REPO_ROOT/scripts/neo-honey-unsynced-rehydrate-demo.sh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --execute)
+      execute=1
+      shift
+      ;;
+    --skip-readiness)
+      skip_readiness=1
+      shift
+      ;;
+    --remote)
+      [[ $# -ge 2 ]] || fail "--remote requires a value"
+      remote="$2"
+      shift 2
+      ;;
+    --canary-root)
+      [[ $# -ge 2 ]] || fail "--canary-root requires a value"
+      canary_root="$(expand_home "$2")"
+      shift 2
+      ;;
+    --evidence-dir)
+      [[ $# -ge 2 ]] || fail "--evidence-dir requires a value"
+      evidence_dir="$2"
+      shift 2
+      ;;
+    --state-dir)
+      [[ $# -ge 2 ]] || fail "--state-dir requires a value"
+      state_dir="$2"
+      shift 2
+      ;;
+    --tcfs-bin)
+      [[ $# -ge 2 ]] || fail "--tcfs-bin requires a value"
+      tcfs_bin="$2"
+      shift 2
+      ;;
+    --honey-host)
+      [[ $# -ge 2 ]] || fail "--honey-host requires a value"
+      honey_host="$2"
+      shift 2
+      ;;
+    --honey-mount-root)
+      [[ $# -ge 2 ]] || fail "--honey-mount-root requires a value"
+      honey_mount_root="$2"
+      shift 2
+      ;;
+    --honey-remote-dir)
+      [[ $# -ge 2 ]] || fail "--honey-remote-dir requires a value"
+      honey_remote_dir="$2"
+      shift 2
+      ;;
+    --honey-tcfs-bin)
+      [[ $# -ge 2 ]] || fail "--honey-tcfs-bin requires a value"
+      honey_tcfs_bin="$2"
+      shift 2
+      ;;
+    --honey-start-mount)
+      honey_start_mount=1
+      honey_existing_mount=0
+      shift
+      ;;
+    --honey-existing-mount)
+      honey_existing_mount=1
+      honey_start_mount=0
+      shift
+      ;;
+    --create-bucket)
+      create_bucket=1
+      shift
+      ;;
+    --forward-aws-env)
+      forward_aws_env=1
+      shift
+      ;;
+    --max-load)
+      [[ $# -ge 2 ]] || fail "--max-load requires a value"
+      max_load="$2"
+      shift 2
+      ;;
+    --min-daemon-uptime-secs)
+      [[ $# -ge 2 ]] || fail "--min-daemon-uptime-secs requires a value"
+      min_daemon_uptime_secs="$2"
+      shift 2
+      ;;
+    --status-timeout-secs)
+      [[ $# -ge 2 ]] || fail "--status-timeout-secs requires a value"
+      status_timeout_secs="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ "$remote" == seaweedfs://* ]] || fail "remote must start with seaweedfs://"
+[[ "$max_load" =~ ^[0-9]+([.][0-9]+)?$ ]] || fail "--max-load must be a number"
+[[ "$min_daemon_uptime_secs" =~ ^[0-9]+$ ]] || fail "--min-daemon-uptime-secs must be an integer"
+[[ "$status_timeout_secs" =~ ^[0-9]+$ ]] || fail "--status-timeout-secs must be an integer"
+
+canary_canon="$(canonical_future_path "$canary_root")"
+home_canon="$(canonical_future_path "$HOME")"
+git_canon="$(canonical_future_path "$HOME/git")"
+[[ "$canary_canon" != "/" ]] || fail "refusing to use filesystem root as canary root"
+[[ "$canary_canon" != "$home_canon" ]] || fail "refusing to use HOME as canary root"
+[[ "$canary_canon" != "$git_canon" ]] || fail "refusing to use ~/git as canary root"
+
+mkdir -p "$evidence_dir"
+readiness_dir="$evidence_dir/readiness"
+operator_script="$evidence_dir/run-when-ready.sh"
+metadata_env="$evidence_dir/run-metadata.env"
+result_env="$evidence_dir/result.env"
+readme_path="$evidence_dir/README.md"
+
+write_metadata() {
+  cat >"$metadata_env" <<EOF
+created_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+run_id=$run_id
+remote=$remote
+canary_root=$canary_canon
+evidence_dir=$evidence_dir
+state_dir=$state_dir
+honey_host=$honey_host
+honey_mount_root=$honey_mount_root
+honey_remote_dir=$honey_remote_dir
+honey_tcfs_bin=$honey_tcfs_bin
+execute=$execute
+skip_readiness=$skip_readiness
+max_load=$max_load
+min_daemon_uptime_secs=$min_daemon_uptime_secs
+status_timeout_secs=$status_timeout_secs
+status_cmd=$status_cmd
+EOF
+}
+
+write_operator_script() {
+  local args=(
+    "$REPO_ROOT/scripts/tin1620-flipflop-canary-harness.sh"
+    --execute
+    --remote "$remote"
+    --canary-root "$canary_canon"
+    --evidence-dir "$evidence_dir"
+    --honey-host "$honey_host"
+    --honey-mount-root "$honey_mount_root"
+    --honey-remote-dir "$honey_remote_dir"
+    --honey-tcfs-bin "$honey_tcfs_bin"
+    --max-load "$max_load"
+    --min-daemon-uptime-secs "$min_daemon_uptime_secs"
+    --status-timeout-secs "$status_timeout_secs"
+  )
+  if [[ -n "$state_dir" ]]; then
+    args+=(--state-dir "$state_dir")
+  fi
+  if [[ -n "$tcfs_bin" ]]; then
+    args+=(--tcfs-bin "$tcfs_bin")
+  fi
+  if [[ "$honey_start_mount" == "1" ]]; then
+    args+=(--honey-start-mount)
+  fi
+  if [[ "$honey_existing_mount" == "1" ]]; then
+    args+=(--honey-existing-mount)
+  fi
+  if [[ "$create_bucket" == "1" ]]; then
+    args+=(--create-bucket)
+  fi
+  if [[ "$forward_aws_env" == "1" ]]; then
+    args+=(--forward-aws-env)
+  fi
+
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'set -euo pipefail\n'
+    printf 'cd %s\n' "$(shell_quote "$REPO_ROOT")"
+    printf 'exec'
+    local arg
+    for arg in "${args[@]}"; do
+      printf ' %s' "$(shell_quote "$arg")"
+    done
+    printf '\n'
+  } >"$operator_script"
+  chmod +x "$operator_script"
+}
+
+write_readme() {
+  cat >"$readme_path" <<EOF
+# TIN-1620 Flip-Flop Canary Evidence
+
+This packet stages the low-load TIN-1620 proof. It is intentionally separate
+from live daemon rollout work.
+
+Default behavior is plan-only:
+
+- no tcfs command is executed;
+- no ssh or scp command is executed;
+- no cargo, nix, or daemon restart is attempted;
+- the canary path is not created until the operator runs \`run-when-ready.sh\`.
+
+Execute only when neo is quiet and the readiness gates pass:
+
+- 1-minute load is at or below ${max_load};
+- a tcfsd process has been stable for at least ${min_daemon_uptime_secs} seconds;
+- \`${status_cmd}\` returns within ${status_timeout_secs} seconds;
+- status output shows storage ready and NATS connected.
+
+The executable proof delegates to
+\`scripts/neo-honey-unsynced-rehydrate-demo.sh\` with:
+
+- canary root: \`${canary_canon}\`;
+- remote: \`${remote}\`;
+- honey host: \`${honey_host}\`;
+- evidence dir: \`${evidence_dir}\`.
+
+Run:
+
+\`\`\`bash
+${operator_script}
+\`\`\`
+EOF
+}
+
+run_readiness_gates() {
+  mkdir -p "$readiness_dir"
+
+  local load_1m
+  local daemon_uptime_secs
+  local status_out="$readiness_dir/tcfs-status.out"
+  local status_err="$readiness_dir/tcfs-status.err"
+  local status_exit
+  local storage_ready=0
+  local nats_ready=0
+  local load_ready=0
+  local daemon_ready=0
+  local failures=()
+
+  load_1m="$(read_current_load)"
+  if [[ "$load_1m" =~ ^[0-9]+([.][0-9]+)?$ ]] && float_le "$load_1m" "$max_load"; then
+    load_ready=1
+  else
+    failures+=("host load too high: load_1m=$load_1m max_load=$max_load")
+  fi
+
+  daemon_uptime_secs="$(read_daemon_uptime_secs)"
+  if [[ "$daemon_uptime_secs" =~ ^[0-9]+$ ]] && int_ge "$daemon_uptime_secs" "$min_daemon_uptime_secs"; then
+    daemon_ready=1
+  else
+    failures+=("tcfsd not stable long enough: daemon_uptime_secs=$daemon_uptime_secs min=$min_daemon_uptime_secs")
+  fi
+
+  if run_shell_with_timeout "$status_timeout_secs" "$status_out" "$status_err" "$status_cmd"; then
+    status_exit=0
+  else
+    status_exit=$?
+    failures+=("tcfs status probe failed: exit=$status_exit")
+  fi
+
+  if [[ -f "$status_out" ]] && status_has_storage_ready "$status_out"; then
+    storage_ready=1
+  else
+    failures+=("tcfs status did not show storage ready")
+  fi
+
+  if [[ -f "$status_out" ]] && status_has_nats_ready "$status_out"; then
+    nats_ready=1
+  else
+    failures+=("tcfs status did not show nats connected")
+  fi
+
+  write_readiness_result "$readiness_dir/readiness.env" \
+    "load_1m=$load_1m" \
+    "max_load=$max_load" \
+    "load_ready=$load_ready" \
+    "daemon_uptime_secs=$daemon_uptime_secs" \
+    "min_daemon_uptime_secs=$min_daemon_uptime_secs" \
+    "daemon_ready=$daemon_ready" \
+    "status_cmd=$status_cmd" \
+    "status_timeout_secs=$status_timeout_secs" \
+    "status_exit=$status_exit" \
+    "storage_ready=$storage_ready" \
+    "nats_ready=$nats_ready"
+
+  if [[ "${#failures[@]}" -gt 0 ]]; then
+    {
+      printf 'status=blocked-host-readiness\n'
+      printf 'proof=pending-neo-quiet\n'
+      printf 'failure_count=%s\n' "${#failures[@]}"
+      local failure
+      local index=1
+      for failure in "${failures[@]}"; do
+        printf 'failure_%s=%s\n' "$index" "$failure"
+        index=$((index + 1))
+      done
+    } >"$result_env"
+    printf 'readiness blocked TIN-1620 flip-flop:\n' >&2
+    printf '  %s\n' "${failures[@]}" >&2
+    return 1
+  fi
+}
+
+write_metadata
+write_operator_script
+write_readme
+
+if [[ "$execute" != "1" ]]; then
+  {
+    printf 'status=plan-only\n'
+    printf 'proof=pending-host-readiness\n'
+    printf 'canary_created=0\n'
+  } >"$result_env"
+  printf 'plan-only: no TCFS or SSH commands were run\n'
+  printf 'evidence: %s\n' "$evidence_dir"
+  printf 'run later: %s\n' "$operator_script"
+  exit 0
+fi
+
+if [[ "$skip_readiness" != "1" ]]; then
+  run_readiness_gates
+fi
+
+[[ -x "$demo_script" ]] || fail "demo script is not executable: $demo_script"
+
+delegate_args=(
+  --remote "$remote"
+  --neo-root "$canary_canon"
+  --evidence-dir "$evidence_dir"
+  --honey-host "$honey_host"
+  --honey-mount-root "$honey_mount_root"
+  --honey-remote-dir "$honey_remote_dir"
+  --honey-tcfs-bin "$honey_tcfs_bin"
+  --push
+  --run-honey
+)
+if [[ -n "$state_dir" ]]; then
+  delegate_args+=(--state-dir "$state_dir")
+fi
+if [[ -n "$tcfs_bin" ]]; then
+  delegate_args+=(--tcfs-bin "$tcfs_bin")
+fi
+if [[ "$honey_start_mount" == "1" ]]; then
+  delegate_args+=(--honey-start-mount)
+fi
+if [[ "$honey_existing_mount" == "1" ]]; then
+  delegate_args+=(--honey-existing-mount)
+fi
+if [[ "$create_bucket" == "1" ]]; then
+  delegate_args+=(--create-bucket)
+fi
+if [[ "$forward_aws_env" == "1" ]]; then
+  delegate_args+=(--forward-aws-env)
+fi
+
+"$demo_script" "${delegate_args[@]}"


### PR DESCRIPTION
## Summary

- Adds a TIN-1620 flipflop canary wrapper for the neo to honey daily-driver proof.
- Keeps default behavior plan-only: no tcfs, ssh, cargo, nix, daemon restart, or real canary path mutation.
- Gates execution on host load, stable tcfsd uptime, bounded tcfs status, storage readiness, and NATS readiness before delegating to the existing neo/honey unsynced rehydrate harness.

## Validation

- bash -n scripts/tin1620-flipflop-canary-harness.sh scripts/test-tin1620-flipflop-canary-harness.sh
- shellcheck scripts/tin1620-flipflop-canary-harness.sh scripts/test-tin1620-flipflop-canary-harness.sh
- bash scripts/test-tin1620-flipflop-canary-harness.sh
- task lazy:test-tin1620-flipflop-canary
- git diff --check

## Runtime posture

This intentionally does not attempt live Stream A proof while neo is load-starved. The harness can be run later via the generated run-when-ready.sh packet once neo is quiet and tcfs status is green.
