### PR TITLE
TIN-1758 harden FileProvider preflight plugin path check

### DIFF
--- a/scripts/macos-fileprovider-preflight.sh
+++ b/scripts/macos-fileprovider-preflight.sh
@@ -206,9 +206,34 @@ detect_app_path() {
   exit 1
 }
 
+canonical_path() {
+  local path="$1"
+  local parent
+  local base
+
+  if [[ -d "$path" ]]; then
+    (cd "$path" && pwd -P)
+    return
+  fi
+
+  parent="$(dirname "$path")"
+  base="$(basename "$path")"
+  if [[ -d "$parent" ]]; then
+    printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$base"
+    return
+  fi
+
+  printf '%s\n' "$path"
+}
+
 check_pluginkit() {
   local output
   local count
+  local expected_extension
+  local expected_extension_canonical
+  local matched_expected_path=0
+  local registered_path_count=0
+  local path
 
   output="$(pluginkit -m -A -D -vvv -i "$PLUGIN_ID" 2>&1)" || {
     echo "pluginkit lookup failed for $PLUGIN_ID" >&2
@@ -233,6 +258,36 @@ check_pluginkit() {
       print_pluginkit_duplicate_hint "$output"
       exit 1
     fi
+  fi
+
+  expected_extension="$APP_PATH/Contents/Extensions/TCFSFileProvider.appex"
+  expected_extension_canonical="$(canonical_path "$expected_extension")"
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    registered_path_count=$((registered_path_count + 1))
+    if [[ "$(canonical_path "$path")" == "$expected_extension_canonical" ]]; then
+      matched_expected_path=1
+    fi
+  done < <(
+    awk '
+      /^[[:space:]]*Path = / {
+        path = $0
+        sub(/^[[:space:]]*Path = /, "", path)
+        print path
+      }
+    ' <<<"$output"
+  )
+
+  if (( registered_path_count == 0 )); then
+    echo "pluginkit output did not include a FileProvider extension path for $PLUGIN_ID" >&2
+    exit 1
+  fi
+
+  if (( matched_expected_path == 0 )); then
+    echo "pluginkit registered FileProvider extension does not match selected app path" >&2
+    echo "selected extension: $expected_extension_canonical" >&2
+    print_pluginkit_duplicate_hint "$output"
+    exit 1
   fi
 }
 

--- a/scripts/test-macos-fileprovider-preflight.sh
+++ b/scripts/test-macos-fileprovider-preflight.sh
@@ -134,8 +134,9 @@ fi
 EOF
 cat >"$FAKE_BIN/pluginkit" <<'EOF'
 #!/usr/bin/env bash
+app_path="${TCFS_FAKE_PLUGIN_APP_PATH:-/Users/test/Applications/TCFSProvider.app}"
 printf 'io.tinyland.tcfs.fileprovider(0.2.0)\n'
-printf '            Path = /Users/test/Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex\n'
+printf '            Path = %s/Contents/Extensions/TCFSFileProvider.appex\n' "$app_path"
 if [[ "${TCFS_FAKE_PLUGIN_DUPES:-0}" == "1" ]]; then
   printf 'io.tinyland.tcfs.fileprovider(0.1.0)\n'
   printf '            Path = /Users/test/git/tummycrypt/build/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex\n'
@@ -223,6 +224,7 @@ fi
 exit 1
 EOF
 chmod +x "$FAKE_BIN"/*
+export TCFS_FAKE_PLUGIN_APP_PATH="$APP_PATH"
 
 OUT="${TMPDIR}/positive.out"
 ERR="${TMPDIR}/positive.err"
@@ -379,6 +381,27 @@ assert_contains "${TMPDIR}/dupes.combined" "multiple FileProvider registrations 
 assert_contains "${TMPDIR}/dupes.combined" "registered FileProvider extension paths:"
 assert_contains "${TMPDIR}/dupes.combined" "/Users/test/git/tummycrypt/build/TCFSProvider.app"
 assert_contains "${TMPDIR}/dupes.combined" "cleanup is not performed automatically"
+
+STALE_OUT="${TMPDIR}/stale-plugin.out"
+STALE_ERR="${TMPDIR}/stale-plugin.err"
+if env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_PLUGIN_APP_PATH=/Users/test/Applications/TCFSProvider.app \
+  bash "$SCRIPT" \
+    --expected-version 0.12.2 \
+    --config "$CONFIG_PATH" \
+    --fileprovider-config "$FILEPROVIDER_CONFIG" \
+    --app-path "$APP_PATH" \
+    --cloud-root "$CLOUD_ROOT" \
+    >"$STALE_OUT" \
+    2>"$STALE_ERR"; then
+  printf 'expected stale pluginkit registration to fail\n' >&2
+  exit 1
+fi
+cat "$STALE_OUT" "$STALE_ERR" >"${TMPDIR}/stale-plugin.combined"
+assert_contains "${TMPDIR}/stale-plugin.combined" "pluginkit registered FileProvider extension does not match selected app path"
+assert_contains "${TMPDIR}/stale-plugin.combined" "selected extension:"
+assert_contains "${TMPDIR}/stale-plugin.combined" "TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex"
+assert_contains "${TMPDIR}/stale-plugin.combined" "/Users/test/Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex"
+assert_contains "${TMPDIR}/stale-plugin.combined" "cleanup is not performed automatically"
 
 UNAVAILABLE_OUT="${TMPDIR}/unavailable.out"
 UNAVAILABLE_ERR="${TMPDIR}/unavailable.err"


### PR DESCRIPTION
## Summary

- Make `macos-fileprovider-preflight.sh` verify that PlugInKit's registered FileProvider extension path belongs to the selected `APP_PATH`.
- Add a fake-platform regression for the single stale-registration case: one PlugInKit record, but pointing at a different `TCFSProvider.app`.
- Preserve the existing duplicate-registration diagnostics and cleanup hint.

## Live finding

On neo, the installed-path preflight selected the signed `/Applications/TCFSProvider.app`, but PlugInKit is currently registered to `/Users/jess/Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex`. The old preflight passed because there was only one registration. With this patch, the same live preflight fails before any materialization claim.

## Validation

- `bash -n scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh`
- `shellcheck scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh`
- `bash scripts/test-macos-fileprovider-preflight.sh`
- `task lazy:test-macos-preflight`
- `git diff --check`
- live non-mutating installed-path preflight now fails on the stale PlugInKit path as intended
