### PR TITLE
feat(sync): add repo git keep-both resolver

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -322,16 +322,19 @@ enum Commands {
         state: Option<PathBuf>,
     },
 
-    /// Resolve a sync conflict for a file
+    /// Resolve a sync conflict for a file or git repo group
     ///
     /// When two devices modify the same file without syncing, a conflict is
     /// detected. Use this command to pick a resolution strategy.
     Resolve {
-        /// Path to the conflicted file
+        /// Path to the conflicted file, or a git repo root for repo-group keep-both
         path: PathBuf,
         /// Resolution strategy: keep-local, keep-remote, keep-both, or defer
         #[arg(long, short = 's', value_parser = ["keep-local", "keep-remote", "keep-both", "defer"])]
         strategy: Option<String>,
+        /// Execute repo-group git keep-both. Without this flag, repo mode is a dry-run.
+        #[arg(long)]
+        execute: bool,
     },
 
     /// List recorded sync conflicts (read-only)
@@ -906,14 +909,18 @@ async fn main() -> Result<()> {
         } => cmd_rm(&config, &path, prefix.as_deref(), state.as_deref()).await,
         Commands::Trash { action } => cmd_trash(&config, action).await,
         Commands::MigratePrefix { dry_run } => cmd_migrate_prefix(&config, dry_run).await,
