### PR TITLE
DRAFT: fix(tcfs-file-provider): repair grpc-feature device_ctx compile — FileProvider staticlib CI red (agent-drafted, needs review)

### DIFF
--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -37,7 +37,7 @@
 /// `encrypted_file_key`, so those backends would fall through to "no file key"
 /// and write encrypted chunk bytes verbatim. This guard turns that into a loud,
 /// explicit error instead.
-#[cfg(any(feature = "direct", feature = "grpc"))]
+#[cfg(any(feature = "direct", test))]
 pub(crate) fn ensure_master_decryptable(
     manifest: &tcfs_sync::manifest::SyncManifest,
 ) -> anyhow::Result<()> {
@@ -116,6 +116,7 @@ fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapM
 fn resolve_recipients(
     config: &serde_json::Value,
     requested: tcfs_core::config::WrapMode,
+    master_key: &tcfs_crypto::MasterKey,
 ) -> Option<(Vec<tcfs_crypto::AgeFileKeyRecipient>, bool)> {
     // Inlined-first: the Keychain-provided config copy carries the active
     // recipients so the sandboxed FileProvider never reads devices.json. These
@@ -196,7 +197,9 @@ fn resolve_recipients(
                 "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing \
                  per-device recipients from an unverified registry — using master wrap."
             );
-            return base;
+            // `None` signals the caller (build_encryption_context) to fall back
+            // to the master-only context (`base`), matching the daemon.
+            return None;
         }
         Err(e) => {
             tracing::warn!(
@@ -316,7 +319,7 @@ pub(crate) fn build_encryption_context(
         return base;
     }
 
-    let (recipients, all_capable) = match resolve_recipients(config, requested) {
+    let (recipients, all_capable) = match resolve_recipients(config, requested, master_key) {
         Some(v) => v,
         None => return base,
     };


### PR DESCRIPTION
## DRAFT (agent-drafted, needs review)

> **Heads-up for the reviewer:** the CI red this branch targets is **already fixed on `main`** by commit `8eabc80` ("fix(fileprovider): compile grpc-only per-device context", merged in #500). This branch was cut from the **pre-fix** parent `c7f725c` per the task spec and independently arrived at the **identical** fix. The only substantive difference vs `main` is a 2-line explanatory comment. **Likely close-without-merge** unless you want the comment.

### The CI failure (Track B — `.github` #36)

The `FileProvider staticlib (macOS)` job (`.github/workflows/ci.yml`, job `fileprovider-staticlib`) runs four steps; the **fourth** is the one that was red:

```
cargo check -p tcfs-file-provider --no-default-features --features grpc
```

It failed to compile:

```
error[E0425]: cannot find value `master_key` in this scope
   --> crates/tcfs-file-provider/src/device_ctx.rs:191
error[E0425]: cannot find value `base` in this scope
   --> crates/tcfs-file-provider/src/device_ctx.rs:199
```

The first three steps (`cargo build -p tcfs-file-provider --release` with default `direct` features, staticlib existence, cbindgen header) all pass — the break is **grpc-feature-only**, which is why the default build and the normal test run never caught it.

### Root cause

`crates/tcfs-file-provider/src/device_ctx.rs`. The B4 signed-registry change made `DeviceRegistry::load_verified()` take the master key for signature verification. In the daemon (`crates/tcfsd/src/grpc.rs`) that call lives **inside** `build_encryption_context`, where both `master_key` and `base` (the master-only `EncryptionContext`) are in scope, so `return base;` is valid.

In the FileProvider crate the registry-loading logic was factored into a separate helper, `resolve_recipients(config, requested) -> Option<(Vec<…>, bool)>`, which has **neither** `master_key` nor `base` in scope:

- line ~191: `load_verified(&registry_path, master_key.as_bytes())` — `master_key` undefined here
- line ~199 (unsigned-legacy branch): `return base;` — `base` is an `EncryptionContext` that doesn't exist in this `Option`-returning helper

Because `build_encryption_context` and its helpers are `#[cfg(feature = "grpc")]`-only and the default build/tests use `direct`, this shipped silently from `c7f725c`.

### Fix (identical to landed `8eabc80`)

Mirrors the daemon's `build_encryption_context` behavior contract:

1. Thread `master_key: &tcfs_crypto::MasterKey` into `resolve_recipients` and pass it to `load_verified()`.
2. The unsigned-legacy branch returns `None` — the helper's "use master wrap" signal (the caller maps `None -> return base`) — instead of the out-of-scope `base`.
3. Update the call site to pass `master_key`.
4. Re-gate `ensure_master_decryptable` to `#[cfg(any(feature = "direct", test))]` — its only callers are the `direct` backend and the grpc-gated test module — which also clears a grpc-only `dead_code` warning.

Fail-closed posture is unchanged and `wrap_mode=master` stays byte-identical: an unsigned/tampered registry still falls back to the shared master wrap.

### Reproduced + verified

- **Repro:** `cargo check -p tcfs-file-provider --no-default-features --features grpc` on `c7f725c` → the two `E0425` errors above.
- **Verified:** same command after the fix → compiles, **zero warnings**.

### Local gate

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets` — exit 0; `tcfs-file-provider` clean under `direct` + `grpc`. The only warnings are 2 pre-existing ones in `crates/tcfsd/src/grpc.rs:1442,1875` (untouched crate, not introduced here).
- `cargo test -p tcfs-file-provider` (direct) and `… --no-default-features --features grpc` — all pass (grpc: 22 lib + 25 ffi; direct: 25 ffi). The grpc lib tests exercise the exact `resolve_recipients` / `build_encryption_context` paths changed here.
- `cargo check` under `direct`, `grpc`, and `uniffi` — all compile.
- `cargo-deny` is pre-existing-red (RUSTSEC, PR #500) — out of scope, not run.
