### PR TITLE
Fence per-file git conflict resolution

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -8092,6 +8092,7 @@ enabled = false
         let mut state = tcfs_sync::state::StateCache::open(&state_path).unwrap();
 
         let ordinary_path = sync_root.join("notes.txt");
+        std::fs::write(&ordinary_path, b"local ordinary").unwrap();
         let mut ordinary = tcfs_sync::state::make_sync_state(
             &ordinary_path,
             "ordinary".to_string(),
@@ -8113,6 +8114,7 @@ enabled = false
         state.set(&ordinary_path, ordinary);
 
         let git_path = git_parent.join("main");
+        std::fs::write(&git_path, b"0123456789012345678901234567890123456789\n").unwrap();
         let mut git_entry = tcfs_sync::state::make_sync_state(
             &git_path,
             "git".to_string(),

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -9,6 +9,7 @@
 //!   push <local> [<prefix>]      - upload file or directory tree to SeaweedFS
 //!   pull <manifest> [<local>]    - download file from manifest path
 //!   sync-status [<path>]         - show local sync state for a file/dir
+//!   conflicts                    - list recorded sync conflicts
 //!   index inspect <path>         - inspect one remote index entry read-only
 
 use anyhow::{Context, Result};
@@ -17,6 +18,7 @@ use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use secrecy::ExposeSecret;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -146,6 +148,13 @@ enum Commands {
     SyncStatus {
         /// Path to check (default: current directory)
         path: Option<PathBuf>,
+        /// Path to the sync state cache JSON file (overrides config)
+        #[arg(long, env = "TCFS_STATE_PATH")]
+        state: Option<PathBuf>,
+    },
+
+    /// List recorded sync conflicts from the local state cache
+    Conflicts {
         /// Path to the sync state cache JSON file (overrides config)
         #[arg(long, env = "TCFS_STATE_PATH")]
         state: Option<PathBuf>,
@@ -322,10 +331,12 @@ enum Commands {
         state: Option<PathBuf>,
     },
 
-    /// Resolve a sync conflict for a file
+    /// Resolve a sync conflict for a non-git file
     ///
     /// When two devices modify the same file without syncing, a conflict is
-    /// detected. Use this command to pick a resolution strategy.
+    /// detected. Use this command to pick a resolution strategy. Per-file
+    /// resolution of `.git` internals is refused by the daemon; those conflicts
+    /// must stay deferred until repo-level git resolution handles them.
     Resolve {
         /// Path to the conflicted file
         path: PathBuf,
@@ -744,6 +755,7 @@ async fn main() -> Result<()> {
         Commands::SyncStatus { path, state } => {
             cmd_sync_status(&config, path.as_deref(), state.as_deref())
         }
+        Commands::Conflicts { state } => cmd_conflicts(&config, state.as_deref()),
         Commands::Index { action } => cmd_index(&config, action).await,
         Commands::Storage { action } => cmd_storage(&config, action).await,
         Commands::Cache { action } => match action {
@@ -1112,6 +1124,37 @@ enum SyncStatusPathReport {
     Untracked {
         canonical: PathBuf,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConflictListReport {
+    state_path: PathBuf,
+    git_groups: Vec<GitConflictGroup>,
+    ordinary: Vec<ConflictListEntry>,
+}
+
+impl ConflictListReport {
+    fn total(&self) -> usize {
+        self.ordinary.len()
+            + self
+                .git_groups
+                .iter()
+                .map(|group| group.entries.len())
+                .sum::<usize>()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitConflictGroup {
+    repo: String,
+    entries: Vec<ConflictListEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConflictListEntry {
+    rel_path: String,
+    local_device: String,
+    remote_device: String,
 }
 
 fn build_sync_status_report(
@@ -1637,6 +1680,72 @@ async fn remove_adjacent_stub_after_pull(local_path: &Path) -> Result<()> {
     }
 }
 
+fn build_conflicts_report(
+    config: &tcfs_core::config::TcfsConfig,
+    state_override: Option<&Path>,
+) -> Result<ConflictListReport> {
+    let state_path = resolve_state_path(config, state_override);
+    let state = tcfs_sync::state::StateCache::open(&state_path)
+        .with_context(|| format!("opening state cache: {}", state_path.display()))?;
+
+    let mut ordinary = Vec::new();
+    let mut grouped: BTreeMap<String, Vec<ConflictListEntry>> = BTreeMap::new();
+
+    for (path, entry) in tcfs_sync::state::StateCacheBackend::all_entries(&state) {
+        if entry.status != tcfs_sync::state::FileSyncStatus::Conflict && entry.conflict.is_none() {
+            continue;
+        }
+
+        let conflict = entry.conflict.as_ref();
+        let rel_path = conflict
+            .map(|info| info.rel_path.clone())
+            .unwrap_or_else(|| path.clone());
+        let row = ConflictListEntry {
+            rel_path: rel_path.clone(),
+            local_device: conflict
+                .map(|info| info.local_device.clone())
+                .unwrap_or_else(|| entry.device_id.clone()),
+            remote_device: conflict
+                .map(|info| info.remote_device.clone())
+                .unwrap_or_default(),
+        };
+
+        if let Some(repo) = git_conflict_group_label(&rel_path) {
+            grouped.entry(repo).or_default().push(row);
+        } else {
+            ordinary.push(row);
+        }
+    }
+
+    ordinary.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+    let git_groups = grouped
+        .into_iter()
+        .map(|(repo, mut entries)| {
+            entries.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+            GitConflictGroup { repo, entries }
+        })
+        .collect();
+
+    Ok(ConflictListReport {
+        state_path,
+        git_groups,
+        ordinary,
+    })
+}
+
+fn git_conflict_group_label(rel_path: &str) -> Option<String> {
+    if !tcfs_sync::git_safety::is_git_internal_path(rel_path) {
+        return None;
+    }
+    let repo_root = tcfs_sync::git_safety::repo_root_for_git_path(Path::new(""), rel_path)?;
+    let label = repo_root.to_string_lossy();
+    if label.is_empty() {
+        Some(".".to_string())
+    } else {
+        Some(label.into_owned())
+    }
+}
+
 /// If the pulled file is a TCFS git bundle (`.git-tcfs-bundle`), reconstruct
 /// the repo's `.git` metadata in place so the rehydrated working tree has
 /// working history (`git log` / `git status` / `git fetch`).
@@ -1743,6 +1852,60 @@ fn cmd_sync_status(
     }
 
     Ok(())
+}
+
+fn cmd_conflicts(
+    config: &tcfs_core::config::TcfsConfig,
+    state_override: Option<&Path>,
+) -> Result<()> {
+    let report = build_conflicts_report(config, state_override)?;
+
+    println!("State cache: {}", report.state_path.display());
+    println!("Conflicts: {}", report.total());
+
+    if report.total() == 0 {
+        println!("No conflicts recorded.");
+        return Ok(());
+    }
+
+    if !report.git_groups.is_empty() {
+        println!();
+        println!("Git conflict groups:");
+        for group in &report.git_groups {
+            println!("  {} ({} path(s))", group.repo, group.entries.len());
+            for entry in &group.entries {
+                println!(
+                    "    {}  local={} remote={}",
+                    entry.rel_path,
+                    empty_dash(&entry.local_device),
+                    empty_dash(&entry.remote_device)
+                );
+            }
+        }
+    }
+
+    if !report.ordinary.is_empty() {
+        println!();
+        println!("File conflicts:");
+        for entry in &report.ordinary {
+            println!(
+                "  {}  local={} remote={}",
+                entry.rel_path,
+                empty_dash(&entry.local_device),
+                empty_dash(&entry.remote_device)
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn empty_dash(value: &str) -> &str {
+    if value.is_empty() {
+        "-"
+    } else {
+        value
+    }
 }
 
 // ── `tcfs index` ─────────────────────────────────────────────────────────────
@@ -7914,6 +8077,73 @@ enabled = false
             }
             other => panic!("expected tracked status, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cli_conflicts_groups_git_internal_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("tree");
+        let git_parent = sync_root.join("repo/.git/refs/heads");
+        std::fs::create_dir_all(&git_parent).unwrap();
+        std::fs::create_dir_all(&sync_root).unwrap();
+
+        let state_path = dir.path().join("state.json");
+        let config = test_config(&sync_root);
+        let mut state = tcfs_sync::state::StateCache::open(&state_path).unwrap();
+
+        let ordinary_path = sync_root.join("notes.txt");
+        let mut ordinary = tcfs_sync::state::make_sync_state(
+            &ordinary_path,
+            "ordinary".to_string(),
+            1,
+            "data/manifests/ordinary".to_string(),
+        )
+        .unwrap();
+        ordinary.status = tcfs_sync::state::FileSyncStatus::Conflict;
+        ordinary.conflict = Some(tcfs_sync::conflict::ConflictInfo {
+            rel_path: "notes.txt".into(),
+            local_vclock: tcfs_sync::conflict::VectorClock::new(),
+            remote_vclock: tcfs_sync::conflict::VectorClock::new(),
+            local_blake3: "local".into(),
+            remote_blake3: "remote".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 42,
+        });
+        state.set(&ordinary_path, ordinary);
+
+        let git_path = git_parent.join("main");
+        let mut git_entry = tcfs_sync::state::make_sync_state(
+            &git_path,
+            "git".to_string(),
+            1,
+            "data/manifests/git".to_string(),
+        )
+        .unwrap();
+        git_entry.status = tcfs_sync::state::FileSyncStatus::Conflict;
+        git_entry.conflict = Some(tcfs_sync::conflict::ConflictInfo {
+            rel_path: "repo/.git/refs/heads/main".into(),
+            local_vclock: tcfs_sync::conflict::VectorClock::new(),
+            remote_vclock: tcfs_sync::conflict::VectorClock::new(),
+            local_blake3: "local-git".into(),
+            remote_blake3: "remote-git".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 43,
+        });
+        state.set(&git_path, git_entry);
+        state.flush().unwrap();
+
+        let report = build_conflicts_report(&config, Some(&state_path)).unwrap();
+        assert_eq!(report.total(), 2);
+        assert_eq!(report.ordinary.len(), 1);
+        assert_eq!(report.ordinary[0].rel_path, "notes.txt");
+        assert_eq!(report.git_groups.len(), 1);
+        assert_eq!(report.git_groups[0].repo, "repo");
+        assert_eq!(
+            report.git_groups[0].entries[0].rel_path,
+            "repo/.git/refs/heads/main"
+        );
     }
 
     #[tokio::test]

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1699,7 +1699,9 @@ fn build_conflicts_report(
         let conflict = entry.conflict.as_ref();
         let rel_path = conflict
             .map(|info| info.rel_path.clone())
-            .unwrap_or_else(|| path.clone());
+            .unwrap_or_else(|| {
+                state_key_to_display_rel_path(&path, config.sync.sync_root.as_deref())
+            });
         let row = ConflictListEntry {
             rel_path: rel_path.clone(),
             local_device: conflict
@@ -1737,13 +1739,37 @@ fn git_conflict_group_label(rel_path: &str) -> Option<String> {
     if !tcfs_sync::git_safety::is_git_internal_path(rel_path) {
         return None;
     }
-    let repo_root = tcfs_sync::git_safety::repo_root_for_git_path(Path::new(""), rel_path)?;
+    let normalized = rel_path.replace('\\', "/");
+    let repo_root = tcfs_sync::git_safety::repo_root_for_git_path(Path::new(""), &normalized)?;
     let label = repo_root.to_string_lossy();
     if label.is_empty() {
         Some(".".to_string())
     } else {
         Some(label.into_owned())
     }
+}
+
+fn state_key_to_display_rel_path(path: &str, sync_root: Option<&Path>) -> String {
+    let path_buf = Path::new(path);
+    if let Some(root) = sync_root {
+        if let Ok(rel) = path_buf.strip_prefix(root) {
+            return path_to_slash_string(rel);
+        }
+        if let (Ok(path), Ok(root)) = (std::fs::canonicalize(path_buf), std::fs::canonicalize(root))
+        {
+            if let Ok(rel) = path.strip_prefix(root) {
+                return path_to_slash_string(rel);
+            }
+        }
+    }
+    path.replace('\\', "/")
+}
+
+fn path_to_slash_string(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 /// If the pulled file is a TCFS git bundle (`.git-tcfs-bundle`), reconstruct
@@ -8123,16 +8149,6 @@ enabled = false
         )
         .unwrap();
         git_entry.status = tcfs_sync::state::FileSyncStatus::Conflict;
-        git_entry.conflict = Some(tcfs_sync::conflict::ConflictInfo {
-            rel_path: "repo/.git/refs/heads/main".into(),
-            local_vclock: tcfs_sync::conflict::VectorClock::new(),
-            remote_vclock: tcfs_sync::conflict::VectorClock::new(),
-            local_blake3: "local-git".into(),
-            remote_blake3: "remote-git".into(),
-            local_device: "neo".into(),
-            remote_device: "honey".into(),
-            detected_at: 43,
-        });
         state.set(&git_path, git_entry);
         state.flush().unwrap();
 
@@ -8145,6 +8161,10 @@ enabled = false
         assert_eq!(
             report.git_groups[0].entries[0].rel_path,
             "repo/.git/refs/heads/main"
+        );
+        assert_eq!(
+            git_conflict_group_label("repo\\.git\\refs\\heads\\main").as_deref(),
+            Some("repo")
         );
     }
 

--- a/crates/tcfs-mcp/src/server.rs
+++ b/crates/tcfs-mcp/src/server.rs
@@ -235,7 +235,7 @@ impl TcfsMcp {
     }
 
     #[tool(
-        description = "Resolve a sync conflict by choosing a resolution strategy. Valid resolutions: keep_local, keep_remote, keep_both, defer"
+        description = "Resolve a non-git sync conflict by choosing a resolution strategy. Valid resolutions: keep_local, keep_remote, keep_both, defer. Git-internal .git paths only support defer; repo-level git resolution must handle those conflicts."
     )]
     async fn resolve_conflict(
         &self,

--- a/crates/tcfs-sync/src/git_safety.rs
+++ b/crates/tcfs-sync/src/git_safety.rs
@@ -12,6 +12,20 @@ use std::path::Path;
 /// internals are skipped by the collector in bundle mode.
 pub const GIT_BUNDLE_REL_PATH: &str = ".git-tcfs-bundle";
 
+/// True if a path lies inside a Git administrative directory.
+///
+/// Accepts repo-relative or absolute paths and treats `.git` as a path
+/// component, not a substring. This intentionally matches raw `.git` sync
+/// surfaces, including nested repos and submodule gitdirs under
+/// `.git/modules/**`.
+pub fn is_git_internal_path(path: &str) -> bool {
+    let path = path.replace('\\', "/");
+    path == ".git"
+        || path.starts_with(".git/")
+        || path.contains("/.git/")
+        || path.ends_with("/.git")
+}
+
 /// Result of checking whether a .git directory is safe to sync.
 #[derive(Debug, Clone, Default)]
 pub struct GitSafetyCheck {
@@ -624,5 +638,29 @@ mod tests {
         let check = git_is_safe(&git_dir);
         assert!(!check.blocking.is_empty());
         assert!(check.blocking[0].contains("merge"));
+    }
+
+    #[test]
+    fn classifies_git_internal_paths_by_component() {
+        for path in [
+            ".git",
+            ".git/HEAD",
+            "repo/.git/refs/heads/main",
+            "/tmp/repo/.git/objects/ab/cdef",
+            "repo/.git/modules/dep/refs/heads/main",
+            "repo\\.git\\refs\\heads\\main",
+        ] {
+            assert!(is_git_internal_path(path), "{path}");
+        }
+
+        for path in [
+            ".gitignore",
+            "repo/.gitignore",
+            "repo/git/HEAD",
+            "repo/dot.git/HEAD",
+            "repo/.gitmodules",
+        ] {
+            assert!(!is_git_internal_path(path), "{path}");
+        }
     }
 }

--- a/crates/tcfs-sync/src/git_safety.rs
+++ b/crates/tcfs-sync/src/git_safety.rs
@@ -289,6 +289,7 @@ fn is_hex_sha(s: &str) -> bool {
 pub fn repo_root_for_git_path(local_root: &Path, rel_path: &str) -> Option<std::path::PathBuf> {
     // Split the rel path on the first `.git` component. Everything before it is
     // the repo subdir (possibly empty).
+    let rel_path = rel_path.replace('\\', "/");
     let mut prefix_components: Vec<&str> = Vec::new();
     let mut found = false;
     for comp in rel_path.split('/') {

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -1390,10 +1390,7 @@ async fn read_remote_ref_sha(
 
 /// True if a repo-relative path lies inside a `.git` directory.
 fn is_git_internal_path(rel_path: &str) -> bool {
-    rel_path == ".git"
-        || rel_path.starts_with(".git/")
-        || rel_path.contains("/.git/")
-        || rel_path.ends_with("/.git")
+    git_safety::is_git_internal_path(rel_path)
 }
 
 /// Compare when both sides exist and the local entry is a symbolic link.

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -1557,7 +1557,7 @@ async fn spawn_state_sync_loop(
                                     // OnDemand mode (under threshold): conditional auto-pull
                                     match conflict_mode.as_str() {
                                         "auto" => {
-                                            handle_auto_pull(
+                                            let should_ack = handle_auto_pull(
                                                 &device_id,
                                                 &event_device,
                                                 rel_path,
@@ -1571,6 +1571,9 @@ async fn spawn_state_sync_loop(
                                                 &storage_prefix,
                                             )
                                             .await;
+                                            if !should_ack {
+                                                continue;
+                                            }
 
                                             // Invalidate FUSE negative cache so the
                                             // new file appears in readdir immediately
@@ -1726,7 +1729,7 @@ async fn handle_auto_pull(
     path_locks: &tcfs_sync::state::PathLocks,
     sync_root: Option<&std::path::Path>,
     storage_prefix: &str,
-) {
+) -> bool {
     // Determine local path for this rel_path
     let local_path = match sync_root {
         Some(root) => root.join(rel_path),
@@ -1740,7 +1743,7 @@ async fn handle_auto_pull(
                         path = %rel_path,
                         "no sync_root configured and file not in state cache, skipping auto-pull"
                     );
-                    return;
+                    return true;
                 }
             }
         }
@@ -1765,7 +1768,7 @@ async fn handle_auto_pull(
                     storage_prefix,
                 )
                 .await;
-                return;
+                return true;
             }
         }
     };
@@ -1783,9 +1786,11 @@ async fn handle_auto_pull(
     match outcome {
         tcfs_sync::conflict::SyncOutcome::UpToDate => {
             info!(path = %rel_path, "already up to date");
+            true
         }
         tcfs_sync::conflict::SyncOutcome::LocalNewer => {
             info!(path = %rel_path, "local is newer, skipping pull");
+            true
         }
         tcfs_sync::conflict::SyncOutcome::RemoteNewer => {
             // Guard: defer auto-pull if file is actively being modified
@@ -1794,7 +1799,7 @@ async fn handle_auto_pull(
                 if let Some(entry) = cache.get(&local_path) {
                     if entry.status == tcfs_sync::state::FileSyncStatus::Active {
                         info!(path = %rel_path, "deferring auto-pull: file is actively being modified");
-                        return;
+                        return true;
                     }
                 }
             }
@@ -1808,6 +1813,7 @@ async fn handle_auto_pull(
                 storage_prefix,
             )
             .await;
+            true
         }
         tcfs_sync::conflict::SyncOutcome::Conflict(ref conflict_info) => {
             if should_defer_auto_resolution(rel_path) {
@@ -1816,6 +1822,7 @@ async fn handle_auto_pull(
                     watcher_record_conflict(&mut cache, &local_path, conflict_info.clone());
                     if let Err(e) = cache.flush() {
                         warn!(path = %rel_path, "failed to persist deferred git conflict: {e}");
+                        return false;
                     }
                 }
                 info!(
@@ -1824,7 +1831,7 @@ async fn handle_auto_pull(
                     remote_device = %conflict_info.remote_device,
                     "git-internal conflict detected, deferring auto-resolution"
                 );
-                return;
+                return true;
             }
 
             info!(
@@ -1854,6 +1861,7 @@ async fn handle_auto_pull(
                     info!(path = %rel_path, "AutoResolver: deferred");
                 }
             }
+            true
         }
     }
 }

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -61,6 +61,10 @@ pub fn watcher_record_conflict(
     cache.set(path, synthetic);
 }
 
+fn should_defer_auto_resolution(rel_path: &str) -> bool {
+    tcfs_sync::git_safety::is_git_internal_path(rel_path)
+}
+
 /// Re-export of watcher helpers intended for tests.
 ///
 /// Integration tests under `crates/tcfsd/tests/` compile as external crates
@@ -1806,6 +1810,23 @@ async fn handle_auto_pull(
             .await;
         }
         tcfs_sync::conflict::SyncOutcome::Conflict(ref conflict_info) => {
+            if should_defer_auto_resolution(rel_path) {
+                {
+                    let mut cache = state_cache.lock().await;
+                    watcher_record_conflict(&mut cache, &local_path, conflict_info.clone());
+                    if let Err(e) = cache.flush() {
+                        warn!(path = %rel_path, "failed to persist deferred git conflict: {e}");
+                    }
+                }
+                info!(
+                    path = %rel_path,
+                    local_device = %conflict_info.local_device,
+                    remote_device = %conflict_info.remote_device,
+                    "git-internal conflict detected, deferring auto-resolution"
+                );
+                return;
+            }
+
             info!(
                 path = %rel_path,
                 local_device = %conflict_info.local_device,
@@ -1833,6 +1854,26 @@ async fn handle_auto_pull(
                     info!(path = %rel_path, "AutoResolver: deferred");
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_resolution_defers_git_internal_paths_only() {
+        for path in [
+            ".git/HEAD",
+            "repo/.git/refs/heads/main",
+            "repo/.git/modules/dep/refs/heads/main",
+        ] {
+            assert!(should_defer_auto_resolution(path), "{path}");
+        }
+
+        for path in ["README.md", "repo/.gitignore", "repo/src/main.rs"] {
+            assert!(!should_defer_auto_resolution(path), "{path}");
         }
     }
 }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -24,6 +24,18 @@ use tcfs_core::proto::{
 };
 use tcfs_sync::state::StateCacheBackend;
 
+fn git_internal_resolution_error(path: &str, resolution: &str) -> Option<String> {
+    if resolution == "defer" || !tcfs_sync::git_safety::is_git_internal_path(path) {
+        return None;
+    }
+
+    Some(
+        "git-internal path; per-file conflict resolution is refused for .git metadata. \
+         Use defer to leave this conflict unresolved until repo-group git resolution handles it."
+            .to_string(),
+    )
+}
+
 /// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
 ///
 /// - `Master` (default): legacy shared-master wrap. Byte-identical to the prior
@@ -1545,14 +1557,27 @@ impl TcfsDaemon for TcfsDaemonImpl {
             }
         };
 
+        let path = std::path::PathBuf::from(&req.path);
+        if let Some(error) = git_internal_resolution_error(&req.path, &resolution) {
+            warn!(
+                path = %req.path,
+                resolution = %resolution,
+                device = %self.device_id,
+                "refusing per-file resolution for git-internal path"
+            );
+            return Ok(tonic::Response::new(ResolveConflictResponse {
+                success: false,
+                resolved_path: String::new(),
+                error,
+            }));
+        }
+
         info!(
             path = %req.path,
             resolution = %resolution,
             device = %self.device_id,
             "conflict resolution requested"
         );
-
-        let path = std::path::PathBuf::from(&req.path);
 
         // Reload state from disk in case the CLI wrote new entries
         {
@@ -3860,6 +3885,44 @@ mod tests {
 
         assert!(!resp.success);
         assert!(resp.error.contains("invalid resolution"));
+    }
+
+    #[tokio::test]
+    async fn resolve_conflict_refuses_git_internal_keep_strategies() {
+        let daemon = test_daemon();
+
+        for resolution in ["keep_local", "keep_remote", "keep_both"] {
+            let resp = daemon
+                .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                    path: "repo/.git/refs/heads/main".into(),
+                    resolution: resolution.into(),
+                }))
+                .await
+                .unwrap()
+                .into_inner();
+
+            assert!(!resp.success, "{resolution}");
+            assert!(resp.resolved_path.is_empty(), "{resolution}");
+            assert!(resp.error.contains("git-internal path"), "{resolution}");
+            assert!(resp.error.contains("per-file"), "{resolution}");
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_conflict_allows_git_internal_defer_noop() {
+        let daemon = test_daemon();
+        let resp = daemon
+            .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                path: "repo/.git/refs/heads/main".into(),
+                resolution: "defer".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.success);
+        assert_eq!(resp.resolved_path, "repo/.git/refs/heads/main");
+        assert!(resp.error.is_empty());
     }
 
     #[tokio::test]

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -24,16 +24,49 @@ use tcfs_core::proto::{
 };
 use tcfs_sync::state::StateCacheBackend;
 
-fn git_internal_resolution_error(path: &str, resolution: &str) -> Option<String> {
-    if resolution == "defer" || !tcfs_sync::git_safety::is_git_internal_path(path) {
+fn git_internal_resolution_error(
+    path: &Path,
+    resolution: &str,
+    state_entry: Option<&tcfs_sync::state::SyncState>,
+) -> Option<String> {
+    if resolution == "defer" {
         return None;
     }
 
-    Some(
+    let raw_path = path.to_string_lossy();
+    let is_git_internal = tcfs_sync::git_safety::is_git_internal_path(&raw_path)
+        || path_resolves_to_git_internal(path)
+        || state_entry
+            .and_then(|entry| entry.conflict.as_ref())
+            .is_some_and(|conflict| {
+                tcfs_sync::git_safety::is_git_internal_path(&conflict.rel_path)
+            });
+
+    is_git_internal.then(|| {
         "git-internal path; per-file conflict resolution is refused for .git metadata. \
          Use defer to leave this conflict unresolved until repo-group git resolution handles it."
-            .to_string(),
-    )
+            .to_string()
+    })
+}
+
+fn path_resolves_to_git_internal(path: &Path) -> bool {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        if tcfs_sync::git_safety::is_git_internal_path(&canonical.to_string_lossy()) {
+            return true;
+        }
+    }
+
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Ok(parent) = std::fs::canonicalize(parent) else {
+        return false;
+    };
+    let resolved = match path.file_name() {
+        Some(name) => parent.join(name),
+        None => parent,
+    };
+    tcfs_sync::git_safety::is_git_internal_path(&resolved.to_string_lossy())
 }
 
 /// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
@@ -1557,8 +1590,18 @@ impl TcfsDaemon for TcfsDaemonImpl {
             }
         };
 
+        // Reload state from disk in case the CLI wrote new entries
         let path = std::path::PathBuf::from(&req.path);
-        if let Some(error) = git_internal_resolution_error(&req.path, &resolution) {
+        let state_entry = {
+            let mut cache = self.state_cache.lock().await;
+            if let Err(e) = cache.reload_from_disk() {
+                tracing::warn!("failed to reload state cache: {e}");
+            }
+            cache.get(&path).cloned()
+        };
+
+        if let Some(error) = git_internal_resolution_error(&path, &resolution, state_entry.as_ref())
+        {
             warn!(
                 path = %req.path,
                 resolution = %resolution,
@@ -1578,14 +1621,6 @@ impl TcfsDaemon for TcfsDaemonImpl {
             device = %self.device_id,
             "conflict resolution requested"
         );
-
-        // Reload state from disk in case the CLI wrote new entries
-        {
-            let mut cache = self.state_cache.lock().await;
-            if let Err(e) = cache.reload_from_disk() {
-                tracing::warn!("failed to reload state cache: {e}");
-            }
-        }
 
         match resolution.as_str() {
             "defer" => {
@@ -3906,6 +3941,55 @@ mod tests {
             assert!(resp.error.contains("git-internal path"), "{resolution}");
             assert!(resp.error.contains("per-file"), "{resolution}");
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn resolve_conflict_refuses_git_internal_symlink_alias() {
+        let daemon = test_daemon();
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let git_heads = repo.join(".git/refs/heads");
+        std::fs::create_dir_all(&git_heads).unwrap();
+        let git_path = git_heads.join("main");
+        std::fs::write(&git_path, b"0123456789012345678901234567890123456789\n").unwrap();
+
+        let alias = dir.path().join("refslink");
+        std::os::unix::fs::symlink(repo.join(".git/refs"), &alias).unwrap();
+        let alias_path = alias.join("heads/main");
+
+        let mut entry = test_sync_state("data/manifests/git", 1_700_000_000);
+        entry.status = tcfs_sync::state::FileSyncStatus::Conflict;
+        entry.conflict = Some(tcfs_sync::conflict::ConflictInfo {
+            rel_path: "repo/.git/refs/heads/main".into(),
+            local_vclock: tcfs_sync::conflict::VectorClock::new(),
+            remote_vclock: tcfs_sync::conflict::VectorClock::new(),
+            local_blake3: "local-git".into(),
+            remote_blake3: "remote-git".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 43,
+        });
+
+        {
+            let mut cache = daemon.state_cache.lock().await;
+            cache.set(&git_path, entry);
+            cache.flush().unwrap();
+        }
+
+        let resp = daemon
+            .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                path: alias_path.display().to_string(),
+                resolution: "keep_remote".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(!resp.success);
+        assert!(resp.resolved_path.is_empty());
+        assert!(resp.error.contains("git-internal path"));
+        assert!(resp.error.contains("per-file"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

First implementation slice from the divergent `.git` keep-both design:

- refuse destructive per-file `ResolveConflict` strategies on `.git` internals while allowing `defer` as the no-op
- make daemon auto-resolution persist and defer `.git` conflicts before `AutoResolver` can choose keep-local/keep-remote
- add a shared `tcfs_sync::git_safety::is_git_internal_path` predicate and reuse it from reconcile
- add `tcfs conflicts` to list recorded conflicts from the local state cache, grouped by git repo for `.git` internals
- update CLI/MCP descriptions so humans and agents see the boundary

## Safety intent

This does not implement divergent git keep-both yet. It removes the unsafe splice paths first: per-file keep-local/keep-remote/keep-both and daemon auto-resolve no longer mutate raw `.git` paths. True repo-level resolution remains deferred to the next slice.

## Validation

- `cargo fmt --all`
- `git diff --check`

I intentionally did not run local cargo/nix builds or tests on neo; CI should do compile/test validation off the laptop build path.
