### PR TITLE
Harden git conflict fence paths and persistence

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -6814,11 +6814,13 @@ struct ConflictGroup {
 /// [`repo_root_for_git_path`](tcfs_sync::git_safety::repo_root_for_git_path)
 /// locates the `.git` boundary.
 fn conflict_repo_root(cache_key: &str, rel_path: &str) -> Option<PathBuf> {
+    let rel_path = rel_path.replace('\\', "/");
+    let cache_key = cache_key.replace('\\', "/");
     let local_root = cache_key
-        .strip_suffix(rel_path)
+        .strip_suffix(&rel_path)
         .map(|s| s.trim_end_matches('/'))
         .unwrap_or("");
-    tcfs_sync::git_safety::repo_root_for_git_path(Path::new(local_root), rel_path)
+    tcfs_sync::git_safety::repo_root_for_git_path(Path::new(local_root), &rel_path)
 }
 
 /// Group recorded conflicts by their enclosing git repo (for `.git`-internal
@@ -7134,6 +7136,10 @@ mod tests {
                 mk_conflict("repoB/.git/HEAD"),
             ),
             (
+                "/sync/repoC/.git/refs/heads/main".to_string(),
+                mk_conflict("repoC\\.git\\refs\\heads\\main"),
+            ),
+            (
                 "/sync/notes/todo.txt".to_string(),
                 mk_conflict("notes/todo.txt"),
             ),
@@ -7141,8 +7147,12 @@ mod tests {
 
         let groups = group_conflicts(&items);
 
-        // Two git repo groups + one flat non-git bucket.
-        assert_eq!(groups.len(), 3, "expected repoA, repoB, and a flat bucket");
+        // Three git repo groups + one flat non-git bucket.
+        assert_eq!(
+            groups.len(),
+            4,
+            "expected repoA, repoB, repoC, and a flat bucket"
+        );
 
         let repo_a = groups
             .iter()
@@ -7172,6 +7182,14 @@ mod tests {
             .find(|g| g.repo_root.as_deref() == Some("/sync/repoB"))
             .expect("repoB group present");
         assert_eq!(repo_b.paths.len(), 1);
+
+        let repo_c = groups
+            .iter()
+            .find(|g| g.repo_root.as_deref() == Some("/sync/repoC"))
+            .expect("repoC group present");
+        assert_eq!(repo_c.paths.len(), 1);
+        assert!(repo_c.paths[0].git_internal);
+        assert_eq!(repo_c.paths[0].head_ref.as_deref(), Some("refs/heads/main"));
 
         // The non-git conflict is flat (no repo_root), and not git-internal.
         let flat = groups

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1138,6 +1138,8 @@ pub struct UploadResult {
     pub hash: String,
     pub chunks: usize,
     pub bytes: u64,
+    /// Vector clock committed in the uploaded manifest/state entry.
+    pub vclock: VectorClock,
     /// true if file was already up-to-date (skipped)
     pub skipped: bool,
     /// Sync outcome if conflict detection was performed
@@ -1485,6 +1487,7 @@ async fn upload_file_with_device_with_state(
                 hash: cached.blake3.clone(),
                 chunks: cached.chunk_count,
                 bytes: cached.size,
+                vclock: cached.vclock.clone(),
                 skipped: true,
                 outcome: Some(SyncOutcome::UpToDate),
             };
@@ -1662,6 +1665,7 @@ async fn upload_file_with_device_with_state(
                             hash: file_hash_hex,
                             chunks: 0,
                             bytes: file_size,
+                            vclock: remote_manifest_obj.vclock.clone(),
                             skipped: true,
                             outcome: Some(sync_outcome),
                         },
@@ -1691,6 +1695,7 @@ async fn upload_file_with_device_with_state(
                             hash: file_hash_hex,
                             chunks: 0,
                             bytes: file_size,
+                            vclock: sync_state.vclock.clone(),
                             skipped: true,
                             outcome: Some(sync_outcome),
                         },
@@ -1718,6 +1723,7 @@ async fn upload_file_with_device_with_state(
                             hash: file_hash_hex,
                             chunks: 0,
                             bytes: file_size,
+                            vclock: sync_state.vclock.clone(),
                             skipped: true,
                             outcome: Some(sync_outcome),
                         },
@@ -1777,6 +1783,7 @@ async fn upload_file_with_device_with_state(
                 hash: file_hash_hex,
                 chunks: chunk_count,
                 bytes: file_size,
+                vclock: sync_state.vclock.clone(),
                 skipped: false,
                 outcome: None,
             },
@@ -2249,6 +2256,7 @@ async fn upload_file_with_device_with_state(
             hash: file_hash_hex,
             chunks: num_chunks,
             bytes: file_size,
+            vclock: sync_state.vclock.clone(),
             skipped: false,
             outcome,
         },
@@ -2321,6 +2329,7 @@ pub async fn upload_symlink_with_device(
         device_id.to_string(),
         target.len() as u64,
     )?;
+    let result_vclock = sync_state.vclock.clone();
     state.set(local_path, sync_state);
 
     let assume_fresh_prefix = upload_assume_fresh_prefix();
@@ -2338,6 +2347,7 @@ pub async fn upload_symlink_with_device(
         hash: symlink_hash,
         chunks: 0,
         bytes: target.len() as u64,
+        vclock: result_vclock,
         skipped: false,
         outcome: None,
     })
@@ -4862,6 +4872,39 @@ mod tests {
         // Verify content matches
         let content = std::fs::read_to_string(&dl_path).unwrap();
         assert_eq!(content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn upload_result_vclock_matches_committed_manifest_and_state() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        let local = dir.path().join("todo.txt");
+        std::fs::write(&local, b"ship the watcher event clock").unwrap();
+
+        let up = upload_file_with_device(
+            &op,
+            &local,
+            "data",
+            &mut state,
+            None,
+            "neo",
+            Some("notes/todo.txt"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(!up.skipped);
+        assert_eq!(up.vclock.get("neo"), 1);
+
+        let manifest_bytes = op.read(&up.remote_path).await.unwrap();
+        let manifest = SyncManifest::from_bytes(&manifest_bytes.to_bytes()).unwrap();
+        let cached = state.get(&local).unwrap();
+
+        assert_eq!(up.vclock, manifest.vclock);
+        assert_eq!(up.vclock, cached.vclock);
     }
 
     #[test]

--- a/crates/tcfs-sync/src/git_safety.rs
+++ b/crates/tcfs-sync/src/git_safety.rs
@@ -275,6 +275,7 @@ fn is_hex_sha(s: &str) -> bool {
 pub fn repo_root_for_git_path(local_root: &Path, rel_path: &str) -> Option<std::path::PathBuf> {
     // Split the rel path on the first `.git` component. Everything before it is
     // the repo subdir (possibly empty).
+    let rel_path = rel_path.replace('\\', "/");
     let mut prefix_components: Vec<&str> = Vec::new();
     let mut found = false;
     for comp in rel_path.split('/') {
@@ -303,6 +304,7 @@ pub fn repo_root_for_git_path(local_root: &Path, rel_path: &str) -> Option<std::
 pub fn head_ref_for_git_path(rel_path: &str) -> Option<String> {
     // Locate the `.git/refs/heads/` segment and take the remainder as the
     // branch name (which may itself contain slashes, e.g. `feature/x`).
+    let rel_path = rel_path.replace('\\', "/");
     let needle = ".git/refs/heads/";
     let idx = rel_path.find(needle)?;
     let branch = &rel_path[idx + needle.len()..];

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -653,6 +653,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                                     let nats_device = device.clone();
                                                     let nats_hash = upload_result.hash.clone();
                                                     let nats_size = upload_result.bytes;
+                                                    let nats_vclock = upload_result.vclock.clone();
                                                     let nats_remote = upload_result.remote_path.clone();
                                                     let nats_handle = nats.clone();
                                                     let pub_metrics = metrics.clone();
@@ -663,7 +664,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                                                                 rel_path,
                                                                 blake3: nats_hash,
                                                                 size: nats_size,
-                                                                vclock: Default::default(),
+                                                                vclock: nats_vclock,
                                                                 manifest_path: nats_remote,
                                                                 timestamp: tcfs_sync::StateEvent::now(),
                                                             };
@@ -1553,11 +1554,12 @@ async fn spawn_state_sync_loop(
                                     // OnDemand mode (under threshold): conditional auto-pull
                                     match conflict_mode.as_str() {
                                         "auto" => {
-                                            handle_auto_pull(
+                                            let should_ack = handle_auto_pull(
                                                 &device_id,
                                                 &event_device,
                                                 rel_path,
                                                 blake3,
+                                                *size,
                                                 remote_vclock,
                                                 manifest_path,
                                                 &operator,
@@ -1567,6 +1569,9 @@ async fn spawn_state_sync_loop(
                                                 &storage_prefix,
                                             )
                                             .await;
+                                            if !should_ack {
+                                                continue;
+                                            }
 
                                             // Invalidate FUSE negative cache so the
                                             // new file appears in readdir immediately
@@ -1725,6 +1730,7 @@ async fn handle_auto_pull(
     remote_device: &str,
     rel_path: &str,
     remote_blake3: &str,
+    remote_size: u64,
     remote_vclock: &tcfs_sync::conflict::VectorClock,
     manifest_path: &str,
     operator: &Arc<tokio::sync::Mutex<Option<opendal::Operator>>>,
@@ -1732,7 +1738,7 @@ async fn handle_auto_pull(
     path_locks: &tcfs_sync::state::PathLocks,
     sync_root: Option<&std::path::Path>,
     storage_prefix: &str,
-) {
+) -> bool {
     // Determine local path for this rel_path
     let local_path = match sync_root {
         Some(root) => root.join(rel_path),
@@ -1746,7 +1752,7 @@ async fn handle_auto_pull(
                         path = %rel_path,
                         "no sync_root configured and file not in state cache, skipping auto-pull"
                     );
-                    return;
+                    return true;
                 }
             }
         }
@@ -1762,8 +1768,11 @@ async fn handle_auto_pull(
                 // New file from remote — download it
                 info!(path = %rel_path, from = %remote_device, "new file from remote, pulling");
                 drop(cache);
-                do_auto_download(
+                return do_auto_download(
                     device_id,
+                    remote_blake3,
+                    remote_size,
+                    remote_vclock,
                     manifest_path,
                     &local_path,
                     operator,
@@ -1771,7 +1780,6 @@ async fn handle_auto_pull(
                     storage_prefix,
                 )
                 .await;
-                return;
             }
         }
     };
@@ -1789,9 +1797,11 @@ async fn handle_auto_pull(
     match outcome {
         tcfs_sync::conflict::SyncOutcome::UpToDate => {
             info!(path = %rel_path, "already up to date");
+            true
         }
         tcfs_sync::conflict::SyncOutcome::LocalNewer => {
             info!(path = %rel_path, "local is newer, skipping pull");
+            true
         }
         tcfs_sync::conflict::SyncOutcome::RemoteNewer => {
             // Guard: defer auto-pull if file is actively being modified
@@ -1800,20 +1810,23 @@ async fn handle_auto_pull(
                 if let Some(entry) = cache.get(&local_path) {
                     if entry.status == tcfs_sync::state::FileSyncStatus::Active {
                         info!(path = %rel_path, "deferring auto-pull: file is actively being modified");
-                        return;
+                        return true;
                     }
                 }
             }
             info!(path = %rel_path, from = %remote_device, "remote is newer, auto-pulling");
             do_auto_download(
                 device_id,
+                remote_blake3,
+                remote_size,
+                remote_vclock,
                 manifest_path,
                 &local_path,
                 operator,
                 state_cache,
                 storage_prefix,
             )
-            .await;
+            .await
         }
         tcfs_sync::conflict::SyncOutcome::Conflict(ref conflict_info) => {
             // keep-both PR-1 (safety invariant S2): automatic per-file
@@ -1826,11 +1839,19 @@ async fn handle_auto_pull(
             // `tcfs conflicts`). The conflict stays recorded by the reconcile
             // engine's Conflict arm, so it remains visible and re-tried.
             if auto_conflict_must_defer(rel_path) {
+                {
+                    let mut cache = state_cache.lock().await;
+                    watcher_record_conflict(&mut cache, &local_path, conflict_info.clone());
+                    if let Err(e) = cache.flush() {
+                        warn!(path = %rel_path, "failed to persist deferred git conflict: {e}");
+                        return false;
+                    }
+                }
                 info!(
                     path = %rel_path,
                     "AutoResolver: deferring .git-internal conflict (repo-group resolution required)"
                 );
-                return;
+                return true;
             }
             info!(
                 path = %rel_path,
@@ -1845,8 +1866,11 @@ async fn handle_auto_pull(
                 }
                 Some(tcfs_sync::conflict::Resolution::KeepRemote) => {
                     info!(path = %rel_path, "AutoResolver: keeping remote");
-                    do_auto_download(
+                    return do_auto_download(
                         device_id,
+                        remote_blake3,
+                        remote_size,
+                        remote_vclock,
                         manifest_path,
                         &local_path,
                         operator,
@@ -1859,6 +1883,7 @@ async fn handle_auto_pull(
                     info!(path = %rel_path, "AutoResolver: deferred");
                 }
             }
+            true
         }
     }
 }
@@ -1876,12 +1901,15 @@ async fn handle_auto_pull(
 /// We only update the state cache so vector clocks stay in sync.
 async fn do_auto_download(
     _device_id: &str,
+    expected_blake3: &str,
+    expected_size: u64,
+    expected_vclock: &tcfs_sync::conflict::VectorClock,
     manifest_path: &str,
     local_path: &std::path::Path,
     operator: &Arc<tokio::sync::Mutex<Option<opendal::Operator>>>,
     state_cache: &Arc<tokio::sync::Mutex<tcfs_sync::state::StateCache>>,
     _storage_prefix: &str,
-) {
+) -> bool {
     // Verify the manifest exists in S3 (confirms push completed)
     let op = {
         let guard = operator.lock().await;
@@ -1889,7 +1917,7 @@ async fn do_auto_download(
             Some(op) => op.clone(),
             None => {
                 warn!("no storage operator for auto-pull verification");
-                return;
+                return false;
             }
         }
     };
@@ -1900,6 +1928,21 @@ async fn do_auto_download(
             let manifest_bytes = manifest_data.to_bytes();
             match tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes) {
                 Ok(manifest) => {
+                    if manifest.file_hash != expected_blake3
+                        || manifest.file_size != expected_size
+                        || manifest.vclock != *expected_vclock
+                    {
+                        warn!(
+                            path = %local_path.display(),
+                            manifest = %manifest_path,
+                            event_hash = %expected_blake3,
+                            manifest_hash = %manifest.file_hash,
+                            event_size = expected_size,
+                            manifest_size = manifest.file_size,
+                            "auto-pull: manifest does not match state event; withholding ack"
+                        );
+                        return false;
+                    }
                     info!(
                         path = %local_path.display(),
                         manifest = %manifest_path,
@@ -1914,6 +1957,7 @@ async fn do_auto_download(
                         .unwrap_or_default()
                         .as_secs();
                     let mut cache = state_cache.lock().await;
+                    let previous = cache.get(local_path).cloned();
                     cache.set(
                         local_path,
                         tcfs_sync::state::SyncState {
@@ -1931,23 +1975,25 @@ async fn do_auto_download(
                     );
                     if let Err(e) = cache.flush() {
                         warn!(error = %e, "state cache flush failed");
+                        match previous {
+                            Some(previous) => cache.set(local_path, previous),
+                            None => cache.remove(local_path),
+                        }
+                        return false;
                     }
                     debug!(
                         key = %local_path.display(),
                         hash = %manifest.file_hash,
                         "auto-pull: state cache updated with remote metadata"
                     );
+                    true
                 }
                 Err(e) => {
                     warn!(
                         manifest = %manifest_path,
                         "auto-pull: failed to parse manifest: {e}"
                     );
-                    // Still mark as verified even if parse fails
-                    let mut cache = state_cache.lock().await;
-                    if let Err(e) = cache.flush() {
-                        warn!(error = %e, "state cache flush failed");
-                    }
+                    false
                 }
             }
         }
@@ -1957,6 +2003,7 @@ async fn do_auto_download(
                 manifest = %manifest_path,
                 "auto-pull: manifest not found in S3: {e}"
             );
+            false
         }
     }
 }
@@ -2023,7 +2070,9 @@ fn ensure_dirs(config: &TcfsConfig) {
 
 #[cfg(test)]
 mod keep_both_pr1_tests {
-    use super::auto_conflict_must_defer;
+    use super::{auto_conflict_must_defer, handle_auto_pull};
+    use opendal::services::Memory;
+    use opendal::Operator;
 
     #[test]
     fn auto_defers_git_internal_conflicts() {
@@ -2041,5 +2090,215 @@ mod keep_both_pr1_tests {
         assert!(!auto_conflict_must_defer("src/main.rs"));
         // A file merely named like git but not under a `.git` dir is not fenced.
         assert!(!auto_conflict_must_defer("docs/gitignore-notes.md"));
+    }
+
+    #[tokio::test]
+    async fn git_conflict_flush_failure_withholds_ack_signal() {
+        // If a deferred `.git` conflict cannot be persisted, the auto-pull
+        // handler must return false so the NATS caller skips ack and lets
+        // JetStream redeliver. This is the event-loss guard for PR-1.
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("sync");
+        let rel_path = "repo/.git/refs/heads/main";
+        let local_path = sync_root.join(rel_path);
+
+        let blocked_parent = dir.path().join("state-parent-is-file");
+        std::fs::write(&blocked_parent, b"not a directory").unwrap();
+        let mut state_cache =
+            tcfs_sync::state::StateCache::open(&blocked_parent.join("state.json")).unwrap();
+        state_cache.set(
+            &local_path,
+            tcfs_sync::state::SyncState {
+                blake3: "local".into(),
+                size: 0,
+                mtime: 0,
+                chunk_count: 0,
+                remote_path: rel_path.into(),
+                last_synced: 0,
+                vclock: tcfs_sync::conflict::VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: None,
+                status: tcfs_sync::state::FileSyncStatus::Synced,
+            },
+        );
+
+        let state_cache = std::sync::Arc::new(tokio::sync::Mutex::new(state_cache));
+        let operator = std::sync::Arc::new(tokio::sync::Mutex::new(None));
+        let remote_vclock = tcfs_sync::conflict::VectorClock::new();
+
+        let should_ack = handle_auto_pull(
+            "neo",
+            "honey",
+            rel_path,
+            "remote",
+            0,
+            &remote_vclock,
+            "data/manifests/git",
+            &operator,
+            &state_cache,
+            &tcfs_sync::state::PathLocks::new(),
+            Some(&sync_root),
+            "data",
+        )
+        .await;
+
+        assert!(
+            !should_ack,
+            "failed deferred-conflict persistence must withhold ack"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_download_failure_withholds_ack_signal() {
+        // Once handle_auto_pull owns the ack/no-ack decision, ordinary
+        // auto-download verification failures must also return false. Otherwise
+        // a missing operator/bad manifest/missing manifest would ack and drop
+        // the event before the remote file is represented in state.
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("sync");
+        let state_path = dir.path().join("state.json");
+        let state_cache = std::sync::Arc::new(tokio::sync::Mutex::new(
+            tcfs_sync::state::StateCache::open(&state_path).unwrap(),
+        ));
+        let operator = std::sync::Arc::new(tokio::sync::Mutex::new(None));
+        let remote_vclock = tcfs_sync::conflict::VectorClock::new();
+
+        let should_ack = handle_auto_pull(
+            "neo",
+            "honey",
+            "notes/todo.txt",
+            "remote",
+            0,
+            &remote_vclock,
+            "data/manifests/notes/todo.txt",
+            &operator,
+            &state_cache,
+            &tcfs_sync::state::PathLocks::new(),
+            Some(&sync_root),
+            "data",
+        )
+        .await;
+
+        assert!(
+            !should_ack,
+            "failed auto-download verification must withhold ack"
+        );
+    }
+
+    fn memory_operator() -> Operator {
+        Operator::new(Memory::default()).unwrap().finish()
+    }
+
+    fn test_manifest(
+        file_hash: &str,
+        file_size: u64,
+        vclock: tcfs_sync::conflict::VectorClock,
+    ) -> tcfs_sync::manifest::SyncManifest {
+        tcfs_sync::manifest::SyncManifest {
+            version: 2,
+            file_hash: file_hash.into(),
+            file_size,
+            chunks: Vec::new(),
+            vclock,
+            written_by: "honey".into(),
+            written_at: 1_700_000_000,
+            rel_path: Some("notes/todo.txt".into()),
+            mode: None,
+            mtime: None,
+            encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn auto_download_flush_failure_rolls_back_in_memory_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("sync");
+        let rel_path = "notes/todo.txt";
+        let local_path = sync_root.join(rel_path);
+        let blocked_parent = dir.path().join("state-parent-is-file");
+        std::fs::write(&blocked_parent, b"not a directory").unwrap();
+        let state_cache = std::sync::Arc::new(tokio::sync::Mutex::new(
+            tcfs_sync::state::StateCache::open(&blocked_parent.join("state.json")).unwrap(),
+        ));
+
+        let mut remote_vclock = tcfs_sync::conflict::VectorClock::new();
+        remote_vclock.tick("honey");
+        let manifest = test_manifest("remote", 5, remote_vclock.clone());
+        let op = memory_operator();
+        op.write(
+            "data/manifests/notes/todo.txt",
+            manifest.to_bytes().unwrap(),
+        )
+        .await
+        .unwrap();
+        let operator = std::sync::Arc::new(tokio::sync::Mutex::new(Some(op)));
+
+        for attempt in 0..2 {
+            let should_ack = handle_auto_pull(
+                "neo",
+                "honey",
+                rel_path,
+                "remote",
+                5,
+                &remote_vclock,
+                "data/manifests/notes/todo.txt",
+                &operator,
+                &state_cache,
+                &tcfs_sync::state::PathLocks::new(),
+                Some(&sync_root),
+                "data",
+            )
+            .await;
+            assert!(
+                !should_ack,
+                "attempt {attempt}: failed flush must keep withholding ack"
+            );
+            let cache = state_cache.lock().await;
+            assert!(
+                cache.get(&local_path).is_none(),
+                "attempt {attempt}: failed flush must not leave remote state in memory"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn auto_download_manifest_mismatch_withholds_ack_signal() {
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("sync");
+        let state_path = dir.path().join("state.json");
+        let state_cache = std::sync::Arc::new(tokio::sync::Mutex::new(
+            tcfs_sync::state::StateCache::open(&state_path).unwrap(),
+        ));
+
+        let mut remote_vclock = tcfs_sync::conflict::VectorClock::new();
+        remote_vclock.tick("honey");
+        let manifest = test_manifest("stale", 5, remote_vclock.clone());
+        let op = memory_operator();
+        op.write(
+            "data/manifests/notes/todo.txt",
+            manifest.to_bytes().unwrap(),
+        )
+        .await
+        .unwrap();
+        let operator = std::sync::Arc::new(tokio::sync::Mutex::new(Some(op)));
+
+        let should_ack = handle_auto_pull(
+            "neo",
+            "honey",
+            "notes/todo.txt",
+            "remote",
+            5,
+            &remote_vclock,
+            "data/manifests/notes/todo.txt",
+            &operator,
+            &state_cache,
+            &tcfs_sync::state::PathLocks::new(),
+            Some(&sync_root),
+            "data",
+        )
+        .await;
+
+        assert!(!should_ack, "manifest/event mismatch must withhold ack");
     }
 }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -24,6 +24,62 @@ use tcfs_core::proto::{
 };
 use tcfs_sync::state::StateCacheBackend;
 
+fn path_resolves_to_git_internal(path: &Path) -> bool {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        if tcfs_sync::git_safety::repo_root_for_git_path(
+            Path::new(""),
+            &canonical.to_string_lossy(),
+        )
+        .is_some()
+        {
+            return true;
+        }
+    }
+
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Ok(parent) = std::fs::canonicalize(parent) else {
+        return false;
+    };
+    let resolved = match path.file_name() {
+        Some(name) => parent.join(name),
+        None => parent,
+    };
+    tcfs_sync::git_safety::repo_root_for_git_path(Path::new(""), &resolved.to_string_lossy())
+        .is_some()
+}
+
+fn resolve_conflict_git_fence_error(
+    path: &Path,
+    resolution: &str,
+    state_entry: Option<&tcfs_sync::state::SyncState>,
+) -> Option<String> {
+    if resolution == "defer" {
+        return None;
+    }
+
+    let raw_path = path.to_string_lossy();
+    let is_git_internal = tcfs_sync::git_safety::repo_root_for_git_path(Path::new(""), &raw_path)
+        .is_some()
+        || path_resolves_to_git_internal(path)
+        || state_entry
+            .and_then(|entry| entry.conflict.as_ref())
+            .is_some_and(|conflict| {
+                tcfs_sync::git_safety::repo_root_for_git_path(Path::new(""), &conflict.rel_path)
+                    .is_some()
+            });
+
+    is_git_internal.then(|| {
+        format!(
+            "'{}' is a git-internal path; per-file resolution ({resolution}) would corrupt the \
+             repository object store. Resolve the whole repo group instead \
+             (future: `tcfs resolve <repo> --keep-both`). Inspect with `tcfs conflicts`.",
+            path.display()
+        )
+    })
+}
+
 /// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
 ///
 /// - `Master` (default): legacy shared-master wrap. Byte-identical to the prior
@@ -1545,14 +1601,19 @@ impl TcfsDaemon for TcfsDaemonImpl {
             }
         };
 
-        info!(
-            path = %req.path,
-            resolution = %resolution,
-            device = %self.device_id,
-            "conflict resolution requested"
-        );
-
         let path = std::path::PathBuf::from(&req.path);
+
+        // Reload state from disk in case the CLI wrote new entries. The git
+        // fence below also consults the stored ConflictInfo rel_path, which is
+        // the authoritative repo-relative path when the request arrived through
+        // a symlink alias or another local spelling.
+        let state_entry = {
+            let mut cache = self.state_cache.lock().await;
+            if let Err(e) = cache.reload_from_disk() {
+                tracing::warn!("failed to reload state cache: {e}");
+            }
+            cache.get(&path).cloned()
+        };
 
         // keep-both PR-1 (safety invariant S1): per-file conflict resolution
         // must NEVER touch `.git` internals. keep_local rewrites the manifest,
@@ -1564,9 +1625,8 @@ impl TcfsDaemon for TcfsDaemonImpl {
         // `defer` is a no-op (records intent only) and stays allowed. This
         // guard also covers the MCP `resolve_conflict` tool, which is a thin
         // passthrough to this same RPC.
-        if resolution != "defer"
-            && tcfs_sync::git_safety::repo_root_for_git_path(std::path::Path::new(""), &req.path)
-                .is_some()
+        if let Some(error) =
+            resolve_conflict_git_fence_error(&path, &resolution, state_entry.as_ref())
         {
             tracing::warn!(
                 path = %req.path,
@@ -1576,22 +1636,16 @@ impl TcfsDaemon for TcfsDaemonImpl {
             return Ok(tonic::Response::new(ResolveConflictResponse {
                 success: false,
                 resolved_path: String::new(),
-                error: format!(
-                    "'{}' is a git-internal path; per-file resolution ({}) would corrupt the \
-                     repository object store. Resolve the whole repo group instead \
-                     (future: `tcfs resolve <repo> --keep-both`). Inspect with `tcfs conflicts`.",
-                    req.path, resolution
-                ),
+                error,
             }));
         }
 
-        // Reload state from disk in case the CLI wrote new entries
-        {
-            let mut cache = self.state_cache.lock().await;
-            if let Err(e) = cache.reload_from_disk() {
-                tracing::warn!("failed to reload state cache: {e}");
-            }
-        }
+        info!(
+            path = %req.path,
+            resolution = %resolution,
+            device = %self.device_id,
+            "conflict resolution requested"
+        );
 
         match resolution.as_str() {
             "defer" => {
@@ -3927,6 +3981,103 @@ mod tests {
             assert!(!resp.success, "{strat} on a .git path must be refused");
             assert!(resp.error.contains("git-internal"), "strat={strat}");
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn resolve_conflict_refuses_git_internal_symlink_alias() {
+        // A local path spelling with no `.git` component can still resolve into
+        // `.git`; the fence must classify the resolved path and stored
+        // ConflictInfo, not just the raw request string.
+        let daemon = test_daemon();
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        let git_heads = repo.join(".git/refs/heads");
+        std::fs::create_dir_all(&git_heads).unwrap();
+        let git_path = git_heads.join("main");
+        std::fs::write(&git_path, b"0123456789012345678901234567890123456789\n").unwrap();
+
+        let alias = dir.path().join("refslink");
+        std::os::unix::fs::symlink(repo.join(".git/refs"), &alias).unwrap();
+        let alias_path = alias.join("heads/main");
+
+        let mut entry = test_sync_state("data/manifests/git", 1_700_000_000);
+        entry.status = tcfs_sync::state::FileSyncStatus::Conflict;
+        entry.conflict = Some(tcfs_sync::conflict::ConflictInfo {
+            rel_path: "repo/.git/refs/heads/main".into(),
+            local_vclock: tcfs_sync::conflict::VectorClock::new(),
+            remote_vclock: tcfs_sync::conflict::VectorClock::new(),
+            local_blake3: "local-git".into(),
+            remote_blake3: "remote-git".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 43,
+            times_recorded: 1,
+        });
+
+        {
+            let mut cache = daemon.state_cache.lock().await;
+            cache.set(&git_path, entry);
+            cache.flush().unwrap();
+        }
+
+        let resp = daemon
+            .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                path: alias_path.display().to_string(),
+                resolution: "keep_remote".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(!resp.success);
+        assert!(resp.resolved_path.is_empty());
+        assert!(resp.error.contains("git-internal"));
+        assert!(resp.error.contains("per-file"));
+    }
+
+    #[tokio::test]
+    async fn resolve_conflict_refuses_stored_git_internal_rel_path() {
+        // A cache key can be an ordinary local spelling while the recorded
+        // ConflictInfo carries the authoritative repo-relative `.git` path.
+        // The fence must consult that stored rel_path before keep_* can write.
+        let daemon = test_daemon();
+        let dir = tempfile::tempdir().unwrap();
+        let request_path = dir.path().join("visible-conflict");
+        std::fs::write(&request_path, b"ordinary-looking path").unwrap();
+
+        let mut entry = test_sync_state("data/manifests/git", 1_700_000_000);
+        entry.status = tcfs_sync::state::FileSyncStatus::Conflict;
+        entry.conflict = Some(tcfs_sync::conflict::ConflictInfo {
+            rel_path: "repo/.git/refs/heads/main".into(),
+            local_vclock: tcfs_sync::conflict::VectorClock::new(),
+            remote_vclock: tcfs_sync::conflict::VectorClock::new(),
+            local_blake3: "local-git".into(),
+            remote_blake3: "remote-git".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 44,
+            times_recorded: 1,
+        });
+
+        {
+            let mut cache = daemon.state_cache.lock().await;
+            cache.set(&request_path, entry);
+            cache.flush().unwrap();
+        }
+
+        let resp = daemon
+            .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                path: request_path.display().to_string(),
+                resolution: "keep_remote".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(!resp.success);
+        assert!(resp.resolved_path.is_empty());
+        assert!(resp.error.contains("git-internal"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #526 / replacement for the now-conflicted #525 hardening deltas.

#526 landed the keep-both PR-1 fence and `tcfs conflicts` surface. This PR carries only the adversarial fixes that were still missing on current `main`:

- close `ResolveConflict` alias bypasses by checking raw path, canonical/parent-resolved path, and stored `ConflictInfo.rel_path`
- persist deferred `.git` auto-resolve conflicts before acking NATS events
- withhold NATS ack if that persistence fails, so JetStream can redeliver
- normalize backslash-style paths in git repo grouping / `repo_root_for_git_path`
- add regression coverage for symlink-alias resolve and backslash grouping

## Validation

- `cargo fmt --all`
- `git diff --check`

No local cargo/nix builds or tests were run on neo. CI should perform compile/test validation remotely.
