### PR TITLE
DRAFT: TIN-1417 B4 sign the device registry (Ed25519, master-derived) (agent-drafted, needs review)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -1450,9 +1451,11 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2",
  "signature",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5393,6 +5396,8 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "blake3",
+ "ed25519-dalek",
+ "hkdf",
  "hostname",
  "keepass",
  "keyring",
@@ -5403,6 +5408,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
+ "sha2",
  "tcfs-core",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ aes-siv = { version = "0.7" }
 hkdf = { version = "0.12" }
 sha2 = { version = "0.10" }
 rand = { version = "0.8" }
+# Ed25519 signing for the device registry (TIN-1417 B4). Already present in the
+# lockfile transitively (async-nats -> nkeys); pinned here for direct use.
+ed25519-dalek = { version = "2" }
 bip39 = { version = "2" }
 keyring = { version = "3" }
 

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -740,7 +740,7 @@ async fn main() -> Result<()> {
                 sync_remote,
             } => cmd_device_enroll(&config, name, repair_placeholder, sync_remote).await,
             DeviceAction::List => cmd_device_list(),
-            DeviceAction::Revoke { name } => cmd_device_revoke(&name),
+            DeviceAction::Revoke { name } => cmd_device_revoke(&config, &name),
             DeviceAction::Status => cmd_device_status(),
             DeviceAction::Invite { expiry_hours, qr } => {
                 cmd_device_invite(&config, expiry_hours, qr).await
@@ -963,7 +963,10 @@ fn load_device_id(config: &tcfs_core::config::TcfsConfig) -> String {
                     let new_id = registry
                         .backfill_device_id(&device_name)
                         .expect("backfill_device_id with valid device name");
-                    if let Err(e) = registry.save(&registry_path) {
+                    // TIN-1417 B4: keep the signature valid after a backfill write.
+                    if let Err(e) =
+                        save_registry_signed_or_warn(&mut registry, &registry_path, config)
+                    {
                         eprintln!("warning: failed to save backfilled device registry: {e}");
                     } else {
                         eprintln!(
@@ -1130,11 +1133,24 @@ fn build_encryption_context(
         .device_identity
         .clone()
         .unwrap_or_else(tcfs_secrets::device::default_registry_path);
-    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
-        Ok(r) => r,
+    // TIN-1417 B4: build recipients only from a signature-VERIFIED registry;
+    // an unsigned/tampered registry falls back to the shared master wrap.
+    let registry = match tcfs_secrets::device::DeviceRegistry::load_verified(
+        &registry_path,
+        master_key.as_bytes(),
+    ) {
+        Ok((r, tcfs_secrets::device::RegistryTrust::Signed)) => r,
+        Ok((_, tcfs_secrets::device::RegistryTrust::UnsignedLegacy)) => {
+            tracing::warn!(
+                "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing \
+                 per-device recipients from an unverified registry — using master wrap."
+            );
+            return base;
+        }
         Err(e) => {
             tracing::warn!(
-                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+                "wrap_mode={requested:?}: device registry FAILED signature verification ({e}); \
+                 refusing per-device recipients — using master wrap (fail-closed)"
             );
             return base;
         }
@@ -3649,7 +3665,9 @@ async fn cmd_init(config: &tcfs_core::config::TcfsConfig, options: InitOptions<'
     let (device_id, device_key) = registry.enroll_local(&device_name, None);
     let device_key_path = tcfs_secrets::device::device_secret_key_path(&registry_path, &device_id);
     tcfs_secrets::device::save_device_secret_key(&device_key_path, &device_key.secret_key, false)?;
-    registry.save(&registry_path)?;
+    // TIN-1417 B4: sign the registry with the freshly written master key so the
+    // very first registry on disk is signed (no migration window for new setups).
+    registry.save_signed(&registry_path, master_key.as_bytes())?;
 
     let init_config = build_init_config(config, &master_key_path, &registry_path, &device_name);
     if !skip_config {
@@ -4169,12 +4187,14 @@ fn cmd_device_list() -> Result<()> {
 
 // ── `tcfs device revoke` ─────────────────────────────────────────────────────
 
-fn cmd_device_revoke(name: &str) -> Result<()> {
+fn cmd_device_revoke(config: &tcfs_core::config::TcfsConfig, name: &str) -> Result<()> {
     let registry_path = tcfs_secrets::device::default_registry_path();
     let mut registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path)?;
 
     if registry.revoke(name) {
-        registry.save(&registry_path)?;
+        // TIN-1417 B4: re-sign so the revocation is recorded in a signed envelope
+        // (revoked + revoked_at), making per-device revocation trustworthy.
+        save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
         println!("Revoked device: {}", name);
     } else {
         anyhow::bail!("Device '{}' not found", name);
@@ -4236,15 +4256,38 @@ async fn cmd_device_enroll(
         enrolled_or_repaired = true;
     }
 
-    registry.save(&registry_path)?;
+    save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
 
     if sync_remote {
         let op = build_operator(config).await?;
         let meta_prefix = config.storage.resolved_prefix();
-        let remote = tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?;
+        // TIN-1417 B4: verify the remote registry before merging so a tampered
+        // remote registry is rejected rather than silently merged into ours.
+        let remote = match master_key_for_registry_signing(config) {
+            Some(mk) => {
+                let (remote, _trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
+                    &op,
+                    meta_prefix,
+                    mk.as_bytes(),
+                )
+                .await?;
+                remote
+            }
+            None => tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?,
+        };
         merge_device_registry(&mut registry, &remote)?;
-        tcfs_secrets::device::DeviceRegistry::sync_to_remote(&registry, &op, meta_prefix).await?;
-        registry.save(&registry_path)?;
+        match master_key_for_registry_signing(config) {
+            Some(mk) => {
+                registry
+                    .sync_to_remote_signed(&op, meta_prefix, mk.as_bytes())
+                    .await?
+            }
+            None => {
+                tcfs_secrets::device::DeviceRegistry::sync_to_remote(&registry, &op, meta_prefix)
+                    .await?
+            }
+        }
+        save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
     }
 
     if enrolled_or_repaired {
@@ -4954,6 +4997,39 @@ fn read_rotation_state(path: &Path) -> Result<KeyRotationState> {
     let data = std::fs::read(path)
         .with_context(|| format!("reading key rotation state: {}", path.display()))?;
     serde_json::from_slice(&data).context("parsing key rotation state")
+}
+
+/// Best-effort load of the master key for *signing the device registry*
+/// (TIN-1417 B4). Returns `None` (with a loud warning) when no master key file is
+/// configured/readable, so registry mutations still succeed but leave the
+/// registry unsigned for the migration window instead of hard-failing.
+fn master_key_for_registry_signing(
+    config: &tcfs_core::config::TcfsConfig,
+) -> Option<tcfs_crypto::MasterKey> {
+    let path = config.crypto.master_key_file.as_ref()?;
+    match read_master_key(path) {
+        Ok(k) => Some(k),
+        Err(e) => {
+            tracing::warn!(
+                "TIN-1417 B4: cannot read master key for registry signing ({e}); the device \
+                 registry will be written UNSIGNED. Per-device wrapping will refuse to trust it."
+            );
+            None
+        }
+    }
+}
+
+/// Sign (if a master key is available) and save the registry to disk. Falls back
+/// to an unsigned save with a warning when no master key is configured.
+fn save_registry_signed_or_warn(
+    registry: &mut tcfs_secrets::device::DeviceRegistry,
+    path: &Path,
+    config: &tcfs_core::config::TcfsConfig,
+) -> Result<()> {
+    match master_key_for_registry_signing(config) {
+        Some(mk) => registry.save_signed(path, mk.as_bytes()),
+        None => registry.save(path),
+    }
 }
 
 fn read_master_key(path: &Path) -> Result<tcfs_crypto::MasterKey> {

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -439,6 +439,14 @@ enum DeviceAction {
         /// Merge the local registry with the storage-backed fleet registry
         #[arg(long)]
         sync_remote: bool,
+        /// TIN-1417 B4 migration escape hatch: explicitly accept and re-sign an
+        /// UNSIGNED (legacy) remote registry during `--sync-remote`. Without this
+        /// flag an unsigned remote is REFUSED on the merge path, because merging
+        /// then re-signing it with the local master would launder an
+        /// attacker-injected recipient into a validly-signed registry. Only pass
+        /// this when you trust the remote object store has not been tampered with.
+        #[arg(long, requires = "sync_remote")]
+        accept_unsigned_remote: bool,
     },
     /// List enrolled devices
     List,
@@ -738,7 +746,17 @@ async fn main() -> Result<()> {
                 name,
                 repair_placeholder,
                 sync_remote,
-            } => cmd_device_enroll(&config, name, repair_placeholder, sync_remote).await,
+                accept_unsigned_remote,
+            } => {
+                cmd_device_enroll(
+                    &config,
+                    name,
+                    repair_placeholder,
+                    sync_remote,
+                    accept_unsigned_remote,
+                )
+                .await
+            }
             DeviceAction::List => cmd_device_list(),
             DeviceAction::Revoke { name } => cmd_device_revoke(&config, &name),
             DeviceAction::Status => cmd_device_status(),
@@ -4210,6 +4228,7 @@ async fn cmd_device_enroll(
     name: Option<String>,
     repair_placeholder: bool,
     sync_remote: bool,
+    accept_unsigned_remote: bool,
 ) -> Result<()> {
     let device_name = name.unwrap_or_else(tcfs_secrets::device::default_device_name);
     let registry_path = tcfs_secrets::device::default_registry_path();
@@ -4261,19 +4280,32 @@ async fn cmd_device_enroll(
     if sync_remote {
         let op = build_operator(config).await?;
         let meta_prefix = config.storage.resolved_prefix();
-        // TIN-1417 B4: verify the remote registry before merging so a tampered
-        // remote registry is rejected rather than silently merged into ours.
+        // TIN-1417 B4: verify the remote registry before merging. The remote object
+        // store is the primary tamper surface, so a signature-PRESENT-but-invalid
+        // remote is hard-rejected by `load_remote_verified`. An UNSIGNED (legacy)
+        // remote verifies as `UnsignedLegacy` and its trust MUST be bound here: if
+        // we merged it and then re-signed the result with our real master, an
+        // attacker who stripped the signature and injected a recipient would have
+        // their entry LAUNDERED into a validly-signed registry. So we refuse to
+        // merge an unsigned remote unless the operator explicitly opts in with
+        // `--accept-unsigned-remote` (loud warning below).
         let remote = match master_key_for_registry_signing(config) {
             Some(mk) => {
-                let (remote, _trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
+                let (remote, trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
                     &op,
                     meta_prefix,
                     mk.as_bytes(),
                 )
                 .await?;
+                enforce_remote_merge_trust(trust, accept_unsigned_remote)?;
                 remote
             }
-            None => tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?,
+            None => {
+                // No master key available: we cannot verify the remote at all, and
+                // we will write the merged result UNSIGNED anyway (no laundering
+                // into a signed registry is possible). Preserve legacy behaviour.
+                tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?
+            }
         };
         merge_device_registry(&mut registry, &remote)?;
         match master_key_for_registry_signing(config) {
@@ -4316,6 +4348,59 @@ async fn cmd_device_enroll(
     }
 
     Ok(())
+}
+
+/// TIN-1417 B4 — close the unsigned-remote LAUNDERING bypass on the enroll
+/// `--sync-remote` path.
+///
+/// `load_remote_verified` already HARD-REJECTS a signature-present-but-invalid
+/// remote (tampering). The remaining hole is `RegistryTrust::UnsignedLegacy`: an
+/// attacker can strip the signature off the remote `devices.json` and inject a
+/// hostile recipient; the stripped registry verifies as "unsigned" rather than
+/// "tampered". If we merged that into our local registry and then re-signed the
+/// result with the real master key, the injected recipient would be laundered
+/// into a validly-signed registry — defeating B4 entirely.
+///
+/// So we REFUSE to merge an unsigned remote by default. The operator may opt in
+/// with `--accept-unsigned-remote` (e.g. a genuine one-time migration of a
+/// trusted legacy fleet), which logs a loud warning and proceeds.
+///
+/// MIGRATION WINDOW (TODO TIN-1417 B5, hard-reject by 2026-09-01): once all
+/// fleets have re-signed at least once, drop `--accept-unsigned-remote` and make
+/// an unsigned remote on the merge path an unconditional hard error. Track the
+/// last-seen-unsigned timestamp in fleet telemetry to confirm the window can
+/// close.
+fn enforce_remote_merge_trust(
+    trust: tcfs_secrets::device::RegistryTrust,
+    accept_unsigned_remote: bool,
+) -> Result<()> {
+    match trust {
+        tcfs_secrets::device::RegistryTrust::Signed => Ok(()),
+        tcfs_secrets::device::RegistryTrust::UnsignedLegacy => {
+            if accept_unsigned_remote {
+                tracing::warn!(
+                    "TIN-1417 B4: merging an UNSIGNED (legacy) remote device registry because \
+                     --accept-unsigned-remote was passed. Its recipient set is UNVERIFIED; you \
+                     are about to RE-SIGN it with this device's master key. Only proceed if you \
+                     trust the remote object store has not been tampered with."
+                );
+                eprintln!(
+                    "WARNING: accepting and re-signing an UNSIGNED remote device registry \
+                     (--accept-unsigned-remote). Its recipients are UNVERIFIED."
+                );
+                Ok(())
+            } else {
+                anyhow::bail!(
+                    "TIN-1417 B4: refusing to merge an UNSIGNED (legacy) remote device registry \
+                     on the enroll --sync-remote path. Merging then re-signing it with this \
+                     device's master key would launder any attacker-injected recipient into a \
+                     validly-signed registry. Re-save the remote with a master-key-holding \
+                     command to sign it, or (only if you trust the remote store) re-run with \
+                     --accept-unsigned-remote to explicitly accept and re-sign it."
+                );
+            }
+        }
+    }
 }
 
 fn repair_placeholder_device_key(
@@ -6379,6 +6464,114 @@ mod tests {
         assert!(tcfs_secrets::device::is_real_age_public_key(
             &merged.public_key
         ));
+    }
+
+    // ── TIN-1417 B4: unsigned-remote LAUNDERING bypass is BLOCKED ──────────────
+
+    /// End-to-end attack reproduction: an attacker with object-store write access
+    /// strips the signature off the remote `devices.json` and injects a hostile
+    /// recipient. A normal master-holder running `tcfs device enroll --sync-remote`
+    /// must REFUSE to merge it (so the injected recipient is never re-signed into a
+    /// validly-signed registry), unless `--accept-unsigned-remote` is passed.
+    #[tokio::test]
+    async fn unsigned_remote_with_injected_recipient_is_refused_not_laundered() {
+        let op = memory_op();
+        let meta_prefix = "data";
+        let master = master_key(0x42);
+
+        // 1. Honest fleet publishes a SIGNED remote registry.
+        let mut honest = tcfs_secrets::device::DeviceRegistry::default();
+        honest.enroll(
+            "alpha",
+            &tcfs_secrets::device::generate_local_device_key().public_key,
+            None,
+        );
+        honest
+            .sync_to_remote_signed(&op, meta_prefix, master.as_bytes())
+            .await
+            .unwrap();
+
+        // 2. Attacker rewrites the remote: injects a hostile recipient AND strips
+        //    the signature envelope so it reads as UnsignedLegacy (not "tampered").
+        let key = format!("{meta_prefix}/tcfs-meta/devices.json");
+        let raw = op.read(&key).await.unwrap().to_bytes().to_vec();
+        let mut value: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+        let attacker_pubkey = tcfs_secrets::device::generate_local_device_key().public_key;
+        value["devices"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "name": "attacker",
+                "device_id": "attacker-id",
+                "public_key": attacker_pubkey,
+                "enrolled_at": 1,
+                "revoked": false
+            }));
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("registry_signature");
+        obj.remove("signer_pubkey");
+        obj.remove("sig_alg");
+        op.write(&key, serde_json::to_vec(&value).unwrap())
+            .await
+            .unwrap();
+
+        // 3. Master-holder loads + verifies the remote: it is UnsignedLegacy
+        //    (signature stripped), NOT a hard tamper error.
+        let (remote, trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
+            &op,
+            meta_prefix,
+            master.as_bytes(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(trust, tcfs_secrets::device::RegistryTrust::UnsignedLegacy);
+        assert!(
+            remote.devices.iter().any(|d| d.name == "attacker"),
+            "sanity: the stripped remote really does carry the injected recipient"
+        );
+
+        // 4. The merge-path trust gate must REFUSE it (no laundering).
+        let err = enforce_remote_merge_trust(trust.clone(), false).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("UNSIGNED") && msg.contains("launder"),
+            "unsigned remote must be refused on the merge path: {msg}"
+        );
+
+        // 5. Prove the laundering would have happened WITHOUT the gate: if we had
+        //    merged + re-signed, the attacker's recipient would be in a validly
+        //    signed registry. The gate is what prevents that, so we never merge.
+        let mut local = tcfs_secrets::device::DeviceRegistry::default();
+        // Gate refuses -> local stays clean; we never call merge.
+        assert!(
+            !local.devices.iter().any(|d| d.name == "attacker"),
+            "local registry must NOT contain the laundered recipient"
+        );
+        // Demonstrate the counterfactual is real (defense-in-depth assertion):
+        merge_device_registry(&mut local, &remote).unwrap();
+        local.sign(master.as_bytes()).unwrap();
+        assert!(
+            local.find("attacker").is_some()
+                && local.verify_signature(master.as_bytes()).unwrap()
+                    == tcfs_secrets::device::RegistryTrust::Signed,
+            "counterfactual: merging an unsigned remote then re-signing DOES launder \
+             the recipient — which is exactly why the merge-path gate must refuse it"
+        );
+    }
+
+    /// The explicit operator escape hatch (`--accept-unsigned-remote`) allows the
+    /// unsigned remote through, for genuine one-time legacy migration.
+    #[test]
+    fn accept_unsigned_remote_flag_allows_merge() {
+        enforce_remote_merge_trust(tcfs_secrets::device::RegistryTrust::UnsignedLegacy, true)
+            .expect("--accept-unsigned-remote must allow an unsigned remote through");
+    }
+
+    /// A signed remote always passes the gate regardless of the flag.
+    #[test]
+    fn signed_remote_passes_merge_gate() {
+        enforce_remote_merge_trust(tcfs_secrets::device::RegistryTrust::Signed, false)
+            .expect("a signed remote must pass the merge gate");
     }
 
     #[test]

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -119,11 +119,25 @@ pub(crate) fn build_encryption_context(
         .map(std::path::PathBuf::from)
         .unwrap_or_else(tcfs_secrets::device::default_registry_path);
 
-    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
-        Ok(r) => r,
+    // TIN-1417 B4: the recipient set must come from a signature-VERIFIED registry.
+    // Like the daemon/CLI, an unsigned or tampered registry falls back to the
+    // shared master wrap rather than wrapping to an unverified recipient.
+    let registry = match tcfs_secrets::device::DeviceRegistry::load_verified(
+        &registry_path,
+        master_key.as_bytes(),
+    ) {
+        Ok((r, tcfs_secrets::device::RegistryTrust::Signed)) => r,
+        Ok((_, tcfs_secrets::device::RegistryTrust::UnsignedLegacy)) => {
+            tracing::warn!(
+                "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing \
+                 per-device recipients from an unverified registry — using master wrap."
+            );
+            return base;
+        }
         Err(e) => {
             tracing::warn!(
-                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+                "wrap_mode={requested:?}: device registry FAILED signature verification ({e}); \
+                 refusing per-device recipients — using master wrap (fail-closed)"
             );
             return base;
         }
@@ -207,9 +221,16 @@ mod tests {
             description: None,
             enrolled_at: 0,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
-        registry.save(&registry_path).expect("save registry");
+        // TIN-1417 B4: build_encryption_context now requires a signature-verified
+        // registry, so sign with the same master key the tests use.
+        registry
+            .save_signed(&registry_path, master().as_bytes())
+            .expect("save signed registry");
 
         let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
         tcfs_secrets::device::save_device_secret_key(&secret_path, &key.secret_key, true)
@@ -310,9 +331,14 @@ mod tests {
             description: None,
             enrolled_at: 0,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
-        registry.save(&registry_path).unwrap();
+        registry
+            .save_signed(&registry_path, master().as_bytes())
+            .unwrap();
 
         let config = serde_json::json!({
             "wrap_mode": "per_device",

--- a/crates/tcfs-mcp/src/server.rs
+++ b/crates/tcfs-mcp/src/server.rs
@@ -857,6 +857,9 @@ mod tests {
                     description: Some("primary".into()),
                     enrolled_at: 1,
                     revoked: false,
+                    revoked_at: None,
+                    enrolled_by: None,
+                    signing_pubkey: None,
                     last_nats_seq: 7,
                 },
                 tcfs_secrets::device::DeviceIdentity {
@@ -867,9 +870,15 @@ mod tests {
                     description: None,
                     enrolled_at: 2,
                     revoked: true,
+                    revoked_at: Some(2),
+                    enrolled_by: None,
+                    signing_pubkey: None,
                     last_nats_seq: 3,
                 },
             ],
+            registry_signature: None,
+            signer_pubkey: None,
+            sig_alg: None,
         };
         registry.save(&registry_path).unwrap();
 

--- a/crates/tcfs-secrets/Cargo.toml
+++ b/crates/tcfs-secrets/Cargo.toml
@@ -29,6 +29,9 @@ hostname = "0.4"
 uuid = { workspace = true }
 blake3 = { workspace = true }
 opendal = { workspace = true }
+ed25519-dalek = { workspace = true }
+hkdf = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -1,13 +1,46 @@
 //! Device identity management for multi-device E2E encryption.
 //!
-//! Each device gets its own age X25519 keypair, signed by the master identity.
-//! Device keys are stored in the platform keychain or an age-encrypted file.
+//! Each device gets its own age X25519 keypair. Device secret keys are stored in
+//! the platform keychain or an owner-only age-encrypted file.
+//!
+//! ## Registry integrity (TIN-1417 B4)
+//!
+//! The *registry itself* (the list of devices, which doubles as the per-device
+//! age **recipient set**) is the high-value attack surface: anyone with direct
+//! object-store write access to `meta_prefix/tcfs-meta/devices.json` could inject
+//! a hostile recipient, un-revoke a device, or drop a device. To make per-device
+//! revocation trustworthy the registry is wrapped in an **Ed25519 signature** over
+//! a canonical serialization of the device list.
+//!
+//! The signing key is *derived deterministically from the master key* via
+//! HKDF-SHA256 (domain `tcfs-device-registry-signing-v1`), so any master-key
+//! holder can sign and verify without distributing new key material. The
+//! signature and the signer's Ed25519 verifying key are stored alongside the
+//! device list in the same JSON object (see [`SIGNATURE_FIELD`]). Old (unsigned)
+//! registries still deserialize for a bounded back-compat migration window, but
+//! the recipient-set builders refuse to wrap to recipients from a registry that
+//! fails verification — they fall back to the shared master wrap instead.
+//!
+//! `signing_key_hash` on a [`DeviceIdentity`] is a BLAKE3 self-fingerprint of the
+//! device's *own* public key — it is NOT a signature and conveys no authority.
 
 use anyhow::{Context, Result};
+use base64::Engine as _;
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+
+/// HKDF info string domain-separating the registry-signing key from every other
+/// master-derived key. Changing this string rotates every registry signature.
+const REGISTRY_SIGNING_INFO: &[u8] = b"tcfs-device-registry-signing-v1";
+
+/// Signature algorithm tag stored in the envelope. Lets future versions migrate.
+const REGISTRY_SIG_ALG: &str = "ed25519-hkdf-sha256-v1";
+
+/// JSON field that carries the base64 Ed25519 signature in the on-disk envelope.
+pub const SIGNATURE_FIELD: &str = "registry_signature";
 
 /// A registered device identity
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,6 +62,23 @@ pub struct DeviceIdentity {
     pub enrolled_at: u64,
     /// Whether this device is revoked
     pub revoked: bool,
+    /// Unix timestamp at which this device was revoked, if any (TIN-1417 B4).
+    /// `None` for active devices and for legacy entries revoked before this field
+    /// existed; set by [`DeviceRegistry::revoke`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<u64>,
+    /// Ed25519 verifying key of the device that enrolled this one, base64
+    /// (TIN-1417 B4). Optional/forward-looking: lets a future per-event signed
+    /// log attribute enrollment. `None` on legacy entries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enrolled_by: Option<String>,
+    /// This device's own Ed25519 signing public key, base64 (TIN-1417 B4).
+    /// Reserved for a future per-device append-only signed-event log; the SEV-1
+    /// fix signs the *whole registry* with the master-derived key, so this is
+    /// `None` today and carries no authority when present. `#[serde(default)]`
+    /// keeps legacy registries parseable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing_pubkey: Option<String>,
     /// Last NATS JetStream sequence processed by this device
     #[serde(default)]
     pub last_nats_seq: u64,
@@ -57,11 +107,67 @@ impl RollCall {
     }
 }
 
-/// Device registry: tracks all enrolled devices for this user
+/// Device registry: tracks all enrolled devices for this user.
+///
+/// The registry is the per-device age **recipient set**, so its integrity is
+/// security-critical (TIN-1417 B4). When persisted it is wrapped in an Ed25519
+/// signature (see [`DeviceRegistry::sign`] / [`DeviceRegistry::verify_signature`]);
+/// the signature and signer pubkey live in `registry_signature` / `signer_pubkey`
+/// and are deliberately excluded from the signed payload so they can be (re)written
+/// without invalidating the signature over the device list.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DeviceRegistry {
     /// List of enrolled devices
     pub devices: Vec<DeviceIdentity>,
+    /// Base64 Ed25519 signature over the canonical device list (TIN-1417 B4).
+    /// `None` for an unsigned/legacy registry. Not part of the signed payload.
+    #[serde(
+        default,
+        rename = "registry_signature",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub registry_signature: Option<String>,
+    /// Base64 Ed25519 verifying key of whoever signed the registry (the
+    /// master-derived signer). Bound into verification: a signature that verifies
+    /// against an *unexpected* signer is still rejected. Not part of the signed
+    /// payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signer_pubkey: Option<String>,
+    /// Signature algorithm tag, e.g. `ed25519-hkdf-sha256-v1`. Not part of the
+    /// signed payload (the algorithm is implied by the verifier).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sig_alg: Option<String>,
+}
+
+/// Outcome of verifying a loaded registry against the master-derived signer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryTrust {
+    /// Envelope carried a valid signature from the expected master-derived signer.
+    Signed,
+    /// Legacy registry with no signature. Accepted only inside the migration
+    /// window; callers must treat its recipient set as UNVERIFIED.
+    UnsignedLegacy,
+}
+
+/// HKDF-derive the deterministic Ed25519 registry-signing key from the master key.
+///
+/// Domain-separated by [`REGISTRY_SIGNING_INFO`] so it is independent of the
+/// manifest/name keys. Every master-key holder derives the same signer, so no new
+/// key distribution is required to sign or verify the registry.
+fn registry_signing_key(master_key_bytes: &[u8; 32]) -> SigningKey {
+    let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, master_key_bytes);
+    let mut seed = [0u8; 32];
+    // HKDF-Expand into 32 bytes never fails for this length.
+    hk.expand(REGISTRY_SIGNING_INFO, &mut seed)
+        .expect("HKDF expand into 32 bytes is infallible");
+    let key = SigningKey::from_bytes(&seed);
+    seed.fill(0);
+    key
+}
+
+/// Base64 (standard, padded) helper used for signatures and keys.
+fn b64() -> base64::engine::general_purpose::GeneralPurpose {
+    base64::engine::general_purpose::STANDARD
 }
 
 /// Newly generated local device key material.
@@ -75,7 +181,11 @@ pub struct LocalDeviceKey {
 }
 
 impl DeviceRegistry {
-    /// Load device registry from a JSON file
+    /// Load device registry from a JSON file (no signature verification).
+    ///
+    /// Retained for non-crypto callers (e.g. `tcfs device list`, status probes)
+    /// that have no master key. Security-sensitive callers that build a per-device
+    /// **recipient set** MUST use [`DeviceRegistry::load_verified`] instead.
     pub fn load(path: &Path) -> Result<Self> {
         if !path.exists() {
             return Ok(Self::default());
@@ -86,7 +196,45 @@ impl DeviceRegistry {
             .with_context(|| format!("parsing device registry: {}", path.display()))
     }
 
-    /// Save device registry to a JSON file
+    /// Load a registry from a JSON file AND verify its signature (TIN-1417 B4).
+    ///
+    /// Returns the registry plus its [`RegistryTrust`]. A present-but-invalid
+    /// signature (tampered device list, un-revoked entry, injected recipient, or a
+    /// signature from a non-master-derived key) is a HARD error. A registry with
+    /// no signature loads as [`RegistryTrust::UnsignedLegacy`] (migration window)
+    /// — callers MUST NOT build a per-device recipient set from an unsigned
+    /// registry. A missing file is an empty, signed-by-construction registry.
+    pub fn load_verified(
+        path: &Path,
+        master_key_bytes: &[u8; 32],
+    ) -> Result<(Self, RegistryTrust)> {
+        if !path.exists() {
+            return Ok((Self::default(), RegistryTrust::Signed));
+        }
+        let reg = Self::load(path)?;
+        let trust = reg.verify_signature(master_key_bytes).with_context(|| {
+            format!(
+                "verifying device registry signature: {} (refusing to trust a tampered registry)",
+                path.display()
+            )
+        })?;
+        if trust == RegistryTrust::UnsignedLegacy {
+            tracing::warn!(
+                path = %path.display(),
+                "device registry is UNSIGNED (legacy). Accepting inside the TIN-1417 B4 \
+                 migration window, but its recipient set is UNVERIFIED and will not be used \
+                 for per-device wrapping. Re-save with a master-key-holding command to sign it."
+            );
+        }
+        Ok((reg, trust))
+    }
+
+    /// Save device registry to a JSON file.
+    ///
+    /// NOTE: this writes whatever signature envelope is currently on `self`. To
+    /// produce a *freshly signed* registry use [`DeviceRegistry::save_signed`],
+    /// which signs with the master-derived key before writing. Raw `save` is
+    /// retained for non-crypto callers and round-trips an existing envelope.
     pub fn save(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
@@ -104,6 +252,16 @@ impl DeviceRegistry {
         Ok(())
     }
 
+    /// Sign with the master-derived key, then persist to a JSON file (TIN-1417 B4).
+    ///
+    /// This is the preferred writer for any mutating command: it guarantees the
+    /// on-disk registry carries a fresh, valid signature so subsequent
+    /// verification (load-side and recipient-set builders) succeeds.
+    pub fn save_signed(&mut self, path: &Path, master_key_bytes: &[u8; 32]) -> Result<()> {
+        self.sign(master_key_bytes)?;
+        self.save(path)
+    }
+
     /// Add a new device
     pub fn add(&mut self, device: DeviceIdentity) {
         self.devices.push(device);
@@ -112,6 +270,110 @@ impl DeviceRegistry {
     /// List active (non-revoked) devices
     pub fn active_devices(&self) -> impl Iterator<Item = &DeviceIdentity> {
         self.devices.iter().filter(|d| !d.revoked)
+    }
+
+    // ── TIN-1417 B4: registry signing / verification ─────────────────────────
+
+    /// Build the canonical, deterministic byte string that is signed.
+    ///
+    /// Independent of map/field ordering, of the envelope fields (signature,
+    /// signer pubkey, alg) and of pretty-printing: it serializes a *sorted* copy
+    /// of the device list to canonical JSON. Two registries with the same device
+    /// set (regardless of insertion order or signature) produce identical bytes,
+    /// so the signature is stable and tamper-evident.
+    fn canonical_signing_payload(&self) -> Result<Vec<u8>> {
+        let mut devices = self.devices.clone();
+        // Deterministic order: by device_id, then name (stable for empty ids).
+        devices.sort_by(|a, b| {
+            a.device_id
+                .cmp(&b.device_id)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        // serde_json serializes struct fields in declaration order, giving a
+        // canonical encoding for a fixed schema. Domain-prefix the algorithm tag
+        // so a signature can never be replayed under a different scheme.
+        let body = serde_json::to_vec(&devices).context("serializing canonical device list")?;
+        let mut msg = Vec::with_capacity(body.len() + REGISTRY_SIG_ALG.len() + 1);
+        msg.extend_from_slice(REGISTRY_SIG_ALG.as_bytes());
+        msg.push(0u8);
+        msg.extend_from_slice(&body);
+        Ok(msg)
+    }
+
+    /// Sign the registry with the master-derived Ed25519 key (TIN-1417 B4).
+    ///
+    /// Populates `registry_signature`, `signer_pubkey` and `sig_alg`. Idempotent:
+    /// re-signing an unchanged device list reproduces the same signature.
+    pub fn sign(&mut self, master_key_bytes: &[u8; 32]) -> Result<()> {
+        let signing_key = registry_signing_key(master_key_bytes);
+        let payload = self.canonical_signing_payload()?;
+        let sig: Signature = signing_key.sign(&payload);
+        let verifying: VerifyingKey = signing_key.verifying_key();
+        self.registry_signature = Some(b64().encode(sig.to_bytes()));
+        self.signer_pubkey = Some(b64().encode(verifying.to_bytes()));
+        self.sig_alg = Some(REGISTRY_SIG_ALG.to_string());
+        Ok(())
+    }
+
+    /// Verify the registry signature against the master-derived signer.
+    ///
+    /// Returns [`RegistryTrust::Signed`] on a valid signature from the expected
+    /// (master-derived) signer. Returns [`RegistryTrust::UnsignedLegacy`] for a
+    /// registry that carries NO signature (migration window). Returns a hard
+    /// `Err` when a signature is present but does not verify, is malformed, or was
+    /// produced by an unexpected (non-master-derived) signer — i.e. tampering.
+    pub fn verify_signature(&self, master_key_bytes: &[u8; 32]) -> Result<RegistryTrust> {
+        let expected = registry_signing_key(master_key_bytes).verifying_key();
+
+        match (&self.registry_signature, &self.signer_pubkey) {
+            (None, None) => Ok(RegistryTrust::UnsignedLegacy),
+            (Some(_), None) | (None, Some(_)) => Err(anyhow::anyhow!(
+                "device registry signature envelope is incomplete (signature/signer_pubkey \
+                 mismatch); refusing to trust"
+            )),
+            (Some(sig_b64), Some(signer_b64)) => {
+                // 1. The signer pubkey in the envelope MUST be the master-derived
+                //    one. A signature that verifies against an attacker-chosen key
+                //    is worthless, so bind to the expected signer first.
+                let signer_bytes = b64()
+                    .decode(signer_b64.as_bytes())
+                    .context("decoding registry signer pubkey")?;
+                let signer_arr: [u8; 32] = signer_bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("registry signer pubkey is not 32 bytes"))?;
+                if signer_arr != expected.to_bytes() {
+                    return Err(anyhow::anyhow!(
+                        "device registry signed by an UNEXPECTED key (not the master-derived \
+                         signer); refusing to trust — possible tampering or wrong master key"
+                    ));
+                }
+
+                // 2. Verify the signature over the canonical payload.
+                let sig_bytes = b64()
+                    .decode(sig_b64.as_bytes())
+                    .context("decoding registry signature")?;
+                let sig_arr: [u8; 64] = sig_bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("registry signature is not 64 bytes"))?;
+                let signature = Signature::from_bytes(&sig_arr);
+                let payload = self.canonical_signing_payload()?;
+                expected.verify(&payload, &signature).map_err(|_| {
+                    anyhow::anyhow!(
+                        "device registry signature FAILED verification; the device list was \
+                         tampered with or re-signed by a different key"
+                    )
+                })?;
+                Ok(RegistryTrust::Signed)
+            }
+        }
+    }
+
+    /// True when the registry carries a signature envelope (signed or tampered),
+    /// as opposed to an unsigned legacy registry.
+    pub fn is_signed(&self) -> bool {
+        self.registry_signature.is_some() || self.signer_pubkey.is_some()
     }
 
     /// Roll-call probe for the per-device wrapping CONTRACT (TIN-1417).
@@ -144,10 +406,19 @@ impl DeviceRegistry {
         }
     }
 
-    /// Revoke a device by name
+    /// Revoke a device by name.
+    ///
+    /// Sets `revoked = true` and stamps `revoked_at` (TIN-1417 B4) so the signed
+    /// envelope records *when* the device lost trust. Callers must re-`sign` and
+    /// persist the registry afterwards; the whole-registry signature plus
+    /// `revoked_at` is the SEV-1 fix (a full append-only signed-event log is a
+    /// follow-up).
     pub fn revoke(&mut self, name: &str) -> bool {
         if let Some(device) = self.devices.iter_mut().find(|d| d.name == name) {
             device.revoked = true;
+            if device.revoked_at.is_none() {
+                device.revoked_at = Some(now_unix());
+            }
             true
         } else {
             false
@@ -184,10 +455,7 @@ impl DeviceRegistry {
     /// Enroll a new device: generates a UUID, creates identity, adds to registry.
     pub fn enroll(&mut self, name: &str, public_key: &str, description: Option<String>) -> String {
         let device_id = uuid::Uuid::new_v4().to_string();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+        let now = now_unix();
 
         let signing_hash = blake3::hash(public_key.as_bytes()).to_hex().as_str()[..16].to_string();
 
@@ -199,6 +467,9 @@ impl DeviceRegistry {
             description,
             enrolled_at: now,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
 
@@ -220,7 +491,9 @@ impl DeviceRegistry {
         (device_id, key)
     }
 
-    /// Load device registry from S3 remote storage.
+    /// Load device registry from S3 remote storage (no signature verification).
+    ///
+    /// Security-sensitive callers must use [`DeviceRegistry::load_remote_verified`].
     pub async fn load_remote(op: &opendal::Operator, meta_prefix: &str) -> Result<Self> {
         let key = format!(
             "{}/tcfs-meta/devices.json",
@@ -238,7 +511,37 @@ impl DeviceRegistry {
         }
     }
 
-    /// Sync (upload) device registry to S3 remote storage.
+    /// Load the remote registry AND verify its signature (TIN-1417 B4).
+    ///
+    /// The remote object store is the primary tamper surface: anyone with direct
+    /// write access to `meta_prefix/tcfs-meta/devices.json` could inject a hostile
+    /// recipient. A present-but-invalid signature is a HARD error; an unsigned
+    /// remote registry returns [`RegistryTrust::UnsignedLegacy`] with a warning.
+    pub async fn load_remote_verified(
+        op: &opendal::Operator,
+        meta_prefix: &str,
+        master_key_bytes: &[u8; 32],
+    ) -> Result<(Self, RegistryTrust)> {
+        let reg = Self::load_remote(op, meta_prefix).await?;
+        if reg.devices.is_empty() && !reg.is_signed() {
+            // Nothing was stored yet (NotFound -> default); treat as trusted-empty.
+            return Ok((reg, RegistryTrust::Signed));
+        }
+        let trust = reg
+            .verify_signature(master_key_bytes)
+            .context("verifying remote device registry signature")?;
+        if trust == RegistryTrust::UnsignedLegacy {
+            tracing::warn!(
+                "remote device registry is UNSIGNED (legacy). Accepting inside the TIN-1417 B4 \
+                 migration window; its recipient set is UNVERIFIED."
+            );
+        }
+        Ok((reg, trust))
+    }
+
+    /// Sync (upload) device registry to S3 remote storage (writes current envelope).
+    ///
+    /// Prefer [`DeviceRegistry::sync_to_remote_signed`] which re-signs first.
     pub async fn sync_to_remote(&self, op: &opendal::Operator, meta_prefix: &str) -> Result<()> {
         let key = format!(
             "{}/tcfs-meta/devices.json",
@@ -249,6 +552,17 @@ impl DeviceRegistry {
             .await
             .map_err(|e| anyhow::anyhow!("writing remote device registry: {e}"))?;
         Ok(())
+    }
+
+    /// Sign with the master-derived key, then upload to S3 (TIN-1417 B4).
+    pub async fn sync_to_remote_signed(
+        &mut self,
+        op: &opendal::Operator,
+        meta_prefix: &str,
+        master_key_bytes: &[u8; 32],
+    ) -> Result<()> {
+        self.sign(master_key_bytes)?;
+        self.sync_to_remote(op, meta_prefix).await
     }
 
     /// Enroll a device with a real age X25519 keypair and sync to remote S3.
@@ -328,6 +642,14 @@ pub fn is_real_age_public_key(public_key: &str) -> bool {
     public_key.parse::<age::x25519::Recipient>().is_ok()
 }
 
+/// Current Unix time in seconds (saturating to 0 before the epoch).
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 /// Get the default device registry path
 pub fn default_registry_path() -> PathBuf {
     let config_dir = dirs_path();
@@ -369,6 +691,9 @@ mod tests {
             description: None,
             enrolled_at: 1000,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
 
@@ -388,11 +713,16 @@ mod tests {
             description: None,
             enrolled_at: 1000,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
 
         assert!(reg.revoke("old-phone"));
         assert_eq!(reg.active_devices().count(), 0);
+        // revoke() stamps revoked_at (TIN-1417 B4).
+        assert!(reg.find("old-phone").unwrap().revoked_at.is_some());
         assert!(!reg.revoke("nonexistent"));
     }
 
@@ -410,6 +740,9 @@ mod tests {
             description: Some("my test device".into()),
             enrolled_at: 2000,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 42,
         });
         reg.save(&path).unwrap();
@@ -543,5 +876,246 @@ mod tests {
             !rc.all_capable(),
             "an empty active set must not satisfy the contract gate"
         );
+    }
+
+    // ── TIN-1417 B4: signed registry ──────────────────────────────────────────
+
+    const MASTER_A: [u8; 32] = [0x11; 32];
+    const MASTER_B: [u8; 32] = [0x22; 32];
+
+    fn signed_registry(master: &[u8; 32]) -> DeviceRegistry {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("alpha", &real_pubkey(), None);
+        reg.enroll("beta", &real_pubkey(), None);
+        reg.sign(master).unwrap();
+        reg
+    }
+
+    #[test]
+    fn sign_then_verify_roundtrips() {
+        let reg = signed_registry(&MASTER_A);
+        assert!(reg.is_signed());
+        assert_eq!(
+            reg.verify_signature(&MASTER_A).unwrap(),
+            RegistryTrust::Signed
+        );
+    }
+
+    #[test]
+    fn signing_is_deterministic_for_same_device_set() {
+        let mut a = DeviceRegistry::default();
+        let pk1 = real_pubkey();
+        let pk2 = real_pubkey();
+        a.enroll("one", &pk1, None);
+        a.enroll("two", &pk2, None);
+        // Same devices (same ids/keys) inserted in the OPPOSITE order.
+        let mut b = DeviceRegistry {
+            devices: a.devices.iter().cloned().rev().collect(),
+            ..Default::default()
+        };
+        a.sign(&MASTER_A).unwrap();
+        b.sign(&MASTER_A).unwrap();
+        assert_eq!(
+            a.registry_signature, b.registry_signature,
+            "canonical signing payload must be order-independent"
+        );
+    }
+
+    #[test]
+    fn tamper_inject_recipient_fails_verification() {
+        let mut reg = signed_registry(&MASTER_A);
+        // Attacker appends a hostile recipient but cannot re-sign.
+        reg.enroll("attacker", &real_pubkey(), None);
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(
+            err.to_string().contains("FAILED verification"),
+            "injecting a recipient must fail signature verification: {err:#}"
+        );
+    }
+
+    #[test]
+    fn tamper_unrevoke_fails_verification() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("keep", &real_pubkey(), None);
+        reg.enroll("gone", &real_pubkey(), None);
+        reg.revoke("gone");
+        reg.sign(&MASTER_A).unwrap();
+        assert_eq!(
+            reg.verify_signature(&MASTER_A).unwrap(),
+            RegistryTrust::Signed
+        );
+        // Attacker un-revokes the device in place.
+        reg.devices
+            .iter_mut()
+            .find(|d| d.name == "gone")
+            .unwrap()
+            .revoked = false;
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(
+            err.to_string().contains("FAILED verification"),
+            "un-revoking a device must fail signature verification: {err:#}"
+        );
+    }
+
+    #[test]
+    fn tamper_flip_field_fails_verification() {
+        let mut reg = signed_registry(&MASTER_A);
+        reg.devices[0].public_key = real_pubkey();
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(err.to_string().contains("FAILED verification"), "{err:#}");
+    }
+
+    #[test]
+    fn signature_from_unrelated_key_is_rejected() {
+        // Registry signed by master B is rejected when verified against master A.
+        let reg = signed_registry(&MASTER_B);
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(
+            err.to_string().contains("UNEXPECTED key"),
+            "a signature from a non-master-derived signer must be rejected: {err:#}"
+        );
+    }
+
+    #[test]
+    fn forged_signer_pubkey_is_rejected() {
+        // Attacker re-signs with their OWN ed25519 key and swaps in their pubkey;
+        // verification must still reject because the signer isn't master-derived.
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("victim", &real_pubkey(), None);
+        let attacker = registry_signing_key(&MASTER_B); // any non-master-A key
+        let payload = reg.canonical_signing_payload().unwrap();
+        let sig: Signature = attacker.sign(&payload);
+        reg.registry_signature = Some(b64().encode(sig.to_bytes()));
+        reg.signer_pubkey = Some(b64().encode(attacker.verifying_key().to_bytes()));
+        reg.sig_alg = Some(REGISTRY_SIG_ALG.to_string());
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(err.to_string().contains("UNEXPECTED key"), "{err:#}");
+    }
+
+    #[test]
+    fn incomplete_envelope_is_rejected() {
+        let mut reg = signed_registry(&MASTER_A);
+        reg.signer_pubkey = None; // signature present but signer missing
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(err.to_string().contains("incomplete"), "{err:#}");
+    }
+
+    #[test]
+    fn unsigned_legacy_registry_loads_with_migration_trust() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("legacy", &real_pubkey(), None);
+        assert!(!reg.is_signed());
+        assert_eq!(
+            reg.verify_signature(&MASTER_A).unwrap(),
+            RegistryTrust::UnsignedLegacy
+        );
+    }
+
+    #[test]
+    fn legacy_json_without_new_fields_still_parses() {
+        // A registry as written by the pre-B4 code: no envelope, no new fields.
+        let legacy = r#"{
+            "devices": [
+                {
+                    "name": "old",
+                    "device_id": "id-1",
+                    "public_key": "age1legacy",
+                    "enrolled_at": 100,
+                    "revoked": false
+                }
+            ]
+        }"#;
+        let reg: DeviceRegistry = serde_json::from_str(legacy).unwrap();
+        assert_eq!(reg.devices.len(), 1);
+        assert_eq!(reg.devices[0].revoked_at, None);
+        assert_eq!(reg.devices[0].enrolled_by, None);
+        assert!(!reg.is_signed());
+    }
+
+    #[test]
+    fn save_signed_then_load_verified_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("devices.json");
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("disk", &real_pubkey(), None);
+        reg.save_signed(&path, &MASTER_A).unwrap();
+
+        let (loaded, trust) = DeviceRegistry::load_verified(&path, &MASTER_A).unwrap();
+        assert_eq!(trust, RegistryTrust::Signed);
+        assert_eq!(loaded.devices.len(), 1);
+
+        // A registry signed by a different master fails load_verified.
+        let err = DeviceRegistry::load_verified(&path, &MASTER_B).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("UNEXPECTED key"),
+            "load_verified must reject a registry signed by a different master: {err:#}"
+        );
+    }
+
+    #[test]
+    fn load_verified_missing_file_is_trusted_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        let (reg, trust) = DeviceRegistry::load_verified(&path, &MASTER_A).unwrap();
+        assert!(reg.devices.is_empty());
+        assert_eq!(trust, RegistryTrust::Signed);
+    }
+
+    #[test]
+    fn tampered_on_disk_json_fails_load_verified() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("devices.json");
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("orig", &real_pubkey(), None);
+        reg.save_signed(&path, &MASTER_A).unwrap();
+
+        // Tamper with the JSON on disk: inject a hostile recipient by hand.
+        let mut value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let devices = value["devices"].as_array_mut().unwrap();
+        devices.push(serde_json::json!({
+            "name": "evil",
+            "device_id": "evil-id",
+            "public_key": real_pubkey(),
+            "enrolled_at": 1,
+            "revoked": false
+        }));
+        std::fs::write(&path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+
+        let err = DeviceRegistry::load_verified(&path, &MASTER_A).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("verifying device registry signature")
+                || err.to_string().contains("FAILED verification"),
+            "a hand-tampered on-disk registry must fail load_verified: {err:#}"
+        );
+    }
+
+    #[test]
+    fn unsigned_registry_serializes_without_new_envelope_or_identity_fields() {
+        // Back-compat: an UNSIGNED registry must serialize byte-compatibly with
+        // the pre-B4 schema — none of the new optional fields leak into the JSON,
+        // so older readers see exactly what they used to.
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("plain", &real_pubkey(), None);
+        let json = serde_json::to_string(&reg).unwrap();
+        for forbidden in [
+            "registry_signature",
+            "signer_pubkey",
+            "sig_alg",
+            "revoked_at",
+            "enrolled_by",
+            "signing_pubkey",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "unsigned registry must not emit `{forbidden}` (back-compat): {json}"
+            );
+        }
+        // A signed registry, by contrast, DOES carry the envelope fields.
+        reg.sign(&MASTER_A).unwrap();
+        let signed = serde_json::to_string(&reg).unwrap();
+        assert!(signed.contains("registry_signature"));
+        assert!(signed.contains("signer_pubkey"));
     }
 }

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -26,7 +26,7 @@
 
 use anyhow::{Context, Result};
 use base64::Engine as _;
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -144,8 +144,15 @@ pub struct DeviceRegistry {
 pub enum RegistryTrust {
     /// Envelope carried a valid signature from the expected master-derived signer.
     Signed,
-    /// Legacy registry with no signature. Accepted only inside the migration
-    /// window; callers must treat its recipient set as UNVERIFIED.
+    /// Legacy registry with no signature. Accepted only inside the bounded
+    /// TIN-1417 B4 migration window; callers MUST treat its recipient set as
+    /// UNVERIFIED and MUST NOT launder it into a signed registry (see
+    /// `enforce_remote_merge_trust` on the enroll `--sync-remote` path).
+    ///
+    /// MIGRATION WINDOW (TODO TIN-1417 B5, hard-reject by 2026-09-01): once every
+    /// fleet has re-saved at least once with a master key, the read-side builders
+    /// and the remote-merge path should reject `UnsignedLegacy` outright instead
+    /// of falling back to the master wrap / requiring an opt-in flag.
     UnsignedLegacy,
 }
 
@@ -359,7 +366,10 @@ impl DeviceRegistry {
                     .map_err(|_| anyhow::anyhow!("registry signature is not 64 bytes"))?;
                 let signature = Signature::from_bytes(&sig_arr);
                 let payload = self.canonical_signing_payload()?;
-                expected.verify(&payload, &signature).map_err(|_| {
+                // verify_strict (not verify): rejects non-canonical / small-order
+                // signature components, closing Ed25519 malleability so a tampered
+                // registry cannot ride along on a malleable-but-valid signature.
+                expected.verify_strict(&payload, &signature).map_err(|_| {
                     anyhow::anyhow!(
                         "device registry signature FAILED verification; the device list was \
                          tampered with or re-signed by a different key"

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -243,6 +243,31 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         warn!("E2E encryption: configured but master key unavailable");
     }
 
+    // TIN-1417 B4: ensure the on-disk device registry is signed with the
+    // master-derived key. The auto-enroll above runs before the master key is
+    // available, so a first-run registry is written unsigned; re-sign it here so
+    // per-device wrapping can trust it. Best-effort: a load/verify failure here
+    // (e.g. a registry signed by a *different* master) is logged, not fatal.
+    if let Some(ref mk) = master_key {
+        match tcfs_secrets::device::DeviceRegistry::load_verified(&registry_path, mk.as_bytes()) {
+            Ok((_, tcfs_secrets::device::RegistryTrust::Signed)) => {}
+            Ok((mut reg, tcfs_secrets::device::RegistryTrust::UnsignedLegacy)) => {
+                if let Err(e) = reg.save_signed(&registry_path, mk.as_bytes()) {
+                    warn!("TIN-1417 B4: failed to sign device registry: {e}");
+                } else {
+                    info!("TIN-1417 B4: signed previously-unsigned device registry");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "TIN-1417 B4: device registry failed signature verification ({e}); leaving \
+                     as-is. Per-device wrapping will refuse to trust it until re-signed with the \
+                     correct master key."
+                );
+            }
+        }
+    }
+
     // Build storage operator and verify connectivity
     let mut operator: Option<opendal::Operator> = None;
     let storage_ok = if let Some(s3) = cred_store.read().await.as_ref().and_then(|c| c.s3.as_ref())

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -58,11 +58,27 @@ pub(crate) fn build_encryption_context(
         .device_identity
         .clone()
         .unwrap_or_else(tcfs_secrets::device::default_registry_path);
-    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
-        Ok(r) => r,
+    // TIN-1417 B4: the recipient set MUST come from a signature-VERIFIED registry.
+    // A tampered/unsigned registry must never source per-device recipients —
+    // fall back to the shared master wrap (and warn) instead of wrapping to an
+    // unverified, possibly-hostile recipient.
+    let registry = match tcfs_secrets::device::DeviceRegistry::load_verified(
+        &registry_path,
+        master_key.as_bytes(),
+    ) {
+        Ok((r, tcfs_secrets::device::RegistryTrust::Signed)) => r,
+        Ok((_, tcfs_secrets::device::RegistryTrust::UnsignedLegacy)) => {
+            tracing::warn!(
+                "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing to \
+                 build a per-device recipient set from an unverified registry — using master \
+                 wrap. Re-save the registry with a master-key command to sign it."
+            );
+            return base;
+        }
         Err(e) => {
             tracing::warn!(
-                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+                "wrap_mode={requested:?}: device registry FAILED signature verification ({e}); \
+                 refusing per-device recipients — using master wrap (fail-closed)"
             );
             return base;
         }


### PR DESCRIPTION
## DRAFT (agent-drafted, needs review) — TIN-1417 B4 (SEV-1)

Makes per-device revocation trustworthy by signing the device registry.

### Problem
`crates/tcfs-secrets/src/device.rs` stored the device registry as plain
`serde_json` with **no signature verification**. The registry is also the
per-device **age recipient set** (`active_devices()` -> `build_encryption_context`
-> `wrap_file_key_for_age_recipients`). Anyone with direct object-store write to
`meta_prefix/tcfs-meta/devices.json` could inject a hostile recipient, un-revoke
a device, or drop one. `signing_key_hash` is a BLAKE3 **self-fingerprint**, not a
signature; the module doc-comment falsely claimed the registry was "signed by the
master identity".

### Design
- **Signing key**: HKDF-SHA256 from the master key, domain
  `tcfs-device-registry-signing-v1`, into an Ed25519 `SigningKey`. Every
  master-key holder derives the same signer — **no new key distribution**.
- **Envelope**: `registry_signature` / `signer_pubkey` / `sig_alg` stored
  alongside `devices` in the same JSON object. Excluded from the signed payload
  so they can be (re)written without invalidating it. serde ignores unknown
  fields, so old readers keep parsing.
- **Canonical payload**: device list sorted by `device_id` then `name`,
  serialized deterministically, prefixed by the algorithm tag. Order-independent
  and tamper-evident.
- **Verify** binds to the master-derived signer FIRST (a signature from any other
  key is rejected even if internally valid), then verifies the signature. A
  present-but-invalid signature is a HARD error. An unsigned registry is
  `RegistryTrust::UnsignedLegacy` — accepted only in a bounded migration window
  with a loud warn.
- New `DeviceIdentity` fields: `revoked_at`, `enrolled_by`, `signing_pubkey`
  (optional, back-compat). `revoke()` stamps `revoked_at`.

### Where recipient-set verification is enforced (fail-closed)
All three `build_encryption_context` readers now call `load_verified` and
**refuse to build a per-device recipient set** from an unsigned/tampered
registry, falling back to the shared master wrap instead of wrapping to an
unverified recipient:
- `crates/tcfsd/src/grpc.rs` (daemon)
- `crates/tcfs-cli/src/main.rs` (CLI)
- `crates/tcfs-file-provider/src/device_ctx.rs` (FileProvider, grpc backend)

Writers sign the registry: `tcfs init`, `device enroll`, `device revoke`,
device-id backfill, and remote sync; the daemon re-signs a first-run/unsigned
registry once the master key is loaded.

### Back-compat / safety
- `wrap_mode` stays **master** by default. The `Master` path returns before any
  verification, so **default behavior is byte-identical**.
- An unsigned registry serializes **without** any of the new fields (guarded by a
  test), so old readers see identical JSON.

### Tests (all passing)
tcfs-secrets (40) + readers: tampered `devices.json` (inject recipient /
un-revoke / flip field) fails verification on load; registry signed by an
unrelated key rejected; forged signer pubkey rejected; recipient-set builders
refuse an unverified registry; sign->serialize->load->verify round-trip; legacy
unsigned registry loads with a warn; back-compat serialization guard.

### FULL LOCAL CI GATE
- `cargo fmt --all -- --check`: CLEAN
- `cargo clippy` (tcfs-secrets/tcfsd/tcfs-cli/tcfs-mcp + file-provider grpc):
  no NEW warnings (the 2 remaining `needless_borrow` warnings in `grpc.rs` are
  pre-existing on `origin/main`, in code untouched by this change).
- `cargo test`: tcfs-secrets 40, tcfsd/tcfs-cli/tcfs-mcp suites, file-provider
  (grpc) device_ctx 8 — all green.
- `cargo-deny` is pre-existing-RED (RUSTSEC) on `origin/main` — not addressed.

### Needs human review / follow-ups
- **Swift / FileProvider**: not compiled in this sandbox. Under the macOS
  sandbox the `.appex` cannot fs-read `~/.config/tcfs`; it reads config from the
  shared Keychain. This PR keeps the existing `device_ctx.rs` fs-read pattern and
  only adds signature verification on top. For real per-device FP reads the Swift
  host must also inline the active recipients + this device's age secret into the
  Keychain config copy, and the Rust read-side must prefer the inlined values
  before the fs fallback. **Requires real-device Xcode build + FileProvider QA.**
- Migration window policy (when to stop accepting `UnsignedLegacy`) is left open.
- Per-event append-only signed log is a deliberate follow-up; this PR is the
  whole-registry signature + `revoked_at` SEV-1 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)