### PR TITLE
docs: define git roam daily-driver acceptance

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -107,8 +107,8 @@ tasks:
   lazy:check:
     desc: Run lazy hydration harness/static regression checks
     cmds:
-      - bash -n scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-tcfs-rollout-readiness.sh scripts/test-macos-tcfs-rollout-readiness.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
-      - shellcheck scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-tcfs-rollout-readiness.sh scripts/test-macos-tcfs-rollout-readiness.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
+      - bash -n scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/git-roam-daily-driver-harness.sh scripts/test-git-roam-daily-driver-harness.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-tcfs-rollout-readiness.sh scripts/test-macos-tcfs-rollout-readiness.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
+      - shellcheck scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/git-roam-daily-driver-harness.sh scripts/test-git-roam-daily-driver-harness.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-tcfs-rollout-readiness.sh scripts/test-macos-tcfs-rollout-readiness.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
       - python3 -m py_compile scripts/asc-fileprovider-lab-provision.py scripts/tcfs-smoke-endpoint-preflight.py scripts/test-tcfs-smoke-endpoint-preflight.py scripts/large-workdir-inventory.py scripts/test-large-workdir-inventory.py
       - task: lazy:test-linux-lifecycle-demo
       - task: lazy:test-mounted-smoke
@@ -121,6 +121,7 @@ tasks:
       - task: lazy:test-neo-honey-conflict
       - task: lazy:test-git-repo-canary
       - task: lazy:test-git-repo-restore-proof
+      - task: lazy:test-git-roam-daily-driver
       - task: lazy:test-tcfs-symlink-package-probe
       - task: lazy:test-home-canary-linux-xr-shadow
       - task: lazy:test-home-canary-linux-xr-storage-posture
@@ -674,6 +675,46 @@ tasks:
     desc: Regression-test the git repo fresh-tree restore proof helper
     cmds:
       - bash scripts/test-git-repo-restore-proof.sh
+
+  lazy:git-roam-daily-driver-plan:
+    desc: "Plan-only evidence packet for the ~/git daily-driver roam story"
+    cmds:
+      - cmd: |
+          bash -euo pipefail <<'EOF'
+          args=()
+
+          if [[ -n "${REPO:-}" ]]; then
+            args+=(--repo "$REPO")
+          fi
+          if [[ -n "${AGENT_ROOT:-}" ]]; then
+            args+=(--agent-root "$AGENT_ROOT")
+          fi
+          if [[ -n "${NAME:-}" ]]; then
+            args+=(--name "$NAME")
+          fi
+          if [[ -n "${ORIGIN_HOST:-}" ]]; then
+            args+=(--origin-host "$ORIGIN_HOST")
+          fi
+          if [[ -n "${CONTINUATION_HOST:-}" ]]; then
+            args+=(--continuation-host "$CONTINUATION_HOST")
+          fi
+          if [[ -n "${THIRD_HOST:-}" ]]; then
+            args+=(--third-host "$THIRD_HOST")
+          fi
+          if [[ -n "${REMOTE_PREFIX:-}" ]]; then
+            args+=(--remote-prefix "$REMOTE_PREFIX")
+          fi
+          if [[ -n "${EVIDENCE_DIR:-}" ]]; then
+            args+=(--evidence-dir "$EVIDENCE_DIR")
+          fi
+
+          scripts/git-roam-daily-driver-harness.sh "${args[@]}"
+          EOF
+
+  lazy:test-git-roam-daily-driver:
+    desc: Regression-test the git roam daily-driver plan-only harness
+    cmds:
+      - bash scripts/test-git-roam-daily-driver-harness.sh
 
   lazy:storage-large-restore-slo:
     desc: "Evaluate a storage large-restore packet against optional SLO budgets"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -707,6 +707,12 @@ tasks:
           if [[ -n "${EVIDENCE_DIR:-}" ]]; then
             args+=(--evidence-dir "$EVIDENCE_DIR")
           fi
+          if [[ -n "${MAX_HASH_FILES:-}" ]]; then
+            args+=(--max-hash-files "$MAX_HASH_FILES")
+          fi
+          if [[ -n "${MAX_HASH_FILE_BYTES:-}" ]]; then
+            args+=(--max-hash-file-bytes "$MAX_HASH_FILE_BYTES")
+          fi
 
           scripts/git-roam-daily-driver-harness.sh "${args[@]}"
           EOF

--- a/docs/ops/git-repo-canary-dogfood.md
+++ b/docs/ops/git-repo-canary-dogfood.md
@@ -261,3 +261,9 @@ A live repo can become a candidate only after a shadow packet proves all of:
    that repo into TCFS.
 9. source symlinks are not skipped during push and rehydrate as symlinks with
    exact matching targets
+
+The broader "machine does not matter" claim has an additional acceptance matrix:
+[git-roam-daily-driver-acceptance-2026-06-08.md](git-roam-daily-driver-acceptance-2026-06-08.md).
+That matrix must pass for dirty WIP, Git metadata, agent context, unsync,
+conflict behavior, and reverse-origin flow before citing any repo canary as
+daily-driver `~/git` readiness.

