### PR TITLE
docs: reconcile TCFS frontier truth after PZM recovery

### DIFF
--- a/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
+++ b/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
@@ -6,6 +6,16 @@ onboarding plan toward a daily-driver fleet.
 Tracker: `TIN-1617` (epic). New sub-issues: `TIN-1736`, `TIN-1737`,
 `TIN-1738`, `TIN-1740`.
 
+2026-07-05 truth update: this document is now historical sequencing context,
+not the current frontier. Since it was written, the neo↔honey live repo path has
+advanced materially: fast-forward `.git` conflict resolution landed, the
+bidirectional FF handoff canary has live evidence under `TIN-1620`, and the
+divergent keep-both ladder has PR-1/PR-2/PR-3 merged with PR-4 still
+deploy-gated. The current stop rule is no broad `~/git` or home takeover until
+two small repos clear R0-R5 both directions and the remaining divergent no-loss
+guard is deployed and proven. Per-device forward secrecy remains gated on the
+fresh `tcfs key rotate` rebuild tracked by `TIN-2551`.
+
 This document does not replace
 [large-workdir-onboarding-design-2026-05-25.md](large-workdir-onboarding-design-2026-05-25.md);
 it re-orders that ladder around three operator decisions and adds the

--- a/docs/ops/per-device-crypto-migration-2026-06-06.md
+++ b/docs/ops/per-device-crypto-migration-2026-06-06.md
@@ -9,6 +9,15 @@ should be read as the operator-facing companion to that design recon.
 
 Date: 2026-06-06.
 
+2026-07-05 truth update: the forward-secrecy rotation action described here is
+not currently accepted as a usable implementation surface. Linear `TIN-2551`
+supersedes the old `TIN-1899` completion claim for `tcfs key rotate <prefix>`:
+the WIP rotation path was adversarially reviewed and found to have
+revocation-defeating defects. Keep the expand/contract migration sequencing
+below as the current per-device wrapping plan, but treat `tcfs key rotate
+<prefix>` as a rebuild gate, not an available operator remedy, until `TIN-2551`
+lands with fresh tests and review.
+
 Grounding: every primitive, phase, and revocation claim here derives from
 `docs/ops/per-device-crypto-identity-design-2026-05-18.md` (the "design doc"
 below). Where this plan adds operational structure not in the design doc — an
@@ -255,14 +264,16 @@ under this plan:
   180) and anything still carrying a wrap it can open.
 - Critically: content that is already-pulled, OR still carries a master wrap
   (any v2 master/dual manifest), OR is not-yet-rekeyed, stays master-decryptable
-  until `tcfs key rotate <prefix>` re-chunks and rewraps it as `per_device` (v3).
-  Revocation alone does NOT rewrite historical manifests (design doc lines
-  151–162). Forward secrecy is a SEPARATE, explicit, expensive operator action.
+  until a rebuilt-and-reviewed `tcfs key rotate <prefix>` re-chunks and rewraps
+  it as `per_device` (v3). Revocation alone does NOT rewrite historical
+  manifests (design doc lines 151–162). Forward secrecy is a SEPARATE, explicit,
+  expensive operator action, and as of 2026-07-05 the accepted implementation is
+  still gated on `TIN-2551`.
 
 State this plainly in operator and CHANGELOG messaging: "Revoking a device stops
 it from reading newly written content. It does not retroactively lock the device
 out of content it already synced, and it does not lock it out of unchanged files
-until you run `tcfs key rotate`."
+until a reviewed `tcfs key rotate` rebuild has rotated that prefix."
 
 ## Ratified Seven Questions (design doc lines 280–312)
 
@@ -285,9 +296,11 @@ until you run `tcfs key rotate`."
 ## Residual Risks
 
 - **Manual / partial forward secrecy**: revocation is not forward-secret by
-  itself; the operator must run `tcfs key rotate <prefix>` per affected prefix,
-  and any prefix not rotated stays master-decryptable (it is still a v2
-  master/dual manifest) to the revoked device.
+  itself; the operator must run an accepted `tcfs key rotate <prefix>` per
+  affected prefix, and any prefix not rotated stays master-decryptable (it is
+  still a v2 master/dual manifest) to the revoked device. As of 2026-07-05 that
+  rotation implementation is explicitly not accepted; track the rebuild in
+  `TIN-2551`.
 - **Deferred NATS advisory leg**: sub-second revocation propagation is out of
   scope; the fleet accepts S3 eventual-consistency timing and must document the
   propagation window.

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -30,15 +30,22 @@ coverage and the clearest end-to-end validation story.
   target for the current shipped `.deb` assets because the packages require
   newer glibc/OpenSSL ABI floors than bookworm provides.
 
