### PR TITLE
cleanup(tcfs-sync): dead-code + DRY in the conflict/reconcile chokepoints (pre .git-aware-resolution)

### DIFF
--- a/crates/tcfs-sync/src/conflict.rs
+++ b/crates/tcfs-sync/src/conflict.rs
@@ -177,24 +177,9 @@ pub fn compare_clocks(
     match local.partial_cmp_vc(remote) {
         Some(Ordering::Greater) => SyncOutcome::LocalNewer,
         Some(Ordering::Less) => SyncOutcome::RemoteNewer,
-        Some(Ordering::Equal) => {
-            // Same clock but different content — treat as conflict
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            SyncOutcome::Conflict(ConflictInfo {
-                rel_path: rel_path.to_string(),
-                local_vclock: local.clone(),
-                remote_vclock: remote.clone(),
-                local_blake3: local_blake3.to_string(),
-                remote_blake3: remote_blake3.to_string(),
-                local_device: local_device.to_string(),
-                remote_device: remote_device.to_string(),
-                detected_at: now,
-            })
-        }
-        None => {
+        // Equal clock with differing content, or concurrent (incomparable)
+        // clocks — both are conflicts with identical ConflictInfo.
+        Some(Ordering::Equal) | None => {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()

--- a/crates/tcfs-sync/src/git_safety.rs
+++ b/crates/tcfs-sync/src/git_safety.rs
@@ -157,27 +157,6 @@ pub fn restore_git_bundle_into(bundle: &Path, repo_root: &Path) -> anyhow::Resul
     Ok(())
 }
 
-/// Backwards-compatible clone-based restore (creates a fresh checkout at
-/// `target`). Retained for callers that want a standalone clone rather than an
-/// in-place working-tree restore.
-pub fn restore_git_from_bundle(bundle: &Path, target: &Path) -> anyhow::Result<()> {
-    let output = std::process::Command::new("git")
-        .args([
-            "clone",
-            &bundle.to_string_lossy(),
-            &target.to_string_lossy(),
-        ])
-        .output()
-        .map_err(|e| anyhow::anyhow!("running git clone from bundle: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git clone from bundle failed: {stderr}");
-    }
-
-    Ok(())
-}
-
 /// Run a git command in `cwd`, returning an error with captured stderr on
 /// non-zero exit.
 fn run_git(cwd: &Path, args: &[&str]) -> anyhow::Result<()> {

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -195,7 +195,7 @@ pub async fn list_remote_index(
         if rel_path.is_empty()
             || rel_path.ends_with('/')
             || rel_path == DIR_MARKER
-            || rel_path.ends_with("/.tcfs_dir")
+            || rel_path.ends_with(DIR_MARKER_SUFFIX)
         {
             continue;
         }
@@ -697,9 +697,6 @@ async fn classify_path(
         (None, None, None) => ReconcileAction::UpToDate {
             rel_path: rel_path.to_string(),
         },
-        // Local exists, not remote, but was tracked — local is newer
-        // (This case is covered above, but the compiler needs exhaustive matching
-        //  for the tracked_opt variations. The (Some, None, None) case above handles it.)
     }
 }
 
@@ -790,6 +787,20 @@ async fn compare_both_exist(
         remote_device,
     );
 
+    outcome_to_action(outcome, rel_path, local_path, remote_entry)
+}
+
+/// Map a `SyncOutcome` to the corresponding `ReconcileAction`.
+///
+/// Shared tail for `compare_both_exist` and `compare_both_exist_symlink`: both
+/// resolve the same vector-clock decision into the same push/pull/conflict
+/// action, so the mapping lives here to keep the two sites in lockstep.
+fn outcome_to_action(
+    outcome: crate::conflict::SyncOutcome,
+    rel_path: &str,
+    local_path: &Path,
+    remote_entry: &RemoteIndexEntry,
+) -> ReconcileAction {
     match outcome {
         crate::conflict::SyncOutcome::UpToDate => ReconcileAction::UpToDate {
             rel_path: rel_path.to_string(),
@@ -889,26 +900,7 @@ async fn compare_both_exist_symlink(
         remote_device,
     );
 
-    match outcome {
-        crate::conflict::SyncOutcome::UpToDate => ReconcileAction::UpToDate {
-            rel_path: rel_path.to_string(),
-        },
-        crate::conflict::SyncOutcome::LocalNewer => ReconcileAction::Push {
-            local_path: local_path.to_path_buf(),
-            rel_path: rel_path.to_string(),
-            reason: PushReason::LocalNewer,
-        },
-        crate::conflict::SyncOutcome::RemoteNewer => ReconcileAction::Pull {
-            rel_path: rel_path.to_string(),
-            manifest_hash: remote_entry.manifest_hash.clone(),
-            size: remote_entry.size,
-            reason: PullReason::RemoteNewer,
-        },
-        crate::conflict::SyncOutcome::Conflict(info) => ReconcileAction::Conflict {
-            rel_path: rel_path.to_string(),
-            info,
-        },
-    }
+    outcome_to_action(outcome, rel_path, local_path, remote_entry)
 }
 
 // ── Execution ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

A small, **behavior-preserving** dead-code + DRY cleanup of the conflict-resolution / reconcile chokepoints in `crates/tcfs-sync`, prepping them for the (separate, later) `.git`-aware conflict-resolution feature. **No sync/conflict behavior changes.**

## Items (each behavior-preserving)

1. **`reconcile.rs` `classify_path` — delete stale dead comment block.** Removed the trailing comment after the `(None, None, None)` match arm describing a "Local exists, not remote, but was tracked" case that is already handled by the `(Some, None, Some)` arm above. Comment-only; no logic change.
2. **`reconcile.rs` `list_remote_index` — use `DIR_MARKER_SUFFIX` const.** Replaced the literal `"/.tcfs_dir"` with the existing `const DIR_MARKER_SUFFIX: &str = "/.tcfs_dir"` (byte-identical value, already used in `list_remote_empty_dirs`). Value-identical.
3. **`conflict.rs` `compare_clocks` — collapse two identical Conflict arms.** The `Some(Ordering::Equal)` and `None` arms built byte-identical `ConflictInfo`; merged into one `Some(Ordering::Equal) | None =>` arm with a single `now` / `unwrap_or_default()`. Both inputs still produce the same `SyncOutcome::Conflict` with the same `ConflictInfo`. Logically identical.
4. **`reconcile.rs` — extract the shared `outcome -> ReconcileAction` tail.** The four-arm match mapping `SyncOutcome` to `ReconcileAction` was byte-identical in `compare_both_exist` and `compare_both_exist_symlink`. Extracted into one private helper and called from both sites. Pure code motion, zero behavior change.

   Helper signature:
   ```rust
   fn outcome_to_action(
       outcome: crate::conflict::SyncOutcome,
       rel_path: &str,
       local_path: &Path,
       remote_entry: &RemoteIndexEntry,
   ) -> ReconcileAction
   ```
5. **`git_safety.rs` — delete dead `pub fn restore_git_from_bundle`.** `grep -rn restore_git_from_bundle crates/ tests/` showed **zero callers**; it is superseded by `restore_git_bundle_into` (the fn actually used by `tcfs-cli` and `engine.rs`). Removed.

## Deliberately excluded (rejected as unsafe — left exactly as-is)

These are behavior-changing / feature-PR territory and were intentionally **not** touched:

- `reconcile.rs` Conflict arm / `mark_conflict` swap (behavior-changing).
- `conflict.rs` `(true, true) => None` (needed for match exhaustiveness).
- `AutoResolver` / `ConflictResolver` / `Resolution` variants / `compare_clocks` signature / `partial_cmp_vc` / `is_concurrent` / `chunk_hashes` / `is_legacy` (all live, incl. integration tests).
- `reconcile.rs` UpToDate-on-hash-failure policy + the `SystemTime` double-compute.
- The `refs/heads/*.lock` literal-not-glob in `git_safety.rs` (left for the feature PR).

## Why now

These are the chokepoints the upcoming `.git`-aware conflict-resolution feature will modify. Clearing dead code and the duplicated `outcome -> action` mapping first keeps the two reconcile paths (regular file + symlink) in lockstep and shrinks the feature PR's blast radius. See the **G5-git-5 CONCURRENT-WRITE CORRUPTION** gap in `docs/ops/repo-roam-test-plan-2026-06-08.md`, which is expected to fail until conflict resolution is made `.git`-aware.

## Validation (full local CI gate)

- `cargo fmt --all -- --check` — clean (exit 0).
- `cargo clippy --workspace --all-targets` — **zero** warnings in `tcfs-sync`; the only workspace warnings are 2 pre-existing `needless_borrow` in `crates/tcfsd/src/grpc.rs` (lines 1442, 1876), confirmed identical on `origin/main` and unrelated to this diff.
- `cargo test -p tcfs-sync` — 324 passed, 0 failed.
- `cargo test -p tcfsd` — 58 passed, 0 failed (run because `conflict.rs` is consumed by `tcfsd`).