--- a/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
+++ b/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
@@ -1,0 +1,238 @@
+# `~/git` Roam Daily-Driver Acceptance - 2026-06-08
+
+Status: acceptance plan for the "machine does not matter" TCFS user story.
+
+Related trackers: `TIN-1617`, `TIN-1620`, `TIN-1738`, `TIN-1899`.
+
+Related runbooks:
+
+- [large-workdir-daily-driver-sequencing-2026-05-30.md](large-workdir-daily-driver-sequencing-2026-05-30.md)
+- [claude-projects-roam-enrollment-2026-06-08.md](claude-projects-roam-enrollment-2026-06-08.md)
+- [git-repo-canary-dogfood.md](git-repo-canary-dogfood.md)
+
+## Golden Objective
+
+An enrolled operator can start work on any enrolled host, leave that work
+uncommitted, SSH into another enrolled host, browse the same logical `~/git`
+namespace, hydrate the needed repo and agent context, continue work, then
+optionally unsync either host without losing the remote encrypted copy.
+
+The claim is not "every byte under `~/git` is blindly mirrored." The claim is:
+
+1. enrolled repo roots are discoverable from every enrolled host;
+2. active working-tree state can be continued from any enrolled host;
+3. the Git history/refs needed to understand that work are restored by the
+   Git-safety path, not by naive live `.git/objects` mirroring;
+4. agent context for the same work is present through the `~/.claude/projects`
+   reconcile root; and
+5. secrets, live databases, caches, generated outputs, and large disposable
+   artifacts stay denied or snapshot-only.
+
+## What Must Be True
+
+The daily-driver story is only proven when all of these hold together for the
+same repo/session pair:
+
+- **Any origin host:** work can begin on `neo`, `honey`, or the next enrolled
+  host such as `bumble`.
+- **Any continuation host:** another enrolled host can traverse the repo path
+  before full hydration, hydrate only what is needed, and continue.
+- **Dirty WIP:** modified tracked files, untracked files, deletes, renames, file
+  mode changes, and symlink targets survive the round trip.
+- **Git metadata:** `git status --porcelain=v1 -b`, `git rev-parse HEAD`,
+  current branch, local refs, and the restored object graph match the source
+  snapshot after the Git bundle restore path runs.
+- **Agent continuity:** the matching `~/.claude/projects` session/subtree
+  converges with the repo so an agent can resume with the same transcript and
+  path references.
+- **Unsync/cloud-only:** either host can evict local bodies while preserving
+  stubs/metadata, and a later open or explicit hydrate restores exact bytes.
+- **Conflict visibility:** concurrent edits to the same file produce an
+  explicit conflict/recovery state, while independent sibling edits converge.
+- **Policy safety:** denied paths never enter a push plan, evidence packet, or
+  remote prefix.
+
+## Enrollment Model
+
+Use repo-by-repo enrollment. Do not flip broad `~/git` ownership as the first
+move.
+
+Recommended root classes:
+
+| Class | Default posture | Notes |
+| --- | --- | --- |
+| Working tree files | Sync | Normal source files, docs, tests, configs. |
+| `.git` | Git-safety bundle/restore | Restore real history and refs; do not rely on naive live object mirroring. |
+| Agent context | Scheduled reconcile | `~/.claude/projects` under `agent/claude-projects`; keep auth roots out. |
+| Generated output | Deny | `target`, `node_modules`, `.svelte-kit`, `build`, `.venv`, caches. |
+| Secrets/auth | Deny fail-closed | `.env*`, `auth.json`, `.credentials.json`, SOPS secret trees, SSH/GPG material. |
+| Live DB/WAL | Deny or snapshot-only | `*.sqlite`, `*.db`, `*-wal`, `*-shm`; never live-mirror open WAL streams. |
+| Large artifacts | Repo-specific | Example: `rockies/.artifacts` needs explicit policy. |
+
+## Acceptance Gates
+
+### R0 - Policy And Inventory
+
+For each candidate repo, archive:
+
+- root path, machine, hostname, timestamp, TCFS version, wrap mode, device list;
+- `git status --porcelain=v1 -b`;
+- `git rev-parse HEAD`, current branch, local refs summary;
+- untracked file inventory;
+- symlink inventory and targets;
+- unsupported special files;
+- generated-output and secret deny matches; and
+- expected remote prefix.
+
+Pass condition: denied paths are listed as denied, not silently omitted from the
+evidence.
+
+### R1 - Single-Origin Dirty WIP
+
+Start on `neo` with one small candidate repo and create a dirty snapshot:
+
+- modify a tracked source file;
+- add one untracked file;
+- delete one tracked file;
+- rename one file;
+- include one symlink or mode-change fixture when the repo supports it; and
+- append to the matching `~/.claude/projects` session.
+
+Pass condition: `honey` hydrates the repo and agent session, then reports the
+same dirty state and exact plaintext hashes.
+
+### R2 - Reverse Origin
+
+Repeat R1 with the mutation originating on `honey` and continuing on `neo`.
+
+Pass condition: the direction does not matter. This is the minimum proof for
+"work can start anywhere" across two hosts.
+
+### R3 - Unsync And Cloud-Only
+
+After R1/R2 converge:
+
+- unsync the source host;
+- verify local bodies are evicted while stubs/metadata remain where applicable;
+- hydrate on the continuation host;
+- reopen on the source host and rehydrate exact bytes.
+
+Pass condition: unsync is a local storage decision, not a data-loss event.
+
+### R4 - Git Bundle Restore
+
+Restore the repo into a fresh tree on the continuation host using the Git-safety
+bundle path.
+
+Pass condition:
+
+- `git fsck` passes where practical;
+- `git status --porcelain=v1 -b` matches the source snapshot;
+- `git rev-parse HEAD` matches;
+- local refs/branches needed by the WIP are present; and
+- the working tree and untracked files match the source evidence.
+
+### R5 - Conflict And Independent Edits
+
+Run both cases:
+
+- same-file concurrent edit on two hosts; and
+- independent sibling edits on two hosts.
+
+Pass condition: same-file conflict is explicit and recoverable; independent
+sibling edits converge without manual object surgery.
+
+### R6 - Third-Host Readiness
+
+Before claiming `bumble` or any new server:
+
+- enroll the device through the hardened enrollment path;
+- prove the same remote prefix and device registry converge;
+- run R1/R3 from `bumble` as origin or continuation; and
+- confirm no host-specific absolute paths are baked into repo state except
+  expected local config.
+
+Pass condition: the test matrix expands by adding one host row, not by writing a
+new special-case flow.
+
+## Candidate Repo Order
+
+Start with repos that expose the behavior without turning scale into the first
+failure mode:
+
+1. `ci-templates` - small operational repo, good first repo.
+2. `site.scaffold` - useful generated-output excludes (`node_modules`,
+   `.svelte-kit`, `build`).
+3. `dell-7810` - already useful in the bounded agent-session proof.
+4. `yt-text` / Tubebrain checkout - Rust target-dir exclude coverage.
+5. `xoxdwm` - review secret-feature fixture names before enrollment.
+6. `rockies` - only after `.artifacts` policy is explicit.
+7. `linux-xr` / `linux-xr-fast` - stress/WIP gate, not first daily-driver repo.
+
+## Evidence Packet Contract
+
+Every live repo-roam packet should contain:
+
+- `source.env`: origin host, continuation host, repo path, remote prefix, TCFS
+  binary path/version/hash, wrap mode, device ids.
+- `git-source.txt` and `git-continuation.txt`: status, branch, HEAD, refs
+  summary, and `git fsck` result when run.
+- `tree-source.sha256` and `tree-continuation.sha256`: plaintext file hashes
+  after applying the deny policy.
+- `agent-source.sha256` and `agent-continuation.sha256`: matching
+  `~/.claude/projects` session/subtree hashes.
+- `policy-deny.txt`: denied candidates observed during inventory.
+- `unsync.log`: local eviction / rehydrate transcript.
+- `conflict.log`: conflict or independent-edit transcript when that gate runs.
+- `result.env`: one machine-readable status with the allowed claim boundary.
+
+The packet must name whether it proves shadow-only, live repo, two-host, or
+three-host behavior. A packet that proves only shadow restore must not be cited
+as broad live `~/git` readiness.
+
+## Harness Gap List
+
+Existing helpers already cover important pieces:
+
+- `task lazy:git-roam-daily-driver-plan`
+- `task lazy:git-repo-canary`
+- `task lazy:git-repo-restore-proof`
+- `task lazy:neo-honey-unsynced-rehydrate-plan`
+- `task lazy:neo-honey-reverse-unsynced-rehydrate-plan`
+- `task lazy:neo-honey-delete-rename-unsynced-plan`
+- `task lazy:neo-honey-conflict-plan`
+
+Missing combined harnesses before the golden objective can be claimed:
+
+1. `git-roam-dirty-wip` - upgrades the plan-only packet into an executed R1
+   dirty snapshot and asserts exact
+   continuation state.
+2. `git-roam-reverse-origin` - same test with `honey` as origin.
+3. `git-roam-agent-coupled` - ties repo evidence to the matching
+   `~/.claude/projects` session evidence.
+4. `git-roam-third-host` - parameterizes the host matrix so `bumble` is another
+   row, not a new script family.
+5. `git-roam-policy-leak` - fails if any denied secret/live-DB/generated path
+   appears in push plans, evidence manifests, or remote listing samples.
+
+## Stop Rules
+
+- Do not bulk-enroll all of `~/git` before two small repos pass R0-R5 in both
+  directions.
+- Do not treat `~/.claude/projects` roam as proof that repo WIP roams; it only
+  proves agent context.
+- Do not treat Git shadow restore as proof that a live repo can be managed until
+  dirty WIP, unsync, and conflict gates pass.
+- Do not claim per-device revoke/rotate field security until the live fleet is
+  in `PerDevice` wrap mode and the revoked-device canary proves denial after
+  `tcfs key rotate <prefix>`.
+- Do not enroll live SQLite/WAL, auth files, `.env*`, SSH/GPG material, or SOPS
+  secret trees.
+
+## Next Implementation Slice
+
+The next low-risk code slice is a plan-only harness that emits the R0-R5 packet
+shape for one selected repo without mutating TCFS state. After that, wire
+execution to the existing `git-repo-canary`, reverse-origin, delete/rename,
+conflict, and restore-proof helpers so the combined user story is tested as one
+claim instead of five unrelated proofs.

