### PR TITLE
fix(fileprovider): restore cargo-deny and grpc-only build gates

### DIFF
--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -37,7 +37,7 @@
 /// `encrypted_file_key`, so those backends would fall through to "no file key"
 /// and write encrypted chunk bytes verbatim. This guard turns that into a loud,
 /// explicit error instead.
-#[cfg(any(feature = "direct", feature = "grpc"))]
+#[cfg(any(feature = "direct", test))]
 pub(crate) fn ensure_master_decryptable(
     manifest: &tcfs_sync::manifest::SyncManifest,
 ) -> anyhow::Result<()> {
@@ -116,6 +116,7 @@ fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapM
 fn resolve_recipients(
     config: &serde_json::Value,
     requested: tcfs_core::config::WrapMode,
+    master_key: &tcfs_crypto::MasterKey,
 ) -> Option<(Vec<tcfs_crypto::AgeFileKeyRecipient>, bool)> {
     // Inlined-first: the Keychain-provided config copy carries the active
     // recipients so the sandboxed FileProvider never reads devices.json. These
@@ -196,7 +197,7 @@ fn resolve_recipients(
                 "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing \
                  per-device recipients from an unverified registry — using master wrap."
             );
-            return base;
+            return None;
         }
         Err(e) => {
             tracing::warn!(
@@ -316,7 +317,7 @@ pub(crate) fn build_encryption_context(
         return base;
     }
 
-    let (recipients, all_capable) = match resolve_recipients(config, requested) {
+    let (recipients, all_capable) = match resolve_recipients(config, requested, master_key) {
         Some(v) => v,
         None => return base,
     };

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ targets = [
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
     "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
+    "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ targets = [
 [advisories]
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
+    "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,6 @@ targets = [
 [advisories]
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
-    "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]


### PR DESCRIPTION
## Summary

- ignore the active `RUSTSEC-2026-0173` proc-macro-error2 unmaintained advisory with a scoped build-time dependency justification
- keep the `RUSTSEC-2026-0097` rand advisory ignore because CI's current advisory DB still reports `rand 0.8.5` through `age`; TCFS does not install a custom logger that calls `rand::rng()`
- fix the FileProvider `--no-default-features --features grpc` build by passing the master key into signed-registry recipient resolution and returning the caller's master fallback via `None`
- tighten `ensure_master_decryptable` to compile only for the direct backend or tests, removing the grpc-only dead-code warning

## Validation

- `~/.cargo/bin/cargo deny check`
- `~/.cargo/bin/cargo check -p tcfs-file-provider --no-default-features --features grpc`
- `~/.cargo/bin/cargo test -p tcfs-file-provider --no-default-features --features grpc ensure_master_decryptable_rejects_per_device_manifest`
- `git diff --check`
