### PR TITLE
TIN-1620: dev-env zero-diff fingerprint for the repo-roam ladder

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -629,6 +629,42 @@ tasks:
     cmds:
       - bash scripts/test-git-repo-canary.sh
 
+  lazy:dev-env-fingerprint:
+    desc: "Git-aware dev-env zero-diff fingerprint (G5/TIN-1620 precision layer over T2/T3/T8/T10)"
+    cmds:
+      - cmd: |
+          bash -euo pipefail <<'EOF'
+          mode="${MODE:-self-test}"
+          case "$mode" in
+            self-test)
+              scripts/repo-roam-fingerprint.sh self-test "${OUT_DIR:-}"
+              ;;
+            capture)
+              : "${REPO:?set REPO=<git worktree> for MODE=capture}"
+              : "${OUT_DIR:?set OUT_DIR=<evidence dir> for MODE=capture}"
+              scripts/repo-roam-fingerprint.sh capture "$REPO" "$OUT_DIR"
+              ;;
+            compare)
+              : "${DIR_A:?set DIR_A=<source fingerprint> for MODE=compare}"
+              : "${DIR_B:?set DIR_B=<rehydrated fingerprint> for MODE=compare}"
+              scripts/repo-roam-fingerprint.sh compare "$DIR_A" "$DIR_B"
+              ;;
+            seed-canary)
+              : "${OUT_DIR:?set OUT_DIR=<throwaway dir> for MODE=seed-canary}"
+              scripts/repo-roam-fingerprint.sh seed-canary "$OUT_DIR"
+              ;;
+            *)
+              echo "MODE must be self-test|capture|compare|seed-canary" >&2
+              exit 2
+              ;;
+          esac
+          EOF
+
+  lazy:test-dev-env-fingerprint:
+    desc: Regression-test the git-aware dev-env fingerprint tool
+    cmds:
+      - bash scripts/test-repo-roam-fingerprint.sh
+
   lazy:git-repo-restore-proof:
     desc: "Fresh-tree restore proof for an existing pushed git repo canary packet"
     cmds:

