### PR TITLE
feat(sync): harden git keep-both prerequisites

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -6713,6 +6713,7 @@ async fn cmd_resolve(
                     remote_vclock: tcfs_sync::conflict::VectorClock::new(),
                     detected_at: 0,
                     times_recorded: 0,
+                    remote_manifest_key: None,
                 }
             });
             match resolve_conflict_interactive(&info) {
@@ -7114,6 +7115,7 @@ mod tests {
             remote_device: "honey".into(),
             detected_at: 1_700_000_000,
             times_recorded: 3,
+            remote_manifest_key: None,
         }
     }
 

--- a/crates/tcfs-sync/src/conflict.rs
+++ b/crates/tcfs-sync/src/conflict.rs
@@ -89,7 +89,17 @@ impl VectorClock {
 // ── Sync Outcome ──────────────────────────────────────────────────────────────
 
 /// Result of comparing a local file's state against a remote version.
+///
+/// This is a short-lived decision value: `compare_clocks` returns it and the
+/// caller immediately matches it into a `ReconcileAction`. It is never held in
+/// bulk collections, so the size gap between the data-carrying `Conflict`
+/// variant and the unit variants is immaterial — boxing `ConflictInfo` here
+/// would add an allocation per classification for no benefit and ripple through
+/// ~20 match sites across crates. keep-both PR-2 grew `ConflictInfo` by one
+/// `Option<String>` (`remote_manifest_key`), nudging it just past clippy's
+/// 200-byte `large_enum_variant` threshold; allow it for this transient enum.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum SyncOutcome {
     /// Local version is newer — safe to push.
     LocalNewer,
@@ -128,6 +138,20 @@ pub struct ConflictInfo {
     /// state caches — written before this field existed — deserializing to 0.
     #[serde(default)]
     pub times_recorded: u64,
+    /// Storage key (S3/prefix path) of the remote side's manifest for this
+    /// path, captured when the conflict is classified.
+    ///
+    /// keep-both PR-2 data-model graft: the remote ref blob's manifest key is
+    /// only in scope at classification time (`reconcile::outcome_to_action`,
+    /// where the remote manifest path is already computed) — NOT at the later
+    /// record site, which holds only the local state entry. A future PR-3
+    /// resolve verb needs this key to fetch the remote ref SHA directly instead
+    /// of depending on the incidental, unversioned `SyncState.remote_path`.
+    /// `None` for conflicts recorded before this field existed (old state
+    /// caches) and for any path where the key was not captured. `serde(default)`
+    /// keeps those older caches deserializing.
+    #[serde(default)]
+    pub remote_manifest_key: Option<String>,
 }
 
 // ── Resolution ────────────────────────────────────────────────────────────────
@@ -202,6 +226,11 @@ pub fn compare_clocks(
                 remote_device: remote_device.to_string(),
                 detected_at: now,
                 times_recorded: 0,
+                // Not in scope here: `compare_clocks` sees only hashes/clocks,
+                // not the remote manifest storage key. Populated later at
+                // `reconcile::outcome_to_action`, where the remote manifest
+                // path is already computed. (keep-both PR-2)
+                remote_manifest_key: None,
             })
         }
     }
@@ -388,6 +417,7 @@ mod tests {
             remote_device: "beta".into(),
             detected_at: 0,
             times_recorded: 0,
+            remote_manifest_key: None,
         };
         // "alpha" < "beta" → keep local
         assert_eq!(resolver.resolve(&info), Some(Resolution::KeepLocal));
@@ -451,5 +481,41 @@ mod tests {
         let reparsed: ConflictInfo = serde_json::from_str(&bytes).unwrap();
         assert_eq!(reparsed.times_recorded, 0);
         assert_eq!(reparsed.rel_path, "repo/.git/refs/heads/main");
+    }
+
+    #[test]
+    fn conflict_info_serde_roundtrips_without_remote_manifest_key() {
+        // keep-both PR-2 back-compat (test c): a state cache written before
+        // `remote_manifest_key` existed has no such field. `#[serde(default)]`
+        // must deserialize it to None so old caches load unchanged.
+        let legacy = r#"{
+            "rel_path": "repo/.git/refs/heads/main",
+            "local_vclock": {"clocks": {}},
+            "remote_vclock": {"clocks": {}},
+            "local_blake3": "aaa",
+            "remote_blake3": "bbb",
+            "local_device": "neo",
+            "remote_device": "honey",
+            "detected_at": 1700000000,
+            "times_recorded": 2
+        }"#;
+        let info: ConflictInfo =
+            serde_json::from_str(legacy).expect("legacy ConflictInfo must deserialize");
+        assert_eq!(
+            info.remote_manifest_key, None,
+            "missing remote_manifest_key must default to None"
+        );
+        // Unrelated fields still parse correctly.
+        assert_eq!(info.times_recorded, 2);
+
+        // A populated key round-trips losslessly.
+        let mut with_key = info.clone();
+        with_key.remote_manifest_key = Some("data/manifests/deadbeef".to_string());
+        let bytes = serde_json::to_string(&with_key).unwrap();
+        let reparsed: ConflictInfo = serde_json::from_str(&bytes).unwrap();
+        assert_eq!(
+            reparsed.remote_manifest_key.as_deref(),
+            Some("data/manifests/deadbeef")
+        );
     }
 }

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1677,6 +1677,8 @@ async fn upload_file_with_device_with_state(
                     let remote_manifest_path = current_remote_manifest_path
                         .clone()
                         .unwrap_or_else(|| remote_manifest.clone());
+                    let mut conflict_info = conflict_info.clone();
+                    conflict_info.remote_manifest_key = Some(remote_manifest_path.clone());
                     // Record local state with conflict info so `tcfs resolve` can find it
                     let mut sync_state = make_sync_state_full(
                         local_path,
@@ -1697,7 +1699,7 @@ async fn upload_file_with_device_with_state(
                             bytes: file_size,
                             vclock: sync_state.vclock.clone(),
                             skipped: true,
-                            outcome: Some(sync_outcome),
+                            outcome: Some(SyncOutcome::Conflict(conflict_info)),
                         },
                         Some(sync_state),
                     ));
