### PR TITLE
Release prep: v0.12.14 (finalize the deny-set + TIN-1758 line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ Current release-proof posture is tracked in `docs/release/evidence/` and
 `docs/ops/product-reality-and-priority.md`; older entries below may describe
 historical release intent rather than the current supported/proven surface.
 
+## [0.12.14] - 2026-06-03
+
+First finalized release of the 0.12.13→0.12.14 line (0.12.13 shipped only as
+rc1–rc4 prereleases). Captures the fail-closed secrets deny-set and the
+daemon-startup reliability fixes that landed on `main` after `v0.12.13-rc4` —
+previously present in deployed builds but in no published tag.
+
+### Security
+
+- **Fail-closed secrets deny-set in the sync `Blacklist`** (TIN-1737,
+  `crates/tcfs-sync/src/blacklist.rs`): secret-bearing paths are never synced —
+  `.ssh/`, `.gnupg/`, `sops-nix/` directories; `auth.json`, `.netrc`,
+  `.pgpass`, `.credentials.json` files; `.env*` files; and `.sqlite*`/`.db*`
+  suffixes. Enforced fail-closed so a misconfiguration cannot leak credentials.
+- **Per-device file-key wrapping substrate** (TIN-1417, behind a flag,
+  default off): age-recipient per-device key wrapping is now available via
+  `crypto.per_device_wrapping`; the default remains shared-master so existing
+  fleets are unaffected until the migration lands.
+- **Enrollment & auth hardening**: single-use enrollment invites; admin-gated
+  enrollment control RPCs; device-invite enrollment bootstrap (TIN-1424);
+  real local age identities generated on enrollment; auth sessions are now
+  persisted and attached to protected RPCs.
+
+### Added
+
+- **Device registry sync during enrollment** (#476): enrolling a device now
+  publishes it into the shared device registry.
+- **FileProvider config rendering** (#466, TIN-1425): the daemon and CLI
+  render the FileProvider config from the active config; `tcfs init` writes a
+  config; FileProvider surface contract is asserted in CI (TIN-1547).
+- **`natsTls` config option** (default `false`, #473).
+- **Storage restore SLO budgets** in CI (TIN-1622).
+
+### Fixed
+
+- **Daemon control-plane startup hangs** (TIN-1758): readiness no longer blocks
+  on remote index discovery; the FileProvider socket bind is kept off the
+  runtime workers and serves late socket binds — the daemon comes up reliably
+  under load.
+- **`tcfs pull <abspath>`** writing into a hash-named file in the cwd instead of
+  the requested path (#473).
+- Hardened large-restore retry observability; avoided a macOS LaunchAgent
+  config restart loop (#457).
+
 ## [0.12.13] - 2026-05-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-auth"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-chunks"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cli"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cloudfilter"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-core"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "prost",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-crypto"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "aes-siv",
  "age",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-dbus"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-e2e"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-file-provider"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-fuse"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5346,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-mcp"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-nfs"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-secrets"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sops"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-storage"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sync"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "age",
  "anyhow",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-tui"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-vfs"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "tcfsd"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.13"
+version = "0.12.14"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps workspace to **0.12.14** and logs the CHANGELOG. First finalized release of the 0.12.13→0.12.14 line — 0.12.13 shipped only as rc1–rc4. Closes the provenance gap where the **fail-closed secrets deny-set (TIN-1737)** and **TIN-1758 daemon-startup fixes** are in deployed builds but in no published tag (public "Latest" is still v0.12.12).

## What's in 0.12.14 (vs v0.12.13-rc4)
**Security**
- TIN-1737 fail-closed secrets deny-set in the sync Blacklist (.ssh/.gnupg/sops-nix, auth.json/.netrc/.pgpass/.credentials.json, .env*, .sqlite*/.db*)
- TIN-1417 per-device file-key wrapping substrate (behind flag, default off — fleets unaffected)
- Enrollment/auth hardening: single-use invites, admin-gated control RPCs, device-invite bootstrap (TIN-1424), real local age identities, persisted auth sessions

**Added**: device registry sync on enrollment (#476); FileProvider config render (#466/TIN-1425) + surface contract (TIN-1547); natsTls option (#473); storage restore SLO budgets (TIN-1622).

**Fixed**: TIN-1758 daemon control-plane startup hangs; `tcfs pull <abspath>` cwd hash-file bug (#473); large-restore retry observability; macOS LaunchAgent restart loop (#457).

## Diff
- Cargo.toml: workspace version 0.12.13 → 0.12.14
- Cargo.lock: 19 workspace members bumped (no other deps moved)
- CHANGELOG.md: new [0.12.14] entry

## Not included
- PR #481 (git-bundle dev-env parity) — still draft; targets v0.12.15.

## Release steps after merge
Tag `v0.12.14` on the merge commit + push → release.yml builds/publishes. Then rebuild + redeploy neo (it currently reports 0.12.13) and re-verify deny-set markers + `tcfsd --version`.