### PR TITLE
DRAFT: TIN-1417 B3 — restore Phase-1 dual-write + per_device_wrap_strict flag (agent-drafted, needs review)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1105,6 +1105,11 @@ fn resolve_sync_status_lookup_path(path: &Path) -> Result<PathBuf> {
 /// recipients. Falls back to legacy shared-master wrapping (logging why) if the
 /// registry can't be loaded, has no real recipients, or this device's age secret
 /// is missing — never producing content this device cannot read back.
+///
+/// By default (Phase-1) the write path DUAL-WRITES: per-device `wrapped_file_keys`
+/// plus the master-wrapped `encrypted_file_key` as a rollback fallback. Setting
+/// `crypto.per_device_wrap_strict` flips it to the CONTRACT (clean-cut) behavior
+/// that drops the master wrap — only safe after a fleet roll-call.
 fn build_encryption_context(
     config: &tcfs_core::config::TcfsConfig,
     device_id: &str,
@@ -1156,6 +1161,7 @@ fn build_encryption_context(
         }
     };
     base.with_device_wrapping(recipients, Some(identity))
+        .with_strict_device_wrap(config.crypto.per_device_wrap_strict)
 }
 
 // ── `tcfs push` ───────────────────────────────────────────────────────────────

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -329,12 +329,24 @@ pub struct CryptoConfig {
     /// Generated once per vault. If unset and passphrase_file is used, a random
     /// salt is generated and must be persisted by the caller.
     pub kdf_salt: Option<String>,
-    /// Wrap file keys per-device (age/X25519) for non-revoked devices instead of
-    /// under the shared master key (TIN-1417). When true, new manifests carry
-    /// `wrapped_file_keys` and omit `encrypted_file_key`, so a revoked device
-    /// cannot decrypt newly written content. Default false (legacy shared-master)
-    /// until a fleet has real per-device identities enrolled.
+    /// Wrap file keys per-device (age/X25519) for non-revoked devices in addition
+    /// to the shared master key (TIN-1417). This is the EXPAND switch: when true,
+    /// new manifests carry `wrapped_file_keys`. By default it remains a Phase-1
+    /// DUAL-WRITE — manifests ALSO keep the master-wrapped `encrypted_file_key`
+    /// as a rollback fallback readable by old binaries and the master-key path —
+    /// so per-device readers and master-key readers can both decrypt. Default
+    /// false (legacy shared-master) until a fleet has real per-device identities
+    /// enrolled. See `per_device_wrap_strict` to CONTRACT (drop the master wrap).
     pub per_device_wrapping: bool,
+    /// Strict per-device wrapping: the CONTRACT switch (TIN-1417 Phase-2). Only
+    /// meaningful when `per_device_wrapping` is true. When true, new manifests
+    /// OMIT the master-wrapped `encrypted_file_key` and carry ONLY
+    /// `wrapped_file_keys`, so a revoked device (absent from the recipient set)
+    /// cannot decrypt newly written content AND there is no master-key rollback.
+    /// This is unreadable by old binaries / the master-key-only path, so it is
+    /// only safe after a fleet roll-call confirms every active device has a real
+    /// per-device identity enrolled. Default false (dual-write rollback cushion).
+    pub per_device_wrap_strict: bool,
 }
 
 impl Default for CryptoConfig {
@@ -349,6 +361,7 @@ impl Default for CryptoConfig {
             passphrase_file: None,
             kdf_salt: None,
             per_device_wrapping: false,
+            per_device_wrap_strict: false,
         }
     }
 }

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -986,14 +986,25 @@ pub struct EncryptionContext {
     pub master_key: tcfs_crypto::MasterKey,
     /// Active-device recipients for per-device FileKey wrapping (TIN-1417).
     ///
-    /// When non-empty, writes emit per-device `wrapped_file_keys` and OMIT the
-    /// master-wrapped `encrypted_file_key`, so a device removed from this set
-    /// (revoked) cannot decrypt newly written content. Empty = legacy
-    /// shared-master behavior.
+    /// When non-empty, writes emit per-device `wrapped_file_keys`. By default
+    /// (`strict_device_wrap == false`) this is a Phase-1 DUAL-WRITE: the
+    /// master-wrapped `encrypted_file_key` is ALSO kept as a rollback fallback,
+    /// so both per-device and master-key readers can decrypt. When
+    /// `strict_device_wrap` is true the master wrap is OMITTED (clean-cut), so a
+    /// device removed from this set (revoked) cannot decrypt newly written
+    /// content. Empty = legacy shared-master behavior.
     pub device_recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
     /// This device's age identity, used to unwrap per-device manifests on read.
     /// `None` relies on the master-key fallback (legacy manifests).
     pub device_identity: Option<DeviceUnwrapIdentity>,
+    /// Strict (CONTRACT) per-device wrapping. Only consulted when
+    /// `device_recipients` is non-empty. When false (default), the write path
+    /// DUAL-WRITES both the master wrap and the per-device wraps (rollback
+    /// cushion). When true, the master wrap is dropped and only
+    /// `wrapped_file_keys` is emitted — the original TIN-1417 clean-cut. Safe to
+    /// enable only after a fleet roll-call. Maps to
+    /// `crypto.per_device_wrap_strict`.
+    pub strict_device_wrap: bool,
 }
 
 /// A local device's age X25519 identity for unwrapping per-device manifests.
