### PR TITLE
fix(deny): resolve RUSTSEC-2026-0189/0190 (anyhow bump + justified rmcp stdio-only ignore)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/deny.toml
+++ b/deny.toml
@@ -14,7 +14,9 @@ ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
     "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
+    "RUSTSEC-2026-0189",  # rmcp <1.4 Streamable-HTTP-server Host-header DNS rebinding — tcfs-mcp is stdio-only (rmcp::transport::stdio, tcfs-mcp/src/main.rs) and the workspace enables only server/transport-io/macros/schemars features, so the vulnerable HTTP transport is not compiled in; revisit on the rmcp 1.x major bump
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
+    # RUSTSEC-2026-0190 (anyhow) fixed by bumping anyhow 1.0.102 -> 1.0.103 in Cargo.lock
 ]
 
 [licenses]


### PR DESCRIPTION
cargo-deny is red on main tip 9bf26fb and therefore on all four open PRs (#506/#513/#514/#515).

- **RUSTSEC-2026-0190 (anyhow)**: real fix — in-semver bump 1.0.102 → 1.0.103 (Cargo.lock only).
- **RUSTSEC-2026-0189 (rmcp <1.4)**: Streamable-HTTP-server Host-header DNS rebinding. tcfs-mcp runs **stdio only** (`rmcp::transport::stdio`, `crates/tcfs-mcp/src/main.rs`) and the workspace enables only `server, transport-io, macros, schemars` features — the vulnerable HTTP transport is **not compiled** into any tcfs binary. Justified ignore, matching the existing deny.toml pattern; revisit on the rmcp 1.x major bump.

`cargo deny check advisories` green locally. Unblocks the merge queue (fence #515 → harness #506 → release #514 → FF #513).