### PR TITLE
ci(nix): build+publish full aarch64-darwin closure (incl. tcfsd) off-neo — fixes the neo local-compile trap

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -97,6 +97,10 @@ jobs:
     name: Build macOS aarch64
     runs-on: macos-14
     needs: flake-check
+    # id-token: write is required for FlakeHub Cache OIDC push (below).
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
 
@@ -106,6 +110,17 @@ jobs:
           extra_nix_config: |
             extra-substituters = https://nix-cache.tinyland.dev/main
             extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
+
+      # FlakeHub Cache is the canonical nix cache the fleet substitutes from
+      # (lab nix/home-manager/nix.nix: "Attic replaced by FlakeHub"; macbook-neo
+      # trusts cache.flakehub.com). This action sets up a post-build push hook so
+      # EVERY darwin store path built below is published to FlakeHub Cache — which
+      # is what lets neo `nix-switch` SUBSTITUTE the aarch64-darwin closure
+      # (incl. tcfsd) instead of ever compiling locally. Requires this repo to be
+      # enrolled in FlakeHub Cache; no-ops with a warning if not yet enrolled.
+      - name: Set up FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@main
+        continue-on-error: true
 
       - name: Configure Attic
         run: |
@@ -119,6 +134,12 @@ jobs:
             echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
           fi
 
+      # NOTE: the aarch64-darwin DAEMON closure (tcfsd/tcfsd-app/staticlib) was
+      # previously NOT built here — only cli/tui/mcp — so macbook-neo could not
+      # substitute a new tcfsd and silently fell back to a LOCAL compile
+      # (2026-07-04 incident: a full day of neo compilation). Build the full set
+      # here on the GitHub macos-14 runner (off-neo, off-PZM) so the whole
+      # darwin closure lands in the caches and neo only ever substitutes.
       - name: Build tcfs-cli (no FUSE on macOS)
         run: nix build --accept-flake-config --fallback .#tcfs-cli
 
@@ -128,10 +149,19 @@ jobs:
       - name: Build tcfs-mcp
         run: nix build --accept-flake-config --fallback .#tcfs-mcp
 
+      - name: Build tcfsd (daemon)
+        run: nix build --accept-flake-config --fallback .#tcfsd
+
+      - name: Build tcfsd-app (FileProvider app bundle)
+        run: nix build --accept-flake-config --fallback .#tcfsd-app
+
+      - name: Build tcfs-file-provider-staticlib
+        run: nix build --accept-flake-config --fallback .#tcfs-file-provider-staticlib
+
       - name: Push to Attic
         if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
         run: |
-          for pkg in tcfs-cli tcfs-tui tcfs-mcp; do
+          for pkg in tcfs-cli tcfs-tui tcfs-mcp tcfsd tcfsd-app tcfs-file-provider-staticlib; do
             nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
             attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
           done

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -96,6 +96,10 @@ jobs:
   build-macos-aarch64:
     name: Build macOS aarch64
     runs-on: macos-14
+    # Hard stop well under the 6h hosted-runner ceiling: a wedged job must fail
+    # loud with hours to spare, not silently eat the whole window (both prior
+    # runs of this job died at exactly 6h00m inside "Set up FlakeHub Cache").
+    timeout-minutes: 300
     needs: flake-check
     # id-token: write is required for FlakeHub Cache OIDC push (below).
     permissions:
@@ -118,8 +122,13 @@ jobs:
       # is what lets neo `nix-switch` SUBSTITUTE the aarch64-darwin closure
       # (incl. tcfsd) instead of ever compiling locally. Requires this repo to be
       # enrolled in FlakeHub Cache; no-ops with a warning if not yet enrolled.
+      # continue-on-error alone is not enough: when un-enrolled this action can
+      # HANG rather than fail (observed twice: job cancelled at exactly the 6h
+      # ceiling with every build step still skipped) — timeout-minutes converts
+      # the hang into the warning this comment always assumed.
       - name: Set up FlakeHub Cache
         uses: DeterminateSystems/flakehub-cache-action@main
+        timeout-minutes: 10
         continue-on-error: true
 
       - name: Configure Attic


### PR DESCRIPTION
## Current correction — 2026-07-05

Do not treat this PR as evidence that PZM is hardware-blocked or that the external SSD is the current TCFS blocker. Follow-up investigation found the SSD/APFS path re-enumerated and the current remote-builder failure is the Determinate Nix `ssh-ng://` remote-store path (`nix-daemon --stdio`, `MonitorFdHup kevent add: Invalid argument`), with `ssh://`/serve-style transport and non-PZM CI/cache lanes as the durable direction. This PR is therefore a tactical off-neo cache/prebuild lane only, and its cancelled macOS check must be refreshed before any merge consideration.

---

## Why
On 2026-07-04, `nix-switch` on **macbook-neo** silently compiled tcfs **locally for ~a full day**. Current corrected root-cause framing:
1. The SSD/APFS path on **petting-zoo-mini** re-enumerated and verified clean; do not treat PZM hardware or the external SSD as the current TCFS blocker.
2. The observed remote-builder failure is specific to Determinate Nix 3.17.3 `ssh-ng://` remote-store startup on macOS (`nix-daemon --stdio`, `MonitorFdHup kevent add: Invalid argument`).
3. This PR is therefore only a tactical off-neo cache/prebuild lane. The durable builder direction is `ssh://`/serve-style transport or GF/remote-cache execution patterns, with neo prevented from compiling locally.

## What this does
- Builds the **full** aarch64-darwin closure (adds `tcfsd`, `tcfsd-app`, `tcfs-file-provider-staticlib`) on the GitHub **macos-14** runner — genuinely off-neo, off-PZM.
- Publishes to **FlakeHub Cache** (`cache.flakehub.com` — the canonical fleet cache neo trusts; lab `nix.nix`: *"Attic replaced by FlakeHub"*) **and** keeps the **Attic** push (the GF-fabric nix-cache in the `nix-cache` namespace) extended to the daemon set.
- Net: neo `nix-switch` **substitutes** the darwin closure instead of compiling. PZM becomes optional, not a SPOF.

## Notes for review
- FlakeHub Cache push needs this repo **enrolled in FlakeHub Cache** (`id-token: write` added). The step is `continue-on-error` so CI stays green before enrollment; the Attic path works today with the existing `ATTIC_TOKEN`.
- The Bazel REAPI CAS at `grpc://bazel-cache.nix-cache.svc.cluster.local:9092` is **not** a nix-closure target (gRPC, cluster-internal) — the GF-fabric nix cache is the Attic in the same `nix-cache` namespace, which this already targets.

Pairs with the lab **fail-loud + preflight** PR so a dead builder errors in seconds instead of burning neo.

Linear: TIN-1620.