--- a/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
+++ b/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
@@ -69,6 +69,20 @@ Recommended root classes:
 | Live DB/WAL | Deny or snapshot-only | `*.sqlite`, `*.db`, `*-wal`, `*-shm`; never live-mirror open WAL streams. |
 | Large artifacts | Repo-specific | Example: `rockies/.artifacts` needs explicit policy. |
 
+### Git Metadata Mode Boundary
+
+`sync_git_dirs` is currently a global `sync` config field consumed by
+`tcfs reconcile` through `Blacklist::from_sync_config`, not a per-root
+`extraReconcileRoots` knob. The default Git mode is `bundle`: raw `.git`
+internals are skipped, a `.git-tcfs-bundle` object is synced, and pull-side
+restore reconstructs Git history/refs from that bundle.
+
+Raw `.git` as ordinary files (`git_sync_mode = "raw"`) is a separate stress
+mode. It may become useful for exact index/stash/worktree experiments, but it
+is not the default daily-driver claim and must prove index/mtime, lockfile,
+symlink, mode, and concurrent-operation safety before it can replace the
+bundle/restore path.
+
 ## Acceptance Gates
 
 ### R0 - Policy And Inventory
@@ -203,6 +217,11 @@ Existing helpers already cover important pieces:
 - `task lazy:neo-honey-conflict-plan`
 
 Missing combined harnesses before the golden objective can be claimed:
+
+The plan-only harness bounds hash collection by default so a real agent
+transcript tree cannot become an accidental long-running scan. Use
+`MAX_HASH_FILES=0 MAX_HASH_FILE_BYTES=0` only when the live canary intentionally
+needs full plaintext hash manifests.
 
 1. `git-roam-dirty-wip` - upgrades the plan-only packet into an executed R1
    dirty snapshot and asserts exact

--- a/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
+++ b/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
@@ -181,3 +181,4 @@ Inherits the global stop rules from the productionization todo, plus:
 - `TIN-1620` one expendable live repo (G5) · `TIN-1546`/`TIN-1622` storage soak
 - Design seed: [large-workdir-onboarding-design-2026-05-25.md](large-workdir-onboarding-design-2026-05-25.md)
 - Execution checklist: [tcfs-daily-driver-productionization-todo-2026-05-24.md](tcfs-daily-driver-productionization-todo-2026-05-24.md)
+- `~/git` daily-driver acceptance: [git-roam-daily-driver-acceptance-2026-06-08.md](git-roam-daily-driver-acceptance-2026-06-08.md)

