### PR TITLE
TIN-1758 add FileProvider fetch diagnostics and smoke SDK fix

### DIFF
--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -488,6 +488,17 @@ run_bounded_append_to_log() {
   return "$status"
 }
 
+swift_helper_available() {
+  command -v swift >/dev/null 2>&1
+}
+
+run_swift_helper() {
+  # Nix dev shells export SDKROOT/DEVELOPER_DIR to the Nix Apple SDK. The
+  # system Swift driver then sees a mismatched SDK and fails before the helper
+  # can exercise FileProvider. Use the host Xcode defaults for these probes.
+  /usr/bin/env -u SDKROOT -u DEVELOPER_DIR swift "$@"
+}
+
 wait_for_pid_with_timeout() {
   local pid="$1"
   local timeout_secs="$2"
@@ -1680,12 +1691,12 @@ run_coordinated_root_listing() {
 
   [[ "$COORDINATED_READ" != "0" ]] || return 2
   [[ -f "$helper" ]] || return 2
-  command -v swift >/dev/null 2>&1 || return 2
+  swift_helper_available || return 2
 
   run_bounded_to_log \
     "$label" \
     "$LOG_SHOW_TIMEOUT_SECS" \
-    swift "$helper" "$root" || return "$?"
+    run_swift_helper "$helper" "$root" || return "$?"
 
   listing="$(cat "$LOG_DIR/${label}.log" 2>/dev/null || true)"
   [[ -n "$listing" ]] || return 1
@@ -1810,8 +1821,8 @@ read_fileprovider_file() {
   local helper="$REPO_ROOT/scripts/macos-fileprovider-coordinated-read.swift"
   local pid
 
-  if [[ "$COORDINATED_READ" != "0" && -f "$helper" ]] && command -v swift >/dev/null 2>&1; then
-    swift "$helper" "$path" "$hydrated_copy" &
+  if [[ "$COORDINATED_READ" != "0" && -f "$helper" ]] && swift_helper_available; then
+    run_swift_helper "$helper" "$path" "$hydrated_copy" &
     pid="$!"
     wait_for_pid_with_timeout "$pid" "$READ_TIMEOUT_SECS" "coordinated FileProvider read"
   else

--- a/scripts/test-macos-postinstall-smoke.sh
+++ b/scripts/test-macos-postinstall-smoke.sh
@@ -400,6 +400,17 @@ if [[ -n "${TCFS_FAKE_FIND_HANG_TARGET:-}" ]]; then
 fi
 exec /usr/bin/find "$@"
 EOF
+cat >"$FAKE_BIN/env" <<'EOF'
+#!/usr/bin/env bash
+exec /usr/bin/env "$@"
+EOF
+cat >"$FAKE_BIN/xattr" <<'EOF'
+#!/usr/bin/env bash
+for path in "$@"; do
+  [[ "$path" == -* ]] && continue
+  printf '%s: %s\n' "com.apple.provenance" "$path"
+done
+EOF
 cat >"$APP_PATH/Contents/MacOS/TCFSProvider" <<'EOF'
 #!/usr/bin/env bash
 if [[ -n "${TCFS_FAKE_HOST_BINARY_LOG:-}" ]]; then
@@ -485,6 +496,10 @@ if [[ -n "${TCFS_FAKE_SWIFT_LOG:-}" ]]; then
   printf 'swift' >>"$TCFS_FAKE_SWIFT_LOG"
   printf ' %q' "$@" >>"$TCFS_FAKE_SWIFT_LOG"
   printf '\n' >>"$TCFS_FAKE_SWIFT_LOG"
+fi
+if [[ -n "${TCFS_FAKE_SWIFT_ENV_LOG:-}" ]]; then
+  printf 'SDKROOT=%s\n' "${SDKROOT:-}" >>"$TCFS_FAKE_SWIFT_ENV_LOG"
+  printf 'DEVELOPER_DIR=%s\n' "${DEVELOPER_DIR:-}" >>"$TCFS_FAKE_SWIFT_ENV_LOG"
 fi
 
 helper="${1:-}"
@@ -885,6 +900,8 @@ assert_fails_contains \
 assert_fails_contains \
   "FileProvider extension used build-time embedded config" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     TCFS_FAKE_EXTENSION_LOG="2026-04-30 TCFSFileProvider extension loadConfig: loaded from build-time embedded config" \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
@@ -900,6 +917,8 @@ assert_fails_contains \
 assert_fails_contains \
   "FileProvider extension did not log shared Keychain config load" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     TCFS_FAKE_EXTENSION_LOG="" \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
@@ -915,6 +934,8 @@ assert_fails_contains \
 assert_fails_contains \
   "expected file is not backed by a visible remote index entry" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     TCFS_FAKE_INDEX_STATUS="missing_index" \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
@@ -931,6 +952,8 @@ printf 'wrong content\n' >"${TMPDIR}/wrong-content.txt"
 assert_fails_contains \
   "hydrated file content mismatch" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
       --config "$CONFIG_PATH" \
@@ -1144,6 +1167,8 @@ mkdir -p "$DISABLED_ROOT"
 assert_fails_contains \
   "FileProvider domain is disabled by macOS (NSFileProviderErrorDomain -2011)" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     TCFS_FAKE_FILEPROVIDER_SYSTEM_LOG='2026-05-01 fileproviderd FP -2011 "Sync is not enabled for TCFSProvider."' \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
@@ -1151,10 +1176,38 @@ assert_fails_contains \
       --app-path "$APP_PATH" \
       --cloud-root "$DISABLED_ROOT" \
       --log-dir "${TMPDIR}/domain-disabled-logs" \
-      --timeout 2
+      --timeout 1
 
 assert_contains \
   "${TMPDIR}/domain-disabled-logs/fileprovider-system.log" \
   'Sync is not enabled for TCFSProvider'
+
+SWIFT_ENV_LOG="${TMPDIR}/swift-env.log"
+SWIFT_ENV_OUT="${TMPDIR}/swift-env.out"
+if ! env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \
+  SDKROOT="/nix/store/bad-apple-sdk" \
+  DEVELOPER_DIR="/nix/store/bad-developer-dir" \
+  TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+  TCFS_FAKE_FIND_PERMISSION_TARGET="$CLOUD_ROOT" \
+  TCFS_FAKE_SWIFT_LIST_TARGET="$CLOUD_ROOT" \
+  TCFS_FAKE_SWIFT_LIST_OUTPUT="$CLOUD_ROOT/Projects" \
+  TCFS_FAKE_SWIFT_ENV_LOG="$SWIFT_ENV_LOG" \
+  LOG_SHOW_TIMEOUT_SECS=1 \
+  bash "$SCRIPT" \
+    --expected-version 0.12.2 \
+    --config "$CONFIG_PATH" \
+    --app-path "$APP_PATH" \
+    --cloud-root "$CLOUD_ROOT" \
+    --log-dir "${TMPDIR}/swift-env-logs" \
+    --timeout 2 \
+    >"$SWIFT_ENV_OUT" 2>&1; then
+  cat "$SWIFT_ENV_OUT" >&2 || true
+  exit 1
+fi
+assert_contains "$SWIFT_ENV_OUT" "coordinated enumeration sample:"
+assert_contains "$SWIFT_ENV_LOG" "SDKROOT="
+assert_contains "$SWIFT_ENV_LOG" "DEVELOPER_DIR="
+assert_not_contains "$SWIFT_ENV_LOG" "/nix/store/bad-apple-sdk"
+assert_not_contains "$SWIFT_ENV_LOG" "/nix/store/bad-developer-dir"
 
 printf 'macOS post-install smoke tests passed\n'

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -119,8 +119,12 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     ) -> Progress {
         // Start with estimated size; updated by callback as real size is known
         let progress = Progress(totalUnitCount: 0)
+        let itemId = itemIdentifier.rawValue
+
+        logger.error("fetchContents start for \(itemId, privacy: .public)")
 
         guard let prov = provider else {
+            logger.error("fetchContents provider unavailable for \(itemId, privacy: .public)")
             completionHandler(nil, nil, NSFileProviderError(.serverUnreachable))
             return progress
         }
@@ -132,7 +136,9 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             let tempDir = FileManager.default.temporaryDirectory
             let tempFile = tempDir.appendingPathComponent(UUID().uuidString)
 
-            let itemId = itemIdentifier.rawValue
+            logger.error(
+                "fetchContents fetching \(itemId, privacy: .public) to \(tempFile.path, privacy: .public)"
+            )
 
             // C callback that updates NSProgress from Rust's chunk loop
             let callback: @convention(c) (UInt64, UInt64, UnsafeRawPointer?) -> Void = {
@@ -160,6 +166,9 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                 let fileSize = (try? FileManager.default.attributesOfItem(
                     atPath: tempFile.path
                 )[.size] as? UInt64) ?? 0
+                logger.error(
+                    "fetchContents completed for \(itemId, privacy: .public): bytes=\(fileSize)"
+                )
 
                 let parentId = TCFSFileProviderExtension.parentIdentifier(forPath: itemId)
                 let item = TCFSFileProviderItem(


### PR DESCRIPTION
## Summary

- runs macOS post-install Swift helper probes with host SDK defaults by unsetting poisoned Nix `SDKROOT` / `DEVELOPER_DIR`
- adds fake-platform regression coverage for the poisoned SDK case without relying on `/usr/bin/python3`
- adds FileProvider `fetchContents` lifecycle logging so the next live smoke packet can distinguish provider unavailable, fetch start, and fetch completion

## Why

Live neo diagnosis showed `/usr/bin/swift` can fail before the FileProvider helper runs when a Nix dev shell exports Apple SDK paths. After pinning the rc4 user app, CLI pull proved storage/object/crypto were readable, but FileProvider materialization still failed with `NSFileProviderErrorDomain -1004`. The extension needs fetch lifecycle logs for that remaining boundary.

## Validation

- `bash -n scripts/macos-postinstall-smoke.sh scripts/test-macos-postinstall-smoke.sh`
- `shellcheck -e SC2016 scripts/macos-postinstall-smoke.sh scripts/test-macos-postinstall-smoke.sh`
- `bash scripts/test-macos-postinstall-smoke.sh`
- `task lazy:test-macos-postinstall`
- `task lazy:test-fileprovider-surface-contract`
- `git diff --check origin/main...HEAD`

## Notes

Untracked live evidence packets from neo were intentionally left out of this branch.