@@ -5375,13 +5377,25 @@ mod tests {
         .unwrap();
 
         assert!(result.skipped);
-        assert!(matches!(result.outcome, Some(SyncOutcome::Conflict(_))));
+        let result_conflict = match result.outcome {
+            Some(SyncOutcome::Conflict(info)) => info,
+            other => panic!("expected conflict outcome, got: {other:?}"),
+        };
+        assert_eq!(
+            result_conflict.remote_manifest_key.as_deref(),
+            Some("data/manifests/remotehash123")
+        );
 
         let entry = state.get(&local).expect("conflicted state entry");
         assert_eq!(entry.status, FileSyncStatus::Conflict);
-        assert!(
-            entry.conflict.is_some(),
-            "conflict payload should be preserved"
+        assert_eq!(
+            entry
+                .conflict
+                .as_ref()
+                .expect("conflict payload should be preserved")
+                .remote_manifest_key
+                .as_deref(),
+            Some("data/manifests/remotehash123")
         );
     }
 

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -178,9 +178,11 @@ pub struct ExecutionResult {
     pub bytes_uploaded: u64,
     pub bytes_downloaded: u64,
     /// Ref-class `.git` actions (`refs/**`, `packed-refs`, `HEAD`) that were
-    /// deferred this run because an object action for the same repo failed
-    /// (objects-before-refs barrier). These are not errors: the next reconcile
-    /// cycle re-plans them once the objects land.
+    /// deferred this run rather than applied. Two causes, both fail-closed and
+    /// non-error: an object action for the same repo failed
+    /// (objects-before-refs barrier), or the repo's `.git/tcfs.lock` is held by
+    /// a live foreign holder (keep-both PR-2, S3). The next reconcile cycle
+    /// re-plans them once the objects land / the holder releases.
     pub deferred_git_refs: Vec<String>,
 }
 
@@ -804,6 +806,24 @@ fn git_ref_barrier_hit(rel_path: &str, local_root: &Path, barred: &BTreeSet<Path
         .is_some_and(|root| barred.contains(&root))
 }
 
+/// True when `rel_path` is a ref-class `.git` path whose enclosing repo is held
+/// by a live FOREIGN `.git/tcfs.lock` holder this run — the action must be
+/// deferred (keep-both PR-2, S3). Only ref-class paths (`refs/**`,
+/// `packed-refs`, `HEAD`, submodule ref-class) gate on the lock; object-class
+/// (`.git/objects/**`) and normal-file writes are content-addressed / atomic
+/// and proceed as today.
+fn git_ref_foreign_lock_hit(
+    rel_path: &str,
+    local_root: &Path,
+    foreign_locked: &BTreeSet<PathBuf>,
+) -> bool {
+    if foreign_locked.is_empty() || !is_git_ref_class_path(rel_path) {
+        return false;
+    }
+    git_safety::repo_root_for_git_path(local_root, rel_path)
+        .is_some_and(|root| foreign_locked.contains(&root))
+}
+
 /// Extract the plan-time head-ref pins carried by a `.git` fast-forward action
 /// (push or pull). Ordinary actions carry no pins and yield `None`.
 fn git_ff_ref_pins(action: &ReconcileAction) -> Option<&[GitRefPin]> {
@@ -835,20 +855,40 @@ fn git_ff_pins_still_valid(local_root: &Path, pins: &[GitRefPin]) -> bool {
     })
 }
 
