### PR TITLE
DRAFT: TIN-1417 B1 propagate per_device_wrapping + device_registry_path to FileProvider config (agent-drafted, needs review)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -3896,6 +3896,27 @@ struct FileProviderInitConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     daemon_socket: Option<String>,
     master_key_file: String,
+    /// Per-device file-key wrapping (TIN-1417 / Track B1). Mirrors
+    /// `crypto.per_device_wrapping` from the active config. The FileProvider
+    /// extension reads this key to decide whether to build a device-aware
+    /// `EncryptionContext` (see `tcfs-file-provider` `device_ctx`). Omitted
+    /// from the rendered JSON when false so the default-off output stays
+    /// byte-identical to the legacy master-only bootstrap.
+    #[serde(skip_serializing_if = "is_false")]
+    per_device_wrapping: bool,
+    /// Path to the device registry (`devices.json`) the FileProvider must read
+    /// to resolve active age recipients + this device's secret
+    /// (`device-<id>.age` alongside it). Only emitted when
+    /// `per_device_wrapping` is true; the extension otherwise falls back to its
+    /// own default registry path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    device_registry_path: Option<String>,
+}
+
+/// `skip_serializing_if` predicate so `per_device_wrapping` is omitted from the
+/// rendered FileProvider JSON when off, keeping default-off output unchanged.
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 fn build_fileprovider_init_config(
@@ -3904,6 +3925,18 @@ fn build_fileprovider_init_config(
     master_key_path: &Path,
     device_id: &str,
 ) -> FileProviderInitConfig {
+    let per_device_wrapping = config.crypto.per_device_wrapping;
+    // Only surface the device registry path when per-device wrapping is on, so
+    // the default-off rendered JSON is byte-identical to the legacy bootstrap.
+    let device_registry_path = if per_device_wrapping {
+        Some(
+            resolve_fileprovider_registry_path(config)
+                .to_string_lossy()
+                .into_owned(),
+        )
+    } else {
+        None
+    };
     FileProviderInitConfig {
         s3_endpoint: config.storage.endpoint.clone(),
         s3_bucket: config.storage.bucket.clone(),
@@ -3918,7 +3951,23 @@ fn build_fileprovider_init_config(
             .as_ref()
             .map(|path| path.to_string_lossy().into_owned()),
         master_key_file: master_key_path.to_string_lossy().into_owned(),
+        per_device_wrapping,
+        device_registry_path,
     }
+}
+
+/// Resolve the device-registry (`devices.json`) path the FileProvider should
+/// read for per-device unwrap. Mirrors `resolve_fileprovider_device_id`: prefer
+/// the configured `sync.device_identity` registry path, falling back to the
+/// shared default. The device secret key (`device-<id>.age`) lives alongside
+/// this file and is derived by the extension via
+/// `tcfs_secrets::device::device_secret_key_path`.
+fn resolve_fileprovider_registry_path(config: &tcfs_core::config::TcfsConfig) -> PathBuf {
+    config
+        .sync
+        .device_identity
+        .clone()
+        .unwrap_or_else(tcfs_secrets::device::default_registry_path)
 }
 
 async fn write_fileprovider_init_config(
@@ -5857,6 +5906,103 @@ mod tests {
         assert_eq!(
             json["master_key_file"].as_str(),
             Some(master_key_path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn build_fileprovider_init_config_omits_per_device_keys_when_disabled() {
+        // Default-off must stay byte-identical to the legacy master-only
+        // bootstrap: the per-device keys are absent from the rendered JSON.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        assert!(!config.crypto.per_device_wrapping);
+        // Even with a registry path configured, off => not emitted.
+        config.sync.device_identity = Some(dir.path().join("devices.json"));
+
+        let s3 = tcfs_secrets::S3Credentials {
+            access_key_id: "access-key".into(),
+            secret_access_key: secrecy::SecretString::from("secret-key".to_string()),
+            endpoint: config.storage.endpoint.clone(),
+            region: config.storage.region.clone(),
+        };
+        let master_key_path = dir.path().join("master.key");
+        let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
+
+        assert!(!rendered.per_device_wrapping);
+        assert_eq!(rendered.device_registry_path, None);
+
+        let json = serde_json::to_value(&rendered).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(
+            !obj.contains_key("per_device_wrapping"),
+            "per_device_wrapping must be omitted when off (byte-identical default)"
+        );
+        assert!(
+            !obj.contains_key("device_registry_path"),
+            "device_registry_path must be omitted when wrapping is off"
+        );
+    }
+
+    #[test]
+    fn build_fileprovider_init_config_emits_per_device_keys_when_enabled() {
+        // When per-device wrapping is on, the rendered FileProvider config must
+        // carry the keys PR #492's read path consumes: `per_device_wrapping`
+        // (true) and `device_registry_path` (the configured registry).
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("devices.json");
+        let mut config = test_config(dir.path());
+        config.crypto.per_device_wrapping = true;
+        config.sync.device_identity = Some(registry_path.clone());
+
+        let s3 = tcfs_secrets::S3Credentials {
+            access_key_id: "access-key".into(),
+            secret_access_key: secrecy::SecretString::from("secret-key".to_string()),
+            endpoint: config.storage.endpoint.clone(),
+            region: config.storage.region.clone(),
+        };
+        let master_key_path = dir.path().join("master.key");
+        let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
+
+        assert!(rendered.per_device_wrapping);
+        assert_eq!(
+            rendered.device_registry_path.as_deref(),
+            Some(registry_path.to_string_lossy().as_ref())
+        );
+
+        let json = serde_json::to_value(&rendered).unwrap();
+        assert_eq!(json["per_device_wrapping"], serde_json::Value::Bool(true));
+        assert_eq!(
+            json["device_registry_path"].as_str(),
+            Some(registry_path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn build_fileprovider_init_config_falls_back_to_default_registry_when_enabled() {
+        // With wrapping on but no explicit registry, fall back to the shared
+        // default registry path (matching the extension's own fallback).
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.crypto.per_device_wrapping = true;
+        config.sync.device_identity = None;
+
+        let s3 = tcfs_secrets::S3Credentials {
+            access_key_id: "access-key".into(),
+            secret_access_key: secrecy::SecretString::from("secret-key".to_string()),
+            endpoint: config.storage.endpoint.clone(),
+            region: config.storage.region.clone(),
+        };
+        let master_key_path = dir.path().join("master.key");
+        let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
+
+        assert!(rendered.per_device_wrapping);
+        assert_eq!(
+            rendered.device_registry_path,
+            Some(
+                tcfs_secrets::device::default_registry_path()
+                    .to_string_lossy()
+                    .into_owned()
+            )
         );
     }
 


### PR DESCRIPTION
**DRAFT (agent-drafted, needs review)** — config-plumbing for delicate per-device crypto. **Does NOT flip `crypto.per_device_wrapping`** (still default `false`); default-off rendered output is byte-identical to the legacy master-only bootstrap.

## TIN-1417 Track B1-CONFIG: make `per_device_wrapping` + `device_registry_path` reach the FileProvider

### Problem
PR #492 wired the FileProvider **read** path to honor per-device wrapping: its `device_ctx::build_encryption_context` reads `per_device_wrapping` (bool) and `device_registry_path` (string) from the extension's JSON config, then loads the device registry + this device's `device-<id>.age` secret and attaches them via `.with_device_wrapping`. But **no in-repo producer emitted those two keys** — the rendered FileProvider config (`tcfs config fileprovider` / `tcfs init --fileprovider-config-out`) never carried them, so the read path always fell back to master-only. This is the real B1 enablement gate.

### Change (in-repo, implemented)
`crates/tcfs-cli/src/main.rs`:
- `FileProviderInitConfig` gains two fields that land in the flat JSON the FP parses:
  - `per_device_wrapping: bool` — mirrors `crypto.per_device_wrapping` from the active config. `#[serde(skip_serializing_if = "is_false")]` so it is **omitted** when off.
  - `device_registry_path: Option<String>` — resolved from `sync.device_identity` (the `devices.json` registry), falling back to `tcfs_secrets::device::default_registry_path()`. Only populated when wrapping is on (`skip_serializing_if = "Option::is_none"`).
- New helper `resolve_fileprovider_registry_path` (mirrors `resolve_fileprovider_device_id`'s registry resolution).
- The extension derives the device secret path itself (`device-<id>.age` next to the registry) via `tcfs_secrets::device::device_secret_key_path`, matching #492 — so no separate secret-path key is emitted.

### Default-off is byte-identical
When `crypto.per_device_wrapping = false` (the default), **both keys are omitted** from the rendered JSON, so the bootstrap output is byte-for-byte the same as before this PR. The FP reads `per_device_wrapping` defaulting to `false` when absent, so an old/off config behaves exactly as today. Covered by `build_fileprovider_init_config_omits_per_device_keys_when_disabled` (asserts the JSON object does not contain the keys, even when a registry path is configured).

### Tests (new)
- `build_fileprovider_init_config_omits_per_device_keys_when_disabled` — default-off omits both keys.
- `build_fileprovider_init_config_emits_per_device_keys_when_enabled` — on => `per_device_wrapping: true` + `device_registry_path` = configured registry.
- `build_fileprovider_init_config_falls_back_to_default_registry_when_enabled` — on with no `sync.device_identity` => falls back to the shared default registry path.

### FULL LOCAL CI GATE
- `cargo fmt --all -- --check` — **clean** (exit 0).
- `cargo clippy --workspace --all-targets` — **exit 0**, no new warnings on the touched crate (`tcfs-cli`: 0). The only warning emitted is pre-existing `tcfsd (lib test) generated 2 warnings` in an untouched crate.
- `cargo test -p tcfs-cli fileprovider` — **10 passed, 0 failed** (incl. the 3 new tests).

---

## FileProvider config-read + sandbox-secret findings (research)

**How the extension reads its config** (`swift/fileprovider/Sources/Extension/FileProviderExtension.swift:587` `loadConfig`), in priority order:
1. build-time embedded base64 (diagnostic only),
2. **shared Keychain** (securityd XPC, no filesystem I/O — the production path),
3. XDG `~/.config/tcfs/fileprovider/config.json` (sandbox temp-exception, unreliable for the .appex),
4. App Group container `config.json` (deadlock-prone, last resort).

The config JSON is parsed into one flat `serde_json::Value`; the new keys are top-level snake_case, exactly matching what `device_ctx::build_encryption_context` and `tcfs_provider_new` read.

**Sandbox-secret finding (important).** The HostApp's `provisionConfig` (`HostApp.swift:299`, `configForKeychain:367`) does NOT just copy the config into the Keychain — it **reads `master_key_file` from disk in the (non-extension) host process and inlines the 32 bytes as `master_key_base64`** into the Keychain copy. This exists precisely because the sandboxed extension cannot reliably read arbitrary `~/.config/tcfs/...` filesystem paths. **By that same constraint, PR #492's `device_ctx` calls `DeviceRegistry::load(registry_path)` and `std::fs::read_to_string(device-<id>.age)` directly — those filesystem reads will likely FAIL inside the extension sandbox** when the config arrives via Keychain (the production path), even though `device_registry_path` is now present. Emitting the keys is necessary but **not sufficient** for production per-device reads; the host must inline the registry recipients + this device's secret into the Keychain copy the same way it inlines the master key (see spec below). The XDG-path lane *may* let the extension read the files directly, but that lane is explicitly documented as unreliable for the .appex.

---

## OUT-OF-REPO SPEC (not changed here — do NOT edit lab from this PR)

### 1. Lab nix render — `/Users/jess/git/lab/nix/home-manager/tummycrypt.nix`
The lab **hand-renders** the FP `config.json` (it does NOT call `tcfs config fileprovider`).
- **tcfsd config TOML** (`configTomlText`, ~line 153 `[crypto]`): add, gated on an opt-in option, `per_device_wrapping = true` and ensure `[sync] device_identity = "${config.xdg.configHome}/tcfs/devices.json"` is set (the registry path). Keep default `false`.
- **FP `config.json` heredoc** (~line 1697): when per-device is enabled, add:
  - `"per_device_wrapping": true,`
  - `"device_registry_path": "${homeDir}/.config/tcfs/devices.json",`
  Prefer switching this render to invoke `tcfs config fileprovider --out "$FP_CONFIG_DIR/config.json"` so it inherits this PR's emitter instead of duplicating the schema by hand.
- Ensure the device registry (`devices.json`) and this device's `device-<id>.age` are materialized (lab already age-key-generates around lines 1366-1394; extend to enroll a tcfs device identity and persist `device-<id>.age` with mode 0600).

### 2. Swift HostApp keychain enrichment — `swift/fileprovider/Sources/HostApp/HostApp.swift`
Extend `configForKeychain` (line 367), exactly mirroring the existing `master_key_base64` inlining, so the sandboxed extension never needs filesystem access:
- If the config has `per_device_wrapping == true`, read `device_registry_path` from the JSON, load `devices.json`, and inline:
  - the active age recipients (so the extension does not need to read `devices.json`), e.g. `device_recipients_json` (array of `{device_id, public_key}`), AND
  - this device's secret (read `device-<id>.age` next to the registry, base64- or raw-inline it as e.g. `device_secret_base64` for the resolved `device_id`).
- This requires a corresponding **`device_ctx` change in `tcfs-file-provider`** (follow-up to #492) to prefer inlined recipients/secret from the config Value before falling back to filesystem `DeviceRegistry::load` + `read_to_string`. Without that, the present #492 filesystem reads will fail in-sandbox.

### 3. App-Group sandbox secret access — `swift/fileprovider/resources/Extension.entitlements`
Current entitlements: `app-sandbox`, `network.client`, `application-groups [group.io.tinyland.tcfs]`, `keychain-access-groups`. There is **no** broad filesystem entitlement. So:
- **Preferred**: inline registry recipients + device secret into the Keychain config (spec #2) — no new entitlement, no filesystem read in the extension.
- If instead the files must be read directly, the registry + `device-<id>.age` must live in the **App Group container** (`~/Library/Group Containers/group.io.tinyland.tcfs/`) and `device_registry_path` must point there — but App-Group file reads in the .appex are documented here as deadlock-prone (3s-timeout last-resort). Keychain inlining is the safe path.

---

## Candid confidence
High on the in-repo emitter + default-off byte-identical guarantee (tested). The keys now match #492's reader exactly. **Loudly flagged**: emitting the keys is necessary but **not sufficient** for production per-device reads — the Swift host must inline the registry recipients + device secret into the Keychain copy (spec #2) and #492's `device_ctx` must be taught to read them, because the sandboxed extension cannot reliably read `devices.json`/`device-<id>.age` from `~/.config/tcfs`. All of that is gated off by `per_device_wrapping=false` and is downstream of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