@@ -1014,10 +1025,15 @@ impl EncryptionContext {
             master_key,
             device_recipients: Vec::new(),
             device_identity: None,
+            strict_device_wrap: false,
         }
     }
 
     /// Attach per-device wrapping recipients and this device's unwrap identity.
+    ///
+    /// Leaves `strict_device_wrap` at its current value (default false =
+    /// dual-write). Use [`Self::with_strict_device_wrap`] to opt into the
+    /// master-omitted clean-cut after a fleet roll-call.
     pub fn with_device_wrapping(
         mut self,
         recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
@@ -1025,6 +1041,15 @@ impl EncryptionContext {
     ) -> Self {
         self.device_recipients = recipients;
         self.device_identity = identity;
+        self
+    }
+
+    /// Set strict (CONTRACT) per-device wrapping: when `true`, the write path
+    /// drops the master wrap and emits ONLY `wrapped_file_keys`. When `false`
+    /// (default) it dual-writes both the master wrap and the per-device wraps as
+    /// a rollback cushion. Maps to `crypto.per_device_wrap_strict`.
+    pub fn with_strict_device_wrap(mut self, strict: bool) -> Self {
+        self.strict_device_wrap = strict;
         self
     }
 }
@@ -1850,10 +1875,14 @@ async fn upload_file_with_device_with_state(
     ensure_source_matches_snapshot(local_path, &snapshot, "manifest publish")?;
 
     // Wrap the file key for the manifest. With per-device recipients (TIN-1417)
-    // we emit only per-device `wrapped_file_keys` and OMIT the master-wrapped
-    // `encrypted_file_key`, so a revoked device (absent from the recipient set)
-    // cannot decrypt new content. Without recipients we keep the legacy
-    // shared-master wrap for backward compatibility.
+    // we emit per-device `wrapped_file_keys`. By default this is a Phase-1
+    // DUAL-WRITE: we ALSO keep the master-wrapped `encrypted_file_key` as a
+    // rollback fallback, so per-device readers and master-key/old-binary readers
+    // can both decrypt. When `strict_device_wrap` is set (the CONTRACT switch,
+    // `crypto.per_device_wrap_strict`, only after a fleet roll-call) we OMIT the
+    // master wrap, so a revoked device (absent from the recipient set) cannot
+    // decrypt new content. Without recipients we keep the legacy shared-master
+    // wrap for backward compatibility.
     #[cfg(feature = "crypto")]
     let (encrypted_file_key, wrapped_file_keys) = if let (Some(ctx), Some(ref fk)) =
         (encryption, &file_key)
@@ -1874,7 +1903,19 @@ async fn upload_file_with_device_with_state(
                     wrapped_key: w.wrapped_key,
                 })
                 .collect();
