### PR TITLE
feat(keep-both PR-1): fence .git conflicts from per-file resolution + `tcfs conflicts` read verb

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -334,6 +334,22 @@ enum Commands {
         strategy: Option<String>,
     },
 
+    /// List recorded sync conflicts (read-only)
+    ///
+    /// Reads conflicts straight from the sync state cache — no daemon RPC, no
+    /// writes, no resolution. `.git`-internal conflicts are grouped by their
+    /// enclosing repository so a diverged repo shows as one entry with both
+    /// sides' HEADs (honest "objects not local yet" degradation when the remote
+    /// object has not roamed in); non-`.git` conflicts are listed flat.
+    Conflicts {
+        /// Emit machine-readable JSON instead of the human summary
+        #[arg(long)]
+        json: bool,
+        /// Path to the sync state cache JSON file (overrides config)
+        #[arg(long, env = "TCFS_STATE_PATH")]
+        state: Option<PathBuf>,
+    },
+
     /// Manage the sync trash (staged deletes)
     ///
     /// When trash is enabled, deleted files are moved to a .tcfs-trash/ prefix
@@ -903,6 +919,7 @@ async fn main() -> Result<()> {
                 )
             }
         }
+        Commands::Conflicts { json, state } => cmd_conflicts(&config, json, state.as_deref()).await,
     }
 }
 
