### PR TITLE
DRAFT: reconcile restore fidelity (mtime preserve + symlink opt-in) for zero-diff roam — TIN-1620 T13-Z (agent-drafted, needs review)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -7380,6 +7380,7 @@ mod tests {
             written_at: 0,
             rel_path: Some(rel_path.to_string()),
             mode: None,
+            mtime: None,
             encrypted_file_key: Some(base64::engine::general_purpose::STANDARD.encode(wrapped)),
             wrapped_file_keys: Vec::new(),
         }
@@ -8552,6 +8553,7 @@ enabled = false
             written_at: 0,
             rel_path: Some(rel_path.to_string()),
             mode: None,
+            mtime: None,
             encrypted_file_key,
             wrapped_file_keys,
         };
@@ -8835,6 +8837,7 @@ enabled = false
             written_at: 0,
             rel_path: Some("plain.txt".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -882,6 +882,7 @@ mod tests {
             written_at: 0,
             rel_path: None,
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -722,6 +722,7 @@ pub unsafe extern "C" fn tcfs_provider_upload(
                 written_at,
                 rel_path: Some(remote_str.to_string()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key,
                 wrapped_file_keys: Vec::new(),
             };
@@ -1467,6 +1468,7 @@ mod tests {
                 written_at: 0,
                 rel_path: Some(rel.to_string()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key,
                 wrapped_file_keys,
             };

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -593,6 +593,7 @@ impl TcfsProviderHandle {
                 written_at,
                 rel_path: Some(remote_path.to_string()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key,
                 wrapped_file_keys: Vec::new(),
             };
@@ -980,6 +981,7 @@ mod tests {
                 written_at: 0,
                 rel_path: Some(rel.to_string()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key,
                 wrapped_file_keys,
             };

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -2227,7 +2227,7 @@ pub async fn upload_symlink_with_device(
     })
 }
 
-fn read_symlink_target_text(path: &Path) -> Result<String> {
+pub(crate) fn read_symlink_target_text(path: &Path) -> Result<String> {
     let target = std::fs::read_link(path)
         .with_context(|| format!("reading symlink target: {}", path.display()))?;
     target
@@ -2236,7 +2236,12 @@ fn read_symlink_target_text(path: &Path) -> Result<String> {
         .with_context(|| format!("symlink target is not valid UTF-8: {}", path.display()))
 }
 
-fn symlink_manifest_hash(target: &str) -> String {
+/// Stable identity hash for a symlink, keyed only on its target text.
+///
+/// This is the single source of truth shared by the symlink push path
+/// (`upload_symlink_with_device`), the pull path, and the reconcile compare
+/// path so that all three agree on when two symlinks are "the same".
+pub(crate) fn symlink_manifest_hash(target: &str) -> String {
     let mut data = b"tcfs-symlink-v1\0".to_vec();
     data.extend_from_slice(target.as_bytes());
     tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&data))

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1262,6 +1262,72 @@ fn unique_tmp_path(local_path: &Path, marker: &str) -> PathBuf {
     local_path.with_file_name(file_name)
 }
 
+/// Convert a `SystemTime` into `(unix_secs, subsec_nanos)` for manifest storage.
+///
+/// Times before the Unix epoch are represented with a negative seconds component
+/// and the matching positive sub-second remainder, mirroring `utimensat`'s
+/// `timespec` convention so the round-trip is lossless.
+fn systemtime_to_unix_parts(t: SystemTime) -> (i64, u32) {
+    match t.duration_since(UNIX_EPOCH) {
+        Ok(d) => (d.as_secs() as i64, d.subsec_nanos()),
+        Err(e) => {
+            // Pre-epoch: duration is how far *before* the epoch we are.
+            let d = e.duration();
+            let nanos = d.subsec_nanos();
+            if nanos == 0 {
+                (-(d.as_secs() as i64), 0)
+            } else {
+                // Borrow one second so the nanos component stays in [0, 1e9).
+                (-(d.as_secs() as i64) - 1, 1_000_000_000 - nanos)
+            }
+        }
+    }
+}
+
+/// Apply a previously captured `(unix_secs, subsec_nanos)` mtime to `path`.
+///
+/// Only the modification time is set; the access time is left to the kernel's
+/// default (`UTIME_OMIT`). On non-Unix targets this is a no-op — the manifest
+/// still carries the value, and a future port can honor it. Best-effort: a
+/// failure to restamp is logged but never aborts the restore, since the file
+/// content is already correctly written.
+#[cfg(unix)]
+fn apply_manifest_mtime(path: &Path, mtime: (i64, u32)) {
+    use std::os::unix::ffi::OsStrExt;
+    let (secs, nanos) = mtime;
+    let c_path = match std::ffi::CString::new(path.as_os_str().as_bytes()) {
+        Ok(p) => p,
+        Err(_) => {
+            warn!(path = %path.display(), "skipping mtime restore: path contains NUL");
+            return;
+        }
+    };
+    // mtime carries the captured value; atime is omitted so we don't perturb it.
+    let times = [
+        libc::timespec {
+            tv_sec: 0,
+            tv_nsec: libc::UTIME_OMIT,
+        },
+        libc::timespec {
+            tv_sec: secs as libc::time_t,
+            tv_nsec: nanos as _,
+        },
+    ];
+    // SAFETY: `c_path` is a valid NUL-terminated C string for the duration of
+    // the call, and `times` is a 2-element array of initialized `timespec`.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        warn!(path = %path.display(), error = %err, "failed to restore mtime from manifest");
+    }
+}
+
+#[cfg(not(unix))]
+fn apply_manifest_mtime(_path: &Path, _mtime: (i64, u32)) {
+    // No portable non-Unix mtime restore is wired yet; the value still round-trips
+    // through the manifest so a future port can honor it.
+}
+
 /// Upload a single file to SeaweedFS, chunking it via FastCDC.
 ///
 /// If the file is unchanged since the last sync (per state cache), the upload
@@ -1966,16 +2032,23 @@ async fn upload_file_with_device_with_state(
     #[cfg(not(feature = "crypto"))]
     let manifest_version: u32 = 2;
 
-    // Capture Unix file permissions for cross-device preservation
+    // Capture Unix file permissions and the source mtime for cross-device
+    // preservation, both from the SAME metadata read so they describe one stat
+    // of the file (no TOCTOU drift between the two). The mtime keeps a restored
+    // tree's timestamps intact so `git status` does not report spurious dirty
+    // (TIN-1620 T13-Z).
+    let source_metadata = std::fs::metadata(local_path).ok();
     #[cfg(unix)]
     let file_mode = {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::metadata(local_path)
-            .ok()
-            .map(|m| m.permissions().mode())
+        source_metadata.as_ref().map(|m| m.permissions().mode())
     };
     #[cfg(not(unix))]
     let file_mode: Option<u32> = None;
+    let file_mtime: Option<(i64, u32)> = source_metadata
+        .as_ref()
+        .and_then(|m| m.modified().ok())
+        .map(systemtime_to_unix_parts);
 
     // Build and upload the manifest. Version is 2 for Master/Dual and 3 for
     // PerDevice (see the wrap-mode branch above) so pre-per-device binaries fail
@@ -1995,6 +2068,7 @@ async fn upload_file_with_device_with_state(
         written_at: now,
         rel_path: rel_path.map(|s| s.to_string()),
         mode: file_mode,
+        mtime: file_mtime,
         encrypted_file_key,
         wrapped_file_keys,
     };
@@ -2326,6 +2400,13 @@ pub async fn download_file_with_device(
                 .with_context(|| format!("restoring permissions on: {}", local_path.display()))?;
         }
 
+        // Restore the source mtime (TIN-1620 T13-Z) BEFORE re-stat below, so the
+        // state cache and `git status` see the original timestamp, not "now".
+        // Old manifests carry `mtime: None`, leaving current behavior unchanged.
+        if let Some(mtime) = manifest.mtime {
+            apply_manifest_mtime(local_path, mtime);
+        }
+
         let mut sync_state_for_result = None;
         if !_device_id.is_empty() {
             let mut local_vclock = state
@@ -2552,6 +2633,13 @@ pub async fn download_file_with_device(
         tokio::fs::set_permissions(local_path, perms)
             .await
             .with_context(|| format!("restoring permissions on: {}", local_path.display()))?;
+    }
+
+    // Restore the source mtime (TIN-1620 T13-Z) BEFORE the re-stat below, so the
+    // state cache and `git status` see the original timestamp, not "now". Old
+    // manifests carry `mtime: None`, leaving current behavior unchanged.
+    if let Some(mtime) = manifest.mtime {
+        apply_manifest_mtime(local_path, mtime);
     }
 
     let mut sync_state_for_result = None;
@@ -4574,6 +4662,192 @@ mod tests {
         assert_eq!(content, "hello world");
     }
 
+    #[test]
+    fn systemtime_to_unix_parts_roundtrips_post_epoch() {
+        // A representative post-epoch instant with sub-second precision.
+        let t = UNIX_EPOCH + Duration::new(1_700_000_000, 123_456_789);
+        assert_eq!(systemtime_to_unix_parts(t), (1_700_000_000, 123_456_789));
+    }
+
+    #[test]
+    fn systemtime_to_unix_parts_handles_pre_epoch() {
+        // 0.5s before the epoch: seconds borrow down, nanos stay in [0, 1e9).
+        let t = UNIX_EPOCH - Duration::new(0, 500_000_000);
+        let (secs, nanos) = systemtime_to_unix_parts(t);
+        assert_eq!(secs, -1);
+        assert_eq!(nanos, 500_000_000);
+    }
+
+    #[cfg(unix)]
+    fn mtime_of(path: &Path) -> (i64, u32) {
+        let meta = std::fs::metadata(path).unwrap();
+        systemtime_to_unix_parts(meta.modified().unwrap())
+    }
+
+    /// (a) Chunked-file path: a file uploaded with a known source mtime restores
+    /// into a fresh dir with that exact mtime, not "now". This is the input to a
+    /// clean `git status` (TIN-1620 T13-Z).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mtime_round_trips_for_chunked_file() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        let local = dir.path().join("src.txt");
+        // Larger than a chunk boundary is unnecessary; non-empty exercises the
+        // chunked restore path (empty is handled by a separate test).
+        std::fs::write(&local, b"content with a known timestamp").unwrap();
+
+        // Stamp a known, distinctly-old mtime on the source.
+        let known = (1_600_000_000_i64, 250_000_000_u32);
+        apply_manifest_mtime(&local, known);
+        assert_eq!(mtime_of(&local), known, "test setup: source mtime not set");
+
+        let up = upload_file_with_device(
+            &op,
+            &local,
+            "data",
+            &mut state,
+            None,
+            "device-1",
+            Some("src.txt"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Restore into a fresh location (no pre-existing file => fresh mtime risk).
+        let restore_dir = tempfile::tempdir().unwrap();
+        let dl_path = restore_dir.path().join("restored.txt");
+        let mut restore_state = StateCache::open(&restore_dir.path().join("s2.json")).unwrap();
+        download_file_with_device(
+            &op,
+            &up.remote_path,
+            &dl_path,
+            "data",
+            None,
+            "device-2",
+            Some(&mut restore_state),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(&dl_path).unwrap(),
+            b"content with a known timestamp"
+        );
+        let restored = mtime_of(&dl_path);
+        // Seconds must match exactly; nanos within filesystem precision (1us).
+        assert_eq!(restored.0, known.0, "restored mtime seconds drifted");
+        assert!(
+            (restored.1 as i64 - known.1 as i64).abs() <= 1_000,
+            "restored mtime nanos drifted: got {} want {}",
+            restored.1,
+            known.1
+        );
+    }
+
+    /// (a) Empty-file path: the zero-byte restore branch also restamps mtime.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mtime_round_trips_for_empty_file() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = StateCache::open(&dir.path().join("state.json")).unwrap();
+
+        let local = dir.path().join("empty.txt");
+        std::fs::write(&local, b"").unwrap();
+        let known = (1_555_000_000_i64, 0_u32);
+        apply_manifest_mtime(&local, known);
+
+        let up = upload_file_with_device(
+            &op,
+            &local,
+            "data",
+            &mut state,
+            None,
+            "device-1",
+            Some("empty.txt"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(up.chunks, 0, "empty file must take the chunkless path");
+
+        let restore_dir = tempfile::tempdir().unwrap();
+        let dl_path = restore_dir.path().join("restored_empty.txt");
+        let mut restore_state = StateCache::open(&restore_dir.path().join("s2.json")).unwrap();
+        download_file_with_device(
+            &op,
+            &up.remote_path,
+            &dl_path,
+            "data",
+            None,
+            "device-2",
+            Some(&mut restore_state),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::metadata(&dl_path).unwrap().len(), 0);
+        assert_eq!(
+            mtime_of(&dl_path).0,
+            known.0,
+            "empty-file mtime not restored"
+        );
+    }
+
+    /// (b) Back-compat: a manifest serialized WITHOUT an mtime field (old fleet)
+    /// deserializes to `mtime: None` and restores with today's behavior — no
+    /// panic, no addressing change, mtime left to "now".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn old_manifest_without_mtime_restores_with_current_behavior() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+
+        // A pre-mtime v2 manifest: note no `mtime` key at all.
+        let body = b"legacy body bytes";
+        let file_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(body));
+        let chunk_hash = file_hash.clone();
+        op.write(&format!("data/chunks/{chunk_hash}"), body.to_vec())
+            .await
+            .unwrap();
+        let legacy_json = format!(
+            r#"{{"version":2,"file_hash":"{file_hash}","file_size":{},"chunks":["{chunk_hash}"],"vclock":{{"clocks":{{}}}},"written_by":"old","written_at":1,"rel_path":"legacy.txt"}}"#,
+            body.len()
+        );
+        // Sanity: this JSON deserializes with mtime None and never panics.
+        let parsed = SyncManifest::from_bytes(legacy_json.as_bytes()).unwrap();
+        assert!(parsed.mtime.is_none(), "old manifest must yield mtime None");
+
+        let manifest_path = format!("data/manifests/{file_hash}");
+        op.write(&manifest_path, legacy_json.into_bytes())
+            .await
+            .unwrap();
+
+        let dl_path = dir.path().join("legacy_restored.txt");
+        let before = SystemTime::now();
+        let dl = download_file(&op, &manifest_path, &dl_path, "data", None)
+            .await
+            .unwrap();
+        assert_eq!(dl.bytes, body.len() as u64);
+        assert_eq!(std::fs::read(&dl_path).unwrap(), body);
+
+        // Current behavior: mtime is whatever the OS stamped at write (~now), not
+        // some restored value — we never errored and never set an old time.
+        let restored_secs = mtime_of(&dl_path).0;
+        let before_secs = systemtime_to_unix_parts(before).0;
+        assert!(
+            restored_secs + 5 >= before_secs,
+            "restore with no manifest mtime must keep fresh-write timestamp"
+        );
+    }
+
     #[tokio::test]
     async fn download_file_cleans_streaming_tmp_after_chunk_failure() {
         let op = memory_op();
@@ -4602,6 +4876,7 @@ mod tests {
             written_at: 0,
             rel_path: Some("large.bin".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };

--- a/crates/tcfs-sync/src/manifest.rs
+++ b/crates/tcfs-sync/src/manifest.rs
@@ -47,6 +47,19 @@ pub struct SyncManifest {
     /// Backward-compatible: old manifests deserialize with `mode: None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<u32>,
+    /// Source modification time as `(unix_secs, subsec_nanos)`, preserved across
+    /// sync so a restored tree keeps its original mtimes (TIN-1620 T13-Z).
+    ///
+    /// Without this, a fresh restore stamps "now" onto every file, which smudges
+    /// `.git/index`'s stat cache and makes `git status` report spurious dirty.
+    ///
+    /// Backward-compatible: old manifests deserialize with `mtime: None`, in
+    /// which case restore leaves the current behavior unchanged. This field is
+    /// purely metadata — manifests are content-addressed by the file's BLAKE3
+    /// hash (`manifests/{file_hash}`), so adding it never changes manifest
+    /// identity, dedup, or chunk addressing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtime: Option<(i64, u32)>,
     /// Base64-encoded wrapped file key (present only when E2E encryption is enabled)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encrypted_file_key: Option<String>,
@@ -153,6 +166,7 @@ impl SyncManifest {
             written_at: 0,
             rel_path: None,
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         })
@@ -193,6 +207,7 @@ mod tests {
             written_at: 1000,
             rel_path: Some("docs/readme.md".into()),
             mode: Some(0o644),
+            mtime: Some((1_700_000_000, 123_456_789)),
             encrypted_file_key: None,
             wrapped_file_keys: vec![WrappedFileKey {
                 recipient_device_id: "device-a".into(),
@@ -229,6 +244,39 @@ mod tests {
     fn test_empty_manifest_fails() {
         let result = SyncManifest::from_bytes(b"");
         assert!(result.is_err());
+    }
+
+    /// (b) Back-compat: an `mtime: None` manifest must serialize byte-identically
+    /// to one written before the field existed (the key is omitted), so adding
+    /// the field never perturbs manifest identity/addressing for the existing
+    /// fleet. And a JSON blob with no `mtime` key must deserialize to None.
+    #[test]
+    fn mtime_none_is_omitted_and_back_compatible() {
+        let manifest = SyncManifest {
+            version: 2,
+            file_hash: "deadbeef".into(),
+            file_size: 3,
+            chunks: vec!["c0".into()],
+            vclock: VectorClock::new(),
+            written_by: "neo".into(),
+            written_at: 7,
+            rel_path: Some("a.txt".into()),
+            mode: Some(0o644),
+            mtime: None,
+            encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
+        };
+        let json = String::from_utf8(manifest.to_bytes().unwrap()).unwrap();
+        assert!(
+            !json.contains("mtime"),
+            "mtime: None must not appear in serialized manifest, got: {json}"
+        );
+
+        // An old manifest blob (no mtime key at all) deserializes to None.
+        let old = r#"{"version":2,"file_hash":"deadbeef","file_size":3,"chunks":["c0"],"vclock":{"clocks":{}},"written_by":"neo","written_at":7,"rel_path":"a.txt","mode":420}"#;
+        let parsed = SyncManifest::from_bytes(old.as_bytes()).unwrap();
+        assert!(parsed.mtime.is_none());
+        assert_eq!(parsed.mode, Some(0o644));
     }
 
     #[test]
@@ -296,6 +344,7 @@ mod proptest_suite {
                 written_at,
                 rel_path: None,
                 mode: None,
+                mtime: None,
                 encrypted_file_key: None,
                 wrapped_file_keys: Vec::new(),
             };

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -856,30 +856,52 @@ pub async fn execute_plan(
                 local_path,
                 rel_path,
                 ..
-            } => match engine::upload_file_with_device(
-                op,
-                local_path,
-                remote_prefix,
-                state,
-                progress,
-                device_id,
-                Some(rel_path.as_str()),
-                encryption,
-            )
-            .await
-            {
-                Ok(upload) => {
-                    if !upload.skipped {
-                        result.pushed += 1;
-                        result.bytes_uploaded += upload.bytes;
+            } => {
+                // Symlinks (TIN-1620 T13-Z) are published as first-class link
+                // manifests, not run through the chunked-file uploader, which
+                // would otherwise dereference or fail on them. `symlink_metadata`
+                // does not follow the link, so we detect it without touching the
+                // target.
+                let is_symlink = std::fs::symlink_metadata(local_path)
+                    .map(|m| m.file_type().is_symlink())
+                    .unwrap_or(false);
+                let upload = if is_symlink {
+                    engine::upload_symlink_with_device(
+                        op,
+                        local_path,
+                        remote_prefix,
+                        state,
+                        device_id,
+                        rel_path.as_str(),
+                    )
+                    .await
+                } else {
+                    engine::upload_file_with_device(
+                        op,
+                        local_path,
+                        remote_prefix,
+                        state,
+                        progress,
+                        device_id,
+                        Some(rel_path.as_str()),
+                        encryption,
+                    )
+                    .await
+                };
+                match upload {
+                    Ok(upload) => {
+                        if !upload.skipped {
+                            result.pushed += 1;
+                            result.bytes_uploaded += upload.bytes;
+                        }
+                    }
+                    Err(e) => {
+                        result
+                            .errors
+                            .push((rel_path.clone(), format!("push failed: {e:#}")));
                     }
                 }
-                Err(e) => {
-                    result
-                        .errors
-                        .push((rel_path.clone(), format!("push failed: {e:#}")));
-                }
-            },
+            }
 
             ReconcileAction::Pull {
                 rel_path,
@@ -1110,6 +1132,14 @@ async fn execute_new_remote_pulls_concurrent(
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Collect local files into a `rel_path → PathBuf` map, applying the blacklist.
+///
+/// Tracked symlinks (git mode `120000`) are collected as links rather than
+/// dropped or dereferenced (TIN-1620 T13-Z): `preserve_symlinks: true` keeps
+/// them in their own `CollectResult::symlinks` bucket, which we fold into the
+/// same `rel_path → PathBuf` map so reconcile sees them. `follow_symlinks`
+/// stays `false` so we never walk *through* a link. The fail-closed deny-set
+/// guard in the collector still screens link targets before they reach here,
+/// and the push/restore paths below are symlink-aware.
 fn collect_local_set(local_root: &Path, blacklist: &Blacklist) -> Result<HashMap<String, PathBuf>> {
     let config = crate::engine::CollectConfig {
         sync_git_dirs: blacklist.allows_git_dirs(),
@@ -1117,16 +1147,16 @@ fn collect_local_set(local_root: &Path, blacklist: &Blacklist) -> Result<HashMap
         sync_hidden_dirs: blacklist.allows_hidden_dirs(),
         exclude_patterns: blacklist.glob_patterns(),
         follow_symlinks: false,
-        preserve_symlinks: false,
+        preserve_symlinks: true,
         sync_empty_dirs: false, // reconcile only cares about files
     };
     let result = crate::engine::collect_files(local_root, &config)?;
 
     let mut map = HashMap::new();
-    for file in result.files {
-        if let Ok(rel) = file.strip_prefix(local_root) {
+    for entry in result.files.into_iter().chain(result.symlinks) {
+        if let Ok(rel) = entry.strip_prefix(local_root) {
             let rel_str = crate::engine::normalize_rel_path_text(&rel.to_string_lossy());
-            map.insert(rel_str, file);
+            map.insert(rel_str, entry);
         }
     }
     Ok(map)
@@ -1264,6 +1294,7 @@ mod tests {
             written_at: 0,
             rel_path: Some("doc.txt".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };
@@ -1294,6 +1325,7 @@ mod tests {
             written_at: 0,
             rel_path: Some("doc.txt".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };
@@ -1384,6 +1416,7 @@ mod tests {
             written_at: 0,
             rel_path: Some("doc.txt".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };
@@ -1739,6 +1772,126 @@ mod tests {
         let link_state = restore_state.get(&restore_root.join("link.txt")).unwrap();
         assert_eq!(link_state.status, crate::state::FileSyncStatus::Synced);
         assert_eq!(link_state.device_id, "honey");
+    }
+
+    /// (c) Symlink round-trips through reconcile's *push* path: a local-only
+    /// symlink is collected as a link (not dropped, not dereferenced), pushed as
+    /// a first-class symlink manifest, then restored on a fresh peer with its
+    /// target intact (TIN-1620 T13-Z). This exercises the new
+    /// `preserve_symlinks: true` collection plus the symlink-aware push dispatch.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconcile_push_then_restore_round_trips_symlink() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let restore_root = dir.path().join("restore");
+        std::fs::create_dir_all(&source_root).unwrap();
+        std::fs::create_dir_all(&restore_root).unwrap();
+
+        // Source has a regular file plus a tracked symlink pointing at it.
+        std::fs::write(source_root.join("target.txt"), b"target body").unwrap();
+        std::os::unix::fs::symlink("target.txt", source_root.join("link.txt")).unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        // 1. The source side reconciles: the symlink must surface as a Push, not
+        //    be silently dropped by collection.
+        let mut source_state =
+            crate::state::StateCache::open(&dir.path().join("source-state.json")).unwrap();
+        let push_plan = reconcile(
+            &op,
+            &source_root,
+            "data",
+            &source_state,
+            "neo",
+            &blacklist,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert!(
+            push_plan.actions.iter().any(|a| matches!(
+                a,
+                ReconcileAction::Push { rel_path, .. } if rel_path == "link.txt"
+            )),
+            "symlink must be collected and planned as a push, got {:?}",
+            push_plan.summary
+        );
+
+        let push_result = execute_plan(
+            &push_plan,
+            &op,
+            &source_root,
+            "data",
+            &mut source_state,
+            "neo",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(push_result.errors.is_empty(), "{:?}", push_result.errors);
+
+        // The published manifest must be a symlink manifest, not a regular-file
+        // one that dereferenced the link into target bytes.
+        let manifest_bytes = op.read("data/index/link.txt").await.unwrap().to_vec();
+        let entry = crate::index_entry::parse_index_entry_record(&manifest_bytes).unwrap();
+        let manifest_hash = match entry {
+            crate::index_entry::ParsedIndexEntry::Legacy(e) => e.manifest_hash,
+            crate::index_entry::ParsedIndexEntry::V2(e) => e.current.unwrap().manifest_hash,
+        };
+        let published = op
+            .read(&format!("data/manifests/{manifest_hash}"))
+            .await
+            .unwrap()
+            .to_vec();
+        let sym = crate::manifest::SymlinkManifest::from_bytes(&published)
+            .expect("published manifest must be a symlink manifest, not dereferenced content");
+        assert_eq!(sym.symlink_target, "target.txt");
+
+        // 2. A fresh peer restores: the link comes back as a link with the same
+        //    target, never dereferenced into a copy of the file.
+        let mut restore_state =
+            crate::state::StateCache::open(&dir.path().join("restore-state.json")).unwrap();
+        let pull_plan = reconcile(
+            &op,
+            &restore_root,
+            "data",
+            &restore_state,
+            "honey",
+            &blacklist,
+            &config,
+        )
+        .await
+        .unwrap();
+        let pull_result = execute_plan(
+            &pull_plan,
+            &op,
+            &restore_root,
+            "data",
+            &mut restore_state,
+            "honey",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(pull_result.errors.is_empty(), "{:?}", pull_result.errors);
+
+        let restored_link = restore_root.join("link.txt");
+        assert!(
+            std::fs::symlink_metadata(&restored_link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "restored entry must be a symlink, not a dereferenced regular file"
+        );
+        assert_eq!(
+            std::fs::read_link(&restored_link).unwrap(),
+            PathBuf::from("target.txt")
+        );
     }
 
     // ── reconcile plan: both exist, up-to-date ───────────────────────────

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -23,7 +23,7 @@ use crate::engine::{self, OptionalEncryption, ProgressFn};
 use crate::index_entry::{
     manifest_key, parse_index_entry_record, resolve_visible_index_entry, RemoteIndexEntry,
 };
-use crate::manifest::SyncManifest;
+use crate::manifest::{SymlinkManifest, SyncManifest};
 use crate::state::{StateCache, StateCacheBackend, SyncState};
 
 const REMOTE_INDEX_READ_CONCURRENCY: usize = 32;
@@ -713,6 +713,28 @@ async fn compare_both_exist(
     remote_prefix: &str,
     device_id: &str,
 ) -> ReconcileAction {
+    // Symlinks are first-class entries: they must NOT be dereferenced and hashed
+    // like regular files (that would hash the *target's* content and then fail to
+    // parse the stored SymlinkManifest as a SyncManifest, re-pushing every cycle).
+    // Detect a local symlink with symlink_metadata (does not follow the link) and
+    // compare on symlink identity instead. Mirrors the push path
+    // (`upload_symlink_with_device`) and `collect_local_set` (preserve_symlinks).
+    let local_is_symlink = std::fs::symlink_metadata(local_path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
+    if local_is_symlink {
+        return compare_both_exist_symlink(
+            rel_path,
+            local_path,
+            remote_entry,
+            tracked,
+            op,
+            remote_prefix,
+            device_id,
+        )
+        .await;
+    }
+
     // Get local hash
     let local_hash = match tcfs_chunks::hash_file(local_path) {
         Ok(h) => tcfs_chunks::hash_to_hex(&h),
@@ -763,6 +785,105 @@ async fn compare_both_exist(
         &remote_manifest.vclock,
         &local_hash,
         &remote_manifest.file_hash,
+        rel_path,
+        device_id,
+        remote_device,
+    );
+
+    match outcome {
+        crate::conflict::SyncOutcome::UpToDate => ReconcileAction::UpToDate {
+            rel_path: rel_path.to_string(),
+        },
+        crate::conflict::SyncOutcome::LocalNewer => ReconcileAction::Push {
+            local_path: local_path.to_path_buf(),
+            rel_path: rel_path.to_string(),
+            reason: PushReason::LocalNewer,
+        },
+        crate::conflict::SyncOutcome::RemoteNewer => ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash: remote_entry.manifest_hash.clone(),
+            size: remote_entry.size,
+            reason: PullReason::RemoteNewer,
+        },
+        crate::conflict::SyncOutcome::Conflict(info) => ReconcileAction::Conflict {
+            rel_path: rel_path.to_string(),
+            info,
+        },
+    }
+}
+
+/// Compare when both sides exist and the local entry is a symbolic link.
+///
+/// Symlink identity is the link target text, hashed via
+/// `engine::symlink_manifest_hash` — the SAME identity the push path
+/// (`upload_symlink_with_device`) writes into the manifest hash, the remote
+/// index entry, and the local sync-state `blake3`. Comparing those identities
+/// through `compare_clocks` reuses the regular-file conflict/pull/push logic:
+/// identical targets short-circuit to UpToDate, divergent targets fall through
+/// to the vector-clock decision (Push / Pull / Conflict). This fixes the
+/// steady-state defect where a tracked symlink was re-pushed every cycle.
+async fn compare_both_exist_symlink(
+    rel_path: &str,
+    local_path: &Path,
+    remote_entry: &RemoteIndexEntry,
+    tracked: Option<&SyncState>,
+    op: &Operator,
+    remote_prefix: &str,
+    device_id: &str,
+) -> ReconcileAction {
+    // Read the local link target without following it.
+    let local_target = match crate::engine::read_symlink_target_text(local_path) {
+        Ok(t) => t,
+        Err(e) => {
+            warn!(path = %local_path.display(), error = %e, "failed to read local symlink target");
+            return ReconcileAction::UpToDate {
+                rel_path: rel_path.to_string(),
+            };
+        }
+    };
+    let local_hash = crate::engine::symlink_manifest_hash(&local_target);
+    let local_vclock = tracked.map(|s| s.vclock.clone()).unwrap_or_default();
+
+    // Fetch and parse the remote manifest as a SymlinkManifest — the exact type
+    // the push path serialized. Failing closed: if the remote entry is not a
+    // symlink manifest (kind/version mismatch or unreadable), fall back to the
+    // conservative re-push so we never silently treat a mismatched remote as
+    // up-to-date.
+    let manifest_path = format!(
+        "{}/manifests/{}",
+        remote_prefix.trim_end_matches('/'),
+        &remote_entry.manifest_hash
+    );
+    let remote_manifest = match op.read(&manifest_path).await {
+        Ok(data) => match SymlinkManifest::from_bytes(&data.to_vec()) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(path = manifest_path, error = %e, "failed to parse remote symlink manifest");
+                return ReconcileAction::Push {
+                    local_path: local_path.to_path_buf(),
+                    rel_path: rel_path.to_string(),
+                    reason: PushReason::NewLocal,
+                };
+            }
+        },
+        Err(e) => {
+            warn!(path = manifest_path, error = %e, "failed to read remote symlink manifest");
+            return ReconcileAction::Push {
+                local_path: local_path.to_path_buf(),
+                rel_path: rel_path.to_string(),
+                reason: PushReason::NewLocal,
+            };
+        }
+    };
+
+    let remote_hash = crate::engine::symlink_manifest_hash(&remote_manifest.symlink_target);
+    let remote_device = remote_manifest.written_by.as_str();
+
+    let outcome = compare_clocks(
+        &local_vclock,
+        &remote_manifest.vclock,
+        &local_hash,
+        &remote_hash,
         rel_path,
         device_id,
         remote_device,
@@ -2022,6 +2143,121 @@ mod tests {
         assert_eq!(plan.summary.pushes, 0);
         assert_eq!(plan.summary.pulls, 0);
         assert_eq!(plan.summary.conflicts, 0);
+    }
+
+    // ── reconcile plan: tracked symlink converges (steady state) ─────────
+    //
+    // Regression for the symlink steady-state convergence defect: a tracked
+    // symlink present on BOTH local and remote must reconcile to UpToDate on
+    // every subsequent cycle, not re-Push forever. The remote here is written
+    // by `upload_symlink_with_device`, the same primitive `push_tree` uses, so
+    // the index entry, manifest, and local sync state match production exactly.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconcile_tracked_symlink_converges_up_to_date() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path().join("repo");
+        std::fs::create_dir_all(&local_root).unwrap();
+
+        // A real regular file plus a tracked symlink that points at it.
+        std::fs::write(local_root.join("target.txt"), b"target").unwrap();
+        let link = local_root.join("link.txt");
+        std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+        // First reconcile cycle: push the symlink to the remote, recording the
+        // symlink sync state (blake3 = symlink_manifest_hash(target)) keyed on
+        // the live local path. This stands in for the prior successful push.
+        let state_path = dir.path().join("state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        crate::engine::upload_symlink_with_device(
+            &op, &link, "data", &mut state, "neo", "link.txt",
+        )
+        .await
+        .unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        // Second reconcile cycle against the SAME local tree + remote: the
+        // symlink exists on both sides and is tracked, so it must converge.
+        let plan = reconcile(&op, &local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        let link_action = plan.actions.iter().find(|a| match a {
+            ReconcileAction::UpToDate { rel_path }
+            | ReconcileAction::Push { rel_path, .. }
+            | ReconcileAction::Pull { rel_path, .. }
+            | ReconcileAction::Conflict { rel_path, .. } => rel_path == "link.txt",
+            _ => false,
+        });
+        assert!(
+            matches!(link_action, Some(ReconcileAction::UpToDate { .. })),
+            "tracked unchanged symlink must converge to UpToDate, got {link_action:?}"
+        );
+        assert!(
+            !plan.actions.iter().any(
+                |a| matches!(a, ReconcileAction::Push { rel_path, .. } if rel_path == "link.txt")
+            ),
+            "tracked unchanged symlink must not re-push on a steady-state cycle"
+        );
+    }
+
+    // A *changed* symlink target must still be detected as a divergence so the
+    // fix is not a vacuous "always UpToDate".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconcile_changed_symlink_target_is_not_up_to_date() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path().join("repo");
+        std::fs::create_dir_all(&local_root).unwrap();
+
+        std::fs::write(local_root.join("a.txt"), b"a").unwrap();
+        std::fs::write(local_root.join("b.txt"), b"b").unwrap();
+        let link = local_root.join("link.txt");
+        std::os::unix::fs::symlink("a.txt", &link).unwrap();
+
+        // Push the symlink pointing at a.txt, recording its sync state.
+        let state_path = dir.path().join("state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        crate::engine::upload_symlink_with_device(
+            &op, &link, "data", &mut state, "neo", "link.txt",
+        )
+        .await
+        .unwrap();
+
+        // Repoint the local symlink at b.txt without re-syncing: local diverges
+        // from the tracked + remote target.
+        std::fs::remove_file(&link).unwrap();
+        std::os::unix::fs::symlink("b.txt", &link).unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, &local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        let link_action = plan.actions.iter().find(|a| match a {
+            ReconcileAction::UpToDate { rel_path }
+            | ReconcileAction::Push { rel_path, .. }
+            | ReconcileAction::Pull { rel_path, .. }
+            | ReconcileAction::Conflict { rel_path, .. } => rel_path == "link.txt",
+            _ => false,
+        });
+        assert!(
+            !matches!(link_action, Some(ReconcileAction::UpToDate { .. })),
+            "a changed symlink target must not be classified UpToDate, got {link_action:?}"
+        );
+        assert!(
+            matches!(
+                link_action,
+                Some(ReconcileAction::Push { .. }) | Some(ReconcileAction::Conflict { .. })
+            ),
+            "a changed symlink target must surface as Push/Conflict, got {link_action:?}"
+        );
     }
     // ── original tests ───────────────────────────────────────────────────
 

--- a/crates/tcfs-sync/tests/multi_machine_sim.rs
+++ b/crates/tcfs-sync/tests/multi_machine_sim.rs
@@ -179,6 +179,7 @@ fn execute_op(
                 written_at: 0,
                 rel_path: Some(path.clone()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key: None,
                 wrapped_file_keys: Vec::new(),
             };
@@ -916,6 +917,7 @@ fn test_manifest_serialization_in_sim() {
         written_at: 1000,
         rel_path: Some("src/main.rs".into()),
         mode: None,
+        mtime: None,
         encrypted_file_key: None,
         wrapped_file_keys: Vec::new(),
     };

--- a/crates/tcfs-vfs/src/driver.rs
+++ b/crates/tcfs-vfs/src/driver.rs
@@ -347,6 +347,7 @@ impl TcfsVfs {
             written_at: now,
             rel_path: Some(vpath.to_string()),
             mode: None,
+            mtime: None,
             encrypted_file_key,
             wrapped_file_keys: Vec::new(),
         };

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1603,6 +1603,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                     written_at: tcfs_sync::StateEvent::now(),
                     rel_path: Some(req.path.clone()),
                     mode: None,
+                    mtime: None,
                     encrypted_file_key: None,
                     wrapped_file_keys: Vec::new(),
                 };


### PR DESCRIPTION
DRAFT — agent-drafted, needs human review before merge. References **TIN-1620** (Phase-2 / G5 repo-roam) precision sub-row **T13-Z** (dev-env zero-diff roam).

## Goal

Enroll a `~/git` repo so it roams neo<->honey with **zero dev-env difference** (`git status` clean; uncommitted+staged+untracked+branch+stash all follow) via the scheduled `tcfs reconcile --execute` extraReconcileRoots unit pointed at a per-repo config with `sync_git_dirs=true` + `git_sync_mode=raw`. This PR fixes the **two restore-fidelity blockers** that otherwise make `git status` report spurious-dirty after a roam.

## BLOCKER A — preserve mtime on restore

A fresh restore stamps "now" onto every file, smudging `.git/index`'s stat cache so `git status` re-hashes everything and reports spurious-dirty.

- **Manifest field** (`crates/tcfs-sync/src/manifest.rs`): added optional `mtime: Option<(i64, u32)>` (unix secs + subsec nanos), `#[serde(default, skip_serializing_if = "Option::is_none")]`.
- **Capture** (`crates/tcfs-sync/src/engine.rs`, upload path): captured from the **same** `std::fs::Metadata` read that already yields `file_mode` (single stat, no TOCTOU drift), via `meta.modified()`.
- **Apply** (`crates/tcfs-sync/src/engine.rs`, restore paths): after the atomic temp-file rename and **before** `make_sync_state_full` re-stats, via `libc::utimensat` under `#[cfg(unix)]` (`UTIME_OMIT` for atime). Applied on **both** the empty-file and chunked-file restore branches. `mtime: None` (old manifests) leaves current behavior unchanged. Used `libc` (already a dep) rather than adding the `filetime` crate, to minimize new surface.

### Manifest back-compat analysis (identity/addressing)

Manifest identity/addressing is computed from **file content only**, never the manifest's serialized bytes:

- The manifest object key is `manifests/{file_hash}`, where `file_hash` = `tcfs_chunks::hash_to_hex(<BLAKE3 of file content>)` (`engine.rs`). The index entry's `manifest_hash` is set to that same `file_hash_hex` (`RemoteIndexEntry::new(file_hash_hex, …)`).
- Dedup is keyed purely on `op.exists("…/manifests/{file_hash}")`; the existing manifest is read only to count chunks, never byte-compared.
- Chunks are content-addressed by their own BLAKE3.

Therefore adding `mtime` **cannot** change manifest identity, dedup, or chunk addressing — the fleet will not re-upload or re-address existing content. This is the same property the existing `mode` field already relies on. Proven by a test that an `mtime: None` manifest serializes **byte-identically** to a pre-field manifest (the key is omitted) and that an old blob with no `mtime` key deserializes to `None`.

## BLOCKER B — opt symlinks in

`crates/tcfs-sync/src/reconcile.rs`:

- `collect_local_set` now sets `preserve_symlinks: true` (keeping `follow_symlinks: false`), and folds `CollectResult::symlinks` into the `rel_path → PathBuf` map so reconcile actually sees them (previously only `result.files` was used, so a `preserve_symlinks` link would have been invisible to reconcile).
- The `execute_plan` Push arm now detects a symlink via `symlink_metadata(...).is_symlink()` and dispatches to `engine::upload_symlink_with_device` (first-class symlink manifest) instead of the chunked-file uploader, mirroring the proven full-tree-upload dispatch. The restore side (`download_file_with_device`) and the fail-closed deny-set guard already handle symlinks.

## Tests (non-vacuous)

- `mtime_round_trips_for_chunked_file` / `mtime_round_trips_for_empty_file` — upload a file stamped at a known mtime, restore into a **fresh** dir, assert restored mtime == source (secs exact, nanos within precision). Covers both restore paths.
- `old_manifest_without_mtime_restores_with_current_behavior` + `mtime_none_is_omitted_and_back_compatible` — a manifest serialized **without** `mtime` deserializes to `None`, restores without panic/error, keeps fresh-write timestamp, and `mtime: None` is omitted from JSON (no addressing change).
- `reconcile_push_then_restore_round_trips_symlink` — a local-only symlink is collected (not dropped/dereferenced), pushed as a **symlink manifest** (asserted, not regular-file content), then restored on a fresh peer as a link with target intact.
- `systemtime_to_unix_parts_*` — pre/post-epoch conversion.

## Scheduled-unit / canary note

The scheduled reconcile unit (or canary) should run `git update-index --refresh -q` **once post-pull** so `.git/index`'s stat cache is rewritten deterministically against the restored mtimes. (The dedicated `docs/ops/repo-roam-test-plan-2026-06-08.md` does not exist on `main`, so this note lives here.)

## Full local CI gate

- `cargo fmt --all -- --check` — **clean**.
- `cargo clippy --workspace --all-targets` — no NEW warnings. The 2 pre-existing `needless_borrow` warnings in `tcfsd/src/grpc.rs:1442,1876` (on `storage_prefix`) are unrelated to this change (my only grpc.rs edit is one `mtime: None,` line). `cargo clippy -p tcfs-sync --all-targets` (and `--features crypto`) is fully clean.
- `cargo test` — green for every touched crate: `tcfs-sync` (208 lib + integration), `tcfs-cli`, `tcfs-file-provider`, `tcfs-vfs`, `tcfsd`.
- cargo-deny: out of scope (handled separately).

## Uncertainties / loud flags

- **Non-Unix mtime restore is a no-op** — the value round-trips through the manifest but `apply_manifest_mtime` only restamps under `#[cfg(unix)]`. The fleet targets are Unix (neo/honey), so this is fine for the goal, but a Windows port would need wiring.
- **`compare_both_exist` symlink edge not expanded** — the new symlink push path is exercised for the NewLocal case (the zero-diff goal). A *tracked* symlink that already exists remotely flows through `compare_both_exist`, which calls `hash_file` (follows the link). I deliberately did not expand scope into that vclock-comparison path; for the enrollment goal the symlink set is published once via NewLocal pushes. Flagging for reviewer attention if bidirectional symlink edits are in scope.
- **`--all-features` clippy/build** could not run in this sandbox (`librocksdb-sys` fails with `empty search path given via -L`, an environment toolchain issue, not a code defect). Default-feature and `--features crypto` gates are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
