### PR TITLE
release: cut v0.12.16 (carries #513 FF conflict resolution)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-auth"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-chunks"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cli"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cloudfilter"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-core"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "prost",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-crypto"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "aes-siv",
  "age",
@@ -5269,7 +5269,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-dbus"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-e2e"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-file-provider"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-fuse"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-mcp"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5372,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-nfs"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-secrets"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5422,7 +5422,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sops"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-storage"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sync"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "age",
  "anyhow",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-tui"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-vfs"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "tcfsd"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.15"
+version = "0.12.16"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,8 @@ ignore = [
     "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
     "RUSTSEC-2026-0189",  # rmcp <1.4 Streamable-HTTP-server Host-header DNS rebinding — tcfs-mcp is stdio-only (rmcp::transport::stdio, tcfs-mcp/src/main.rs) and the workspace enables only server/transport-io/macros/schemars features, so the vulnerable HTTP transport is not compiled in; revisit on the rmcp 1.x major bump
+    "RUSTSEC-2026-0194",  # quick-xml <0.41 O(N^2) duplicate-attribute check DoS — transitive, semver-capped by opendal 0.55/reqsign 0.16.5/plist; the XML parsed is our own SeaweedFS S3 responses inside the WireGuard tailnet + local plists, never internet-untrusted; DoS-class only; revisit on the opendal 0.56+ bump
+    "RUSTSEC-2026-0195",  # quick-xml <0.41 unbounded NsReader namespace allocations DoS — same transitive pin + same trusted-XML topology as 0194; revisit on the opendal 0.56+ bump
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
     # RUSTSEC-2026-0190 (anyhow) fixed by bumping anyhow 1.0.102 -> 1.0.103 in Cargo.lock
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -15,8 +15,8 @@ ignore = [
     "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
     "RUSTSEC-2026-0189",  # rmcp <1.4 Streamable-HTTP-server Host-header DNS rebinding — tcfs-mcp is stdio-only (rmcp::transport::stdio, tcfs-mcp/src/main.rs) and the workspace enables only server/transport-io/macros/schemars features, so the vulnerable HTTP transport is not compiled in; revisit on the rmcp 1.x major bump
-    "RUSTSEC-2026-0194",  # quick-xml <0.41 O(N^2) duplicate-attribute check DoS — transitive, semver-capped by opendal 0.55/reqsign 0.16.5/plist; the XML parsed is our own SeaweedFS S3 responses inside the WireGuard tailnet + local plists, never internet-untrusted; DoS-class only; revisit on the opendal 0.56+ bump
-    "RUSTSEC-2026-0195",  # quick-xml <0.41 unbounded NsReader namespace allocations DoS — same transitive pin + same trusted-XML topology as 0194; revisit on the opendal 0.56+ bump
+    "RUSTSEC-2026-0194",  # quick-xml <0.41 quadratic XML attribute duplicate check — transitive only via opendal/reqsign S3 XML response handling and service-manager/plist launchd plist parsing. opendal 0.55 pins quick-xml 0.38 and opendal 0.57 still pins quick-xml 0.39/0.40 while adding RUSTSEC-2023-0071 via rsa; revisit when upstream opendal/reqsign publish quick-xml >=0.41 support.
+    "RUSTSEC-2026-0195",  # quick-xml <0.41 NsReader namespace allocation DoS — same transitive upstream constraint/risk boundary as RUSTSEC-2026-0194; TCFS does not directly parse attacker-supplied XML with quick-xml.
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
     # RUSTSEC-2026-0190 (anyhow) fixed by bumping anyhow 1.0.102 -> 1.0.103 in Cargo.lock
 ]


### PR DESCRIPTION
Workspace version bump 0.12.15 → 0.12.16 (Cargo.toml + 19-member lock restamp, zero dep changes).

**What lands in 0.12.16 vs the deployed 0.12.15:** #513 (`c40f075`) — bidirectional `.git`-aware fast-forward conflict resolution. FF ref conflicts reclassified by git ancestry (atomic per-repo winner; divergent stays Conflict with zero writes), plan-time ref-SHA pins re-verified at execute in both directions, per-repo objects-before-refs barrier, `.git` lockfiles denied from roam, submodule + detached-HEAD ref-class fail-closed veto. Merged after four adversarial review rounds ([r2](https://github.com/Jesssullivan/tummycrypt/pull/513#issuecomment-4861376526), [r3](https://github.com/Jesssullivan/tummycrypt/pull/513#issuecomment-4862809477), r4 approve).

Deploy plan: merge → tinyland sync → lab flake bump → nix-switch neo+honey → **live honey→neo bidirectional handoff canary** (the R3 5-conflict stall, expected to auto-converge) + #506 harness demo against the deployed binary.

Linear: TIN-1620, TIN-2296.