--- a/scripts/git-roam-daily-driver-harness.sh
+++ b/scripts/git-roam-daily-driver-harness.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+#
+# Plan-only packet generator for the TCFS `~/git` daily-driver roam story.
+#
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/git-roam-daily-driver-harness.sh [options]
+
+Create a plan-only evidence packet for one repo plus matching agent context.
+This does not call tcfs, ssh, cargo, nix, or mutate the repo.
+
+Options:
+  --repo <path>                 Git worktree to inspect. Default: $PWD
+  --agent-root <path>           Agent context root. Default: ~/.claude/projects
+  --name <name>                 Packet name. Default: basename of --repo
+  --origin-host <host>          Host where work starts. Default: hostname
+  --continuation-host <host>    Host where work continues. Default: honey
+  --third-host <host>           Optional third enrolled host, e.g. bumble
+  --remote-prefix <prefix>      Expected TCFS prefix. Default: git-roam/<name>
+  --evidence-dir <path>         Evidence output dir
+  -h, --help                    Show this help
+
+Environment mirrors:
+  TCFS_GIT_ROAM_REPO
+  TCFS_GIT_ROAM_AGENT_ROOT
+  TCFS_GIT_ROAM_NAME
+  TCFS_GIT_ROAM_ORIGIN_HOST
+  TCFS_GIT_ROAM_CONTINUATION_HOST
+  TCFS_GIT_ROAM_THIRD_HOST
+  TCFS_GIT_ROAM_REMOTE_PREFIX
+  TCFS_GIT_ROAM_EVIDENCE_DIR
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+canonical_existing_path() {
+  local path="$1"
+  [[ -e "$path" ]] || fail "path does not exist: $path"
+  (cd "$path" && pwd -P)
+}
+
+sanitize_name() {
+  local name="$1"
+  name="${name##*/}"
+  name="$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '-')"
+  name="${name#-}"
+  name="${name%-}"
+  [[ -n "$name" ]] || name="repo"
+  printf '%s\n' "$name"
+}
+
+host_name() {
+  hostname 2>/dev/null || printf 'unknown-host\n'
+}
+
+write_tree_hashes() {
+  local root="$1"
+  local output="$2"
+  local mode="$3"
+
+  : >"$output"
+  if [[ ! -d "$root" ]]; then
+    printf 'status=missing root=%s\n' "$root" >"$output"
+    return 0
+  fi
+
+  (
+    cd "$root"
+    case "$mode" in
+      repo)
+        find . -type f \
+          ! -path './.git/*' \
+          ! -path './node_modules/*' \
+          ! -path './target/*' \
+          ! -path './.svelte-kit/*' \
+          ! -path './build/*' \
+          ! -path './.venv/*' \
+          -print | LC_ALL=C sort
+        ;;
+      agent)
+        find . -type f \
+          ! -name 'auth.json' \
+          ! -name '.credentials.json' \
+          ! -name 'mcp-auth.json' \
+          ! -name 'mcp-needs-auth-cache.json' \
+          ! -name '*.sqlite' \
+          ! -name '*.db' \
+          ! -name '*-wal' \
+          ! -name '*-shm' \
+          ! -path './.cache/*' \
+          -print | LC_ALL=C sort
+        ;;
+      *)
+        fail "unknown hash mode: $mode"
+        ;;
+    esac
+  ) | while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    (cd "$root" && shasum -a 256 "$rel")
+  done >"$output"
+}
+
+write_symlinks() {
+  local root="$1"
+  local output="$2"
+
+  : >"$output"
+  [[ -d "$root" ]] || return 0
+  while IFS= read -r link_path; do
+    [[ -n "$link_path" ]] || continue
+    printf '%s -> %s\n' "$link_path" "$(readlink "$link_path" 2>/dev/null || true)"
+  done < <(find "$root" -type l -print | LC_ALL=C sort)
+}
+
+write_policy_scan() {
+  local root="$1"
+  local label="$2"
+  local output="$3"
+
+  [[ -d "$root" ]] || return 0
+  {
+    while IFS= read -r path; do
+      [[ -n "$path" ]] || continue
+      local base
+      base="$(basename "$path")"
+      case "$path" in
+        */.git|*/.git/*)
+          printf '%s\tgit-safety\t%s\n' "$label" "$path"
+          ;;
+        */node_modules|*/node_modules/*|*/target|*/target/*|*/.svelte-kit|*/.svelte-kit/*|*/build|*/build/*|*/.venv|*/.venv/*)
+          printf '%s\tgenerated-deny\t%s\n' "$label" "$path"
+          ;;
+        */.ssh|*/.ssh/*|*/.gnupg|*/.gnupg/*|*/.config/sops-nix/secrets|*/.config/sops-nix/secrets/*)
+          printf '%s\tsecret-deny\t%s\n' "$label" "$path"
+          ;;
+      esac
+      case "$base" in
+        .env|.env.*|auth.json|.credentials.json|mcp-auth.json|mcp-needs-auth-cache.json|session-env)
+          printf '%s\tsecret-deny\t%s\n' "$label" "$path"
+          ;;
+        *.sqlite|*.db|*-wal|*-shm|*.wal|*.shm)
+          printf '%s\tlive-db-deny\t%s\n' "$label" "$path"
+          ;;
+        *.log)
+          printf '%s\tlog-deny\t%s\n' "$label" "$path"
+          ;;
+      esac
+    done < <(find "$root" -print | LC_ALL=C sort)
+  } >>"$output"
+}
+
+repo_root="${TCFS_GIT_ROAM_REPO:-$PWD}"
+agent_root="${TCFS_GIT_ROAM_AGENT_ROOT:-$HOME/.claude/projects}"
+packet_name="${TCFS_GIT_ROAM_NAME:-}"
+origin_host="${TCFS_GIT_ROAM_ORIGIN_HOST:-$(host_name)}"
+continuation_host="${TCFS_GIT_ROAM_CONTINUATION_HOST:-honey}"
+third_host="${TCFS_GIT_ROAM_THIRD_HOST:-}"
+remote_prefix="${TCFS_GIT_ROAM_REMOTE_PREFIX:-}"
+evidence_dir="${TCFS_GIT_ROAM_EVIDENCE_DIR:-}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || fail "--repo requires a value"
+      repo_root="$2"
+      shift 2
+      ;;
+    --agent-root)
+      [[ $# -ge 2 ]] || fail "--agent-root requires a value"
+      agent_root="$2"
+      shift 2
+      ;;
+    --name)
+      [[ $# -ge 2 ]] || fail "--name requires a value"
+      packet_name="$2"
+      shift 2
+      ;;
+    --origin-host)
+      [[ $# -ge 2 ]] || fail "--origin-host requires a value"
+      origin_host="$2"
+      shift 2
+      ;;
+    --continuation-host)
+      [[ $# -ge 2 ]] || fail "--continuation-host requires a value"
+      continuation_host="$2"
+      shift 2
+      ;;
+    --third-host)
+      [[ $# -ge 2 ]] || fail "--third-host requires a value"
+      third_host="$2"
+      shift 2
+      ;;
+    --remote-prefix)
+      [[ $# -ge 2 ]] || fail "--remote-prefix requires a value"
+      remote_prefix="$2"
+      shift 2
+      ;;
+    --evidence-dir)
+      [[ $# -ge 2 ]] || fail "--evidence-dir requires a value"
+      evidence_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+repo_root="$(canonical_existing_path "$repo_root")"
+git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+  fail "repo is not a git worktree: $repo_root"
+
+if [[ -z "$packet_name" ]]; then
+  packet_name="$(sanitize_name "$repo_root")"
+else
+  packet_name="$(sanitize_name "$packet_name")"
+fi
+remote_prefix="${remote_prefix:-git-roam/$packet_name}"
+
+if [[ -n "$agent_root" && -d "$agent_root" ]]; then
+  agent_root="$(canonical_existing_path "$agent_root")"
+fi
+
+if [[ -z "$evidence_dir" ]]; then
+  evidence_dir="docs/release/evidence/git-roam-${packet_name}-${timestamp}"
+fi
+mkdir -p "$evidence_dir"
+
+git_status_count="$(git -C "$repo_root" status --porcelain=v1 | wc -l | tr -d ' ')"
+
+{
+  printf 'status=plan-only\n'
+  printf 'packet=git-roam-daily-driver\n'
+  printf 'name=%s\n' "$packet_name"
+  printf 'repo=%s\n' "$repo_root"
+  printf 'agent_root=%s\n' "$agent_root"
+  printf 'origin_host=%s\n' "$origin_host"
+  printf 'continuation_host=%s\n' "$continuation_host"
+  printf 'third_host=%s\n' "$third_host"
+  printf 'remote_prefix=%s\n' "$remote_prefix"
+  printf 'dirty_status_count=%s\n' "$git_status_count"
+  printf 'tcfs_mutation=0\n'
+  printf 'ssh_mutation=0\n'
+  printf 'live_repo_claim=0\n'
+  printf 'daily_driver_claim=0\n'
+} >"$evidence_dir/source.env"
+
+{
+  printf '# source git status\n'
+  git -C "$repo_root" status --porcelain=v1 -b
+  printf '\n# head\n'
+  git -C "$repo_root" rev-parse HEAD
+  printf '\n# branch\n'
+  git -C "$repo_root" branch --show-current || true
+  printf '\n# refs\n'
+  git -C "$repo_root" show-ref --heads --tags || true
+} >"$evidence_dir/git-source.txt"
+
+write_tree_hashes "$repo_root" "$evidence_dir/tree-source.sha256" repo
+write_tree_hashes "$agent_root" "$evidence_dir/agent-source.sha256" agent
+write_symlinks "$repo_root" "$evidence_dir/symlinks.txt"
+: >"$evidence_dir/policy-deny.txt"
+write_policy_scan "$repo_root" repo "$evidence_dir/policy-deny.txt"
+write_policy_scan "$agent_root" agent "$evidence_dir/policy-deny.txt"
+
+cat >"$evidence_dir/gates.env" <<EOF
+r0_policy_inventory=planned
+r1_single_origin_dirty_wip=pending-live
+r2_reverse_origin=pending-live
+r3_unsync_cloud_only=pending-live
+r4_git_bundle_restore=pending-live
+r5_conflict_independent_edits=pending-live
+r6_third_host=pending-third-host
+EOF
+
+cat >"$evidence_dir/result.env" <<EOF
+status=plan-only
+proof=git-roam-daily-driver-packet-shape
+allowed_claim=packet-shape-only
+live_tcfs_mutation=0
+daily_driver_git_claim=0
+EOF
+
+cat >"$evidence_dir/README.md" <<EOF
+# TCFS Git Roam Daily-Driver Packet
+
+Status: plan-only.
+
+Repo: \`$repo_root\`
+Agent root: \`$agent_root\`
+Origin host: \`$origin_host\`
+Continuation host: \`$continuation_host\`
+Third host: \`$third_host\`
+Remote prefix: \`$remote_prefix\`
+
+This packet records the evidence shape for the \`~/git\` daily-driver roam
+story. It does not call TCFS, SSH, cargo, Nix, or mutate the repo.
+
+Use this packet to wire the live R0-R6 gates from
+\`docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md\`.
+EOF
+
+printf 'git roam daily-driver evidence: %s\n' "$evidence_dir"
+printf 'status: plan-only\n'

--- a/scripts/git-roam-daily-driver-harness.sh
+++ b/scripts/git-roam-daily-driver-harness.sh
@@ -63,6 +63,43 @@ host_name() {
   hostname 2>/dev/null || printf 'unknown-host\n'
 }
 
+emit_candidate_paths() {
+  local root="$1"
+  local mode="$2"
+
+  (
+    cd "$root"
+    case "$mode" in
+      repo)
+        find . -type f \
+          ! -path './.git/*' \
+          ! -path './node_modules/*' \
+          ! -path './target/*' \
+          ! -path './.svelte-kit/*' \
+          ! -path './build/*' \
+          ! -path './.venv/*' \
+          -print
+        ;;
+      agent)
+        find . -type f \
+          ! -name 'auth.json' \
+          ! -name '.credentials.json' \
+          ! -name 'mcp-auth.json' \
+          ! -name 'mcp-needs-auth-cache.json' \
+          ! -name '*.sqlite' \
+          ! -name '*.db' \
+          ! -name '*-wal' \
+          ! -name '*-shm' \
+          ! -path './.cache/*' \
+          -print
+        ;;
+      *)
+        fail "unknown hash mode: $mode"
+        ;;
+    esac
+  )
+}
+
 write_tree_hashes() {
   local root="$1"
   local output="$2"
@@ -83,40 +120,12 @@ write_tree_hashes() {
   local hashed=0
   local skipped_by_count=0
   local skipped_by_size=0
-  local list_file
-  list_file="$(mktemp "${TMPDIR:-/tmp}/tcfs-git-roam-hash-list.XXXXXX")"
 
-  (
-    cd "$root"
-    case "$mode" in
-      repo)
-        find . -type f \
-          ! -path './.git/*' \
-          ! -path './node_modules/*' \
-          ! -path './target/*' \
-          ! -path './.svelte-kit/*' \
-          ! -path './build/*' \
-          ! -path './.venv/*' \
-          -print | LC_ALL=C sort
-        ;;
-      agent)
-        find . -type f \
-          ! -name 'auth.json' \
-          ! -name '.credentials.json' \
-          ! -name 'mcp-auth.json' \
-          ! -name 'mcp-needs-auth-cache.json' \
-          ! -name '*.sqlite' \
-          ! -name '*.db' \
-          ! -name '*-wal' \
-          ! -name '*-shm' \
-          ! -path './.cache/*' \
-          -print | LC_ALL=C sort
-        ;;
-      *)
-        fail "unknown hash mode: $mode"
-        ;;
-    esac
-  ) >"$list_file"
+  local list_file=""
+  if [[ "$max_files" == "0" ]]; then
+    list_file="$(mktemp "${TMPDIR:-/tmp}/tcfs-git-roam-hash-list.XXXXXX")"
+    emit_candidate_paths "$root" "$mode" | LC_ALL=C sort >"$list_file"
+  fi
 
   while IFS= read -r rel; do
     [[ -n "$rel" ]] || continue
@@ -141,8 +150,16 @@ write_tree_hashes() {
     hashed=$((hashed + 1))
     printf 'scanned=%s\nhashed=%s\nskipped_by_count=%s\nskipped_by_size=%s\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \
       "$scanned" "$hashed" "$skipped_by_count" "$skipped_by_size" "$max_files" "$max_file_bytes" >"$meta_output"
-  done >"$output" <"$list_file"
-  rm -f "$list_file"
+  done >"$output" < <(
+    if [[ -n "$list_file" ]]; then
+      cat "$list_file"
+    else
+      emit_candidate_paths "$root" "$mode"
+    fi
+  )
+  if [[ -n "$list_file" ]]; then
+    rm -f "$list_file"
+  fi
 
   if [[ ! -s "$meta_output" ]]; then
     printf 'scanned=0\nhashed=0\nskipped_by_count=0\nskipped_by_size=0\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \

--- a/scripts/git-roam-daily-driver-harness.sh
+++ b/scripts/git-roam-daily-driver-harness.sh
@@ -20,6 +20,8 @@ Options:
   --third-host <host>           Optional third enrolled host, e.g. bumble
   --remote-prefix <prefix>      Expected TCFS prefix. Default: git-roam/<name>
   --evidence-dir <path>         Evidence output dir
+  --max-hash-files <n>          Hash at most n files per tree. Default: 5000; 0 = unlimited
+  --max-hash-file-bytes <n>     Skip individual files larger than n bytes. Default: 52428800; 0 = unlimited
   -h, --help                    Show this help
 
 Environment mirrors:
@@ -31,6 +33,8 @@ Environment mirrors:
   TCFS_GIT_ROAM_THIRD_HOST
   TCFS_GIT_ROAM_REMOTE_PREFIX
   TCFS_GIT_ROAM_EVIDENCE_DIR
+  TCFS_GIT_ROAM_MAX_HASH_FILES
+  TCFS_GIT_ROAM_MAX_HASH_FILE_BYTES
 EOF
 }
 
@@ -63,12 +67,24 @@ write_tree_hashes() {
   local root="$1"
   local output="$2"
   local mode="$3"
+  local max_files="$4"
+  local max_file_bytes="$5"
+  local meta_output="$6"
 
   : >"$output"
+  : >"$meta_output"
   if [[ ! -d "$root" ]]; then
     printf 'status=missing root=%s\n' "$root" >"$output"
+    printf 'status=missing\n' >"$meta_output"
     return 0
   fi
+
+  local scanned=0
+  local hashed=0
+  local skipped_by_count=0
+  local skipped_by_size=0
+  local list_file
+  list_file="$(mktemp "${TMPDIR:-/tmp}/tcfs-git-roam-hash-list.XXXXXX")"
 
   (
     cd "$root"
@@ -100,10 +116,38 @@ write_tree_hashes() {
         fail "unknown hash mode: $mode"
         ;;
     esac
-  ) | while IFS= read -r rel; do
+  ) >"$list_file"
+
+  while IFS= read -r rel; do
     [[ -n "$rel" ]] || continue
+    if rel_path_is_denied "$rel"; then
+      continue
+    fi
+    scanned=$((scanned + 1))
+    if [[ "$max_files" != "0" && "$hashed" -ge "$max_files" ]]; then
+      skipped_by_count=1
+      printf 'scanned=%s\nhashed=%s\nskipped_by_count=%s\nskipped_by_size=%s\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \
+        "$scanned" "$hashed" "$skipped_by_count" "$skipped_by_size" "$max_files" "$max_file_bytes" >"$meta_output"
+      break
+    fi
+    local file_size
+    file_size="$(cd "$root" && wc -c <"$rel" | tr -d ' ')"
+    if [[ "$max_file_bytes" != "0" && "$file_size" -gt "$max_file_bytes" ]]; then
+      skipped_by_size=$((skipped_by_size + 1))
+      printf 'SKIP_SIZE %s %s\n' "$file_size" "$rel"
+      continue
+    fi
     (cd "$root" && shasum -a 256 "$rel")
-  done >"$output"
+    hashed=$((hashed + 1))
+    printf 'scanned=%s\nhashed=%s\nskipped_by_count=%s\nskipped_by_size=%s\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \
+      "$scanned" "$hashed" "$skipped_by_count" "$skipped_by_size" "$max_files" "$max_file_bytes" >"$meta_output"
+  done >"$output" <"$list_file"
+  rm -f "$list_file"
+
+  if [[ ! -s "$meta_output" ]]; then
+    printf 'scanned=0\nhashed=0\nskipped_by_count=0\nskipped_by_size=0\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \
+      "$max_files" "$max_file_bytes" >"$meta_output"
+  fi
 }
 
 write_symlinks() {
@@ -115,7 +159,36 @@ write_symlinks() {
   while IFS= read -r link_path; do
     [[ -n "$link_path" ]] || continue
     printf '%s -> %s\n' "$link_path" "$(readlink "$link_path" 2>/dev/null || true)"
-  done < <(find "$root" -type l -print | LC_ALL=C sort)
+  done >"$output" < <(find "$root" -type l -print | LC_ALL=C sort)
+}
+
+rel_path_is_denied() {
+  local rel="$1"
+  local base
+  base="$(basename "$rel")"
+
+  case "$rel" in
+    ./.git|./.git/*|*/.git|*/.git/*|\
+    ./node_modules|./node_modules/*|*/node_modules|*/node_modules/*|\
+    ./target|./target/*|*/target|*/target/*|\
+    ./.svelte-kit|./.svelte-kit/*|*/.svelte-kit|*/.svelte-kit/*|\
+    ./build|./build/*|*/build|*/build/*|\
+    ./.venv|./.venv/*|*/.venv|*/.venv/*|\
+    ./.ssh|./.ssh/*|*/.ssh|*/.ssh/*|\
+    ./.gnupg|./.gnupg/*|*/.gnupg|*/.gnupg/*|\
+    ./.config/sops-nix/secrets|./.config/sops-nix/secrets/*|*/.config/sops-nix/secrets|*/.config/sops-nix/secrets/*)
+      return 0
+      ;;
+  esac
+
+  case "$base" in
+    .env|.env.*|auth.json|.credentials.json|mcp-auth.json|mcp-needs-auth-cache.json|session-env|\
+    *.sqlite|*.db|*-wal|*-shm|*.wal|*.shm|*.log)
+      return 0
+      ;;
+  esac
+
+  return 1
 }
 
 write_policy_scan() {
@@ -163,6 +236,8 @@ continuation_host="${TCFS_GIT_ROAM_CONTINUATION_HOST:-honey}"
 third_host="${TCFS_GIT_ROAM_THIRD_HOST:-}"
 remote_prefix="${TCFS_GIT_ROAM_REMOTE_PREFIX:-}"
 evidence_dir="${TCFS_GIT_ROAM_EVIDENCE_DIR:-}"
+max_hash_files="${TCFS_GIT_ROAM_MAX_HASH_FILES:-5000}"
+max_hash_file_bytes="${TCFS_GIT_ROAM_MAX_HASH_FILE_BYTES:-52428800}"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 
 while [[ $# -gt 0 ]]; do
@@ -207,6 +282,16 @@ while [[ $# -gt 0 ]]; do
       evidence_dir="$2"
       shift 2
       ;;
+    --max-hash-files)
+      [[ $# -ge 2 ]] || fail "--max-hash-files requires a value"
+      max_hash_files="$2"
+      shift 2
+      ;;
+    --max-hash-file-bytes)
+      [[ $# -ge 2 ]] || fail "--max-hash-file-bytes requires a value"
+      max_hash_file_bytes="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -216,6 +301,9 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+[[ "$max_hash_files" =~ ^[0-9]+$ ]] || fail "--max-hash-files must be a non-negative integer"
+[[ "$max_hash_file_bytes" =~ ^[0-9]+$ ]] || fail "--max-hash-file-bytes must be a non-negative integer"
 
 repo_root="$(canonical_existing_path "$repo_root")"
 git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
@@ -250,6 +338,8 @@ git_status_count="$(git -C "$repo_root" status --porcelain=v1 | wc -l | tr -d ' 
   printf 'third_host=%s\n' "$third_host"
   printf 'remote_prefix=%s\n' "$remote_prefix"
   printf 'dirty_status_count=%s\n' "$git_status_count"
+  printf 'max_hash_files=%s\n' "$max_hash_files"
+  printf 'max_hash_file_bytes=%s\n' "$max_hash_file_bytes"
   printf 'tcfs_mutation=0\n'
   printf 'ssh_mutation=0\n'
   printf 'live_repo_claim=0\n'
@@ -267,8 +357,10 @@ git_status_count="$(git -C "$repo_root" status --porcelain=v1 | wc -l | tr -d ' 
   git -C "$repo_root" show-ref --heads --tags || true
 } >"$evidence_dir/git-source.txt"
 
-write_tree_hashes "$repo_root" "$evidence_dir/tree-source.sha256" repo
-write_tree_hashes "$agent_root" "$evidence_dir/agent-source.sha256" agent
+write_tree_hashes "$repo_root" "$evidence_dir/tree-source.sha256" repo \
+  "$max_hash_files" "$max_hash_file_bytes" "$evidence_dir/tree-source.hash.env"
+write_tree_hashes "$agent_root" "$evidence_dir/agent-source.sha256" agent \
+  "$max_hash_files" "$max_hash_file_bytes" "$evidence_dir/agent-source.hash.env"
 write_symlinks "$repo_root" "$evidence_dir/symlinks.txt"
 : >"$evidence_dir/policy-deny.txt"
 write_policy_scan "$repo_root" repo "$evidence_dir/policy-deny.txt"

--- a/scripts/test-git-roam-daily-driver-harness.sh
+++ b/scripts/test-git-roam-daily-driver-harness.sh
@@ -66,6 +66,8 @@ bash "$SCRIPT" \
   --continuation-host honey \
   --third-host bumble \
   --remote-prefix git/ci-templates \
+  --max-hash-files 1 \
+  --max-hash-file-bytes 20 \
   --evidence-dir "$EVIDENCE" \
   >"$OUT"
 
@@ -76,13 +78,17 @@ assert_contains "$EVIDENCE/source.env" "origin_host=neo"
 assert_contains "$EVIDENCE/source.env" "continuation_host=honey"
 assert_contains "$EVIDENCE/source.env" "third_host=bumble"
 assert_contains "$EVIDENCE/source.env" "remote_prefix=git/ci-templates"
+assert_contains "$EVIDENCE/source.env" "max_hash_files=1"
+assert_contains "$EVIDENCE/source.env" "max_hash_file_bytes=20"
 assert_contains "$EVIDENCE/source.env" "tcfs_mutation=0"
 assert_contains "$EVIDENCE/source.env" "daily_driver_claim=0"
 assert_contains "$EVIDENCE/git-source.txt" "##"
 assert_contains "$EVIDENCE/git-source.txt" "README.md"
-assert_contains "$EVIDENCE/tree-source.sha256" "./README.md"
-assert_contains "$EVIDENCE/tree-source.sha256" "./src/new.txt"
+assert_contains "$EVIDENCE/tree-source.hash.env" "hashed=1"
+assert_contains "$EVIDENCE/tree-source.hash.env" "skipped_by_count="
+assert_contains "$EVIDENCE/tree-source.hash.env" "max_hash_files=1"
 assert_contains "$EVIDENCE/agent-source.sha256" "./project-one/session.jsonl"
+assert_contains "$EVIDENCE/agent-source.hash.env" "hashed=1"
 assert_contains "$EVIDENCE/policy-deny.txt" "secret-deny"
 assert_contains "$EVIDENCE/policy-deny.txt" ".env.local"
 assert_contains "$EVIDENCE/policy-deny.txt" "generated-deny"
@@ -91,6 +97,19 @@ assert_contains "$EVIDENCE/policy-deny.txt" "live-db-deny"
 assert_contains "$EVIDENCE/gates.env" "r1_single_origin_dirty_wip=pending-live"
 assert_contains "$EVIDENCE/result.env" "daily_driver_git_claim=0"
 assert_contains "$EVIDENCE/README.md" "Status: plan-only."
+
+UNBOUNDED="$TMPDIR/evidence-unbounded"
+bash "$SCRIPT" \
+  --repo "$FIXTURE" \
+  --agent-root "$AGENT" \
+  --name ci-templates \
+  --max-hash-files 0 \
+  --max-hash-file-bytes 0 \
+  --evidence-dir "$UNBOUNDED" \
+  >"$TMPDIR/out-unbounded.txt"
+assert_contains "$UNBOUNDED/tree-source.sha256" "./README.md"
+assert_contains "$UNBOUNDED/tree-source.sha256" "./src/new.txt"
+assert_contains "$UNBOUNDED/agent-source.sha256" "./project-one/session.jsonl"
 
 NOT_GIT="$TMPDIR/not-git"
 mkdir -p "$NOT_GIT"

--- a/scripts/test-git-roam-daily-driver-harness.sh
+++ b/scripts/test-git-roam-daily-driver-harness.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Regression tests for git-roam-daily-driver-harness.sh.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/git-roam-daily-driver-harness.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-git-roam-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+
+  local out="$TMPDIR/failure.out"
+  local err="$TMPDIR/failure.err"
+  if "$@" >"$out" 2>"$err"; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+  cat "$out" "$err" >"$TMPDIR/failure.combined"
+  assert_contains "$TMPDIR/failure.combined" "$expected"
+}
+
+FIXTURE="$TMPDIR/repo"
+AGENT="$TMPDIR/agent"
+EVIDENCE="$TMPDIR/evidence"
+mkdir -p "$FIXTURE/src" "$AGENT/project-one"
+
+git -C "$FIXTURE" init -q
+git -C "$FIXTURE" config user.name "TCFS Test"
+git -C "$FIXTURE" config user.email "tcfs-test@example.invalid"
+git -C "$FIXTURE" config commit.gpgsign false
+printf '# fixture\n' >"$FIXTURE/README.md"
+printf 'fn main() {}\n' >"$FIXTURE/src/main.rs"
+git -C "$FIXTURE" add README.md src/main.rs
+git -C "$FIXTURE" commit -q -m "initial fixture"
+
+printf 'changed\n' >>"$FIXTURE/README.md"
+printf 'new file\n' >"$FIXTURE/src/new.txt"
+mkdir -p "$FIXTURE/node_modules/pkg"
+printf 'generated\n' >"$FIXTURE/node_modules/pkg/generated.js"
+printf 'secret\n' >"$FIXTURE/.env.local"
+printf 'session line\n' >"$AGENT/project-one/session.jsonl"
+printf 'db\n' >"$AGENT/project-one/state.sqlite"
+
+OUT="$TMPDIR/out.txt"
+bash "$SCRIPT" \
+  --repo "$FIXTURE" \
+  --agent-root "$AGENT" \
+  --name ci-templates \
+  --origin-host neo \
+  --continuation-host honey \
+  --third-host bumble \
+  --remote-prefix git/ci-templates \
+  --evidence-dir "$EVIDENCE" \
+  >"$OUT"
+
+assert_contains "$OUT" "git roam daily-driver evidence:"
+assert_contains "$EVIDENCE/source.env" "status=plan-only"
+assert_contains "$EVIDENCE/source.env" "name=ci-templates"
+assert_contains "$EVIDENCE/source.env" "origin_host=neo"
+assert_contains "$EVIDENCE/source.env" "continuation_host=honey"
+assert_contains "$EVIDENCE/source.env" "third_host=bumble"
+assert_contains "$EVIDENCE/source.env" "remote_prefix=git/ci-templates"
+assert_contains "$EVIDENCE/source.env" "tcfs_mutation=0"
+assert_contains "$EVIDENCE/source.env" "daily_driver_claim=0"
+assert_contains "$EVIDENCE/git-source.txt" "##"
+assert_contains "$EVIDENCE/git-source.txt" "README.md"
+assert_contains "$EVIDENCE/tree-source.sha256" "./README.md"
+assert_contains "$EVIDENCE/tree-source.sha256" "./src/new.txt"
+assert_contains "$EVIDENCE/agent-source.sha256" "./project-one/session.jsonl"
+assert_contains "$EVIDENCE/policy-deny.txt" "secret-deny"
+assert_contains "$EVIDENCE/policy-deny.txt" ".env.local"
+assert_contains "$EVIDENCE/policy-deny.txt" "generated-deny"
+assert_contains "$EVIDENCE/policy-deny.txt" "node_modules"
+assert_contains "$EVIDENCE/policy-deny.txt" "live-db-deny"
+assert_contains "$EVIDENCE/gates.env" "r1_single_origin_dirty_wip=pending-live"
+assert_contains "$EVIDENCE/result.env" "daily_driver_git_claim=0"
+assert_contains "$EVIDENCE/README.md" "Status: plan-only."
+
+NOT_GIT="$TMPDIR/not-git"
+mkdir -p "$NOT_GIT"
+assert_fails_contains \
+  "repo is not a git worktree" \
+  bash "$SCRIPT" --repo "$NOT_GIT" --evidence-dir "$TMPDIR/not-git-evidence"
+
+printf 'git roam daily-driver harness tests passed\n'


### PR DESCRIPTION
## Summary

- Defines the integrated `~/git` daily-driver roam acceptance matrix for the "machine does not matter" user story.
- Adds a plan-only git roam harness that emits the R0-R6 packet shape without TCFS, SSH, cargo, Nix, or live repo mutation.
- Makes the Git metadata boundary explicit: default `sync_git_dirs` mode is bundle/restore; raw `.git` is a separate stress mode, not the default daily-driver claim.
- Bounds hash sampling by default and records hash metadata so real agent transcript trees do not become accidental long-running scans.
- Wires the harness into Taskfile lazy targets and links the acceptance matrix from the existing large-workdir and git canary docs.

## Validation

- `bash -n scripts/git-roam-daily-driver-harness.sh scripts/test-git-roam-daily-driver-harness.sh`
- `shellcheck scripts/git-roam-daily-driver-harness.sh scripts/test-git-roam-daily-driver-harness.sh`
- `bash scripts/test-git-roam-daily-driver-harness.sh`
- `task lazy:test-git-roam-daily-driver`
- `git diff --check`
- Bounded real-candidate dry packet: `dell-7810` + matching Claude project context, `MAX_HASH_FILES=25`, `MAX_HASH_FILE_BYTES=1048576`, output under `/tmp`, no TCFS/SSH mutation.

## Claim boundary

This PR does not enroll `~/git`, widen `~/.claude/projects`, run TCFS, or mutate fleet state. It creates the explicit test/evidence contract needed before broad `~/git` daily-driver claims.