### PR TITLE
DRAFT: TIN-1417 inline per-device recipients + age secret into Keychain config (agent-drafted, needs review)

### DIFF
--- a/crates/tcfs-file-provider/Cargo.toml
+++ b/crates/tcfs-file-provider/Cargo.toml
@@ -51,6 +51,9 @@ required-features = ["uniffi"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Used by device_ctx grpc-feature tests to expose generated age secrets when
+# constructing inlined-config JSON (TIN-1417 Keychain inlining read-side tests).
+secrecy = { workspace = true }
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -87,34 +87,58 @@ fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapM
 /// Under the macOS FileProvider sandbox the `.appex` cannot `fs`-read
 /// `~/.config/tcfs` (where the device registry lives); it receives its config
 /// from the shared Keychain instead. The Swift host therefore inlines the
-/// already-VERIFIED active recipients into the Keychain config copy under
-/// `device_recipients`, exactly mirroring how it inlines `master_key_base64`.
-/// When that key is present we trust it verbatim and never touch the filesystem;
-/// otherwise we fall back to loading `devices.json` (the non-sandboxed path used
-/// by the daemon/CLI and by tests).
+/// active recipients into the Keychain config copy under `device_recipients`,
+/// mirroring how it inlines `master_key_base64`. When that key is present we
+/// prefer it over the filesystem; otherwise we fall back to loading
+/// `devices.json` (the non-sandboxed path used by the daemon/CLI and by tests).
+///
+/// TRUST SCOPE (read this carefully — it is a security boundary):
+/// The inlined recipients are RE-VALIDATED here for age-key WELL-FORMEDNESS
+/// only — each `recipient` must parse as a real `age::x25519::Recipient` (via
+/// `is_real_age_public_key`) or it is dropped from the wrap set. We do NOT, and
+/// cannot, verify the AUTHENTICITY of the underlying registry: the registry the
+/// Swift host reads is not signature-verified, so a forged/tampered registry
+/// could still inline a well-formed-but-attacker-controlled recipient. Closing
+/// that gap is the job of the Ed25519-signed device registry (B4, separate and
+/// currently unmerged); it is explicitly OUT OF SCOPE for this inlining change,
+/// which only mirrors the existing (forgeable) trust posture into the sandbox.
 ///
 /// Returns `(recipients, all_capable)`. `all_capable` reflects whether every
-/// active device carries a real age recipient — for the inlined path it is
-/// supplied by the host under `device_recipients_all_capable` (the host runs the
-/// same roll-call against the verified registry); for the fs path it is derived
-/// from the loaded registry's `roll_call()`. It gates the PerDevice contract
-/// mode exactly as the daemon's roll-call gate does.
+/// active device carries a real age recipient. We RE-DERIVE it HERE on the Rust
+/// side from our own re-validated recipient set rather than trusting the host's
+/// `device_recipients_all_capable` boolean (the Swift `isRealAgePublicKey` is a
+/// prefix/length heuristic, so a host over-count must never be allowed to drop
+/// the master wrap and lock this device out — see the inlined branch below). For
+/// the fs path it is likewise derived from the loaded registry's `roll_call()`.
+/// It gates the PerDevice contract mode exactly as the daemon's roll-call gate
+/// does.
 #[cfg(feature = "grpc")]
 fn resolve_recipients(
     config: &serde_json::Value,
     requested: tcfs_core::config::WrapMode,
 ) -> Option<(Vec<tcfs_crypto::AgeFileKeyRecipient>, bool)> {
-    // Inlined-first: the Keychain-provided config copy carries the verified
-    // active recipients so the sandboxed FileProvider never reads devices.json.
+    // Inlined-first: the Keychain-provided config copy carries the active
+    // recipients so the sandboxed FileProvider never reads devices.json. These
+    // are re-validated for age-key WELL-FORMEDNESS below; their registry
+    // AUTHENTICITY is NOT verified here (out of scope — pending B4 signed
+    // registry).
     if let Some(arr) = config
         .get("device_recipients")
         .and_then(serde_json::Value::as_array)
     {
+        // Count every inlined entry the host *claims* is active so we can detect
+        // a host over-count: any entry that fails our own age-recipient parse
+        // means "not all active devices are per-device-capable" -> all_capable
+        // MUST be false regardless of what the host asserted.
+        let inlined_total = arr.len();
         let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = arr
             .iter()
             .filter_map(|entry| {
                 let device_id = entry.get("device_id")?.as_str()?.to_string();
                 let recipient = entry.get("recipient")?.as_str()?.to_string();
+                // Re-validate WELL-FORMEDNESS only (real age::x25519::Recipient
+                // parse). A Swift false-positive cannot inject a malformed
+                // recipient into the wrap set.
                 if !tcfs_secrets::device::is_real_age_public_key(&recipient) {
                     return None;
                 }
@@ -131,12 +155,24 @@ fn resolve_recipients(
             );
             return None;
         }
-        // The host computes capability against the verified registry; default to
-        // false (no PerDevice drop) when the signal is absent.
-        let all_capable = config
-            .get("device_recipients_all_capable")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
+        // HARDENING (availability): RE-DERIVE all_capable in Rust from our own
+        // re-validated recipient set — do NOT trust the host-provided
+        // `device_recipients_all_capable` boolean. The Swift `isRealAgePublicKey`
+        // is only a prefix/length heuristic; if it over-counts (asserts a
+        // malformed key is real) and we trusted its boolean, Rust could enter
+        // PerDevice, drop the master wrap, and lock out a device that actually
+        // lacks a usable recipient. all_capable is true iff EVERY inlined entry
+        // the host listed as active also parsed as a real age recipient here.
+        let all_capable = recipients.len() == inlined_total;
+        if !all_capable {
+            tracing::warn!(
+                "wrap_mode={requested:?}: {} of {} inlined recipient(s) failed Rust age-key \
+                 re-validation; re-deriving all_capable=false (keeping master wrap) regardless \
+                 of host device_recipients_all_capable",
+                inlined_total - recipients.len(),
+                inlined_total
+            );
+        }
         return Some((recipients, all_capable));
     }
 
@@ -615,7 +651,7 @@ mod tests {
         assert_eq!(
             ctx.wrap_mode,
             tcfs_sync::engine::WrapMode::PerDevice,
-            "inlined all_capable=true should keep PerDevice"
+            "Rust-re-derived all_capable (1 of 1 well-formed) should keep PerDevice"
         );
         assert_eq!(
             ctx.device_recipients.len(),
@@ -634,11 +670,65 @@ mod tests {
         );
     }
 
-    /// The inlined `device_recipients_all_capable=false` signal trips the same
-    /// roll-call gate as the fs path: PerDevice downgrades to Dual (keeping the
-    /// master wrap) even though recipients + secret are present.
+    /// all_capable is RE-DERIVED in Rust, NOT trusted from the host boolean.
+    /// Here a single inlined recipient is malformed (would fail the real
+    /// `age::x25519::Recipient` parse) while a second is well-formed, and the
+    /// host asserts `device_recipients_all_capable=true` (a Swift over-count via
+    /// its prefix/length heuristic). Rust must drop the malformed recipient,
+    /// re-derive all_capable=FALSE (1 of 2 entries failed re-validation), and
+    /// therefore downgrade PerDevice -> Dual (keeping the master wrap) instead of
+    /// locking the device out. This is the core hardening guard.
     #[test]
-    fn inlined_not_all_capable_downgrades_per_device_to_dual() {
+    fn host_all_capable_true_with_malformed_recipient_redrives_false_in_rust() {
+        let good = tcfs_secrets::device::generate_local_device_key();
+        let secret = good.secret_key.expose_secret().to_string();
+        // Precondition: confirm the keys are what we expect — one real, one not.
+        assert!(tcfs_secrets::device::is_real_age_public_key(
+            &good.public_key
+        ));
+        let bogus = "age1-this-is-not-a-real-bech32-age-recipient-key-000000";
+        assert!(
+            !tcfs_secrets::device::is_real_age_public_key(bogus),
+            "bogus recipient must fail the real age parse"
+        );
+
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_recipients": [
+                { "device_id": "device-a", "recipient": good.public_key },
+                { "device_id": "device-b", "recipient": bogus }
+            ],
+            // Host LIES (over-counts via its heuristic): claims all capable.
+            "device_recipients_all_capable": true,
+            "device_secret": secret,
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        // The malformed recipient is dropped from the wrap set...
+        assert_eq!(
+            ctx.device_recipients.len(),
+            1,
+            "malformed inlined recipient must be dropped by Rust re-validation"
+        );
+        assert_eq!(ctx.device_recipients[0].device_id, "device-a");
+        // ...and all_capable is re-derived to false (1 of 2 failed), so despite
+        // the host's all_capable=true we must NOT drop the master wrap.
+        assert_eq!(
+            ctx.wrap_mode,
+            tcfs_sync::engine::WrapMode::Dual,
+            "host all_capable=true must be IGNORED; Rust re-derivation -> Dual, \
+             keeping the master wrap (no lockout)"
+        );
+        assert!(ctx.device_identity.is_some());
+    }
+
+    /// The inlined `device_recipients_all_capable=false` signal must NOT be able
+    /// to FORCE all_capable when Rust re-derivation says every inlined recipient
+    /// is well-formed. Re-derivation is authoritative: with a single valid
+    /// recipient (1 of 1 parsed) all_capable re-derives TRUE and PerDevice is
+    /// kept, even though the host asserted `false`. (The host boolean is not
+    /// trusted in EITHER direction.)
+    #[test]
+    fn host_all_capable_false_is_overridden_by_rust_when_recipients_well_formed() {
         let key = tcfs_secrets::device::generate_local_device_key();
         let secret = key.secret_key.expose_secret().to_string();
         let config = serde_json::json!({
@@ -646,14 +736,16 @@ mod tests {
             "device_recipients": [
                 { "device_id": "device-a", "recipient": key.public_key }
             ],
+            // Host asserts NOT all capable; Rust re-derivation disagrees.
             "device_recipients_all_capable": false,
             "device_secret": secret,
         });
         let ctx = build_encryption_context(&config, "device-a", &master());
         assert_eq!(
             ctx.wrap_mode,
-            tcfs_sync::engine::WrapMode::Dual,
-            "all_capable=false must downgrade PerDevice -> Dual"
+            tcfs_sync::engine::WrapMode::PerDevice,
+            "Rust re-derivation (1 of 1 well-formed) -> all_capable=true; host \
+             false is not trusted"
         );
         assert_eq!(ctx.device_recipients.len(), 1);
         assert!(ctx.device_identity.is_some());

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -81,38 +81,66 @@ fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapM
     }
 }
 
-/// Build a DEVICE-AWARE `EncryptionContext` for the FileProvider read path,
-/// mirroring `tcfsd`'s `build_encryption_context`.
+/// Resolve the active per-device recipient set, PREFERRING values inlined into
+/// the config over an on-disk registry read (TIN-1417 Keychain inlining).
 ///
-/// Default-off invariant: returns `EncryptionContext::new(master_key)` verbatim
-/// unless the config selects a non-`Master` `wrap_mode` (or the legacy
-/// `per_device_wrapping: true` alias). In that case it loads the device registry
-/// plus this device's age secret and attaches them, like the daemon, and applies
-/// the same roll-call gate (PerDevice downgrades to Dual unless every active
-/// device has a real age recipient).
+/// Under the macOS FileProvider sandbox the `.appex` cannot `fs`-read
+/// `~/.config/tcfs` (where the device registry lives); it receives its config
+/// from the shared Keychain instead. The Swift host therefore inlines the
+/// already-VERIFIED active recipients into the Keychain config copy under
+/// `device_recipients`, exactly mirroring how it inlines `master_key_base64`.
+/// When that key is present we trust it verbatim and never touch the filesystem;
+/// otherwise we fall back to loading `devices.json` (the non-sandboxed path used
+/// by the daemon/CLI and by tests).
 ///
-/// Like the daemon, this falls back to the master-only context (and logs why)
-/// only when per-device wrapping is requested but the registry/recipients/secret
-/// are unavailable — it never produces a context that this device cannot read
-/// back. The engine's read switch independently fails CLOSED if it then meets a
-/// per-device manifest with no identity attached.
+/// Returns `(recipients, all_capable)`. `all_capable` reflects whether every
+/// active device carries a real age recipient — for the inlined path it is
+/// supplied by the host under `device_recipients_all_capable` (the host runs the
+/// same roll-call against the verified registry); for the fs path it is derived
+/// from the loaded registry's `roll_call()`. It gates the PerDevice contract
+/// mode exactly as the daemon's roll-call gate does.
 #[cfg(feature = "grpc")]
-pub(crate) fn build_encryption_context(
+fn resolve_recipients(
     config: &serde_json::Value,
-    device_id: &str,
-    master_key: &tcfs_crypto::MasterKey,
-) -> tcfs_sync::engine::EncryptionContext {
-    use tcfs_core::config::WrapMode;
-    use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
-
-    let base = EncryptionContext::new(master_key.clone());
-
-    // Default-off: byte-identical master-only behavior unless explicitly enabled.
-    let requested = wrap_mode_from_config(config);
-    if requested == WrapMode::Master {
-        return base;
+    requested: tcfs_core::config::WrapMode,
+) -> Option<(Vec<tcfs_crypto::AgeFileKeyRecipient>, bool)> {
+    // Inlined-first: the Keychain-provided config copy carries the verified
+    // active recipients so the sandboxed FileProvider never reads devices.json.
+    if let Some(arr) = config
+        .get("device_recipients")
+        .and_then(serde_json::Value::as_array)
+    {
+        let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = arr
+            .iter()
+            .filter_map(|entry| {
+                let device_id = entry.get("device_id")?.as_str()?.to_string();
+                let recipient = entry.get("recipient")?.as_str()?.to_string();
+                if !tcfs_secrets::device::is_real_age_public_key(&recipient) {
+                    return None;
+                }
+                Some(tcfs_crypto::AgeFileKeyRecipient {
+                    device_id,
+                    recipient,
+                })
+            })
+            .collect();
+        if recipients.is_empty() {
+            tracing::warn!(
+                "wrap_mode={requested:?}: inlined device_recipients present but empty/invalid; \
+                 using master wrap"
+            );
+            return None;
+        }
+        // The host computes capability against the verified registry; default to
+        // false (no PerDevice drop) when the signal is absent.
+        let all_capable = config
+            .get("device_recipients_all_capable")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        return Some((recipients, all_capable));
     }
 
+    // FS fallback (non-sandboxed daemon/CLI/test path): load the registry.
     let registry_path = config
         .get("device_registry_path")
         .and_then(serde_json::Value::as_str)
@@ -125,7 +153,7 @@ pub(crate) fn build_encryption_context(
             tracing::warn!(
                 "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
             );
-            return base;
+            return None;
         }
     };
 
@@ -141,36 +169,122 @@ pub(crate) fn build_encryption_context(
         tracing::warn!(
             "wrap_mode={requested:?} enabled but no active age recipients; using master wrap"
         );
-        return base;
+        return None;
     }
 
+    let all_capable = registry.roll_call().all_capable();
+    Some((recipients, all_capable))
+}
+
+/// Resolve THIS device's age unwrap identity, PREFERRING a secret inlined into
+/// the config over an on-disk `device-<id>.age` read (TIN-1417 Keychain
+/// inlining).
+///
+/// The macOS FileProvider `.appex` cannot `fs`-read `device-<id>.age`, so the
+/// Swift host inlines this device's armored age secret into the Keychain config
+/// copy under `device_secret`, mirroring `master_key_base64`. When present we use
+/// it verbatim; otherwise we fall back to reading `device-<id>.age` from disk
+/// (the daemon/CLI/test path).
+#[cfg(feature = "grpc")]
+fn resolve_device_identity(
+    config: &serde_json::Value,
+    device_id: &str,
+    requested: tcfs_core::config::WrapMode,
+) -> Option<tcfs_sync::engine::DeviceUnwrapIdentity> {
+    use tcfs_sync::engine::DeviceUnwrapIdentity;
+
+    // Inlined-first: prefer the Keychain-provided secret over the fs read.
+    if let Some(secret) = config
+        .get("device_secret")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+    {
+        return Some(DeviceUnwrapIdentity {
+            device_id: device_id.to_string(),
+            secret: secret.trim().to_string(),
+        });
+    }
+
+    // FS fallback: read device-<id>.age relative to the registry path.
+    let registry_path = config
+        .get("device_registry_path")
+        .and_then(serde_json::Value::as_str)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(tcfs_secrets::device::default_registry_path);
     let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
-    let identity = match std::fs::read_to_string(&secret_path) {
-        Ok(s) => DeviceUnwrapIdentity {
+    match std::fs::read_to_string(&secret_path) {
+        Ok(s) => Some(DeviceUnwrapIdentity {
             device_id: device_id.to_string(),
             secret: s.trim().to_string(),
-        },
+        }),
         Err(e) => {
             tracing::warn!(
                 "wrap_mode={requested:?}: local device secret unreadable ({e}); using master wrap"
             );
-            return base;
+            None
         }
+    }
+}
+
+/// Build a DEVICE-AWARE `EncryptionContext` for the FileProvider read path,
+/// mirroring `tcfsd`'s `build_encryption_context`.
+///
+/// Default-off invariant: returns `EncryptionContext::new(master_key)` verbatim
+/// unless the config selects a non-`Master` `wrap_mode` (or the legacy
+/// `per_device_wrapping: true` alias). In that case it resolves the active
+/// recipient set plus this device's age secret and attaches them, like the
+/// daemon, and applies the same roll-call gate (PerDevice downgrades to Dual
+/// unless every active device has a real age recipient).
+///
+/// SANDBOX (TIN-1417): both the recipient set and this device's secret are
+/// resolved INLINED-FIRST — preferring values the Swift host wrote into the
+/// shared-Keychain config copy (`device_recipients` / `device_secret`) over an
+/// on-disk read of `devices.json` / `device-<id>.age`. The macOS FileProvider
+/// `.appex` cannot `fs`-read `~/.config/tcfs`, so the inlined path is the only
+/// one that works in-sandbox; the fs path remains the fallback for the
+/// non-sandboxed daemon/CLI and for tests.
+///
+/// Like the daemon, this falls back to the master-only context (and logs why)
+/// only when per-device wrapping is requested but the registry/recipients/secret
+/// are unavailable — it never produces a context that this device cannot read
+/// back. The engine's read switch independently fails CLOSED if it then meets a
+/// per-device manifest with no identity attached.
+#[cfg(feature = "grpc")]
+pub(crate) fn build_encryption_context(
+    config: &serde_json::Value,
+    device_id: &str,
+    master_key: &tcfs_crypto::MasterKey,
+) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
+    use tcfs_sync::engine::EncryptionContext;
+
+    let base = EncryptionContext::new(master_key.clone());
+
+    // Default-off: byte-identical master-only behavior unless explicitly enabled.
+    let requested = wrap_mode_from_config(config);
+    if requested == WrapMode::Master {
+        return base;
+    }
+
+    let (recipients, all_capable) = match resolve_recipients(config, requested) {
+        Some(v) => v,
+        None => return base,
+    };
+
+    let identity = match resolve_device_identity(config, device_id, requested) {
+        Some(id) => id,
+        None => return base,
     };
 
     // Roll-call gate: refuse PerDevice (drop master wrap) unless every active
     // device is per-device-capable; otherwise degrade to Dual + warn.
     let effective = if requested == WrapMode::PerDevice {
-        let roll_call = registry.roll_call();
-        if roll_call.all_capable() {
+        if all_capable {
             WrapMode::PerDevice
         } else {
             tracing::warn!(
-                active = roll_call.active,
-                capable = roll_call.capable,
-                blockers = ?roll_call.incapable_devices,
-                "wrap_mode=PerDevice REFUSED by roll-call gate; falling back to Dual \
-                 (keeping the master wrap)"
+                "wrap_mode=PerDevice REFUSED by roll-call gate (not all active devices \
+                 carry a real age recipient); falling back to Dual (keeping the master wrap)"
             );
             WrapMode::Dual
         }
@@ -184,6 +298,7 @@ pub(crate) fn build_encryption_context(
 #[cfg(all(test, feature = "grpc"))]
 mod tests {
     use super::*;
+    use secrecy::ExposeSecret;
     use tcfs_secrets::device::{DeviceIdentity, DeviceRegistry};
 
     fn master() -> tcfs_crypto::MasterKey {
@@ -473,6 +588,146 @@ mod tests {
         .await
         .expect("default FP context must read master-only manifest unchanged");
         assert_eq!(std::fs::read(&dst).unwrap(), content);
+    }
+
+    /// SANDBOX (TIN-1417): the INLINED Keychain-config path is preferred over any
+    /// fs read. With `device_recipients` + `device_secret` inlined and NO
+    /// registry/secret on disk (and a deliberately bogus `device_registry_path`),
+    /// the context still attaches recipients + this device's identity — proving
+    /// the FileProvider `.appex` can build a device-aware context without ever
+    /// touching `~/.config/tcfs`.
+    #[test]
+    fn inlined_recipients_and_secret_are_preferred_without_fs() {
+        let key = tcfs_secrets::device::generate_local_device_key();
+        let secret = key.secret_key.expose_secret().to_string();
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            // Point at a path that does NOT exist on disk to prove no fs read
+            // happens when the inlined values are present.
+            "device_registry_path": "/nonexistent/tcfs/devices.json",
+            "device_recipients": [
+                { "device_id": "device-a", "recipient": key.public_key }
+            ],
+            "device_recipients_all_capable": true,
+            "device_secret": secret,
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(
+            ctx.wrap_mode,
+            tcfs_sync::engine::WrapMode::PerDevice,
+            "inlined all_capable=true should keep PerDevice"
+        );
+        assert_eq!(
+            ctx.device_recipients.len(),
+            1,
+            "inlined recipient set must be used"
+        );
+        assert_eq!(ctx.device_recipients[0].device_id, "device-a");
+        let identity = ctx
+            .device_identity
+            .as_ref()
+            .expect("inlined secret must attach a device identity");
+        assert_eq!(identity.device_id, "device-a");
+        assert_eq!(
+            identity.secret, secret,
+            "inlined secret must be used verbatim (no fs read)"
+        );
+    }
+
+    /// The inlined `device_recipients_all_capable=false` signal trips the same
+    /// roll-call gate as the fs path: PerDevice downgrades to Dual (keeping the
+    /// master wrap) even though recipients + secret are present.
+    #[test]
+    fn inlined_not_all_capable_downgrades_per_device_to_dual() {
+        let key = tcfs_secrets::device::generate_local_device_key();
+        let secret = key.secret_key.expose_secret().to_string();
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_recipients": [
+                { "device_id": "device-a", "recipient": key.public_key }
+            ],
+            "device_recipients_all_capable": false,
+            "device_secret": secret,
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(
+            ctx.wrap_mode,
+            tcfs_sync::engine::WrapMode::Dual,
+            "all_capable=false must downgrade PerDevice -> Dual"
+        );
+        assert_eq!(ctx.device_recipients.len(), 1);
+        assert!(ctx.device_identity.is_some());
+    }
+
+    /// The fs path is the FALLBACK: when no inlined values are present the context
+    /// is built from `devices.json` + `device-<id>.age` exactly as before. This is
+    /// the daemon/CLI/non-sandboxed path. (Regression guard that inlining did not
+    /// break the on-disk path.)
+    #[test]
+    fn fs_path_is_used_as_fallback_when_not_inlined() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _pub = provision_device(tmp.path(), "device-a");
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(ctx.wrap_mode, tcfs_sync::engine::WrapMode::PerDevice);
+        assert_eq!(ctx.device_recipients.len(), 1);
+        let identity = ctx
+            .device_identity
+            .as_ref()
+            .expect("fs fallback must attach a device identity");
+        assert!(identity.secret.starts_with("AGE-SECRET-KEY-"));
+    }
+
+    /// Mixed precedence: inlined recipients but NO inlined secret -> the secret is
+    /// resolved via the fs fallback. Proves the two resolvers are independent and
+    /// each is inlined-first / fs-fallback on its own.
+    #[test]
+    fn inlined_recipients_with_fs_secret_fallback() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pub_key = provision_device(tmp.path(), "device-a");
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+            "device_recipients": [
+                { "device_id": "device-a", "recipient": pub_key }
+            ],
+            "device_recipients_all_capable": true,
+            // No device_secret -> falls back to reading device-a.age from disk.
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(ctx.wrap_mode, tcfs_sync::engine::WrapMode::PerDevice);
+        assert_eq!(ctx.device_recipients.len(), 1);
+        let identity = ctx
+            .device_identity
+            .as_ref()
+            .expect("secret should resolve via fs fallback");
+        assert!(identity.secret.starts_with("AGE-SECRET-KEY-"));
+    }
+
+    /// Inlined `device_secret` present but recipients absent and no on-disk
+    /// registry -> recipient resolution fails, so the context fails back to
+    /// master-only (never a half-wired identity-only context). Fail-safe.
+    #[test]
+    fn inlined_secret_without_recipients_falls_back_to_master() {
+        let key = tcfs_secrets::device::generate_local_device_key();
+        let secret = key.secret_key.expose_secret().to_string();
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_registry_path": "/nonexistent/tcfs/devices.json",
+            "device_secret": secret,
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert!(
+            ctx.device_recipients.is_empty(),
+            "no recipients resolvable -> master-only"
+        );
+        assert!(
+            ctx.device_identity.is_none(),
+            "must not attach a half-wired identity-only context"
+        );
     }
 
     /// The fail-loud guard for the master-only backends rejects per-device

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -372,30 +372,178 @@ struct TCFSProviderApp {
             return config
         }
 
+        // (1) Master-key material — the established inlining (host reads
+        //     master_key_file from ~/.config/tcfs and inlines master_key_base64
+        //     so the sandboxed FileProvider .appex can decrypt without an fs read).
         if let encoded = object["master_key_base64"] as? String, !encoded.isEmpty {
-            return serializeConfigObject(object, fallback: config)
-        }
-
-        guard let keyPath = object["master_key_file"] as? String, !keyPath.isEmpty else {
+            // Already inlined; still try the per-device enrichment below.
+        } else if let keyPath = object["master_key_file"] as? String, !keyPath.isEmpty {
+            let expandedKeyPath = (keyPath as NSString).expandingTildeInPath
+            let keyURL = URL(fileURLWithPath: expandedKeyPath)
+            if let keyData = try? Data(contentsOf: keyURL) {
+                if keyData.count == 32 {
+                    object["master_key_base64"] = keyData.base64EncodedString()
+                    hostEvent("provisionConfig: added master key material to Keychain copy")
+                } else {
+                    hostEvent(
+                        "provisionConfig: master_key_file has invalid byte length \(keyData.count)"
+                    )
+                }
+            } else {
+                hostEvent("provisionConfig: master_key_file could not be read")
+            }
+        } else {
             hostLogger.warning("provisionConfig: no master_key_file for Keychain enrichment")
-            return serializeConfigObject(object, fallback: config)
         }
 
-        let expandedKeyPath = (keyPath as NSString).expandingTildeInPath
-        let keyURL = URL(fileURLWithPath: expandedKeyPath)
-        guard let keyData = try? Data(contentsOf: keyURL) else {
-            hostEvent("provisionConfig: master_key_file could not be read")
-            return serializeConfigObject(object, fallback: config)
-        }
+        // (2) Per-device material (TIN-1417) — inert unless wrap_mode is
+        //     dual/per_device. The macOS FileProvider .appex cannot fs-read
+        //     ~/.config/tcfs (devices.json / device-<id>.age), so the host (which
+        //     CAN read them) inlines the active recipients + this device's age
+        //     secret into the Keychain config copy, mirroring master_key_base64.
+        enrichPerDeviceMaterial(&object)
 
-        guard keyData.count == 32 else {
-            hostEvent("provisionConfig: master_key_file has invalid byte length \(keyData.count)")
-            return serializeConfigObject(object, fallback: config)
-        }
-
-        object["master_key_base64"] = keyData.base64EncodedString()
-        hostEvent("provisionConfig: added master key material to Keychain copy")
         return serializeConfigObject(object, fallback: config)
+    }
+
+    /// Returns true when the config selects a non-master wrap mode (dual /
+    /// per_device, or the legacy `per_device_wrapping: true` alias). Per-device
+    /// Keychain inlining is INERT for the default `master` mode — the inlined
+    /// fields are simply not written, keeping wrap_mode=master byte-identical.
+    private static func wrapModeIsPerDevice(_ object: [String: Any]) -> Bool {
+        if let mode = object["wrap_mode"] as? String, !mode.isEmpty {
+            return mode == "dual" || mode == "per_device"
+        }
+        if let legacy = object["per_device_wrapping"] as? Bool {
+            return legacy
+        }
+        return false
+    }
+
+    /// Inline the active per-device recipients and THIS device's age secret into
+    /// the Keychain config copy so the sandboxed FileProvider can build a
+    /// device-aware EncryptionContext without reading ~/.config/tcfs.
+    ///
+    /// The inlined keys are consumed by the Rust read-side
+    /// (`crates/tcfs-file-provider/src/device_ctx.rs`,
+    /// `resolve_recipients` / `resolve_device_identity`), which prefers them over
+    /// the on-disk registry/secret:
+    ///   - `device_recipients`: [{ "device_id", "recipient" }, ...] — active,
+    ///     non-revoked devices that carry a real age recipient.
+    ///   - `device_recipients_all_capable`: Bool — the host's roll-call result
+    ///     (every active device carries a real age recipient). Gates the
+    ///     PerDevice contract drop on the Rust side exactly like the daemon.
+    ///   - `device_secret`: String — this device's armored age secret
+    ///     (`device-<device_id>.age` contents).
+    ///
+    /// DRAFT / UNVERIFIED: this cannot be compiled or device-tested in the agent
+    /// sandbox; it needs a real-device Xcode build + FileProvider QA. The
+    /// registry here is read with NO signature verification (see B4 — the
+    /// DeviceRegistry is forgeable today); this code only mirrors the existing
+    /// trust posture and does NOT add a new trust boundary.
+    private static func enrichPerDeviceMaterial(_ object: inout [String: Any]) {
+        guard wrapModeIsPerDevice(object) else {
+            // wrap_mode=master (default): leave the config untouched.
+            return
+        }
+
+        // Resolve the registry path: explicit override, else default
+        // ~/.config/tcfs/devices.json.
+        let registryPath: String
+        if let explicit = object["device_registry_path"] as? String, !explicit.isEmpty {
+            registryPath = (explicit as NSString).expandingTildeInPath
+        } else {
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            registryPath = home.appendingPathComponent(".config/tcfs/devices.json").path
+        }
+
+        let registryURL = URL(fileURLWithPath: registryPath)
+        guard let registryData = try? Data(contentsOf: registryURL),
+              let registryObject = try? JSONSerialization.jsonObject(with: registryData)
+              as? [String: Any],
+              let devices = registryObject["devices"] as? [[String: Any]]
+        else {
+            hostEvent("provisionConfig: device registry unreadable; skipping per-device inlining")
+            return
+        }
+
+        // Active (non-revoked) devices that carry a *real* age recipient. Mirrors
+        // the Rust `active_devices().filter(is_real_age_public_key)` and the
+        // roll-call gate (all_capable = no active device lacks a real recipient).
+        var recipients: [[String: String]] = []
+        var activeCount = 0
+        var capableCount = 0
+        for device in devices {
+            let revoked = (device["revoked"] as? Bool) ?? false
+            if revoked { continue }
+            activeCount += 1
+            guard let deviceId = device["device_id"] as? String, !deviceId.isEmpty,
+                  let publicKey = device["public_key"] as? String,
+                  isRealAgePublicKey(publicKey)
+            else {
+                continue
+            }
+            capableCount += 1
+            recipients.append(["device_id": deviceId, "recipient": publicKey])
+        }
+
+        guard !recipients.isEmpty else {
+            hostEvent("provisionConfig: no active age recipients; skipping per-device inlining")
+            return
+        }
+
+        object["device_recipients"] = recipients
+        // all_capable iff every active device carried a real recipient.
+        object["device_recipients_all_capable"] = (activeCount == capableCount)
+
+        // Inline THIS device's age secret (device-<device_id>.age), resolved
+        // relative to the registry directory — mirrors the Rust
+        // `device_secret_key_path(registry_path, device_id)` layout.
+        if let deviceId = object["device_id"] as? String, !deviceId.isEmpty {
+            let registryDir = registryURL.deletingLastPathComponent()
+            let secretURL = registryDir.appendingPathComponent("device-\(deviceId).age")
+            if let secretData = try? Data(contentsOf: secretURL),
+               let secret = String(data: secretData, encoding: .utf8) {
+                let trimmed = secret.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    object["device_secret"] = trimmed
+                    hostEvent(
+                        "provisionConfig: inlined \(recipients.count) recipient(s) + device "
+                            + "secret for \(deviceId) (all_capable="
+                            + "\(activeCount == capableCount))"
+                    )
+                } else {
+                    hostEvent("provisionConfig: device secret file empty; recipients inlined only")
+                }
+            } else {
+                // Recipients inlined but no local secret — the Rust read-side then
+                // falls back to its fs read (which fails closed in-sandbox). We do
+                // NOT inline a partial/empty secret.
+                hostEvent("provisionConfig: device-\(deviceId).age unreadable; recipients only")
+            }
+        } else {
+            hostEvent("provisionConfig: no device_id in config; cannot inline device secret")
+        }
+    }
+
+    /// Approximate Swift mirror of `tcfs_secrets::device::is_real_age_public_key`,
+    /// which in Rust does a FULL `age::x25519::Recipient` bech32 parse. Swift has
+    /// no age crate here, so this only checks the `age1` prefix and a plausible
+    /// length — a deliberately conservative heuristic.
+    ///
+    /// SAFETY: the Rust read-side (`resolve_recipients`) RE-VALIDATES every
+    /// inlined recipient with the real `is_real_age_public_key`, so a Swift
+    /// false-positive cannot inject a malformed recipient into the wrap set. The
+    /// one Swift-only signal the Rust side trusts is
+    /// `device_recipients_all_capable`; a Swift over-count there could let the
+    /// Rust side enter PerDevice (drop the master wrap) prematurely. Hardening
+    /// this to a real bech32/age parse on the Swift side is a follow-up (needs an
+    /// age-Swift dependency); flagged for real-device review.
+    private static func isRealAgePublicKey(_ publicKey: String) -> Bool {
+        let trimmed = publicKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        // age1 + bech32 payload; real keys are ~62 chars. Require a healthy
+        // minimum to reject obvious placeholders without over-trusting.
+        return trimmed.hasPrefix("age1") && trimmed.count >= 50
     }
 
     private static func serializeConfigObject(

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -526,24 +526,142 @@ struct TCFSProviderApp {
         }
     }
 
-    /// Approximate Swift mirror of `tcfs_secrets::device::is_real_age_public_key`,
-    /// which in Rust does a FULL `age::x25519::Recipient` bech32 parse. Swift has
-    /// no age crate here, so this only checks the `age1` prefix and a plausible
-    /// length — a deliberately conservative heuristic.
+    /// Swift mirror of `tcfs_secrets::device::is_real_age_public_key`, which in
+    /// Rust does a FULL `age::x25519::Recipient` bech32 parse. Swift has no age
+    /// crate here, so this performs a real bech32 decode in pure Swift —
+    /// validating the `age` human-readable part, the bech32 charset, the BCH
+    /// checksum, and that the decoded payload is exactly the 32-byte X25519
+    /// public key an age recipient carries — instead of a prefix/length
+    /// heuristic. An age v1 recipient is `bech32("age", x25519_pubkey[32])`.
     ///
-    /// SAFETY: the Rust read-side (`resolve_recipients`) RE-VALIDATES every
-    /// inlined recipient with the real `is_real_age_public_key`, so a Swift
-    /// false-positive cannot inject a malformed recipient into the wrap set. The
-    /// one Swift-only signal the Rust side trusts is
-    /// `device_recipients_all_capable`; a Swift over-count there could let the
-    /// Rust side enter PerDevice (drop the master wrap) prematurely. Hardening
-    /// this to a real bech32/age parse on the Swift side is a follow-up (needs an
-    /// age-Swift dependency); flagged for real-device review.
+    /// DEFENSE IN DEPTH (this is one of two layers — neither is solely trusted):
+    ///   1. The Rust read-side (`resolve_recipients`) RE-VALIDATES every inlined
+    ///      recipient with the real `is_real_age_public_key` and RE-DERIVES
+    ///      `all_capable` from its OWN re-validated set — it does NOT trust the
+    ///      host's `device_recipients_all_capable` boolean. So even a Swift
+    ///      false-positive here cannot inject a malformed recipient into the wrap
+    ///      set NOR force a premature PerDevice master-wrap drop (lockout).
+    ///   2. This bech32 decode tightens the host-side roll call so the inlined
+    ///      `device_recipients_all_capable` signal is accurate in the common
+    ///      case, reducing spurious Dual downgrades.
+    ///
+    /// NOTE: this still does not verify registry AUTHENTICITY (a forged registry
+    /// can carry a genuinely well-formed attacker recipient) — that is B4's
+    /// signed-registry job, out of scope here.
+    ///
+    /// DRAFT / UNVERIFIED: cannot be compiled or device-tested in the agent
+    /// sandbox; needs a real-device Xcode build + FileProvider QA. Do not claim
+    /// Swift build success.
     private static func isRealAgePublicKey(_ publicKey: String) -> Bool {
         let trimmed = publicKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        // age1 + bech32 payload; real keys are ~62 chars. Require a healthy
-        // minimum to reject obvious placeholders without over-trusting.
-        return trimmed.hasPrefix("age1") && trimmed.count >= 50
+        guard let decoded = decodeBech32(trimmed), decoded.hrp == "age" else {
+            return false
+        }
+        // age v1 recipient payload is the raw 32-byte X25519 public key.
+        return decoded.data.count == 32
+    }
+
+    /// Minimal bech32 decoder (BIP-0173) sufficient to validate an age v1
+    /// recipient: lowercase-only, HRP separated by the last `1`, valid charset,
+    /// and a correct BCH checksum. Returns the human-readable part and the
+    /// 8-bit-regrouped data payload, or nil on any malformation. (age uses
+    /// classic bech32, not bech32m.)
+    private static func decodeBech32(_ input: String) -> (hrp: String, data: [UInt8])? {
+        // Reject mixed case (bech32 forbids it) and non-ASCII.
+        let lower = input.lowercased()
+        if lower != input && input.uppercased() != input {
+            return nil
+        }
+        let s = lower
+        guard s.count >= 8, s.count <= 1023, s.allSatisfy({ $0.isASCII }) else {
+            return nil
+        }
+        guard let sepIndex = s.lastIndex(of: "1") else { return nil }
+        let hrp = String(s[s.startIndex..<sepIndex])
+        let dataPart = String(s[s.index(after: sepIndex)...])
+        // HRP must be non-empty; data part must include the 6-char checksum.
+        guard !hrp.isEmpty, dataPart.count >= 6 else { return nil }
+        guard hrp.allSatisfy({ c in
+            guard let v = c.asciiValue else { return false }
+            return v >= 33 && v <= 126
+        }) else { return nil }
+
+        let charset = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+        var values: [UInt8] = []
+        values.reserveCapacity(dataPart.count)
+        for c in dataPart {
+            guard let idx = charset.firstIndex(of: c) else { return nil }
+            values.append(UInt8(idx))
+        }
+
+        guard bech32VerifyChecksum(hrp: hrp, values: values) else { return nil }
+
+        // Strip the 6-symbol checksum and regroup 5-bit -> 8-bit.
+        let payload5 = Array(values.dropLast(6))
+        guard let payload8 = convertBits(payload5, from: 5, to: 8, pad: false) else {
+            return nil
+        }
+        return (hrp, payload8)
+    }
+
+    private static func bech32HrpExpand(_ hrp: String) -> [UInt8] {
+        let bytes = Array(hrp.utf8)
+        var out: [UInt8] = []
+        out.reserveCapacity(bytes.count * 2 + 1)
+        for b in bytes { out.append(b >> 5) }
+        out.append(0)
+        for b in bytes { out.append(b & 31) }
+        return out
+    }
+
+    private static func bech32Polymod(_ values: [UInt8]) -> UInt32 {
+        let gen: [UInt32] = [0x3b6a_57b2, 0x2650_8e6d, 0x1ea1_19fa, 0x3d42_33dd, 0x2a14_62b3]
+        var chk: UInt32 = 1
+        for v in values {
+            let top = chk >> 25
+            chk = ((chk & 0x1ff_ffff) << 5) ^ UInt32(v)
+            for i in 0..<5 where ((top >> UInt32(i)) & 1) == 1 {
+                chk ^= gen[i]
+            }
+        }
+        return chk
+    }
+
+    private static func bech32VerifyChecksum(hrp: String, values: [UInt8]) -> Bool {
+        // Classic bech32 constant is 1 (bech32m would be 0x2bc830a3).
+        bech32Polymod(bech32HrpExpand(hrp) + values) == 1
+    }
+
+    /// Regroup a base-2^`from` array into base-2^`to`. Mirrors the reference
+    /// bech32 `convertbits`. With `pad: false` any leftover bits must be zero.
+    private static func convertBits(
+        _ data: [UInt8],
+        from: UInt32,
+        to: UInt32,
+        pad: Bool
+    ) -> [UInt8]? {
+        var acc: UInt32 = 0
+        var bits: UInt32 = 0
+        var out: [UInt8] = []
+        let maxv: UInt32 = (1 << to) - 1
+        for value in data {
+            let v = UInt32(value)
+            if (v >> from) != 0 { return nil }
+            acc = (acc << from) | v
+            bits += from
+            while bits >= to {
+                bits -= to
+                out.append(UInt8((acc >> bits) & maxv))
+            }
+        }
+        if pad {
+            if bits > 0 {
+                out.append(UInt8((acc << (to - bits)) & maxv))
+            }
+        } else if bits >= from || ((acc << (to - bits)) & maxv) != 0 {
+            return nil
+        }
+        return out
     }
 
     private static func serializeConfigObject(


### PR DESCRIPTION
## DRAFT (agent-drafted, needs review)

TIN-1417 KEYCHAIN track. Closes the macOS FileProvider canary blocker: the `.appex` cannot `fs`-read `~/.config/tcfs` under the sandbox, so the per-device wrap read path (device registry + `device-<id>.age`) was unreachable in-sandbox. This mirrors the established `master_key_base64` Keychain inlining for the per-device material.

**Default behavior is byte-identical when `wrap_mode=master` (the default).** The inlining is inert in that mode on both sides.

### Rust read-side (TESTABLE — full gate green)

`crates/tcfs-file-provider/src/device_ctx.rs`:
- `build_encryption_context` now resolves both the recipient set and this device's secret **INLINED-FIRST**, preferring config values over the on-disk read:
  - `device_recipients`: `[{ "device_id", "recipient" }, ...]` — verified active recipients.
  - `device_recipients_all_capable`: `Bool` — host roll-call result; gates the PerDevice contract drop exactly like the daemon.
  - `device_secret`: this device's armored age secret.
- The on-disk `devices.json` / `device-<id>.age` read remains the **fallback** for the non-sandboxed daemon/CLI and for tests.
- Every inlined recipient is re-validated with `is_real_age_public_key` on the Rust side, so a Swift heuristic false-positive cannot inject a malformed recipient.
- 5 new tests: inlined-preferred-without-fs (bogus registry path proves no fs read), `all_capable=false` downgrade PerDevice→Dual, fs fallback when not inlined, mixed inlined-recipients + fs-secret, and inlined-secret-without-recipients fail-safe to master-only.

### Swift host (DRAFT — UNVERIFIED in this environment)

`swift/fileprovider/Sources/HostApp/HostApp.swift`: `configForKeychain` now also inlines the active per-device recipients + this device's age secret into the Keychain config copy, **inert when `wrap_mode=master`**, mirroring the master-key inlining pattern.

**This Swift change CANNOT be compiled or device-tested in the agent sandbox.** It needs a real-device Xcode build + live FileProvider QA. Specifically:
1. Build the macOS FileProvider host + extension in Xcode on real hardware.
2. With a `wrap_mode=dual` or `per_device` config, confirm the host log lines `provisionConfig: inlined N recipient(s) + device secret for <id>` appear.
3. Confirm the sandboxed `.appex` reads a per-device (`wrapped_file_keys`) manifest end-to-end WITHOUT any `~/.config/tcfs` fs access (the inlined path), and that `wrap_mode=master` config produces a byte-identical Keychain copy (no new `device_*` keys).
4. Verify the Keychain config copy size/round-trip with the added fields.

### Gate (Rust only)
- `cargo fmt --all -- --check`: CLEAN.
- `cargo clippy -p tcfs-file-provider --no-default-features --features grpc --all-targets`: no NEW warnings (only the pre-existing `ensure_master_decryptable` dead-code warning, identical on `origin/main`); default-feature clippy clean.
- `cargo test -p tcfs-file-provider --no-default-features --features grpc`: all pass (13 device_ctx + 25 ffi).
- `cargo-deny` is pre-existing-red (RUSTSEC) on `origin/main` — not touched.

### Candid caveats
- **The Swift side is unverified in this environment** — flagged above; needs real-device QA.
- The `isRealAgePublicKey` Swift helper is a prefix/length heuristic (no age-Swift crate available), not a full bech32 parse. The Rust side re-validates recipients, so this only affects the `all_capable` count (a Swift over-count could enter PerDevice prematurely). Hardening to a real parse is a follow-up.
- This reads the **forgeable** DeviceRegistry (see B4) with no signature verification; it mirrors the existing trust posture and adds no new trust boundary. Registry authenticity is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