@@ -6673,18 +6690,32 @@ async fn cmd_resolve(
     let resolution = match strategy {
         Some(s) => s.replace('-', "_"),
         None => {
-            // Interactive mode: reuse the existing interactive resolver
-            let dummy_info = tcfs_sync::conflict::ConflictInfo {
-                rel_path: path.to_string_lossy().to_string(),
-                local_blake3: String::new(),
-                remote_blake3: String::new(),
-                local_device: "local".to_string(),
-                remote_device: "remote".to_string(),
-                local_vclock: tcfs_sync::conflict::VectorClock::new(),
-                remote_vclock: tcfs_sync::conflict::VectorClock::new(),
-                detected_at: 0,
-            };
-            match resolve_conflict_interactive(&dummy_info) {
+            // Interactive mode: reuse the existing interactive resolver.
+            //
+            // keep-both PR-1: fetch the REAL recorded ConflictInfo for this
+            // path from the state cache (device names, content hashes, clocks)
+            // instead of the previous dummy placeholder, so the prompt shows
+            // the actual divergence. If no conflict is recorded for the path we
+            // fall back to a minimal record and say so, rather than lying with
+            // empty hashes.
+            let info = load_conflict_info(config, path).unwrap_or_else(|| {
+                println!(
+                    "No conflict recorded for {} in the state cache — prompting with minimal info.",
+                    path.display()
+                );
+                tcfs_sync::conflict::ConflictInfo {
+                    rel_path: path.to_string_lossy().to_string(),
+                    local_blake3: String::new(),
+                    remote_blake3: String::new(),
+                    local_device: "local".to_string(),
+                    remote_device: "remote".to_string(),
+                    local_vclock: tcfs_sync::conflict::VectorClock::new(),
+                    remote_vclock: tcfs_sync::conflict::VectorClock::new(),
+                    detected_at: 0,
+                    times_recorded: 0,
+                }
+            });
+            match resolve_conflict_interactive(&info) {
                 tcfs_sync::conflict::Resolution::KeepLocal => "keep_local".to_string(),
                 tcfs_sync::conflict::Resolution::KeepRemote => "keep_remote".to_string(),
                 tcfs_sync::conflict::Resolution::KeepBoth => "keep_both".to_string(),
@@ -6716,6 +6747,288 @@ async fn cmd_resolve(
         }
     } else {
         anyhow::bail!("resolution failed: {}", resp.error);
+    }
+
+    Ok(())
+}
+
+/// Load the recorded [`ConflictInfo`] for `path` from the state cache, if any.
+///
+/// keep-both PR-1 (piece 5): the interactive `tcfs resolve` prompt used to feed
+/// a dummy placeholder; this reads the real record (device names, hashes,
+/// clocks) directly from the state cache — no daemon RPC.
+fn load_conflict_info(
+    config: &tcfs_core::config::TcfsConfig,
+    path: &Path,
+) -> Option<tcfs_sync::conflict::ConflictInfo> {
+    let state_path = resolve_state_path(config, None);
+    let state = tcfs_sync::state::StateCache::open(&state_path).ok()?;
+    // Prefer an exact key match; fall back to a repo-relative suffix match so
+    // both absolute and relative paths resolve.
+    if let Some(info) = state.get(path).and_then(|s| s.conflict.clone()) {
+        return Some(info);
+    }
+    let key = path.to_string_lossy();
+    state
+        .get_by_rel_path(&key)
+        .and_then(|(_, s)| s.conflict.clone())
+}
+
+// ── `tcfs conflicts` (read-only) ────────────────────────────────────────────
+
+/// One conflicting path inside a group, as rendered for `tcfs conflicts`.
+#[derive(Debug, Clone, serde::Serialize)]
+struct ConflictPathReport {
+    /// Repo-relative path of the conflicting file.
+    rel_path: String,
+    /// True when the path is `.git`-internal.
+    git_internal: bool,
+    /// The head ref (`refs/heads/<branch>`) when this is a head-ref conflict.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    head_ref: Option<String>,
+    local_device: String,
+    remote_device: String,
+    /// Unix timestamp of first detection (preserved across re-records).
+    detected_at: u64,
+    /// Number of reconcile cycles that re-recorded this conflict.
+    times_recorded: u64,
+}
+
+/// A group of conflicts sharing one enclosing `.git` repo, or the flat bucket
+/// of non-`.git` conflicts (`repo_root == None`).
+#[derive(Debug, Clone, serde::Serialize)]
+struct ConflictGroup {
+    /// Absolute repo root for a `.git` group; `None` for the non-git bucket.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repo_root: Option<String>,
+    /// True for a `.git`-internal repo group.
+    is_git: bool,
+    paths: Vec<ConflictPathReport>,
+}
+
+/// Derive the absolute enclosing `.git` repo root for a conflicted cache entry,
+/// or `None` when the path is not git-internal.
+///
+/// The cache key is `<canonical local root>/<rel_path>`; stripping the
+/// repo-relative suffix recovers the sync root, then
+/// [`repo_root_for_git_path`](tcfs_sync::git_safety::repo_root_for_git_path)
+/// locates the `.git` boundary.
+fn conflict_repo_root(cache_key: &str, rel_path: &str) -> Option<PathBuf> {
+    let local_root = cache_key
+        .strip_suffix(rel_path)
+        .map(|s| s.trim_end_matches('/'))
+        .unwrap_or("");
+    tcfs_sync::git_safety::repo_root_for_git_path(Path::new(local_root), rel_path)
+}
+
+/// Group recorded conflicts by their enclosing git repo (for `.git`-internal
+/// paths) or into a single flat bucket (non-`.git`). Pure — no disk or network,
+/// so it is directly unit-testable. Git groups are ordered by repo root; the
+/// flat non-git bucket (if any) sorts last.
+fn group_conflicts(items: &[(String, tcfs_sync::conflict::ConflictInfo)]) -> Vec<ConflictGroup> {
+    use std::collections::BTreeMap;
+    let mut git_groups: BTreeMap<String, ConflictGroup> = BTreeMap::new();
+    let mut flat: Vec<ConflictPathReport> = Vec::new();
+
+    for (key, info) in items {
+        let rel = info.rel_path.as_str();
+        let repo_root = conflict_repo_root(key, rel);
+        let report = ConflictPathReport {
+            rel_path: rel.to_string(),
+            git_internal: repo_root.is_some(),
+            head_ref: tcfs_sync::git_safety::head_ref_for_git_path(rel),
+            local_device: info.local_device.clone(),
+            remote_device: info.remote_device.clone(),
+            detected_at: info.detected_at,
+            times_recorded: info.times_recorded,
+        };
+        match repo_root {
+            Some(root) => {
+                let root_str = root.to_string_lossy().to_string();
+                git_groups
+                    .entry(root_str.clone())
+                    .or_insert_with(|| ConflictGroup {
+                        repo_root: Some(root_str),
+                        is_git: true,
+                        paths: Vec::new(),
+                    })
+                    .paths
+                    .push(report);
+            }
+            None => flat.push(report),
+        }
+    }
+
+    let mut out: Vec<ConflictGroup> = git_groups.into_values().collect();
+    if !flat.is_empty() {
+        out.push(ConflictGroup {
+            repo_root: None,
+            is_git: false,
+            paths: flat,
+        });
+    }
+    out
+}
+
+/// Resolve a repo's current HEAD to `<shortsha> <summary>` via
+/// `git log --oneline -1`, or `None` when the repo/HEAD cannot be read.
+fn git_head_oneline(repo_root: &Path) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["-C", &repo_root.to_string_lossy(), "log", "--oneline", "-1"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+/// Age of a conflict as a coarse human string ("3d", "5h", "12m", "<1m").
+fn conflict_age(detected_at: u64) -> String {
+    if detected_at == 0 {
+        return "unknown".to_string();
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let secs = now.saturating_sub(detected_at);
+    if secs >= 86_400 {
+        format!("{}d", secs / 86_400)
+    } else if secs >= 3_600 {
+        format!("{}h", secs / 3_600)
+    } else if secs >= 60 {
+        format!("{}m", secs / 60)
+    } else {
+        "<1m".to_string()
+    }
+}
+
+/// `tcfs conflicts` — list recorded conflicts from the state cache, grouped by
+/// repo for `.git`-internal paths. Read-only: no daemon RPC, no writes.
+async fn cmd_conflicts(
+    config: &tcfs_core::config::TcfsConfig,
+    json: bool,
+    state_override: Option<&Path>,
+) -> Result<()> {
+    let state_path = resolve_state_path(config, state_override);
+    let state = tcfs_sync::state::StateCache::open(&state_path)
+        .with_context(|| format!("opening state cache: {}", state_path.display()))?;
+
+    let items: Vec<(String, tcfs_sync::conflict::ConflictInfo)> = state
+        .conflicts()
+        .into_iter()
+        .filter_map(|(k, s)| s.conflict.as_ref().map(|c| (k.to_string(), c.clone())))
+        .collect();
+
+    let groups = group_conflicts(&items);
+
+    if json {
+        // Render each group with resolvable HEAD evidence for `.git` groups.
+        // The remote HEAD commit SHA is NOT carried in the offline state cache
+        // (only a content hash + device); we surface honest degradation rather
+        // than fetch it here — the resolve verb (PR-3) performs that fetch.
+        let rendered: Vec<serde_json::Value> = groups
+            .iter()
+            .map(|g| {
+                let local_head = g
+                    .repo_root
+                    .as_deref()
+                    .map(Path::new)
+                    .and_then(git_head_oneline);
+                serde_json::json!({
+                    "repo_root": g.repo_root,
+                    "is_git": g.is_git,
+                    "local_head": local_head,
+                    "remote_head": serde_json::Value::Null,
+                    "remote_head_note": if g.is_git {
+                        Some("remote commit SHA not in offline state cache (objects not local yet / requires resolve-verb ref fetch)")
+                    } else {
+                        None
+                    },
+                    "paths": g.paths,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "state_path": state_path.to_string_lossy(),
+                "conflict_count": items.len(),
+                "groups": rendered,
+            }))?
+        );
+        return Ok(());
+    }
+
+    if items.is_empty() {
+        println!("No recorded conflicts.");
+        return Ok(());
+    }
+
+    println!(
+        "{} conflict(s) across {} group(s):",
+        items.len(),
+        groups.len()
+    );
+    for g in &groups {
+        println!();
+        match &g.repo_root {
+            Some(root) => {
+                println!("repo: {}", root);
+                match git_head_oneline(Path::new(root)) {
+                    Some(head) => println!("  local HEAD:  {}", head),
+                    None => println!("  local HEAD:  <unreadable> ({})", root),
+                }
+                // Remote HEAD is not available offline (state cache carries a
+                // content hash + device, not the remote commit SHA).
+                let remote_device = g
+                    .paths
+                    .first()
+                    .map(|p| p.remote_device.as_str())
+                    .unwrap_or("?");
+                println!(
+                    "  remote HEAD: <objects not local yet> (from {}; resolve to fetch)",
+                    remote_device
+                );
+                for p in &g.paths {
+                    let kind = match &p.head_ref {
+                        Some(r) => format!("head {}", r),
+                        None => "git-internal".to_string(),
+                    };
+                    println!(
+                        "  - {} [{}] age={} recorded={}x",
+                        p.rel_path,
+                        kind,
+                        conflict_age(p.detected_at),
+                        p.times_recorded
+                    );
+                }
+                println!(
+                    "  resolve: tcfs resolve {} --keep-both   (repo-group; not yet available in this build)",
+                    root
+                );
+            }
+            None => {
+                println!("non-git conflicts:");
+                for p in &g.paths {
+                    println!(
+                        "  - {} age={} recorded={}x (local={} remote={})",
+                        p.rel_path,
+                        conflict_age(p.detected_at),
+                        p.times_recorded,
+                        p.local_device,
+                        p.remote_device
+                    );
+                    println!("    resolve: tcfs resolve {}", p.rel_path);
+                }
+            }
+        }
     }
 
     Ok(())
@@ -6786,6 +7099,89 @@ mod tests {
 
     fn master_key(fill: u8) -> tcfs_crypto::MasterKey {
         tcfs_crypto::MasterKey::from_bytes([fill; tcfs_crypto::KEY_SIZE])
+    }
+
+    fn mk_conflict(rel: &str) -> tcfs_sync::conflict::ConflictInfo {
+        tcfs_sync::conflict::ConflictInfo {
+            rel_path: rel.to_string(),
+            local_vclock: tcfs_sync::conflict::VectorClock::new(),
+            remote_vclock: tcfs_sync::conflict::VectorClock::new(),
+            local_blake3: "aaaa".into(),
+            remote_blake3: "bbbb".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 1_700_000_000,
+            times_recorded: 3,
+        }
+    }
+
+    #[test]
+    fn conflicts_group_by_repo_and_classify_git_paths() {
+        // keep-both PR-1 (piece 3): `.git`-internal conflicts group by their
+        // enclosing repo; non-`.git` conflicts fall into a flat bucket.
+        // Cache keys are `<sync root>/<rel_path>`.
+        let items = vec![
+            (
+                "/sync/repoA/.git/refs/heads/main".to_string(),
+                mk_conflict("repoA/.git/refs/heads/main"),
+            ),
+            (
+                "/sync/repoA/.git/index".to_string(),
+                mk_conflict("repoA/.git/index"),
+            ),
+            (
+                "/sync/repoB/.git/HEAD".to_string(),
+                mk_conflict("repoB/.git/HEAD"),
+            ),
+            (
+                "/sync/notes/todo.txt".to_string(),
+                mk_conflict("notes/todo.txt"),
+            ),
+        ];
+
+        let groups = group_conflicts(&items);
+
+        // Two git repo groups + one flat non-git bucket.
+        assert_eq!(groups.len(), 3, "expected repoA, repoB, and a flat bucket");
+
+        let repo_a = groups
+            .iter()
+            .find(|g| g.repo_root.as_deref() == Some("/sync/repoA"))
+            .expect("repoA group present");
+        assert!(repo_a.is_git);
+        assert_eq!(repo_a.paths.len(), 2, "both repoA paths in one group");
+        // The head-ref path is classified with its ref name; index is not.
+        let head = repo_a
+            .paths
+            .iter()
+            .find(|p| p.rel_path.ends_with("refs/heads/main"))
+            .unwrap();
+        assert_eq!(head.head_ref.as_deref(), Some("refs/heads/main"));
+        assert!(head.git_internal);
+        assert_eq!(head.times_recorded, 3);
+        let index = repo_a
+            .paths
+            .iter()
+            .find(|p| p.rel_path.ends_with(".git/index"))
+            .unwrap();
+        assert!(index.head_ref.is_none());
+        assert!(index.git_internal);
+
+        let repo_b = groups
+            .iter()
+            .find(|g| g.repo_root.as_deref() == Some("/sync/repoB"))
+            .expect("repoB group present");
+        assert_eq!(repo_b.paths.len(), 1);
+
+        // The non-git conflict is flat (no repo_root), and not git-internal.
+        let flat = groups
+            .iter()
+            .find(|g| g.repo_root.is_none())
+            .expect("flat bucket present");
+        assert!(!flat.is_git);
+        assert_eq!(flat.paths.len(), 1);
+        assert!(!flat.paths[0].git_internal);
+        assert_eq!(flat.paths[0].rel_path, "notes/todo.txt");
     }
 
     fn test_config(sync_root: &Path) -> tcfs_core::config::TcfsConfig {

--- a/crates/tcfs-sync/src/conflict.rs
+++ b/crates/tcfs-sync/src/conflict.rs
@@ -120,6 +120,14 @@ pub struct ConflictInfo {
     pub remote_device: String,
     /// Unix timestamp when conflict was detected
     pub detected_at: u64,
+    /// Number of reconcile cycles that have re-recorded this conflict.
+    ///
+    /// Bumped at the reconcile record site instead of being overwritten each
+    /// cycle, so `tcfs conflicts` can surface a forever-Conflict repo (the
+    /// record-only arm that never converges). `serde(default)` keeps older
+    /// state caches — written before this field existed — deserializing to 0.
+    #[serde(default)]
+    pub times_recorded: u64,
 }
 
 // ── Resolution ────────────────────────────────────────────────────────────────
@@ -193,6 +201,7 @@ pub fn compare_clocks(
                 local_device: local_device.to_string(),
                 remote_device: remote_device.to_string(),
                 detected_at: now,
+                times_recorded: 0,
             })
         }
     }
@@ -378,6 +387,7 @@ mod tests {
             local_device: "alpha".into(),
             remote_device: "beta".into(),
             detected_at: 0,
+            times_recorded: 0,
         };
         // "alpha" < "beta" → keep local
         assert_eq!(resolver.resolve(&info), Some(Resolution::KeepLocal));
@@ -410,8 +420,36 @@ mod tests {
         match compare_clocks(&a, &b, "hash_a", "hash_b", "f.txt", "d1", "d2") {
             SyncOutcome::Conflict(info) => {
                 assert_eq!(info.rel_path, "f.txt");
+                // A freshly recorded conflict starts at zero cycles.
+                assert_eq!(info.times_recorded, 0);
             }
             other => panic!("expected Conflict, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn conflict_info_deserializes_without_times_recorded_field() {
+        // A state cache written before `times_recorded` existed must still
+        // deserialize (serde default → 0), and round-trip cleanly afterwards.
+        let legacy = r#"{
+            "rel_path": "repo/.git/refs/heads/main",
+            "local_vclock": {"clocks": {}},
+            "remote_vclock": {"clocks": {}},
+            "local_blake3": "aaa",
+            "remote_blake3": "bbb",
+            "local_device": "neo",
+            "remote_device": "honey",
+            "detected_at": 1700000000
+        }"#;
+        let info: ConflictInfo =
+            serde_json::from_str(legacy).expect("legacy ConflictInfo must deserialize");
+        assert_eq!(info.times_recorded, 0, "missing field must default to 0");
+        assert_eq!(info.detected_at, 1_700_000_000);
+
+        // Round-trip: serialize then re-parse preserves the (defaulted) value.
+        let bytes = serde_json::to_string(&info).unwrap();
+        let reparsed: ConflictInfo = serde_json::from_str(&bytes).unwrap();
+        assert_eq!(reparsed.times_recorded, 0);
+        assert_eq!(reparsed.rel_path, "repo/.git/refs/heads/main");
     }
 }

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -1735,11 +1735,25 @@ pub async fn execute_plan(
             }
 
             ReconcileAction::Conflict { rel_path, info } => {
-                // Record conflict in state cache for later resolution
+                // Record conflict in state cache for later resolution.
+                //
+                // keep-both PR-1: this arm re-records the same conflict every
+                // reconcile cycle (the record-only, never-converges arm for
+                // diverged `.git` groups). Bump `times_recorded` and preserve
+                // the original `detected_at` across cycles instead of
+                // overwriting them, so `tcfs conflicts` can surface how long /
+                // how many cycles a conflict has persisted.
                 if let Some((key, existing)) = state.get_by_rel_path(rel_path) {
                     let key_owned = key.to_string();
                     let mut updated = existing.clone();
-                    updated.conflict = Some(info.clone());
+                    let mut info = info.clone();
+                    if let Some(prior) = updated.conflict.as_ref() {
+                        info.times_recorded = prior.times_recorded.saturating_add(1);
+                        info.detected_at = prior.detected_at;
+                    } else {
+                        info.times_recorded = 1;
+                    }
+                    updated.conflict = Some(info);
                     state.set(Path::new(&key_owned), updated);
                 }
                 result.conflicts_recorded += 1;

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -396,6 +396,21 @@ impl StateCache {
             .map(|(k, v)| (k.as_str(), v))
     }
 
+    /// Read-only view of every entry that currently carries a recorded
+    /// conflict, as `(cache key, state)` pairs.
+    ///
+    /// The cache key is the normalized (canonical-parent) local path; the
+    /// recorded `ConflictInfo` (with its repo-relative `rel_path`) lives on the
+    /// returned [`SyncState`]. Used by `tcfs conflicts` to enumerate and group
+    /// conflicts without any daemon RPC. Order is unspecified (HashMap).
+    pub fn conflicts(&self) -> Vec<(&str, &SyncState)> {
+        self.entries
+            .iter()
+            .filter(|(_, s)| s.conflict.is_some())
+            .map(|(k, v)| (k.as_str(), v))
+            .collect()
+    }
+
     /// Flush dirty changes to disk using an atomic write (write then rename).
     ///
     /// Persists cache metadata alongside entries so restart recovery does not
@@ -1465,6 +1480,7 @@ mod tests {
             local_device: "neo".into(),
             remote_device: "honey".into(),
             detected_at: 1700000000,
+            times_recorded: 0,
         };
 
         cache.set(
@@ -1542,6 +1558,7 @@ mod tests {
                     local_device: "neo".into(),
                     remote_device: "honey".into(),
                     detected_at: 0,
+                    times_recorded: 0,
                 }),
                 status: FileSyncStatus::Conflict,
             },
@@ -1595,6 +1612,7 @@ mod tests {
                         local_device: "neo".into(),
                         remote_device: "honey".into(),
                         detected_at: 0,
+                        times_recorded: 0,
                     }),
                     status: FileSyncStatus::Conflict,
                 },
@@ -1663,6 +1681,7 @@ mod tests {
             local_device: "neo".into(),
             remote_device: "honey".into(),
             detected_at: 0,
+            times_recorded: 0,
         };
 
         assert!(cache.mark_conflict(&file_path, conflict.clone()));

--- a/crates/tcfs-sync/tests/e2e_conflict_resolution.rs
+++ b/crates/tcfs-sync/tests/e2e_conflict_resolution.rs
@@ -154,6 +154,7 @@ fn resolution_variants_exhaustive() {
         local_device: "device-a".into(),
         remote_device: "device-b".into(),
         detected_at: 1700000000,
+        times_recorded: 0,
     };
 
     // KeepLocal: local_device < remote_device => AutoResolver picks KeepLocal
@@ -398,6 +399,7 @@ fn auto_resolver_deterministic() {
         local_device: "device-b".into(),
         remote_device: "device-a".into(),
         detected_at: 0,
+        times_recorded: 0,
     };
 
     let resolver = AutoResolver;

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -1708,6 +1708,16 @@ async fn spawn_state_sync_loop(
     }
 }
 
+/// keep-both PR-1 (S2): true when an auto-resolvable conflict path is
+/// `.git`-internal and must be deferred rather than resolved per file.
+///
+/// Automatic per-file resolution over `.git` internals is the G5-git-5
+/// corruption vector; the daemon's NATS auto path defers these so the operator
+/// resolves the repo group deliberately.
+fn auto_conflict_must_defer(rel_path: &str) -> bool {
+    tcfs_sync::git_safety::repo_root_for_git_path(std::path::Path::new(""), rel_path).is_some()
+}
+
 /// Handle auto-pull logic for a remote FileSynced event.
 #[allow(clippy::too_many_arguments)]
 async fn handle_auto_pull(
@@ -1806,6 +1816,22 @@ async fn handle_auto_pull(
             .await;
         }
         tcfs_sync::conflict::SyncOutcome::Conflict(ref conflict_info) => {
+            // keep-both PR-1 (safety invariant S2): automatic per-file
+            // resolution must NEVER touch `.git` internals. AutoResolver's
+            // lexicographic KeepRemote would auto-download the remote ref/index
+            // over this device's object store with zero `.git` awareness — the
+            // G5-git-5 interleave vector. Defer `.git`-internal conflicts
+            // unconditionally; the operator resolves the repo group deliberately
+            // (future: `tcfs resolve <repo> --keep-both`; inspect with
+            // `tcfs conflicts`). The conflict stays recorded by the reconcile
+            // engine's Conflict arm, so it remains visible and re-tried.
+            if auto_conflict_must_defer(rel_path) {
+                info!(
+                    path = %rel_path,
+                    "AutoResolver: deferring .git-internal conflict (repo-group resolution required)"
+                );
+                return;
+            }
             info!(
                 path = %rel_path,
                 local_device = %conflict_info.local_device,
@@ -1992,5 +2018,28 @@ fn ensure_dirs(config: &TcfsConfig) {
                 warn!(path = %parent.display(), "failed to create FileProvider socket dir: {e}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod keep_both_pr1_tests {
+    use super::auto_conflict_must_defer;
+
+    #[test]
+    fn auto_defers_git_internal_conflicts() {
+        // keep-both PR-1 (S2): the NATS auto path defers `.git`-internal
+        // conflicts instead of auto-downloading them per file.
+        assert!(auto_conflict_must_defer("myrepo/.git/refs/heads/main"));
+        assert!(auto_conflict_must_defer("myrepo/.git/index"));
+        assert!(auto_conflict_must_defer("nested/dir/proj/.git/HEAD"));
+    }
+
+    #[test]
+    fn auto_resolves_normal_files() {
+        // Ordinary (non-`.git`) file conflicts keep today's auto behavior.
+        assert!(!auto_conflict_must_defer("notes/todo.txt"));
+        assert!(!auto_conflict_must_defer("src/main.rs"));
+        // A file merely named like git but not under a `.git` dir is not fenced.
+        assert!(!auto_conflict_must_defer("docs/gitignore-notes.md"));
     }
 }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1554,6 +1554,37 @@ impl TcfsDaemon for TcfsDaemonImpl {
 
         let path = std::path::PathBuf::from(&req.path);
 
+        // keep-both PR-1 (safety invariant S1): per-file conflict resolution
+        // must NEVER touch `.git` internals. keep_local rewrites the manifest,
+        // keep_remote splices the remote device's ref/index over this device's
+        // object store, and keep_both renames a loose ref into the branch
+        // namespace — each is the G5-git-5 `.git` corruption vector (no lock,
+        // no fsck, no objects-before-refs ordering). Refuse them for any
+        // `.git`-internal path and point the operator at repo-group resolution.
+        // `defer` is a no-op (records intent only) and stays allowed. This
+        // guard also covers the MCP `resolve_conflict` tool, which is a thin
+        // passthrough to this same RPC.
+        if resolution != "defer"
+            && tcfs_sync::git_safety::repo_root_for_git_path(std::path::Path::new(""), &req.path)
+                .is_some()
+        {
+            tracing::warn!(
+                path = %req.path,
+                resolution = %resolution,
+                "refusing per-file resolution of a .git-internal conflict"
+            );
+            return Ok(tonic::Response::new(ResolveConflictResponse {
+                success: false,
+                resolved_path: String::new(),
+                error: format!(
+                    "'{}' is a git-internal path; per-file resolution ({}) would corrupt the \
+                     repository object store. Resolve the whole repo group instead \
+                     (future: `tcfs resolve <repo> --keep-both`). Inspect with `tcfs conflicts`.",
+                    req.path, resolution
+                ),
+            }));
+        }
+
         // Reload state from disk in case the CLI wrote new entries
         {
             let mut cache = self.state_cache.lock().await;
@@ -3860,6 +3891,81 @@ mod tests {
 
         assert!(!resp.success);
         assert!(resp.error.contains("invalid resolution"));
+    }
+
+    #[tokio::test]
+    async fn resolve_conflict_refuses_git_internal_path() {
+        // keep-both PR-1 (S1): keep_remote on a `.git`-internal ref must be
+        // refused with repo-group guidance and ZERO side effects.
+        let daemon = test_daemon();
+        let resp = daemon
+            .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                path: "myrepo/.git/refs/heads/main".into(),
+                resolution: "keep_remote".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!resp.success, "keep_remote on a .git path must be refused");
+        assert!(
+            resp.error.contains("git-internal"),
+            "error must name the git-internal refusal, got: {}",
+            resp.error
+        );
+        assert!(resp.resolved_path.is_empty());
+
+        // keep_both and keep_local on a `.git` path are likewise refused.
+        for strat in ["keep_both", "keep_local"] {
+            let resp = daemon
+                .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                    path: "myrepo/.git/index".into(),
+                    resolution: strat.into(),
+                }))
+                .await
+                .unwrap()
+                .into_inner();
+            assert!(!resp.success, "{strat} on a .git path must be refused");
+            assert!(resp.error.contains("git-internal"), "strat={strat}");
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_conflict_defer_allowed_on_git_internal_path() {
+        // `defer` records intent only (no writes), so it stays allowed even for
+        // a `.git`-internal path — the fence targets keep_* only.
+        let daemon = test_daemon();
+        let resp = daemon
+            .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                path: "myrepo/.git/refs/heads/main".into(),
+                resolution: "defer".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.success, "defer must be allowed on a .git path");
+        assert!(resp.error.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_conflict_fence_ignores_normal_file_path() {
+        // A NON-`.git` file path must NOT hit the fence: keep_remote proceeds
+        // past the guard and fails later for an ordinary reason (no state /
+        // no remote path), never with the git-internal refusal.
+        let daemon = test_daemon();
+        let resp = daemon
+            .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                path: "notes/todo.txt".into(),
+                resolution: "keep_remote".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!resp.success, "no state for the path → still fails");
+        assert!(
+            !resp.error.contains("git-internal"),
+            "a normal file must not be fenced as git-internal, got: {}",
+            resp.error
+        );
     }
 
     #[tokio::test]

--- a/crates/tcfsd/tests/watcher_conflict_no_entry.rs
+++ b/crates/tcfsd/tests/watcher_conflict_no_entry.rs
@@ -19,6 +19,7 @@ fn sample_info() -> ConflictInfo {
         local_device: "local".to_string(),
         remote_device: "remote".to_string(),
         detected_at: 0,
+        times_recorded: 0,
     }
 }
 


### PR DESCRIPTION
## keep-both PR-1 — fence `.git` conflicts from per-file resolution + `tcfs conflicts` read verb

Rung 1 of the divergent-`.git` keep-both design (`docs/design/git-divergent-keep-both-2026-07-02.md` §5 PR-1, #523). **Pure safety + visibility: zero new write capability, no operator decision required, no deploy dependency.** It closes two `.git`-corruption vectors that are reachable on the deployed fleet **today**, and adds a read-only way to see stuck conflicts.

### The two live corruption vectors this fences

1. **`grpc.rs` `resolve_conflict` had no `.git` guard** — reachable via both `tcfs resolve` (CLI) and the MCP `resolve_conflict` tool (a thin passthrough to the same RPC). `keep_remote`/`keep_both` on a `.git/refs/heads/*` path splice one device's ref/index over the other's object store (`keep_both` renames a loose ref into the branch namespace and uploads it) — the G5-git-5 fsck-corruption vector: no lock, no fsck, no objects-before-refs ordering.
2. **`daemon.rs` NATS auto-resolve had no `.git` awareness** — under `conflict_mode=auto`, `AutoResolver` applies a lexicographic KeepLocal/KeepRemote **per file** with zero `.git` awareness, auto-downloading a remote ref over the local object store (the G5-git-5 interleave vector).

### What PR-1 does (5 pieces)

1. **`.git`-internal refusal at the `resolve_conflict` gRPC entry** (`crates/tcfsd/src/grpc.rs`). `keep_local`/`keep_remote`/`keep_both` on any `.git`-internal path are refused with clear repo-group guidance; `defer` stays a no-op (allowed). Non-`.git` file conflicts resolve exactly as before. Auto-covers the MCP tool (same RPC).
2. **NATS auto-resolve defers `.git`-internal conflicts** (`crates/tcfsd/src/daemon.rs`). The `conflict_mode=auto` path defers (records + skips) `.git`-internal conflicts instead of auto-downloading; non-`.git` conflicts keep today's behavior.
3. **`tcfs conflicts` read verb** (`crates/tcfs-cli/src/main.rs`). Reads conflicts straight from the state cache (no daemon RPC), groups `.git`-internal conflicts by repo root, lists non-`.git` conflicts flat, shows local HEAD (`git log --oneline -1`), age, and `times_recorded`, with honest degradation for the remote HEAD (its commit SHA is not carried in the offline state cache). `--json` supported. Read-only — no writes.
4. **`times_recorded: u64` on `ConflictInfo`** (`crates/tcfs-sync/src/conflict.rs`, `#[serde(default)]`), bumped at the reconcile record site (`reconcile.rs`) on re-record instead of overwriting, with the original `detected_at` preserved across cycles — so a forever-Conflict repo is visible. Old state caches deserialize to `times_recorded=0`.
5. **Real `ConflictInfo` in the interactive `tcfs resolve` prompt** (`crates/tcfs-cli/src/main.rs`) — replaces the dummy placeholder (empty hashes/clocks) with the record loaded from the state cache.

### Deliberately NOT in PR-1

No resolve verb, no ref writes, no lock hardening, no operator questions. This is the fence + the ability to *see*. Later rungs of #523: **PR-2** hard lock respect (+ `ConflictInfo.remote_manifest_key`), **PR-3** the `resolve_git_keep_both` verb (gated on §6 Q1–Q6), **PR-4** loser-side no-loss guard.

### Tests (fail-before / pass-after)

- `grpc.rs`: fence refuses `keep_remote`/`keep_both`/`keep_local` on `.git` paths, allows `defer` on `.git`, and does NOT fence a normal file path.
- `daemon.rs`: NATS-auto defers `.git`-internal conflicts, resolves normal files.
- `conflict.rs`: `ConflictInfo` deserializes without `times_recorded` → 0, round-trips.
- `main.rs`: `tcfs conflicts` groups by repo and classifies head-ref vs other `.git`-internal paths.

Gate: `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets` no new warnings; `cargo test -p tcfs-sync -p tcfs-file-provider -p tcfsd` green.
