### PR TITLE
fence: never roam worktree gitfiles or .git/worktrees/** (merge-gate for #513)

### DIFF
--- a/crates/tcfs-sync/src/blacklist.rs
+++ b/crates/tcfs-sync/src/blacklist.rs
@@ -4,6 +4,7 @@
 //! into a single `Blacklist` type with a unified `check()` method.
 
 use std::path::Path;
+use tracing::debug;
 
 /// Why a path was excluded — useful for debug logging and diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,6 +22,17 @@ pub enum BlacklistReason {
     HiddenDir,
     /// .git directory when `sync_git_dirs` is false.
     GitDir,
+    /// Fail-closed worktree fence: a non-directory named `.git` is a linked
+    /// worktree's (or submodule's) gitfile pointer (`gitdir: <path>`). It
+    /// dangles on any other host, and a roamed deletion of the admin area it
+    /// points at would destroy the origin host's live worktree. Always denied
+    /// regardless of `sync_git_dirs` / `git_sync_mode` (G5 / TIN-1620).
+    GitFilePointer,
+    /// Fail-closed worktree fence: any path containing a `.git/worktrees/`
+    /// segment — the per-worktree admin area (`HEAD`, `index`, `gitdir` with
+    /// absolute host paths). Always denied, even under `sync_git_dirs=true`
+    /// with `git_sync_mode="raw"` (G5 / TIN-1620).
+    GitWorktreesAdmin,
     /// VFS internal directory marker (.tcfs_dir).
     VfsMarker,
 }
@@ -34,6 +46,8 @@ impl std::fmt::Display for BlacklistReason {
             BlacklistReason::StubExtension => write!(f, "stub extension"),
             BlacklistReason::HiddenDir => write!(f, "hidden directory"),
             BlacklistReason::GitDir => write!(f, ".git directory"),
+            BlacklistReason::GitFilePointer => write!(f, "gitfile pointer (linked worktree)"),
+            BlacklistReason::GitWorktreesAdmin => write!(f, ".git/worktrees admin area"),
             BlacklistReason::VfsMarker => write!(f, "VFS marker"),
         }
     }
@@ -94,6 +108,28 @@ fn security_file_reason(name: &str) -> Option<&'static str> {
         }
     }
     None
+}
+
+/// True when `path` contains a `.git/worktrees/` segment — the per-worktree
+/// admin area git maintains for linked worktrees (`HEAD`, `index`, `gitdir`
+/// files that embed absolute host paths). Roamed raw these dangle, and a
+/// roamed `git worktree prune` deletion would sync back and destroy the
+/// origin host's live worktree. Fail-closed: fenced regardless of config
+/// (G5 / TIN-1620).
+fn has_git_worktrees_segment(path: &Path) -> bool {
+    let mut prev_was_dot_git = false;
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(name) => {
+                if prev_was_dot_git && name == "worktrees" {
+                    return true;
+                }
+                prev_was_dot_git = name == ".git";
+            }
+            _ => prev_was_dot_git = false,
+        }
+    }
+    false
 }
 
 /// Centralized exclusion filter for the sync pipeline.
@@ -214,8 +250,17 @@ impl Blacklist {
             }
         }
 
-        // .git directory — check before hidden dir rule
-        if is_dir && name == ".git" {
+        // .git — worktree fence first, then the config-gated dir rule (before
+        // the hidden dir rule).
+        if name == ".git" {
+            // Fail-closed worktree fence: a non-directory named `.git` is a
+            // linked worktree's (or submodule's) gitfile pointer. Never roam
+            // it, regardless of `sync_git_dirs` / `git_sync_mode`
+            // (G5 / TIN-1620).
+            if !is_dir {
+                debug!("fencing gitfile pointer: non-directory .git never roams");
+                return Some(BlacklistReason::GitFilePointer);
+            }
             if !self.sync_git_dirs {
                 return Some(BlacklistReason::GitDir);
             }
@@ -233,9 +278,17 @@ impl Blacklist {
 
     /// Check a full path against the blacklist. Returns first matching reason or None.
     ///
-    /// Checks the final component name against `check_name()`. For the watcher's
-    /// component-walk behavior, use `check_path_components()` instead.
+    /// Applies the fail-closed `.git/worktrees/` fence across the whole path,
+    /// then checks the final component name against `check_name()`. For the
+    /// watcher's component-walk behavior, use `check_path_components()` instead.
     pub fn check(&self, path: &Path, is_dir: bool) -> Option<BlacklistReason> {
+        if has_git_worktrees_segment(path) {
+            debug!(
+                path = %path.display(),
+                "fencing .git/worktrees admin area: never roams"
+            );
+            return Some(BlacklistReason::GitWorktreesAdmin);
+        }
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             self.check_name(name, is_dir)
         } else {
@@ -256,7 +309,16 @@ impl Blacklist {
     /// Check every component of a path (for watcher-style full-path filtering).
     ///
     /// Returns the reason for the first matching component, or None if all pass.
+    /// Also applies the fail-closed `.git/worktrees/` fence across the whole
+    /// path (G5 / TIN-1620).
     pub fn check_path_components(&self, path: &Path) -> Option<BlacklistReason> {
+        if has_git_worktrees_segment(path) {
+            debug!(
+                path = %path.display(),
+                "fencing .git/worktrees admin area: never roams"
+            );
+            return Some(BlacklistReason::GitWorktreesAdmin);
+        }
         for component in path.components() {
             if let std::path::Component::Normal(name) = component {
                 if let Some(name_str) = name.to_str() {
@@ -270,12 +332,20 @@ impl Blacklist {
         None
     }
 
-    /// Check only the fail-closed security deny-set across every path component.
+    /// Check only the fail-closed deny-sets across every path component: the
+    /// security deny-set plus the config-independent `.git/worktrees/` fence.
     ///
     /// This is for cases where a caller intentionally starts from a hidden root
     /// such as `~/.claude/projects`, but must still refuse credential stores,
     /// dotenv files, and live databases anywhere under that root.
     pub fn check_security_path_components(&self, path: &Path) -> Option<BlacklistReason> {
+        if has_git_worktrees_segment(path) {
+            debug!(
+                path = %path.display(),
+                "fencing .git/worktrees admin area: never roams"
+            );
+            return Some(BlacklistReason::GitWorktreesAdmin);
+        }
         for component in path.components() {
             if let std::path::Component::Normal(name) = component {
                 if let Some(name_str) = name.to_str() {
@@ -542,6 +612,94 @@ mod tests {
             bl.check_security_path_components(Path::new("home/jess/.config/sops-nix/secrets/key")),
             Some(BlacklistReason::Security("sops-nix"))
         ));
+    }
+
+    // --- G5 / TIN-1620: linked-worktree fence (gitfile pointers + .git/worktrees) ---
+
+    #[test]
+    fn test_worktree_gitfile_pointer_denied_at_repo_root() {
+        // (a) A non-directory `.git` — a linked worktree's gitfile pointer —
+        // is fenced even under the most permissive config.
+        let bl = Blacklist::new(&[], true, true, "raw");
+        assert_eq!(
+            bl.check_name(".git", false),
+            Some(BlacklistReason::GitFilePointer)
+        );
+        assert_eq!(
+            bl.check(Path::new("wt-linked/.git"), false),
+            Some(BlacklistReason::GitFilePointer)
+        );
+        // Default (git sync off) is denied too — fail closed either way.
+        let bl = Blacklist::default();
+        assert_eq!(
+            bl.check_name(".git", false),
+            Some(BlacklistReason::GitFilePointer)
+        );
+    }
+
+    #[test]
+    fn test_worktrees_admin_area_denied_under_raw() {
+        // (b) `.git/worktrees/**` never roams, even with sync_git_dirs=true
+        // and git_sync_mode="raw".
+        let bl = Blacklist::new(&[], true, true, "raw");
+        for p in [
+            "repo/.git/worktrees",
+            "repo/.git/worktrees/wt-fence/gitdir",
+            "repo/.git/worktrees/wt-fence/HEAD",
+            "repo/.git/worktrees/wt-fence/index",
+        ] {
+            assert_eq!(
+                bl.check(Path::new(p), false),
+                Some(BlacklistReason::GitWorktreesAdmin),
+                "expected {p} to be fenced via check()"
+            );
+            assert_eq!(
+                bl.check_path_components(Path::new(p)),
+                Some(BlacklistReason::GitWorktreesAdmin),
+                "expected {p} to be fenced via component walk"
+            );
+        }
+        // The security-only walk fences it too (config-independent).
+        assert_eq!(
+            bl.check_security_path_components(Path::new("repo/.git/worktrees/wt/HEAD")),
+            Some(BlacklistReason::GitWorktreesAdmin)
+        );
+    }
+
+    #[test]
+    fn test_raw_git_dir_internals_still_roam() {
+        // (c) Regular .git internals are unaffected — the proven raw forward
+        // roam must not regress.
+        let bl = Blacklist::new(&[], true, true, "raw");
+        assert_eq!(bl.check_name(".git", true), None);
+        for p in [
+            "repo/.git/objects/ab/cdef0123456789",
+            "repo/.git/refs/heads/main",
+            "repo/.git/HEAD",
+            "repo/.git/config",
+        ] {
+            assert_eq!(bl.check(Path::new(p), false), None, "{p} should pass");
+            assert_eq!(
+                bl.check_path_components(Path::new(p)),
+                None,
+                "{p} should pass component walk"
+            );
+        }
+        // A directory named `worktrees` NOT under `.git` is a normal dir.
+        assert_eq!(bl.check(Path::new("repo/worktrees/notes.md"), false), None);
+    }
+
+    #[test]
+    fn test_nested_gitfile_pointer_denied_fail_closed() {
+        // (d) A non-directory named `.git` anywhere in the tree (submodule
+        // pointer shape) is fenced — fail closed.
+        let bl = Blacklist::new(&[], true, true, "raw");
+        assert_eq!(
+            bl.check(Path::new("repo/vendor/dep/.git"), false),
+            Some(BlacklistReason::GitFilePointer)
+        );
+        // As a directory it follows the normal .git-dir policy instead.
+        assert_eq!(bl.check(Path::new("repo/vendor/dep/.git"), true), None);
     }
 
     #[test]

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -3346,7 +3346,10 @@ fn collect_files_inner(
         let ft = entry.file_type().context("file_type dir entry")?;
 
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            if let Some(reason) = blacklist.check_name(name, ft.is_dir()) {
+            // Full-path check (not just the name): the fail-closed
+            // `.git/worktrees/` fence needs path context so the per-worktree
+            // admin area is never collected even in raw mode (G5 / TIN-1620).
+            if let Some(reason) = blacklist.check(&path, ft.is_dir()) {
                 match &reason {
                     BlacklistReason::Security(_) => warn!(
                         path = %path.display(),
@@ -4307,6 +4310,82 @@ mod tests {
                 ".claude/projects/demo/notes.md".to_string(),
                 ".claude/projects/demo/session.jsonl".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn collect_raw_git_fences_worktree_admin_and_gitfile_pointers() {
+        // G5 / TIN-1620 worktree fence: raw .git roam must never collect the
+        // per-worktree admin area or gitfile pointers, while regular .git
+        // internals still roam.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Main repo with a linked-worktree admin area.
+        std::fs::create_dir_all(root.join("repo/.git/objects/ab")).unwrap();
+        std::fs::create_dir_all(root.join("repo/.git/refs/heads")).unwrap();
+        std::fs::create_dir_all(root.join("repo/.git/worktrees/wt-fence")).unwrap();
+        std::fs::write(root.join("repo/.git/HEAD"), b"ref: refs/heads/main").unwrap();
+        std::fs::write(root.join("repo/.git/objects/ab/cdef"), b"obj").unwrap();
+        std::fs::write(root.join("repo/.git/refs/heads/main"), b"abc").unwrap();
+        std::fs::write(
+            root.join("repo/.git/worktrees/wt-fence/gitdir"),
+            b"/abs/path/wt-linked/.git\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("repo/.git/worktrees/wt-fence/HEAD"),
+            b"ref: refs/heads/fence",
+        )
+        .unwrap();
+        std::fs::write(root.join("repo/src.rs"), b"fn main() {}").unwrap();
+
+        // Linked worktree: `.git` is a FILE containing `gitdir: <abs path>`.
+        std::fs::create_dir_all(root.join("wt-linked")).unwrap();
+        std::fs::write(
+            root.join("wt-linked/.git"),
+            b"gitdir: /abs/path/repo/.git/worktrees/wt-fence\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("wt-linked/notes.md"), b"work").unwrap();
+
+        // Submodule-shaped gitfile pointer in a subdir.
+        std::fs::create_dir_all(root.join("repo/vendor/dep")).unwrap();
+        std::fs::write(
+            root.join("repo/vendor/dep/.git"),
+            b"gitdir: ../../.git/modules/dep\n",
+        )
+        .unwrap();
+
+        let result = collect_files(
+            root,
+            &CollectConfig {
+                sync_hidden_dirs: true,
+                sync_git_dirs: true,
+                git_sync_mode: "raw".into(),
+                sync_empty_dirs: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let files = rel_names(&result.files, root);
+        // Regular .git internals + working files still roam (no raw regression).
+        assert!(files.contains(&"repo/.git/HEAD".to_string()), "{files:?}");
+        assert!(files.contains(&"repo/.git/objects/ab/cdef".to_string()));
+        assert!(files.contains(&"repo/.git/refs/heads/main".to_string()));
+        assert!(files.contains(&"repo/src.rs".to_string()));
+        assert!(files.contains(&"wt-linked/notes.md".to_string()));
+        // Fenced: nothing under .git/worktrees/, and no gitfile pointers.
+        assert!(
+            files.iter().all(|f| !f.contains(".git/worktrees")),
+            "worktrees admin area must never be collected: {files:?}"
+        );
+        assert!(
+            files
+                .iter()
+                .all(|f| f != "wt-linked/.git" && f != "repo/vendor/dep/.git"),
+            "gitfile pointers must never be collected: {files:?}"
         );
     }
 

--- a/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
+++ b/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
@@ -83,6 +83,31 @@ is not the default daily-driver claim and must prove index/mtime, lockfile,
 symlink, mode, and concurrent-operation safety before it can replace the
 bundle/restore path.
 
+### Linked Worktrees
+
+`git worktree` metadata is fail-closed fenced by the blacklist
+(`crates/tcfs-sync/src/blacklist.rs`), independent of `sync_git_dirs` and
+`git_sync_mode`:
+
+- A non-directory named `.git` — a linked worktree's (or submodule's) gitfile
+  pointer containing `gitdir: <absolute path>` — is never collected or roamed
+  (`BlacklistReason::GitFilePointer`).
+- Any path containing a `.git/worktrees/` segment — the per-worktree admin
+  area holding `HEAD`, `index`, and `gitdir` files with absolute host paths —
+  is never collected or roamed (`BlacklistReason::GitWorktreesAdmin`), even
+  under `sync_git_dirs = true` with `git_sync_mode = "raw"`.
+
+Why: roamed raw, both shapes dangle on the destination host, and under
+bidirectional roam a roamed `git worktree prune` deletion would sync back and
+destroy the origin host's live worktree. The fence trades pointer fidelity for
+safety: a roamed copy of a linked worktree (or a submodule checkout) arrives
+without its `.git` pointer and reads as a plain directory. Real worktree roam
+is design-first work, tracked as an expected-red gate:
+
+| Gate | Scenario | Expected |
+| --- | --- | --- |
+| G5-wt-1 | Real linked-worktree roam: pointer + admin area re-established on the destination host | red (future, design-first, H3) |
+
 ## Acceptance Gates
 
 ### R0 - Policy And Inventory


### PR DESCRIPTION
## Destruction vector

A linked worktree's `.git` is a FILE containing `gitdir: <absolute path>`; the main repo's `.git/worktrees/<name>/` holds per-worktree `HEAD`/`index`/`gitdir` with absolute host paths. Roamed raw, both shapes dangle on the destination host. Under **bidirectional** roam the failure is destructive: a `git worktree prune` (or manual delete) on the roamed copy syncs a deletion of `.git/worktrees/<name>/` back to the origin host and destroys its live worktree.

**#513 (feat/git-ff-resolution) must not merge before this fence lands** — FF/bidirectional resolution makes the reverse path routine.

## Rules (fail-closed, config-independent)

| Rule | Location |
| --- | --- |
| Non-directory named `.git` (gitfile pointer) is DENIED regardless of `sync_git_dirs`/`git_sync_mode` (`BlacklistReason::GitFilePointer`) | `crates/tcfs-sync/src/blacklist.rs` — `check_name()` `.git` arm |
| Any path containing a `.git/worktrees/` segment is DENIED even under `sync_git_dirs=true` + raw (`BlacklistReason::GitWorktreesAdmin`) | `crates/tcfs-sync/src/blacklist.rs` — `has_git_worktrees_segment()` wired into `check()`, `check_path_components()`, `check_security_path_components()` |
| Collector uses path-aware `check()` so the fence applies during raw `.git` descent | `crates/tcfs-sync/src/engine.rs` — `collect_files_inner` |

Normal raw `.git`-dir behavior is otherwise unchanged; fencing logs at `debug`.

## Tests (non-vacuous)

- (a) gitfile pointer at repo root denied — `test_worktree_gitfile_pointer_denied_at_repo_root`
- (b) `.git/worktrees/<n>/gitdir` denied under `sync_git_dirs=true` + raw — `test_worktrees_admin_area_denied_under_raw`
- (c) regular `.git/objects` / `refs` / `HEAD` still ALLOWED under raw (no forward-roam regression) — `test_raw_git_dir_internals_still_roam`
- (d) file named `.git` in a subdir (non-dir) also denied, fail closed — `test_nested_gitfile_pointer_denied_fail_closed`
- End-to-end collector proof with a fabricated main-repo + linked-worktree + submodule-pointer tree — `engine::tests::collect_raw_git_fences_worktree_admin_and_gitfile_pointers`

## Docs

`docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md` — new "Linked Worktrees" subsection: fence semantics + expected-red `G5-wt-1` row for real worktree roam (design-first, H3).

## Flags (loud, conservative-by-design)

- **Submodule gitfile pointers are also fenced** (rule 1 catches any non-dir `.git`). A roamed submodule checkout arrives as a plain directory without its pointer; `git submodule absorbgitdirs`/`init` can regenerate. Deliberate fail-closed trade.
- Fence is collection/watch-side; `.git/worktrees` entries already present in a remote index from earlier syncs are not retro-purged by this PR.
- `.git/modules/` (submodule admin area) is intentionally NOT fenced here — it contains relative paths and roams as normal dirs; out of scope per fence design.

## Local gate

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets` — no new warnings (only the 2 known pre-existing `needless_borrow` in `tcfsd/src/grpc.rs`)
- `cargo test -p tcfs-sync` 329 passed / 0 failed; `cargo test -p tcfsd` 58 passed / 0 failed