+/// Outcome of acquiring cooperative `.git/tcfs.lock` guards for a plan.
+///
+/// keep-both PR-2 (S3): the executor no longer proceeds unconditionally when a
+/// repo's lock cannot be taken. A lock held by a FOREIGN live holder — another
+/// sync cycle or process, a PID `acquire_git_lock` could neither acquire nor
+/// steal as stale — means the cooperative lock fences nothing if we still write
+/// ref-class paths. Those repos are surfaced in `foreign_locked_repos` so the
+/// executor DEFERS their ref-class `.git` actions this run.
+struct GitLockAcquisition {
+    /// Held guards; dropping the vec (with the owning struct) releases all locks.
+    guards: Vec<git_safety::GitLockGuard>,
+    /// Repo roots whose `.git/tcfs.lock` is held by a live foreign holder that
+    /// could not be acquired or stolen-as-stale this run. Ref-class writes for
+    /// these repos are deferred (recorded, not errored); the next cycle
+    /// re-plans them once the holder releases. A STALE (dead-owner, aged) lock
+    /// is stolen by `acquire_git_lock` and returns `Ok`, so a leaked lock never
+    /// lands a repo here — no deadlock on a leaked lock.
+    foreign_locked_repos: BTreeSet<PathBuf>,
+}
+
 /// Acquire cooperative `.git/tcfs.lock` guards for every repo that has a