-## macOS (Experimental Desktop Surface)
+## macOS (Proven Package Lane, Hardening Surface)
 
-macOS has real release artifacts and desktop integration code, but the current
-evidence is weaker than Linux. Treat it as an experimental surface rather than
-as a production-proven platform.
+macOS has real release artifacts and a production Developer ID FileProvider
+proof lane, but the desktop surface is still behind Linux for continuous
+release-day and daily-driver acceptance. Treat package install, basic
+FileProvider lifecycle, and exact hydration/mutation as proven where the cited
+PZM evidence applies; treat first-run UX, badges/progress, recovery, and soak as
+open hardening work.
 
 - **CLI**: Builds and ships for Apple Silicon and Intel
 - **Daemon**: Launchd-oriented runtime exists, but user-facing acceptance coverage is still limited
-- **FileProvider**: Packaged macOS FileProvider app exists in releases; the PZM testing-mode lab proves enumerate, hydrate, evict, rehydrate, mutation upload/readback, and CLI conflict/status content preservation, but production Finder claims remain experimental
+- **FileProvider**: Packaged macOS FileProvider app exists in releases. The PZM
+  production Developer ID lane proves install/signing preflight, domain rebuild,
+  user-visible root enumeration, exact hydrate, evict/rehydrate, mutation
+  upload/readback, rename, and conflict/status preservation without
+  `fileprovider_testing_mode=true`
 - **Finder badges / progress**: Implemented in code and observed only as evidence; not yet a reliable release gate
 - **Filesystem surface**: Experimental; Linux remains the better-proven mount/runtime path
 - **Fleet sync**: Core sync engine and NATS path are shared with Linux, but macOS-specific acceptance coverage is not yet at the same bar
@@ -50,28 +57,20 @@ as a production-proven platform.
   gates.
 - **Homebrew**: manual tap flow required today because the formula is published on the `homebrew-tap` branch, not the default branch
 - **Current proof**: CI covers the Rust FileProvider staticlib/header and iOS
-  Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts;
-  PZM testing-mode lab proof is green beyond read/hydrate; production
-  clean-host Finder proof is still pending. The latest neo inventory confirms
-  the canonical `/Applications/TCFSProvider.app` install is absent and the
-  existing `~/Applications/TCFSProvider.app` fails strict production signing
-  preflight because Keychain access-group entitlements and embedded
-  provisioning profiles are missing. A source-built Developer ID app on neo now
-  passes strict signing-only preflight with compatible local profiles embedded,
-  and a local candidate `.pkg` structure/signature proof wraps it with
-  source-built `tcfs`/`tcfsd`. Remote run `25973109986` proves the current
-  source package can be notarized, stapled, accepted by Gatekeeper install
-  assessment, and pass strict package smoke with stapled-ticket enforcement.
-  That proof is a workflow artifact, not a published release install, and it
-  has not been installed or exercised through Finder.
+  Swift type-check; release workflow cuts `.pkg` and FileProvider artifacts.
+  PZM production Developer ID runs prove the installed-host FileProvider lane
+  through storage `[ok]`, domain add/rebuild, CloudStorage enumeration,
+  HostApp request/download, exact hydrate, evict/rehydrate, mutation
+  upload/readback, rename, and conflict/status preservation. See
+  [macOS Finder and FileProvider Reality](ops/macos-fileprovider-reality.md) for
+  the run numbers and evidence packets.
 - **Current posture**: see [Apple Surface Status](ops/apple-surface-status.md)
   and [Distribution Smoke Matrix](ops/distribution-smoke-matrix.md)
 
 ### Not Yet Proven
 
-- Production Developer ID clean-host Finder/FileProvider acceptance from
-  install through user enablement, register, enumerate, hydrate, mutate, and
-  conflict handling
+- First-run setup from package install to valid config/status without manual
+  operator repair
 - Finder badges, progress UI, or notification behavior as release gates
 - Every published macOS artifact on day zero without explicit post-cut smoke
 


### PR DESCRIPTION
## Summary
- mark the large-workdir sequencing doc as historical context after the live bidirectional FF proof and keep-both PRs
- make TIN-2551 the current truth for per-prefix FileKey rotation / forward secrecy
- align platform support with the proven macOS production Developer ID FileProvider lane

## Validation
- git diff --check (docs-only)

Linear: TIN-1620, TIN-1908, TIN-1417, TIN-2551