### PR TITLE
DRAFT: TIN-1417 B1 FileProvider device-aware EncryptionContext (agent-drafted, needs review)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5316,6 +5316,7 @@ dependencies = [
  "tcfs-chunks",
  "tcfs-core",
  "tcfs-crypto",
+ "tcfs-secrets",
  "tcfs-storage",
  "tcfs-sync",
  "tempfile",

--- a/crates/tcfs-file-provider/Cargo.toml
+++ b/crates/tcfs-file-provider/Cargo.toml
@@ -16,7 +16,7 @@ direct = ["dep:tcfs-storage", "dep:tcfs-chunks", "dep:tcfs-crypto", "dep:tcfs-sy
 ## gRPC backend — delegates metadata/watch operations to tcfsd daemon and
 ## downloads file content in-process so FileProvider temp files are written by
 ## the extension, not by the daemon.
-grpc = ["dep:tonic", "dep:tower", "dep:hyper-util", "dep:tokio-stream", "dep:futures", "dep:tcfs-storage", "dep:tcfs-chunks", "dep:tcfs-crypto", "dep:tcfs-sync", "tcfs-sync/crypto", "dep:opendal", "dep:base64"]
+grpc = ["dep:tonic", "dep:tower", "dep:hyper-util", "dep:tokio-stream", "dep:futures", "dep:tcfs-storage", "dep:tcfs-chunks", "dep:tcfs-crypto", "dep:tcfs-sync", "tcfs-sync/crypto", "dep:tcfs-secrets", "dep:opendal", "dep:base64"]
 ## UniFFI bindings for iOS (proc-macro based, no UDL needed)
 uniffi = ["direct", "dep:uniffi", "dep:tcfs-auth", "dep:blake3"]
 
@@ -26,6 +26,7 @@ tcfs-storage = { path = "../tcfs-storage", optional = true }
 tcfs-chunks = { path = "../tcfs-chunks", optional = true }
 tcfs-crypto = { path = "../tcfs-crypto", optional = true }
 tcfs-sync = { path = "../tcfs-sync", optional = true }
+tcfs-secrets = { path = "../tcfs-secrets", optional = true }
 secrecy = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 opendal = { workspace = true, optional = true }

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -89,9 +89,7 @@ pub(crate) fn build_encryption_context(
     let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!(
-                "per-device wrapping: registry load failed ({e}); using master wrap"
-            );
+            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
             return base;
         }
     };
@@ -158,8 +156,7 @@ mod tests {
         });
         registry.save(&registry_path).expect("save registry");
 
-        let secret_path =
-            tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
+        let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
         tcfs_secrets::device::save_device_secret_key(&secret_path, &key.secret_key, true)
             .expect("save device secret");
 