-            (None, wrapped)
+            // Dual-write (default): keep the master wrap as a rollback fallback.
+            // Strict: drop it (clean-cut, no master-key rollback).
+            let master_b64 = if ctx.strict_device_wrap {
+                None
+            } else {
+                let master_wrapped = tcfs_crypto::wrap_key(&ctx.master_key, fk)
+                    .context("wrapping file key under master (dual-write fallback)")?;
+                Some(base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    &master_wrapped,
+                ))
+            };
+            (master_b64, wrapped)
         }
     } else {
         (None, Vec::new())

--- a/crates/tcfs-sync/tests/per_device_dual_write_test.rs
+++ b/crates/tcfs-sync/tests/per_device_dual_write_test.rs
@@ -1,0 +1,287 @@
+//! Integration tests for Phase-1 DUAL-WRITE per-device file-key wrapping
+//! (TIN-1417, B3). Exercises the real engine write/read paths to prove:
+//!
+//! - Default mode (`per_device_wrap_strict = false`, i.e.
+//!   `EncryptionContext::strict_device_wrap == false`) with non-empty
+//!   `device_recipients` emits BOTH the master-wrapped `encrypted_file_key`
+//!   (rollback fallback) AND per-device `wrapped_file_keys`.
+//! - A dual-written manifest is readable by a per-device reader (via the
+//!   `wrapped_file_keys` switch) AND by a master-key-only reader (via the
+//!   `encrypted_file_key` fallback — the old-binary / master-key path that
+//!   never consults `wrapped_file_keys`).
+//! - STRICT mode (`strict_device_wrap == true`) keeps the original clean-cut:
+//!   only `wrapped_file_keys`, no master rollback.
+//! - The default-off path (no `device_recipients`) is byte-identical to legacy:
+//!   only `encrypted_file_key`, no `wrapped_file_keys`.
+
+#![cfg(feature = "crypto")]
+
+use opendal::Operator;
+use secrecy::ExposeSecret;
+use tempfile::TempDir;
+
+use tcfs_crypto::AgeFileKeyRecipient;
+use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
+use tcfs_sync::manifest::SyncManifest;
+
+fn memory_operator() -> Operator {
+    Operator::new(opendal::services::Memory::default())
+        .expect("memory operator")
+        .finish()
+}
+
+fn master() -> tcfs_crypto::MasterKey {
+    tcfs_crypto::MasterKey::from_bytes([7u8; 32])
+}
+
+/// Freshly generate an age device, returning its wrap recipient and unwrap identity.
+fn device(id: &str) -> (AgeFileKeyRecipient, DeviceUnwrapIdentity) {
+    let key = age::x25519::Identity::generate();
+    let recipient = AgeFileKeyRecipient {
+        device_id: id.to_string(),
+        recipient: key.to_public().to_string(),
+    };
+    let identity = DeviceUnwrapIdentity {
+        device_id: id.to_string(),
+        secret: key.to_string().expose_secret().to_string(),
+    };
+    (recipient, identity)
+}
+
+/// Per-device read context: master key present (for the fallback path) plus this
+/// device's age identity.
+fn read_ctx(id: &DeviceUnwrapIdentity) -> EncryptionContext {
+    EncryptionContext::new(master()).with_device_wrapping(Vec::new(), Some(id.clone()))
+}
+
+/// Master-only read context: no device identity at all. This is the legacy /
+/// old-binary / master-key-direct reader. It can only succeed on a manifest
+/// whose `wrapped_file_keys` is empty (it has no age identity to unwrap them).
+fn master_only_read_ctx() -> EncryptionContext {
+    EncryptionContext::new(master())
+}
+
+async fn read_manifest(op: &Operator, remote_path: &str) -> SyncManifest {
+    let bytes = op.read(remote_path).await.unwrap();
+    SyncManifest::from_bytes(&bytes.to_bytes()).unwrap()
+}
+
+#[tokio::test]
+async fn dual_write_emits_both_fields_and_is_readable_by_both_readers() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/dual-write";
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    let (rec_a, id_a) = device("device-a");
+    let (rec_b, id_b) = device("device-b");
+
+    // Default: per-device wrapping ON (recipients present), strict OFF => DUAL-WRITE.
+    let write_ctx = EncryptionContext::new(master())
+        .with_device_wrapping(vec![rec_a, rec_b], Some(id_a.clone()));
+    assert!(
+        !write_ctx.strict_device_wrap,
+        "default EncryptionContext must be non-strict (dual-write)"
+    );
+
+    let content = b"dual-written payload: readable by master AND per-device readers";
+    let src = tmp.path().join("doc.txt");
+    std::fs::write(&src, content).unwrap();
+
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .expect("upload should succeed");
+
+    // Manifest carries BOTH the master wrap (rollback fallback) and one
+    // per-device wrap per recipient.
+    let manifest = read_manifest(&op, &up.remote_path).await;
+    assert_eq!(
+        manifest.version, 2,
+        "dual-write stays at manifest version 2"
+    );
+    assert_eq!(
+        manifest.wrapped_file_keys.len(),
+        2,
+        "one per-device wrap per recipient"
+    );
+    assert!(
+        manifest.encrypted_file_key.is_some(),
+        "dual-write MUST keep the master-wrapped key as a rollback fallback"
+    );
+    // The master wrap must actually unwrap to a valid file key under the master.
+    let wrapped_master = base64::Engine::decode(
+        &base64::engine::general_purpose::STANDARD,
+        manifest.encrypted_file_key.as_ref().unwrap(),
+    )
+    .expect("master wrap is valid base64");
+    tcfs_crypto::unwrap_key(&master(), &wrapped_master)
+        .expect("dual-write master wrap must unwrap under the master key");
+
+    // (1) Per-device readers (in the recipient set) hydrate exact bytes via the
+    // wrapped_file_keys switch.
+    for id in [&id_a, &id_b] {
+        let dst = tmp.path().join(format!("pd-{}.txt", id.device_id));
+        tcfs_sync::engine::download_file_with_device(
+            &op,
+            &up.remote_path,
+            &dst,
+            prefix,
+            None,
+            &id.device_id,
+            None,
+            Some(&read_ctx(id)),
+        )
+        .await
+        .expect("per-device reader download should succeed");
+        assert_eq!(std::fs::read(&dst).unwrap(), content);
+    }
+
+    // (2) A master-key-only reader (old binary / master-key-direct path) hydrates
+    // exact bytes via the `encrypted_file_key` fallback. That path never consults
+    // `wrapped_file_keys`, so we present the manifest as such a reader sees it:
+    // wrapped_file_keys stripped, encrypted_file_key intact. This proves the
+    // dual-write rollback field is a complete, master-readable copy.
+    let mut master_view = manifest.clone();
+    master_view.wrapped_file_keys.clear();
+    let master_remote = format!("{}/master-view-manifest.bin", prefix);
+    op.write(&master_remote, master_view.to_bytes().unwrap())
+        .await
+        .unwrap();
+
+    let dst_master = tmp.path().join("master-only.txt");
+    tcfs_sync::engine::download_file_with_device(
+        &op,
+        &master_remote,
+        &dst_master,
+        prefix,
+        None,
+        "master-only-reader",
+        None,
+        Some(&master_only_read_ctx()),
+    )
+    .await
+    .expect("master-only reader must hydrate the dual-write rollback fallback");
+    assert_eq!(std::fs::read(&dst_master).unwrap(), content);
+}
+
+#[tokio::test]
+async fn strict_mode_omits_master_wrap() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/strict";
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    let (rec_a, id_a) = device("device-a");
+
+    // CONTRACT: strict ON => clean-cut, only wrapped_file_keys.
+    let write_ctx = EncryptionContext::new(master())
+        .with_device_wrapping(vec![rec_a], Some(id_a.clone()))
+        .with_strict_device_wrap(true);
+
+    let content = b"strict clean-cut payload";
+    let src = tmp.path().join("strict.txt");
+    std::fs::write(&src, content).unwrap();
+
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .expect("upload should succeed");
+
+    let manifest = read_manifest(&op, &up.remote_path).await;
+    assert_eq!(manifest.wrapped_file_keys.len(), 1, "one per-device wrap");
+    assert!(
+        manifest.encrypted_file_key.is_none(),
+        "strict mode must OMIT the master-wrapped key (clean-cut)"
+    );
+
+    // The recipient can still hydrate exact bytes.
+    let dst = tmp.path().join("out.txt");
+    tcfs_sync::engine::download_file_with_device(
+        &op,
+        &up.remote_path,
+        &dst,
+        prefix,
+        None,
+        &id_a.device_id,
+        None,
+        Some(&read_ctx(&id_a)),
+    )
+    .await
+    .expect("recipient download should succeed");
+    assert_eq!(std::fs::read(&dst).unwrap(), content);
+}
+
+#[tokio::test]
+async fn default_off_path_is_legacy_master_only() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/default-off";
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    // per_device_wrapping OFF == no device_recipients. Legacy shared-master.
+    let write_ctx = EncryptionContext::new(master());
+    assert!(
+        write_ctx.device_recipients.is_empty(),
+        "default-off path has no recipients"
+    );
+
+    let content = b"legacy shared-master payload (default-off, unchanged)";
+    let src = tmp.path().join("legacy.txt");
+    std::fs::write(&src, content).unwrap();
+
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .expect("upload should succeed");
+
+    let manifest = read_manifest(&op, &up.remote_path).await;
+    assert!(
+        manifest.encrypted_file_key.is_some(),
+        "default-off keeps the legacy master wrap"
+    );
+    assert!(
+        manifest.wrapped_file_keys.is_empty(),
+        "default-off must NOT emit any per-device wraps (byte-identical legacy)"
+    );
+
+    // Master-only reader hydrates exact bytes — legacy path unchanged.
+    let dst = tmp.path().join("out.txt");
+    tcfs_sync::engine::download_file_with_device(
+        &op,
+        &up.remote_path,
+        &dst,
+        prefix,
+        None,
+        "device-a",
+        None,
+        Some(&master_only_read_ctx()),
+    )
+    .await
+    .expect("master-only reader download should succeed");
+    assert_eq!(std::fs::read(&dst).unwrap(), content);
+}

