### PR TITLE
DRAFT: TIN-1417 tri-state crypto.wrap_mode migration (agent-drafted, needs review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ Current release-proof posture is tracked in `docs/release/evidence/` and
 `docs/ops/product-reality-and-priority.md`; older entries below may describe
 historical release intent rather than the current supported/proven surface.
 
+## [Unreleased]
+
+### Changed
+
+- **Per-device file-key wrapping is now a tri-state `crypto.wrap_mode`**
+  (TIN-1417, replaces the `crypto.per_device_wrapping` boolean). Values:
+  `master` (DEFAULT — shared-master wrap, byte-identical to the previous
+  default), `dual` (EXPAND/transitional — emits BOTH the master wrap and
+  per-device wraps; manifest stays v2 and back-compatible), and `per_device`
+  (CONTRACT — emits per-device wraps ONLY, drops the master wrap for true
+  revocation, and bumps the manifest to v3 so pre-per-device binaries fail
+  CLOSED). Back-compat: a legacy `crypto.per_device_wrapping = true` config
+  deserializes to `dual` (keeps the master fallback); `false`/absent maps to
+  `master`. A present `wrap_mode` is canonical and wins. The daemon REFUSES to
+  drop the master wrap (`per_device`) until a roll-call probe confirms every
+  active, non-revoked device carries a real age recipient; otherwise it falls
+  back to `dual` and warns loudly. Default remains `master`, so existing fleets
+  are unaffected until the migration is explicitly enabled.
+
 ## [0.12.14] - 2026-06-03
 
 First finalized release of the 0.12.13→0.12.14 line (0.12.13 shipped only as

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1100,20 +1100,29 @@ fn resolve_sync_status_lookup_path(path: &Path) -> Result<PathBuf> {
     std::fs::canonicalize(path).map_err(Into::into)
 }
 
-/// Build an `EncryptionContext`, attaching per-device wrapping (TIN-1417) when
-/// `crypto.per_device_wrapping` is enabled and the device registry has real age
-/// recipients. Falls back to legacy shared-master wrapping (logging why) if the
-/// registry can't be loaded, has no real recipients, or this device's age secret
-/// is missing — never producing content this device cannot read back.
+/// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
+///
+/// Mirrors the daemon's `build_encryption_context`:
+/// - `Master` (default): legacy shared-master wrap (byte-identical to before).
+/// - `Dual`: master wrap + per-device wraps (requires a real recipient set).
+/// - `PerDevice`: per-device-only wrap, gated behind a roll-call probe — refused
+///   (and downgraded to `Dual` + a loud warning) unless EVERY active device has
+///   a real age recipient.
+///
+/// Falls back to master (logging why) whenever the registry can't be loaded, has
+/// no real recipients, or this device's age secret is missing — never producing
+/// content this device cannot read back.
 fn build_encryption_context(
     config: &tcfs_core::config::TcfsConfig,
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
-    if !config.crypto.per_device_wrapping {
+    let requested = config.crypto.wrap_mode;
+    if requested == WrapMode::Master {
         return base;
     }
     let registry_path = config
@@ -1124,7 +1133,9 @@ fn build_encryption_context(
     let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
+            tracing::warn!(
+                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+            );
             return base;
         }
     };
@@ -1138,7 +1149,7 @@ fn build_encryption_context(
         .collect();
     if recipients.is_empty() {
         tracing::warn!(
-            "per-device wrapping enabled but no active age recipients; using master wrap"
+            "wrap_mode={requested:?} enabled but no active age recipients; using master wrap"
         );
         return base;
     }
@@ -1150,12 +1161,38 @@ fn build_encryption_context(
         },
         Err(e) => {
             tracing::warn!(
-                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+                "wrap_mode={requested:?}: local device secret unreadable ({e}); using master wrap"
             );
             return base;
         }
     };
-    base.with_device_wrapping(recipients, Some(identity))
+    let effective = resolve_wrap_mode_with_roll_call(requested, &registry);
+    base.with_wrap_mode(effective, recipients, Some(identity))
+}
+
+/// Apply the roll-call gate to a requested wrap mode (CLI mirror of the daemon's
+/// gate). `PerDevice` downgrades to `Dual` (with a loud warning) unless every
+/// active device carries a real age recipient.
+fn resolve_wrap_mode_with_roll_call(
+    requested: tcfs_core::config::WrapMode,
+    registry: &tcfs_secrets::device::DeviceRegistry,
+) -> tcfs_core::config::WrapMode {
+    use tcfs_core::config::WrapMode;
+    if requested != WrapMode::PerDevice {
+        return requested;
+    }
+    let roll_call = registry.roll_call();
+    if roll_call.all_capable() {
+        return WrapMode::PerDevice;
+    }
+    tracing::warn!(
+        active = roll_call.active,
+        capable = roll_call.capable,
+        blockers = ?roll_call.incapable_devices,
+        "wrap_mode=PerDevice REFUSED by roll-call gate: not every active device has a real \
+         age recipient; falling back to Dual (keeping the master wrap)."
+    );
+    WrapMode::Dual
 }
 
 // ── `tcfs push` ───────────────────────────────────────────────────────────────
@@ -3896,27 +3933,28 @@ struct FileProviderInitConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     daemon_socket: Option<String>,
     master_key_file: String,
-    /// Per-device file-key wrapping (TIN-1417 / Track B1). Mirrors
-    /// `crypto.per_device_wrapping` from the active config. The FileProvider
-    /// extension reads this key to decide whether to build a device-aware
-    /// `EncryptionContext` (see `tcfs-file-provider` `device_ctx`). Omitted
-    /// from the rendered JSON when false so the default-off output stays
-    /// byte-identical to the legacy master-only bootstrap.
-    #[serde(skip_serializing_if = "is_false")]
-    per_device_wrapping: bool,
+    /// File-key wrap mode (TIN-1417). Mirrors `crypto.wrap_mode` from the active
+    /// config. The FileProvider extension reads this key to decide whether to
+    /// build a device-aware `EncryptionContext` (see `tcfs-file-provider`
+    /// `device_ctx`). Omitted from the rendered JSON when `Master` (the default)
+    /// so the default-off output stays byte-identical to the legacy master-only
+    /// bootstrap.
+    #[serde(skip_serializing_if = "is_master_wrap_mode")]
+    wrap_mode: tcfs_core::config::WrapMode,
     /// Path to the device registry (`devices.json`) the FileProvider must read
     /// to resolve active age recipients + this device's secret
-    /// (`device-<id>.age` alongside it). Only emitted when
-    /// `per_device_wrapping` is true; the extension otherwise falls back to its
-    /// own default registry path.
+    /// (`device-<id>.age` alongside it). Only emitted when `wrap_mode` is not
+    /// `Master`; the extension otherwise falls back to its own default registry
+    /// path.
     #[serde(skip_serializing_if = "Option::is_none")]
     device_registry_path: Option<String>,
 }
 
-/// `skip_serializing_if` predicate so `per_device_wrapping` is omitted from the
-/// rendered FileProvider JSON when off, keeping default-off output unchanged.
-fn is_false(value: &bool) -> bool {
-    !*value
+/// `skip_serializing_if` predicate so `wrap_mode` is omitted from the rendered
+/// FileProvider JSON when it is the default `Master`, keeping default-off output
+/// byte-identical to the legacy bootstrap.
+fn is_master_wrap_mode(value: &tcfs_core::config::WrapMode) -> bool {
+    *value == tcfs_core::config::WrapMode::Master
 }
 
 fn build_fileprovider_init_config(
@@ -3925,17 +3963,19 @@ fn build_fileprovider_init_config(
     master_key_path: &Path,
     device_id: &str,
 ) -> FileProviderInitConfig {
-    let per_device_wrapping = config.crypto.per_device_wrapping;
-    // Only surface the device registry path when per-device wrapping is on, so
-    // the default-off rendered JSON is byte-identical to the legacy bootstrap.
-    let device_registry_path = if per_device_wrapping {
+    use tcfs_core::config::WrapMode;
+    let wrap_mode = config.crypto.wrap_mode;
+    // Only surface the device registry path when per-device wrapping is involved
+    // (Dual/PerDevice), so the default-off rendered JSON is byte-identical to the
+    // legacy bootstrap.
+    let device_registry_path = if wrap_mode == WrapMode::Master {
+        None
+    } else {
         Some(
             resolve_fileprovider_registry_path(config)
                 .to_string_lossy()
                 .into_owned(),
         )
-    } else {
-        None
     };
     FileProviderInitConfig {
         s3_endpoint: config.storage.endpoint.clone(),
@@ -3951,7 +3991,7 @@ fn build_fileprovider_init_config(
             .as_ref()
             .map(|path| path.to_string_lossy().into_owned()),
         master_key_file: master_key_path.to_string_lossy().into_owned(),
-        per_device_wrapping,
+        wrap_mode,
         device_registry_path,
     }
 }
@@ -5911,12 +5951,12 @@ mod tests {
 
     #[test]
     fn build_fileprovider_init_config_omits_per_device_keys_when_disabled() {
-        // Default-off must stay byte-identical to the legacy master-only
-        // bootstrap: the per-device keys are absent from the rendered JSON.
+        // Default-off (wrap_mode = Master) must stay byte-identical to the legacy
+        // master-only bootstrap: the per-device keys are absent from the JSON.
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path());
-        assert!(!config.crypto.per_device_wrapping);
-        // Even with a registry path configured, off => not emitted.
+        assert_eq!(config.crypto.wrap_mode, tcfs_core::config::WrapMode::Master);
+        // Even with a registry path configured, Master => not emitted.
         config.sync.device_identity = Some(dir.path().join("devices.json"));
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5928,14 +5968,18 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(!rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, tcfs_core::config::WrapMode::Master);
         assert_eq!(rendered.device_registry_path, None);
 
         let json = serde_json::to_value(&rendered).unwrap();
         let obj = json.as_object().unwrap();
         assert!(
+            !obj.contains_key("wrap_mode"),
+            "wrap_mode must be omitted when Master (byte-identical default)"
+        );
+        assert!(
             !obj.contains_key("per_device_wrapping"),
-            "per_device_wrapping must be omitted when off (byte-identical default)"
+            "legacy per_device_wrapping key must never be emitted"
         );
         assert!(
             !obj.contains_key("device_registry_path"),
@@ -5945,13 +5989,13 @@ mod tests {
 
     #[test]
     fn build_fileprovider_init_config_emits_per_device_keys_when_enabled() {
-        // When per-device wrapping is on, the rendered FileProvider config must
-        // carry the keys PR #492's read path consumes: `per_device_wrapping`
-        // (true) and `device_registry_path` (the configured registry).
+        // When wrap_mode is non-Master, the rendered FileProvider config must
+        // carry the keys the read path consumes: `wrap_mode` and
+        // `device_registry_path` (the configured registry).
         let dir = tempfile::tempdir().unwrap();
         let registry_path = dir.path().join("devices.json");
         let mut config = test_config(dir.path());
-        config.crypto.per_device_wrapping = true;
+        config.crypto.wrap_mode = tcfs_core::config::WrapMode::PerDevice;
         config.sync.device_identity = Some(registry_path.clone());
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5963,17 +6007,46 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, tcfs_core::config::WrapMode::PerDevice);
         assert_eq!(
             rendered.device_registry_path.as_deref(),
             Some(registry_path.to_string_lossy().as_ref())
         );
 
         let json = serde_json::to_value(&rendered).unwrap();
-        assert_eq!(json["per_device_wrapping"], serde_json::Value::Bool(true));
+        assert_eq!(
+            json["wrap_mode"],
+            serde_json::Value::String("per_device".to_string())
+        );
         assert_eq!(
             json["device_registry_path"].as_str(),
             Some(registry_path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn build_fileprovider_init_config_emits_dual_wrap_mode() {
+        // Dual must also surface the registry path and emit wrap_mode = "dual".
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("devices.json");
+        let mut config = test_config(dir.path());
+        config.crypto.wrap_mode = tcfs_core::config::WrapMode::Dual;
+        config.sync.device_identity = Some(registry_path.clone());
+
+        let s3 = tcfs_secrets::S3Credentials {
+            access_key_id: "access-key".into(),
+            secret_access_key: secrecy::SecretString::from("secret-key".to_string()),
+            endpoint: config.storage.endpoint.clone(),
+            region: config.storage.region.clone(),
+        };
+        let master_key_path = dir.path().join("master.key");
+        let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
+
+        assert_eq!(rendered.wrap_mode, tcfs_core::config::WrapMode::Dual);
+        let json = serde_json::to_value(&rendered).unwrap();
+        assert_eq!(
+            json["wrap_mode"],
+            serde_json::Value::String("dual".to_string())
         );
     }
 
@@ -5983,7 +6056,7 @@ mod tests {
         // default registry path (matching the extension's own fallback).
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path());
-        config.crypto.per_device_wrapping = true;
+        config.crypto.wrap_mode = tcfs_core::config::WrapMode::PerDevice;
         config.sync.device_identity = None;
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5995,7 +6068,7 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, tcfs_core::config::WrapMode::PerDevice);
         assert_eq!(
             rendered.device_registry_path,
             Some(

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -307,8 +307,46 @@ pub struct FuseConfig {
     pub cache_max_mb: u64,
 }
 
-/// E2E encryption configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// File-key wrap mode (TIN-1417 migration).
+///
+/// Controls how a regular file's per-file key is wrapped in its manifest. This
+/// replaces the legacy boolean `per_device_wrapping`. The three states form an
+/// EXPAND / CONTRACT migration ladder:
+///
+/// - [`WrapMode::Master`] (DEFAULT): wrap ONLY under the shared master key
+///   (`encrypted_file_key`). Byte-identical to the legacy default
+///   (`per_device_wrapping = false`). Any master/old-binary reader can decrypt.
+/// - [`WrapMode::Dual`] (EXPAND / transitional): emit BOTH the master wrap
+///   (`encrypted_file_key`, for rollback + master/old-binary readers) AND the
+///   per-device wraps (`wrapped_file_keys`). Stays manifest **version 2** and is
+///   back-compatible by construction. Safe to roll the fleet through.
+/// - [`WrapMode::PerDevice`] (CONTRACT): emit ONLY the per-device wraps and DROP
+///   the master wrap — true revocation. Bumps the manifest to **version 3** so
+///   pre-per-device binaries fail CLOSED instead of misreading a
+///   v2-with-no-`encrypted_file_key` as keyless. The daemon refuses to write
+///   PerDevice until a roll-call probe confirms every active (non-revoked)
+///   device has a real age recipient; until then it falls back to `Dual` and
+///   warns loudly (never silently drops the master wrap).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WrapMode {
+    /// Master-only wrap. Legacy default; byte-identical to `per_device_wrapping = false`.
+    #[default]
+    Master,
+    /// Transitional dual wrap: master wrap + per-device wraps (manifest v2).
+    Dual,
+    /// Per-device-only wrap, drops the master wrap (manifest v3, true revocation).
+    PerDevice,
+}
+
+/// E2E encryption configuration.
+///
+/// `Deserialize` is hand-written (rather than derived) so that the legacy
+/// boolean `per_device_wrapping` key still parses for back-compat: `true` maps
+/// to [`WrapMode::Dual`] (keeps the master fallback — safe), `false`/absent maps
+/// to [`WrapMode::Master`]. A present `wrap_mode` key always wins. Going forward
+/// `wrap_mode` is canonical and the only key serialized.
+#[derive(Debug, Clone, Serialize)]
 #[serde(default)]
 pub struct CryptoConfig {
     /// Enable client-side encryption (default: false until key is set up)
@@ -329,12 +367,11 @@ pub struct CryptoConfig {
     /// Generated once per vault. If unset and passphrase_file is used, a random
     /// salt is generated and must be persisted by the caller.
     pub kdf_salt: Option<String>,
-    /// Wrap file keys per-device (age/X25519) for non-revoked devices instead of
-    /// under the shared master key (TIN-1417). When true, new manifests carry
-    /// `wrapped_file_keys` and omit `encrypted_file_key`, so a revoked device
-    /// cannot decrypt newly written content. Default false (legacy shared-master)
-    /// until a fleet has real per-device identities enrolled.
-    pub per_device_wrapping: bool,
+    /// File-key wrap mode (TIN-1417). Default [`WrapMode::Master`] (legacy
+    /// shared-master). See [`WrapMode`] for the EXPAND/CONTRACT semantics. A
+    /// legacy `per_device_wrapping = true` config deserializes to
+    /// [`WrapMode::Dual`]; `false`/absent to [`WrapMode::Master`].
+    pub wrap_mode: WrapMode,
 }
 
 impl Default for CryptoConfig {
@@ -348,8 +385,77 @@ impl Default for CryptoConfig {
             device_identity: None,
             passphrase_file: None,
             kdf_salt: None,
-            per_device_wrapping: false,
+            wrap_mode: WrapMode::Master,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for CryptoConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Shadow struct mirrors the serialized shape but additionally accepts the
+        // legacy `per_device_wrapping` boolean. `wrap_mode`, when present, wins.
+        #[derive(Deserialize)]
+        #[serde(default)]
+        struct CryptoConfigShadow {
+            enabled: bool,
+            argon2_mem_cost_kib: u32,
+            argon2_time_cost: u32,
+            argon2_parallelism: u32,
+            master_key_file: Option<PathBuf>,
+            device_identity: Option<PathBuf>,
+            passphrase_file: Option<PathBuf>,
+            kdf_salt: Option<String>,
+            /// Canonical key. `None` when absent so the legacy key can decide.
+            wrap_mode: Option<WrapMode>,
+            /// Legacy back-compat key (TIN-1417). `true` -> Dual, `false`/absent -> Master.
+            per_device_wrapping: Option<bool>,
+        }
+
+        impl Default for CryptoConfigShadow {
+            fn default() -> Self {
+                let base = CryptoConfig::default();
+                Self {
+                    enabled: base.enabled,
+                    argon2_mem_cost_kib: base.argon2_mem_cost_kib,
+                    argon2_time_cost: base.argon2_time_cost,
+                    argon2_parallelism: base.argon2_parallelism,
+                    master_key_file: base.master_key_file,
+                    device_identity: base.device_identity,
+                    passphrase_file: base.passphrase_file,
+                    kdf_salt: base.kdf_salt,
+                    wrap_mode: None,
+                    per_device_wrapping: None,
+                }
+            }
+        }
+
+        let shadow = CryptoConfigShadow::deserialize(deserializer)?;
+
+        // Precedence: an explicit `wrap_mode` wins. Otherwise map the legacy
+        // `per_device_wrapping` boolean (true -> Dual, keeps the master fallback;
+        // false/absent -> Master). Default is Master.
+        let wrap_mode = match shadow.wrap_mode {
+            Some(mode) => mode,
+            None => match shadow.per_device_wrapping {
+                Some(true) => WrapMode::Dual,
+                Some(false) | None => WrapMode::Master,
+            },
+        };
+
+        Ok(CryptoConfig {
+            enabled: shadow.enabled,
+            argon2_mem_cost_kib: shadow.argon2_mem_cost_kib,
+            argon2_time_cost: shadow.argon2_time_cost,
+            argon2_parallelism: shadow.argon2_parallelism,
+            master_key_file: shadow.master_key_file,
+            device_identity: shadow.device_identity,
+            passphrase_file: shadow.passphrase_file,
+            kdf_salt: shadow.kdf_salt,
+            wrap_mode,
+        })
     }
 }
 
@@ -631,5 +737,86 @@ require_session = false
     fn auth_defaults_when_omitted() {
         let config: TcfsConfig = toml::from_str("").unwrap();
         assert!(config.auth.require_session);
+    }
+
+    // ── TIN-1417: crypto.wrap_mode tri-state + legacy back-compat ──────────
+
+    #[test]
+    fn wrap_mode_defaults_to_master() {
+        let config: TcfsConfig = toml::from_str("").unwrap();
+        assert_eq!(
+            config.crypto.wrap_mode,
+            WrapMode::Master,
+            "wrap_mode must default to Master (byte-identical to legacy default)"
+        );
+        // Empty [crypto] section must also default to Master.
+        let config: TcfsConfig = toml::from_str("[crypto]\n").unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn wrap_mode_explicit_values_parse() {
+        for (s, expected) in [
+            ("master", WrapMode::Master),
+            ("dual", WrapMode::Dual),
+            ("per_device", WrapMode::PerDevice),
+        ] {
+            let toml_str = format!("[crypto]\nwrap_mode = \"{s}\"\n");
+            let config: TcfsConfig = toml::from_str(&toml_str).unwrap();
+            assert_eq!(config.crypto.wrap_mode, expected, "wrap_mode = {s}");
+        }
+    }
+
+    #[test]
+    fn legacy_per_device_wrapping_true_maps_to_dual() {
+        // true -> Dual keeps the master fallback (safe transitional mode).
+        let toml_str = "[crypto]\nper_device_wrapping = true\n";
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.crypto.wrap_mode,
+            WrapMode::Dual,
+            "legacy per_device_wrapping = true must map to Dual (keeps master fallback)"
+        );
+    }
+
+    #[test]
+    fn legacy_per_device_wrapping_false_maps_to_master() {
+        let toml_str = "[crypto]\nper_device_wrapping = false\n";
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn explicit_wrap_mode_wins_over_legacy_key() {
+        // When both keys are present, wrap_mode is canonical and wins.
+        let toml_str = "[crypto]\nwrap_mode = \"per_device\"\nper_device_wrapping = false\n";
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.crypto.wrap_mode,
+            WrapMode::PerDevice,
+            "explicit wrap_mode must win over a conflicting legacy per_device_wrapping"
+        );
+
+        let toml_str = "[crypto]\nwrap_mode = \"master\"\nper_device_wrapping = true\n";
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn wrap_mode_serializes_canonically() {
+        // Going forward only wrap_mode is emitted (snake_case); never the legacy key.
+        let config = CryptoConfig {
+            wrap_mode: WrapMode::PerDevice,
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&config).unwrap();
+        assert!(
+            toml_str.contains("wrap_mode = \"per_device\""),
+            "serialized config must emit canonical wrap_mode: {toml_str}"
+        );
+        assert!(
+            !toml_str.contains("per_device_wrapping"),
+            "serialized config must not emit the legacy key: {toml_str}"
+        );
     }
 }

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -17,13 +17,17 @@
 //! carry. See PR body for details.
 //!
 //! BEHAVIOR CONTRACT (must stay true):
-//! - When `per_device_wrapping` is absent/false in the config (the default),
+//! - When `wrap_mode` is absent or `master` in the config (the default),
 //!   `build_encryption_context` returns exactly `EncryptionContext::new(mk)` —
 //!   byte-identical to the prior master-only behavior. Master-only manifests
-//!   read unchanged.
+//!   read unchanged. (The legacy `per_device_wrapping` boolean is still accepted
+//!   as an alias: `true` -> `dual`, `false`/absent -> `master`.)
 //! - When a per-device manifest is encountered without an available device
 //!   identity, the engine read switch fails CLOSED (clear error); we never
 //!   silently master-fall-back, and we never copy raw ciphertext to disk.
+//! - The `PerDevice` (CONTRACT) mode is gated behind the same roll-call probe as
+//!   the daemon: it is downgraded to `Dual` unless every active device carries a
+//!   real age recipient.
 
 /// Fail CLOSED when a manifest that this backend cannot decrypt would otherwise
 /// be copied to disk as raw ciphertext (silent corruption).
@@ -48,16 +52,47 @@ pub(crate) fn ensure_master_decryptable(
     Ok(())
 }
 
+/// Resolve the requested `wrap_mode` from an FP init-config JSON blob (TIN-1417).
+///
+/// Canonical key is `wrap_mode` (`"master" | "dual" | "per_device"`). The legacy
+/// boolean `per_device_wrapping` is still accepted as an alias (`true` -> Dual,
+/// `false`/absent -> Master); a present `wrap_mode` wins. Mirrors the
+/// `CryptoConfig` deserialize back-compat rule.
+#[cfg(feature = "grpc")]
+fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapMode {
+    use tcfs_core::config::WrapMode;
+    if let Some(raw) = config.get("wrap_mode").and_then(serde_json::Value::as_str) {
+        return match raw {
+            "master" => WrapMode::Master,
+            "dual" => WrapMode::Dual,
+            "per_device" => WrapMode::PerDevice,
+            other => {
+                tracing::warn!("unknown wrap_mode {other:?} in FileProvider config; using master");
+                WrapMode::Master
+            }
+        };
+    }
+    match config
+        .get("per_device_wrapping")
+        .and_then(serde_json::Value::as_bool)
+    {
+        Some(true) => WrapMode::Dual,
+        Some(false) | None => WrapMode::Master,
+    }
+}
+
 /// Build a DEVICE-AWARE `EncryptionContext` for the FileProvider read path,
 /// mirroring `tcfsd`'s `build_encryption_context`.
 ///
 /// Default-off invariant: returns `EncryptionContext::new(master_key)` verbatim
-/// unless the config explicitly sets `per_device_wrapping: true`. In that case
-/// it loads the device registry + this device's age secret and attaches them
-/// via `.with_device_wrapping`, exactly like the daemon.
+/// unless the config selects a non-`Master` `wrap_mode` (or the legacy
+/// `per_device_wrapping: true` alias). In that case it loads the device registry
+/// plus this device's age secret and attaches them, like the daemon, and applies
+/// the same roll-call gate (PerDevice downgrades to Dual unless every active
+/// device has a real age recipient).
 ///
 /// Like the daemon, this falls back to the master-only context (and logs why)
-/// only when per-device wrapping is enabled but the registry/recipients/secret
+/// only when per-device wrapping is requested but the registry/recipients/secret
 /// are unavailable — it never produces a context that this device cannot read
 /// back. The engine's read switch independently fails CLOSED if it then meets a
 /// per-device manifest with no identity attached.
@@ -67,16 +102,14 @@ pub(crate) fn build_encryption_context(
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
 
     // Default-off: byte-identical master-only behavior unless explicitly enabled.
-    if !config
-        .get("per_device_wrapping")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-    {
+    let requested = wrap_mode_from_config(config);
+    if requested == WrapMode::Master {
         return base;
     }
 
@@ -89,7 +122,9 @@ pub(crate) fn build_encryption_context(
     let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
+            tracing::warn!(
+                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+            );
             return base;
         }
     };
@@ -104,7 +139,7 @@ pub(crate) fn build_encryption_context(
         .collect();
     if recipients.is_empty() {
         tracing::warn!(
-            "per-device wrapping enabled but no active age recipients; using master wrap"
+            "wrap_mode={requested:?} enabled but no active age recipients; using master wrap"
         );
         return base;
     }
@@ -117,13 +152,33 @@ pub(crate) fn build_encryption_context(
         },
         Err(e) => {
             tracing::warn!(
-                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+                "wrap_mode={requested:?}: local device secret unreadable ({e}); using master wrap"
             );
             return base;
         }
     };
 
-    base.with_device_wrapping(recipients, Some(identity))
+    // Roll-call gate: refuse PerDevice (drop master wrap) unless every active
+    // device is per-device-capable; otherwise degrade to Dual + warn.
+    let effective = if requested == WrapMode::PerDevice {
+        let roll_call = registry.roll_call();
+        if roll_call.all_capable() {
+            WrapMode::PerDevice
+        } else {
+            tracing::warn!(
+                active = roll_call.active,
+                capable = roll_call.capable,
+                blockers = ?roll_call.incapable_devices,
+                "wrap_mode=PerDevice REFUSED by roll-call gate; falling back to Dual \
+                 (keeping the master wrap)"
+            );
+            WrapMode::Dual
+        }
+    } else {
+        requested
+    };
+
+    base.with_wrap_mode(effective, recipients, Some(identity))
 }
 
 #[cfg(all(test, feature = "grpc"))]
@@ -179,27 +234,50 @@ mod tests {
         );
     }
 
-    /// Explicit per_device_wrapping=false also stays master-only.
+    /// Explicit wrap_mode=master also stays master-only.
     #[test]
     fn explicit_disabled_is_master_only() {
+        let config = serde_json::json!({ "wrap_mode": "master" });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert!(ctx.device_recipients.is_empty());
+        assert!(ctx.device_identity.is_none());
+        // Legacy alias: per_device_wrapping=false also stays master-only.
         let config = serde_json::json!({ "per_device_wrapping": false });
         let ctx = build_encryption_context(&config, "device-a", &master());
         assert!(ctx.device_recipients.is_empty());
         assert!(ctx.device_identity.is_none());
     }
 
-    /// When enabled with a real registry + local secret, the context carries this
-    /// device's unwrap identity and the active-device recipient set.
+    /// Legacy `per_device_wrapping = true` maps to Dual (keeps the master
+    /// fallback) and still attaches recipients + this device's identity.
+    #[test]
+    fn legacy_per_device_wrapping_true_attaches_dual_context() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _pub = provision_device(tmp.path(), "device-a");
+        let config = serde_json::json!({
+            "per_device_wrapping": true,
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(ctx.wrap_mode, tcfs_sync::engine::WrapMode::Dual);
+        assert_eq!(ctx.device_recipients.len(), 1);
+        assert!(ctx.device_identity.is_some());
+    }
+
+    /// When wrap_mode=per_device with a real registry + local secret, the context
+    /// carries this device's unwrap identity and the active-device recipient set,
+    /// and (roll-call satisfied) stays in PerDevice.
     #[test]
     fn enabled_attaches_device_identity_and_recipients() {
         let tmp = tempfile::TempDir::new().unwrap();
         let _pub = provision_device(tmp.path(), "device-a");
 
         let config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
         });
         let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(ctx.wrap_mode, tcfs_sync::engine::WrapMode::PerDevice);
 
         assert_eq!(
             ctx.device_recipients.len(),
@@ -237,7 +315,7 @@ mod tests {
         registry.save(&registry_path).unwrap();
 
         let config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": registry_path.to_str().unwrap(),
         });
         let ctx = build_encryption_context(&config, "device-a", &master());
@@ -263,7 +341,7 @@ mod tests {
 
         // Build the write context from the same registry the FP read context uses.
         let enabled_config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
         });
         let write_ctx = build_encryption_context(&enabled_config, "device-a", &master());

--- a/crates/tcfs-file-provider/src/grpc_backend.rs
+++ b/crates/tcfs-file-provider/src/grpc_backend.rs
@@ -239,15 +239,25 @@ async fn fetch_direct_to_file(
             .with_context(|| format!("resolving manifest for: {remote_path}"))?;
 
     // Build the read context with this device's unwrap identity attached
-    // (TIN-1417). With the default config `device_recipients` is empty and
-    // `device_identity` is None, so `with_device_wrapping` is a no-op and this
-    // equals the prior `EncryptionContext::new(mk)` exactly (byte-identical for
-    // master-only manifests). When a per-device (`wrapped_file_keys`) manifest
-    // is read, the engine's read switch fails CLOSED with a clear error if no
+    // (TIN-1417). This is a READ path, so `wrap_mode` (which only drives the
+    // write path) is immaterial here — the engine's read switch branches on the
+    // manifest's own shape (`wrapped_file_keys` vs `encrypted_file_key`). With
+    // the default config `device_recipients` is empty and `device_identity` is
+    // None, so this equals `EncryptionContext::new(mk)` (byte-identical for
+    // master-only manifests). When a per-device (`wrapped_file_keys`) manifest is
+    // read, the engine's read switch fails CLOSED with a clear error if no
     // identity is attached — it never silently master-falls-back.
     let enc_ctx = master_key.as_ref().map(|mk| {
-        tcfs_sync::engine::EncryptionContext::new(mk.clone())
-            .with_device_wrapping(device_recipients, device_identity)
+        let mode = if device_recipients.is_empty() {
+            tcfs_sync::engine::WrapMode::Master
+        } else {
+            tcfs_sync::engine::WrapMode::PerDevice
+        };
+        tcfs_sync::engine::EncryptionContext::new(mk.clone()).with_wrap_mode(
+            mode,
+            device_recipients,
+            device_identity,
+        )
     });
 
     tcfs_sync::engine::download_file_with_device(

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -34,6 +34,29 @@ pub struct DeviceIdentity {
     pub last_nats_seq: u64,
 }
 
+/// Result of a per-device roll-call probe (TIN-1417).
+///
+/// See [`DeviceRegistry::roll_call`]. The CONTRACT (`PerDevice`) wrap mode is
+/// only safe to enter when `all_capable()` is true.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollCall {
+    /// Number of active (non-revoked) devices.
+    pub active: usize,
+    /// Number of active devices that carry a real age recipient.
+    pub capable: usize,
+    /// Names of active devices that lack a real age recipient (the blockers).
+    pub incapable_devices: Vec<String>,
+}
+
+impl RollCall {
+    /// True when at least one active device exists and EVERY active device is
+    /// per-device-capable (has a real age recipient). Only then is it safe to
+    /// drop the shared master wrap.
+    pub fn all_capable(&self) -> bool {
+        self.active > 0 && self.capable == self.active && self.incapable_devices.is_empty()
+    }
+}
+
 /// Device registry: tracks all enrolled devices for this user
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DeviceRegistry {
@@ -89,6 +112,36 @@ impl DeviceRegistry {
     /// List active (non-revoked) devices
     pub fn active_devices(&self) -> impl Iterator<Item = &DeviceIdentity> {
         self.devices.iter().filter(|d| !d.revoked)
+    }
+
+    /// Roll-call probe for the per-device wrapping CONTRACT (TIN-1417).
+    ///
+    /// Inspects every active (non-revoked) device and reports whether each one
+    /// carries a *real* age recipient. The daemon must NOT drop the shared
+    /// master wrap (i.e. enter [`crate`]'s `PerDevice` contract mode) unless this
+    /// returns [`RollCall::all_capable`] true — otherwise a device that lacks a
+    /// real age recipient would be locked out of newly written content.
+    ///
+    /// When the roll call is not satisfied callers fall back to dual-wrapping
+    /// (master + per-device) and log the offending devices, never silently
+    /// dropping the master fallback.
+    pub fn roll_call(&self) -> RollCall {
+        let mut active = 0usize;
+        let mut capable = 0usize;
+        let mut incapable_devices = Vec::new();
+        for d in self.active_devices() {
+            active += 1;
+            if is_real_age_public_key(&d.public_key) {
+                capable += 1;
+            } else {
+                incapable_devices.push(d.name.clone());
+            }
+        }
+        RollCall {
+            active,
+            capable,
+            incapable_devices,
+        }
     }
 
     /// Revoke a device by name
@@ -428,5 +481,67 @@ mod tests {
         let id = reg.enroll("xoxd-bates", "age1xoxd", Some("main server".into()));
         assert!(reg.find_by_id(&id).is_some());
         assert!(reg.find_by_id("nonexistent-uuid").is_none());
+    }
+
+    // ── TIN-1417: roll-call gate for the per-device CONTRACT ───────────────
+
+    fn real_pubkey() -> String {
+        generate_local_device_key().public_key
+    }
+
+    #[test]
+    fn roll_call_all_capable_when_every_active_device_has_real_recipient() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("a", &real_pubkey(), None);
+        reg.enroll("b", &real_pubkey(), None);
+        let rc = reg.roll_call();
+        assert_eq!(rc.active, 2);
+        assert_eq!(rc.capable, 2);
+        assert!(rc.incapable_devices.is_empty());
+        assert!(
+            rc.all_capable(),
+            "all active devices are per-device-capable"
+        );
+    }
+
+    #[test]
+    fn roll_call_blocks_when_any_active_device_lacks_real_recipient() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("real", &real_pubkey(), None);
+        // Placeholder / non-age public key: not a real recipient.
+        reg.enroll("placeholder", "age1xoxd-not-a-real-key", None);
+        let rc = reg.roll_call();
+        assert_eq!(rc.active, 2);
+        assert_eq!(rc.capable, 1);
+        assert_eq!(rc.incapable_devices, vec!["placeholder".to_string()]);
+        assert!(
+            !rc.all_capable(),
+            "must block PerDevice while any active device cannot do per-device unwrap"
+        );
+    }
+
+    #[test]
+    fn roll_call_revoked_devices_do_not_block() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("real", &real_pubkey(), None);
+        reg.enroll("old-placeholder", "age1xoxd-not-a-real-key", None);
+        assert!(reg.revoke("old-placeholder"));
+        let rc = reg.roll_call();
+        assert_eq!(rc.active, 1);
+        assert!(
+            rc.all_capable(),
+            "a revoked non-capable device must not block the roll call"
+        );
+    }
+
+    #[test]
+    fn roll_call_empty_registry_is_not_capable() {
+        let reg = DeviceRegistry::default();
+        let rc = reg.roll_call();
+        assert_eq!(rc.active, 0);
+        assert!(
+            !rc.all_capable(),
+            "an empty active set must not satisfy the contract gate"
+        );
     }
 }

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -982,17 +982,30 @@ where
 /// When present, chunks are encrypted before upload and decrypted after download
 /// using XChaCha20-Poly1305 with per-file keys wrapped by the master key.
 #[cfg(feature = "crypto")]
+pub use tcfs_core::config::WrapMode;
+
+#[cfg(feature = "crypto")]
 pub struct EncryptionContext {
     pub master_key: tcfs_crypto::MasterKey,
+    /// File-key wrap mode (TIN-1417). Drives the write path:
+    /// - [`WrapMode::Master`]: master-only wrap (`encrypted_file_key`), manifest v2.
+    /// - [`WrapMode::Dual`]: BOTH master wrap + per-device wraps, manifest v2.
+    /// - [`WrapMode::PerDevice`]: per-device wraps ONLY (drops master wrap),
+    ///   manifest **v3**.
+    ///
+    /// Callers MUST satisfy the roll-call gate before selecting `PerDevice`
+    /// (see `with_wrap_mode` / the daemon's `build_encryption_context`). When the
+    /// gate is not satisfied callers fall back to `Dual` and warn — the engine
+    /// itself trusts the mode it is handed.
+    pub wrap_mode: WrapMode,
     /// Active-device recipients for per-device FileKey wrapping (TIN-1417).
     ///
-    /// When non-empty, writes emit per-device `wrapped_file_keys` and OMIT the
-    /// master-wrapped `encrypted_file_key`, so a device removed from this set
-    /// (revoked) cannot decrypt newly written content. Empty = legacy
-    /// shared-master behavior.
+    /// Required (non-empty) for `Dual` and `PerDevice`; ignored for `Master`.
+    /// A device removed from this set (revoked) cannot decrypt content written
+    /// after its removal in `PerDevice` mode.
     pub device_recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
     /// This device's age identity, used to unwrap per-device manifests on read.
-    /// `None` relies on the master-key fallback (legacy manifests).
+    /// `None` relies on the master-key fallback (legacy / master / dual manifests).
     pub device_identity: Option<DeviceUnwrapIdentity>,
 }
 
@@ -1008,21 +1021,47 @@ pub struct DeviceUnwrapIdentity {
 
 #[cfg(feature = "crypto")]
 impl EncryptionContext {
-    /// Legacy shared-master context: no per-device recipients or identity.
+    /// Legacy shared-master context: master-only wrap, no per-device recipients
+    /// or identity. [`WrapMode::Master`] — byte-identical to the historical
+    /// default.
     pub fn new(master_key: tcfs_crypto::MasterKey) -> Self {
         Self {
             master_key,
+            wrap_mode: WrapMode::Master,
             device_recipients: Vec::new(),
             device_identity: None,
         }
     }
 
-    /// Attach per-device wrapping recipients and this device's unwrap identity.
+    /// Attach per-device wrapping recipients and this device's unwrap identity,
+    /// selecting [`WrapMode::PerDevice`] (per-device-only, manifest v3).
+    ///
+    /// Prefer [`Self::with_wrap_mode`] when the caller needs `Dual`. This method
+    /// preserves the pre-TIN-1417-enum behavior (recipients present =>
+    /// per-device-only writes) for existing call sites and tests. Callers MUST
+    /// have satisfied the roll-call gate before reaching `PerDevice`.
     pub fn with_device_wrapping(
-        mut self,
+        self,
         recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
         identity: Option<DeviceUnwrapIdentity>,
     ) -> Self {
+        self.with_wrap_mode(WrapMode::PerDevice, recipients, identity)
+    }
+
+    /// Attach an explicit wrap mode plus the per-device recipient set and this
+    /// device's unwrap identity.
+    ///
+    /// For [`WrapMode::Master`] the recipients/identity are still recorded (so
+    /// the same context can read per-device manifests it encounters) but the
+    /// write path emits the master-only wrap. For `Dual`/`PerDevice` the
+    /// recipients drive the per-device wraps.
+    pub fn with_wrap_mode(
+        mut self,
+        wrap_mode: WrapMode,
+        recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
+        identity: Option<DeviceUnwrapIdentity>,
+    ) -> Self {
+        self.wrap_mode = wrap_mode;
         self.device_recipients = recipients;
         self.device_identity = identity;
         self
@@ -1849,22 +1888,27 @@ async fn upload_file_with_device_with_state(
 
     ensure_source_matches_snapshot(local_path, &snapshot, "manifest publish")?;
 
-    // Wrap the file key for the manifest. With per-device recipients (TIN-1417)
-    // we emit only per-device `wrapped_file_keys` and OMIT the master-wrapped
-    // `encrypted_file_key`, so a revoked device (absent from the recipient set)
-    // cannot decrypt new content. Without recipients we keep the legacy
-    // shared-master wrap for backward compatibility.
+    // Wrap the file key for the manifest, branching on the wrap mode (TIN-1417):
+    //
+    // - `Master`  : master-only wrap (`encrypted_file_key`). Byte-identical to
+    //               the legacy default. Manifest stays version 2.
+    // - `Dual`    : EXPAND/transitional. Emit BOTH the master wrap (rollback +
+    //               master/old-binary readers) AND per-device wraps. Version 2
+    //               (back-compatible by construction).
+    // - `PerDevice`: CONTRACT. Emit ONLY per-device wraps and DROP the master
+    //               wrap (true revocation). Bumps the manifest to version 3 so
+    //               pre-per-device binaries fail CLOSED.
+    //
+    // The roll-call gate (daemon/CLI/FP `build_encryption_context`) guarantees
+    // `PerDevice`/`Dual` are only handed here with a real recipient set; we
+    // still fail CLOSED below if `Dual`/`PerDevice` arrives with no recipients
+    // rather than silently writing an unreadable or master-only manifest.
     #[cfg(feature = "crypto")]
-    let (encrypted_file_key, wrapped_file_keys) = if let (Some(ctx), Some(ref fk)) =
-        (encryption, &file_key)
-    {
-        if ctx.device_recipients.is_empty() {
-            let wrapped =
-                tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
-            let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wrapped);
-            (Some(b64), Vec::new())
-        } else {
-            let wrapped = tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
+    let wrap_age_recipients = |ctx: &EncryptionContext,
+                               fk: &tcfs_crypto::FileKey|
+     -> Result<Vec<crate::manifest::WrappedFileKey>> {
+        Ok(
+            tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
                 .context("wrapping file key for device recipients")?
                 .into_iter()
                 .map(|w| crate::manifest::WrappedFileKey {
@@ -1873,17 +1917,54 @@ async fn upload_file_with_device_with_state(
                     algorithm: w.algorithm,
                     wrapped_key: w.wrapped_key,
                 })
-                .collect();
-            (None, wrapped)
-        }
-    } else {
-        (None, Vec::new())
+                .collect(),
+        )
     };
+
+    #[cfg(feature = "crypto")]
+    let (encrypted_file_key, wrapped_file_keys, manifest_version) =
+        if let (Some(ctx), Some(ref fk)) = (encryption, &file_key) {
+            let master_wrap = |fk: &tcfs_crypto::FileKey| -> Result<String> {
+                let wrapped =
+                    tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
+                Ok(base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    &wrapped,
+                ))
+            };
+            match ctx.wrap_mode {
+                WrapMode::Master => (Some(master_wrap(fk)?), Vec::new(), 2u32),
+                WrapMode::Dual => {
+                    if ctx.device_recipients.is_empty() {
+                        anyhow::bail!(
+                        "wrap_mode=Dual requires per-device recipients but none are configured; \
+                             refusing to write (would silently degrade to master-only)"
+                    );
+                    }
+                    (Some(master_wrap(fk)?), wrap_age_recipients(ctx, fk)?, 2u32)
+                }
+                WrapMode::PerDevice => {
+                    if ctx.device_recipients.is_empty() {
+                        // Fail CLOSED: a PerDevice write with no recipients would
+                        // produce a keyless v3 manifest that nobody can read.
+                        anyhow::bail!(
+                            "wrap_mode=PerDevice requires per-device recipients but none are \
+                             configured; refusing to drop the master wrap (fail-closed)"
+                        );
+                    }
+                    (None, wrap_age_recipients(ctx, fk)?, 3u32)
+                }
+            }
+        } else {
+            (None, Vec::new(), 2u32)
+        };
 
     #[cfg(not(feature = "crypto"))]
     let encrypted_file_key: Option<String> = None;
     #[cfg(not(feature = "crypto"))]
     let wrapped_file_keys: Vec<crate::manifest::WrappedFileKey> = Vec::new();
+    #[cfg(not(feature = "crypto"))]
+    let manifest_version: u32 = 2;
 
     // Capture Unix file permissions for cross-device preservation
     #[cfg(unix)]
@@ -1896,14 +1977,16 @@ async fn upload_file_with_device_with_state(
     #[cfg(not(unix))]
     let file_mode: Option<u32> = None;
 
-    // Build and upload SyncManifest v2
+    // Build and upload the manifest. Version is 2 for Master/Dual and 3 for
+    // PerDevice (see the wrap-mode branch above) so pre-per-device binaries fail
+    // CLOSED on a master-wrap-less v3 manifest instead of misreading it.
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
 
     let manifest = SyncManifest {
-        version: 2,
+        version: manifest_version,
         file_hash: file_hash_hex.clone(),
         file_size,
         chunks: chunk_hashes,
@@ -2180,6 +2263,40 @@ pub async fn download_file_with_device(
 
     let manifest = SyncManifest::from_bytes(&manifest_bytes)
         .with_context(|| format!("parsing manifest: {remote_manifest}"))?;
+
+    // Manifest version gate (TIN-1417). v1 (legacy text) and v2 (master/dual)
+    // are always readable. v3 is the per-device-only (CONTRACT) shape that DROPS
+    // the master wrap; a binary without per-device read support MUST fail CLOSED
+    // rather than misread a master-wrap-less manifest as keyless. Any version
+    // beyond what we understand is also rejected.
+    //
+    // With the `crypto` feature, v3 is supported; the per-device unwrap branch
+    // below independently fails CLOSED when no device identity is available. The
+    // `wrapped_file_keys` shape check guards against a v3 claim with no per-device
+    // wraps (which we could not decrypt). Without `crypto`, v3 is never readable.
+    #[cfg(feature = "crypto")]
+    {
+        if manifest.version > 3 {
+            anyhow::bail!(
+                "manifest version {} is newer than this binary supports (max 3) for: {remote_manifest}; refusing (fail-closed)",
+                manifest.version
+            );
+        }
+        if manifest.version == 3 && manifest.wrapped_file_keys.is_empty() {
+            anyhow::bail!(
+                "manifest claims per-device (v3) but carries no wrapped_file_keys for: {remote_manifest}; refusing (fail-closed)"
+            );
+        }
+    }
+    #[cfg(not(feature = "crypto"))]
+    {
+        if manifest.version >= 3 {
+            anyhow::bail!(
+                "manifest version {} requires per-device crypto support not built into this binary for: {remote_manifest}; refusing (fail-closed)",
+                manifest.version
+            );
+        }
+    }
 
     let chunk_hashes = manifest.chunk_hashes();
 

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -2368,37 +2368,17 @@ pub async fn download_file_with_device(
     // (TIN-1417): when present, the file key is unwrapped with this device's age
     // identity. Manifests carrying only the legacy master-wrapped key fall back
     // to master-key unwrap.
+    //
+    // Dual manifests (v2) carry BOTH `wrapped_file_keys` AND a master
+    // `encrypted_file_key`. A device that has NO usable per-device wrap (no
+    // encryption context, no age identity, or no stanza addressing it) MUST fall
+    // back to the master wrap when one is present — this is the whole point of
+    // Dual's rollback/recovery rationale, and keeps a Master-mode/no-identity
+    // device able to read peer-written Dual content. PerDevice manifests (v3)
+    // carry NO master wrap (`encrypted_file_key == None`); for those the
+    // per-device path is the only path and we stay strictly fail-closed.
     #[cfg(feature = "crypto")]
-    let file_key = if !manifest.wrapped_file_keys.is_empty() {
-        let ctx = encryption.ok_or_else(|| {
-            anyhow::anyhow!(
-                "manifest is per-device encrypted but no encryption context provided for: {remote_manifest}"
-            )
-        })?;
-        let identity = ctx.device_identity.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "manifest is per-device encrypted but this device has no age identity for: {remote_manifest}"
-            )
-        })?;
-        let age_wraps: Vec<tcfs_crypto::AgeWrappedFileKey> = manifest
-            .wrapped_file_keys
-            .iter()
-            .map(|w| tcfs_crypto::AgeWrappedFileKey {
-                recipient_device_id: w.recipient_device_id.clone(),
-                recipient: w.recipient.clone(),
-                algorithm: w.algorithm.clone(),
-                wrapped_key: w.wrapped_key.clone(),
-            })
-            .collect();
-        Some(
-            tcfs_crypto::unwrap_file_key_with_age_identity(
-                &age_wraps,
-                &identity.secret,
-                Some(&identity.device_id),
-            )
-            .context("unwrapping per-device file key from manifest")?,
-        )
-    } else if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+    let unwrap_master = |wrapped_b64: &str| -> Result<tcfs_crypto::FileKey> {
         let ctx = encryption.ok_or_else(|| {
             anyhow::anyhow!(
                 "manifest is encrypted but no encryption context provided for: {remote_manifest}"
@@ -2407,10 +2387,64 @@ pub async fn download_file_with_device(
         let wrapped =
             base64::Engine::decode(&base64::engine::general_purpose::STANDARD, wrapped_b64)
                 .context("decoding wrapped file key from manifest")?;
-        Some(
-            tcfs_crypto::unwrap_key(&ctx.master_key, &wrapped)
-                .context("unwrapping file key from manifest")?,
-        )
+        tcfs_crypto::unwrap_key(&ctx.master_key, &wrapped)
+            .context("unwrapping file key from manifest")
+    };
+
+    #[cfg(feature = "crypto")]
+    let file_key = if !manifest.wrapped_file_keys.is_empty() {
+        // Attempt the per-device unwrap first (preferred). Capture the failure
+        // instead of propagating so we can fall back to the master wrap when the
+        // manifest carries one (Dual/v2).
+        let per_device: Result<tcfs_crypto::FileKey> = (|| {
+            let ctx = encryption.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "manifest is per-device encrypted but no encryption context provided for: {remote_manifest}"
+                )
+            })?;
+            let identity = ctx.device_identity.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "manifest is per-device encrypted but this device has no age identity for: {remote_manifest}"
+                )
+            })?;
+            let age_wraps: Vec<tcfs_crypto::AgeWrappedFileKey> = manifest
+                .wrapped_file_keys
+                .iter()
+                .map(|w| tcfs_crypto::AgeWrappedFileKey {
+                    recipient_device_id: w.recipient_device_id.clone(),
+                    recipient: w.recipient.clone(),
+                    algorithm: w.algorithm.clone(),
+                    wrapped_key: w.wrapped_key.clone(),
+                })
+                .collect();
+            tcfs_crypto::unwrap_file_key_with_age_identity(
+                &age_wraps,
+                &identity.secret,
+                Some(&identity.device_id),
+            )
+            .context("unwrapping per-device file key from manifest")
+        })();
+
+        match per_device {
+            Ok(fk) => Some(fk),
+            Err(per_device_err) => {
+                // Fall back to the master wrap ONLY when one is actually present
+                // (Dual/v2). A v3 (PerDevice) manifest has no master wrap and
+                // MUST stay strictly fail-closed — surface the per-device error.
+                if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+                    debug!(
+                        remote = %remote_manifest,
+                        error = %per_device_err,
+                        "per-device unwrap unavailable; falling back to master wrap (Dual manifest)"
+                    );
+                    Some(unwrap_master(wrapped_b64)?)
+                } else {
+                    return Err(per_device_err);
+                }
+            }
+        }
+    } else if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+        Some(unwrap_master(wrapped_b64)?)
     } else {
         None
     };

--- a/crates/tcfs-sync/tests/per_device_wrap_test.rs
+++ b/crates/tcfs-sync/tests/per_device_wrap_test.rs
@@ -14,7 +14,7 @@ use secrecy::ExposeSecret;
 use tempfile::TempDir;
 
 use tcfs_crypto::AgeFileKeyRecipient;
-use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
+use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext, WrapMode};
 
 fn memory_operator() -> Operator {
     Operator::new(opendal::services::Memory::default())
@@ -171,4 +171,187 @@ async fn revoked_device_cannot_decrypt_new_content() {
     .await
     .expect("active device download should succeed");
     assert_eq!(std::fs::read(&dst_a).unwrap(), content);
+}
+
+// ── TIN-1417: tri-state wrap_mode write-path shapes + v3 fail-closed ────────
+
+async fn upload_with_ctx(
+    op: &Operator,
+    tmp: &TempDir,
+    prefix: &str,
+    ctx: &EncryptionContext,
+    content: &[u8],
+) -> tcfs_sync::manifest::SyncManifest {
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+    let src = tmp.path().join("doc.txt");
+    std::fs::write(&src, content).unwrap();
+    let up = tcfs_sync::engine::upload_file_with_device(
+        op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(ctx),
+    )
+    .await
+    .expect("upload should succeed");
+    let bytes = op.read(&up.remote_path).await.unwrap().to_bytes();
+    tcfs_sync::manifest::SyncManifest::from_bytes(&bytes).unwrap()
+}
+
+/// Master mode (DEFAULT): master-wrapped key only, no per-device wraps, v2.
+#[tokio::test]
+async fn wrap_mode_master_emits_encrypted_file_key_only_v2() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let (rec_a, id_a) = device("device-a");
+    // Even with recipients/identity attached, Master must emit master-only.
+    let ctx =
+        EncryptionContext::new(master()).with_wrap_mode(WrapMode::Master, vec![rec_a], Some(id_a));
+    let manifest = upload_with_ctx(&op, &tmp, "test/master", &ctx, b"master payload").await;
+    assert_eq!(manifest.version, 2, "Master stays manifest v2");
+    assert!(
+        manifest.encrypted_file_key.is_some(),
+        "Master must emit the master-wrapped key"
+    );
+    assert!(
+        manifest.wrapped_file_keys.is_empty(),
+        "Master must NOT emit per-device wraps"
+    );
+}
+
+/// Dual mode (EXPAND): BOTH master wrap and per-device wraps, stays v2.
+#[tokio::test]
+async fn wrap_mode_dual_emits_both_fields_v2() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let (rec_a, id_a) = device("device-a");
+    let (rec_b, _id_b) = device("device-b");
+    let ctx = EncryptionContext::new(master()).with_wrap_mode(
+        WrapMode::Dual,
+        vec![rec_a, rec_b],
+        Some(id_a),
+    );
+    let manifest = upload_with_ctx(&op, &tmp, "test/dual", &ctx, b"dual payload").await;
+    assert_eq!(manifest.version, 2, "Dual is back-compatible: stays v2");
+    assert!(
+        manifest.encrypted_file_key.is_some(),
+        "Dual must emit the master wrap (rollback + master readers)"
+    );
+    assert_eq!(
+        manifest.wrapped_file_keys.len(),
+        2,
+        "Dual must also emit one per-device wrap per recipient"
+    );
+}
+
+/// PerDevice mode (CONTRACT): per-device wraps only, master wrap dropped, v3.
+#[tokio::test]
+async fn wrap_mode_per_device_emits_wrapped_only_v3() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let (rec_a, id_a) = device("device-a");
+    let ctx = EncryptionContext::new(master()).with_wrap_mode(
+        WrapMode::PerDevice,
+        vec![rec_a],
+        Some(id_a.clone()),
+    );
+    let manifest = upload_with_ctx(&op, &tmp, "test/perdev", &ctx, b"per-device payload").await;
+    assert_eq!(manifest.version, 3, "PerDevice bumps the manifest to v3");
+    assert!(
+        manifest.encrypted_file_key.is_none(),
+        "PerDevice must DROP the master wrap (true revocation)"
+    );
+    assert!(
+        !manifest.wrapped_file_keys.is_empty(),
+        "PerDevice must emit per-device wraps"
+    );
+}
+
+/// Dual/PerDevice with no recipients must FAIL CLOSED rather than silently
+/// degrading to master-only / writing an unreadable manifest.
+#[tokio::test]
+async fn dual_and_per_device_without_recipients_fail_closed() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+    let src = tmp.path().join("doc.txt");
+    std::fs::write(&src, b"x").unwrap();
+
+    for mode in [WrapMode::Dual, WrapMode::PerDevice] {
+        let ctx = EncryptionContext::new(master()).with_wrap_mode(mode, Vec::new(), None);
+        let res = tcfs_sync::engine::upload_file_with_device(
+            &op,
+            &src,
+            "test/failclosed",
+            &mut state,
+            None,
+            "device-a",
+            None,
+            Some(&ctx),
+        )
+        .await;
+        assert!(
+            res.is_err(),
+            "wrap_mode={mode:?} with no recipients must fail closed"
+        );
+    }
+}
+
+/// A v3 (per-device) manifest must be REJECTED fail-closed by a master-only read
+/// context (a binary/context without a per-device identity).
+#[tokio::test]
+async fn v3_manifest_rejected_fail_closed_by_master_only_read() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/v3-failclosed";
+    let (rec_a, id_a) = device("device-a");
+    let write_ctx = EncryptionContext::new(master()).with_wrap_mode(
+        WrapMode::PerDevice,
+        vec![rec_a],
+        Some(id_a),
+    );
+    let manifest = upload_with_ctx(&op, &tmp, prefix, &write_ctx, b"v3 payload").await;
+    assert_eq!(manifest.version, 3);
+
+    // Reconstruct the remote manifest path the same way upload did.
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state2.db")).unwrap();
+    let src = tmp.path().join("doc.txt");
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .unwrap();
+
+    // Master-only context: no device identity attached -> must fail closed.
+    let master_only = EncryptionContext::new(master());
+    let dst = tmp.path().join("out.txt");
+    let res = tcfs_sync::engine::download_file_with_device(
+        &op,
+        &up.remote_path,
+        &dst,
+        prefix,
+        None,
+        "device-a",
+        None,
+        Some(&master_only),
+    )
+    .await;
+    assert!(
+        res.is_err(),
+        "a master-only context must reject a v3 per-device manifest (fail-closed)"
+    );
+    assert!(
+        !dst.exists(),
+        "fail-closed read must not materialize a file"
+    );
 }

--- a/crates/tcfs-sync/tests/per_device_wrap_test.rs
+++ b/crates/tcfs-sync/tests/per_device_wrap_test.rs
@@ -300,6 +300,82 @@ async fn dual_and_per_device_without_recipients_fail_closed() {
     }
 }
 
+/// A Dual (v2) manifest carries BOTH a master wrap and per-device wraps. A
+/// Master-mode / no-identity read context (e.g. a peer device that never
+/// attached an age identity) MUST fall back to the master wrap and hydrate exact
+/// bytes — NOT error "no age identity". This is the whole point of Dual's
+/// rollback/recovery rationale and the live daemon/FP read path for a Master
+/// device reading peer-written Dual content.
+#[tokio::test]
+async fn dual_manifest_master_only_read_falls_back_to_master_wrap() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/dual-master-read";
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    // Write in Dual mode: recipients + identity attached, master wrap retained.
+    let (rec_a, id_a) = device("device-a");
+    let (rec_b, _id_b) = device("device-b");
+    let write_ctx = EncryptionContext::new(master()).with_wrap_mode(
+        WrapMode::Dual,
+        vec![rec_a, rec_b],
+        Some(id_a),
+    );
+
+    let content = b"dual payload readable by a master-only device with no age identity";
+    let src = tmp.path().join("doc.txt");
+    std::fs::write(&src, content).unwrap();
+
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .expect("dual upload should succeed");
+
+    // Sanity: the manifest is a real Dual manifest (v2, both fields present).
+    let manifest_bytes = op.read(&up.remote_path).await.unwrap().to_bytes();
+    let manifest = tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes).unwrap();
+    assert_eq!(manifest.version, 2, "Dual stays manifest v2");
+    assert!(
+        manifest.encrypted_file_key.is_some(),
+        "Dual must retain the master wrap"
+    );
+    assert!(
+        !manifest.wrapped_file_keys.is_empty(),
+        "Dual must also carry per-device wraps"
+    );
+
+    // Read back with a pure master context: NO device identity attached. The
+    // read switch must NOT error "no age identity"; it must fall back to the
+    // master wrap and produce byte-exact plaintext.
+    let master_only = EncryptionContext::new(master());
+    let dst = tmp.path().join("out.txt");
+    tcfs_sync::engine::download_file_with_device(
+        &op,
+        &up.remote_path,
+        &dst,
+        prefix,
+        None,
+        "master-reader",
+        None,
+        Some(&master_only),
+    )
+    .await
+    .expect("master-only read of a Dual manifest must succeed via master-wrap fallback");
+    assert_eq!(
+        std::fs::read(&dst).unwrap(),
+        content,
+        "master-wrap fallback must reconstruct exact plaintext"
+    );
+}
+
 /// A v3 (per-device) manifest must be REJECTED fail-closed by a master-only read
 /// context (a binary/context without a per-device identity).
 #[tokio::test]

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -24,22 +24,35 @@ use tcfs_core::proto::{
 };
 use tcfs_sync::state::StateCacheBackend;
 
-/// Build an `EncryptionContext`, attaching per-device wrapping (TIN-1417) when
-/// `crypto.per_device_wrapping` is enabled and the device registry has real age
-/// recipients. Falls back to legacy shared-master wrapping (and logs why) if the
-/// registry can't be loaded, has no real recipients, or this device's age secret
-/// is missing — never producing content this device cannot read back.
+/// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
+///
+/// - `Master` (default): legacy shared-master wrap. Byte-identical to the prior
+///   default; returns `EncryptionContext::new(master_key)` verbatim.
+/// - `Dual` (EXPAND): emit BOTH the master wrap and per-device wraps. Requires a
+///   real age recipient set; if none are available we log and fall back to
+///   master (never produce content this device cannot read back).
+/// - `PerDevice` (CONTRACT): drop the master wrap. Gated behind a roll-call
+///   probe — we refuse PerDevice and **fall back to Dual + warn loudly** unless
+///   EVERY active (non-revoked) device carries a real age recipient. We also
+///   fall back if the local device secret is unreadable.
+///
+/// Whenever the requested mode cannot be honored safely we degrade to the most
+/// conservative mode that still keeps every device able to read (Dual, then
+/// Master), and log why — we never silently drop the master fallback.
 pub(crate) fn build_encryption_context(
     config: &TcfsConfig,
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
-    if !config.crypto.per_device_wrapping {
+    let requested = config.crypto.wrap_mode;
+    if requested == WrapMode::Master {
         return base;
     }
+
     let registry_path = config
         .sync
         .device_identity
@@ -48,10 +61,13 @@ pub(crate) fn build_encryption_context(
     let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
+            tracing::warn!(
+                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+            );
             return base;
         }
     };
+
     let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = registry
         .active_devices()
         .filter(|d| tcfs_secrets::device::is_real_age_public_key(&d.public_key))
@@ -62,10 +78,11 @@ pub(crate) fn build_encryption_context(
         .collect();
     if recipients.is_empty() {
         tracing::warn!(
-            "per-device wrapping enabled but no active age recipients; using master wrap"
+            "wrap_mode={requested:?} enabled but no active age recipients; using master wrap"
         );
         return base;
     }
+
     let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
     let identity = match std::fs::read_to_string(&secret_path) {
         Ok(s) => DeviceUnwrapIdentity {
@@ -74,12 +91,44 @@ pub(crate) fn build_encryption_context(
         },
         Err(e) => {
             tracing::warn!(
-                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+                "wrap_mode={requested:?}: local device secret unreadable ({e}); using master wrap"
             );
             return base;
         }
     };
-    base.with_device_wrapping(recipients, Some(identity))
+
+    // Roll-call gate: PerDevice (CONTRACT) drops the master wrap, so it is only
+    // safe when EVERY active device can do per-device unwrap. If not, degrade to
+    // Dual (keeps the master fallback) and warn loudly.
+    let effective = resolve_wrap_mode_with_roll_call(requested, &registry);
+    base.with_wrap_mode(effective, recipients, Some(identity))
+}
+
+/// Apply the roll-call gate to a requested wrap mode.
+///
+/// `PerDevice` is downgraded to `Dual` (with a loud warning) unless every active
+/// device carries a real age recipient. `Master`/`Dual` pass through unchanged.
+pub(crate) fn resolve_wrap_mode_with_roll_call(
+    requested: tcfs_core::config::WrapMode,
+    registry: &tcfs_secrets::device::DeviceRegistry,
+) -> tcfs_core::config::WrapMode {
+    use tcfs_core::config::WrapMode;
+    if requested != WrapMode::PerDevice {
+        return requested;
+    }
+    let roll_call = registry.roll_call();
+    if roll_call.all_capable() {
+        return WrapMode::PerDevice;
+    }
+    tracing::warn!(
+        active = roll_call.active,
+        capable = roll_call.capable,
+        blockers = ?roll_call.incapable_devices,
+        "wrap_mode=PerDevice REFUSED by roll-call gate: not every active device has a real \
+         age recipient; falling back to Dual (keeping the master wrap) to avoid locking out \
+         devices. Enroll real age recipients for the listed devices to enable true revocation."
+    );
+    WrapMode::Dual
 }
 
 /// Implementation of the TcfsDaemon gRPC service
@@ -4046,5 +4095,49 @@ mod tests {
             "docs/nested/deep.md"
         );
         assert_eq!(sanitize_rel_path("./current.txt").unwrap(), "./current.txt");
+    }
+
+    // ── TIN-1417: roll-call gate for the PerDevice CONTRACT ────────────────
+
+    #[test]
+    fn roll_call_gate_passes_per_device_when_all_capable() {
+        use tcfs_core::config::WrapMode;
+        let mut reg = tcfs_secrets::device::DeviceRegistry::default();
+        let real = tcfs_secrets::device::generate_local_device_key().public_key;
+        reg.enroll("a", &real, None);
+        assert_eq!(
+            resolve_wrap_mode_with_roll_call(WrapMode::PerDevice, &reg),
+            WrapMode::PerDevice,
+            "all active devices capable => PerDevice honored"
+        );
+    }
+
+    #[test]
+    fn roll_call_gate_downgrades_per_device_to_dual_when_blocked() {
+        use tcfs_core::config::WrapMode;
+        let mut reg = tcfs_secrets::device::DeviceRegistry::default();
+        let real = tcfs_secrets::device::generate_local_device_key().public_key;
+        reg.enroll("a", &real, None);
+        // A second active device without a real age recipient blocks the contract.
+        reg.enroll("placeholder", "age1xoxd-not-a-real-key", None);
+        assert_eq!(
+            resolve_wrap_mode_with_roll_call(WrapMode::PerDevice, &reg),
+            WrapMode::Dual,
+            "a non-capable active device must downgrade PerDevice -> Dual"
+        );
+    }
+
+    #[test]
+    fn roll_call_gate_passes_dual_and_master_through() {
+        use tcfs_core::config::WrapMode;
+        let reg = tcfs_secrets::device::DeviceRegistry::default();
+        assert_eq!(
+            resolve_wrap_mode_with_roll_call(WrapMode::Master, &reg),
+            WrapMode::Master
+        );
+        assert_eq!(
+            resolve_wrap_mode_with_roll_call(WrapMode::Dual, &reg),
+            WrapMode::Dual
+        );
     }
 }


### PR DESCRIPTION
> DRAFT (agent-drafted, needs review) — please review carefully before merge. Default behavior is unchanged (wrap_mode = Master); no flip is performed.

## What

Replaces the shipped-but-unused boolean `crypto.per_device_wrapping` (v0.12.14, default `false`, set `true` nowhere live) with a tri-state `crypto.wrap_mode { Master, Dual, PerDevice }` (default `Master`), implementing the ratified TIN-1417 EXPAND/CONTRACT migration ladder for per-device file-key wrapping.

| Mode | Manifest | `encrypted_file_key` (master wrap) | `wrapped_file_keys` (per-device) | Manifest version |
|------|----------|-----|-----|-----|
| `master` (DEFAULT) | today's behavior, **byte-identical** | yes | no | 2 |
| `dual` (EXPAND) | transitional, back-compatible | yes | yes | 2 |
| `per_device` (CONTRACT) | true revocation, fail-closed for old readers | no | yes | **3** |

## Enum + back-compat

- `WrapMode` is `#[serde(rename_all = "snake_case")]` → `master | dual | per_device`, default `Master` (`#[default]`).
- `CryptoConfig` has a **hand-written `Deserialize`** (shadow struct) so a legacy `crypto.per_device_wrapping` key still parses: `true` → `Dual` (keeps the master fallback — safe), `false`/absent → `Master`. A present `wrap_mode` is canonical and **wins**. Only `wrap_mode` is serialized going forward (legacy key never emitted).

## v3 handling (fail-closed)

- The engine **write path** (`upload_file_with_device`) branches on `EncryptionContext.wrap_mode`. `PerDevice` drops the master wrap and stamps `version = 3`; `Dual`/`Master` stay `version = 2`. `Dual`/`PerDevice` with an empty recipient set **fail closed** rather than silently degrading to master-only / writing an unreadable manifest.
- The engine **read switch** (`download_file_with_device`) gates on manifest version: v1/v2 always readable; with the `crypto` feature v3 is supported (and the per-device unwrap branch independently fails closed when no device identity is attached); **without `crypto`, v3 is rejected fail-closed**; a v3 manifest with no `wrapped_file_keys`, or any version > 3, is rejected. This is what makes pre-per-device binaries fail CLOSED instead of misreading a master-wrap-less manifest as keyless.

## Roll-call gate

- `DeviceRegistry::roll_call()` returns `RollCall { active, capable, incapable_devices }`; `RollCall::all_capable()` is true only when there is ≥1 active device and **every** active (non-revoked) device carries a real age recipient.
- All three `build_encryption_context` sites (daemon `tcfsd/src/grpc.rs`, `tcfs-cli/src/main.rs`, FP `tcfs-file-provider/src/device_ctx.rs`) **refuse `PerDevice`** (which would drop the master wrap) until the roll-call is satisfied; otherwise they **downgrade to `Dual` and warn loudly** (never silently dropping the master fallback). This is a real guarded check, not a doc note.

## Readers rewired (all previously gated on `per_device_wrapping`)

- `crates/tcfsd/src/grpc.rs` `build_encryption_context` (+ new `resolve_wrap_mode_with_roll_call`)
- `crates/tcfs-cli/src/main.rs` `build_encryption_context` (+ CLI roll-call mirror) and `build_fileprovider_init_config` (now emits canonical `wrap_mode`, omitted when `Master` so default output is byte-identical)
- `crates/tcfs-file-provider/src/device_ctx.rs` `build_encryption_context` (reads `wrap_mode`, accepts the legacy `per_device_wrapping` alias, applies the roll-call gate) and `grpc_backend.rs` (read context now carries an explicit mode)

## Full local CI gate

- `cargo fmt --all -- --check`: **clean**.
- `cargo clippy` (workspace + touched crates incl. `tcfs-sync --features crypto` and FP `--no-default-features --features grpc`): **no new warnings**. Pre-existing only: 2× `&storage_prefix` needless-borrow in `tcfsd/src/grpc.rs` (from commit `abe5526b`, unrelated lines) and `ensure_master_decryptable` dead-code under a grpc-only build.
- `cargo test` for `tcfs-core`, `tcfs-secrets`, `tcfs-sync --features crypto`, `tcfsd`, `tcfs-cli`, `tcfs-file-provider --no-default-features --features grpc`: **all pass**, including new tests for each mode's manifest shape + version, the legacy alias mapping, v3 fail-closed reads, the roll-call downgrade, and the byte-identical Master default.

## Guardrails honored

Cut from `origin/main`; default stays `Master` (no flip); no live-fleet mutation; pushed to origin only. Commit GPG-signed, no AI attribution.

## Known caveats / uncertainties

- `SymlinkManifest` already uses `version = 3` but is a structurally distinct object (`kind: symlink`, `symlink_target`, no `chunks`); the two `from_bytes` paths reject each other's shapes, so the shared version number does not collide. Worth a reviewer's eye.
- The three `build_encryption_context` copies remain duplicated (pre-existing tech debt called out in `device_ctx.rs`); this PR keeps them consistent rather than deduping, to limit blast radius.
- The `direct` + `grpc` FP feature combo still cannot be built together (pre-existing duplicate-FFI-symbol issue, independent of this change); grpc must be built `--no-default-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