@@ -262,8 +259,7 @@ mod tests {
             .unwrap()
             .finish();
         let prefix = "test/fp-per-device";
-        let mut state =
-            tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+        let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
 
         // Build the write context from the same registry the FP read context uses.
         let enabled_config = serde_json::json!({
@@ -281,7 +277,14 @@ mod tests {
         std::fs::write(&src, content).unwrap();
 
         let up = tcfs_sync::engine::upload_file_with_device(
-            &op, &src, prefix, &mut state, None, "device-a", None, Some(&write_ctx),
+            &op,
+            &src,
+            prefix,
+            &mut state,
+            None,
+            "device-a",
+            None,
+            Some(&write_ctx),
         )
         .await
         .expect("per-device upload should succeed");
@@ -298,7 +301,14 @@ mod tests {
         let read_ctx = build_encryption_context(&enabled_config, "device-a", &master());
         let dst_ok = tmp.path().join("ok.txt");
         tcfs_sync::engine::download_file_with_device(
-            &op, &up.remote_path, &dst_ok, prefix, None, "device-a", None, Some(&read_ctx),
+            &op,
+            &up.remote_path,
+            &dst_ok,
+            prefix,
+            None,
+            "device-a",
+            None,
+            Some(&read_ctx),
         )
         .await
         .expect("device-aware FP context should read per-device manifest");
@@ -311,7 +321,14 @@ mod tests {
         assert!(master_only.device_identity.is_none());
         let dst_closed = tmp.path().join("closed.txt");
         let res = tcfs_sync::engine::download_file_with_device(
-            &op, &up.remote_path, &dst_closed, prefix, None, "device-a", None, Some(&master_only),
+            &op,
+            &up.remote_path,
+            &dst_closed,
+            prefix,
+            None,
+            "device-a",
+            None,
+            Some(&master_only),
         )
         .await;
         assert!(
@@ -334,8 +351,7 @@ mod tests {
             .unwrap()
             .finish();
         let prefix = "test/fp-master-only";
-        let mut state =
-            tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+        let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
 
         // Legacy master-only write (no per-device recipients).
         let write_ctx = tcfs_sync::engine::EncryptionContext::new(master());
@@ -344,7 +360,14 @@ mod tests {
         std::fs::write(&src, content).unwrap();
 
         let up = tcfs_sync::engine::upload_file_with_device(
-            &op, &src, prefix, &mut state, None, "device-a", None, Some(&write_ctx),
+            &op,
+            &src,
+            prefix,
+            &mut state,
+            None,
+            "device-a",
+            None,
+            Some(&write_ctx),
         )
         .await
         .expect("master-only upload should succeed");
@@ -360,7 +383,14 @@ mod tests {
         let read_ctx = build_encryption_context(&serde_json::json!({}), "device-a", &master());
         let dst = tmp.path().join("out.txt");
         tcfs_sync::engine::download_file_with_device(
-            &op, &up.remote_path, &dst, prefix, None, "device-a", None, Some(&read_ctx),
+            &op,
+            &up.remote_path,
+            &dst,
+            prefix,
+            None,
+            "device-a",
+            None,
+            Some(&read_ctx),
         )
         .await
         .expect("default FP context must read master-only manifest unchanged");

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -1,0 +1,401 @@
+//! Device-aware encryption-context wiring for the FileProvider backends
+//! (TIN-1417, Track B / B1).
+//!
+//! This is an **FP-local replica** of `tcfsd`'s
+//! `build_encryption_context` (`crates/tcfsd/src/grpc.rs`). The daemon and CLI
+//! both wire per-device unwrap identity onto the `EncryptionContext`; only the
+//! FileProvider direct-read path historically built a master-only context
+//! (`EncryptionContext::new`) and could therefore never read a per-device
+//! (`wrapped_file_keys`-only) manifest. This module closes that gap.
+//!
+//! FOLLOW-UP (dedupe): the daemon, CLI, and this module now carry three copies
+//! of the same registry/secret-loading logic. The clean fix is to lift a single
+//! `build_encryption_context` into a shared crate (e.g. `tcfs-sync`). That was
+//! deliberately deferred here because `tcfs-sync` does not currently depend on
+//! `tcfs-secrets`, and adding that dependency edge to a core crate consumed by
+//! most of the workspace is a broader change than this security fix should
+//! carry. See PR body for details.
+//!
+//! BEHAVIOR CONTRACT (must stay true):
+//! - When `per_device_wrapping` is absent/false in the config (the default),
+//!   `build_encryption_context` returns exactly `EncryptionContext::new(mk)` —
+//!   byte-identical to the prior master-only behavior. Master-only manifests
+//!   read unchanged.
+//! - When a per-device manifest is encountered without an available device
+//!   identity, the engine read switch fails CLOSED (clear error); we never
+//!   silently master-fall-back, and we never copy raw ciphertext to disk.
+
+/// Fail CLOSED when a manifest that this backend cannot decrypt would otherwise
+/// be copied to disk as raw ciphertext (silent corruption).
+///
+/// The `direct`/`uniffi` backends only implement master-key unwrapping. A
+/// per-device manifest carries `wrapped_file_keys` and OMITS the master-wrapped
+/// `encrypted_file_key`, so those backends would fall through to "no file key"
+/// and write encrypted chunk bytes verbatim. This guard turns that into a loud,
+/// explicit error instead.
+#[cfg(any(feature = "direct", feature = "grpc"))]
+pub(crate) fn ensure_master_decryptable(
+    manifest: &tcfs_sync::manifest::SyncManifest,
+) -> anyhow::Result<()> {
+    if !manifest.wrapped_file_keys.is_empty() {
+        anyhow::bail!(
+            "manifest is per-device encrypted (wrapped_file_keys present) but this \
+             FileProvider backend only supports master-key unwrapping; refusing to \
+             materialize raw ciphertext. Use the gRPC backend with a device identity \
+             configured to read per-device content."
+        );
+    }
+    Ok(())
+}
+
+/// Build a DEVICE-AWARE `EncryptionContext` for the FileProvider read path,
+/// mirroring `tcfsd`'s `build_encryption_context`.
+///
+/// Default-off invariant: returns `EncryptionContext::new(master_key)` verbatim
+/// unless the config explicitly sets `per_device_wrapping: true`. In that case
+/// it loads the device registry + this device's age secret and attaches them
+/// via `.with_device_wrapping`, exactly like the daemon.
+///
+/// Like the daemon, this falls back to the master-only context (and logs why)
+/// only when per-device wrapping is enabled but the registry/recipients/secret
+/// are unavailable — it never produces a context that this device cannot read
+/// back. The engine's read switch independently fails CLOSED if it then meets a
+/// per-device manifest with no identity attached.
+#[cfg(feature = "grpc")]
+pub(crate) fn build_encryption_context(
+    config: &serde_json::Value,
+    device_id: &str,
+    master_key: &tcfs_crypto::MasterKey,
+) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
+
+    let base = EncryptionContext::new(master_key.clone());
+
+    // Default-off: byte-identical master-only behavior unless explicitly enabled.
+    if !config
+        .get("per_device_wrapping")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        return base;
+    }
+
+    let registry_path = config
+        .get("device_registry_path")
+        .and_then(serde_json::Value::as_str)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(tcfs_secrets::device::default_registry_path);
+
+    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                "per-device wrapping: registry load failed ({e}); using master wrap"
+            );
+            return base;
+        }
+    };
+
+    let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = registry
+        .active_devices()
+        .filter(|d| tcfs_secrets::device::is_real_age_public_key(&d.public_key))
+        .map(|d| tcfs_crypto::AgeFileKeyRecipient {
+            device_id: d.device_id.clone(),
+            recipient: d.public_key.clone(),
+        })
+        .collect();
+    if recipients.is_empty() {
+        tracing::warn!(
+            "per-device wrapping enabled but no active age recipients; using master wrap"
+        );
+        return base;
+    }
+
+    let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
+    let identity = match std::fs::read_to_string(&secret_path) {
+        Ok(s) => DeviceUnwrapIdentity {
+            device_id: device_id.to_string(),
+            secret: s.trim().to_string(),
+        },
+        Err(e) => {
+            tracing::warn!(
+                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+            );
+            return base;
+        }
+    };
+
+    base.with_device_wrapping(recipients, Some(identity))
+}
+
+#[cfg(all(test, feature = "grpc"))]
+mod tests {
+    use super::*;
+    use tcfs_secrets::device::{DeviceIdentity, DeviceRegistry};
+
+    fn master() -> tcfs_crypto::MasterKey {
+        tcfs_crypto::MasterKey::from_bytes([7u8; 32])
+    }
+
+    /// Materialize a device registry + this device's age secret in `dir`,
+    /// returning (device_id, public_key). Mirrors the on-disk layout the daemon
+    /// and `build_encryption_context` expect: `<dir>/devices.json` plus
+    /// `<dir>/device-<id>.age`.
+    fn provision_device(dir: &std::path::Path, device_id: &str) -> String {
+        let registry_path = dir.join("devices.json");
+        let key = tcfs_secrets::device::generate_local_device_key();
+
+        let mut registry = DeviceRegistry::default();
+        registry.add(DeviceIdentity {
+            name: device_id.to_string(),
+            device_id: device_id.to_string(),
+            public_key: key.public_key.clone(),
+            signing_key_hash: String::new(),
+            description: None,
+            enrolled_at: 0,
+            revoked: false,
+            last_nats_seq: 0,
+        });
+        registry.save(&registry_path).expect("save registry");
+
+        let secret_path =
+            tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
+        tcfs_secrets::device::save_device_secret_key(&secret_path, &key.secret_key, true)
+            .expect("save device secret");
+
+        key.public_key
+    }
+
+    /// Default config (per_device_wrapping absent) yields a master-only context:
+    /// no recipients, no identity — byte-identical to `EncryptionContext::new`.
+    #[test]
+    fn default_config_is_master_only_byte_identical() {
+        let config = serde_json::json!({});
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert!(
+            ctx.device_recipients.is_empty(),
+            "default config must not attach per-device recipients"
+        );
+        assert!(
+            ctx.device_identity.is_none(),
+            "default config must not attach a device identity"
+        );
+    }
+
+    /// Explicit per_device_wrapping=false also stays master-only.
+    #[test]
+    fn explicit_disabled_is_master_only() {
+        let config = serde_json::json!({ "per_device_wrapping": false });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert!(ctx.device_recipients.is_empty());
+        assert!(ctx.device_identity.is_none());
+    }
+
+    /// When enabled with a real registry + local secret, the context carries this
+    /// device's unwrap identity and the active-device recipient set.
+    #[test]
+    fn enabled_attaches_device_identity_and_recipients() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _pub = provision_device(tmp.path(), "device-a");
+
+        let config = serde_json::json!({
+            "per_device_wrapping": true,
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+
+        assert_eq!(
+            ctx.device_recipients.len(),
+            1,
+            "should pick up the single active device recipient"
+        );
+        let identity = ctx
+            .device_identity
+            .as_ref()
+            .expect("enabled config with secret must attach a device identity");
+        assert_eq!(identity.device_id, "device-a");
+        assert!(identity.secret.starts_with("AGE-SECRET-KEY-"));
+    }
+
+    /// Enabled but no local secret on disk -> falls back to master-only (never
+    /// produces a context that cannot read back); the engine read switch then
+    /// fails CLOSED on any per-device manifest it meets.
+    #[test]
+    fn enabled_without_local_secret_falls_back_to_master_only() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Registry exists with a recipient, but this device's secret is absent.
+        let registry_path = tmp.path().join("devices.json");
+        let key = tcfs_secrets::device::generate_local_device_key();
+        let mut registry = DeviceRegistry::default();
+        registry.add(DeviceIdentity {
+            name: "device-a".to_string(),
+            device_id: "device-a".to_string(),
+            public_key: key.public_key,
+            signing_key_hash: String::new(),
+            description: None,
+            enrolled_at: 0,
+            revoked: false,
+            last_nats_seq: 0,
+        });
+        registry.save(&registry_path).unwrap();
+
+        let config = serde_json::json!({
+            "per_device_wrapping": true,
+            "device_registry_path": registry_path.to_str().unwrap(),
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert!(
+            ctx.device_identity.is_none(),
+            "missing local secret must not yield a half-wired identity"
+        );
+    }
+
+    /// End-to-end through the real engine: a per-device (`wrapped_file_keys`)
+    /// manifest is READABLE via the FP-built context with the device identity,
+    /// fails CLOSED via a master-only context (no identity), and a master-only
+    /// manifest still reads unchanged via the FP context.
+    #[tokio::test]
+    async fn per_device_manifest_roundtrips_via_fp_context_and_fails_closed() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _pub = provision_device(tmp.path(), "device-a");
+        let op = opendal::Operator::new(opendal::services::Memory::default())
+            .unwrap()
+            .finish();
+        let prefix = "test/fp-per-device";
+        let mut state =
+            tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+        // Build the write context from the same registry the FP read context uses.
+        let enabled_config = serde_json::json!({
+            "per_device_wrapping": true,
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+        });
+        let write_ctx = build_encryption_context(&enabled_config, "device-a", &master());
+        assert!(
+            !write_ctx.device_recipients.is_empty(),
+            "precondition: write context must have recipients"
+        );
+
+        let content = b"per-device payload read through the FileProvider context";
+        let src = tmp.path().join("doc.txt");
+        std::fs::write(&src, content).unwrap();
+
+        let up = tcfs_sync::engine::upload_file_with_device(
+            &op, &src, prefix, &mut state, None, "device-a", None, Some(&write_ctx),
+        )
+        .await
+        .expect("per-device upload should succeed");
+
+        // The manifest is genuinely per-device (no master-wrapped key).
+        let manifest = tcfs_sync::manifest::SyncManifest::from_bytes(
+            &op.read(&up.remote_path).await.unwrap().to_bytes(),
+        )
+        .unwrap();
+        assert!(!manifest.wrapped_file_keys.is_empty());
+        assert!(manifest.encrypted_file_key.is_none());
+
+        // (1) Readable via the device-aware FP context.
+        let read_ctx = build_encryption_context(&enabled_config, "device-a", &master());
+        let dst_ok = tmp.path().join("ok.txt");
+        tcfs_sync::engine::download_file_with_device(
+            &op, &up.remote_path, &dst_ok, prefix, None, "device-a", None, Some(&read_ctx),
+        )
+        .await
+        .expect("device-aware FP context should read per-device manifest");
+        assert_eq!(std::fs::read(&dst_ok).unwrap(), content);
+
+        // (2) Fails CLOSED with a master-only context (no identity attached) —
+        //     this is the pre-fix FileProvider behavior; it must error, never
+        //     silently fall back or corrupt.
+        let master_only = build_encryption_context(&serde_json::json!({}), "device-a", &master());
+        assert!(master_only.device_identity.is_none());
+        let dst_closed = tmp.path().join("closed.txt");
+        let res = tcfs_sync::engine::download_file_with_device(
+            &op, &up.remote_path, &dst_closed, prefix, None, "device-a", None, Some(&master_only),
+        )
+        .await;
+        assert!(
+            res.is_err(),
+            "master-only context must FAIL CLOSED on a per-device manifest"
+        );
+        assert!(
+            !dst_closed.exists(),
+            "fail-closed read must not materialize a corrupt file"
+        );
+    }
+
+    /// A master-only manifest reads unchanged through the FP context built from a
+    /// default (per_device_wrapping=false) config — byte-identical regression
+    /// guard for the default-off path.
+    #[tokio::test]
+    async fn master_only_manifest_reads_unchanged_via_fp_context() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let op = opendal::Operator::new(opendal::services::Memory::default())
+            .unwrap()
+            .finish();
+        let prefix = "test/fp-master-only";
+        let mut state =
+            tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+        // Legacy master-only write (no per-device recipients).
+        let write_ctx = tcfs_sync::engine::EncryptionContext::new(master());
+        let content = b"legacy master-only payload";
+        let src = tmp.path().join("legacy.txt");
+        std::fs::write(&src, content).unwrap();
+
+        let up = tcfs_sync::engine::upload_file_with_device(
+            &op, &src, prefix, &mut state, None, "device-a", None, Some(&write_ctx),
+        )
+        .await
+        .expect("master-only upload should succeed");
+
+        let manifest = tcfs_sync::manifest::SyncManifest::from_bytes(
+            &op.read(&up.remote_path).await.unwrap().to_bytes(),
+        )
+        .unwrap();
+        assert!(manifest.wrapped_file_keys.is_empty());
+        assert!(manifest.encrypted_file_key.is_some());
+
+        // Default config -> master-only FP context -> reads unchanged.
+        let read_ctx = build_encryption_context(&serde_json::json!({}), "device-a", &master());
+        let dst = tmp.path().join("out.txt");
+        tcfs_sync::engine::download_file_with_device(
+            &op, &up.remote_path, &dst, prefix, None, "device-a", None, Some(&read_ctx),
+        )
+        .await
+        .expect("default FP context must read master-only manifest unchanged");
+        assert_eq!(std::fs::read(&dst).unwrap(), content);
+    }
+
+    /// The fail-loud guard for the master-only backends rejects per-device
+    /// manifests instead of copying raw ciphertext.
+    #[test]
+    fn ensure_master_decryptable_rejects_per_device_manifest() {
+        let base = || tcfs_sync::manifest::SyncManifest {
+            version: 2,
+            file_hash: String::new(),
+            file_size: 0,
+            chunks: Vec::new(),
+            vclock: tcfs_sync::conflict::VectorClock::default(),
+            written_by: "device-a".to_string(),
+            written_at: 0,
+            rel_path: None,
+            mode: None,
+            encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
+        };
+
+        let mut per_device = base();
+        per_device
+            .wrapped_file_keys
+            .push(tcfs_sync::manifest::WrappedFileKey {
+                recipient_device_id: "device-a".to_string(),
+                recipient: "age1example".to_string(),
+                algorithm: "age-x25519-v1".to_string(),
+                wrapped_key: "deadbeef".to_string(),
+            });
+        assert!(ensure_master_decryptable(&per_device).is_err());
+
+        assert!(ensure_master_decryptable(&base()).is_ok());
+    }
+}

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -395,6 +395,11 @@ pub unsafe extern "C" fn tcfs_provider_fetch(
             let manifest =
                 tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes())?;
 
+            // Fail CLOSED on per-device manifests: this direct backend only
+            // unwraps master-wrapped keys. A `wrapped_file_keys` manifest would
+            // otherwise fall through to "no file key" and copy raw ciphertext.
+            crate::device_ctx::ensure_master_decryptable(&manifest)?;
+
             // Unwrap file key if E2EE manifest
             let file_key = match (&prov.master_key, &manifest.encrypted_file_key) {
                 (Some(mk), Some(wrapped_b64)) => {
@@ -515,6 +520,9 @@ pub unsafe extern "C" fn tcfs_provider_fetch_with_progress(
             let manifest_bytes = prov.operator.read(&manifest_path).await?;
             let manifest =
                 tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes())?;
+
+            // Fail CLOSED on per-device manifests (see fetch path above).
+            crate::device_ctx::ensure_master_decryptable(&manifest)?;
 
             let file_key = match (&prov.master_key, &manifest.encrypted_file_key) {
                 (Some(mk), Some(wrapped_b64)) => {

--- a/crates/tcfs-file-provider/src/grpc_backend.rs
+++ b/crates/tcfs-file-provider/src/grpc_backend.rs
@@ -33,6 +33,12 @@ pub struct TcfsProvider {
     /// write into the extension's sandbox temp container.
     direct_operator: Option<opendal::Operator>,
     direct_master_key: Option<tcfs_crypto::MasterKey>,
+    /// Per-device unwrap identity for reading `wrapped_file_keys` manifests
+    /// (TIN-1417). `None` (the default) preserves master-only behavior.
+    direct_device_identity: Option<tcfs_sync::engine::DeviceUnwrapIdentity>,
+    /// Active-device recipients carried alongside the identity so the read
+    /// context can be reconstructed per fetch. Empty in the default config.
+    direct_device_recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
     /// Daemon connection target for lazy reconnection.
     target: DaemonTarget,
     last_error: Mutex<Option<String>>,
@@ -215,11 +221,14 @@ fn error_code_for_fetch_error(error: &anyhow::Error) -> TcfsError {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn fetch_direct_to_file(
     operator: opendal::Operator,
     remote_prefix: String,
     device_id: String,
     master_key: Option<tcfs_crypto::MasterKey>,
+    device_recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
+    device_identity: Option<tcfs_sync::engine::DeviceUnwrapIdentity>,
     remote_path: String,
     dest_path: PathBuf,
     progress: Option<tcfs_sync::engine::ProgressFn>,
@@ -229,9 +238,17 @@ async fn fetch_direct_to_file(
             .await
             .with_context(|| format!("resolving manifest for: {remote_path}"))?;
 
-    let enc_ctx = master_key
-        .as_ref()
-        .map(|mk| tcfs_sync::engine::EncryptionContext::new(mk.clone()));
+    // Build the read context with this device's unwrap identity attached
+    // (TIN-1417). With the default config `device_recipients` is empty and
+    // `device_identity` is None, so `with_device_wrapping` is a no-op and this
+    // equals the prior `EncryptionContext::new(mk)` exactly (byte-identical for
+    // master-only manifests). When a per-device (`wrapped_file_keys`) manifest
+    // is read, the engine's read switch fails CLOSED with a clear error if no
+    // identity is attached — it never silently master-falls-back.
+    let enc_ctx = master_key.as_ref().map(|mk| {
+        tcfs_sync::engine::EncryptionContext::new(mk.clone())
+            .with_device_wrapping(device_recipients, device_identity)
+    });
 
     tcfs_sync::engine::download_file_with_device(
         &operator,
@@ -303,6 +320,19 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
         let direct_operator = build_direct_operator(&config);
         let direct_master_key = master_key_from_config(&config);
 
+        // Build the DEVICE-AWARE read context once (TIN-1417). With the default
+        // config (`per_device_wrapping` absent/false) this yields an empty
+        // recipient set and no identity — byte-identical to the prior
+        // master-only behavior. When enabled, it loads this device's age secret
+        // so per-device (`wrapped_file_keys`) manifests become readable.
+        let (direct_device_recipients, direct_device_identity) = match &direct_master_key {
+            Some(mk) => {
+                let ctx = crate::device_ctx::build_encryption_context(&config, &device_id, mk);
+                (ctx.device_recipients, ctx.device_identity)
+            }
+            None => (Vec::new(), None),
+        };
+
         // Multi-threaded runtime with 2 workers — one for the background watch
         // stream, one for synchronous FFI calls (enumerate, fetch, upload).
         // The gRPC backend only does network I/O (no file coordination), so
@@ -331,6 +361,8 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
             device_id,
             direct_operator,
             direct_master_key,
+            direct_device_identity,
+            direct_device_recipients,
             target,
             last_error: Mutex::new(None),
         }))
@@ -603,6 +635,8 @@ pub unsafe extern "C" fn tcfs_provider_fetch(
         let remote_prefix = prov.remote_prefix.clone();
         let device_id = prov.device_id.clone();
         let direct_master_key = prov.direct_master_key.clone();
+        let direct_device_recipients = prov.direct_device_recipients.clone();
+        let direct_device_identity = prov.direct_device_identity.clone();
         let target = prov.target.clone();
 
         let fetch_result = std::thread::spawn(move || {
@@ -615,6 +649,8 @@ pub unsafe extern "C" fn tcfs_provider_fetch(
                     remote_prefix,
                     device_id,
                     direct_master_key,
+                    direct_device_recipients,
+                    direct_device_identity,
                     remote,
                     dest,
                     None,
@@ -713,6 +749,8 @@ pub unsafe extern "C" fn tcfs_provider_fetch_with_progress(
         let remote_prefix = prov.remote_prefix.clone();
         let device_id = prov.device_id.clone();
         let direct_master_key = prov.direct_master_key.clone();
+        let direct_device_recipients = prov.direct_device_recipients.clone();
+        let direct_device_identity = prov.direct_device_identity.clone();
         let target = prov.target.clone();
 
         let fetch_result = std::thread::spawn(move || {
@@ -734,6 +772,8 @@ pub unsafe extern "C" fn tcfs_provider_fetch_with_progress(
                     remote_prefix,
                     device_id,
                     direct_master_key,
+                    direct_device_recipients,
+                    direct_device_identity,
                     remote,
                     dest,
                     progress,

--- a/crates/tcfs-file-provider/src/lib.rs
+++ b/crates/tcfs-file-provider/src/lib.rs
@@ -96,6 +96,11 @@ mod direct;
 #[cfg(any(feature = "direct", feature = "grpc"))]
 mod storage_bounds;
 
+// Device-aware encryption-context wiring (TIN-1417 / B1), shared across the
+// FileProvider backends.
+#[cfg(any(feature = "direct", feature = "grpc"))]
+mod device_ctx;
+
 #[cfg(feature = "direct")]
 pub use direct::*;
 

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -305,6 +305,17 @@ impl TcfsProviderHandle {
                 message: e.to_string(),
             })?;
 
+            // Fail CLOSED on per-device manifests: this backend only unwraps
+            // master-wrapped keys. A `wrapped_file_keys` manifest would
+            // otherwise fall through to "no file key" and copy raw ciphertext.
+            if !manifest.wrapped_file_keys.is_empty() {
+                return Err(ProviderError::Decryption {
+                    message: "manifest is per-device encrypted (wrapped_file_keys present); \
+                              this backend only supports master-key unwrapping"
+                        .to_string(),
+                });
+            }
+
             let file_key = match (&self.master_key, &manifest.encrypted_file_key) {
                 (Some(mk), Some(wrapped_b64)) => {
                     let wrapped = base64::engine::general_purpose::STANDARD
@@ -400,6 +411,15 @@ impl TcfsProviderHandle {
             .map_err(|e| ProviderError::Storage {
                 message: e.to_string(),
             })?;
+
+            // Fail CLOSED on per-device manifests (see hydrate path above).
+            if !manifest.wrapped_file_keys.is_empty() {
+                return Err(ProviderError::Decryption {
+                    message: "manifest is per-device encrypted (wrapped_file_keys present); \
+                              this backend only supports master-key unwrapping"
+                        .to_string(),
+                });
+            }
 
             // Unwrap file key if encrypted
             let file_key = match (&self.master_key, &manifest.encrypted_file_key) {


### PR DESCRIPTION
**DRAFT (agent-drafted, needs review)** — delicate crypto-adjacent wiring.

## TIN-1417 Track B / B1: FileProvider device-context parity

The hard-gate prerequisite to ever flipping `crypto.per_device_wrapping`.
**This PR does NOT flip it** — the default stays `false` and master-only
behavior is byte-identical.

### Problem
The FileProvider direct-read path built a master-only `EncryptionContext`
(`EncryptionContext::new(mk)` at `grpc_backend.rs:232-234`) and never attached
this device's age unwrap identity. The engine read switch
(`tcfs-sync/src/engine.rs:2226`) takes the `wrapped_file_keys`-non-empty branch
first and requires a device identity; with no identity attached, a per-device
manifest was unreadable via the FileProvider. tcfsd (`tcfsd/src/grpc.rs:32-83`)
and the CLI both wire device identity; only the FileProvider direct path
omitted it.

Separately, the non-prod `direct`/`uniffi` backends matched only on
`encrypted_file_key` and fell through `_ => None`, so a per-device manifest
(which omits the master-wrapped key) would copy **raw ciphertext** to disk —
silent corruption.

### Change
- **New `crate::device_ctx::build_encryption_context`** (FP-local replica of
  tcfsd's): loads the device registry + this device's age secret and attaches
  them via `.with_device_wrapping`. Gated on a `per_device_wrapping` config flag
  that defaults `false` → returns exactly `EncryptionContext::new(mk)` when
  off. Like the daemon, it falls back to master-only (and logs why) if the
  registry/recipients/secret are unavailable — never producing a context this
  device cannot read back.
- **`grpc_backend.rs`**: `fetch_direct_to_file` now builds the device-aware
  context (identity + recipients resolved once in `tcfs_provider_new`).
- **`direct.rs` / `uniffi_bridge.rs`**: FAIL CLOSED on a per-device manifest
  (`wrapped_file_keys` present) with a clear error instead of copying raw
  ciphertext.
- FP crate gains an optional `tcfs-secrets` dependency (enabled by `grpc` only).

### Lifted-to-shared vs FP-local
**FP-local helper.** Lifting one `build_encryption_context` into `tcfs-sync`
(the PREFERRED dedupe) would require adding a `tcfs-secrets` dependency edge to
the core `tcfs-sync` crate, which it does not currently have and which most of
the workspace depends on. That is broader than this security fix should carry,
so the dedupe is flagged as **follow-up**. There are now three copies (tcfsd,
CLI, FP).

### Fail-closed behavior
- per-device manifest + no device identity → engine returns a clear error
  ("this device has no age identity"); never silent master-fallback.
- per-device manifest read by `direct`/`uniffi` → explicit error
  (`ProviderError::Decryption` / `anyhow::bail!`); never raw-ciphertext copy.
- new test asserts the fail-closed read does **not** materialize a file.

### Regression safety / byte-identical default-off
- `per_device_wrapping` defaults false → `with_device_wrapping(empty, None)` is
  a no-op == `EncryptionContext::new(mk)`. Master-only manifests read exactly
  as before. Covered by `master_only_manifest_reads_unchanged_via_fp_context`.
- `crypto.per_device_wrapping` is untouched (still default false).

### Build / test
- `cargo check -p tcfs-file-provider --features grpc` — OK
- `cargo build -p tcfs-file-provider --no-default-features --features grpc` — OK
  (links; the `direct`+`grpc` `#[no_mangle]` symbol clash is **pre-existing on
  main** — `build`/`test` must use `--no-default-features --features grpc`).
- `cargo check -p tcfs-file-provider` (default/direct) — OK
- `cargo check -p tcfs-file-provider --features uniffi` — OK
- `cargo check -p tcfs-sync -p tcfsd` — OK
- New tests: `cargo test -p tcfs-file-provider --no-default-features --features grpc device_ctx`
  → 7 passed (incl. per-device round-trip readable via FP context, fail-closed
  via master-only, and master-only-reads-unchanged).
- Existing FP default-feature tests: 14 + 25 passed.

### Candid confidence note
Moderate-high on the wiring; the engine read switch was already fail-closed and
my change only attaches the identity the engine needs and adds loud guards.
Lower confidence on operational config: the FP config now reads
`per_device_wrapping` and optional `device_registry_path` — the Swift/host
config producers must populate these (and `device-<id>.age` must be readable
inside the extension sandbox) before per-device reads work in production. That
is downstream of this PR and gated off by default. Reviewer should confirm the
config key names match the FileProvider host's JSON producer.