--- a/docs/ops/repo-roam-test-plan-2026-06-08.md
+++ b/docs/ops/repo-roam-test-plan-2026-06-08.md
@@ -1,0 +1,385 @@
+# Repo-Roam Test Plan: dev-env zero-diff fingerprint over the TIN-1620 live-repo ladder
+
+**Status:** runbook / canary plan (agent-drafted, needs operator review)
+**Date:** 2026-06-08
+**Gate:** G5 — one expendable live repo (`TIN-1620`); live-execution child `TIN-1908`
+**Track:** repo-roam == Phase 2 "single live repo" of
+[`large-workdir-onboarding-design-2026-05-25.md`](large-workdir-onboarding-design-2026-05-25.md)
+**Hosts:** `macbook-neo` (Darwin), `honey` (Linux)
+
+---
+
+## 0. What this plan is, and what it is NOT
+
+This is **not new scope**. Repo-roam — "enroll a `~/git` repo so a dev ssh-ing to
+honey/bumble picks up committed + uncommitted + staged + untracked + branch/HEAD +
+stash + agent sessions with zero dev-env difference, via the scheduled
+`tcfs reconcile --path --prefix --execute` unit" — is the **extant** large-workdir
+ladder:
+
+- Phase 2 "single live repo" in
+  [`large-workdir-onboarding-design-2026-05-25.md`](large-workdir-onboarding-design-2026-05-25.md)
+  (Phased Rollout table; `### TIN-1620 One Expendable Live Repo Packet`, lines 445-481).
+- **Gate G5** in
+  [`large-workdir-daily-driver-sequencing-2026-05-30.md`](large-workdir-daily-driver-sequencing-2026-05-30.md)
+  (Gate Model, line 127: *"TIN-1620 acceptance: two-machine
+  browse/hydrate/unsync/rehydrate + conflict (T10/T11) + rollback/fresh-tree
+  restore."*).
+- The **enrollment vehicle** is the already-shipped scheduled-reconcile unit from
+  [`claude-projects-roam-enrollment-2026-06-08.md`](claude-projects-roam-enrollment-2026-06-08.md)
+  (Gate G4 / `TIN-1738`): the `extraReconcileRoots` launchd/systemd unit running
+  `tcfs reconcile --path <p> --prefix <pre> --execute` with the fail-closed
+  `Blacklist::from_sync_config` deny-set. Repo-roam is the **same** mechanism
+  pointed at a `~/git` repo instead of `~/.claude/projects`.
+
+The **only new surface** this plan adds is a **precision layer**: a git-aware
+**dev-env zero-diff fingerprint** asserted on BOTH hosts. It does **not** replace
+any QA-matrix row; it is a tighter assertion *over* existing rows. See §3 for the
+exact row mapping.
+
+The QA matrix is the **existing** one — do not invent rows:
+
+- **T-rows** T1-T15 from the onboarding design (`## QA Matrix`, lines 224-240).
+- **M-rows** M1-M8 from
+  [`lazy-traversal-qa-permutation-matrix-2026-05-09.md`](lazy-traversal-qa-permutation-matrix-2026-05-09.md),
+  cited by the design's Onboarding Pilot Rows table.
+- **G5 / TIN-1620 minimum**: T1, T3, T4, T5, T6, T10, T11 + M3, M5, M5-R, M6, M8.
+
+---
+
+## 1. Reuse map (do NOT rebuild these)
+
+| Need | Reuse | Task |
+| --- | --- | --- |
+| inventory -> isolated shadow -> push -> honey hydrate -> Linux lifecycle (copies the FULL repo incl `.git` as plain files) | `scripts/git-repo-canary.sh` -> `scripts/home-canary-linux-xr-shadow.sh` | `task lazy:git-repo-canary` |
+| read-only pre-enroll inventory (git_present/git_dirty/special-file gate) | `scripts/large-workdir-inventory.py` | `task lazy:large-workdir-inventory` |
+| fresh-tree restore / rollback (the G5 "return to clean exact tree" proof) | `scripts/git-repo-restore-proof.sh` | `task lazy:git-repo-restore-proof` |
+| mounted browse-before-hydrate (T1) + cat-hydrates-exact (T2) + symlink (T12) | `scripts/lazy-hydration-mounted-smoke.sh` | `task lazy:mounted-smoke` |
+| G2/G3 backbone precondition (read-only) | `scripts/honey-backbone-preflight.sh` | `task lazy:honey-backbone-preflight` |
+| neo<->honey unsync/rehydrate, conflict, delete/rename lifecycle (T4-T11 / M-rows) | `scripts/neo-honey-unsynced-rehydrate-demo.sh` + variants | `task lazy:neo-honey-unsynced-rehydrate-plan` etc. |
+| **NEW** — git-aware dev-env zero-diff fingerprint | `scripts/repo-roam-fingerprint.sh` | `task lazy:dev-env-fingerprint` |
+
+Two harnesses referenced below land via their own PRs and are **not yet on
+`main`**, so this plan cites them as integration points rather than dependencies:
+
+- the **TIN-1620 flip-flop** harness (`scripts/tin1620-flipflop-canary-harness.sh`,
+  PR #484) — host-readiness-gated, plan-only by default; wraps the neo<->honey demos.
+- the **Facet-6 .git fsck/conflict** harness
+  (`scripts/git-dotgit-fsck-conflict-harness.sh`, PR #506) — the raw-mode `.git`
+  corruption gate (§7).
+
+The evidence packet shape is the established
+`docs/release/evidence/<run-id>/` convention (`source-inventory/`,
+`shadow-inventory/`, `push/`, `honey/`, `lifecycle/`, `restore-proof/`). This plan
+adds exactly **one** new subtree, `dev-env-fingerprint/`, and **one** gate line.
+
+---
+
+## 2. The dev-env fingerprint tool
+
+`scripts/repo-roam-fingerprint.sh` captures a complete git-SEMANTIC fingerprint of
+a repo and compares two captures, failing on ANY difference:
+
+- `git status --porcelain=v2 --branch` (distinguishes index vs worktree, records
+  the checked-out branch + ahead/behind)
+- HEAD + `symbolic-ref` (branch / detached-HEAD safe) + `write-tree` of the index
+- all refs (`show-ref`) and the branch set
+- staged vs unstaged content (`git diff --cached` / `git diff` hashes) and
+  per-path staged blob shas (`ls-files -s`)
+- untracked set, `stash list` + `refs/stash`, reflog tip
+- **`git fsck --full`** — the corruption gate (clean vs dirty verdict)
+- a sorted `relpath<TAB>mode<TAB>sha256|symlink-target` manifest of tracked +
+  untracked working files, honoring the **same fail-closed deny-set** as the
+  reconcile engine (`.env*`/secret/live-WAL never hashed; recorded `DENIED`) plus
+  `target/ node_modules/ .direnv/` excludes for determinism.
+
+Modes: `capture <repo> <out>`, `compare <a> <b>` (exit 1 on any diff),
+`seed-canary <dir>` (throwaway repo with feature branch + staged + unstaged +
+untracked + stash + exec script + symlink), `self-test` (disposable round-trip).
+
+Self-test / regression: `task lazy:test-dev-env-fingerprint`.
+
+The single green signal is `dev-env-zero-diff=pass`, threaded into the packet's
+`result.env` / `parity-gates.env` next to the existing
+`scoped-project-tree-parity-evidence-complete` gate.
+
+---
+
+## 3. Fingerprint -> existing QA-matrix mapping
+
+The fingerprint does not introduce a new matrix. It is the
+*"…and git confirms the dev env is byte-and-semantically identical, with no
+mid-reconcile corruption"* qualifier on these **existing** rows:
+
+| Existing row (source) | What it already asserts | Fingerprint precision added |
+| --- | --- | --- |
+| **T2 / T3** (design QA Matrix) | exact bytes hydrate / rehydrate on demand | working-file sha256 manifest equality, source vs rehydrated |
+| **T4 / T5 / T6** | clean file/dir unsync; dirty unsync refusal | status/index fingerprint identical after a clean flip-flop; refusal leaves no partial state |
+| **T8 / T9 + M3 / M6** | peer edit/delete/rename rehydrates latest bytes | post-rehydrate fingerprint == the peer's fingerprint |
+| **T10 / T11 + M5 / M5-R** | same-file conflict visible; keep-both recovery | for a repo this means BOTH `.git` states preserved and each fsck-clean |
+| **T12** (symlink parity) | preserve or explicitly fail with a recorded blocker | manifest records every `120000` symlink + target; **reconcile drops these today** (§5) |
+| **T13** (xattrs / modes) | round-trip or documented unsupported | exec-bit/mode round-trips (good); xattrs unsupported (documented) |
+| TIN-1620 packet "rollback proof … clean, exact tree" | fresh-tree restore returns a clean tree | restored-tree fingerprint == pre-push source fingerprint, fsck clean |
+
+The new gate is best treated as sub-row **T13-Z (dev-env zero-diff)** layered on
+T12+T13 — explicitly a *tighter* bar than G5's content-exact minimum, gated behind
+the §5 mitigations. Do **not** claim T13-Z green from existing G5 evidence.
+
+---
+
+## 4. Enrollment: `.git-as-files` is config-scoped, NOT a global flip
+
+Per Facet 4 (verified against source on this branch):
+
+- The `Reconcile` clap variant exposes only `--path/-p`, `--prefix`, `--execute`,
+  `--state` (`crates/tcfs-cli/src/main.rs:288-301`). **There is no
+  `--sync-git-dirs` flag.**
+- `.git` enrollment is gated by `[sync] sync_git_dirs` (default **false**,
+  `crates/tcfs-core/src/config.rs:548`) and the `.git-as-files` choice additionally
+  requires `[sync] git_sync_mode = "raw"` (default is **`"bundle"`**,
+  `config.rs:549`). Raw mode recurses into `.git` and uploads internals as plain
+  objects (`engine.rs:3348-3356`); bundle mode packs a `git bundle` instead.
+- `cmd_reconcile` builds the blacklist via `Blacklist::from_sync_config(&config.sync)`
+  from the single `-c/--config` it loads (`main.rs:6452`), and the gate reads
+  through `allows_git_dirs()` / `git_sync_mode()` at `reconcile.rs:1115-1116` and
+  `engine.rs:3331`.
+
+### Blast radius of a GLOBAL flip (do NOT do this)
+
+Setting `sync_git_dirs = true` in the daemon's shared `/etc/tcfs/config.toml`
+flips it for the long-running daemon AND every default-config CLI call
+(`tcfsd/src/daemon.rs:423` logs `git_dirs = config.sync.sync_git_dirs`). That would
+make the primary `~/tcfs` `sync_root` and the watcher start collecting `.git` for
+**every** repo under any synced root, and (with the default `bundle` mode) trigger
+`collect_git_bundles` across the whole tree — a fleet-wide behavior change. **This
+plan forbids the global flip.**
+
+### The minimal, zero-code, per-root enrollment (recommended)
+
+Point the scheduled unit at a **dedicated per-repo config** with `-c` (or
+`TCFS_CONFIG=`):
+
+```toml
+# ~/.config/tcfs/roam-<repo>.toml  (per-repo, NOT the daemon's shared config)
+sync_root     = "/Users/<you>/git/<repo>"
+remote_prefix = "git-roam/<repo>"          # disposable, repo-scoped prefix
+
+[sync]
+sync_git_dirs   = true       # enroll .git
+git_sync_mode   = "raw"      # operator's choice: .git-as-plain-files (NOT bundle)
+sync_hidden_dirs = true
+```
+
+```
+tcfs reconcile -c ~/.config/tcfs/roam-<repo>.toml \
+  --path ~/git/<repo> --prefix git-roam/<repo> --execute
+```
+
+This scopes the `.git` gate to one root **without touching the daemon's shared
+config** — exactly what the in-tree canary fixture
+(`crates/tcfs-cli/src/main.rs:7461-7497`, which writes `tcfs-canary.toml` with
+`sync_git_dirs = true`, `git_sync_mode = "raw"`) and the `git-repo-canary` evidence
+harness already do. The fail-closed security deny-set (`SECURITY_DIRS`, secret /
+live-WAL suffixes) still applies *underneath* `.git`, so this does **not** bypass
+Gate G0 / `TIN-1737`.
+
+**Verdict:** `~/git` enrollment works **as-is with no Rust change** — via a
+per-repo config on the reconcile unit. An additive `#[arg(long)] sync_git_dirs`
+flag on `Reconcile` is a *nice-to-have* (cleaner one-file unit) but is **not
+required**; if added it must default false (no behavior change) and override
+post-load via `Blacklist::new(...)` instead of `from_sync_config`.
+
+---
+
+## 5. The zero-diff caveat: mtime trap + symlink drop (Facet 5)
+
+A naive `tcfs reconcile` enrollment will **NOT** produce a zero-diff dev env on
+honey as-is. Two blocking defects, both verified in source on this branch:
+
+1. **mtime / index trap.** `SyncManifest` has no source-mtime field (only
+   `written_at`, the publish wall-clock; `manifest.rs:43`), and restore writes via
+   atomic rename with no `set_times`/`utimensat` afterward — the restored file gets
+   a fresh OS mtime. With `.git` synced raw, the restored `.git/index` carries the
+   **source** machine's stat cache while the worktree files beside it get **new**
+   mtimes, so honey's first `git status` force-rehashes the whole tree and smudges
+   the index -> spurious local modification of a synced `.git/index`, sync churn,
+   possible false conflict. There is **no** `git update-index --refresh` anywhere
+   in the codebase to repair this.
+   - **Mitigation (run before the first fingerprint compare):** after rehydrate,
+     run `git -C <repo> update-index --refresh -q` (or a `git status` warm-up)
+     **once**, deterministically, so git rewrites its own stat cache before the dev
+     touches it; then re-sync the smudged `.git/index` as the new synced state.
+     Longer-term fix: preserve mtime on restore (add an mtime field to
+     `SyncManifest`, apply via `filetime`/`utimensat` after the rename and before
+     `make_sync_state_full`).
+
+2. **symlink drop in the reconcile collect path.** `collect_local_set` hardcodes
+   `preserve_symlinks: false` (`reconcile.rs:1120`), so every working-tree symlink
+   is silently dropped — a git-tracked symlink (mode `120000`) then shows as a
+   **deleted** tracked file on honey, failing T12.
+   - **Mitigation:** set `preserve_symlinks: true` (keep `follow_symlinks: false`)
+     in `collect_local_set`; the restore side + ingress deny-set already exist.
+     One-line opt-in.
+
+File **modes / exec bit DO round-trip** (`engine.rs:1969-1976` capture +
+`set_permissions` on restore), so modes are not a zero-diff risk. **xattrs** are
+not captured (document as unsupported per T13). **Empty dirs** and **special
+files** (FIFO/socket/device) are dropped by reconcile but do not affect
+`git status`; the Phase-0 inventory (§6 step R0) flags any repo that contains them.
+
+The fingerprint tool is what makes all of the above **visible** rather than silent:
+it records symlink targets, fsck verdict, and the full manifest, so a failing
+`dev-env-zero-diff` immediately points at the mtime smudge or the missing symlink.
+
+---
+
+## 6. The canary procedure (steps mapped to rows + LIVE markers)
+
+Legend: **[PR]** = exercised by this PR's harness/self-test (no fleet);
+**[LIVE]** = operator/agent-driven on the real neo<->honey fleet, NOT in this PR.
+
+### R0 — Inventory + seed (neo)  · rows: pre-gate, T13 inventory
+
+- **[LIVE]** `task lazy:honey-backbone-preflight` — confirm G2/G3 backbone
+  (`nats_ok`, `storage_ok`, two real `age1…` devices). Hard precondition.
+- **[PR]** Seed a throwaway canary repo and capture its source fingerprint:
+
+  ```
+  scripts/repo-roam-fingerprint.sh seed-canary /tmp/roam-canary
+  scripts/repo-roam-fingerprint.sh capture /tmp/roam-canary \
+    docs/release/evidence/<run-id>/dev-env-fingerprint/source
+  ```
+
+  (For a real expendable repo: `task lazy:large-workdir-inventory` first; require
+  bucket `shadow_pilot_ready`, no blocking special files.)
+
+### R1 — Shadow + enroll + push (neo)  · rows: T1, T2; coverage of uncommitted/staged/untracked as bytes
+
+- **[PR/LIVE]** `task lazy:git-repo-canary` with `--source /tmp/roam-canary`
+  `--allow-dirty-source` and a disposable `--remote .../git-roam/<repo>` prefix —
+  builds the isolated shadow (full repo incl `.git` as plain files), pushes to the
+  disposable prefix. The per-repo `.git-as-files` config (§4) is what scopes the
+  `.git` enrollment.
+- **[LIVE]** In production this is the scheduled `tcfs reconcile -c <per-repo>.toml
+  --path --prefix --execute` unit (§4), not a one-shot, but the canary task proves
+  the same push.
+
+### R2 — Hydrate + fingerprint + compare (honey)  · rows: T1, T2, T3, T12; **gate T13-Z**
+
+- **[LIVE]** On honey: `ls/find` before hydration (T1), `cat` selected file (T2),
+  full hydrate, then the **mtime mitigation** from §5 (`git update-index --refresh
+  -q`) **before** fingerprinting.
+- **[LIVE]** Capture honey's fingerprint and compare to neo's source:
+
+  ```
+  scripts/repo-roam-fingerprint.sh capture <hydrated-repo> \
+    docs/release/evidence/<run-id>/dev-env-fingerprint/rehydrated
+  scripts/repo-roam-fingerprint.sh compare \
+    docs/release/evidence/<run-id>/dev-env-fingerprint/source \
+    docs/release/evidence/<run-id>/dev-env-fingerprint/rehydrated
+  ```
+
+  **Green bar:** `dev-env-zero-diff=pass` AND `fsck=clean` both sides AND no
+  spurious-dirty `git status`. A symlink delta here is the §5 T12 drop; an index
+  delta is the §5 mtime smudge.
+
+### R3 — Flip-flop: unsync neo -> edit+commit honey -> rehydrate neo  · rows: T4, T5, T6, T8, M3, M6
+
+- **[LIVE]** `tcfs unsync <repo>` on neo (clean) -> edit + commit on honey ->
+  rehydrate on neo. Then `compare` neo's rehydrated fingerprint to honey's: must be
+  zero-diff (honey's HEAD/branch/index now on neo, fsck clean).
+- **[LIVE]** Reuse `scripts/neo-honey-unsynced-rehydrate-demo.sh` (and, once
+  landed, the `tin1620-flipflop-canary-harness.sh` readiness gates) for the
+  transport; the fingerprint is the new assertion on top.
+
+### R4 — Rollback / fresh-tree restore  · rows: TIN-1620 packet rollback proof
+
+- **[LIVE]** `task lazy:git-repo-restore-proof` into a clean restore-root, then
+  `capture` the restored tree and `compare` to the R0 source fingerprint: restored
+  == source, fsck clean. This is the G5 "return to a clean, exact tree" proof, now
+  with a git-semantic equality assertion instead of per-file SHA256 only.
+
+### R5 — Conflict / keep-both  · rows: T10, T11, M5, M5-R
+
+- **[LIVE]** Same-file conflict across hosts: conflict visible, local bytes
+  preserved; manual keep-both -> both `.git` states preserved, each fsck-clean and
+  each fingerprint-able. See §7 for the concurrent-`.git` corruption gate.
+
+---
+
+## 7. Concurrent `.git` corruption checks (Facet 6)
+
+Under `git_sync_mode = "raw"` + `conflict_mode = "auto"`, the `AutoResolver`
+resolves each conflicting path independently with **no** awareness that a file is
+part of a `.git` directory, so two machines editing the same repo's `.git`
+concurrently can keep device A's `refs/heads/main` alongside device B's
+object store -> a half-applied ref (`git fsck`:
+`error: refs/heads/main: invalid sha1 pointer`). Aggravator: raw upload checks
+`git_is_safe(.git)` once then streams `.git/*` over many seconds (TOCTOU);
+`acquire_git_lock` exists but is never called on the raw upload path.
+
+The live-repo packet must add five raw-mode `.git` rows (these are the
+`scripts/git-dotgit-fsck-conflict-harness.sh` rows from PR #506, **not** on `main`):
+
+- **G5-git-1 PEER FSCK** — after push-on-A -> rehydrate-on-B, `git fsck --full` is
+  clean, HEAD resolves to a present commit. The fingerprint's `fsck.env` gate
+  enforces this in R2/R3 above.
+- **G5-git-2 NO TORN SNAPSHOT** — a repo with `.git/index.lock` / in-progress
+  rebase is skipped that cycle, never uploaded half-applied.
+- **G5-git-3 CLEAN FLIP-FLOP EXACT** — clean `tcfs unsync` -> rehydrate restores an
+  fsck-clean, byte-exact repo (the R3 fingerprint compare proves this).
+- **G5-git-4 DIRTY-CHILD REFUSAL** — `tcfs unsync` with a dirty `.git` child
+  refuses without `--force`; no partial dehydration (row T6).
+- **G5-git-5 CONCURRENT-WRITE CORRUPTION** — the per-file `.git` conflict interleave
+  under `conflict_mode=auto` MUST be detected by `git fsck` (invalid sha1 pointer).
+  **Until conflict resolution is made `.git`-aware, G5-git-5 is EXPECTED TO FAIL**
+  and stands as the corruption gate that must close before G5 can claim
+  concurrent-edit safety.
+
+**Safe handoff rule:** the `tcfs unsync <repo>` flip-flop is the correct primitive —
+do not let two machines hold the same `.git` hydrated+writable at once. Quiesce git
+on the source host before unsync.
+
+---
+
+## 8. Scale ceiling (claim boundary)
+
+- **Repo-by-repo only.** `TIN-1908`/`TIN-1620` deliberately enroll one repo at a
+  time. Broad `~/git` ownership stays OUT of claim until `TIN-1556` (stable root
+  identity) + `TIN-1416` (subscriptions) land. **Stop rule:** do not bulk-enroll
+  all of `~/git` before two small repos pass R0-R5 in both directions.
+- **Small `.git` first.** `linux-xr` (~6.2 GB mostly `.git`) stays a stress-only
+  target, never a daily-driver enrollment. The serial crypto upload of a multi-GB
+  `.git` can tear mid-cycle (§5/§7), so big-`.git` is explicitly past the Phase-2
+  boundary.
+- **Still NOT claimed** (per TIN-1620 boundary): broad `~/git`, home takeover,
+  production Finder, keep-synced/pin, `/tmp`, general self-service.
+
+### `.git`-as-files vs git-bundle — operator reconciliation item
+
+The shipped acceptance doc's `.git -> Git-safety bundle/restore` root class
+prescribes the **bundle** path for history and warns against naive live
+`.git/objects` mirroring, whereas the operator chose **`.git`-as-plain-files**
+(`git_sync_mode = "raw"`). These are in tension. A raw-mode enrollment must still
+satisfy R4's HEAD/branch/refs/**fsck** assertions — which the fingerprint's
+`fsck.env` + `refs.txt` + `head.env` captures enforce — but the raw path is exactly
+where §7's corruption gate lives. **Flag for operator decision; do not silently
+diverge from the bundle-based R4 acceptance.**
+
+### `stash` is a precision add, not a new ticket
+
+`stash` is not separately enumerated in any ticket; it rides the `.git/refs/stash`
++ reflog restore path. The fingerprint asserts it explicitly (`stash-list.txt`,
+`stash.env`) — a row-level precision add to R4, not a goalpost move.
+
+---
+
+## 9. Guardrails for this plan
+
+- READ-ONLY research + this docs/scripts PR only. No `reconcile --execute` against
+  prod, no daemon/lab changes, no enrolling real repos in this PR.
+- The harness is safe by construction: `seed-canary` refuses `$HOME` / `~/git/*` /
+  filesystem root; `capture` is read-only; the self-test uses a disposable `/tmp`
+  repo. Real repos require an explicit `--source`/`REPO=` argument.
+- All **[LIVE]** steps are operator/agent-driven on the fleet and are **out of
+  scope for this PR**.

--- a/docs/ops/repo-roam-test-plan-2026-06-08.md
+++ b/docs/ops/repo-roam-test-plan-2026-06-08.md
@@ -82,7 +82,10 @@ a repo and compares two captures, failing on ANY difference:
 
 - `git status --porcelain=v2 --branch` (distinguishes index vs worktree, records
   the checked-out branch + ahead/behind)
-- HEAD + `symbolic-ref` (branch / detached-HEAD safe) + `write-tree` of the index
+- HEAD + `symbolic-ref` (branch / detached-HEAD safe). The staged/index identity
+  is captured below via `ls-files -s` blob shas + the `git diff --cached` hash —
+  capture deliberately does **not** run `git write-tree` (that would write tree
+  objects into `<repo>/.git`, breaking the read-only contract)
 - all refs (`show-ref`) and the branch set
 - staged vs unstaged content (`git diff --cached` / `git diff` hashes) and
   per-path staged blob shas (`ls-files -s`)
@@ -101,7 +104,10 @@ Self-test / regression: `task lazy:test-dev-env-fingerprint`.
 
 The single green signal is `dev-env-zero-diff=pass`, threaded into the packet's
 `result.env` / `parity-gates.env` next to the existing
-`scoped-project-tree-parity-evidence-complete` gate.
+`scoped-project-tree-parity-evidence-complete` gate. **A green `self-test` is NOT
+that signal** — see the [PR]/[LIVE] boundary callout in §6: the self-test only
+proves the assertion engine is consistent on one host; the gate-bearing
+`dev-env-zero-diff=pass` comes from the **[LIVE]** R2/R3 cross-host `compare`.
 
 ---
 
@@ -237,6 +243,24 @@ it records symlink targets, fsck verdict, and the full manifest, so a failing
 
 Legend: **[PR]** = exercised by this PR's harness/self-test (no fleet);
 **[LIVE]** = operator/agent-driven on the real neo<->honey fleet, NOT in this PR.
+
+> **[PR] vs [LIVE] boundary — read this before citing any green bar.**
+> A green `task lazy:test-dev-env-fingerprint` / `self-test` proves **only** that
+> the tool is internally consistent: it captures deterministically (same tree ->
+> identical fingerprint) and its negative control trips (a mutated tree ->
+> `compare` fails). It is run against a single disposable `/tmp` repo on **one
+> host**, so it is **NOT** proof of:
+> - **flip-flop zero-diff in either direction** (neo->honey **or** honey->neo) —
+>   that is delegated to the **[LIVE]** R2/R3 steps, which run `capture`/`compare`
+>   across two real hosts;
+> - **live `.git` corruption catching** — the self-test's repos are never torn
+>   mid-reconcile, so `fsck=clean` there proves nothing about concurrent-write
+>   corruption. That is delegated to the **[LIVE]** R2/R5 steps and the **Facet-6
+>   harness** (`scripts/git-dotgit-fsck-conflict-harness.sh`, PR #506; see §7),
+>   whose G5-git-5 row is *expected to fail* until `.git`-aware resolution lands.
+>
+> In short: **[PR] green == the assertion engine works; [LIVE] green == the fleet
+> actually roams with zero diff and no corruption.** Do not conflate the two.
 
 ### R0 — Inventory + seed (neo)  · rows: pre-gate, T13 inventory
 
@@ -379,7 +403,12 @@ diverge from the bundle-based R4 acceptance.**
 - READ-ONLY research + this docs/scripts PR only. No `reconcile --execute` against
   prod, no daemon/lab changes, no enrolling real repos in this PR.
 - The harness is safe by construction: `seed-canary` refuses `$HOME` / `~/git/*` /
-  filesystem root; `capture` is read-only; the self-test uses a disposable `/tmp`
-  repo. Real repos require an explicit `--source`/`REPO=` argument.
+  filesystem root; `capture` is **strictly read-only** — it runs only inspecting
+  plumbing (`fsck`/`status`/`diff`/`ls-files`/`show-ref`/`rev-parse`/`stash
+  list`/`reflog`) plus a plain-file sha256 walk, and never runs `git write-tree`
+  or any index/object-writing command, so it never mutates the target repo (this
+  matters because R0 points `capture` at real expendable repos); the self-test
+  uses a disposable `/tmp` repo. Real repos require an explicit `--source`/`REPO=`
+  argument.
 - All **[LIVE]** steps are operator/agent-driven on the fleet and are **out of
   scope for this PR**.

--- a/scripts/repo-roam-fingerprint.sh
+++ b/scripts/repo-roam-fingerprint.sh
@@ -31,9 +31,13 @@
 #   self-test [<tmp>]          Seed -> capture -> capture -> compare round-trip in
 #                              a disposable temp dir. Never touches a real repo.
 #
-# Safety: capture is READ-ONLY (it runs `git fsck`/`git status`/`git diff` and a
-# plain-file sha256 walk; it never writes into <repo>). seed-canary refuses to
-# operate on $HOME, anything under ~/git, or a filesystem root.
+# Safety: capture is READ-ONLY. It runs only inspecting plumbing
+# (`git fsck`/`git status`/`git diff`/`git ls-files -s`/`git show-ref`/`git
+# rev-parse`/`git stash list`/`git reflog`) plus a plain-file sha256 walk. It does
+# NOT run `git write-tree`, `git add`, or any command that mutates the index or
+# writes objects into <repo>/.git — it never writes a single byte into <repo>.
+# seed-canary refuses to operate on $HOME, anything under ~/git, or a filesystem
+# root.
 #
 # Deny-set / noise control: the working-file manifest honors the SAME fail-closed
 # deny-set posture as the reconcile engine (Blacklist::from_sync_config:
@@ -169,11 +173,16 @@ cmd_capture() {
     | tr '\0' '\n' >"$out/status.txt" || true
 
   # HEAD + branch (detached-HEAD safe).
+  # NOTE: we deliberately do NOT run `git write-tree` here. write-tree writes new
+  # tree objects into <repo>/.git/objects and can touch the index, which would
+  # violate capture's read-only contract (the live R0 step points capture at real
+  # expendable repos). The staged/index identity is already fully captured below
+  # by `git ls-files -s` (mode-aware per-path blob shas -> index-blobs.txt) and the
+  # `git diff --cached` hash (diff-cached.sha256), so write-tree is redundant.
   {
     printf 'head=%s\n' "$("${g[@]}" rev-parse --verify HEAD 2>/dev/null || echo NONE)"
     printf 'symbolic_ref=%s\n' "$("${g[@]}" symbolic-ref -q HEAD 2>/dev/null || echo DETACHED)"
     printf 'branch=%s\n' "$("${g[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo NONE)"
-    printf 'write_tree=%s\n' "$("${g[@]}" write-tree 2>/dev/null || echo NONE)"
   } >"$out/head.env"
 
   # All refs + branch set (so HEAD/branch/refs round-trip is asserted).
@@ -198,10 +207,17 @@ cmd_capture() {
 
   # git fsck --full: the corruption gate. A mid-reconcile / torn .git must NOT
   # produce a clean fsck. We record the raw output AND a normalized verdict.
+  #
+  # Match GENUINE corruption signals only. `git fsck` emits benign informational
+  # notices ("dangling commit <sha>", "dangling blob", "missing blob" for gc'd /
+  # expired reflog tips) on perfectly healthy repos, so we deliberately do NOT
+  # match bare `missing` / `dangling.*commit`. Real corruption surfaces as a
+  # line-anchored `error:` / `fatal:`, an `invalid sha1 pointer`, or a
+  # `broken link` reference.
   local fsck_out="$out/fsck.txt"
   "${g[@]}" fsck --full 2>&1 | sort >"$fsck_out" || true
   local fsck_bad
-  fsck_bad="$(grep -ciE 'invalid sha1 pointer|missing|broken|dangling.*commit|error:|fatal:' "$fsck_out" || true)"
+  fsck_bad="$(grep -ciE '^error:|^fatal:|invalid sha1 pointer|broken link' "$fsck_out" || true)"
   if [[ "$fsck_bad" -eq 0 ]]; then
     printf 'fsck=clean\n' >"$out/fsck.env"
   else

--- a/scripts/repo-roam-fingerprint.sh
+++ b/scripts/repo-roam-fingerprint.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+#
+# repo-roam-fingerprint.sh — git-aware dev-env "zero-diff" fingerprint for the
+# TCFS large-workdir repo-roam ladder (Gate G5 / TIN-1620 / TIN-1908).
+#
+# This is the ONE missing precision layer the research identified: it captures a
+# complete git-SEMANTIC dev-env fingerprint of a repo (status, HEAD, branch,
+# staged/unstaged diffs, stash, untracked, per-file modes, symlink targets,
+# `git fsck --full`, and a sha256 manifest of tracked+untracked working files)
+# and a `compare` mode that exits NONZERO on ANY difference.
+#
+# It PLUGS INTO the existing canary/evidence scaffold; it does NOT duplicate it:
+#   * inventory/shadow/push/honey            -> scripts/git-repo-canary.sh
+#                                               (-> scripts/home-canary-linux-xr-shadow.sh)
+#   * fresh-tree restore / rollback (G5)     -> scripts/git-repo-restore-proof.sh
+#   * cross-host flip-flop lifecycle (T/M)   -> the TIN-1620 flip-flop + neo-honey
+#                                               demo harnesses
+#   * read-only inventory                    -> scripts/large-workdir-inventory.py
+# The fingerprint emits one new evidence subtree, `dev-env-fingerprint/`, and one
+# gate line (`dev-env-zero-diff=pass|fail`) to thread into the packet's
+# result.env / parity-gates.env — it is an ADDITIONAL assertion layered on QA
+# rows T2/T3 (exact bytes), T8/T9 + M3/M6 (peer-edit rehydrate), and
+# T10/T11 + M5/M5-R (conflict / keep-both), NOT a replacement for any row.
+#
+# Modes:
+#   capture <repo> <out_dir>   Write a fingerprint of <repo> into <out_dir>.
+#   compare <dir_a> <dir_b>    Diff two captured fingerprints; exit 1 on any diff.
+#   seed-canary <dir>          Build a THROWAWAY repo with a realistic in-progress
+#                              dev state (feature branch + staged + unstaged +
+#                              untracked + stash + exec script + symlink).
+#   self-test [<tmp>]          Seed -> capture -> capture -> compare round-trip in
+#                              a disposable temp dir. Never touches a real repo.
+#
+# Safety: capture is READ-ONLY (it runs `git fsck`/`git status`/`git diff` and a
+# plain-file sha256 walk; it never writes into <repo>). seed-canary refuses to
+# operate on $HOME, anything under ~/git, or a filesystem root.
+#
+# Deny-set / noise control: the working-file manifest honors the SAME fail-closed
+# deny-set posture as the reconcile engine (Blacklist::from_sync_config:
+# .env*/secret/live-WAL-db never enter a push plan or manifest) plus the usual
+# build-output excludes (target/, node_modules/, .direnv/) so the fingerprint
+# stays deterministic and does not leak secrets into evidence.
+#
+set -euo pipefail
+
+PROG="repo-roam-fingerprint"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/repo-roam-fingerprint.sh capture <repo> <out_dir>
+  scripts/repo-roam-fingerprint.sh compare <dir_a> <dir_b>
+  scripts/repo-roam-fingerprint.sh seed-canary <dir>
+  scripts/repo-roam-fingerprint.sh self-test [<tmp_dir>]
+
+Modes:
+  capture       Read-only git-aware dev-env fingerprint of <repo> into <out_dir>.
+  compare       Diff two fingerprints; exit 1 (and print the diff) on any change.
+  seed-canary   Build a throwaway repo with a realistic dirty/in-progress state.
+  self-test     Disposable seed -> capture -> capture -> compare round-trip.
+
+Environment:
+  REPO_ROAM_FP_EXTRA_EXCLUDES   space-separated extra top-level dir names to omit
+                                from the working-file manifest (defaults already
+                                exclude target node_modules .direnv dist build).
+EOF
+}
+
+fail() {
+  printf '%s: error: %s\n' "$PROG" "$*" >&2
+  exit 1
+}
+
+# Portable sha256 of a single file -> bare hex digest on stdout.
+sha256_file() {
+  local f="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$f" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "$f" | awk '{print $1}'
+  else
+    fail "need sha256sum or shasum"
+  fi
+}
+
+# Portable sha256 of stdin -> bare hex digest on stdout.
+sha256_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    fail "need sha256sum or shasum"
+  fi
+}
+
+# Portable file mode (octal) -> e.g. 100644 / 100755 / 120000-style 0oNNNN.
+file_mode() {
+  local f="$1"
+  if stat -f '%Lp' "$f" >/dev/null 2>&1; then
+    stat -f '%Lp' "$f"           # BSD / macOS
+  else
+    stat -c '%a' "$f"            # GNU / Linux
+  fi
+}
+
+# Canonicalize a path even when its leaf does not yet exist, by resolving the
+# nearest existing ancestor and re-appending the missing tail. Used by the
+# seed-canary safety guard so it can refuse $HOME / ~/git targets pre-mkdir.
+resolve_intended_path() {
+  local p="$1"
+  if [[ -e "$p" ]]; then
+    ( cd "$p" 2>/dev/null && pwd -P ) || printf '%s\n' "$p"
+    return
+  fi
+  local parent base
+  parent="$(dirname -- "$p")"
+  base="$(basename -- "$p")"
+  if [[ -d "$parent" ]]; then
+    printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$base"
+  else
+    printf '%s\n' "$p"
+  fi
+}
+
+# Top-level dir names that never belong in a deterministic working-file manifest.
+default_excludes() {
+  printf '%s\n' target node_modules .direnv dist build .next .turbo
+}
+
+# Fail-closed deny-set patterns mirrored from Blacklist::from_sync_config so the
+# fingerprint manifest never records a secret/live-WAL path that the reconcile
+# engine itself refuses to push.
+is_denied_relpath() {
+  local rel="$1"
+  local base="${rel##*/}"
+  case "$base" in
+    .env|.env.*|*.pem|*.key|id_rsa|id_ed25519|*.sqlite|*.sqlite-wal|*.sqlite-shm|*.db-wal|*.db-shm)
+      return 0 ;;
+  esac
+  case "$rel" in
+    .ssh/*|.gnupg/*|*/secrets/*) return 0 ;;
+  esac
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# capture
+# -----------------------------------------------------------------------------
+cmd_capture() {
+  local repo="$1"
+  local out="$2"
+  [[ -n "$repo" && -n "$out" ]] || { usage >&2; exit 2; }
+  [[ -d "$repo" ]] || fail "repo does not exist: $repo"
+  git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || fail "not a git worktree: $repo"
+
+  local repo_canon
+  repo_canon="$(cd "$repo" && pwd -P)"
+  mkdir -p "$out"
+  out="$(cd "$out" && pwd -P)"
+
+  local g=(git -C "$repo_canon")
+
+  # --- raw git-state captures (deterministic, host-path-independent) ----------
+  # status: porcelain=v2 --branch distinguishes index vs worktree and records
+  # the checked-out branch + ahead/behind. -z for stable ordering.
+  "${g[@]}" -c core.quotepath=false status --porcelain=v2 --branch -z 2>/dev/null \
+    | tr '\0' '\n' >"$out/status.txt" || true
+
+  # HEAD + branch (detached-HEAD safe).
+  {
+    printf 'head=%s\n' "$("${g[@]}" rev-parse --verify HEAD 2>/dev/null || echo NONE)"
+    printf 'symbolic_ref=%s\n' "$("${g[@]}" symbolic-ref -q HEAD 2>/dev/null || echo DETACHED)"
+    printf 'branch=%s\n' "$("${g[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo NONE)"
+    printf 'write_tree=%s\n' "$("${g[@]}" write-tree 2>/dev/null || echo NONE)"
+  } >"$out/head.env"
+
+  # All refs + branch set (so HEAD/branch/refs round-trip is asserted).
+  "${g[@]}" show-ref 2>/dev/null | sort >"$out/refs.txt" || true
+  "${g[@]}" branch -a --format='%(refname)' 2>/dev/null | sort >"$out/branches.txt" || true
+
+  # Staged (index) vs unstaged (worktree) content, captured as stable hashes.
+  printf '%s' "$("${g[@]}" diff --cached 2>/dev/null || true)" \
+    | sha256_stdin >"$out/diff-cached.sha256" || true
+  printf '%s' "$("${g[@]}" diff 2>/dev/null || true)" \
+    | sha256_stdin >"$out/diff-worktree.sha256" || true
+  # Per-path staged blob shas (index identity, mode-aware).
+  "${g[@]}" ls-files -s 2>/dev/null | sort >"$out/index-blobs.txt" || true
+
+  # Untracked + stash + reflog tip.
+  "${g[@]}" -c core.quotepath=false ls-files --others --exclude-standard 2>/dev/null \
+    | sort >"$out/untracked.txt" || true
+  "${g[@]}" stash list --format='%gd %s' 2>/dev/null >"$out/stash-list.txt" || true
+  printf 'stash_ref=%s\n' "$("${g[@]}" rev-parse -q --verify refs/stash 2>/dev/null || echo NONE)" \
+    >"$out/stash.env"
+  "${g[@]}" reflog --format='%H %gs' 2>/dev/null | head -n 50 >"$out/reflog.txt" || true
+
+  # git fsck --full: the corruption gate. A mid-reconcile / torn .git must NOT
+  # produce a clean fsck. We record the raw output AND a normalized verdict.
+  local fsck_out="$out/fsck.txt"
+  "${g[@]}" fsck --full 2>&1 | sort >"$fsck_out" || true
+  local fsck_bad
+  fsck_bad="$(grep -ciE 'invalid sha1 pointer|missing|broken|dangling.*commit|error:|fatal:' "$fsck_out" || true)"
+  if [[ "$fsck_bad" -eq 0 ]]; then
+    printf 'fsck=clean\n' >"$out/fsck.env"
+  else
+    printf 'fsck=dirty\n' >"$out/fsck.env"
+  fi
+
+  # --- working-file manifest (tracked + untracked) ----------------------------
+  # relpath<TAB>mode<TAB>sha256(or symlink target). Honors the deny-set + build
+  # excludes so the manifest is deterministic and secret-free. Sorted for a
+  # stable, host-independent compare.
+  # default excludes plus any space-separated REPO_ROAM_FP_EXTRA_EXCLUDES, one
+  # top-level dir name per line (tr turns the space-separated env list into lines).
+  local excludes
+  excludes="$(default_excludes)"$'\n'"$(printf '%s' "${REPO_ROAM_FP_EXTRA_EXCLUDES:-}" | tr ' ' '\n')"
+  local manifest="$out/working-manifest.tsv"
+  : >"$manifest"
+
+  # Enumerate tracked + untracked (not ignored) files via git, NUL-delimited.
+  local rel abs top
+  while IFS= read -r -d '' rel; do
+    [[ -n "$rel" ]] || continue
+    top="${rel%%/*}"
+    if printf '%s\n' "$excludes" | grep -qxF -- "$top"; then
+      continue
+    fi
+    if is_denied_relpath "$rel"; then
+      printf '%s\tDENIED\tdeny-set\n' "$rel" >>"$manifest"
+      continue
+    fi
+    abs="$repo_canon/$rel"
+    if [[ -L "$abs" ]]; then
+      local tgt
+      tgt="$(readlink -- "$abs" 2>/dev/null || echo UNREADABLE)"
+      printf '%s\t120000\tsymlink:%s\n' "$rel" "$tgt" >>"$manifest"
+    elif [[ -f "$abs" ]]; then
+      printf '%s\t%s\t%s\n' "$rel" "$(file_mode "$abs")" "$(sha256_file "$abs")" >>"$manifest"
+    fi
+  done < <(
+    {
+      git -C "$repo_canon" ls-files -z 2>/dev/null
+      git -C "$repo_canon" ls-files --others --exclude-standard -z 2>/dev/null
+    }
+  )
+
+  LC_ALL=C sort -o "$manifest" "$manifest"
+
+  # --- the single fingerprint digest ------------------------------------------
+  # One content-addressed digest over every git-semantic capture above. compare
+  # mode diffs the component files for a human-readable delta; this digest is the
+  # one-line gate signal.
+  local fp
+  fp="$(
+    {
+      cat "$out/status.txt" "$out/head.env" "$out/refs.txt" "$out/branches.txt" \
+          "$out/diff-cached.sha256" "$out/diff-worktree.sha256" "$out/index-blobs.txt" \
+          "$out/untracked.txt" "$out/stash-list.txt" "$out/stash.env" \
+          "$out/fsck.env" "$manifest" 2>/dev/null
+    } | sha256_stdin
+  )"
+
+  {
+    printf 'tool=%s\n' "$PROG"
+    printf 'captured_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'repo=%s\n' "$repo_canon"
+    printf 'head=%s\n' "$("${g[@]}" rev-parse --verify HEAD 2>/dev/null || echo NONE)"
+    printf 'branch=%s\n' "$("${g[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo NONE)"
+    printf 'status_entries=%s\n' "$("${g[@]}" status --porcelain=v1 2>/dev/null | wc -l | tr -d ' ')"
+    printf 'untracked_entries=%s\n' "$(wc -l <"$out/untracked.txt" | tr -d ' ')"
+    printf 'stash_entries=%s\n' "$(wc -l <"$out/stash-list.txt" | tr -d ' ')"
+    printf 'manifest_entries=%s\n' "$(wc -l <"$manifest" | tr -d ' ')"
+    cat "$out/fsck.env"
+    printf 'fingerprint=%s\n' "$fp"
+  } >"$out/fingerprint.env"
+
+  printf '%s: captured fingerprint of %s -> %s\n' "$PROG" "$repo_canon" "$out"
+  printf 'fingerprint=%s\n' "$fp"
+}
+
+# -----------------------------------------------------------------------------
+# compare
+# -----------------------------------------------------------------------------
+cmd_compare() {
+  local a="$1"
+  local b="$2"
+  [[ -n "$a" && -n "$b" ]] || { usage >&2; exit 2; }
+  [[ -f "$a/fingerprint.env" ]] || fail "no fingerprint at: $a"
+  [[ -f "$b/fingerprint.env" ]] || fail "no fingerprint at: $b"
+
+  local fa fb
+  fa="$(grep '^fingerprint=' "$a/fingerprint.env" | head -n1 | cut -d= -f2-)"
+  fb="$(grep '^fingerprint=' "$b/fingerprint.env" | head -n1 | cut -d= -f2-)"
+
+  # fsck must be clean on BOTH sides — a clean dev env requires a consistent
+  # .git on the roamed-to host, not just per-file byte parity.
+  local fsck_a fsck_b
+  fsck_a="$(grep '^fsck=' "$a/fingerprint.env" | head -n1 | cut -d= -f2-)"
+  fsck_b="$(grep '^fsck=' "$b/fingerprint.env" | head -n1 | cut -d= -f2-)"
+
+  local components=(
+    status.txt head.env refs.txt branches.txt diff-cached.sha256
+    diff-worktree.sha256 index-blobs.txt untracked.txt stash-list.txt
+    stash.env fsck.env working-manifest.tsv
+  )
+  local diff_out="${REPO_ROAM_FP_COMPARE_DIFF:-}"
+  local tmp_diff
+  tmp_diff="$(mktemp "${TMPDIR:-/tmp}/repo-roam-fp-compare.XXXXXX")"
+  local f
+  for f in "${components[@]}"; do
+    if [[ -f "$a/$f" || -f "$b/$f" ]]; then
+      diff -u "$a/$f" "$b/$f" >>"$tmp_diff" 2>&1 || true
+    fi
+  done
+
+  local status=pass
+  if [[ "$fa" != "$fb" ]]; then status=fail; fi
+  if [[ "$fsck_a" != "clean" || "$fsck_b" != "clean" ]]; then status=fail; fi
+
+  if [[ -n "$diff_out" ]]; then
+    cp "$tmp_diff" "$diff_out"
+  fi
+
+  if [[ "$status" == "pass" ]]; then
+    printf '%s: dev-env-zero-diff=pass (fingerprints match, fsck clean both sides)\n' "$PROG"
+    printf 'dev-env-zero-diff=pass\n'
+    rm -f "$tmp_diff"
+    return 0
+  fi
+
+  printf '%s: dev-env-zero-diff=FAIL\n' "$PROG" >&2
+  printf '  fingerprint A=%s\n  fingerprint B=%s\n' "$fa" "$fb" >&2
+  printf '  fsck A=%s  fsck B=%s\n' "$fsck_a" "$fsck_b" >&2
+  if [[ -s "$tmp_diff" ]]; then
+    printf '  --- component diff ---\n' >&2
+    sed 's/^/  /' "$tmp_diff" >&2
+  fi
+  printf 'dev-env-zero-diff=fail\n'
+  rm -f "$tmp_diff"
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# seed-canary — throwaway repo with a realistic in-progress dev state.
+# -----------------------------------------------------------------------------
+cmd_seed_canary() {
+  local dir="$1"
+  [[ -n "$dir" ]] || { usage >&2; exit 2; }
+
+  # Safety: never operate on a real working tree. Resolve the INTENDED target
+  # even when the leaf does not yet exist (canonicalize its parent), and resolve
+  # $HOME the same way, so the guard catches $HOME and ~/git/* before any mkdir
+  # regardless of /tmp -> /private/tmp style symlinks.
+  case "$dir" in
+    /) fail "refusing to seed at filesystem root" ;;
+  esac
+  local dir_canon home_canon git_root
+  dir_canon="$(resolve_intended_path "$dir")"
+  home_canon="$(resolve_intended_path "$HOME")"
+  git_root="$home_canon/git"
+  # Compare both the resolved form and the raw literal (covers a non-existent
+  # $HOME that cannot be canonicalized).
+  if [[ "$dir_canon" == "$home_canon" || "$dir" == "$HOME" ]]; then
+    fail "refusing to seed canary at \$HOME"
+  fi
+  case "$dir_canon" in
+    "$git_root"|"$git_root"/*) fail "refusing to seed canary under ~/git (real repos)" ;;
+  esac
+  case "$dir" in
+    "$HOME"/git|"$HOME"/git/*) fail "refusing to seed canary under ~/git (real repos)" ;;
+  esac
+
+  mkdir -p "$dir"
+  dir="$(cd "$dir" && pwd -P)"
+
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.name "TCFS Roam Canary"
+  git -C "$dir" config user.email "tcfs-roam-canary@example.invalid"
+  git -C "$dir" config commit.gpgsign false
+
+  # Committed history.
+  printf '# roam canary\n\nthrowaway fixture\n' >"$dir/README.md"
+  mkdir -p "$dir/src"
+  printf 'fn main() {}\n' >"$dir/src/main.rs"
+  git -C "$dir" add README.md src/main.rs
+  git -C "$dir" commit -q -m "initial canary commit"
+  printf 'committed-line\n' >>"$dir/src/main.rs"
+  git -C "$dir" commit -qam "second canary commit"
+
+  # Feature branch checked out (branch/HEAD must round-trip).
+  git -C "$dir" checkout -q -b feature/in-progress
+
+  # A stash (refs/stash + reflog must round-trip).
+  printf 'work-to-stash\n' >>"$dir/README.md"
+  git -C "$dir" stash push -q -m "canary wip stash"
+
+  # Staged change (index / git diff --cached).
+  printf 'staged-line\n' >>"$dir/src/main.rs"
+  git -C "$dir" add src/main.rs
+
+  # Unstaged change on a tracked file (worktree / git diff).
+  printf '\nunstaged tail\n' >>"$dir/README.md"
+
+  # Untracked file.
+  printf 'untracked scratch\n' >"$dir/NOTES.txt"
+
+  # Executable script (mode/exec bit must round-trip — T13 modes half).
+  printf '#!/usr/bin/env bash\necho canary\n' >"$dir/run.sh"
+  chmod +x "$dir/run.sh"
+  git -C "$dir" add run.sh
+
+  # Symlink (T12 symlink parity — the reconcile collect path drops these today
+  # unless preserve_symlinks is opted in; the fingerprint makes that visible).
+  ln -s README.md "$dir/README.link"
+
+  printf '%s: seeded throwaway canary repo at %s\n' "$PROG" "$dir"
+  printf '  branch=%s head=%s\n' \
+    "$(git -C "$dir" rev-parse --abbrev-ref HEAD)" \
+    "$(git -C "$dir" rev-parse --short HEAD)"
+}
+
+# -----------------------------------------------------------------------------
+# self-test — disposable seed -> capture -> capture -> compare round-trip.
+# -----------------------------------------------------------------------------
+cmd_self_test() {
+  local base="${1:-}"
+  if [[ -z "$base" ]]; then
+    base="$(mktemp -d "${TMPDIR:-/tmp}/repo-roam-fp-selftest.XXXXXX")"
+    local own=1
+  else
+    mkdir -p "$base"
+    base="$(cd "$base" && pwd -P)"
+    local own=0
+  fi
+  local rc=0
+  (
+    set -e
+    local repo="$base/canary-repo"
+    local fp_a="$base/fp-a"
+    local fp_b="$base/fp-b"
+    cmd_seed_canary "$repo"
+    cmd_capture "$repo" "$fp_a"
+    # Second capture of the SAME unchanged tree must be byte-identical
+    # (proves the fingerprint is deterministic — the precondition for a
+    # source-vs-rehydrated zero-diff comparison).
+    cmd_capture "$repo" "$fp_b"
+    REPO_ROAM_FP_COMPARE_DIFF="$base/compare.diff" cmd_compare "$fp_a" "$fp_b"
+
+    # Negative control: mutate the tree, re-capture, compare MUST fail.
+    printf 'drift\n' >>"$repo/NOTES.txt"
+    local fp_c="$base/fp-c"
+    cmd_capture "$repo" "$fp_c"
+    if cmd_compare "$fp_a" "$fp_c" >/dev/null 2>&1; then
+      printf '%s: self-test FAILED: drift not detected\n' "$PROG" >&2
+      exit 1
+    fi
+    printf '%s: self-test PASSED (deterministic match + drift detected)\n' "$PROG"
+  ) || rc=$?
+  if [[ "$own" -eq 1 ]]; then
+    rm -rf "$base"
+  fi
+  return "$rc"
+}
+
+main() {
+  local mode="${1:-}"
+  [[ -n "$mode" ]] || { usage >&2; exit 2; }
+  shift || true
+  case "$mode" in
+    capture)     cmd_capture "${1:-}" "${2:-}" ;;
+    compare)     cmd_compare "${1:-}" "${2:-}" ;;
+    seed-canary) cmd_seed_canary "${1:-}" ;;
+    self-test)   cmd_self_test "${1:-}" ;;
+    -h|--help)   usage ;;
+    *) printf '%s: unknown mode: %s\n' "$PROG" "$mode" >&2; usage >&2; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/scripts/test-repo-roam-fingerprint.sh
+++ b/scripts/test-repo-roam-fingerprint.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Regression tests for repo-roam-fingerprint.sh. Disposable /tmp repos only;
+# never touches a real worktree.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/repo-roam-fingerprint.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-repo-roam-fp-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+  local out="$TMPDIR/failure.out"
+  local err="$TMPDIR/failure.err"
+  if "$@" >"$out" 2>"$err"; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+  cat "$out" "$err" >"$TMPDIR/failure.combined"
+  assert_contains "$TMPDIR/failure.combined" "$expected"
+}
+
+# --- self-test mode round-trips (deterministic + drift detection) ------------
+SELFTEST_OUT="$TMPDIR/selftest.out"
+bash "$SCRIPT" self-test "$TMPDIR/selftest-base" >"$SELFTEST_OUT" 2>&1
+assert_contains "$SELFTEST_OUT" "self-test PASSED"
+assert_contains "$SELFTEST_OUT" "dev-env-zero-diff=pass"
+
+# --- seed-canary builds the expected dirty/in-progress state -----------------
+REPO="$TMPDIR/canary"
+bash "$SCRIPT" seed-canary "$REPO" >"$TMPDIR/seed.out"
+assert_contains "$TMPDIR/seed.out" "seeded throwaway canary repo"
+test -d "$REPO/.git"
+test -L "$REPO/README.link"
+test -x "$REPO/run.sh"
+# feature branch checked out, stash present.
+[[ "$(git -C "$REPO" rev-parse --abbrev-ref HEAD)" == "feature/in-progress" ]]
+[[ "$(git -C "$REPO" stash list | wc -l | tr -d ' ')" == "1" ]]
+
+# --- capture writes the full fingerprint surface -----------------------------
+FP_A="$TMPDIR/fp-a"
+bash "$SCRIPT" capture "$REPO" "$FP_A" >"$TMPDIR/capture-a.out"
+assert_contains "$TMPDIR/capture-a.out" "captured fingerprint of"
+for f in fingerprint.env status.txt head.env refs.txt branches.txt \
+         diff-cached.sha256 diff-worktree.sha256 index-blobs.txt \
+         untracked.txt stash-list.txt stash.env reflog.txt fsck.txt \
+         fsck.env working-manifest.tsv; do
+  test -f "$FP_A/$f" || { printf 'missing capture file: %s\n' "$f" >&2; exit 1; }
+done
+assert_contains "$FP_A/fingerprint.env" "fsck=clean"
+assert_contains "$FP_A/fingerprint.env" "branch=feature/in-progress"
+assert_contains "$FP_A/fingerprint.env" "stash_entries=1"
+# symlink + exec mode recorded in the working manifest.
+assert_contains "$FP_A/working-manifest.tsv" "README.link"
+assert_contains "$FP_A/working-manifest.tsv" "symlink:README.md"
+assert_contains "$FP_A/working-manifest.tsv" "run.sh"
+# untracked file present.
+assert_contains "$FP_A/untracked.txt" "NOTES.txt"
+
+# --- deny-set posture: a planted secret is recorded DENIED, never hashed -----
+printf 'SECRET=should-not-appear\n' >"$REPO/.env"
+git -C "$REPO" add -f .env
+FP_DENY="$TMPDIR/fp-deny"
+bash "$SCRIPT" capture "$REPO" "$FP_DENY" >/dev/null
+assert_contains "$FP_DENY/working-manifest.tsv" ".env"
+assert_contains "$FP_DENY/working-manifest.tsv" "DENIED"
+if grep -F 'should-not-appear' "$FP_DENY"/* >/dev/null 2>&1; then
+  printf 'secret content leaked into fingerprint evidence\n' >&2
+  exit 1
+fi
+# reset the planted secret out of the way for the unchanged-compare below.
+git -C "$REPO" rm -q --cached .env
+rm -f "$REPO/.env"
+
+# --- compare: identical re-capture passes ------------------------------------
+FP_B="$TMPDIR/fp-b"
+bash "$SCRIPT" capture "$REPO" "$FP_B" >/dev/null
+CMP_OUT="$TMPDIR/compare.out"
+bash "$SCRIPT" compare "$FP_A" "$FP_B" >"$CMP_OUT"
+assert_contains "$CMP_OUT" "dev-env-zero-diff=pass"
+
+# --- compare: a real change fails with a diff --------------------------------
+printf 'drift\n' >>"$REPO/NOTES.txt"
+FP_C="$TMPDIR/fp-c"
+bash "$SCRIPT" capture "$REPO" "$FP_C" >/dev/null
+assert_fails_contains \
+  "dev-env-zero-diff" \
+  bash "$SCRIPT" compare "$FP_A" "$FP_C"
+
+# --- safety: seed-canary refuses HOME ----------------------------------------
+assert_fails_contains \
+  "refusing to seed canary at \$HOME" \
+  env HOME="$TMPDIR/fakehome" bash "$SCRIPT" seed-canary "$TMPDIR/fakehome"
+
+# --- safety: seed-canary refuses ~/git/<repo> --------------------------------
+mkdir -p "$TMPDIR/fakehome2/git"
+assert_fails_contains \
+  "refusing to seed canary under ~/git" \
+  env HOME="$TMPDIR/fakehome2" bash "$SCRIPT" seed-canary "$TMPDIR/fakehome2/git/somerepo"
+
+# --- capture refuses a non-git dir -------------------------------------------
+mkdir -p "$TMPDIR/not-git"
+assert_fails_contains \
+  "not a git worktree" \
+  bash "$SCRIPT" capture "$TMPDIR/not-git" "$TMPDIR/fp-not-git"
+
+printf 'repo-roam-fingerprint tests passed\n'


### PR DESCRIPTION
## What

Adds the **one missing precision layer** the large-workdir research identified for **Gate G5 / TIN-1620** (one expendable live repo): a git-aware **dev-env zero-diff fingerprint** that asserts a roamed `~/git` repo is byte-and-semantically identical across hosts (committed + uncommitted + staged + untracked + branch/HEAD + stash), with **no mid-reconcile `.git` corruption**.

This is **not new scope**. Repo-roam == Phase 2 "single live repo" in `large-workdir-onboarding-design-2026-05-25.md` == Gate G5 in `large-workdir-daily-driver-sequencing-2026-05-30.md` == `TIN-1620` (live-execution child `TIN-1908`). The fingerprint is a **tighter assertion layered ON TOP of the existing QA-matrix rows** (T2/T3, T8/T9+M3/M6, T10/T11+M5/M5-R, T12, T13) — not a new matrix, not a new sync engine.

## [PR] vs [LIVE] — what a green bar in THIS PR does and does NOT prove

> **A green self-test / `task lazy:test-dev-env-fingerprint` is NOT proof of roaming.** It proves **only** that the assertion engine is internally consistent on **one host**: it captures deterministically (same tree -> identical fingerprint) and its negative control trips (a mutated tree -> `compare` fails). Specifically, a green [PR] run is **NOT** proof of:
>
> - **flip-flop zero-diff in either direction** (neo->honey **or** honey->neo) — delegated to the **[LIVE]** R2/R3 steps, which run `capture`/`compare` across two real hosts;
> - **live `.git` corruption catching** — the self-test repos are never torn mid-reconcile, so `fsck=clean` there proves nothing about concurrent-write corruption. Delegated to the **[LIVE]** R2/R5 steps and the **Facet-6 harness** (`scripts/git-dotgit-fsck-conflict-harness.sh`, PR #506), whose `G5-git-5` row is **expected to fail** until `.git`-aware conflict resolution lands.
>
> **[PR] green == the assertion engine works. [LIVE] green == the fleet actually roams with zero diff and no corruption.** Do not conflate them. The gate-bearing `dev-env-zero-diff=pass` comes from the **[LIVE]** cross-host `compare`, not from the self-test. The runbook §6 carries the same callout.

## Files

- `scripts/repo-roam-fingerprint.sh` — `capture` / `compare` (exit nonzero on any diff, fsck-clean required both sides) / `seed-canary` / `self-test`. Honors the fail-closed reconcile deny-set (`.env*`/secret/live-WAL recorded `DENIED`, never hashed). `seed-canary` refuses `$HOME` / `~/git` / fs-root.
- `scripts/test-repo-roam-fingerprint.sh` — regression suite (deterministic match, drift detection, deny-set, safety refusals).
- `docs/ops/repo-roam-test-plan-2026-06-08.md` — the canary runbook, mapping each step **R0-R5** to the existing **T/M rows** + TIN-1620 G5 acceptance, with **[LIVE]** markers for fleet-only steps (out of scope here).
- `Taskfile.yaml` — `lazy:dev-env-fingerprint` + `lazy:test-dev-env-fingerprint`.

## Reuses vs adds

**Reuses** (does not duplicate): `git-repo-canary.sh` -> `home-canary-linux-xr-shadow.sh` (shadow/push, `.git`-as-plain-files), `git-repo-restore-proof.sh` (rollback), `large-workdir-inventory.py`, the neo-honey / TIN-1620 flip-flop lifecycle harnesses, and the `docs/release/evidence/<run-id>/` packet convention. **Adds** exactly one new evidence subtree (`dev-env-fingerprint/`) and one gate line (`dev-env-zero-diff=pass`).

## Key findings documented in the runbook

- **Enrollment works as-is with NO Rust change** (Facet 4): `.git`-as-files is config-scoped via a per-repo `-c` config (`sync_git_dirs=true` + `git_sync_mode="raw"`) on the scheduled `tcfs reconcile --path --prefix --execute` unit. The global flip is **forbidden** (fleet-wide blast radius). An additive `--sync-git-dirs` flag is a nice-to-have, not required.
- **Zero-diff caveats** (Facet 5): the **mtime/index trap** (no source-mtime in `SyncManifest`; restored `.git/index` smudges on first `git status`) needs a `git update-index --refresh` mitigation; the **symlink drop** (`reconcile.rs:1120` `preserve_symlinks:false`) fails T12. The fingerprint makes both visible.
- **Concurrent `.git` corruption gate** (Facet 6): raw-mode per-file `.git` conflict resolution can produce half-applied refs (`git fsck`: invalid sha1 pointer); G5-git-5 is **expected-fail** until resolution is `.git`-aware.
- **Operator-review items**: `.git`-as-files vs git-bundle tension (R4 acceptance currently bundle-based); `stash` as an explicit precision assertion (not a new ticket).

## Validation

- `shellcheck` clean on both scripts.
- `task lazy:test-dev-env-fingerprint` passes; self-test (disposable `/tmp` seed -> capture -> capture -> compare + drift negative control) passes. **Scope of this green: assertion-engine consistency on one host only — see the [PR] vs [LIVE] section above.**
- **`capture` is strictly read-only** (must-fix): it no longer runs `git write-tree` (which previously wrote tree objects into `<repo>/.git/objects` and touched the index). Proven on a scratch `/tmp` repo with a staged change present — the entire `.git` tree is byte-for-byte identical and `git status` + object count are unchanged before/after capture.
- **fsck gate tightened** (must-fix): the corruption grep now matches genuine signals only (`^error:` / `^fatal:` / `invalid sha1 pointer` / `broken link`) and drops broad `missing` / `dangling.*commit` matches that false-positived on healthy repos with gc'd / expired reflogs. Verified: a healthy repo emitting a lone `dangling commit <sha>` notice now reports `fsck=clean` (the old pattern flipped it `dirty`); a repo with an `invalid sha1 pointer` still reports `fsck=dirty`.
- **No live fleet touched.** READ-ONLY research + docs/scripts only.