--- a/crates/tcfs-sync/tests/per_device_wrap_test.rs
+++ b/crates/tcfs-sync/tests/per_device_wrap_test.rs
@@ -1,11 +1,16 @@
 //! Integration tests for per-device file-key wrapping (TIN-1417).
 //!
-//! Exercises the real engine write/read paths to prove:
+//! Exercises the real engine write/read paths. These tests cover the STRICT
+//! (CONTRACT / clean-cut) mode — `EncryptionContext::with_strict_device_wrap(true)`,
+//! i.e. `crypto.per_device_wrap_strict = true` — to prove:
 //! - per-device recipients produce `wrapped_file_keys` and OMIT the
 //!   master-wrapped `encrypted_file_key` (clean-cut), and every recipient can
 //!   hydrate exact bytes;
 //! - a revoked device (absent from the recipient set on a new write) cannot
 //!   decrypt content written after revocation, while an active device can.
+//!
+//! The default Phase-1 DUAL-WRITE mode (strict off) is covered in
+//! `per_device_dual_write_test.rs`.
 
 #![cfg(feature = "crypto")]
 
@@ -55,7 +60,8 @@ async fn per_device_wrap_roundtrip_and_manifest_shape() {
     let (rec_b, id_b) = device("device-b");
 
     let write_ctx = EncryptionContext::new(master())
-        .with_device_wrapping(vec![rec_a, rec_b], Some(id_a.clone()));
+        .with_device_wrapping(vec![rec_a, rec_b], Some(id_a.clone()))
+        .with_strict_device_wrap(true);
 
     let content = b"per-device wrapped payload that should round-trip exactly";
     let src = tmp.path().join("doc.txt");
@@ -118,8 +124,10 @@ async fn revoked_device_cannot_decrypt_new_content() {
     let (_rec_b, id_b) = device("device-b");
 
     // New content is written for the active set [A] only — B has been revoked.
-    let write_ctx =
-        EncryptionContext::new(master()).with_device_wrapping(vec![rec_a], Some(id_a.clone()));
+    // Strict (clean-cut): no master rollback, so revocation is total.
+    let write_ctx = EncryptionContext::new(master())
+        .with_device_wrapping(vec![rec_a], Some(id_a.clone()))
+        .with_strict_device_wrap(true);
 
     let content = b"content written after device-b was revoked";
     let src = tmp.path().join("after-revoke.txt");

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -29,6 +29,11 @@ use tcfs_sync::state::StateCacheBackend;
 /// recipients. Falls back to legacy shared-master wrapping (and logs why) if the
 /// registry can't be loaded, has no real recipients, or this device's age secret
 /// is missing — never producing content this device cannot read back.
+///
+/// By default (Phase-1) the write path DUAL-WRITES: per-device `wrapped_file_keys`
+/// plus the master-wrapped `encrypted_file_key` as a rollback fallback. Setting
+/// `crypto.per_device_wrap_strict` flips it to the CONTRACT (clean-cut) behavior
+/// that drops the master wrap — only safe after a fleet roll-call.
 pub(crate) fn build_encryption_context(
     config: &TcfsConfig,
     device_id: &str,
@@ -80,6 +85,7 @@ pub(crate) fn build_encryption_context(
         }
     };
     base.with_device_wrapping(recipients, Some(identity))
+        .with_strict_device_wrap(config.crypto.per_device_wrap_strict)
 }
 
 /// Implementation of the TcfsDaemon gRPC service


### PR DESCRIPTION
> **DRAFT — agent-drafted, needs review.** Cut from `origin/main`. Does NOT flip any flag; both `crypto.per_device_wrapping` and the new `crypto.per_device_wrap_strict` default **false**. Default-off behavior is byte-identical.

## TRACK B3 — Step 2: restore Phase-1 dual-write + the `per_device_wrap_strict` flag model

The current `origin/main` per-device write path is a **clean-cut Phase-2**: when `device_recipients` is non-empty it emits `wrapped_file_keys` and **drops** `encrypted_file_key` (the master wrap). That leaves no rollback and is unreadable by old binaries / the master-key-only path / the rotate tool. The TIN-1417 design (`docs/ops/per-device-crypto-identity-design-2026-05-18.md:207-216`) specifies **Phase-1 DUAL-WRITE** (both fields) plus a roll-call gate before contracting.

This PR restores that dual-write as the default and gates the contraction behind a new, default-off flag.

### Flag semantics
- `crypto.per_device_wrapping` (**EXPAND**, unchanged default `false`): when true, also wrap the file key to per-device recipients (emit `wrapped_file_keys`).
- `crypto.per_device_wrap_strict` (**CONTRACT**, NEW, default `false`): only meaningful when `per_device_wrapping` is true. When **false (default)** → DUAL-WRITE: keep `encrypted_file_key` (master wrap, the rollback fallback) **and** `wrapped_file_keys`. When **true** → drop the master wrap (today's clean-cut). Strict is only safe **after a fleet roll-call** confirms every active device has a real per-device identity enrolled — and it is unreadable by old binaries / the master-key path.

So: default (`strict=false`) = dual-write; `strict=true` = current clean-cut.

### Changed files
- `crates/tcfs-core/src/config.rs` — new field `crypto.per_device_wrap_strict: bool` (default `false`), mirroring `per_device_wrapping`'s serde/default (`CryptoConfig` has `#[serde(default)]`, so existing config files deserialize unchanged).
- `crates/tcfs-sync/src/engine.rs`:
  - `EncryptionContext` gains `strict_device_wrap: bool` (default `false`) + a minimal `with_strict_device_wrap(bool)` builder. `new()` and `with_device_wrapping(..)` keep their existing signatures (no caller churn).
  - The per-device write branch (was lines 1858-1881; the impl is `upload_file_with_device_with_state`) now DUAL-WRITES `encrypted_file_key` + `wrapped_file_keys` unless `strict_device_wrap` is set, in which case it omits the master wrap. Manifest stays **version 2**.
  - The **read switch (engine.rs:2226-2270) is unchanged** — it already prefers `wrapped_file_keys` and falls back to `encrypted_file_key`, so dual-written manifests are readable by both.
- `crates/tcfsd/src/grpc.rs` and `crates/tcfs-cli/src/main.rs` — both copies of `build_encryption_context` thread the config flag through `.with_strict_device_wrap(config.crypto.per_device_wrap_strict)`. (Did NOT depend on the unmerged #492 FP-local copy.)
- `crates/tcfs-sync/tests/per_device_dual_write_test.rs` — NEW.
- `crates/tcfs-sync/tests/per_device_wrap_test.rs` — pinned to strict mode (its clean-cut / revocation intent), with a header pointer to the new dual-write test.

### Dual-write proof (new tests, all passing)
`per_device_dual_write_test.rs`:
- `dual_write_emits_both_fields_and_is_readable_by_both_readers` — with `per_device_wrapping` ON + strict OFF, the written manifest carries **BOTH** `encrypted_file_key` AND `wrapped_file_keys` (and `version == 2`); the master wrap actually unwraps under the master key; **per-device readers** hydrate exact bytes via the per-device switch; and a **master-key-only reader** (no age identity — the old-binary / master-key-direct path, which never consults `wrapped_file_keys`) hydrates exact bytes via the `encrypted_file_key` fallback.
- `strict_mode_omits_master_wrap` — with strict ON, only `wrapped_file_keys` (no master wrap); recipient still hydrates.
- `default_off_path_is_legacy_master_only` — with no recipients (per_device_wrapping off), only `encrypted_file_key`, no `wrapped_file_keys` (byte-identical legacy).

### FULL LOCAL CI GATE
- `cargo fmt --all -- --check` → **clean**.
- `cargo clippy --workspace --all-targets` → **exit 0, no new warnings**. (Two pre-existing `clippy::needless_borrow` warnings at `grpc.rs:1383` and `grpc.rs:1816` are on `origin/main` and untouched by this PR.)
- `cargo test -p tcfs-sync --features crypto` (the touched tests): `per_device_dual_write_test` **3 passed**, `per_device_wrap_test` **2 passed**, `encrypted_roundtrip_test` **4 passed**.
- `cargo test -p tcfs-core`: **8 passed** (incl. config serde round-trip / full-config parse).

### Operator notes / uncertainty
- **The `per_device_wrap_strict` NAME and model need operator ratification.** "strict" = CONTRACT (drop master wrap). If the fleet prefers a different name (e.g. `per_device_wrap_contract`, `drop_master_wrap`) or a tri-state, that is a trivial rename before merge.
- **Read-path nuance worth a second look:** the read switch is intentionally left unchanged per spec. For a *dual-written* manifest it still takes the per-device branch first (because `wrapped_file_keys` is non-empty) and does **not** fall back to the master wrap if a per-device unwrap fails. The master-readability of a dual-written manifest is therefore realized by readers that go through the `encrypted_file_key` path directly (old binaries, the master-key-only/FileProvider-direct path, the rotate tool) — exactly the rollback audience. The new test simulates that reader faithfully. A modern reader that holds *only* a master key but no age identity will still error on a dual-written manifest under the current switch; if operators want belt-and-suspenders master fallback inside the modern read switch too, that is a follow-up (and a read-switch change, out of scope here).
- **Lab spec (not applied):** `~/git/lab/nix/home-manager/tummycrypt.nix` `[crypto]` block sets only `enabled`/`master_key_file`, so both flags already default false there — no lab change is required to keep defaults off. To later EXPAND, add `per_device_wrapping = true` (after enrolling real per-device identities + `device_registry_path`/`device-<id>.age`); to CONTRACT, add `per_device_wrap_strict = true` only after a roll-call. Do NOT set strict before dual-write has propagated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
