### PR TITLE
DRAFT: TIN-1898 FP direct/uniffi backends read Dual/v2 via master-wrap fallback (agent-drafted, needs review)

### DIFF
--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -32,21 +32,38 @@
 /// Fail CLOSED when a manifest that this backend cannot decrypt would otherwise
 /// be copied to disk as raw ciphertext (silent corruption).
 ///
-/// The `direct`/`uniffi` backends only implement master-key unwrapping. A
-/// per-device manifest carries `wrapped_file_keys` and OMITS the master-wrapped
-/// `encrypted_file_key`, so those backends would fall through to "no file key"
-/// and write encrypted chunk bytes verbatim. This guard turns that into a loud,
-/// explicit error instead.
+/// The `direct`/`uniffi` backends only implement master-key unwrapping (they
+/// carry no per-device age identity). The decision mirrors the engine read
+/// switch (TIN-1898, `tcfs-sync/src/engine.rs` ~:2395): a manifest's
+/// `wrapped_file_keys` being non-empty is NOT on its own a reason to fail —
+/// what matters is whether a usable master wrap is also present.
+///
+/// - **Dual (v2)** manifests carry BOTH `wrapped_file_keys` AND a master
+///   `encrypted_file_key`. A backend with no per-device identity can (and must)
+///   fall back to the master wrap — exactly as the engine does. This guard
+///   therefore PERMITS Dual manifests; the master-unwrap path below handles
+///   them via `encrypted_file_key`.
+/// - **PerDevice (v3)** manifests carry `wrapped_file_keys` and OMIT the
+///   master wrap (`encrypted_file_key == None`). A master-only backend cannot
+///   decrypt them, so it would fall through to "no file key" and write
+///   encrypted chunk bytes verbatim. For these we stay strictly fail-closed and
+///   turn the situation into a loud, explicit error instead of materializing raw
+///   ciphertext.
+///
+/// In short: reject iff `wrapped_file_keys` is non-empty AND there is no master
+/// wrap to fall back to. This keeps `wrap_mode=master` and Dual content readable
+/// on the legacy backends while never silently materializing PerDevice/v3
+/// ciphertext.
 #[cfg(any(feature = "direct", test))]
 pub(crate) fn ensure_master_decryptable(
     manifest: &tcfs_sync::manifest::SyncManifest,
 ) -> anyhow::Result<()> {
-    if !manifest.wrapped_file_keys.is_empty() {
+    if !manifest.wrapped_file_keys.is_empty() && manifest.encrypted_file_key.is_none() {
         anyhow::bail!(
-            "manifest is per-device encrypted (wrapped_file_keys present) but this \
-             FileProvider backend only supports master-key unwrapping; refusing to \
-             materialize raw ciphertext. Use the gRPC backend with a device identity \
-             configured to read per-device content."
+            "manifest is per-device encrypted (wrapped_file_keys present, no master \
+             wrap) but this FileProvider backend only supports master-key unwrapping; \
+             refusing to materialize raw ciphertext. Use the gRPC backend with a device \
+             identity configured to read per-device content."
         );
     }
     Ok(())
@@ -849,10 +866,12 @@ mod tests {
         );
     }
 
-    /// The fail-loud guard for the master-only backends rejects per-device
-    /// manifests instead of copying raw ciphertext.
+    /// The fail-loud guard for the master-only backends rejects PerDevice/v3
+    /// manifests (wrapped_file_keys present, NO master wrap) instead of copying
+    /// raw ciphertext — but PERMITS Dual/v2 manifests (both wraps present) and
+    /// plain master-only manifests, mirroring the engine read switch (TIN-1898).
     #[test]
-    fn ensure_master_decryptable_rejects_per_device_manifest() {
+    fn ensure_master_decryptable_rejects_per_device_but_allows_dual_and_master() {
         let base = || tcfs_sync::manifest::SyncManifest {
             version: 2,
             file_hash: String::new(),
@@ -867,17 +886,38 @@ mod tests {
             wrapped_file_keys: Vec::new(),
         };
 
-        let mut per_device = base();
-        per_device
-            .wrapped_file_keys
-            .push(tcfs_sync::manifest::WrappedFileKey {
-                recipient_device_id: "device-a".to_string(),
-                recipient: "age1example".to_string(),
-                algorithm: "age-x25519-v1".to_string(),
-                wrapped_key: "deadbeef".to_string(),
-            });
-        assert!(ensure_master_decryptable(&per_device).is_err());
+        let wrap = || tcfs_sync::manifest::WrappedFileKey {
+            recipient_device_id: "device-a".to_string(),
+            recipient: "age1example".to_string(),
+            algorithm: "age-x25519-v1".to_string(),
+            wrapped_key: "deadbeef".to_string(),
+        };
 
+        // PerDevice/v3: wrapped_file_keys present, encrypted_file_key absent ->
+        // no master wrap to fall back to -> MUST fail closed.
+        let mut per_device = base();
+        per_device.wrapped_file_keys.push(wrap());
+        assert!(
+            ensure_master_decryptable(&per_device).is_err(),
+            "PerDevice/v3 (no master wrap) must fail closed"
+        );
+
+        // Dual/v2: BOTH wraps present -> master fallback is available -> PERMIT
+        // (the master-unwrap path handles it). Mirrors engine.rs ~:2434.
+        let mut dual = base();
+        dual.wrapped_file_keys.push(wrap());
+        dual.encrypted_file_key = Some("bWFzdGVyd3JhcA==".to_string());
+        assert!(
+            ensure_master_decryptable(&dual).is_ok(),
+            "Dual/v2 (both wraps) must be permitted via the master wrap"
+        );
+
+        // Plain master-only manifest stays readable, unchanged.
+        let mut master_only = base();
+        master_only.encrypted_file_key = Some("bWFzdGVyd3JhcA==".to_string());
+        assert!(ensure_master_decryptable(&master_only).is_ok());
+
+        // Plaintext (no wraps at all) stays readable, unchanged.
         assert!(ensure_master_decryptable(&base()).is_ok());
     }
 }

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -395,9 +395,11 @@ pub unsafe extern "C" fn tcfs_provider_fetch(
             let manifest =
                 tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes())?;
 
-            // Fail CLOSED on per-device manifests: this direct backend only
-            // unwraps master-wrapped keys. A `wrapped_file_keys` manifest would
-            // otherwise fall through to "no file key" and copy raw ciphertext.
+            // Fail CLOSED on PerDevice/v3 manifests: this direct backend only
+            // unwraps master-wrapped keys. A `wrapped_file_keys` manifest with no
+            // master wrap would otherwise fall through to "no file key" and copy
+            // raw ciphertext. Dual/v2 (both wraps present) is permitted and read
+            // via the master wrap below (TIN-1898, mirrors the engine switch).
             crate::device_ctx::ensure_master_decryptable(&manifest)?;
 
             // Unwrap file key if E2EE manifest
@@ -521,7 +523,8 @@ pub unsafe extern "C" fn tcfs_provider_fetch_with_progress(
             let manifest =
                 tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes())?;
 
-            // Fail CLOSED on per-device manifests (see fetch path above).
+            // Fail CLOSED on PerDevice/v3 manifests only (see fetch path above);
+            // Dual/v2 reads via the master wrap (TIN-1898).
             crate::device_ctx::ensure_master_decryptable(&manifest)?;
 
             let file_key = match (&prov.master_key, &manifest.encrypted_file_key) {
@@ -1353,6 +1356,232 @@ mod tests {
             assert!(!item.is_directory);
 
             crate::tcfs_file_items_free(items, count);
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── TIN-1898: Dual/master-wrap fallback on the master-only direct backend ──
+    //
+    // The direct backend carries no per-device age identity. Mirroring the engine
+    // read switch (tcfs-sync/src/engine.rs ~:2395), a Dual/v2 manifest (BOTH a
+    // master `encrypted_file_key` AND `wrapped_file_keys`) must be READABLE here
+    // via the master wrap; a PerDevice/v3 manifest (wrapped_file_keys, NO master
+    // wrap) must stay strictly FAIL-CLOSED; a plain master-only manifest is
+    // unchanged.
+
+    /// Build a `TcfsProvider` over a caller-supplied operator + master key so the
+    /// test can seed the same in-memory store the provider reads from.
+    fn master_provider_on(
+        operator: opendal::Operator,
+        prefix: &str,
+        master_key: tcfs_crypto::MasterKey,
+    ) -> *mut TcfsProvider {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        Box::into_raw(Box::new(TcfsProvider {
+            runtime,
+            operator,
+            remote_prefix: prefix.to_string(),
+            device_id: "test-device".to_string(),
+            master_key: Some(master_key),
+            last_error: Mutex::new(None),
+        }))
+    }
+
+    /// Seed a single-chunk encrypted file under `prefix` for `rel`, returning the
+    /// FileKey-derived ciphertext layout. `include_master` toggles the master
+    /// `encrypted_file_key`; `include_wraps` toggles a `wrapped_file_keys` entry.
+    ///
+    /// Combinations:
+    /// - master only       -> (true,  false): plain v2 master manifest.
+    /// - dual              -> (true,  true) : v2 with BOTH wraps.
+    /// - per-device / v3   -> (false, true) : wrapped_file_keys, NO master wrap.
+    ///
+    /// The per-device wrap is a placeholder `WrappedFileKey` — the master-only
+    /// backend never attempts to unwrap it (it has no identity), exactly as in
+    /// production; only its presence/absence drives the guard decision.
+    fn seed_encrypted_file(
+        operator: &opendal::Operator,
+        prefix: &str,
+        rel: &str,
+        content: &[u8],
+        master_key: &tcfs_crypto::MasterKey,
+        include_master: bool,
+        include_wraps: bool,
+    ) {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("seed runtime");
+        rt.block_on(async {
+            let file_hash = tcfs_chunks::hash_bytes(content);
+            let file_hash_hex = tcfs_chunks::hash_to_hex(&file_hash);
+            let file_id: [u8; 32] = *file_hash.as_bytes();
+
+            let file_key = tcfs_crypto::generate_file_key();
+            let encrypted =
+                tcfs_crypto::encrypt_chunk(&file_key, 0, &file_id, content).expect("encrypt chunk");
+            let chunk_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&encrypted));
+
+            // chunks/<hash> = encrypted chunk bytes
+            operator
+                .write(
+                    &format!("{}/chunks/{}", prefix.trim_end_matches('/'), chunk_hash),
+                    encrypted,
+                )
+                .await
+                .expect("write chunk");
+
+            let encrypted_file_key = if include_master {
+                let wrapped = tcfs_crypto::wrap_key(master_key, &file_key).expect("wrap master");
+                Some(base64::engine::general_purpose::STANDARD.encode(wrapped))
+            } else {
+                None
+            };
+            let wrapped_file_keys = if include_wraps {
+                // Placeholder per-device wrap: never unwrapped by this backend.
+                vec![tcfs_sync::manifest::WrappedFileKey {
+                    recipient_device_id: "device-b".to_string(),
+                    recipient: "age1placeholderrecipientnotparsedbymasterbackend".to_string(),
+                    algorithm: "age-x25519-file-key-v1".to_string(),
+                    wrapped_key: "PLACEHOLDER-WRAP".to_string(),
+                }]
+            } else {
+                Vec::new()
+            };
+
+            let manifest = tcfs_sync::manifest::SyncManifest {
+                // v3 iff per-device-only (no master wrap); else v2.
+                version: if include_wraps && !include_master {
+                    3
+                } else {
+                    2
+                },
+                file_hash: file_hash_hex.clone(),
+                file_size: content.len() as u64,
+                chunks: vec![chunk_hash],
+                vclock: tcfs_sync::conflict::VectorClock::default(),
+                written_by: "device-b".to_string(),
+                written_at: 0,
+                rel_path: Some(rel.to_string()),
+                mode: None,
+                encrypted_file_key,
+                wrapped_file_keys,
+            };
+
+            operator
+                .write(
+                    &format!(
+                        "{}/manifests/{}",
+                        prefix.trim_end_matches('/'),
+                        file_hash_hex
+                    ),
+                    manifest.to_bytes().expect("manifest bytes"),
+                )
+                .await
+                .expect("write manifest");
+
+            let index = tcfs_sync::index_entry::RemoteIndexEntry::new(
+                file_hash_hex,
+                content.len() as u64,
+                1,
+            );
+            operator
+                .write(
+                    &format!("{}/index/{}", prefix.trim_end_matches('/'), rel),
+                    index.to_legacy_bytes(),
+                )
+                .await
+                .expect("write index");
+        });
+    }
+
+    /// A Dual/v2 manifest (master + per-device wraps) is READABLE via the
+    /// master-only direct backend through the master wrap — fetch succeeds and
+    /// the plaintext round-trips. This is the core TIN-1898 fix.
+    #[test]
+    fn dual_manifest_reads_via_master_wrap_on_direct_backend() {
+        let operator = opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "dual";
+        let content = b"dual manifest readable via master fallback on the FP direct backend";
+        seed_encrypted_file(&operator, prefix, "dual.txt", content, &master, true, true);
+
+        let prov = master_provider_on(operator, prefix, master);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        unsafe {
+            let c_item = CString::new("dual.txt").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch(prov, c_item.as_ptr(), c_dest.as_ptr());
+            assert_eq!(
+                err,
+                TcfsError::TcfsErrorNone,
+                "Dual manifest must be readable via the master wrap"
+            );
+            assert_eq!(std::fs::read(&dest).unwrap(), content);
+            tcfs_provider_free(prov);
+        }
+    }
+
+    /// A PerDevice/v3 manifest (wrapped_file_keys, NO master wrap) still FAILS
+    /// CLOSED on the master-only direct backend: fetch errors and no file is
+    /// materialized (never raw ciphertext).
+    #[test]
+    fn per_device_manifest_fails_closed_on_direct_backend() {
+        let operator = opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "pd";
+        let content = b"per-device-only payload that the master-only backend cannot read";
+        seed_encrypted_file(&operator, prefix, "pd.txt", content, &master, false, true);
+
+        let prov = master_provider_on(operator, prefix, master);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        unsafe {
+            let c_item = CString::new("pd.txt").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch(prov, c_item.as_ptr(), c_dest.as_ptr());
+            assert_ne!(
+                err,
+                TcfsError::TcfsErrorNone,
+                "PerDevice/v3 manifest must FAIL CLOSED on the master-only backend"
+            );
+            assert!(
+                !dest.exists(),
+                "fail-closed fetch must not materialize a (corrupt) file"
+            );
+            tcfs_provider_free(prov);
+        }
+    }
+
+    /// A plain master-only manifest reads unchanged on the direct backend —
+    /// regression guard for the default `wrap_mode=master` path.
+    #[test]
+    fn master_only_manifest_reads_unchanged_on_direct_backend() {
+        let operator = opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "mo";
+        let content = b"plain master-only payload, unchanged";
+        seed_encrypted_file(&operator, prefix, "mo.txt", content, &master, true, false);
+
+        let prov = master_provider_on(operator, prefix, master);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        unsafe {
+            let c_item = CString::new("mo.txt").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch(prov, c_item.as_ptr(), c_dest.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert_eq!(std::fs::read(&dest).unwrap(), content);
             tcfs_provider_free(prov);
         }
     }

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -305,13 +305,16 @@ impl TcfsProviderHandle {
                 message: e.to_string(),
             })?;
 
-            // Fail CLOSED on per-device manifests: this backend only unwraps
-            // master-wrapped keys. A `wrapped_file_keys` manifest would
+            // Fail CLOSED on PerDevice/v3 manifests only: this backend unwraps
+            // master-wrapped keys only (no per-device age identity). A manifest
+            // with `wrapped_file_keys` AND no master `encrypted_file_key` would
             // otherwise fall through to "no file key" and copy raw ciphertext.
-            if !manifest.wrapped_file_keys.is_empty() {
+            // Dual/v2 manifests (both wraps present) are readable via the master
+            // wrap below, mirroring the engine read switch (TIN-1898).
+            if !manifest.wrapped_file_keys.is_empty() && manifest.encrypted_file_key.is_none() {
                 return Err(ProviderError::Decryption {
-                    message: "manifest is per-device encrypted (wrapped_file_keys present); \
-                              this backend only supports master-key unwrapping"
+                    message: "manifest is per-device encrypted (wrapped_file_keys present, \
+                              no master wrap); this backend only supports master-key unwrapping"
                         .to_string(),
                 });
             }
@@ -412,11 +415,13 @@ impl TcfsProviderHandle {
                 message: e.to_string(),
             })?;
 
-            // Fail CLOSED on per-device manifests (see hydrate path above).
-            if !manifest.wrapped_file_keys.is_empty() {
+            // Fail CLOSED on PerDevice/v3 manifests only (see hydrate path above):
+            // Dual/v2 (both wraps) is readable via the master wrap; only a
+            // wrapped_file_keys manifest with NO master wrap is refused.
+            if !manifest.wrapped_file_keys.is_empty() && manifest.encrypted_file_key.is_none() {
                 return Err(ProviderError::Decryption {
-                    message: "manifest is per-device encrypted (wrapped_file_keys present); \
-                              this backend only supports master-key unwrapping"
+                    message: "manifest is per-device encrypted (wrapped_file_keys present, \
+                              no master wrap); this backend only supports master-key unwrapping"
                         .to_string(),
                 });
             }
@@ -881,9 +886,197 @@ fn verify_bootstrap_signature(
     Ok(diff == 0)
 }
 
+/// Test-only constructor: build a handle directly over a caller-supplied
+/// operator + optional master key, bypassing the S3/network constructor so
+/// unit tests can seed an in-memory store and exercise the read path.
+#[cfg(test)]
+impl TcfsProviderHandle {
+    fn new_for_test(
+        operator: opendal::Operator,
+        remote_prefix: &str,
+        master_key: Option<tcfs_crypto::MasterKey>,
+    ) -> Arc<Self> {
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        Arc::new(Self {
+            runtime,
+            operator,
+            remote_prefix: remote_prefix.to_string(),
+            device_id: "ios-test".to_string(),
+            master_key,
+            #[cfg(feature = "uniffi")]
+            totp_provider: Arc::new(tcfs_auth::totp::TotpProvider::new(
+                tcfs_auth::totp::TotpConfig::default(),
+            )),
+            #[cfg(feature = "uniffi")]
+            session_store: tcfs_auth::SessionStore::new(),
+        })
+    }
+}
+
 #[cfg(all(test, feature = "uniffi"))]
 mod tests {
     use super::*;
+    use base64::Engine;
+
+    /// Seed a single-chunk encrypted file under `prefix` for `rel`. See the
+    /// direct-backend `seed_encrypted_file` for the layout rationale (TIN-1898).
+    /// `include_master`/`include_wraps` select master-only / dual / per-device.
+    fn seed_encrypted_file(
+        operator: &opendal::Operator,
+        prefix: &str,
+        rel: &str,
+        content: &[u8],
+        master_key: &tcfs_crypto::MasterKey,
+        include_master: bool,
+        include_wraps: bool,
+    ) {
+        let rt = tokio::runtime::Runtime::new().expect("seed runtime");
+        rt.block_on(async {
+            let file_hash = tcfs_chunks::hash_bytes(content);
+            let file_hash_hex = tcfs_chunks::hash_to_hex(&file_hash);
+            let file_id: [u8; 32] = *file_hash.as_bytes();
+
+            let file_key = tcfs_crypto::generate_file_key();
+            let encrypted =
+                tcfs_crypto::encrypt_chunk(&file_key, 0, &file_id, content).expect("encrypt chunk");
+            let chunk_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&encrypted));
+
+            operator
+                .write(
+                    &format!("{}/chunks/{}", prefix.trim_end_matches('/'), chunk_hash),
+                    encrypted,
+                )
+                .await
+                .expect("write chunk");
+
+            let encrypted_file_key = if include_master {
+                let wrapped = tcfs_crypto::wrap_key(master_key, &file_key).expect("wrap master");
+                Some(base64::engine::general_purpose::STANDARD.encode(wrapped))
+            } else {
+                None
+            };
+            let wrapped_file_keys = if include_wraps {
+                vec![tcfs_sync::manifest::WrappedFileKey {
+                    recipient_device_id: "device-b".to_string(),
+                    recipient: "age1placeholderrecipientnotparsedbymasterbackend".to_string(),
+                    algorithm: "age-x25519-file-key-v1".to_string(),
+                    wrapped_key: "PLACEHOLDER-WRAP".to_string(),
+                }]
+            } else {
+                Vec::new()
+            };
+
+            let manifest = tcfs_sync::manifest::SyncManifest {
+                version: if include_wraps && !include_master {
+                    3
+                } else {
+                    2
+                },
+                file_hash: file_hash_hex.clone(),
+                file_size: content.len() as u64,
+                chunks: vec![chunk_hash],
+                vclock: tcfs_sync::conflict::VectorClock::default(),
+                written_by: "device-b".to_string(),
+                written_at: 0,
+                rel_path: Some(rel.to_string()),
+                mode: None,
+                encrypted_file_key,
+                wrapped_file_keys,
+            };
+
+            operator
+                .write(
+                    &format!(
+                        "{}/manifests/{}",
+                        prefix.trim_end_matches('/'),
+                        file_hash_hex
+                    ),
+                    manifest.to_bytes().expect("manifest bytes"),
+                )
+                .await
+                .expect("write manifest");
+
+            let index = tcfs_sync::index_entry::RemoteIndexEntry::new(
+                file_hash_hex,
+                content.len() as u64,
+                1,
+            );
+            operator
+                .write(
+                    &format!("{}/index/{}", prefix.trim_end_matches('/'), rel),
+                    index.to_legacy_bytes(),
+                )
+                .await
+                .expect("write index");
+        });
+    }
+
+    fn memory_operator() -> opendal::Operator {
+        opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish()
+    }
+
+    /// TIN-1898: a Dual/v2 manifest (master + per-device wraps) is READABLE via
+    /// the master-only uniffi backend through the master wrap.
+    #[test]
+    fn dual_manifest_reads_via_master_wrap_on_uniffi_backend() {
+        let operator = memory_operator();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "dual";
+        let content = b"dual manifest readable via master fallback on the uniffi backend";
+        seed_encrypted_file(&operator, prefix, "dual.txt", content, &master, true, true);
+
+        let handle = TcfsProviderHandle::new_for_test(operator, prefix, Some(master));
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        handle
+            .hydrate_file(&format!("{prefix}/index/dual.txt"), dest.to_str().unwrap())
+            .expect("Dual manifest must hydrate via the master wrap");
+        assert_eq!(std::fs::read(&dest).unwrap(), content);
+    }
+
+    /// TIN-1898: a PerDevice/v3 manifest (wrapped_file_keys, NO master wrap)
+    /// still FAILS CLOSED on the master-only uniffi backend and writes no file.
+    #[test]
+    fn per_device_manifest_fails_closed_on_uniffi_backend() {
+        let operator = memory_operator();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "pd";
+        let content = b"per-device-only payload the uniffi master backend cannot read";
+        seed_encrypted_file(&operator, prefix, "pd.txt", content, &master, false, true);
+
+        let handle = TcfsProviderHandle::new_for_test(operator, prefix, Some(master));
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        let res = handle.hydrate_file(&format!("{prefix}/index/pd.txt"), dest.to_str().unwrap());
+        assert!(
+            matches!(res, Err(ProviderError::Decryption { .. })),
+            "PerDevice/v3 must FAIL CLOSED with a Decryption error, got {res:?}"
+        );
+        assert!(
+            !dest.exists(),
+            "fail-closed hydrate must not materialize a (corrupt) file"
+        );
+    }
+
+    /// A plain master-only manifest reads unchanged on the uniffi backend.
+    #[test]
+    fn master_only_manifest_reads_unchanged_on_uniffi_backend() {
+        let operator = memory_operator();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "mo";
+        let content = b"plain master-only payload, unchanged (uniffi)";
+        seed_encrypted_file(&operator, prefix, "mo.txt", content, &master, true, false);
+
+        let handle = TcfsProviderHandle::new_for_test(operator, prefix, Some(master));
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        handle
+            .hydrate_file(&format!("{prefix}/index/mo.txt"), dest.to_str().unwrap())
+            .expect("master-only manifest must hydrate unchanged");
+        assert_eq!(std::fs::read(&dest).unwrap(), content);
+    }
 
     fn test_provider() -> Arc<TcfsProviderHandle> {
         TcfsProviderHandle::new(ProviderConfig {


### PR DESCRIPTION
**DRAFT (agent-drafted, needs review).**

## TIN-1898: apply the Dual/v2 master-wrap fallback to the legacy direct/uniffi FileProvider backends

### Problem
The legacy `direct`/`uniffi` FileProvider backends perform **master-key
unwrapping only** (no per-device age identity). Their fail-closed guard
rejected **any** manifest carrying `wrapped_file_keys`, which also locked out
**Dual (v2)** manifests — those carry BOTH a master `encrypted_file_key` AND
per-device wraps. A Master-mode / no-identity device therefore could not read
peer-written Dual content on these backends, even though the master wrap is
right there.

The live daemon + gRPC read path already does the right thing (engine read
switch, `crates/tcfs-sync/src/engine.rs` ~:2395): try the per-device unwrap;
on failure, fall back to the master wrap **only when `encrypted_file_key` is
present (Dual/v2)**; a PerDevice/v3 manifest (`encrypted_file_key == None`)
stays strictly fail-closed.

### Change — mirror the engine semantics exactly
Reject iff `wrapped_file_keys` is non-empty **AND** `encrypted_file_key` is
`None` (PerDevice/v3). When the master wrap is present (Dual/v2), permit the
read; the existing master-unwrap path handles it via `encrypted_file_key`.

- `crates/tcfs-file-provider/src/device_ctx.rs` — `ensure_master_decryptable`
  now permits Dual and rejects only PerDevice/v3 (used by `direct.rs` fetch +
  fetch_with_progress).
- `crates/tcfs-file-provider/src/uniffi_bridge.rs` — same condition applied
  inline to `hydrate_file` and `hydrate_file_with_progress` (preserving the
  existing `ProviderError::Decryption` variant for the refusal).
- `crates/tcfs-file-provider/src/direct.rs` — comments updated; guard unchanged
  in call shape.

### Invariants preserved
- **`wrap_mode=master` is byte-identical** — a plain master-only manifest
  (`wrapped_file_keys` empty) is untouched.
- **PerDevice/v3 fails CLOSED** — no master wrap means no fallback; never
  materialize raw ciphertext.

### Tests (tcfs-file-provider)
- `direct.rs`: Dual/v2 manifest **reads via the master wrap**; PerDevice/v3
  **fails closed** (no file materialized); master-only unchanged.
- `uniffi_bridge.rs`: same three cases through `hydrate_file`.
- `device_ctx.rs`: `ensure_master_decryptable` permits Dual + master-only,
  rejects PerDevice/v3.

Each test hand-seeds an in-memory OpenDAL store with a real single-chunk
encrypted manifest (master wrap via `wrap_key`, placeholder per-device wrap —
the master-only backend never attempts to unwrap it, exactly as in production).

### Gate (rebased onto current `origin/main`, which includes #500 / the
grpc-compile fix)
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p tcfs-file-provider --all-targets` for `direct` / `uniffi` /
  `grpc`: clean (no new warnings).
- `cargo test -p tcfs-file-provider` (`direct` default, `uniffi`, `grpc`): all
  pass, incl. the new tests.
- `cargo-deny` is pre-existing-red (RUSTSEC, tracked separately) — out of scope.

### Notes for review
- Branch was cut from `origin/main@c7f725c`; that commit had a **pre-existing,
  unrelated grpc-only compile break** in `resolve_recipients`
  (`device_ctx.rs`). It is fixed upstream by `8eabc80` (merged via #500). This
  branch is **rebased onto current `origin/main`** so the full gate is green;
  no behavior from that fix was altered here.
- Out of scope: the gRPC backend already handles per-device reads via a device
  identity; this PR only widens the master-only backends to Dual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
