### PR TITLE
DRAFT: TIN-1417 tri-state crypto.wrap_mode (master|dual|per_device) (agent-drafted, needs review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ Current release-proof posture is tracked in `docs/release/evidence/` and
 `docs/ops/product-reality-and-priority.md`; older entries below may describe
 historical release intent rather than the current supported/proven surface.
 
+## [Unreleased]
+
+### Changed
+
+- **Tri-state `crypto.wrap_mode` replaces `crypto.per_device_wrapping`**
+  (TIN-1417): the boolean flag shipped in 0.12.14 (default off, never flipped
+  live) is replaced by an explicit `crypto.wrap_mode = master | dual |
+  per_device` enum (default `master`). `master` is byte-identical to the prior
+  `per_device_wrapping=false`; `dual` (EXPAND) emits BOTH the master wrap and
+  per-device wraps (v2, back-compatible); `per_device` (CONTRACT) emits only
+  per-device wraps, drops the master wrap, and bumps regular-file manifests to
+  v3 so pre-per-device readers fail closed. Back-compat: a legacy
+  `per_device_wrapping` config key still deserializes — `true` maps to `dual`
+  (keeps the master fallback), `false`/absent maps to `master`; `wrap_mode`
+  wins when both are present. The daemon/CLI/FileProvider refuse to operate in
+  `per_device` until a roll-call probe confirms every active device is
+  per-device-capable, otherwise falling back to `dual` with a loud warning.
+
 ## [0.12.14] - 2026-06-03
 
 First finalized release of the 0.12.13→0.12.14 line (0.12.13 shipped only as

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1100,20 +1100,27 @@ fn resolve_sync_status_lookup_path(path: &Path) -> Result<PathBuf> {
     std::fs::canonicalize(path).map_err(Into::into)
 }
 
-/// Build an `EncryptionContext`, attaching per-device wrapping (TIN-1417) when
-/// `crypto.per_device_wrapping` is enabled and the device registry has real age
-/// recipients. Falls back to legacy shared-master wrapping (logging why) if the
-/// registry can't be loaded, has no real recipients, or this device's age secret
-/// is missing — never producing content this device cannot read back.
+/// Build an `EncryptionContext` for the TIN-1417 tri-state `crypto.wrap_mode`.
+///
+/// Mirrors `tcfsd`'s `build_encryption_context` (`crates/tcfsd/src/grpc.rs`):
+/// `Master` (default) returns the legacy master-only context verbatim; `Dual`
+/// attaches per-device recipients while keeping the master wrap; `PerDevice`
+/// (contract) is GATED behind a roll-call probe and DOWNGRADES to `Dual` (with
+/// a loud warning) unless every active device is per-device-capable. In all
+/// per-device modes it falls back to master-only (logging why) when the
+/// registry/recipients/secret are unavailable — never producing content this
+/// device cannot read back.
 fn build_encryption_context(
     config: &tcfs_core::config::TcfsConfig,
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
-    if !config.crypto.per_device_wrapping {
+    let requested = config.crypto.wrap_mode;
+    if requested == WrapMode::Master {
         return base;
     }
     let registry_path = config
@@ -1128,6 +1135,29 @@ fn build_encryption_context(
             return base;
         }
     };
+
+    // Roll-call code gate (mirror of the daemon): refuse to contract
+    // (`PerDevice`, drops the master wrap) unless every active device is
+    // per-device-capable; otherwise downgrade to `Dual` and warn loudly.
+    let effective_mode = if requested == WrapMode::PerDevice {
+        if registry.per_device_roll_call_ready() {
+            WrapMode::PerDevice
+        } else {
+            let incapable = registry.per_device_incapable_active_devices();
+            tracing::warn!(
+                requested = ?WrapMode::PerDevice,
+                effective = ?WrapMode::Dual,
+                incapable_active_devices = ?incapable,
+                "ROLL-CALL GATE: per_device (contract) wrap_mode requested but not every \
+                 active device is per-device-capable (or registry is empty); refusing to \
+                 drop the master wrap. Falling back to DUAL (master wrap retained)."
+            );
+            WrapMode::Dual
+        }
+    } else {
+        requested
+    };
+
     let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = registry
         .active_devices()
         .filter(|d| tcfs_secrets::device::is_real_age_public_key(&d.public_key))
@@ -1156,6 +1186,7 @@ fn build_encryption_context(
         }
     };
     base.with_device_wrapping(recipients, Some(identity))
+        .with_wrap_mode(effective_mode)
 }
 
 // ── `tcfs push` ───────────────────────────────────────────────────────────────
@@ -3896,27 +3927,21 @@ struct FileProviderInitConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     daemon_socket: Option<String>,
     master_key_file: String,
-    /// Per-device file-key wrapping (TIN-1417 / Track B1). Mirrors
-    /// `crypto.per_device_wrapping` from the active config. The FileProvider
-    /// extension reads this key to decide whether to build a device-aware
-    /// `EncryptionContext` (see `tcfs-file-provider` `device_ctx`). Omitted
-    /// from the rendered JSON when false so the default-off output stays
-    /// byte-identical to the legacy master-only bootstrap.
-    #[serde(skip_serializing_if = "is_false")]
-    per_device_wrapping: bool,
+    /// File-key wrap mode (TIN-1417 tri-state). Mirrors `crypto.wrap_mode` from
+    /// the active config. The FileProvider extension reads this to decide
+    /// whether to build a device-aware `EncryptionContext` (see
+    /// `tcfs-file-provider` `device_ctx`). Omitted from the rendered JSON when
+    /// `master` so the default output stays byte-identical to the legacy
+    /// master-only bootstrap.
+    #[serde(skip_serializing_if = "WrapMode::is_master_ref")]
+    wrap_mode: tcfs_core::config::WrapMode,
     /// Path to the device registry (`devices.json`) the FileProvider must read
     /// to resolve active age recipients + this device's secret
-    /// (`device-<id>.age` alongside it). Only emitted when
-    /// `per_device_wrapping` is true; the extension otherwise falls back to its
-    /// own default registry path.
+    /// (`device-<id>.age` alongside it). Only emitted when `wrap_mode` is a
+    /// per-device mode (`dual`/`per_device`); the extension otherwise falls back
+    /// to its own default registry path.
     #[serde(skip_serializing_if = "Option::is_none")]
     device_registry_path: Option<String>,
-}
-
-/// `skip_serializing_if` predicate so `per_device_wrapping` is omitted from the
-/// rendered FileProvider JSON when off, keeping default-off output unchanged.
-fn is_false(value: &bool) -> bool {
-    !*value
 }
 
 fn build_fileprovider_init_config(
@@ -3925,17 +3950,19 @@ fn build_fileprovider_init_config(
     master_key_path: &Path,
     device_id: &str,
 ) -> FileProviderInitConfig {
-    let per_device_wrapping = config.crypto.per_device_wrapping;
-    // Only surface the device registry path when per-device wrapping is on, so
-    // the default-off rendered JSON is byte-identical to the legacy bootstrap.
-    let device_registry_path = if per_device_wrapping {
+    use tcfs_core::config::WrapMode;
+    let wrap_mode = config.crypto.wrap_mode;
+    // Only surface the device registry path when a per-device mode is active, so
+    // the default (master) rendered JSON is byte-identical to the legacy
+    // bootstrap.
+    let device_registry_path = if wrap_mode == WrapMode::Master {
+        None
+    } else {
         Some(
             resolve_fileprovider_registry_path(config)
                 .to_string_lossy()
                 .into_owned(),
         )
-    } else {
-        None
     };
     FileProviderInitConfig {
         s3_endpoint: config.storage.endpoint.clone(),
@@ -3951,7 +3978,7 @@ fn build_fileprovider_init_config(
             .as_ref()
             .map(|path| path.to_string_lossy().into_owned()),
         master_key_file: master_key_path.to_string_lossy().into_owned(),
-        per_device_wrapping,
+        wrap_mode,
         device_registry_path,
     }
 }
@@ -5911,12 +5938,13 @@ mod tests {
 
     #[test]
     fn build_fileprovider_init_config_omits_per_device_keys_when_disabled() {
-        // Default-off must stay byte-identical to the legacy master-only
+        // Default (master) must stay byte-identical to the legacy master-only
         // bootstrap: the per-device keys are absent from the rendered JSON.
+        use tcfs_core::config::WrapMode;
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path());
-        assert!(!config.crypto.per_device_wrapping);
-        // Even with a registry path configured, off => not emitted.
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+        // Even with a registry path configured, master => not emitted.
         config.sync.device_identity = Some(dir.path().join("devices.json"));
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5928,30 +5956,35 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(!rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, WrapMode::Master);
         assert_eq!(rendered.device_registry_path, None);
 
         let json = serde_json::to_value(&rendered).unwrap();
         let obj = json.as_object().unwrap();
         assert!(
+            !obj.contains_key("wrap_mode"),
+            "wrap_mode must be omitted when master (byte-identical default)"
+        );
+        assert!(
             !obj.contains_key("per_device_wrapping"),
-            "per_device_wrapping must be omitted when off (byte-identical default)"
+            "legacy per_device_wrapping must not be emitted"
         );
         assert!(
             !obj.contains_key("device_registry_path"),
-            "device_registry_path must be omitted when wrapping is off"
+            "device_registry_path must be omitted when wrapping is master"
         );
     }
 
     #[test]
     fn build_fileprovider_init_config_emits_per_device_keys_when_enabled() {
-        // When per-device wrapping is on, the rendered FileProvider config must
-        // carry the keys PR #492's read path consumes: `per_device_wrapping`
-        // (true) and `device_registry_path` (the configured registry).
+        // When a per-device mode is on, the rendered FileProvider config must
+        // carry the keys the FP read path consumes: `wrap_mode` and
+        // `device_registry_path` (the configured registry).
+        use tcfs_core::config::WrapMode;
         let dir = tempfile::tempdir().unwrap();
         let registry_path = dir.path().join("devices.json");
         let mut config = test_config(dir.path());
-        config.crypto.per_device_wrapping = true;
+        config.crypto.wrap_mode = WrapMode::Dual;
         config.sync.device_identity = Some(registry_path.clone());
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5963,14 +5996,14 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, WrapMode::Dual);
         assert_eq!(
             rendered.device_registry_path.as_deref(),
             Some(registry_path.to_string_lossy().as_ref())
         );
 
         let json = serde_json::to_value(&rendered).unwrap();
-        assert_eq!(json["per_device_wrapping"], serde_json::Value::Bool(true));
+        assert_eq!(json["wrap_mode"], serde_json::Value::String("dual".into()));
         assert_eq!(
             json["device_registry_path"].as_str(),
             Some(registry_path.to_string_lossy().as_ref())
@@ -5979,11 +6012,12 @@ mod tests {
 
     #[test]
     fn build_fileprovider_init_config_falls_back_to_default_registry_when_enabled() {
-        // With wrapping on but no explicit registry, fall back to the shared
-        // default registry path (matching the extension's own fallback).
+        // With a per-device mode on but no explicit registry, fall back to the
+        // shared default registry path (matching the extension's own fallback).
+        use tcfs_core::config::WrapMode;
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path());
-        config.crypto.per_device_wrapping = true;
+        config.crypto.wrap_mode = WrapMode::Dual;
         config.sync.device_identity = None;
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5995,7 +6029,7 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, WrapMode::Dual);
         assert_eq!(
             rendered.device_registry_path,
             Some(

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -307,9 +307,78 @@ pub struct FuseConfig {
     pub cache_max_mb: u64,
 }
 
+/// File-key wrapping mode (TIN-1417 tri-state).
+///
+/// Replaces the shipped-but-unused `crypto.per_device_wrapping: bool`
+/// (v0.12.14, default false, never flipped live) with an explicit
+/// expand/contract migration enum. The three modes map directly onto the
+/// migration phases:
+///
+/// - [`WrapMode::Master`] — DEFAULT. Today's master-only wrap: manifests carry
+///   `encrypted_file_key` only. This MUST stay byte-identical to the prior
+///   `per_device_wrapping=false` behavior. Manifests stay v2.
+/// - [`WrapMode::Dual`] — EXPAND / transitional. Manifests carry BOTH the
+///   master wrap (`encrypted_file_key`, for rollback + master/old-binary
+///   readers) AND per-device wraps (`wrapped_file_keys`). Back-compatible by
+///   construction; manifests stay v2.
+/// - [`WrapMode::PerDevice`] — CONTRACT. Manifests carry ONLY per-device
+///   `wrapped_file_keys` (the master wrap is dropped, enabling true
+///   revocation) and are bumped to manifest version 3 so pre-per-device
+///   binaries fail CLOSED rather than misreading a v2-with-no-`encrypted_file_key`
+///   as keyless. The daemon REFUSES to operate in this mode until a roll-call
+///   probe confirms every active device is per-device-capable; until then it
+///   falls back to `Dual` and warns loudly (never silently dropping the master
+///   wrap).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WrapMode {
+    /// Master-only wrap (default; byte-identical to legacy single-wrap).
+    Master,
+    /// Dual wrap: master wrap + per-device wraps (expand / transitional).
+    Dual,
+    /// Per-device only: drop the master wrap, bump manifest to v3 (contract).
+    PerDevice,
+}
+
+impl Default for WrapMode {
+    fn default() -> Self {
+        WrapMode::Master
+    }
+}
+
+impl WrapMode {
+    /// True when this mode emits the master-wrapped `encrypted_file_key`.
+    /// Master and Dual do; PerDevice does not.
+    pub fn emits_master_wrap(self) -> bool {
+        matches!(self, WrapMode::Master | WrapMode::Dual)
+    }
+
+    /// True when this mode emits per-device `wrapped_file_keys`.
+    /// Dual and PerDevice do; Master does not.
+    pub fn emits_per_device_wraps(self) -> bool {
+        matches!(self, WrapMode::Dual | WrapMode::PerDevice)
+    }
+
+    /// True for the contract mode that drops the master wrap and bumps the
+    /// manifest version to 3 (fail-closed for pre-per-device readers).
+    pub fn is_contract(self) -> bool {
+        matches!(self, WrapMode::PerDevice)
+    }
+
+    /// `skip_serializing_if` predicate (takes `&WrapMode`) so the default
+    /// `master` mode is omitted from rendered JSON/TOML, keeping default output
+    /// byte-identical to the legacy master-only bootstrap.
+    pub fn is_master_ref(mode: &WrapMode) -> bool {
+        *mode == WrapMode::Master
+    }
+}
+
 /// E2E encryption configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+// NOTE: `Deserialize` is hand-implemented below (see `impl<'de> Deserialize`)
+// to reconcile the canonical `wrap_mode` with the legacy `per_device_wrapping`
+// bool. Defaults for absent fields are applied there, so no `#[serde(default)]`
+// is needed on this struct.
+#[derive(Debug, Clone, Serialize)]
 pub struct CryptoConfig {
     /// Enable client-side encryption (default: false until key is set up)
     pub enabled: bool,
@@ -329,12 +398,15 @@ pub struct CryptoConfig {
     /// Generated once per vault. If unset and passphrase_file is used, a random
     /// salt is generated and must be persisted by the caller.
     pub kdf_salt: Option<String>,
-    /// Wrap file keys per-device (age/X25519) for non-revoked devices instead of
-    /// under the shared master key (TIN-1417). When true, new manifests carry
-    /// `wrapped_file_keys` and omit `encrypted_file_key`, so a revoked device
-    /// cannot decrypt newly written content. Default false (legacy shared-master)
-    /// until a fleet has real per-device identities enrolled.
-    pub per_device_wrapping: bool,
+    /// File-key wrapping mode (TIN-1417). Canonical going forward. Default
+    /// [`WrapMode::Master`] (legacy shared-master, byte-identical to the prior
+    /// `per_device_wrapping=false`). See [`WrapMode`] for the full semantics and
+    /// the expand(`Dual`)->contract(`PerDevice`) migration mapping.
+    ///
+    /// Back-compat: a legacy `per_device_wrapping` field still deserializes
+    /// (`true` -> [`WrapMode::Dual`] so the master fallback is kept, `false`/
+    /// absent -> [`WrapMode::Master`]). When both are present, `wrap_mode` wins.
+    pub wrap_mode: WrapMode,
 }
 
 impl Default for CryptoConfig {
@@ -348,8 +420,65 @@ impl Default for CryptoConfig {
             device_identity: None,
             passphrase_file: None,
             kdf_salt: None,
-            per_device_wrapping: false,
+            wrap_mode: WrapMode::Master,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for CryptoConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        /// Mirror of `CryptoConfig` with both the canonical `wrap_mode` and the
+        /// legacy `per_device_wrapping` bool present so we can reconcile them.
+        /// All fields `Option` so absent keys fall back to the struct default.
+        ///
+        /// Intentionally NOT `deny_unknown_fields`: the prior derived
+        /// `Deserialize` (with `#[serde(default)]`) silently tolerated unknown
+        /// keys, and configs in the wild may carry forward-compat keys; rejecting
+        /// them would be a back-compat regression.
+        #[derive(Deserialize)]
+        struct Raw {
+            enabled: Option<bool>,
+            argon2_mem_cost_kib: Option<u32>,
+            argon2_time_cost: Option<u32>,
+            argon2_parallelism: Option<u32>,
+            master_key_file: Option<PathBuf>,
+            device_identity: Option<PathBuf>,
+            passphrase_file: Option<PathBuf>,
+            kdf_salt: Option<String>,
+            /// Canonical going forward. Wins over `per_device_wrapping`.
+            wrap_mode: Option<WrapMode>,
+            /// Legacy back-compat field (TIN-1417 pre-tri-state). `true` maps to
+            /// `Dual` (keeps the master fallback — never silently drops it),
+            /// `false`/absent maps to `Master`.
+            per_device_wrapping: Option<bool>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let defaults = CryptoConfig::default();
+
+        // wrap_mode wins; otherwise map the legacy bool; otherwise default.
+        let wrap_mode = match raw.wrap_mode {
+            Some(mode) => mode,
+            None => match raw.per_device_wrapping {
+                Some(true) => WrapMode::Dual,
+                Some(false) | None => WrapMode::Master,
+            },
+        };
+
+        Ok(CryptoConfig {
+            enabled: raw.enabled.unwrap_or(defaults.enabled),
+            argon2_mem_cost_kib: raw.argon2_mem_cost_kib.unwrap_or(defaults.argon2_mem_cost_kib),
+            argon2_time_cost: raw.argon2_time_cost.unwrap_or(defaults.argon2_time_cost),
+            argon2_parallelism: raw.argon2_parallelism.unwrap_or(defaults.argon2_parallelism),
+            master_key_file: raw.master_key_file.or(defaults.master_key_file),
+            device_identity: raw.device_identity.or(defaults.device_identity),
+            passphrase_file: raw.passphrase_file.or(defaults.passphrase_file),
+            kdf_salt: raw.kdf_salt.or(defaults.kdf_salt),
+            wrap_mode,
+        })
     }
 }
 
@@ -631,5 +760,85 @@ require_session = false
     fn auth_defaults_when_omitted() {
         let config: TcfsConfig = toml::from_str("").unwrap();
         assert!(config.auth.require_session);
+    }
+
+    // ── TIN-1417 wrap_mode tri-state + back-compat ──────────────────────────
+
+    #[test]
+    fn wrap_mode_defaults_to_master_when_absent() {
+        let config: TcfsConfig = toml::from_str("[crypto]\nenabled = true\n").unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+        // Whole-config default also lands on Master.
+        assert_eq!(TcfsConfig::default().crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn wrap_mode_parses_all_three_values() {
+        for (s, expected) in [
+            ("master", WrapMode::Master),
+            ("dual", WrapMode::Dual),
+            ("per_device", WrapMode::PerDevice),
+        ] {
+            let toml_str = format!("[crypto]\nwrap_mode = \"{s}\"\n");
+            let config: TcfsConfig = toml::from_str(&toml_str).unwrap();
+            assert_eq!(config.crypto.wrap_mode, expected, "wrap_mode = {s:?}");
+        }
+    }
+
+    #[test]
+    fn legacy_per_device_wrapping_true_maps_to_dual() {
+        // true -> Dual keeps the master fallback (never silently drops it).
+        let config: TcfsConfig =
+            toml::from_str("[crypto]\nper_device_wrapping = true\n").unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Dual);
+    }
+
+    #[test]
+    fn legacy_per_device_wrapping_false_maps_to_master() {
+        let config: TcfsConfig =
+            toml::from_str("[crypto]\nper_device_wrapping = false\n").unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn wrap_mode_wins_over_legacy_per_device_wrapping() {
+        // When both keys are present, the canonical wrap_mode is authoritative.
+        let config: TcfsConfig = toml::from_str(
+            "[crypto]\nwrap_mode = \"per_device\"\nper_device_wrapping = false\n",
+        )
+        .unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::PerDevice);
+
+        let config2: TcfsConfig = toml::from_str(
+            "[crypto]\nwrap_mode = \"master\"\nper_device_wrapping = true\n",
+        )
+        .unwrap();
+        assert_eq!(config2.crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn crypto_config_tolerates_unknown_keys() {
+        // Back-compat: the prior derived Deserialize silently ignored unknown
+        // keys; the hand-written one must too (no deny_unknown_fields).
+        let config: TcfsConfig =
+            toml::from_str("[crypto]\nwrap_mode = \"dual\"\nsome_future_key = 7\n").unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Dual);
+    }
+
+    #[test]
+    fn wrap_mode_serializes_as_snake_case() {
+        // toml serialization renders the enum via the snake_case rename.
+        let rendered = toml::to_string(&CryptoConfig::default()).unwrap();
+        assert!(
+            rendered.contains("wrap_mode = \"master\""),
+            "default must serialize wrap_mode as \"master\": {rendered}"
+        );
+        let mut dual = CryptoConfig::default();
+        dual.wrap_mode = WrapMode::PerDevice;
+        let rendered_pd = toml::to_string(&dual).unwrap();
+        assert!(
+            rendered_pd.contains("wrap_mode = \"per_device\""),
+            "PerDevice must serialize as \"per_device\": {rendered_pd}"
+        );
     }
 }

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -17,13 +17,14 @@
 //! carry. See PR body for details.
 //!
 //! BEHAVIOR CONTRACT (must stay true):
-//! - When `per_device_wrapping` is absent/false in the config (the default),
-//!   `build_encryption_context` returns exactly `EncryptionContext::new(mk)` —
-//!   byte-identical to the prior master-only behavior. Master-only manifests
-//!   read unchanged.
-//! - When a per-device manifest is encountered without an available device
-//!   identity, the engine read switch fails CLOSED (clear error); we never
-//!   silently master-fall-back, and we never copy raw ciphertext to disk.
+//! - When `wrap_mode` is `master`/absent (the default; legacy
+//!   `per_device_wrapping: false` also maps here), `build_encryption_context`
+//!   returns exactly `EncryptionContext::new(mk)` — byte-identical to the prior
+//!   master-only behavior. Master-only manifests read unchanged.
+//! - When a per-device-only (v3) manifest is encountered without an available
+//!   device identity and no master wrap to fall back to, the engine read switch
+//!   fails CLOSED (clear error); we never silently master-fall-back where no
+//!   master wrap exists, and we never copy raw ciphertext to disk.
 
 /// Fail CLOSED when a manifest that this backend cannot decrypt would otherwise
 /// be copied to disk as raw ciphertext (silent corruption).
@@ -48,35 +49,69 @@ pub(crate) fn ensure_master_decryptable(
     Ok(())
 }
 
+/// Resolve the effective [`WrapMode`] from the FileProvider init-config JSON.
+///
+/// Canonical key going forward is `wrap_mode` (`"master"` | `"dual"` |
+/// `"per_device"`). For back-compat we also accept the legacy
+/// `per_device_wrapping` bool (`true` -> `Dual`, keeping the master fallback;
+/// `false`/absent -> `Master`). `wrap_mode` wins when both are present. This
+/// mirrors the `CryptoConfig` deserializer in `tcfs-core`.
+#[cfg(feature = "grpc")]
+fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapMode {
+    use tcfs_core::config::WrapMode;
+    if let Some(raw) = config.get("wrap_mode").and_then(serde_json::Value::as_str) {
+        match raw {
+            "master" => return WrapMode::Master,
+            "dual" => return WrapMode::Dual,
+            "per_device" => return WrapMode::PerDevice,
+            other => {
+                tracing::warn!(
+                    "FileProvider config has unknown wrap_mode {other:?}; using master wrap"
+                );
+                return WrapMode::Master;
+            }
+        }
+    }
+    match config
+        .get("per_device_wrapping")
+        .and_then(serde_json::Value::as_bool)
+    {
+        Some(true) => WrapMode::Dual,
+        Some(false) | None => WrapMode::Master,
+    }
+}
+
 /// Build a DEVICE-AWARE `EncryptionContext` for the FileProvider read path,
 /// mirroring `tcfsd`'s `build_encryption_context`.
 ///
-/// Default-off invariant: returns `EncryptionContext::new(master_key)` verbatim
-/// unless the config explicitly sets `per_device_wrapping: true`. In that case
-/// it loads the device registry + this device's age secret and attaches them
-/// via `.with_device_wrapping`, exactly like the daemon.
+/// Default invariant: returns `EncryptionContext::new(master_key)` verbatim
+/// unless the config selects a per-device `wrap_mode` (`dual`/`per_device`, or
+/// the legacy `per_device_wrapping: true`). In that case it loads the device
+/// registry + this device's age secret and attaches them via
+/// `.with_device_wrapping`, exactly like the daemon, applying the same roll-call
+/// gate (contract `per_device` downgrades to `dual` unless every active device
+/// is per-device-capable).
 ///
 /// Like the daemon, this falls back to the master-only context (and logs why)
-/// only when per-device wrapping is enabled but the registry/recipients/secret
+/// only when a per-device mode is selected but the registry/recipients/secret
 /// are unavailable — it never produces a context that this device cannot read
 /// back. The engine's read switch independently fails CLOSED if it then meets a
-/// per-device manifest with no identity attached.
+/// per-device-only (v3) manifest with no identity attached and no master wrap.
 #[cfg(feature = "grpc")]
 pub(crate) fn build_encryption_context(
     config: &serde_json::Value,
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
 
-    // Default-off: byte-identical master-only behavior unless explicitly enabled.
-    if !config
-        .get("per_device_wrapping")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-    {
+    // Default: byte-identical master-only behavior unless a per-device mode is
+    // explicitly selected.
+    let requested = wrap_mode_from_config(config);
+    if requested == WrapMode::Master {
         return base;
     }
 
@@ -92,6 +127,29 @@ pub(crate) fn build_encryption_context(
             tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
             return base;
         }
+    };
+
+    // Roll-call gate (mirror of the daemon): refuse to contract (`per_device`)
+    // unless every active device is per-device-capable; otherwise downgrade to
+    // `dual` and warn loudly. On the read path this primarily affects writes the
+    // FileProvider performs through the engine.
+    let effective_mode = if requested == WrapMode::PerDevice {
+        if registry.per_device_roll_call_ready() {
+            WrapMode::PerDevice
+        } else {
+            let incapable = registry.per_device_incapable_active_devices();
+            tracing::warn!(
+                requested = ?WrapMode::PerDevice,
+                effective = ?WrapMode::Dual,
+                incapable_active_devices = ?incapable,
+                "ROLL-CALL GATE: per_device (contract) wrap_mode requested but not every \
+                 active device is per-device-capable (or registry is empty); refusing to \
+                 drop the master wrap. Falling back to DUAL (master wrap retained)."
+            );
+            WrapMode::Dual
+        }
+    } else {
+        requested
     };
 
     let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = registry
@@ -124,6 +182,7 @@ pub(crate) fn build_encryption_context(
     };
 
     base.with_device_wrapping(recipients, Some(identity))
+        .with_wrap_mode(effective_mode)
 }
 
 #[cfg(all(test, feature = "grpc"))]
@@ -163,10 +222,11 @@ mod tests {
         key.public_key
     }
 
-    /// Default config (per_device_wrapping absent) yields a master-only context:
+    /// Default config (wrap_mode absent) yields a master-only context:
     /// no recipients, no identity — byte-identical to `EncryptionContext::new`.
     #[test]
     fn default_config_is_master_only_byte_identical() {
+        use tcfs_core::config::WrapMode;
         let config = serde_json::json!({});
         let ctx = build_encryption_context(&config, "device-a", &master());
         assert!(
@@ -177,26 +237,63 @@ mod tests {
             ctx.device_identity.is_none(),
             "default config must not attach a device identity"
         );
+        assert_eq!(ctx.wrap_mode, WrapMode::Master);
     }
 
-    /// Explicit per_device_wrapping=false also stays master-only.
+    /// Explicit wrap_mode=master (and legacy per_device_wrapping=false) stays
+    /// master-only.
     #[test]
     fn explicit_disabled_is_master_only() {
-        let config = serde_json::json!({ "per_device_wrapping": false });
-        let ctx = build_encryption_context(&config, "device-a", &master());
+        let ctx = build_encryption_context(
+            &serde_json::json!({ "wrap_mode": "master" }),
+            "device-a",
+            &master(),
+        );
         assert!(ctx.device_recipients.is_empty());
         assert!(ctx.device_identity.is_none());
+
+        // Legacy back-compat: per_device_wrapping=false also maps to master.
+        let legacy = build_encryption_context(
+            &serde_json::json!({ "per_device_wrapping": false }),
+            "device-a",
+            &master(),
+        );
+        assert!(legacy.device_recipients.is_empty());
+        assert!(legacy.device_identity.is_none());
     }
 
-    /// When enabled with a real registry + local secret, the context carries this
-    /// device's unwrap identity and the active-device recipient set.
+    /// Legacy `per_device_wrapping: true` maps to DUAL (master wrap retained),
+    /// never silently dropping the master fallback.
+    #[test]
+    fn legacy_per_device_wrapping_true_maps_to_dual() {
+        use tcfs_core::config::WrapMode;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _pub = provision_device(tmp.path(), "device-a");
+        let config = serde_json::json!({
+            "per_device_wrapping": true,
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(
+            ctx.wrap_mode,
+            WrapMode::Dual,
+            "legacy per_device_wrapping=true must map to Dual"
+        );
+        assert_eq!(ctx.device_recipients.len(), 1);
+        assert!(ctx.device_identity.is_some());
+    }
+
+    /// When a per-device mode is set with a real registry + local secret, the
+    /// context carries this device's unwrap identity and the active-device
+    /// recipient set.
     #[test]
     fn enabled_attaches_device_identity_and_recipients() {
+        use tcfs_core::config::WrapMode;
         let tmp = tempfile::TempDir::new().unwrap();
         let _pub = provision_device(tmp.path(), "device-a");
 
         let config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
         });
         let ctx = build_encryption_context(&config, "device-a", &master());
@@ -206,6 +303,8 @@ mod tests {
             1,
             "should pick up the single active device recipient"
         );
+        // Single device with a real age key => roll-call ready => PerDevice stays.
+        assert_eq!(ctx.wrap_mode, WrapMode::PerDevice);
         let identity = ctx
             .device_identity
             .as_ref()
@@ -237,7 +336,7 @@ mod tests {
         registry.save(&registry_path).unwrap();
 
         let config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": registry_path.to_str().unwrap(),
         });
         let ctx = build_encryption_context(&config, "device-a", &master());
@@ -261,15 +360,22 @@ mod tests {
         let prefix = "test/fp-per-device";
         let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
 
-        // Build the write context from the same registry the FP read context uses.
+        // Build the write context from the same registry the FP read context
+        // uses. `per_device` (contract) drops the master wrap; the single
+        // real-age device makes the roll-call gate green so it stays PerDevice.
         let enabled_config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
         });
         let write_ctx = build_encryption_context(&enabled_config, "device-a", &master());
         assert!(
             !write_ctx.device_recipients.is_empty(),
             "precondition: write context must have recipients"
+        );
+        assert_eq!(
+            write_ctx.wrap_mode,
+            tcfs_core::config::WrapMode::PerDevice,
+            "single real-age device must pass the roll-call gate"
         );
 
         let content = b"per-device payload read through the FileProvider context";

--- a/crates/tcfs-file-provider/src/grpc_backend.rs
+++ b/crates/tcfs-file-provider/src/grpc_backend.rs
@@ -321,10 +321,12 @@ pub unsafe extern "C" fn tcfs_provider_new(config_json: *const c_char) -> *mut T
         let direct_master_key = master_key_from_config(&config);
 
         // Build the DEVICE-AWARE read context once (TIN-1417). With the default
-        // config (`per_device_wrapping` absent/false) this yields an empty
-        // recipient set and no identity — byte-identical to the prior
-        // master-only behavior. When enabled, it loads this device's age secret
-        // so per-device (`wrapped_file_keys`) manifests become readable.
+        // config (`wrap_mode` master/absent) this yields an empty recipient set
+        // and no identity — byte-identical to the prior master-only behavior.
+        // When a per-device mode is set, it loads this device's age secret so
+        // per-device (`wrapped_file_keys`) manifests become readable. Only the
+        // recipients + identity are threaded onward (this is a read-only restore
+        // path); the write-side `wrap_mode` is not consulted on read.
         let (direct_device_recipients, direct_device_identity) = match &direct_master_key {
             Some(mk) => {
                 let ctx = crate::device_ctx::build_encryption_context(&config, &device_id, mk);

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -91,6 +91,43 @@ impl DeviceRegistry {
         self.devices.iter().filter(|d| !d.revoked)
     }
 
+    /// Roll-call gate for the TIN-1417 per-device (contract) wrap mode.
+    ///
+    /// Returns the device IDs of every active (non-revoked) device that is NOT
+    /// per-device-capable — i.e. whose `public_key` is not a real, parseable age
+    /// recipient ([`is_real_age_public_key`]). An empty list means every active
+    /// device can be wrapped for, so it is safe to DROP the master wrap and emit
+    /// per-device-only (v3) manifests.
+    ///
+    /// The daemon MUST refuse to operate in `WrapMode::PerDevice` while this list
+    /// is non-empty (it would strand those devices), falling back to dual-write
+    /// instead. An empty registry (no active devices) also returns empty, but
+    /// callers should additionally require at least one recipient before
+    /// contracting — there is no point dropping the master wrap with nobody to
+    /// wrap for. See [`Self::per_device_roll_call_ready`].
+    pub fn per_device_incapable_active_devices(&self) -> Vec<String> {
+        self.active_devices()
+            .filter(|d| !is_real_age_public_key(&d.public_key))
+            .map(|d| d.device_id.clone())
+            .collect()
+    }
+
+    /// True when it is safe to operate in `WrapMode::PerDevice` (contract):
+    /// there is at least one active device AND every active device is
+    /// per-device-capable (has a real age recipient). When this is false the
+    /// daemon must fall back to `WrapMode::Dual` and warn — never silently drop
+    /// the master wrap.
+    pub fn per_device_roll_call_ready(&self) -> bool {
+        let mut any = false;
+        for device in self.active_devices() {
+            any = true;
+            if !is_real_age_public_key(&device.public_key) {
+                return false;
+            }
+        }
+        any
+    }
+
     /// Revoke a device by name
     pub fn revoke(&mut self, name: &str) -> bool {
         if let Some(device) = self.devices.iter_mut().find(|d| d.name == name) {
@@ -428,5 +465,81 @@ mod tests {
         let id = reg.enroll("xoxd-bates", "age1xoxd", Some("main server".into()));
         assert!(reg.find_by_id(&id).is_some());
         assert!(reg.find_by_id("nonexistent-uuid").is_none());
+    }
+
+    // ── TIN-1417 per-device roll-call gate ──────────────────────────────────
+
+    fn real_age_device(name: &str) -> DeviceIdentity {
+        let key = generate_local_device_key();
+        DeviceIdentity {
+            name: name.into(),
+            device_id: name.into(),
+            public_key: key.public_key,
+            signing_key_hash: String::new(),
+            description: None,
+            enrolled_at: 0,
+            revoked: false,
+            last_nats_seq: 0,
+        }
+    }
+
+    fn placeholder_device(name: &str) -> DeviceIdentity {
+        DeviceIdentity {
+            name: name.into(),
+            device_id: name.into(),
+            public_key: "age1placeholder-not-a-real-recipient".into(),
+            signing_key_hash: String::new(),
+            description: None,
+            enrolled_at: 0,
+            revoked: false,
+            last_nats_seq: 0,
+        }
+    }
+
+    #[test]
+    fn roll_call_empty_registry_is_not_ready() {
+        let reg = DeviceRegistry::default();
+        assert!(
+            !reg.per_device_roll_call_ready(),
+            "empty registry must not authorize contract mode (nobody to wrap for)"
+        );
+        assert!(reg.per_device_incapable_active_devices().is_empty());
+    }
+
+    #[test]
+    fn roll_call_ready_when_all_active_devices_are_real_age() {
+        let mut reg = DeviceRegistry::default();
+        reg.add(real_age_device("a"));
+        reg.add(real_age_device("b"));
+        assert!(reg.per_device_roll_call_ready());
+        assert!(reg.per_device_incapable_active_devices().is_empty());
+    }
+
+    #[test]
+    fn roll_call_blocked_by_a_placeholder_active_device() {
+        let mut reg = DeviceRegistry::default();
+        reg.add(real_age_device("a"));
+        reg.add(placeholder_device("b"));
+        assert!(
+            !reg.per_device_roll_call_ready(),
+            "a single non-per-device-capable active device must block the contract"
+        );
+        assert_eq!(
+            reg.per_device_incapable_active_devices(),
+            vec!["b".to_string()]
+        );
+    }
+
+    #[test]
+    fn roll_call_ignores_revoked_incapable_devices() {
+        // A revoked placeholder device must NOT block the contract — it is not
+        // an active recipient and will not be wrapped for.
+        let mut reg = DeviceRegistry::default();
+        reg.add(real_age_device("a"));
+        let mut revoked = placeholder_device("b");
+        revoked.revoked = true;
+        reg.add(revoked);
+        assert!(reg.per_device_roll_call_ready());
+        assert!(reg.per_device_incapable_active_devices().is_empty());
     }
 }

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -986,14 +986,30 @@ pub struct EncryptionContext {
     pub master_key: tcfs_crypto::MasterKey,
     /// Active-device recipients for per-device FileKey wrapping (TIN-1417).
     ///
-    /// When non-empty, writes emit per-device `wrapped_file_keys` and OMIT the
-    /// master-wrapped `encrypted_file_key`, so a device removed from this set
-    /// (revoked) cannot decrypt newly written content. Empty = legacy
-    /// shared-master behavior.
+    /// Populated for `Dual` and `PerDevice` modes. When non-empty, writes emit
+    /// per-device `wrapped_file_keys`. Whether the master wrap is ALSO emitted
+    /// is governed by [`EncryptionContext::wrap_mode`], not by emptiness of this
+    /// field. Empty = no per-device recipients available (master-only output
+    /// regardless of mode).
     pub device_recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
     /// This device's age identity, used to unwrap per-device manifests on read.
     /// `None` relies on the master-key fallback (legacy manifests).
     pub device_identity: Option<DeviceUnwrapIdentity>,
+    /// Wrap mode governing what the write path emits (TIN-1417 tri-state):
+    ///
+    /// - `Master`  — `encrypted_file_key` only (v2). DEFAULT, byte-identical to
+    ///   legacy single-wrap.
+    /// - `Dual`    — BOTH `encrypted_file_key` AND `wrapped_file_keys` (v2,
+    ///   back-compatible by construction).
+    /// - `PerDevice` — `wrapped_file_keys` only, manifest bumped to v3 so
+    ///   pre-per-device readers fail CLOSED.
+    ///
+    /// IMPORTANT: this is the effective mode AFTER the daemon's roll-call gate
+    /// has run. A caller that wants `PerDevice` but cannot prove every active
+    /// device is per-device-capable MUST downgrade this to `Dual` before
+    /// constructing the context — the engine trusts this field as authoritative
+    /// and does not re-run the roll-call.
+    pub wrap_mode: tcfs_core::config::WrapMode,
 }
 
 /// A local device's age X25519 identity for unwrapping per-device manifests.
@@ -1009,15 +1025,23 @@ pub struct DeviceUnwrapIdentity {
 #[cfg(feature = "crypto")]
 impl EncryptionContext {
     /// Legacy shared-master context: no per-device recipients or identity.
+    /// Mode defaults to [`WrapMode::Master`] — byte-identical single-wrap.
     pub fn new(master_key: tcfs_crypto::MasterKey) -> Self {
         Self {
             master_key,
             device_recipients: Vec::new(),
             device_identity: None,
+            wrap_mode: tcfs_core::config::WrapMode::Master,
         }
     }
 
     /// Attach per-device wrapping recipients and this device's unwrap identity.
+    ///
+    /// Leaves the wrap mode unchanged. Callers that want `Dual` or `PerDevice`
+    /// output set the mode explicitly via [`EncryptionContext::with_wrap_mode`]
+    /// AFTER (or alongside) this call. Note that on the WRITE path, master-only
+    /// `Master` output is still produced when `recipients` is empty even if a
+    /// non-`Master` mode is requested, because there is nobody to wrap for.
     pub fn with_device_wrapping(
         mut self,
         recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
@@ -1025,6 +1049,14 @@ impl EncryptionContext {
     ) -> Self {
         self.device_recipients = recipients;
         self.device_identity = identity;
+        self
+    }
+
+    /// Set the effective wrap mode. This is the post-roll-call mode: a caller
+    /// that requested `PerDevice` but could not prove fleet capability must pass
+    /// `Dual` here instead. See [`EncryptionContext::wrap_mode`].
+    pub fn with_wrap_mode(mut self, mode: tcfs_core::config::WrapMode) -> Self {
+        self.wrap_mode = mode;
         self
     }
 }
@@ -1849,32 +1881,62 @@ async fn upload_file_with_device_with_state(
 
     ensure_source_matches_snapshot(local_path, &snapshot, "manifest publish")?;
 
-    // Wrap the file key for the manifest. With per-device recipients (TIN-1417)
-    // we emit only per-device `wrapped_file_keys` and OMIT the master-wrapped
-    // `encrypted_file_key`, so a revoked device (absent from the recipient set)
-    // cannot decrypt new content. Without recipients we keep the legacy
-    // shared-master wrap for backward compatibility.
+    // Wrap the file key for the manifest per the TIN-1417 tri-state wrap mode:
+    //
+    // - Master    — master-wrapped `encrypted_file_key` only (v2). DEFAULT,
+    //   byte-identical to legacy single-wrap.
+    // - Dual      — BOTH `encrypted_file_key` (master, rollback + old readers)
+    //   AND per-device `wrapped_file_keys` (v2, back-compatible).
+    // - PerDevice — per-device `wrapped_file_keys` only; the master wrap is
+    //   DROPPED so a revoked device cannot decrypt new content (v3).
+    //
+    // Safety floor: if a non-`Master` mode is requested but there are no
+    // per-device recipients (nobody to wrap for), we fall CLOSED to master-only
+    // output (v2) rather than emitting a keyless or unreadable manifest. The
+    // `manifest_version` we compute below reflects the wraps actually emitted,
+    // NOT the requested mode — so a v3 manifest is produced ONLY when per-device
+    // wraps are present and the master wrap is genuinely absent.
     #[cfg(feature = "crypto")]
     let (encrypted_file_key, wrapped_file_keys) = if let (Some(ctx), Some(ref fk)) =
         (encryption, &file_key)
     {
-        if ctx.device_recipients.is_empty() {
+        use tcfs_core::config::WrapMode;
+
+        let wrap_master = || -> Result<String> {
             let wrapped =
                 tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
-            let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wrapped);
-            (Some(b64), Vec::new())
+            Ok(base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                &wrapped,
+            ))
+        };
+        let wrap_per_device = || -> Result<Vec<crate::manifest::WrappedFileKey>> {
+            Ok(
+                tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
+                    .context("wrapping file key for device recipients")?
+                    .into_iter()
+                    .map(|w| crate::manifest::WrappedFileKey {
+                        recipient_device_id: w.recipient_device_id,
+                        recipient: w.recipient,
+                        algorithm: w.algorithm,
+                        wrapped_key: w.wrapped_key,
+                    })
+                    .collect(),
+            )
+        };
+
+        // Effective mode: a non-Master mode with no recipients degrades to
+        // Master (we cannot wrap for an empty recipient set).
+        let effective = if ctx.device_recipients.is_empty() {
+            WrapMode::Master
         } else {
-            let wrapped = tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
-                .context("wrapping file key for device recipients")?
-                .into_iter()
-                .map(|w| crate::manifest::WrappedFileKey {
-                    recipient_device_id: w.recipient_device_id,
-                    recipient: w.recipient,
-                    algorithm: w.algorithm,
-                    wrapped_key: w.wrapped_key,
-                })
-                .collect();
-            (None, wrapped)
+            ctx.wrap_mode
+        };
+
+        match effective {
+            WrapMode::Master => (Some(wrap_master()?), Vec::new()),
+            WrapMode::Dual => (Some(wrap_master()?), wrap_per_device()?),
+            WrapMode::PerDevice => (None, wrap_per_device()?),
         }
     } else {
         (None, Vec::new())
@@ -1884,6 +1946,18 @@ async fn upload_file_with_device_with_state(
     let encrypted_file_key: Option<String> = None;
     #[cfg(not(feature = "crypto"))]
     let wrapped_file_keys: Vec<crate::manifest::WrappedFileKey> = Vec::new();
+
+    // Manifest version reflects the wraps actually emitted. A per-device-only
+    // manifest (per-device wraps present, master wrap dropped) is v3 so a
+    // pre-per-device reader fails CLOSED instead of misreading a
+    // v2-with-no-encrypted_file_key as keyless. Master and Dual stay v2 (Dual is
+    // back-compatible by construction — it still carries the master wrap).
+    let manifest_version: u32 =
+        if encrypted_file_key.is_none() && !wrapped_file_keys.is_empty() {
+            3
+        } else {
+            2
+        };
 
     // Capture Unix file permissions for cross-device preservation
     #[cfg(unix)]
@@ -1903,7 +1977,7 @@ async fn upload_file_with_device_with_state(
         .as_secs();
 
     let manifest = SyncManifest {
-        version: 2,
+        version: manifest_version,
         file_hash: file_hash_hex.clone(),
         file_size,
         chunks: chunk_hashes,
@@ -2247,40 +2321,97 @@ pub async fn download_file_with_device(
         });
     }
 
-    // Unwrap the file key if the manifest is encrypted. Prefer per-device wraps
-    // (TIN-1417): when present, the file key is unwrapped with this device's age
-    // identity. Manifests carrying only the legacy master-wrapped key fall back
-    // to master-key unwrap.
+    // Unwrap the file key if the manifest is encrypted. The TIN-1417 read
+    // switch handles all three on-wire shapes:
+    //
+    // - v2 master-only (`encrypted_file_key`, no `wrapped_file_keys`):
+    //   master-key unwrap (legacy path, unchanged).
+    // - v2 dual (BOTH wraps present): prefer this device's per-device wrap when
+    //   it has an age identity; otherwise FALL BACK to the master wrap. The
+    //   master wrap is the whole point of dual — a master-only / old-binary
+    //   reader must still succeed.
+    // - v3 per-device-only (`wrapped_file_keys`, no `encrypted_file_key`):
+    //   per-device unwrap REQUIRED. With no encryption context or no age
+    //   identity we fail CLOSED — there is no master wrap to fall back to, and a
+    //   v3 manifest by construction means the writer intended true revocation.
+    //
+    // A v3 manifest reaching a reader with `feature = "crypto"` disabled is
+    // already rejected upstream (chunks cannot be decrypted); the
+    // `MAX_SUPPORTED_VERSION` gate in `SyncManifest::from_bytes` additionally
+    // fails closed for any version above v3.
     #[cfg(feature = "crypto")]
     let file_key = if !manifest.wrapped_file_keys.is_empty() {
-        let ctx = encryption.ok_or_else(|| {
-            anyhow::anyhow!(
-                "manifest is per-device encrypted but no encryption context provided for: {remote_manifest}"
-            )
-        })?;
-        let identity = ctx.device_identity.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "manifest is per-device encrypted but this device has no age identity for: {remote_manifest}"
-            )
-        })?;
-        let age_wraps: Vec<tcfs_crypto::AgeWrappedFileKey> = manifest
-            .wrapped_file_keys
-            .iter()
-            .map(|w| tcfs_crypto::AgeWrappedFileKey {
-                recipient_device_id: w.recipient_device_id.clone(),
-                recipient: w.recipient.clone(),
-                algorithm: w.algorithm.clone(),
-                wrapped_key: w.wrapped_key.clone(),
+        // Per-device wraps present (v2 dual or v3 per-device-only).
+        let has_master_fallback = manifest.encrypted_file_key.is_some();
+        let device_unwrap = encryption.and_then(|ctx| {
+            ctx.device_identity.as_ref().map(|identity| {
+                let age_wraps: Vec<tcfs_crypto::AgeWrappedFileKey> = manifest
+                    .wrapped_file_keys
+                    .iter()
+                    .map(|w| tcfs_crypto::AgeWrappedFileKey {
+                        recipient_device_id: w.recipient_device_id.clone(),
+                        recipient: w.recipient.clone(),
+                        algorithm: w.algorithm.clone(),
+                        wrapped_key: w.wrapped_key.clone(),
+                    })
+                    .collect();
+                tcfs_crypto::unwrap_file_key_with_age_identity(
+                    &age_wraps,
+                    &identity.secret,
+                    Some(&identity.device_id),
+                )
+                .context("unwrapping per-device file key from manifest")
             })
-            .collect();
-        Some(
-            tcfs_crypto::unwrap_file_key_with_age_identity(
-                &age_wraps,
-                &identity.secret,
-                Some(&identity.device_id),
-            )
-            .context("unwrapping per-device file key from manifest")?,
-        )
+        });
+
+        match device_unwrap {
+            // Successfully unwrapped with this device's identity.
+            Some(Ok(fk)) => Some(fk),
+            // Had an identity but the per-device unwrap failed. If a master wrap
+            // is present (dual), fall back to it below; otherwise (v3) the
+            // failure is terminal.
+            Some(Err(e)) if !has_master_fallback => {
+                return Err(e.context(format!(
+                    "per-device manifest unwrap failed and no master wrap to fall back to: {remote_manifest}"
+                )));
+            }
+            // No identity available. For v3 (no master fallback) this is
+            // fail-closed; for dual we fall through to the master wrap.
+            None if !has_master_fallback => {
+                let _ = encryption.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "manifest is per-device encrypted but no encryption context provided for: {remote_manifest}"
+                    )
+                })?;
+                anyhow::bail!(
+                    "manifest is per-device-only (v3) but this device has no age \
+                     identity and there is no master wrap to fall back to: {remote_manifest}"
+                );
+            }
+            // Dual manifest, no identity (or unwrap failed): fall back to the
+            // master wrap handled by the `encrypted_file_key` branch below.
+            _ => {
+                let wrapped_b64 = manifest.encrypted_file_key.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "internal: dual manifest lost its master wrap during read for: {remote_manifest}"
+                    )
+                })?;
+                let ctx = encryption.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "manifest is encrypted but no encryption context provided for: {remote_manifest}"
+                    )
+                })?;
+                let wrapped = base64::Engine::decode(
+                    &base64::engine::general_purpose::STANDARD,
+                    wrapped_b64,
+                )
+                .context("decoding wrapped file key from manifest")?;
+                Some(
+                    tcfs_crypto::unwrap_key(&ctx.master_key, &wrapped)
+                        .context("unwrapping file key from manifest (dual master fallback)")?,
+                )
+            }
+        }
     } else if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
         let ctx = encryption.ok_or_else(|| {
             anyhow::anyhow!(

--- a/crates/tcfs-sync/src/manifest.rs
+++ b/crates/tcfs-sync/src/manifest.rs
@@ -116,20 +116,46 @@ impl SymlinkManifest {
 }
 
 impl SyncManifest {
-    /// Parse manifest bytes, auto-detecting v1 (text) vs v2 (JSON).
+    /// Highest regular-file manifest version this binary understands.
+    ///
+    /// v2 = vclock-era (master and/or dual wrap). v3 = per-device-only
+    /// (TIN-1417 contract: `wrapped_file_keys` present, master wrap dropped).
+    /// A regular-file manifest carrying a version ABOVE this is rejected
+    /// fail-closed so a future writer cannot trick an older reader into
+    /// misinterpreting its schema.
+    pub const MAX_SUPPORTED_VERSION: u32 = 3;
+
+    /// Parse manifest bytes, auto-detecting v1 (text) vs v2/v3 (JSON).
     ///
     /// v1 format: newline-separated chunk hashes (no JSON)
-    /// v2 format: JSON object with version field
+    /// v2 format: JSON object with version field (master and/or dual wrap)
+    /// v3 format: JSON object, per-device-only wrap (master wrap dropped)
+    ///
+    /// Fails CLOSED on a regular-file JSON manifest whose `version` exceeds
+    /// [`Self::MAX_SUPPORTED_VERSION`] (TIN-1417): a pre-per-device reader must
+    /// refuse a per-device-only v3 manifest rather than silently treating a
+    /// v2-with-no-`encrypted_file_key` as keyless. Note that symlink manifests
+    /// (also `version: 3`, but carrying `kind: symlink`) are dispatched
+    /// separately via [`SymlinkManifest::from_bytes`] and never reach here.
     pub fn from_bytes(data: &[u8]) -> anyhow::Result<Self> {
         let text = String::from_utf8(data.to_vec())
             .map_err(|e| anyhow::anyhow!("manifest is not UTF-8: {e}"))?;
 
-        // Try JSON (v2) first. JSON-shaped manifests that do not match the
+        // Try JSON (v2/v3) first. JSON-shaped manifests that do not match the
         // regular-file schema must fail closed instead of being treated as v1
         // newline manifests.
         if text.trim_start().starts_with('{') {
-            return serde_json::from_str::<SyncManifest>(&text)
-                .map_err(|e| anyhow::anyhow!("parsing regular-file manifest JSON: {e}"));
+            let manifest: SyncManifest = serde_json::from_str(&text)
+                .map_err(|e| anyhow::anyhow!("parsing regular-file manifest JSON: {e}"))?;
+            if manifest.version > Self::MAX_SUPPORTED_VERSION {
+                anyhow::bail!(
+                    "unsupported regular-file manifest version {} (this binary supports \
+                     up to v{}); refusing to read fail-closed",
+                    manifest.version,
+                    Self::MAX_SUPPORTED_VERSION
+                );
+            }
+            return Ok(manifest);
         }
 
         // Fall back to v1 text format: newline-separated chunk hashes

--- a/crates/tcfs-sync/tests/per_device_wrap_test.rs
+++ b/crates/tcfs-sync/tests/per_device_wrap_test.rs
@@ -13,6 +13,7 @@ use opendal::Operator;
 use secrecy::ExposeSecret;
 use tempfile::TempDir;
 
+use tcfs_core::config::WrapMode;
 use tcfs_crypto::AgeFileKeyRecipient;
 use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
@@ -54,8 +55,11 @@ async fn per_device_wrap_roundtrip_and_manifest_shape() {
     let (rec_a, id_a) = device("device-a");
     let (rec_b, id_b) = device("device-b");
 
+    // PerDevice (contract) mode: emit only `wrapped_file_keys`, drop the master
+    // wrap, write a v3 manifest.
     let write_ctx = EncryptionContext::new(master())
-        .with_device_wrapping(vec![rec_a, rec_b], Some(id_a.clone()));
+        .with_device_wrapping(vec![rec_a, rec_b], Some(id_a.clone()))
+        .with_wrap_mode(WrapMode::PerDevice);
 
     let content = b"per-device wrapped payload that should round-trip exactly";
     let src = tmp.path().join("doc.txt");
@@ -86,6 +90,10 @@ async fn per_device_wrap_roundtrip_and_manifest_shape() {
     assert!(
         manifest.encrypted_file_key.is_none(),
         "per-device manifest must not carry the master-wrapped key (clean-cut)"
+    );
+    assert_eq!(
+        manifest.version, 3,
+        "per-device-only (contract) manifests must be v3 so pre-per-device readers fail closed"
     );
 
     // Both recipients hydrate exact bytes.
@@ -118,8 +126,10 @@ async fn revoked_device_cannot_decrypt_new_content() {
     let (_rec_b, id_b) = device("device-b");
 
     // New content is written for the active set [A] only — B has been revoked.
-    let write_ctx =
-        EncryptionContext::new(master()).with_device_wrapping(vec![rec_a], Some(id_a.clone()));
+    // PerDevice (contract) mode drops the master wrap so B has no fallback.
+    let write_ctx = EncryptionContext::new(master())
+        .with_device_wrapping(vec![rec_a], Some(id_a.clone()))
+        .with_wrap_mode(WrapMode::PerDevice);
 
     let content = b"content written after device-b was revoked";
     let src = tmp.path().join("after-revoke.txt");

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -24,20 +24,33 @@ use tcfs_core::proto::{
 };
 use tcfs_sync::state::StateCacheBackend;
 
-/// Build an `EncryptionContext`, attaching per-device wrapping (TIN-1417) when
-/// `crypto.per_device_wrapping` is enabled and the device registry has real age
-/// recipients. Falls back to legacy shared-master wrapping (and logs why) if the
-/// registry can't be loaded, has no real recipients, or this device's age secret
-/// is missing — never producing content this device cannot read back.
+/// Build an `EncryptionContext` for the TIN-1417 tri-state `crypto.wrap_mode`.
+///
+/// - `Master` (default): legacy master-only wrap, byte-identical to the prior
+///   `per_device_wrapping=false`. Returns `EncryptionContext::new` verbatim.
+/// - `Dual`: master wrap + per-device wraps, when the registry yields real age
+///   recipients and this device's age secret is readable.
+/// - `PerDevice` (contract): per-device-only. GATED behind a roll-call probe —
+///   the daemon REFUSES to drop the master wrap unless every active
+///   (non-revoked) device is per-device-capable. When the roll-call is not
+///   green, it DOWNGRADES to `Dual` and warns loudly; it never silently drops
+///   the master wrap.
+///
+/// In all per-device modes, if the registry can't be loaded, has no real
+/// recipients, or this device's age secret is missing, it falls back to legacy
+/// shared-master wrapping (and logs why) — never producing content this device
+/// cannot read back.
 pub(crate) fn build_encryption_context(
     config: &TcfsConfig,
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
-    if !config.crypto.per_device_wrapping {
+    let requested = config.crypto.wrap_mode;
+    if requested == WrapMode::Master {
         return base;
     }
     let registry_path = config
@@ -52,6 +65,31 @@ pub(crate) fn build_encryption_context(
             return base;
         }
     };
+
+    // Roll-call code gate: the contract (PerDevice) mode drops the master wrap,
+    // which strands any active device that is not per-device-capable. Refuse to
+    // contract until every active device has a real age recipient; otherwise
+    // fall back to Dual (master wrap retained) and warn loudly.
+    let effective_mode = if requested == WrapMode::PerDevice {
+        if registry.per_device_roll_call_ready() {
+            WrapMode::PerDevice
+        } else {
+            let incapable = registry.per_device_incapable_active_devices();
+            tracing::warn!(
+                requested = ?WrapMode::PerDevice,
+                effective = ?WrapMode::Dual,
+                incapable_active_devices = ?incapable,
+                "ROLL-CALL GATE: per_device (contract) wrap_mode requested but not every \
+                 active device is per-device-capable (or registry is empty); refusing to \
+                 drop the master wrap. Falling back to DUAL (master wrap retained). Enroll \
+                 real age recipients for the listed devices to enable contract mode."
+            );
+            WrapMode::Dual
+        }
+    } else {
+        requested
+    };
+
     let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = registry
         .active_devices()
         .filter(|d| tcfs_secrets::device::is_real_age_public_key(&d.public_key))
@@ -80,6 +118,7 @@ pub(crate) fn build_encryption_context(
         }
     };
     base.with_device_wrapping(recipients, Some(identity))
+        .with_wrap_mode(effective_mode)
 }
 
 /// Implementation of the TcfsDaemon gRPC service


### PR DESCRIPTION
## DRAFT — agent-drafted, needs review

Implements the ratified TIN-1417 decision: replace the shipped-but-never-flipped `crypto.per_device_wrapping: bool` (v0.12.14, default false, set true nowhere live) with a tri-state `crypto.wrap_mode { master | dual | per_device }`, default `master`.

### Semantics
| `wrap_mode` | Manifest carries | Version | Phase |
|---|---|---|---|
| `master` (DEFAULT) | `encrypted_file_key` only | v2 | baseline — **byte-identical** to `per_device_wrapping=false` |
| `dual` | BOTH `encrypted_file_key` AND `wrapped_file_keys` | v2 | EXPAND (back-compatible) |
| `per_device` | `wrapped_file_keys` only (master wrap dropped) | **v3** | CONTRACT (true revocation; pre-per-device readers fail CLOSED) |

### Back-compat
A legacy `per_device_wrapping` config key still deserializes: `true` -> `dual` (keeps the master fallback — never silently dropped), `false`/absent -> `master`. `wrap_mode` wins when both are present. `CryptoConfig` now has a hand-written `Deserialize` (tolerates unknown keys; no `deny_unknown_fields`).

### Roll-call code gate
The daemon, CLI, and FileProvider REFUSE to operate in `per_device` (contract) until `DeviceRegistry::per_device_roll_call_ready()` confirms every active (non-revoked) device has a real age recipient. Otherwise they DOWNGRADE to `dual` and warn loudly — they never silently drop the master wrap. There is also a write-path safety floor: a non-`master` mode with zero recipients falls closed to master-only v2 output.

### Readers/writers rewired off the old bool
- `crates/tcfsd/src/grpc.rs` `build_encryption_context` (canonical roll-call gate)
- `crates/tcfs-cli/src/main.rs` `build_encryption_context` + `build_fileprovider_init_config` (emits `wrap_mode`)
- `crates/tcfs-file-provider/src/device_ctx.rs` (`wrap_mode_from_config` with `per_device_wrapping` back-compat + roll-call gate)
- `crates/tcfs-sync/src/engine.rs` write path (tri-state wrap + manifest-version selection) and read switch (v2 master/dual with master fallback, v3 per-device fail-closed)
- `crates/tcfs-sync/src/manifest.rs` `from_bytes` rejects regular-file versions above v3 fail-closed (`MAX_SUPPORTED_VERSION`)
- `EncryptionContext` gains a `wrap_mode` field (post-roll-call effective mode) + `with_wrap_mode` builder

### Manifest v3 namespace note (reviewer attention)
The merged symlink work (#491) already uses `version: 3` for symlinks, discriminated by `kind: symlink`. Regular-file per-device v3 manifests have no `kind` field and dispatch through `SyncManifest::from_bytes`; symlink v3 manifests dispatch first via `SymlinkManifest::from_bytes` (requires `version==3 && kind==symlink`). The two are structurally unambiguous, but any future v3 regular-file schema change must preserve the no-`kind` discriminator.

### Verification
All affected-crate tests pass with correctly-scoped features (`tcfs-sync --features crypto`, `tcfs-file-provider --no-default-features --features grpc`; `--all-features` is unrelated-blocked by a `librocksdb-sys` C build failure in this sandbox):
- tcfs-core 15 passed (incl. wrap_mode back-compat: legacy true->dual, false->master, wrap_mode wins, unknown-key tolerance, snake_case serialization)
- tcfs-secrets 26 passed (incl. roll-call gate: empty-not-ready, all-real-ready, placeholder-blocks, revoked-ignored)
- tcfs-sync crypto: `per_device_wrap_roundtrip_and_manifest_shape` (asserts v3 + per-device-only), `revoked_device_cannot_decrypt_new_content`, full unit + symlink/conflict/blacklist suites
- tcfs-file-provider grpc: 8 device_ctx tests incl. byte-identical default, legacy->dual, roll-call-green per_device, per-device read + fail-closed, master regression guard

### Guardrails honored
No merge. No flip — `wrap_mode` defaults to `master` everywhere; nothing sets it to `dual`/`per_device` in shipped config. No fleet mutation. Master mode is byte-identical to today. Fail CLOSED throughout. Commit GPG-signed; no AI attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