-        Commands::Resolve { path, strategy } => {
+        Commands::Resolve {
+            path,
+            strategy,
+            execute,
+        } => {
             #[cfg(unix)]
             {
-                cmd_resolve(&config, &path, strategy.as_deref()).await
+                cmd_resolve(&config, &path, strategy.as_deref(), execute).await
             }
             #[cfg(not(unix))]
             {
-                let _ = (path, strategy);
+                let _ = (path, strategy, execute);
                 anyhow::bail!(
                     "resolve command requires the daemon (not available on this platform)"
                 )
@@ -6686,10 +6693,30 @@ async fn cmd_resolve(
     config: &tcfs_core::config::TcfsConfig,
     path: &Path,
     strategy: Option<&str>,
+    execute: bool,
 ) -> Result<()> {
-    let resolution = match strategy {
-        Some(s) => s.replace('-', "_"),
-        None => {
+    let is_git_repo = path.join(".git").is_dir();
+    let requested = strategy.map(|s| s.replace('-', "_"));
+
+    let resolution = match (is_git_repo, requested.as_deref()) {
+        (true, None) | (true, Some("keep_both")) => {
+            if execute {
+                "git_keep_both_execute".to_string()
+            } else {
+                "git_keep_both_dry_run".to_string()
+            }
+        }
+        (true, Some(other)) => {
+            anyhow::bail!(
+                "repo-group conflict resolution for {} supports keep-both only, got {other}",
+                path.display()
+            );
+        }
+        (false, Some(_)) if execute => {
+            anyhow::bail!("--execute is only valid for repo-group git keep-both resolution");
+        }
+        (false, Some(s)) => s.to_string(),
+        (false, None) => {
             // Interactive mode: reuse the existing interactive resolver.
             //
             // keep-both PR-1: fetch the REAL recorded ConflictInfo for this
@@ -6742,8 +6769,21 @@ async fn cmd_resolve(
         .into_inner();
 
     if resp.success {
-        println!("Conflict resolved ({}): {}", resolution, path.display());
-        if !resp.resolved_path.is_empty() && resp.resolved_path != path.to_string_lossy() {
+        let is_repo_mode = resolution.starts_with("git_keep_both_");
+        if is_repo_mode {
+            if !resp.error.is_empty() {
+                println!("{}", resp.error);
+            }
+            if !execute {
+                println!("Dry-run only. Re-run with --execute to mutate refs and clear conflicts.");
+            }
+        } else {
+            println!("Conflict resolved ({}): {}", resolution, path.display());
+        }
+        if !is_repo_mode
+            && !resp.resolved_path.is_empty()
+            && resp.resolved_path != path.to_string_lossy()
+        {
             println!("  Conflict copy: {}", resp.resolved_path);
         }
     } else {
@@ -7013,7 +7053,7 @@ async fn cmd_conflicts(
                     );
                 }
                 println!(
-                    "  resolve: tcfs resolve {} --keep-both   (repo-group; not yet available in this build)",
+                    "  resolve: tcfs resolve {} --strategy keep-both --execute   (repo-group)",
                     root
                 );
             }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -6762,6 +6762,10 @@ async fn cmd_resolve(
             tcfs_core::proto::ResolveConflictRequest {
                 path: path.to_string_lossy().to_string(),
                 resolution: resolution.clone(),
+                // Operator provenance: this is the human-driven `tcfs resolve`
+                // CLI. It is the ONLY caller allowed to reach the repo-group
+                // git keep-both write path (grpc gates git_keep_both_* on this).
+                operator_cli: true,
             },
         ))
         .await

--- a/crates/tcfs-core/src/proto/tcfs.proto
+++ b/crates/tcfs-core/src/proto/tcfs.proto
@@ -170,6 +170,12 @@ message CredentialStatusResponse {
 message ResolveConflictRequest {
   string path = 1;
   string resolution = 2;
+  // Operator provenance marker. Set ONLY by the `tcfs resolve` CLI. It gates
+  // the live `.git` WRITE path (repo-group git keep-both): the daemon refuses
+  // `git_keep_both_dry_run` / `git_keep_both_execute` unless this is true. The
+  // MCP `resolve_conflict` tool's input does NOT expose this field, so an MCP /
+  // automated / NATS client can never forge operator deliberation.
+  bool operator_cli = 3;
 }
 message ResolveConflictResponse {
   bool success = 1;

--- a/crates/tcfs-mcp/src/server.rs
+++ b/crates/tcfs-mcp/src/server.rs
@@ -241,12 +241,31 @@ impl TcfsMcp {
         &self,
         Parameters(input): Parameters<ResolveConflictInput>,
     ) -> String {
+        // Repo-group git keep-both (`git_keep_both_dry_run` /
+        // `git_keep_both_execute`) is a live `.git` WRITE path that parks peer
+        // branch heads and ticks the local clock to dominate the fleet. It MUST
+        // be operator-deliberate and reachable ONLY from the `tcfs resolve`
+        // CLI — never an MCP agent. Refuse it here (layer 1); the daemon also
+        // refuses it without operator-CLI provenance (layer 2), and this tool's
+        // input intentionally cannot set that provenance flag.
+        if input.resolution.trim_start().starts_with("git_keep_both") {
+            return serde_json::json!({
+                "error": "repo-group git keep-both is operator-only and cannot be run through \
+                          MCP: it is a live .git write path that parks peer branch heads. Run it \
+                          deliberately from the CLI: `tcfs resolve <repo> --strategy keep-both \
+                          [--execute]`.",
+            })
+            .to_string();
+        }
         match self.connect().await {
             Ok(mut client) => {
                 match client
                     .resolve_conflict(ResolveConflictRequest {
                         path: input.rel_path.clone(),
                         resolution: input.resolution.clone(),
+                        // MCP is never operator-CLI provenance. The daemon
+                        // refuses git_keep_both_* without this being true.
+                        operator_cli: false,
                     })
                     .await
                 {
@@ -835,10 +854,41 @@ mod tests {
             vec![ResolveConflictRequest {
                 path: "docs/report.md".into(),
                 resolution: "keep_both".into(),
+                operator_cli: false,
             }]
         );
 
         harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn resolve_conflict_rejects_repo_git_keep_both() {
+        // BLOCKING 1a: the repo-group git keep-both write path must be
+        // unreachable from MCP. Both dry-run and execute must be refused BEFORE
+        // any RPC / connection is attempted. Point the client at a bogus socket
+        // that no daemon serves: if the guard short-circuited correctly we get
+        // the operator-only refusal; a "failed to connect" error would instead
+        // prove the request leaked toward the daemon.
+        let bogus = std::path::PathBuf::from("/nonexistent/tcfs-keep-both-guard.sock");
+        let mcp = TcfsMcp::new(bogus, None);
+        for resolution in ["git_keep_both_dry_run", "git_keep_both_execute"] {
+            let value = parse_json(
+                mcp.resolve_conflict(Parameters(ResolveConflictInput {
+                    rel_path: "myrepo".into(),
+                    resolution: resolution.into(),
+                }))
+                .await,
+            );
+            let err = value["error"].as_str().unwrap_or_default();
+            assert!(
+                err.contains("operator-only"),
+                "{resolution} must be refused with operator-only guidance, got: {value}"
+            );
+            assert!(
+                !err.contains("connect"),
+                "{resolution} must be refused BEFORE any daemon connection, got: {value}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tcfs-sync/src/blacklist.rs
+++ b/crates/tcfs-sync/src/blacklist.rs
@@ -42,6 +42,14 @@ pub enum BlacklistReason {
     /// with `git_sync_mode="raw"` (M-3 / PR #513). `Cargo.lock` / `flake.lock`
     /// live OUTSIDE `.git`, so they are unaffected.
     GitLockFile,
+    /// Fail-closed undo-bundle fence: any path containing a `.git/tcfs-undo/`
+    /// segment — the legacy in-tree location of the keep-both undo bundle. The
+    /// bundle now lives under the machine-local state dir (see
+    /// `conflict_git::write_undo_bundle`), but a pre-existing in-tree bundle
+    /// (full-history `git bundle --all`, fresh uuid, never GC'd) must never
+    /// roam. Always denied, even under `sync_git_dirs=true` /
+    /// `git_sync_mode="raw"` (BLOCKING 2 / #529).
+    GitTcfsUndo,
     /// VFS internal directory marker (.tcfs_dir).
     VfsMarker,
 }
@@ -58,6 +66,7 @@ impl std::fmt::Display for BlacklistReason {
             BlacklistReason::GitFilePointer => write!(f, "gitfile pointer (linked worktree)"),
             BlacklistReason::GitWorktreesAdmin => write!(f, ".git/worktrees admin area"),
             BlacklistReason::GitLockFile => write!(f, "git lockfile"),
+            BlacklistReason::GitTcfsUndo => write!(f, ".git/tcfs-undo bundle"),
             BlacklistReason::VfsMarker => write!(f, "VFS marker"),
         }
     }
@@ -132,6 +141,27 @@ fn has_git_worktrees_segment(path: &Path) -> bool {
         match component {
             std::path::Component::Normal(name) => {
                 if prev_was_dot_git && name == "worktrees" {
+                    return true;
+                }
+                prev_was_dot_git = name == ".git";
+            }
+            _ => prev_was_dot_git = false,
+        }
+    }
+    false
+}
+
+/// True when `path` contains a `.git/tcfs-undo/` segment — the legacy in-tree
+/// location of the keep-both undo bundle (a full-history `git bundle --all`
+/// with a fresh uuid, never GC'd). The bundle now lives under the machine-local
+/// state dir, but a pre-existing in-tree bundle must never roam as an ordinary
+/// `.git/**` file. Fail-closed regardless of config (BLOCKING 2 / #529).
+fn has_git_tcfs_undo_segment(path: &Path) -> bool {
+    let mut prev_was_dot_git = false;
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(name) => {
+                if prev_was_dot_git && name == "tcfs-undo" {
                     return true;
                 }
                 prev_was_dot_git = name == ".git";
@@ -324,6 +354,10 @@ impl Blacklist {
             debug!(path = %path.display(), "fencing git lockfile: never roams");
             return Some(BlacklistReason::GitLockFile);
         }
+        if has_git_tcfs_undo_segment(path) {
+            debug!(path = %path.display(), "fencing .git/tcfs-undo bundle: never roams");
+            return Some(BlacklistReason::GitTcfsUndo);
+        }
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             self.check_name(name, is_dir)
         } else {
@@ -357,6 +391,10 @@ impl Blacklist {
         if is_git_lockfile_path(path) {
             debug!(path = %path.display(), "fencing git lockfile: never roams");
             return Some(BlacklistReason::GitLockFile);
+        }
+        if has_git_tcfs_undo_segment(path) {
+            debug!(path = %path.display(), "fencing .git/tcfs-undo bundle: never roams");
+            return Some(BlacklistReason::GitTcfsUndo);
         }
         for component in path.components() {
             if let std::path::Component::Normal(name) = component {
@@ -763,6 +801,32 @@ mod tests {
         assert_eq!(bl.check(Path::new("repo/Cargo.lock"), false), None);
         assert_eq!(bl.check(Path::new("repo/flake.lock"), false), None);
         assert_eq!(bl.check_name("Cargo.lock", false), None);
+    }
+
+    // --- BLOCKING 2 / #529: in-tree keep-both undo bundle never roams ---
+    #[test]
+    fn test_git_tcfs_undo_denied_even_under_raw() {
+        // The undo bundle now lives under the state dir, but a pre-existing
+        // in-tree `.git/tcfs-undo/**` bundle must be fenced fail-closed even
+        // with sync_git_dirs=true + git_sync_mode="raw".
+        let bl = Blacklist::new(&[], true, true, "raw");
+        for p in [
+            "repo/.git/tcfs-undo/keep-both-abc.bundle",
+            "repo/vendor/dep/.git/tcfs-undo/keep-both-xyz.bundle",
+        ] {
+            assert_eq!(
+                bl.check(Path::new(p), false),
+                Some(BlacklistReason::GitTcfsUndo),
+                "{p} must be undo-fenced via check()"
+            );
+            assert_eq!(
+                bl.check_path_components(Path::new(p)),
+                Some(BlacklistReason::GitTcfsUndo),
+                "{p} must be undo-fenced via component walk"
+            );
+        }
+        // A dir named `tcfs-undo` NOT under `.git` is a normal dir.
+        assert_eq!(bl.check(Path::new("repo/tcfs-undo/notes.md"), false), None);
     }
 
     #[test]

--- a/crates/tcfs-sync/src/conflict_git.rs
+++ b/crates/tcfs-sync/src/conflict_git.rs
@@ -1,0 +1,639 @@
+//! Repo-group `.git` conflict resolution helpers.
+//!
+//! Per-file conflict resolution is intentionally fenced away from `.git`
+//! internals. A divergent raw-git repo has to be resolved as one group: inspect
+//! the recorded conflicts, park the remote branch heads under a TCFS namespace,
+//! verify the repository before/after, then clear the group atomically.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, bail, Context, Result};
+use opendal::Operator;
+use uuid::Uuid;
+
+use crate::engine::{self, OptionalEncryption};
+use crate::git_safety;
+use crate::state::{FileSyncStatus, StateCache};
+
+/// User-visible mode for repo-group keep-both resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitKeepBothMode {
+    /// Validate and print the planned operation. No refs or state entries are
+    /// mutated.
+    DryRun,
+    /// Apply the plan after all preconditions pass.
+    Execute,
+}
+
+impl GitKeepBothMode {
+    pub fn is_execute(self) -> bool {
+        self == Self::Execute
+    }
+}
+
+/// One branch head that would be, or was, parked under `refs/tcfs/theirs/**`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitKeepBothParkedRef {
+    pub conflict_rel_path: String,
+    pub head_ref: String,
+    pub park_ref: String,
+    pub local_sha: String,
+    pub remote_sha: String,
+    pub cache_key: String,
+}
+
+/// Outcome from repo-group keep-both resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitKeepBothResult {
+    pub repo_root: PathBuf,
+    pub mode: GitKeepBothMode,
+    pub parked_refs: Vec<GitKeepBothParkedRef>,
+    pub undo_bundle: Option<PathBuf>,
+}
+
+impl GitKeepBothResult {
+    pub fn summary(&self) -> String {
+        let action = match self.mode {
+            GitKeepBothMode::DryRun => "dry-run",
+            GitKeepBothMode::Execute => "executed",
+        };
+        format!(
+            "git keep-both {action}: {} ref(s) for {}",
+            self.parked_refs.len(),
+            self.repo_root.display()
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GitConflictCandidate {
+    cache_key: String,
+    rel_path: String,
+    head_ref: String,
+    remote_manifest_key: String,
+    remote_device: String,
+    resolved_vclock: crate::conflict::VectorClock,
+}
+
+#[derive(Debug, Clone)]
+struct AppliedParkRef {
+    ref_name: String,
+    previous_sha: Option<String>,
+}
+
+/// Resolve a raw `.git` divergent conflict group by parking the remote branch
+/// heads under `refs/tcfs/theirs/<device>/heads/**`.
+///
+/// This PR-3 helper handles the winner-side operation only. It does not create
+/// merge commits, push to remote storage, or claim broad daily-driver safety.
+/// A later reconcile/upload cycle publishes the updated refs through the normal
+/// object-before-ref path.
+pub async fn resolve_repo_keep_both(
+    op: &Operator,
+    state: &mut StateCache,
+    repo_root: &Path,
+    remote_prefix: &str,
+    device_id: &str,
+    mode: GitKeepBothMode,
+    encryption: OptionalEncryption<'_>,
+) -> Result<GitKeepBothResult> {
+    let repo_root = repo_root
+        .canonicalize()
+        .with_context(|| format!("canonicalizing repo root: {}", repo_root.display()))?;
+    let git_dir = repo_root.join(".git");
+    if !git_dir.is_dir() {
+        bail!("{} is not a git repository root", repo_root.display());
+    }
+
+    let candidates = collect_repo_conflicts(state, &repo_root)?;
+    if candidates.is_empty() {
+        return Ok(GitKeepBothResult {
+            repo_root,
+            mode,
+            parked_refs: Vec::new(),
+            undo_bundle: None,
+        });
+    }
+
+    let safety = git_safety::git_is_safe(&git_dir);
+    if !safety.blocking.is_empty() {
+        bail!("git repository is busy: {}", safety.blocking.join("; "));
+    }
+    ensure_clean_worktree(&repo_root)?;
+    run_git(&repo_root, &["fsck", "--full"]).context("pre-resolution git fsck")?;
+
+    let mut parked_refs = Vec::with_capacity(candidates.len());
+    for candidate in &candidates {
+        let remote_sha = read_remote_ref_sha(
+            op,
+            &candidate.remote_manifest_key,
+            remote_prefix,
+            device_id,
+            encryption,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "reading remote ref for {} from {}",
+                candidate.rel_path, candidate.remote_manifest_key
+            )
+        })?;
+        ensure_commit_present(&repo_root, &remote_sha)?;
+        let local_sha = git_safety::local_ref_sha(&repo_root, &candidate.head_ref)
+            .ok_or_else(|| anyhow!("local ref is missing: {}", candidate.head_ref))?;
+        if local_sha == remote_sha {
+            bail!(
+                "{} is no longer divergent; rerun reconcile before keep-both",
+                candidate.head_ref
+            );
+        }
+        let park_ref = park_ref_for(&candidate.remote_device, &candidate.head_ref)?;
+        ensure_park_ref_available(&repo_root, &park_ref, &remote_sha)?;
+        parked_refs.push(GitKeepBothParkedRef {
+            conflict_rel_path: candidate.rel_path.clone(),
+            head_ref: candidate.head_ref.clone(),
+            park_ref,
+            local_sha,
+            remote_sha,
+            cache_key: candidate.cache_key.clone(),
+        });
+    }
+
+    if mode == GitKeepBothMode::DryRun {
+        return Ok(GitKeepBothResult {
+            repo_root,
+            mode,
+            parked_refs,
+            undo_bundle: None,
+        });
+    }
+
+    let _guard = git_safety::acquire_git_lock(&git_dir)
+        .with_context(|| format!("acquiring {}", git_dir.join("tcfs.lock").display()))?;
+
+    // Re-check after acquiring the cooperative lock. The lock protects TCFS
+    // peers; a local git command may still have started immediately before the
+    // lock landed.
+    let safety = git_safety::git_is_safe(&git_dir);
+    if !safety.blocking.is_empty() {
+        bail!("git repository became busy: {}", safety.blocking.join("; "));
+    }
+    ensure_clean_worktree(&repo_root)?;
+    run_git(&repo_root, &["fsck", "--full"]).context("locked pre-resolution git fsck")?;
+
+    for parked in &parked_refs {
+        ensure_local_ref_still_pinned(&repo_root, parked)?;
+        ensure_park_ref_available(&repo_root, &parked.park_ref, &parked.remote_sha)?;
+    }
+
+    let undo_bundle = write_undo_bundle(&repo_root)?;
+    let mut applied = Vec::new();
+    for parked in &parked_refs {
+        if git_safety::local_ref_sha(&repo_root, &parked.park_ref).as_deref()
+            == Some(parked.remote_sha.as_str())
+        {
+            continue;
+        }
+        let zero = zero_oid_like(&parked.remote_sha);
+        let args = [
+            "update-ref",
+            parked.park_ref.as_str(),
+            parked.remote_sha.as_str(),
+            zero.as_str(),
+        ];
+        if let Err(err) = run_git(&repo_root, &args) {
+            rollback_refs(&repo_root, &applied);
+            return Err(err).with_context(|| format!("parking {}", parked.head_ref));
+        }
+        applied.push(AppliedParkRef {
+            ref_name: parked.park_ref.clone(),
+            previous_sha: None,
+        });
+    }
+
+    if let Err(err) = run_git(&repo_root, &["fsck", "--full"]) {
+        rollback_refs(&repo_root, &applied);
+        return Err(err).context("post-resolution git fsck");
+    }
+
+    let state_snapshot = state.snapshot_cache_keys(
+        candidates
+            .iter()
+            .map(|candidate| candidate.cache_key.as_str()),
+    );
+    for candidate in &candidates {
+        let mut resolved_vclock = candidate.resolved_vclock.clone();
+        resolved_vclock.tick(device_id);
+        if !state.resolve_conflict_by_cache_key(
+            &candidate.cache_key,
+            resolved_vclock,
+            device_id.to_string(),
+        ) {
+            rollback_refs(&repo_root, &applied);
+            state.restore_cache_key_snapshot(&state_snapshot);
+            bail!(
+                "state entry vanished while clearing conflict: {}",
+                candidate.cache_key
+            );
+        }
+    }
+    if let Err(err) = state.flush() {
+        rollback_refs(&repo_root, &applied);
+        state.restore_cache_key_snapshot(&state_snapshot);
+        return Err(err).context("flushing resolved git conflicts");
+    }
+
+    Ok(GitKeepBothResult {
+        repo_root,
+        mode,
+        parked_refs,
+        undo_bundle: Some(undo_bundle),
+    })
+}
+
+fn collect_repo_conflicts(
+    state: &StateCache,
+    repo_root: &Path,
+) -> Result<Vec<GitConflictCandidate>> {
+    let mut out = Vec::new();
+    for (cache_key, entry) in state.conflicts() {
+        if entry.status != FileSyncStatus::Conflict {
+            continue;
+        }
+        let Some(conflict) = entry.conflict.as_ref() else {
+            continue;
+        };
+        let rel_path = conflict.rel_path.replace('\\', "/");
+        let local_root = local_root_from_cache_key(cache_key, &rel_path);
+        let Some(root) = git_safety::repo_root_for_git_path(&local_root, &rel_path) else {
+            continue;
+        };
+        if root.canonicalize().ok().as_deref() != Some(repo_root) {
+            continue;
+        }
+        let Some(head_ref) = git_safety::head_ref_for_git_path(&rel_path) else {
+            bail!(
+                "unparkable .git conflict {}; only branch-head refs are supported in PR-3",
+                rel_path
+            );
+        };
+        let Some(remote_manifest_key) = conflict.remote_manifest_key.clone() else {
+            bail!(
+                "{} has no remote_manifest_key; rerun reconcile with a PR-2 binary first",
+                rel_path
+            );
+        };
+        let mut resolved_vclock = conflict.local_vclock.clone();
+        resolved_vclock.merge(&conflict.remote_vclock);
+        out.push(GitConflictCandidate {
+            cache_key: cache_key.to_string(),
+            rel_path,
+            head_ref,
+            remote_manifest_key,
+            remote_device: conflict.remote_device.clone(),
+            resolved_vclock,
+        });
+    }
+    out.sort_by(|a, b| a.head_ref.cmp(&b.head_ref));
+    Ok(out)
+}
+
+fn local_root_from_cache_key(cache_key: &str, rel_path: &str) -> PathBuf {
+    let cache_key = cache_key.replace('\\', "/");
+    let suffix = rel_path.trim_start_matches('/');
+    let root = cache_key
+        .strip_suffix(suffix)
+        .map(|s| s.trim_end_matches('/'))
+        .unwrap_or("");
+    PathBuf::from(root)
+}
+
+async fn read_remote_ref_sha(
+    op: &Operator,
+    remote_manifest_key: &str,
+    remote_prefix: &str,
+    device_id: &str,
+    encryption: OptionalEncryption<'_>,
+) -> Result<String> {
+    let temp_path = std::env::temp_dir().join(format!("tcfs-remote-ref-{}", Uuid::new_v4()));
+    let download = engine::download_file_with_device(
+        op,
+        remote_manifest_key,
+        &temp_path,
+        remote_prefix,
+        None,
+        device_id,
+        None,
+        encryption,
+    )
+    .await;
+    let bytes = match download {
+        Ok(_) => std::fs::read(&temp_path)
+            .with_context(|| format!("reading downloaded ref {}", temp_path.display()))?,
+        Err(err) => {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(err);
+        }
+    };
+    let _ = std::fs::remove_file(&temp_path);
+    git_safety::parse_ref_sha(&bytes).ok_or_else(|| anyhow!("remote ref content is not a SHA"))
+}
+
+fn park_ref_for(remote_device: &str, head_ref: &str) -> Result<String> {
+    let branch = head_ref
+        .strip_prefix("refs/heads/")
+        .ok_or_else(|| anyhow!("not a branch head ref: {head_ref}"))?;
+    let safe_device = remote_device
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    Ok(format!("refs/tcfs/theirs/{safe_device}/heads/{branch}"))
+}
+
+fn ensure_clean_worktree(repo_root: &Path) -> Result<()> {
+    let out = Command::new("git")
+        .args(["status", "--porcelain=v1", "--untracked-files=normal"])
+        .current_dir(repo_root)
+        .output()
+        .context("running git status")?;
+    if !out.status.success() {
+        bail!(
+            "git status failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    if !out.stdout.is_empty() {
+        bail!("git worktree is dirty; refusing repo-group keep-both");
+    }
+    Ok(())
+}
+
+fn ensure_commit_present(repo_root: &Path, sha: &str) -> Result<()> {
+    run_git(repo_root, &["cat-file", "-e", &format!("{sha}^{{commit}}")])
+        .with_context(|| format!("remote commit object is missing locally: {sha}"))
+}
+
+fn ensure_local_ref_still_pinned(repo_root: &Path, parked: &GitKeepBothParkedRef) -> Result<()> {
+    let Some(current) = git_safety::local_ref_sha(repo_root, &parked.head_ref) else {
+        bail!("local ref vanished before execute: {}", parked.head_ref);
+    };
+    if current != parked.local_sha {
+        bail!(
+            "local ref moved before execute: {} was {}, now {}; rerun reconcile",
+            parked.head_ref,
+            parked.local_sha,
+            current
+        );
+    }
+    Ok(())
+}
+
+fn ensure_park_ref_available(repo_root: &Path, park_ref: &str, remote_sha: &str) -> Result<()> {
+    if let Some(existing) = git_safety::local_ref_sha(repo_root, park_ref) {
+        if existing != remote_sha {
+            bail!(
+                "park ref {park_ref} already exists at {existing}; refusing to overwrite with {remote_sha}"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn zero_oid_like(oid: &str) -> String {
+    "0".repeat(oid.len())
+}
+
+fn write_undo_bundle(repo_root: &Path) -> Result<PathBuf> {
+    let undo_dir = repo_root.join(".git/tcfs-undo");
+    std::fs::create_dir_all(&undo_dir)
+        .with_context(|| format!("creating undo dir {}", undo_dir.display()))?;
+    let bundle = undo_dir.join(format!("keep-both-{}.bundle", Uuid::new_v4()));
+    let bundle_str = bundle.to_string_lossy().to_string();
+    run_git(repo_root, &["bundle", "create", &bundle_str, "--all"])
+        .context("creating undo bundle")?;
+    run_git(repo_root, &["bundle", "verify", &bundle_str]).context("verifying undo bundle")?;
+    Ok(bundle)
+}
+
+fn rollback_refs(repo_root: &Path, refs: &[AppliedParkRef]) {
+    for r in refs.iter().rev() {
+        match r.previous_sha.as_deref() {
+            Some(previous) => {
+                let _ = run_git(repo_root, &["update-ref", r.ref_name.as_str(), previous]);
+            }
+            None => {
+                let _ = run_git(repo_root, &["update-ref", "-d", r.ref_name.as_str()]);
+            }
+        }
+    }
+}
+
+fn run_git(repo_root: &Path, args: &[&str]) -> Result<()> {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo_root)
+        .output()
+        .with_context(|| format!("running git {args:?}"))?;
+    if !out.status.success() {
+        bail!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal::services::Memory;
+
+    #[test]
+    fn park_ref_sanitizes_device_and_preserves_branch() {
+        assert_eq!(
+            park_ref_for("honey/local", "refs/heads/feature/x").unwrap(),
+            "refs/tcfs/theirs/honey-local/heads/feature/x"
+        );
+    }
+
+    #[test]
+    fn local_root_is_derived_from_cache_key_and_rel_path() {
+        assert_eq!(
+            local_root_from_cache_key(
+                "/tmp/root/repo/.git/refs/heads/main",
+                "repo/.git/refs/heads/main"
+            ),
+            PathBuf::from("/tmp/root")
+        );
+    }
+
+    #[tokio::test]
+    async fn dry_run_refuses_missing_remote_manifest_key() {
+        let op = Operator::new(Memory::default()).unwrap().finish();
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git_safety::run_git(&repo, &["init", "--quiet", "--initial-branch=main"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.email", "tcfs@example.invalid"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.name", "TCFS Test"]).unwrap();
+        std::fs::write(repo.join("file.txt"), b"base").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "base", "--quiet"]).unwrap();
+        let head_path = repo.join(".git/refs/heads/main");
+
+        let mut state = StateCache::open(&dir.path().join("state.json")).unwrap();
+        let mut local = crate::conflict::VectorClock::new();
+        local.tick("neo");
+        let mut remote = crate::conflict::VectorClock::new();
+        remote.tick("honey");
+        state.set(
+            &head_path,
+            crate::state::SyncState {
+                blake3: "local".into(),
+                size: 41,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/manifests/local".into(),
+                last_synced: 0,
+                vclock: local.clone(),
+                device_id: "neo".into(),
+                conflict: Some(crate::conflict::ConflictInfo {
+                    rel_path: "repo/.git/refs/heads/main".into(),
+                    local_vclock: local,
+                    remote_vclock: remote,
+                    local_blake3: "local".into(),
+                    remote_blake3: "remote".into(),
+                    local_device: "neo".into(),
+                    remote_device: "honey".into(),
+                    detected_at: 1,
+                    times_recorded: 1,
+                    remote_manifest_key: None,
+                }),
+                status: FileSyncStatus::Conflict,
+            },
+        );
+
+        let err = resolve_repo_keep_both(
+            &op,
+            &mut state,
+            &repo,
+            "data",
+            "neo",
+            GitKeepBothMode::DryRun,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("remote_manifest_key"));
+    }
+
+    #[test]
+    fn execute_refuses_moved_local_head() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git_safety::run_git(&repo, &["init", "--quiet", "--initial-branch=main"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.email", "tcfs@example.invalid"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.name", "TCFS Test"]).unwrap();
+        std::fs::write(repo.join("file.txt"), b"base").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "base", "--quiet"]).unwrap();
+        let base = git_safety::local_ref_sha(&repo, "HEAD").unwrap();
+
+        let parked = GitKeepBothParkedRef {
+            conflict_rel_path: "repo/.git/refs/heads/main".into(),
+            head_ref: "refs/heads/main".into(),
+            park_ref: "refs/tcfs/theirs/honey/heads/main".into(),
+            local_sha: base,
+            remote_sha: "0123456789012345678901234567890123456789".into(),
+            cache_key: "repo/.git/refs/heads/main".into(),
+        };
+
+        std::fs::write(repo.join("file.txt"), b"moved").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "moved", "--quiet"]).unwrap();
+
+        let err = ensure_local_ref_still_pinned(&repo, &parked).unwrap_err();
+        assert!(err.to_string().contains("local ref moved"));
+    }
+
+    #[test]
+    fn clean_worktree_check_refuses_untracked_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git_safety::run_git(&repo, &["init", "--quiet", "--initial-branch=main"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.email", "tcfs@example.invalid"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.name", "TCFS Test"]).unwrap();
+        std::fs::write(repo.join("tracked.txt"), b"base").unwrap();
+        git_safety::run_git(&repo, &["add", "tracked.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "base", "--quiet"]).unwrap();
+
+        std::fs::write(repo.join("untracked.txt"), b"wip").unwrap();
+
+        let err = ensure_clean_worktree(&repo).unwrap_err();
+        assert!(err.to_string().contains("dirty"));
+    }
+
+    #[test]
+    fn execute_refuses_to_overwrite_different_parked_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git_safety::run_git(&repo, &["init", "--quiet", "--initial-branch=main"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.email", "tcfs@example.invalid"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.name", "TCFS Test"]).unwrap();
+        std::fs::write(repo.join("file.txt"), b"one").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "one", "--quiet"]).unwrap();
+        let first = git_safety::local_ref_sha(&repo, "HEAD").unwrap();
+        std::fs::write(repo.join("file.txt"), b"two").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "two", "--quiet"]).unwrap();
+        let second = git_safety::local_ref_sha(&repo, "HEAD").unwrap();
+
+        let park_ref = "refs/tcfs/theirs/honey/heads/main";
+        git_safety::run_git(&repo, &["update-ref", park_ref, &first]).unwrap();
+
+        let err = ensure_park_ref_available(&repo, park_ref, &second).unwrap_err();
+        assert!(err.to_string().contains("refusing to overwrite"));
+    }
+
+    #[test]
+    fn rollback_restores_previous_parked_ref_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git_safety::run_git(&repo, &["init", "--quiet", "--initial-branch=main"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.email", "tcfs@example.invalid"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.name", "TCFS Test"]).unwrap();
+        std::fs::write(repo.join("file.txt"), b"one").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "one", "--quiet"]).unwrap();
+        let first = git_safety::local_ref_sha(&repo, "HEAD").unwrap();
+        std::fs::write(repo.join("file.txt"), b"two").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "two", "--quiet"]).unwrap();
+        let second = git_safety::local_ref_sha(&repo, "HEAD").unwrap();
+
+        let park_ref = "refs/tcfs/theirs/honey/heads/main";
+        git_safety::run_git(&repo, &["update-ref", park_ref, &second]).unwrap();
+        rollback_refs(
+            &repo,
+            &[AppliedParkRef {
+                ref_name: park_ref.into(),
+                previous_sha: Some(first.clone()),
+            }],
+        );
+
+        assert_eq!(git_safety::local_ref_sha(&repo, park_ref), Some(first));
+    }
+}

--- a/crates/tcfs-sync/src/conflict_git.rs
+++ b/crates/tcfs-sync/src/conflict_git.rs
@@ -67,13 +67,28 @@ impl GitKeepBothResult {
 }
 
 #[derive(Debug, Clone)]
+enum GitConflictKind {
+    /// A branch-head ref (`.git/refs/heads/**`). Park the peer's head under
+    /// `refs/tcfs/theirs/<device>/heads/**` and keep the local head.
+    Park {
+        head_ref: String,
+        remote_manifest_key: String,
+        remote_device: String,
+    },
+    /// A non-ref-class `.git` workdir/reflog path (`.git/index`,
+    /// `.git/logs/**`, `.git/COMMIT_EDITMSG`, ...). Design steps 7/9 keep the
+    /// winner's local version and clear the conflict; the loser's commits are
+    /// preserved by the parked theirs-ref, so the loser's index/reflog need not
+    /// be materialized. No ref is touched for these.
+    KeepLocal,
+}
+
+#[derive(Debug, Clone)]
 struct GitConflictCandidate {
     cache_key: String,
     rel_path: String,
-    head_ref: String,
-    remote_manifest_key: String,
-    remote_device: String,
     resolved_vclock: crate::conflict::VectorClock,
+    kind: GitConflictKind,
 }
 
 #[derive(Debug, Clone)]
@@ -89,12 +104,14 @@ struct AppliedParkRef {
 /// merge commits, push to remote storage, or claim broad daily-driver safety.
 /// A later reconcile/upload cycle publishes the updated refs through the normal
 /// object-before-ref path.
+#[allow(clippy::too_many_arguments)]
 pub async fn resolve_repo_keep_both(
     op: &Operator,
     state: &mut StateCache,
     repo_root: &Path,
     remote_prefix: &str,
     device_id: &str,
+    undo_state_dir: &Path,
     mode: GitKeepBothMode,
     encryption: OptionalEncryption<'_>,
 ) -> Result<GitKeepBothResult> {
@@ -123,11 +140,22 @@ pub async fn resolve_repo_keep_both(
     ensure_clean_worktree(&repo_root)?;
     run_git(&repo_root, &["fsck", "--full"]).context("pre-resolution git fsck")?;
 
-    let mut parked_refs = Vec::with_capacity(candidates.len());
+    let mut parked_refs = Vec::new();
     for candidate in &candidates {
+        // KeepLocal candidates (index/logs/COMMIT_EDITMSG) park nothing; the
+        // winner's version stays and the conflict clears in the state loop
+        // below.
+        let GitConflictKind::Park {
+            head_ref,
+            remote_manifest_key,
+            remote_device,
+        } = &candidate.kind
+        else {
+            continue;
+        };
         let remote_sha = read_remote_ref_sha(
             op,
-            &candidate.remote_manifest_key,
+            remote_manifest_key,
             remote_prefix,
             device_id,
             encryption,
@@ -136,23 +164,23 @@ pub async fn resolve_repo_keep_both(
         .with_context(|| {
             format!(
                 "reading remote ref for {} from {}",
-                candidate.rel_path, candidate.remote_manifest_key
+                candidate.rel_path, remote_manifest_key
             )
         })?;
         ensure_commit_present(&repo_root, &remote_sha)?;
-        let local_sha = git_safety::local_ref_sha(&repo_root, &candidate.head_ref)
-            .ok_or_else(|| anyhow!("local ref is missing: {}", candidate.head_ref))?;
+        let local_sha = git_safety::local_ref_sha(&repo_root, head_ref)
+            .ok_or_else(|| anyhow!("local ref is missing: {}", head_ref))?;
         if local_sha == remote_sha {
             bail!(
                 "{} is no longer divergent; rerun reconcile before keep-both",
-                candidate.head_ref
+                head_ref
             );
         }
-        let park_ref = park_ref_for(&candidate.remote_device, &candidate.head_ref)?;
+        let park_ref = park_ref_for(remote_device, head_ref)?;
         ensure_park_ref_available(&repo_root, &park_ref, &remote_sha)?;
         parked_refs.push(GitKeepBothParkedRef {
             conflict_rel_path: candidate.rel_path.clone(),
-            head_ref: candidate.head_ref.clone(),
+            head_ref: head_ref.clone(),
             park_ref,
             local_sha,
             remote_sha,
@@ -187,7 +215,15 @@ pub async fn resolve_repo_keep_both(
         ensure_park_ref_available(&repo_root, &parked.park_ref, &parked.remote_sha)?;
     }
 
-    let undo_bundle = write_undo_bundle(&repo_root)?;
+    // The undo bundle captures `--all` refs before we park anything. It is only
+    // meaningful when refs actually change, so skip it for a pure keep-local
+    // group (no write-only cost). It is written under the machine-local state
+    // dir, never in-tree (BLOCKING 2 / design S6).
+    let undo_bundle = if parked_refs.is_empty() {
+        None
+    } else {
+        Some(write_undo_bundle(&repo_root, undo_state_dir)?)
+    };
     let mut applied = Vec::new();
     for parked in &parked_refs {
         if git_safety::local_ref_sha(&repo_root, &parked.park_ref).as_deref()
@@ -248,7 +284,7 @@ pub async fn resolve_repo_keep_both(
         repo_root,
         mode,
         parked_refs,
-        undo_bundle: Some(undo_bundle),
+        undo_bundle,
     })
 }
 
@@ -272,30 +308,53 @@ fn collect_repo_conflicts(
         if root.canonicalize().ok().as_deref() != Some(repo_root) {
             continue;
         }
-        let Some(head_ref) = git_safety::head_ref_for_git_path(&rel_path) else {
-            bail!(
-                "unparkable .git conflict {}; only branch-head refs are supported in PR-3",
-                rel_path
-            );
-        };
-        let Some(remote_manifest_key) = conflict.remote_manifest_key.clone() else {
-            bail!(
-                "{} has no remote_manifest_key; rerun reconcile with a PR-2 binary first",
-                rel_path
-            );
-        };
         let mut resolved_vclock = conflict.local_vclock.clone();
         resolved_vclock.merge(&conflict.remote_vclock);
+
+        let kind = match git_safety::head_ref_for_git_path(&rel_path) {
+            // Branch-head ref under `.git/refs/heads/**`: parkable. It needs a
+            // PR-2 remote manifest key so we can read the peer's head SHA.
+            Some(head_ref) => {
+                let Some(remote_manifest_key) = conflict.remote_manifest_key.clone() else {
+                    bail!(
+                        "{} has no remote_manifest_key; rerun reconcile with a PR-2 binary first",
+                        rel_path
+                    );
+                };
+                GitConflictKind::Park {
+                    head_ref,
+                    remote_manifest_key,
+                    remote_device: conflict.remote_device.clone(),
+                }
+            }
+            // Not a branch head. Only GENUINELY UNPARKABLE ref-valued paths veto
+            // the whole group: `packed-refs`, `refs/**` outside `refs/heads/`,
+            // detached/symbolic `HEAD`, and submodule refs — parking those
+            // safely is out of scope for PR-3 and dropping them would lose refs.
+            // Non-ref-class workdir/reflog state (`.git/index`, `.git/logs/**`,
+            // `.git/COMMIT_EDITMSG`) is design-intended kept-local (steps 7/9),
+            // which is what makes the verb usable on real divergent repos where
+            // those paths almost always differ.
+            None => {
+                if crate::reconcile::is_git_ref_class_path(&rel_path) {
+                    bail!(
+                        "unparkable ref-class .git conflict {}; only branch-head refs \
+                         (.git/refs/heads/**) are parkable in PR-3",
+                        rel_path
+                    );
+                }
+                GitConflictKind::KeepLocal
+            }
+        };
+
         out.push(GitConflictCandidate {
             cache_key: cache_key.to_string(),
             rel_path,
-            head_ref,
-            remote_manifest_key,
-            remote_device: conflict.remote_device.clone(),
             resolved_vclock,
+            kind,
         });
     }
-    out.sort_by(|a, b| a.head_ref.cmp(&b.head_ref));
+    out.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
     Ok(out)
 }
 
@@ -410,8 +469,19 @@ fn zero_oid_like(oid: &str) -> String {
     "0".repeat(oid.len())
 }
 
-fn write_undo_bundle(repo_root: &Path) -> Result<PathBuf> {
-    let undo_dir = repo_root.join(".git/tcfs-undo");
+/// Write the pre-resolution `git bundle --all` escape hatch under the
+/// machine-local state dir — NEVER in-tree.
+///
+/// The bundle used to live at `repo_root/.git/tcfs-undo/**`, but that is a
+/// plain `.git/**` file that raw-mode `.git` collection roams: it grew a
+/// full-history bundle (fresh uuid, never GC'd) on every execute across the
+/// fleet. Anchoring it to the state dir (outside any sync root), keyed by a
+/// hash of the repo root, keeps it a genuine local-only rollback aid
+/// (BLOCKING 2 / design S6). `blacklist.rs` also fail-closed denies
+/// `.git/tcfs-undo/**` so any pre-existing in-tree bundle can never roam.
+fn write_undo_bundle(repo_root: &Path, state_dir: &Path) -> Result<PathBuf> {
+    let repo_hex = blake3::hash(repo_root.to_string_lossy().as_bytes()).to_hex();
+    let undo_dir = state_dir.join("keep-both-undo").join(&repo_hex[..16]);
     std::fs::create_dir_all(&undo_dir)
         .with_context(|| format!("creating undo dir {}", undo_dir.display()))?;
     let bundle = undo_dir.join(format!("keep-both-{}.bundle", Uuid::new_v4()));
@@ -527,6 +597,7 @@ mod tests {
             &repo,
             "data",
             "neo",
+            dir.path(),
             GitKeepBothMode::DryRun,
             None,
         )
@@ -635,5 +706,245 @@ mod tests {
         );
 
         assert_eq!(git_safety::local_ref_sha(&repo, park_ref), Some(first));
+    }
+
+    fn init_repo(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+        git_safety::run_git(path, &["init", "--quiet", "--initial-branch=main"]).unwrap();
+        git_safety::run_git(path, &["config", "user.email", "tcfs@example.invalid"]).unwrap();
+        git_safety::run_git(path, &["config", "user.name", "TCFS Test"]).unwrap();
+    }
+
+    fn commit(path: &Path, file: &str, body: &str, msg: &str) -> String {
+        std::fs::write(path.join(file), body.as_bytes()).unwrap();
+        git_safety::run_git(path, &["add", file]).unwrap();
+        git_safety::run_git(path, &["commit", "-m", msg, "--quiet"]).unwrap();
+        git_safety::local_ref_sha(path, "HEAD").unwrap()
+    }
+
+    fn conflict_state(
+        rel_path: &str,
+        remote_manifest_key: Option<String>,
+        local: &crate::conflict::VectorClock,
+        remote: &crate::conflict::VectorClock,
+    ) -> crate::state::SyncState {
+        crate::state::SyncState {
+            blake3: "local".into(),
+            size: 41,
+            mtime: 0,
+            chunk_count: 1,
+            remote_path: "data/manifests/head".into(),
+            last_synced: 0,
+            vclock: local.clone(),
+            device_id: "winner".into(),
+            conflict: Some(crate::conflict::ConflictInfo {
+                rel_path: rel_path.into(),
+                local_vclock: local.clone(),
+                remote_vclock: remote.clone(),
+                local_blake3: "local".into(),
+                remote_blake3: "remote".into(),
+                local_device: "winner".into(),
+                remote_device: "loser".into(),
+                detected_at: 1,
+                times_recorded: 1,
+                remote_manifest_key,
+            }),
+            status: FileSyncStatus::Conflict,
+        }
+    }
+
+    /// End-to-end Execute over two genuinely divergent `.git` repos (winner +
+    /// loser, sharing a base, neither a fast-forward of the other). Exercises
+    /// the real resolver — a no-op/stub resolver would leave the theirs-ref
+    /// absent and fail invariant (i). Also drives the veto reconciliation
+    /// (CHANGES-NEEDED 4) by including a divergent `.git/index` that must ride
+    /// kept-local, and asserts idempotency (CHANGES-NEEDED 3).
+    #[tokio::test]
+    async fn execute_parks_theirs_keeps_local_and_is_idempotent() {
+        let op = Operator::new(Memory::default()).unwrap().finish();
+        let dir = tempfile::tempdir().unwrap();
+        let state_dir = dir.path().join("state-dir");
+        std::fs::create_dir_all(&state_dir).unwrap();
+
+        // Shared base, then two divergent commits (no FF direction).
+        let base = dir.path().join("base");
+        init_repo(&base);
+        commit(&base, "file.txt", "base", "base");
+        let winner = dir.path().join("winner");
+        let loser = dir.path().join("loser");
+        git_safety::run_git(
+            dir.path(),
+            &[
+                "clone",
+                "--quiet",
+                &base.to_string_lossy(),
+                &winner.to_string_lossy(),
+            ],
+        )
+        .unwrap();
+        git_safety::run_git(
+            dir.path(),
+            &[
+                "clone",
+                "--quiet",
+                &base.to_string_lossy(),
+                &loser.to_string_lossy(),
+            ],
+        )
+        .unwrap();
+        init_repo(&winner); // re-assert identity (clone copies base config, but be explicit)
+        init_repo(&loser);
+        let head_w = commit(&winner, "file.txt", "winner work", "winner");
+        let head_l = commit(&loser, "file.txt", "loser work", "loser");
+        assert_ne!(head_w, head_l);
+
+        // Objects-before-refs: the loser's commit is present in the winner's
+        // object store (a prior reconcile would have roamed the objects). Fetch
+        // brings the objects in without moving any winner ref.
+        git_safety::run_git(
+            &winner,
+            &[
+                "fetch",
+                "--quiet",
+                &loser.to_string_lossy(),
+                "refs/heads/main",
+            ],
+        )
+        .unwrap();
+        ensure_commit_present(&winner, &head_l).unwrap();
+
+        // Publish the loser's branch-head ref content as a PR-2 remote manifest
+        // so read_remote_ref_sha can recover the peer head SHA.
+        let ref_blob = dir.path().join("loser-ref-blob");
+        std::fs::write(&ref_blob, format!("{head_l}\n")).unwrap();
+        let mut up_state = StateCache::open(&dir.path().join("upload-state.json")).unwrap();
+        let up = engine::upload_file_with_device(
+            &op,
+            &ref_blob,
+            "data",
+            &mut up_state,
+            None,
+            "loser",
+            Some("loser/.git/refs/heads/main"),
+            None,
+        )
+        .await
+        .unwrap();
+        let manifest_key = up.remote_path.clone();
+
+        let state_path = dir.path().join("state.json");
+        let ref_key = winner.join(".git/refs/heads/main");
+        let index_key = winner.join(".git/index");
+        let mut local = crate::conflict::VectorClock::new();
+        local.tick("winner");
+        let mut remote = crate::conflict::VectorClock::new();
+        remote.tick("loser");
+
+        let inject = |state: &mut StateCache| {
+            state.set(
+                &ref_key,
+                conflict_state(
+                    "winner/.git/refs/heads/main",
+                    Some(manifest_key.clone()),
+                    &local,
+                    &remote,
+                ),
+            );
+            // Divergent non-ref-class path: must ride kept-local, not veto.
+            state.set(
+                &index_key,
+                conflict_state("winner/.git/index", None, &local, &remote),
+            );
+        };
+
+        let mut state = StateCache::open(&state_path).unwrap();
+        inject(&mut state);
+
+        let result = resolve_repo_keep_both(
+            &op,
+            &mut state,
+            &winner,
+            "data",
+            "winner",
+            &state_dir,
+            GitKeepBothMode::Execute,
+            None,
+        )
+        .await
+        .expect("execute should succeed on genuinely divergent repos");
+
+        let park_ref = "refs/tcfs/theirs/loser/heads/main";
+        // (i) loser head parked at the CORRECT remote SHA.
+        assert_eq!(result.parked_refs.len(), 1, "one branch head parked");
+        assert_eq!(
+            git_safety::local_ref_sha(&winner, park_ref).as_deref(),
+            Some(head_l.as_str()),
+            "theirs-ref must point at the loser's head SHA"
+        );
+        // (ii) winner's local head + HEAD untouched, winner's commit intact.
+        assert_eq!(
+            git_safety::local_ref_sha(&winner, "refs/heads/main").as_deref(),
+            Some(head_w.as_str()),
+            "winner head must be untouched"
+        );
+        assert_eq!(
+            git_safety::local_ref_sha(&winner, "HEAD").as_deref(),
+            Some(head_w.as_str())
+        );
+        ensure_commit_present(&winner, &head_w).unwrap();
+        // (iii) repository verifies clean.
+        run_git(&winner, &["fsck", "--full"]).expect("fsck clean after execute");
+        // (iv) BOTH heads reachable, no lost commits.
+        let rev_list = std::process::Command::new("git")
+            .args(["rev-list", "--all"])
+            .current_dir(&winner)
+            .output()
+            .unwrap();
+        let reachable = String::from_utf8_lossy(&rev_list.stdout);
+        assert!(reachable.contains(&head_w), "winner head reachable");
+        assert!(reachable.contains(&head_l), "parked loser head reachable");
+        // KeepLocal + parked conflicts both cleared.
+        assert!(
+            state.conflicts().is_empty(),
+            "all conflicts (ref + index) cleared after execute"
+        );
+        // Undo bundle lives under the state dir, NEVER in-tree.
+        let bundle = result.undo_bundle.expect("undo bundle written");
+        assert!(
+            bundle.starts_with(&state_dir),
+            "undo bundle under state dir"
+        );
+        assert!(
+            !bundle.starts_with(winner.join(".git")),
+            "undo bundle must NOT be under the repo .git"
+        );
+
+        // (v) a second Execute is idempotent: re-inject the (re-detected)
+        // conflict and re-run. No error, no double-park, refs unchanged.
+        inject(&mut state);
+        let again = resolve_repo_keep_both(
+            &op,
+            &mut state,
+            &winner,
+            "data",
+            "winner",
+            &state_dir,
+            GitKeepBothMode::Execute,
+            None,
+        )
+        .await
+        .expect("second execute idempotent");
+        assert_eq!(again.parked_refs.len(), 1);
+        assert_eq!(
+            git_safety::local_ref_sha(&winner, park_ref).as_deref(),
+            Some(head_l.as_str()),
+            "theirs-ref still at loser head (no double-park)"
+        );
+        assert_eq!(
+            git_safety::local_ref_sha(&winner, "refs/heads/main").as_deref(),
+            Some(head_w.as_str()),
+            "winner head still untouched on re-run"
+        );
+        run_git(&winner, &["fsck", "--full"]).expect("fsck clean after idempotent re-run");
     }
 }

--- a/crates/tcfs-sync/src/git_safety.rs
+++ b/crates/tcfs-sync/src/git_safety.rs
@@ -34,7 +34,6 @@ pub fn git_is_safe(git_dir: &Path) -> GitSafetyCheck {
         "index.lock",
         "HEAD.lock",
         "gc.pid",
-        "refs/heads/*.lock",
         "shallow.lock",
         "packed-refs.lock",
     ];
@@ -45,6 +44,7 @@ pub fn git_is_safe(git_dir: &Path) -> GitSafetyCheck {
             check.blocking.push(format!("lock file exists: {}", lock));
         }
     }
+    collect_ref_head_locks(&git_dir.join("refs/heads"), "refs/heads", &mut check);
 
     // In-progress operations
     let in_progress = [
@@ -76,6 +76,24 @@ pub fn git_is_safe(git_dir: &Path) -> GitSafetyCheck {
     }
 
     check
+}
+
+fn collect_ref_head_locks(dir: &Path, rel: &str, check: &mut GitSafetyCheck) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        let child_rel = format!("{rel}/{name}");
+        if path.is_dir() {
+            collect_ref_head_locks(&path, &child_rel, check);
+        } else if name.ends_with(".lock") {
+            check
+                .blocking
+                .push(format!("lock file exists: {child_rel}"));
+        }
+    }
 }
 
 /// Create a git bundle for atomic .git snapshot.
@@ -540,6 +558,25 @@ mod tests {
         let check = git_is_safe(&git_dir);
         assert!(!check.blocking.is_empty());
         assert!(check.blocking[0].contains("index.lock"));
+    }
+
+    #[test]
+    fn test_unsafe_with_nested_branch_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let git_dir = dir.path().join(".git");
+        let branch_dir = git_dir.join("refs/heads/feature");
+        std::fs::create_dir_all(&branch_dir).unwrap();
+        std::fs::write(branch_dir.join("x.lock"), b"").unwrap();
+
+        let check = git_is_safe(&git_dir);
+        assert!(
+            check
+                .blocking
+                .iter()
+                .any(|entry| entry.contains("refs/heads/feature/x.lock")),
+            "nested branch lock must block: {:?}",
+            check.blocking
+        );
     }
 
     #[test]

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod auto_unsync;
 pub mod blacklist;
 pub mod conflict;
+pub mod conflict_git;
 pub mod engine;
 pub mod git_safety;
 pub mod index_entry;

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -740,7 +740,7 @@ fn git_apply_rank(a: &ReconcileAction) -> u8 {
 /// AFTER objects: `.git/refs/**`, `.git/packed-refs`, and `.git/HEAD` — plus the
 /// same layout inside a submodule's real gitdir at `.git/modules/<name>/**`
 /// (M-4, PR #513) so raw-roamed submodule internals get the ordering + barrier.
-fn is_git_ref_class_path(rel: &str) -> bool {
+pub(crate) fn is_git_ref_class_path(rel: &str) -> bool {
     if !is_git_internal_path(rel) {
         return false;
     }

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -236,6 +236,13 @@ pub struct StateCache {
     last_flush: Instant,
 }
 
+/// In-memory rollback snapshot for a bounded set of state-cache keys.
+#[derive(Debug, Clone)]
+pub struct StateCacheKeySnapshot {
+    entries: HashMap<String, Option<SyncState>>,
+    dirty: bool,
+}
+
 impl StateCache {
     /// Load or create a state cache at the given path.
     ///
@@ -411,6 +418,37 @@ impl StateCache {
             .collect()
     }
 
+    /// Capture a bounded set of cache entries so callers can roll back
+    /// in-memory mutations if their outer atomic operation fails.
+    pub fn snapshot_cache_keys<'a, I>(&self, cache_keys: I) -> StateCacheKeySnapshot
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let entries = cache_keys
+            .into_iter()
+            .map(|key| (key.to_string(), self.entries.get(key).cloned()))
+            .collect();
+        StateCacheKeySnapshot {
+            entries,
+            dirty: self.dirty,
+        }
+    }
+
+    /// Restore entries captured by [`StateCache::snapshot_cache_keys`].
+    pub fn restore_cache_key_snapshot(&mut self, snapshot: &StateCacheKeySnapshot) {
+        for (key, state) in &snapshot.entries {
+            match state {
+                Some(state) => {
+                    self.entries.insert(key.clone(), state.clone());
+                }
+                None => {
+                    self.entries.remove(key);
+                }
+            }
+        }
+        self.dirty = snapshot.dirty;
+    }
+
     /// Flush dirty changes to disk using an atomic write (write then rename).
     ///
     /// Persists cache metadata alongside entries so restart recovery does not
@@ -513,6 +551,31 @@ impl StateCache {
         if let Some(entry) = self.entries.get_mut(&key) {
             entry.conflict = None;
             entry.status = FileSyncStatus::Synced;
+            self.dirty = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Clear conflict state for an already-known cache key and replace its
+    /// vector clock with the resolution clock.
+    ///
+    /// Repo-group `.git` resolution operates on conflict groups discovered via
+    /// [`StateCache::conflicts`]. Those records already carry canonical cache
+    /// keys; using the key directly avoids re-canonicalizing paths while the
+    /// resolver is mutating refs under `.git/tcfs.lock`.
+    pub fn resolve_conflict_by_cache_key(
+        &mut self,
+        cache_key: &str,
+        vclock: VectorClock,
+        device_id: String,
+    ) -> bool {
+        if let Some(entry) = self.entries.get_mut(cache_key) {
+            entry.conflict = None;
+            entry.status = FileSyncStatus::Synced;
+            entry.vclock = vclock;
+            entry.device_id = device_id;
             self.dirty = true;
             true
         } else {
@@ -1575,6 +1638,57 @@ mod tests {
 
         cache.resolve_conflict(&file_path);
         assert!(cache.dirty, "cache must be dirty after resolve_conflict");
+    }
+
+    #[test]
+    fn cache_key_snapshot_restores_conflict_and_dirty_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let mut cache = StateCache::open(&path).unwrap();
+
+        let file_path = dir.path().join("file.txt");
+        std::fs::write(&file_path, b"x").unwrap();
+
+        cache.set(
+            &file_path,
+            SyncState {
+                blake3: "abc".into(),
+                size: 1,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/index/file.txt".into(),
+                last_synced: 0,
+                vclock: VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: Some(crate::conflict::ConflictInfo {
+                    rel_path: "file.txt".into(),
+                    local_vclock: VectorClock::new(),
+                    remote_vclock: VectorClock::new(),
+                    local_blake3: "abc".into(),
+                    remote_blake3: "def".into(),
+                    local_device: "neo".into(),
+                    remote_device: "honey".into(),
+                    detected_at: 0,
+                    times_recorded: 0,
+                    remote_manifest_key: None,
+                }),
+                status: FileSyncStatus::Conflict,
+            },
+        );
+        cache.flush().unwrap();
+        assert!(!cache.dirty);
+
+        let key = cache.conflicts()[0].0.to_string();
+        let snapshot = cache.snapshot_cache_keys([key.as_str()]);
+        assert!(cache.resolve_conflict_by_cache_key(&key, VectorClock::new(), "neo".into()));
+        assert!(cache.dirty);
+        assert!(cache.entries.get(&key).unwrap().conflict.is_none());
+
+        cache.restore_cache_key_snapshot(&snapshot);
+        let restored = cache.entries.get(&key).unwrap();
+        assert_eq!(restored.status, FileSyncStatus::Conflict);
+        assert!(restored.conflict.is_some());
+        assert!(!cache.dirty);
     }
 
     #[test]

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -1837,9 +1837,10 @@ async fn handle_auto_pull(
             // over this device's object store with zero `.git` awareness — the
             // G5-git-5 interleave vector. Defer `.git`-internal conflicts
             // unconditionally; the operator resolves the repo group deliberately
-            // (future: `tcfs resolve <repo> --keep-both`; inspect with
-            // `tcfs conflicts`). The conflict stays recorded by the reconcile
-            // engine's Conflict arm, so it remains visible and re-tried.
+            // (`tcfs resolve <repo> --strategy keep-both --execute`; inspect
+            // with `tcfs conflicts`). The conflict stays recorded by the
+            // reconcile engine's Conflict arm, so it remains visible and
+            // re-tried.
             if auto_conflict_must_defer(rel_path) {
                 {
                     let mut cache = state_cache.lock().await;

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -88,6 +88,32 @@ fn repo_keep_both_mode(resolution: &str) -> Option<tcfs_sync::conflict_git::GitK
     }
 }
 
+/// Machine-local directory for the keep-both undo bundle. It MUST be outside any
+/// sync root, so anchor it to the daemon state DB's directory (the same
+/// machine-local location the state cache uses; see `worker.rs`/`daemon.rs`).
+/// Expands a leading `~/` and falls back to the platform data dir (BLOCKING 2).
+fn undo_bundle_state_dir(config: &TcfsConfig) -> PathBuf {
+    config
+        .sync
+        .state_db
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(expand_home_prefix)
+        .unwrap_or_else(|| dirs::data_dir().unwrap_or_default().join("tcfsd"))
+}
+
+/// Expand a leading `~/` against the current user's home directory. Leaves any
+/// other path untouched.
+fn expand_home_prefix(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    path.to_path_buf()
+}
+
 /// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
 ///
 /// - `Master` (default): legacy shared-master wrap. Byte-identical to the prior
@@ -408,6 +434,7 @@ impl TcfsDaemonImpl {
                 .ok_or_else(|| tonic::Status::unavailable("no storage operator"))?
         };
         let prefix = self.config.storage.resolved_prefix().to_string();
+        let undo_state_dir = undo_bundle_state_dir(&self.config);
         let enc_ctx = {
             let mk_guard = self.master_key.lock().await;
             mk_guard
@@ -426,6 +453,7 @@ impl TcfsDaemonImpl {
                 path,
                 &prefix,
                 &self.device_id,
+                &undo_state_dir,
                 mode,
                 enc_ctx.as_ref(),
             )
@@ -1686,6 +1714,32 @@ impl TcfsDaemon for TcfsDaemonImpl {
         };
 
         if let Some(mode) = repo_keep_both_mode(&resolution) {
+            // Operator-deliberate invariant: repo-group git keep-both is a live
+            // `.git` WRITE path (parks peer branch heads, ticks the local clock
+            // to dominate the fleet). It is reachable ONLY through the human
+            // `tcfs resolve` CLI, which sets `operator_cli=true`. MCP's tool
+            // input cannot set that flag (and MCP also rejects git_keep_both_*
+            // before reaching this RPC), and no auto/NATS path sets it — so an
+            // agent / generic client can never trigger committed-work loss.
+            // Fail closed. This dispatch stays ahead of the per-file `.git`
+            // fence below because the repo-group path targets the repo ROOT
+            // (not a `.git`-internal path); the fence is for per-file
+            // keep_local/keep_remote/keep_both and does not apply here.
+            if !req.operator_cli {
+                tracing::warn!(
+                    path = %req.path,
+                    resolution = %resolution,
+                    "refusing repo-group git keep-both: missing operator CLI provenance"
+                );
+                return Ok(tonic::Response::new(ResolveConflictResponse {
+                    success: false,
+                    resolved_path: String::new(),
+                    error: "repo-group git keep-both is operator-only: run it deliberately from \
+                            the CLI (`tcfs resolve <repo> --strategy keep-both [--execute]`), not \
+                            through MCP or an automated client"
+                        .to_string(),
+                }));
+            }
             return self.resolve_git_keep_both_repo(&path, mode).await;
         }
 
@@ -4022,6 +4076,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_conflict_repo_git_keep_both_requires_operator_cli() {
+        // BLOCKING 1b: repo-group git keep-both must be refused (fail-closed)
+        // when operator-CLI provenance is absent — i.e. for MCP / automated /
+        // generic clients that cannot set `operator_cli`. Both dry-run and
+        // execute are gated BEFORE any storage/ref work happens.
+        let daemon = test_daemon();
+        for resolution in ["git_keep_both_dry_run", "git_keep_both_execute"] {
+            let resp = daemon
+                .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
+                    path: "myrepo".into(),
+                    resolution: resolution.into(),
+                    operator_cli: false,
+                }))
+                .await
+                .unwrap()
+                .into_inner();
+            assert!(
+                !resp.success,
+                "{resolution} must be refused without operator provenance"
+            );
+            assert!(
+                resp.error.contains("operator-only"),
+                "{resolution} error must direct to the CLI, got: {}",
+                resp.error
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn resolve_conflict_refuses_git_internal_path() {
         // keep-both PR-1 (S1): keep_remote on a `.git`-internal ref must be
         // refused with repo-group guidance and ZERO side effects.
@@ -4030,6 +4113,7 @@ mod tests {
             .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
                 path: "myrepo/.git/refs/heads/main".into(),
                 resolution: "keep_remote".into(),
+                ..Default::default()
             }))
             .await
             .unwrap()
@@ -4048,6 +4132,7 @@ mod tests {
                 .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
                     path: "myrepo/.git/index".into(),
                     resolution: strat.into(),
+                    ..Default::default()
                 }))
                 .await
                 .unwrap()
@@ -4100,6 +4185,7 @@ mod tests {
             .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
                 path: alias_path.display().to_string(),
                 resolution: "keep_remote".into(),
+                ..Default::default()
             }))
             .await
             .unwrap()
@@ -4146,6 +4232,7 @@ mod tests {
             .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
                 path: request_path.display().to_string(),
                 resolution: "keep_remote".into(),
+                ..Default::default()
             }))
             .await
             .unwrap()
@@ -4165,6 +4252,7 @@ mod tests {
             .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
                 path: "myrepo/.git/refs/heads/main".into(),
                 resolution: "defer".into(),
+                ..Default::default()
             }))
             .await
             .unwrap()
@@ -4183,6 +4271,7 @@ mod tests {
             .resolve_conflict(tonic::Request::new(ResolveConflictRequest {
                 path: "notes/todo.txt".into(),
                 resolution: "keep_remote".into(),
+                ..Default::default()
             }))
             .await
             .unwrap()

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -74,10 +74,18 @@ fn resolve_conflict_git_fence_error(
         format!(
             "'{}' is a git-internal path; per-file resolution ({resolution}) would corrupt the \
              repository object store. Resolve the whole repo group instead \
-             (future: `tcfs resolve <repo> --keep-both`). Inspect with `tcfs conflicts`.",
+             (`tcfs resolve <repo> --strategy keep-both --execute`). Inspect with `tcfs conflicts`.",
             path.display()
         )
     })
+}
+
+fn repo_keep_both_mode(resolution: &str) -> Option<tcfs_sync::conflict_git::GitKeepBothMode> {
+    match resolution {
+        "git_keep_both_dry_run" => Some(tcfs_sync::conflict_git::GitKeepBothMode::DryRun),
+        "git_keep_both_execute" => Some(tcfs_sync::conflict_git::GitKeepBothMode::Execute),
+        _ => None,
+    }
 }
 
 /// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
@@ -384,6 +392,63 @@ impl TcfsDaemonImpl {
             totp_provider,
             webauthn_provider,
             rate_limiter,
+        }
+    }
+
+    async fn resolve_git_keep_both_repo(
+        &self,
+        path: &Path,
+        mode: tcfs_sync::conflict_git::GitKeepBothMode,
+    ) -> Result<tonic::Response<ResolveConflictResponse>, tonic::Status> {
+        let op = {
+            let op_guard = self.operator.lock().await;
+            op_guard
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| tonic::Status::unavailable("no storage operator"))?
+        };
+        let prefix = self.config.storage.resolved_prefix().to_string();
+        let enc_ctx = {
+            let mk_guard = self.master_key.lock().await;
+            mk_guard
+                .as_ref()
+                .map(|mk| build_encryption_context(&self.config, &self.device_id, mk))
+        };
+
+        let result = {
+            let mut cache = self.state_cache.lock().await;
+            if let Err(e) = cache.reload_from_disk() {
+                tracing::warn!("failed to reload state cache: {e}");
+            }
+            tcfs_sync::conflict_git::resolve_repo_keep_both(
+                &op,
+                &mut cache,
+                path,
+                &prefix,
+                &self.device_id,
+                mode,
+                enc_ctx.as_ref(),
+            )
+            .await
+        };
+
+        match result {
+            Ok(result) => {
+                if mode.is_execute() {
+                    self.publish_conflict_resolved(&path.to_string_lossy(), "git_keep_both")
+                        .await;
+                }
+                Ok(tonic::Response::new(ResolveConflictResponse {
+                    success: true,
+                    resolved_path: result.repo_root.display().to_string(),
+                    error: result.summary(),
+                }))
+            }
+            Err(e) => Ok(tonic::Response::new(ResolveConflictResponse {
+                success: false,
+                resolved_path: String::new(),
+                error: format!("{e:#}"),
+            })),
         }
     }
 
@@ -1588,7 +1653,12 @@ impl TcfsDaemon for TcfsDaemonImpl {
         let req = request.into_inner();
 
         let resolution = match req.resolution.as_str() {
-            "keep_local" | "keep_remote" | "keep_both" | "defer" => req.resolution.clone(),
+            "keep_local"
+            | "keep_remote"
+            | "keep_both"
+            | "defer"
+            | "git_keep_both_dry_run"
+            | "git_keep_both_execute" => req.resolution.clone(),
             other => {
                 return Ok(tonic::Response::new(ResolveConflictResponse {
                     success: false,
@@ -1614,6 +1684,10 @@ impl TcfsDaemon for TcfsDaemonImpl {
             }
             cache.get(&path).cloned()
         };
+
+        if let Some(mode) = repo_keep_both_mode(&resolution) {
+            return self.resolve_git_keep_both_repo(&path, mode).await;
+        }
 
         // keep-both PR-1 (safety invariant S1): per-file conflict resolution
         // must NEVER touch `.git` internals. keep_local rewrites the manifest,


### PR DESCRIPTION
## Summary

Adds the PR-3 repo-group `.git` keep-both resolver for divergent branch-head conflicts. The resolver parks the remote branch tip under `refs/tcfs/theirs/<device>/heads/<branch>` while preserving the local branch head, then clears the conflict group only after Git safety checks and state flush succeed.

Refs TIN-1620 / G5-git keep-both lane. Stacked after #528, now rebased on `main`.

## Changes

- Adds `tcfs_sync::conflict_git::resolve_repo_keep_both` with dry-run and execute modes.
- Routes `tcfs resolve <repo> --strategy keep-both` through a dry-run by default, with `--execute` required for mutation.
- Adds daemon RPC routing for internal `git_keep_both_*` resolutions.
- Adds bounded state-cache snapshots so ref rollback does not leave in-memory conflicts falsely cleared.
- Tightens Git safety around branch `.lock` files and untracked worktree dirt.
- Adds focused regression coverage for missing remote manifests, moved local refs, parked-ref overwrite refusal, rollback behavior, untracked worktrees, state snapshot restore, and nested branch locks.

## Test plan

- [x] `~/.cargo/bin/cargo fmt --all -- --check` passes locally
- [x] `git diff --check origin/main..HEAD` passes locally
- [x] Focused read-only adversarial re-review reported no blockers
- [ ] `task test` passes locally
- [ ] `task lint` passes locally
- [ ] Verified affected functionality manually

Local build/test/clippy were intentionally not run on neo. Remote GitHub Actions are the build/test authority for this lane.

## Checklist

- [x] Docs updated (if user-facing behavior changed)
- [ ] CHANGELOG.md updated (if applicable)
- [x] No secrets or credentials in diff