-/// `.git/*` Push or Pull action in `plan`. Returns the held guards; dropping the
-/// returned vec releases all locks. Repos whose `.git` is mid-operation or whose
-/// lock is already held are skipped (logged), so a busy repo does not abort the
-/// whole plan — it simply re-reconciles next cycle.
-fn acquire_git_locks_for_plan(
-    plan: &ReconcilePlan,
-    local_root: &Path,
-) -> Vec<git_safety::GitLockGuard> {
+/// `.git/*` write action in `plan`. Returns the held guards plus the set of
+/// repos whose lock is held by a live foreign holder (ref-class writes there
+/// must defer, keep-both PR-2). Repos whose `.git` is mid-operation are skipped
+/// (logged) and keep today's behavior — a busy repo simply re-reconciles next
+/// cycle.
+fn acquire_git_locks_for_plan(plan: &ReconcilePlan, local_root: &Path) -> GitLockAcquisition {
     let mut repos: BTreeSet<PathBuf> = BTreeSet::new();
     for action in &plan.actions {
         let rel = match action {
-            ReconcileAction::Push { rel_path, .. } => rel_path.as_str(),
-            ReconcileAction::Pull { rel_path, .. } => rel_path.as_str(),
+            ReconcileAction::Push { rel_path, .. }
+            | ReconcileAction::Pull { rel_path, .. }
+            | ReconcileAction::DeleteLocal { rel_path, .. }
+            | ReconcileAction::DeleteRemote { rel_path } => rel_path.as_str(),
             _ => continue,
         };
         if !is_git_internal_path(rel) {
@@ -860,6 +900,7 @@ fn acquire_git_locks_for_plan(
     }
 
     let mut guards = Vec::new();
+    let mut foreign_locked_repos: BTreeSet<PathBuf> = BTreeSet::new();
     for repo_root in repos {
         let git_dir = repo_root.join(".git");
         if !git_dir.is_dir() {
@@ -877,15 +918,25 @@ fn acquire_git_locks_for_plan(
         match git_safety::acquire_git_lock(&git_dir) {
             Ok(guard) => guards.push(guard),
             Err(e) => {
+                // A live FOREIGN holder owns this repo's `.git/tcfs.lock`. A
+                // stale (dead-owner, aged) lock would have been stolen and
+                // returned Ok, so this Err means the lock is genuinely held —
+                // writing ref-class paths anyway would race the holder. Record
+                // the repo so the executor DEFERS its ref-class actions this
+                // run (keep-both PR-2, S3) instead of proceeding unlocked.
                 warn!(
                     repo = %repo_root.display(),
                     error = %format!("{e:#}"),
-                    "git ff: could not acquire tcfs.lock; proceeding without lock"
+                    "git ff: foreign holder owns tcfs.lock; deferring ref-class writes for this repo"
                 );
+                foreign_locked_repos.insert(repo_root);
             }
         }
     }
-    guards
+    GitLockAcquisition {
+        guards,
+        foreign_locked_repos,
+    }
 }
 
 /// Classify a single path into a reconciliation action.
@@ -1056,7 +1107,7 @@ async fn compare_both_exist(
         remote_device,
     );
 
-    outcome_to_action(outcome, rel_path, local_path, remote_entry)
+    outcome_to_action(outcome, rel_path, local_path, remote_entry, &manifest_path)
 }
 
 /// Map a `SyncOutcome` to the corresponding `ReconcileAction`.
@@ -1069,6 +1120,7 @@ fn outcome_to_action(
     rel_path: &str,
     local_path: &Path,
     remote_entry: &RemoteIndexEntry,
+    remote_manifest_key: &str,
 ) -> ReconcileAction {
     match outcome {
         crate::conflict::SyncOutcome::UpToDate => ReconcileAction::UpToDate {
@@ -1085,10 +1137,21 @@ fn outcome_to_action(
             size: remote_entry.size,
             reason: PullReason::RemoteNewer,
         },
-        crate::conflict::SyncOutcome::Conflict(info) => ReconcileAction::Conflict {
-            rel_path: rel_path.to_string(),
-            info,
-        },
+        crate::conflict::SyncOutcome::Conflict(mut info) => {
+            // keep-both PR-2 data-model graft: capture the remote side's
+            // manifest storage key (the S3/prefix path this classification
+            // already computed to read the remote manifest). This is the only
+            // point where the remote manifest hash is in scope — the later
+            // record site (`ReconcileAction::Conflict` arm) holds only the
+            // local state entry — so populate it here; the value rides the
+            // `ConflictInfo` into the recorded conflict. A future PR-3 resolve
+            // verb fetches the remote ref SHA from this key.
+            info.remote_manifest_key = Some(remote_manifest_key.to_string());
+            ReconcileAction::Conflict {
+                rel_path: rel_path.to_string(),
+                info,
+            }
+        }
     }
 }
 
@@ -1473,10 +1536,36 @@ async fn compare_both_exist_symlink(
         remote_device,
     );
 
-    outcome_to_action(outcome, rel_path, local_path, remote_entry)
+    outcome_to_action(outcome, rel_path, local_path, remote_entry, &manifest_path)
 }
 
 // ── Execution ────────────────────────────────────────────────────────────────
+
+fn new_remote_pull_fast_path_safe(plan: &ReconcilePlan) -> bool {
+    plan.actions.iter().all(|action| {
+        matches!(
+            action,
+            ReconcileAction::Pull {
+                reason: PullReason::NewRemote,
+                ..
+            } | ReconcileAction::CreateDirectory { .. }
+                | ReconcileAction::UpToDate { .. }
+        )
+    }) && plan.actions.iter().any(|action| {
+        matches!(
+            action,
+            ReconcileAction::Pull {
+                reason: PullReason::NewRemote,
+                ..
+            }
+        )
+    }) && plan.actions.iter().all(|action| {
+        !matches!(
+            action,
+            ReconcileAction::Pull { rel_path, .. } if is_git_ref_class_path(rel_path)
+        )
+    })
+}
 
 /// Execute a reconciliation plan, performing all I/O operations.
 ///
@@ -1492,28 +1581,7 @@ pub async fn execute_plan(
     encryption: OptionalEncryption<'_>,
     progress: Option<&ProgressFn>,
 ) -> Result<ExecutionResult> {
-    if encryption.is_none()
-        && progress.is_none()
-        && plan.actions.iter().all(|action| {
-            matches!(
-                action,
-                ReconcileAction::Pull {
-                    reason: PullReason::NewRemote,
-                    ..
-                } | ReconcileAction::CreateDirectory { .. }
-                    | ReconcileAction::UpToDate { .. }
-            )
-        })
-        && plan.actions.iter().any(|action| {
-            matches!(
-                action,
-                ReconcileAction::Pull {
-                    reason: PullReason::NewRemote,
-                    ..
-                }
-            )
-        })
-    {
+    if encryption.is_none() && progress.is_none() && new_remote_pull_fast_path_safe(plan) {
         let result = execute_new_remote_pulls_concurrent(
             plan,
             op,
@@ -1539,12 +1607,17 @@ pub async fn execute_plan(
     // TOCTOU guard for raw `.git` sync: hold a cooperative `.git/tcfs.lock` for
     // every repo that has a `.git/*` action in this plan, for the whole execute
     // window. This stops a concurrent commit (which rewrites refs/index mid-run)
-    // from tearing the push. Best-effort: if a repo's lock cannot be acquired
-    // (another sync in progress) or the `.git` is mid-operation, we still run —
-    // the FF reclassifier only ever moves toward a fast-forward winner, and a
-    // failed/locked repo simply re-reconciles next cycle. Guards live for the
-    // duration of this function and drop (release) on return.
-    let _git_locks = acquire_git_locks_for_plan(plan, local_root);
+    // from tearing the push. keep-both PR-2 (S3): if a repo's lock is held by a
+    // live FOREIGN holder, the cooperative lock fences nothing were we to write
+    // ref-class paths anyway — so those repos' ref-class actions DEFER this run
+    // (see `git_ref_foreign_lock_hit` below); object-class and normal-file
+    // writes still proceed. A STALE (dead-owner, aged) lock is stolen on
+    // acquire, so a leaked lock never deadlocks a repo. Repos mid-`.git`
+    // operation keep today's behavior (skipped, re-reconciled next cycle).
+    // Guards live for the duration of this function and drop (release) on return.
+    let git_lock_acq = acquire_git_locks_for_plan(plan, local_root);
+    let foreign_locked_repos = &git_lock_acq.foreign_locked_repos;
+    let _git_locks = &git_lock_acq.guards;
 
     // Objects-before-refs BARRIER (per repo, both directions): the plan orders
     // `.git/objects/**` ahead of ref-class paths, but ordering alone is not a
@@ -1555,9 +1628,28 @@ pub async fn execute_plan(
     let mut git_object_failed_repos: BTreeSet<PathBuf> = BTreeSet::new();
 
     for action in &plan.actions {
-        if let ReconcileAction::Push { rel_path, .. } | ReconcileAction::Pull { rel_path, .. } =
-            action
-        {
+        let git_write_rel_path = match action {
+            ReconcileAction::Push { rel_path, .. }
+            | ReconcileAction::Pull { rel_path, .. }
+            | ReconcileAction::DeleteLocal { rel_path, .. }
+            | ReconcileAction::DeleteRemote { rel_path } => Some(rel_path),
+            _ => None,
+        };
+        if let Some(rel_path) = git_write_rel_path {
+            // keep-both PR-2 (S3): a live FOREIGN holder owns this repo's
+            // `.git/tcfs.lock`. Writing ref-class paths while another sync holds
+            // the lock races it, so DEFER this repo's ref-class actions this run
+            // (recorded, not errored); the next cycle re-plans them once the
+            // holder releases. Object-class and normal-file writes are
+            // unaffected — only ref-class paths gate on the lock.
+            if git_ref_foreign_lock_hit(rel_path, local_root, foreign_locked_repos) {
+                info!(
+                    path = %rel_path,
+                    "git lock: foreign holder owns .git/tcfs.lock; deferring ref action"
+                );
+                result.deferred_git_refs.push(rel_path.clone());
+                continue;
+            }
             if git_ref_barrier_hit(rel_path, local_root, &git_object_failed_repos) {
                 info!(
                     path = %rel_path,
@@ -1753,6 +1845,11 @@ pub async fn execute_plan(
                     } else {
                         info.times_recorded = 1;
                     }
+                    // keep-both PR-2: `info.remote_manifest_key` was populated at
+                    // classification (`outcome_to_action`), the only site where the
+                    // remote manifest storage key is in scope; it rides through here
+                    // unchanged so the recorded conflict carries the key a future
+                    // PR-3 resolve verb needs to fetch the remote ref SHA.
                     updated.conflict = Some(info);
                     state.set(Path::new(&key_owned), updated);
                 }
@@ -3090,5 +3187,229 @@ mod tests {
         // Object data and non-git paths → never veto.
         assert!(!ff_group_vetoes("repo/.git/objects/ab/cdef"));
         assert!(!ff_group_vetoes("repo/src/refs.rs"));
+    }
+
+    // ── keep-both PR-2 (S3): executor hard-respects a foreign `.git/tcfs.lock` ──
+
+    /// A `.git` Push action for `rel` (the class of the path is what matters to
+    /// the lock gate; `local_path`/reason are inert here).
+    fn git_push(rel: &str) -> ReconcileAction {
+        ReconcileAction::Push {
+            local_path: PathBuf::from(rel),
+            rel_path: rel.to_string(),
+            reason: PushReason::LocalNewer,
+        }
+    }
+
+    fn git_pull_new_remote(rel: &str) -> ReconcileAction {
+        ReconcileAction::Pull {
+            rel_path: rel.to_string(),
+            manifest_hash: "remote-manifest".to_string(),
+            size: 41,
+            reason: PullReason::NewRemote,
+        }
+    }
+
+    fn plan_of(actions: Vec<ReconcileAction>) -> ReconcilePlan {
+        ReconcilePlan {
+            actions,
+            summary: ReconcileSummary::default(),
+            device_id: "test-device".to_string(),
+            generated_at: 0,
+        }
+    }
+
+    /// Backdate a lock file's mtime past the staleness threshold, so the ONLY
+    /// variable between the live-owner and dead-owner tests is owner liveness.
+    fn age_lock(lock_path: &Path) {
+        let old = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        let f = std::fs::File::options()
+            .write(true)
+            .open(lock_path)
+            .unwrap();
+        f.set_times(std::fs::FileTimes::new().set_modified(old))
+            .unwrap();
+    }
+
+    /// (test a) A FOREIGN live holder of `.git/tcfs.lock` forces this repo's
+    /// ref-class `.git` writes to DEFER, while object-class and normal-file
+    /// writes are unaffected. Fail-before: without the foreign-lock plumbing the
+    /// executor took no note of the held lock and wrote refs anyway.
+    #[test]
+    fn foreign_live_lock_defers_ref_class_writes_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let git_dir = local_root.join("repo/.git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+
+        // Simulate a live FOREIGN holder: lock owned by PID 1 (init/launchd —
+        // always alive, genuinely not this process), backdated past staleness so
+        // youth is not what keeps it held. A live owner is never stolen.
+        let lock_path = git_dir.join("tcfs.lock");
+        std::fs::write(&lock_path, "1 0\n").unwrap();
+        age_lock(&lock_path);
+
+        let plan = plan_of(vec![
+            git_push("repo/.git/refs/heads/main"), // ref-class → defers
+            git_push("repo/.git/objects/ab/cdef01234567"), // object-class → runs
+            git_push("repo/notes.txt"),            // normal file → runs
+        ]);
+
+        let acq = acquire_git_locks_for_plan(&plan, local_root);
+        let repo_root = local_root.join("repo");
+
+        assert!(
+            acq.foreign_locked_repos.contains(&repo_root),
+            "a live foreign tcfs.lock holder must mark the repo foreign-locked"
+        );
+        assert!(
+            acq.guards.is_empty(),
+            "no guard is acquired while a foreign holder lives"
+        );
+        assert!(
+            lock_path.exists(),
+            "the foreign holder's lock must be left in place"
+        );
+
+        // Only ref-class paths in the foreign-locked repo defer.
+        assert!(
+            git_ref_foreign_lock_hit(
+                "repo/.git/refs/heads/main",
+                local_root,
+                &acq.foreign_locked_repos
+            ),
+            "ref-class write must defer under a foreign lock"
+        );
+        assert!(
+            !git_ref_foreign_lock_hit(
+                "repo/.git/objects/ab/cdef01234567",
+                local_root,
+                &acq.foreign_locked_repos
+            ),
+            "object-class write proceeds (content-addressed, never conflicts)"
+        );
+        assert!(
+            !git_ref_foreign_lock_hit("repo/notes.txt", local_root, &acq.foreign_locked_repos),
+            "normal-file write proceeds"
+        );
+    }
+
+    /// (test c) The all-NewRemote concurrent pull fast path returns before
+    /// normal execute-plan lock acquisition. It must therefore refuse plans
+    /// containing ref-class `.git` pulls and let the main executor path apply
+    /// the foreign-lock gate.
+    #[test]
+    fn new_remote_ref_class_pull_disables_pre_lock_fast_path() {
+        let normal_plan = plan_of(vec![
+            git_pull_new_remote("repo/.git/objects/ab/cdef01234567"),
+            ReconcileAction::CreateDirectory {
+                rel_path: "repo/.git/objects/ab".to_string(),
+            },
+        ]);
+        assert!(
+            new_remote_pull_fast_path_safe(&normal_plan),
+            "object-class new-remote pulls may still use the concurrent fast path"
+        );
+
+        let ref_plan = plan_of(vec![git_pull_new_remote("repo/.git/refs/heads/main")]);
+        assert!(
+            !new_remote_pull_fast_path_safe(&ref_plan),
+            "ref-class new-remote pulls must go through the locked executor path"
+        );
+
+        let submodule_ref_plan = plan_of(vec![git_pull_new_remote(
+            "repo/.git/modules/sub/refs/heads/main",
+        )]);
+        assert!(
+            !new_remote_pull_fast_path_safe(&submodule_ref_plan),
+            "submodule ref-class pulls must also go through the locked executor path"
+        );
+    }
+
+    /// (test d) Ref-class deletes are writes too: a plan containing only a
+    /// delete must still discover a live foreign `.git/tcfs.lock` holder so the
+    /// main executor can defer it instead of removing the ref through the lock.
+    #[test]
+    fn foreign_lock_acquisition_covers_ref_class_deletes() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let git_dir = local_root.join("repo/.git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+
+        let lock_path = git_dir.join("tcfs.lock");
+        std::fs::write(&lock_path, "1 0\n").unwrap();
+        age_lock(&lock_path);
+
+        let plan = plan_of(vec![
+            ReconcileAction::DeleteLocal {
+                local_path: local_root.join("repo/.git/refs/heads/main"),
+                rel_path: "repo/.git/refs/heads/main".to_string(),
+            },
+            ReconcileAction::DeleteRemote {
+                rel_path: "repo/.git/packed-refs".to_string(),
+            },
+        ]);
+        let acq = acquire_git_locks_for_plan(&plan, local_root);
+        let repo_root = local_root.join("repo");
+
+        assert!(
+            acq.foreign_locked_repos.contains(&repo_root),
+            "delete-only ref-class plans must still mark the repo foreign-locked"
+        );
+        assert!(
+            git_ref_foreign_lock_hit(
+                "repo/.git/refs/heads/main",
+                local_root,
+                &acq.foreign_locked_repos
+            ),
+            "local ref delete must defer under a foreign lock"
+        );
+        assert!(
+            git_ref_foreign_lock_hit(
+                "repo/.git/packed-refs",
+                local_root,
+                &acq.foreign_locked_repos
+            ),
+            "remote packed-refs delete must defer under a foreign lock"
+        );
+    }
+
+    /// (test b) A STALE lock (dead owner, aged past the threshold) is stolen on
+    /// acquire and yields a held guard — a leaked lock must NEVER deadlock this
+    /// repo's ref-class writes. Same fixture as (a) but a dead PID.
+    #[test]
+    fn stale_dead_lock_is_stealable_no_deadlock() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let git_dir = local_root.join("repo/.git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+
+        // Leaked lock: dead owner PID (far past any real pid space), aged past
+        // the staleness threshold. Must be stolen, not treated as foreign-held.
+        let lock_path = git_dir.join("tcfs.lock");
+        std::fs::write(&lock_path, "999999999 0\n").unwrap();
+        age_lock(&lock_path);
+
+        let plan = plan_of(vec![git_push("repo/.git/refs/heads/main")]);
+        let acq = acquire_git_locks_for_plan(&plan, local_root);
+        let repo_root = local_root.join("repo");
+
+        assert!(
+            !acq.foreign_locked_repos.contains(&repo_root),
+            "a stale dead-owner lock must be stolen, not deferred as foreign-held"
+        );
+        assert_eq!(
+            acq.guards.len(),
+            1,
+            "stealing the stale lock yields exactly one held guard (no deadlock)"
+        );
+        assert!(
+            !git_ref_foreign_lock_hit(
+                "repo/.git/refs/heads/main",
+                local_root,
+                &acq.foreign_locked_repos
+            ),
+            "ref-class writes proceed once the stale lock is stolen"
+        );
     }
 }

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -488,6 +488,12 @@ impl StateCache {
     ) -> bool {
         let key = path_key(local_path);
         if let Some(entry) = self.entries.get_mut(&key) {
+            let mut conflict = conflict;
+            if conflict.remote_manifest_key.is_none() {
+                if let Some(existing) = entry.conflict.as_ref() {
+                    conflict.remote_manifest_key = existing.remote_manifest_key.clone();
+                }
+            }
             entry.conflict = Some(conflict);
             entry.status = FileSyncStatus::Conflict;
             self.dirty = true;
@@ -1481,6 +1487,7 @@ mod tests {
             remote_device: "honey".into(),
             detected_at: 1700000000,
             times_recorded: 0,
+            remote_manifest_key: None,
         };
 
         cache.set(
@@ -1559,6 +1566,7 @@ mod tests {
                     remote_device: "honey".into(),
                     detected_at: 0,
                     times_recorded: 0,
+                    remote_manifest_key: None,
                 }),
                 status: FileSyncStatus::Conflict,
             },
@@ -1613,6 +1621,7 @@ mod tests {
                         remote_device: "honey".into(),
                         detected_at: 0,
                         times_recorded: 0,
+                        remote_manifest_key: None,
                     }),
                     status: FileSyncStatus::Conflict,
                 },
@@ -1682,6 +1691,7 @@ mod tests {
             remote_device: "honey".into(),
             detected_at: 0,
             times_recorded: 0,
+            remote_manifest_key: None,
         };
 
         assert!(cache.mark_conflict(&file_path, conflict.clone()));
@@ -1692,6 +1702,83 @@ mod tests {
         assert_eq!(stored.rel_path, conflict.rel_path);
         assert_eq!(stored.local_device, conflict.local_device);
         assert_eq!(stored.remote_device, conflict.remote_device);
+    }
+
+    #[test]
+    fn mark_conflict_preserves_existing_remote_manifest_key_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut cache = StateCache::open(&path).unwrap();
+
+        let file_path = dir.path().join("conflicted.txt");
+        std::fs::write(&file_path, b"data").unwrap();
+
+        cache.set(
+            &file_path,
+            SyncState {
+                blake3: "abc".into(),
+                size: 4,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/index/conflicted.txt".into(),
+                last_synced: 0,
+                vclock: VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: None,
+                status: FileSyncStatus::Synced,
+            },
+        );
+
+        let mut conflict = crate::conflict::ConflictInfo {
+            rel_path: "conflicted.txt".into(),
+            local_vclock: VectorClock::new(),
+            remote_vclock: VectorClock::new(),
+            local_blake3: "abc".into(),
+            remote_blake3: "def".into(),
+            local_device: "neo".into(),
+            remote_device: "honey".into(),
+            detected_at: 0,
+            times_recorded: 0,
+            remote_manifest_key: Some("data/manifests/first".into()),
+        };
+        assert!(cache.mark_conflict(&file_path, conflict.clone()));
+
+        conflict.remote_manifest_key = None;
+        assert!(cache.mark_conflict(&file_path, conflict));
+        assert_eq!(
+            cache
+                .get(&file_path)
+                .unwrap()
+                .conflict
+                .as_ref()
+                .unwrap()
+                .remote_manifest_key
+                .as_deref(),
+            Some("data/manifests/first")
+        );
+
+        let replacement = crate::conflict::ConflictInfo {
+            remote_manifest_key: Some("data/manifests/replacement".into()),
+            ..cache
+                .get(&file_path)
+                .unwrap()
+                .conflict
+                .as_ref()
+                .unwrap()
+                .clone()
+        };
+        assert!(cache.mark_conflict(&file_path, replacement));
+        assert_eq!(
+            cache
+                .get(&file_path)
+                .unwrap()
+                .conflict
+                .as_ref()
+                .unwrap()
+                .remote_manifest_key
+                .as_deref(),
+            Some("data/manifests/replacement")
+        );
     }
 
     #[test]

--- a/crates/tcfs-sync/tests/e2e_conflict_resolution.rs
+++ b/crates/tcfs-sync/tests/e2e_conflict_resolution.rs
@@ -155,6 +155,7 @@ fn resolution_variants_exhaustive() {
         remote_device: "device-b".into(),
         detected_at: 1700000000,
         times_recorded: 0,
+        remote_manifest_key: None,
     };
 
     // KeepLocal: local_device < remote_device => AutoResolver picks KeepLocal
@@ -400,6 +401,7 @@ fn auto_resolver_deterministic() {
         remote_device: "device-a".into(),
         detected_at: 0,
         times_recorded: 0,
+        remote_manifest_key: None,
     };
 
     let resolver = AutoResolver;

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -1828,7 +1828,9 @@ async fn handle_auto_pull(
             )
             .await
         }
-        tcfs_sync::conflict::SyncOutcome::Conflict(ref conflict_info) => {
+        tcfs_sync::conflict::SyncOutcome::Conflict(conflict_info) => {
+            let mut conflict_info = conflict_info;
+            conflict_info.remote_manifest_key = Some(manifest_path.to_string());
             // keep-both PR-1 (safety invariant S2): automatic per-file
             // resolution must NEVER touch `.git` internals. AutoResolver's
             // lexicographic KeepRemote would auto-download the remote ref/index
@@ -1860,7 +1862,7 @@ async fn handle_auto_pull(
                 "conflict detected, applying AutoResolver"
             );
             let resolver = tcfs_sync::conflict::AutoResolver;
-            match resolver.resolve(conflict_info) {
+            match resolver.resolve(&conflict_info) {
                 Some(tcfs_sync::conflict::Resolution::KeepLocal) => {
                     info!(path = %rel_path, "AutoResolver: keeping local");
                 }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -4013,6 +4013,7 @@ mod tests {
             remote_device: "honey".into(),
             detected_at: 43,
             times_recorded: 1,
+            remote_manifest_key: None,
         });
 
         {
@@ -4058,6 +4059,7 @@ mod tests {
             remote_device: "honey".into(),
             detected_at: 44,
             times_recorded: 1,
+            remote_manifest_key: None,
         });
 
         {

--- a/crates/tcfsd/tests/watcher_conflict_no_entry.rs
+++ b/crates/tcfsd/tests/watcher_conflict_no_entry.rs
@@ -20,6 +20,7 @@ fn sample_info() -> ConflictInfo {
         remote_device: "remote".to_string(),
         detected_at: 0,
         times_recorded: 0,
+        remote_manifest_key: None,
     }
 }
 


### PR DESCRIPTION
## Summary

PR-2 prerequisite hardening for divergent `.git` keep-both: make the executor hard-respect foreign `.git/tcfs.lock` holders for ref-class writes and persist the remote manifest key on conflict records so the future keep-both verb can fetch the remote ref blob directly.

Linear: TIN-2548
Design: #523
Depends on: #526, #527

## Changes

- Add `ConflictInfo.remote_manifest_key: Option<String>` with serde-default back-compat.
- Populate the manifest key from reconcile classification, engine upload conflicts, and daemon auto-conflict handling.
- Preserve an existing manifest key in `StateCache::mark_conflict` when a legacy caller supplies `None`.
- Defer ref-class `.git` writes when a live foreign `.git/tcfs.lock` holder exists.
- Include ref-class deletes in lock acquisition/defer handling.
- Disable the all-`NewRemote` concurrent pull fast path for ref-class `.git` pulls so those writes go through the lock-aware executor.
- Add targeted regression coverage for stale-lock stealing, foreign-lock defer behavior, delete-only ref plans, fast-path exclusion, serde back-compat, and manifest-key preservation.

## Test plan

- [ ] `task test` passes locally
- [ ] `task lint` passes locally
- [x] `cargo fmt --all -- --check` passes locally
- [x] `git diff --check origin/main...HEAD` passes locally
- [x] Independent read-only review of lock-defer semantics: clean after fixes
- [x] Independent read-only review of manifest-key data model: clean after fixes
- [ ] GitHub Actions remote CI green

Local build/test tasks intentionally not run on neo; expensive validation should stay on GitHub Actions / remote build infrastructure.

## Checklist

- [ ] Docs updated (if user-facing behavior changed)
- [ ] CHANGELOG.md updated (if applicable)
- [x] No secrets or credentials in diff
