### PR TITLE
test: harden repo-roam fingerprint deny-set

### DIFF
--- a/docs/ops/repo-roam-test-plan-2026-06-08.md
+++ b/docs/ops/repo-roam-test-plan-2026-06-08.md
@@ -92,9 +92,11 @@ a repo and compares two captures, failing on ANY difference:
 - untracked set, `stash list` + `refs/stash`, reflog tip
 - **`git fsck --full`** — the corruption gate (clean vs dirty verdict)
 - a sorted `relpath<TAB>mode<TAB>sha256|symlink-target` manifest of tracked +
-  untracked working files, honoring the **same fail-closed deny-set** as the
-  reconcile engine (`.env*`/secret/live-WAL never hashed; recorded `DENIED`) plus
-  `target/ node_modules/ .direnv/` excludes for determinism.
+  untracked working files, honoring or exceeding the reconcile engine's
+  **fail-closed deny-set** (`.env*`, credential files such as `auth.json` /
+  `.credentials.json`, SSH/GPG/SOPS secret components, and live SQLite/DB/WAL
+  files are recorded `DENIED`, never hashed) plus `target/ node_modules/
+  .direnv/` excludes for determinism.
 
 Modes: `capture <repo> <out>`, `compare <a> <b>` (exit 1 on any diff),
 `seed-canary <dir>` (throwaway repo with feature branch + staged + unstaged +

--- a/scripts/repo-roam-fingerprint.sh
+++ b/scripts/repo-roam-fingerprint.sh
@@ -134,16 +134,24 @@ default_excludes() {
 
 # Fail-closed deny-set patterns mirrored from Blacklist::from_sync_config so the
 # fingerprint manifest never records a secret/live-WAL path that the reconcile
-# engine itself refuses to push.
+# engine itself refuses to push. This intentionally errs on the side of denying
+# a little more than the engine, never less.
 is_denied_relpath() {
   local rel="$1"
   local base="${rel##*/}"
   case "$base" in
-    .env|.env.*|*.pem|*.key|id_rsa|id_ed25519|*.sqlite|*.sqlite-wal|*.sqlite-shm|*.db-wal|*.db-shm)
+    .credentials.json|auth.json|.netrc|.pgpass|\
+    .env|.env.*|*.env|\
+    *.pem|*.key|id_rsa|id_ed25519|\
+    *.sqlite|*.sqlite3|*.sqlite-wal|*.sqlite-shm|*.db|*.db-wal|*.db-shm)
       return 0 ;;
   esac
   case "$rel" in
-    .ssh/*|.gnupg/*|*/secrets/*) return 0 ;;
+    .ssh|.ssh/*|*/.ssh|*/.ssh/*|\
+    .gnupg|.gnupg/*|*/.gnupg|*/.gnupg/*|\
+    sops-nix|sops-nix/*|*/sops-nix|*/sops-nix/*|\
+    secrets|secrets/*|*/secrets|*/secrets/*)
+      return 0 ;;
   esac
   return 1
 }

--- a/scripts/test-repo-roam-fingerprint.sh
+++ b/scripts/test-repo-roam-fingerprint.sh
@@ -71,20 +71,52 @@ assert_contains "$FP_A/working-manifest.tsv" "run.sh"
 # untracked file present.
 assert_contains "$FP_A/untracked.txt" "NOTES.txt"
 
-# --- deny-set posture: a planted secret is recorded DENIED, never hashed -----
-printf 'SECRET=should-not-appear\n' >"$REPO/.env"
-git -C "$REPO" add -f .env
+# --- deny-set posture: planted secrets are recorded DENIED, never hashed -----
+secret_paths=(
+  ".env"
+  ".env.local"
+  "service.env"
+  ".credentials.json"
+  "auth.json"
+  ".netrc"
+  ".pgpass"
+  "logs_2.sqlite"
+  "logs_2.sqlite3"
+  "logs_2.sqlite-wal"
+  "logs_2.sqlite-shm"
+  "opencode.db"
+  "opencode.db-wal"
+  "opencode.db-shm"
+  ".ssh/id_ed25519"
+  ".gnupg/private-keys-v1.d/key"
+  "sops-nix/secrets/example"
+  "nested/secrets/token"
+)
+for secret_path in "${secret_paths[@]}"; do
+  mkdir -p "$REPO/$(dirname "$secret_path")"
+  printf 'SECRET=should-not-appear:%s\n' "$secret_path" >"$REPO/$secret_path"
+  git -C "$REPO" add -f "$secret_path"
+done
 FP_DENY="$TMPDIR/fp-deny"
 bash "$SCRIPT" capture "$REPO" "$FP_DENY" >/dev/null
-assert_contains "$FP_DENY/working-manifest.tsv" ".env"
-assert_contains "$FP_DENY/working-manifest.tsv" "DENIED"
+for secret_path in "${secret_paths[@]}"; do
+  assert_contains "$FP_DENY/working-manifest.tsv" "$secret_path"
+  if ! awk -F '\t' -v path="$secret_path" '$1 == path && $2 == "DENIED" { found=1 } END { exit found ? 0 : 1 }' \
+      "$FP_DENY/working-manifest.tsv"; then
+    printf 'expected %s to be recorded as DENIED\n' "$secret_path" >&2
+    cat "$FP_DENY/working-manifest.tsv" >&2
+    exit 1
+  fi
+done
 if grep -F 'should-not-appear' "$FP_DENY"/* >/dev/null 2>&1; then
   printf 'secret content leaked into fingerprint evidence\n' >&2
   exit 1
 fi
-# reset the planted secret out of the way for the unchanged-compare below.
-git -C "$REPO" rm -q --cached .env
-rm -f "$REPO/.env"
+# reset the planted secrets out of the way for the unchanged-compare below.
+git -C "$REPO" rm -qr --cached -- "${secret_paths[@]}"
+for secret_path in "${secret_paths[@]}"; do
+  rm -f "$REPO/$secret_path"
+done
 
 # --- compare: identical re-capture passes ------------------------------------
 FP_B="$TMPDIR/fp-b"


### PR DESCRIPTION
## Summary

- Widens the repo-roam fingerprint evidence deny-set to match or exceed the TCFS fail-closed security policy.
- Records credential files, dotenv variants, live SQLite/DB/WAL files, SSH/GPG/SOPS secret components, and generic secrets components as DENIED instead of hashing their contents.
- Expands the regression test from a single .env fixture to a matrix that proves denied content does not leak into evidence.
- Tightens the repo-roam runbook wording to reflect the expanded deny coverage.

## Validation

- bash -n scripts/repo-roam-fingerprint.sh scripts/test-repo-roam-fingerprint.sh
- shellcheck scripts/repo-roam-fingerprint.sh scripts/test-repo-roam-fingerprint.sh
- bash scripts/test-repo-roam-fingerprint.sh
- task lazy:test-dev-env-fingerprint
- git diff --check

## Claim Boundary

This does not enroll repos or touch fleet state. It only fixes the evidence-layer policy leak found during the repo-roam workstream review.
