### PR TITLE
tcfs: loser-side no-loss guard for git keep-both (TIN-2552)

### DIFF
--- a/crates/tcfs-sync/src/conflict_git.rs
+++ b/crates/tcfs-sync/src/conflict_git.rs
@@ -416,6 +416,46 @@ fn park_ref_for(remote_device: &str, head_ref: &str) -> Result<String> {
     Ok(format!("refs/tcfs/theirs/{safe_device}/heads/{branch}"))
 }
 
+/// Namespace a ref under `refs/tcfs/theirs/<device>/**` so its target objects
+/// become fsck-reachable on this machine and the ref never collides across
+/// devices. Reuses `park_ref_for` for branch heads (`refs/heads/<b>` →
+/// `.../heads/<b>`) and adds `refs/stash` (`→ .../stash`). Returns `None` for
+/// any other ref name (callers must not silently park it).
+///
+/// Used by the winner-side resolver's park_ref_for path AND by the reconcile
+/// loser-side no-loss guard (PR-4, S10), which parks the LOCAL head under its
+/// OWN device id before a divergent pull overwrites it.
+pub(crate) fn theirs_ref_name(device: &str, ref_name: &str) -> Option<String> {
+    if ref_name == "refs/stash" {
+        let safe_device = device
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect::<String>();
+        return Some(format!("refs/tcfs/theirs/{safe_device}/stash"));
+    }
+    park_ref_for(device, ref_name).ok()
+}
+
+/// Create-only park of `sha` at `park_ref` in `repo_root` using the same
+/// zero-OID compare-and-swap the winner-side resolver uses: refuse if the ref
+/// already exists at a DIFFERENT sha, no-op if it already points at `sha`
+/// (idempotent re-run), otherwise `update-ref <park_ref> <sha> <zero-oid>`.
+pub(crate) fn park_ref_create_only(repo_root: &Path, park_ref: &str, sha: &str) -> Result<()> {
+    ensure_park_ref_available(repo_root, park_ref, sha)?;
+    if git_safety::local_ref_sha(repo_root, park_ref).as_deref() == Some(sha) {
+        return Ok(());
+    }
+    let zero = zero_oid_like(sha);
+    run_git(repo_root, &["update-ref", park_ref, sha, zero.as_str()])
+        .with_context(|| format!("parking {sha} at {park_ref}"))
+}
+
 fn ensure_clean_worktree(repo_root: &Path) -> Result<()> {
     let out = Command::new("git")
         .args(["status", "--porcelain=v1", "--untracked-files=normal"])
@@ -479,7 +519,7 @@ fn zero_oid_like(oid: &str) -> String {
 /// hash of the repo root, keeps it a genuine local-only rollback aid
 /// (BLOCKING 2 / design S6). `blacklist.rs` also fail-closed denies
 /// `.git/tcfs-undo/**` so any pre-existing in-tree bundle can never roam.
-fn write_undo_bundle(repo_root: &Path, state_dir: &Path) -> Result<PathBuf> {
+pub(crate) fn write_undo_bundle(repo_root: &Path, state_dir: &Path) -> Result<PathBuf> {
     let repo_hex = blake3::hash(repo_root.to_string_lossy().as_bytes()).to_hex();
     let undo_dir = state_dir.join("keep-both-undo").join(&repo_hex[..16]);
     std::fs::create_dir_all(&undo_dir)

--- a/crates/tcfs-sync/src/conflict_git.rs
+++ b/crates/tcfs-sync/src/conflict_git.rs
@@ -176,8 +176,7 @@ pub async fn resolve_repo_keep_both(
                 head_ref
             );
         }
-        let park_ref = park_ref_for(remote_device, head_ref)?;
-        ensure_park_ref_available(&repo_root, &park_ref, &remote_sha)?;
+        let park_ref = park_ref_for_available(&repo_root, remote_device, head_ref, &remote_sha)?;
         parked_refs.push(GitKeepBothParkedRef {
             conflict_rel_path: candidate.rel_path.clone(),
             head_ref: head_ref.clone(),
@@ -212,7 +211,7 @@ pub async fn resolve_repo_keep_both(
 
     for parked in &parked_refs {
         ensure_local_ref_still_pinned(&repo_root, parked)?;
-        ensure_park_ref_available(&repo_root, &parked.park_ref, &parked.remote_sha)?;
+        ensure_selected_park_ref_available(&repo_root, &parked.park_ref, &parked.remote_sha)?;
     }
 
     // The undo bundle captures `--all` refs before we park anything. It is only
@@ -416,6 +415,16 @@ fn park_ref_for(remote_device: &str, head_ref: &str) -> Result<String> {
     Ok(format!("refs/tcfs/theirs/{safe_device}/heads/{branch}"))
 }
 
+fn park_ref_for_available(
+    repo_root: &Path,
+    remote_device: &str,
+    head_ref: &str,
+    sha: &str,
+) -> Result<String> {
+    let base = park_ref_for(remote_device, head_ref)?;
+    available_park_ref(repo_root, &base, sha)
+}
+
 /// Namespace a ref under `refs/tcfs/theirs/<device>/**` so its target objects
 /// become fsck-reachable on this machine and the ref never collides across
 /// devices. Reuses `park_ref_for` for branch heads (`refs/heads/<b>` →
@@ -443,17 +452,19 @@ pub(crate) fn theirs_ref_name(device: &str, ref_name: &str) -> Option<String> {
 }
 
 /// Create-only park of `sha` at `park_ref` in `repo_root` using the same
-/// zero-OID compare-and-swap the winner-side resolver uses: refuse if the ref
-/// already exists at a DIFFERENT sha, no-op if it already points at `sha`
-/// (idempotent re-run), otherwise `update-ref <park_ref> <sha> <zero-oid>`.
-pub(crate) fn park_ref_create_only(repo_root: &Path, park_ref: &str, sha: &str) -> Result<()> {
-    ensure_park_ref_available(repo_root, park_ref, sha)?;
-    if git_safety::local_ref_sha(repo_root, park_ref).as_deref() == Some(sha) {
-        return Ok(());
+/// zero-OID compare-and-swap the winner-side resolver uses: if the base ref
+/// already exists at a different sha, choose the documented `-<sha12>` suffix;
+/// no-op if the selected ref already points at `sha` (idempotent re-run),
+/// otherwise `update-ref <selected_ref> <sha> <zero-oid>`.
+pub(crate) fn park_ref_create_only(repo_root: &Path, park_ref: &str, sha: &str) -> Result<String> {
+    let park_ref = available_park_ref(repo_root, park_ref, sha)?;
+    if git_safety::local_ref_sha(repo_root, &park_ref).as_deref() == Some(sha) {
+        return Ok(park_ref);
     }
     let zero = zero_oid_like(sha);
-    run_git(repo_root, &["update-ref", park_ref, sha, zero.as_str()])
-        .with_context(|| format!("parking {sha} at {park_ref}"))
+    run_git(repo_root, &["update-ref", &park_ref, sha, zero.as_str()])
+        .with_context(|| format!("parking {sha} at {park_ref}"))?;
+    Ok(park_ref)
 }
 
 fn ensure_clean_worktree(repo_root: &Path) -> Result<()> {
@@ -494,7 +505,24 @@ fn ensure_local_ref_still_pinned(repo_root: &Path, parked: &GitKeepBothParkedRef
     Ok(())
 }
 
-fn ensure_park_ref_available(repo_root: &Path, park_ref: &str, remote_sha: &str) -> Result<()> {
+fn available_park_ref(repo_root: &Path, park_ref: &str, remote_sha: &str) -> Result<String> {
+    if let Some(existing) = git_safety::local_ref_sha(repo_root, park_ref) {
+        if existing == remote_sha {
+            return Ok(park_ref.to_string());
+        }
+        let suffix_len = remote_sha.len().min(12);
+        let suffixed = format!("{park_ref}-{}", &remote_sha[..suffix_len]);
+        ensure_selected_park_ref_available(repo_root, &suffixed, remote_sha)?;
+        return Ok(suffixed);
+    }
+    Ok(park_ref.to_string())
+}
+
+fn ensure_selected_park_ref_available(
+    repo_root: &Path,
+    park_ref: &str,
+    remote_sha: &str,
+) -> Result<()> {
     if let Some(existing) = git_safety::local_ref_sha(repo_root, park_ref) {
         if existing != remote_sha {
             bail!(
@@ -695,7 +723,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_refuses_to_overwrite_different_parked_ref() {
+    fn occupied_park_ref_gets_sha_suffix() {
         let dir = tempfile::tempdir().unwrap();
         let repo = dir.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
@@ -714,8 +742,17 @@ mod tests {
         let park_ref = "refs/tcfs/theirs/honey/heads/main";
         git_safety::run_git(&repo, &["update-ref", park_ref, &first]).unwrap();
 
-        let err = ensure_park_ref_available(&repo, park_ref, &second).unwrap_err();
-        assert!(err.to_string().contains("refusing to overwrite"));
+        let selected = available_park_ref(&repo, park_ref, &second).unwrap();
+        assert_eq!(
+            selected,
+            format!("refs/tcfs/theirs/honey/heads/main-{}", &second[..12])
+        );
+        assert_eq!(
+            park_ref_create_only(&repo, park_ref, &second).unwrap(),
+            selected
+        );
+        assert_eq!(git_safety::local_ref_sha(&repo, park_ref), Some(first));
+        assert_eq!(git_safety::local_ref_sha(&repo, &selected), Some(second));
     }
 
     #[test]

--- a/crates/tcfs-sync/src/conflict_git.rs
+++ b/crates/tcfs-sync/src/conflict_git.rs
@@ -510,10 +510,18 @@ fn available_park_ref(repo_root: &Path, park_ref: &str, remote_sha: &str) -> Res
         if existing == remote_sha {
             return Ok(park_ref.to_string());
         }
-        let suffix_len = remote_sha.len().min(12);
-        let suffixed = format!("{park_ref}-{}", &remote_sha[..suffix_len]);
-        ensure_selected_park_ref_available(repo_root, &suffixed, remote_sha)?;
-        return Ok(suffixed);
+        let min_suffix_len = remote_sha.len().min(12);
+        for suffix_len in min_suffix_len..=remote_sha.len() {
+            let suffixed = format!("{park_ref}-{}", &remote_sha[..suffix_len]);
+            match git_safety::local_ref_sha(repo_root, &suffixed) {
+                Some(existing) if existing == remote_sha => return Ok(suffixed),
+                Some(_) => continue,
+                None => return Ok(suffixed),
+            }
+        }
+        bail!(
+            "no available park ref for {remote_sha}: base {park_ref} and every SHA-prefixed suffix are occupied"
+        );
     }
     Ok(park_ref.to_string())
 }
@@ -752,6 +760,46 @@ mod tests {
             selected
         );
         assert_eq!(git_safety::local_ref_sha(&repo, park_ref), Some(first));
+        assert_eq!(git_safety::local_ref_sha(&repo, &selected), Some(second));
+    }
+
+    #[test]
+    fn occupied_sha12_suffix_widens_until_available() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git_safety::run_git(&repo, &["init", "--quiet", "--initial-branch=main"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.email", "tcfs@example.invalid"]).unwrap();
+        git_safety::run_git(&repo, &["config", "user.name", "TCFS Test"]).unwrap();
+        std::fs::write(repo.join("file.txt"), b"one").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "one", "--quiet"]).unwrap();
+        let first = git_safety::local_ref_sha(&repo, "HEAD").unwrap();
+        std::fs::write(repo.join("file.txt"), b"two").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "two", "--quiet"]).unwrap();
+        let second = git_safety::local_ref_sha(&repo, "HEAD").unwrap();
+        std::fs::write(repo.join("file.txt"), b"three").unwrap();
+        git_safety::run_git(&repo, &["add", "file.txt"]).unwrap();
+        git_safety::run_git(&repo, &["commit", "-m", "three", "--quiet"]).unwrap();
+        let third = git_safety::local_ref_sha(&repo, "HEAD").unwrap();
+
+        let park_ref = "refs/tcfs/theirs/honey/heads/main";
+        let sha12_ref = format!("{park_ref}-{}", &second[..12]);
+        git_safety::run_git(&repo, &["update-ref", park_ref, &first]).unwrap();
+        git_safety::run_git(&repo, &["update-ref", &sha12_ref, &third]).unwrap();
+
+        let selected = available_park_ref(&repo, park_ref, &second).unwrap();
+        assert_eq!(
+            selected,
+            format!("refs/tcfs/theirs/honey/heads/main-{}", &second[..13])
+        );
+        assert_eq!(
+            park_ref_create_only(&repo, park_ref, &second).unwrap(),
+            selected
+        );
+        assert_eq!(git_safety::local_ref_sha(&repo, park_ref), Some(first));
+        assert_eq!(git_safety::local_ref_sha(&repo, &sha12_ref), Some(third));
         assert_eq!(git_safety::local_ref_sha(&repo, &selected), Some(second));
     }
 

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -1045,26 +1045,45 @@ fn git_dir_head_is_symbolic(git_dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn packed_refs_shas(bytes: &[u8]) -> Vec<String> {
-    String::from_utf8_lossy(bytes)
-        .lines()
-        .filter_map(|line| {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
+fn git_ref_name_valid(ref_name: &str) -> bool {
+    ref_name.starts_with("refs/")
+        && std::process::Command::new("git")
+            .args(["check-ref-format", ref_name])
+            .output()
+            .map(|out| out.status.success())
+            .unwrap_or(false)
+}
+
+fn packed_refs_valid_shas(bytes: &[u8]) -> Option<Vec<String>> {
+    let mut shas = Vec::new();
+    for line in String::from_utf8_lossy(bytes).lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(peeled) = trimmed.strip_prefix('^') {
+            if peeled.split_whitespace().count() != 1 {
                 return None;
             }
-            let token = trimmed
-                .strip_prefix('^')
-                .unwrap_or(trimmed)
-                .split_whitespace()
-                .next()?;
-            git_safety::parse_ref_sha(token.as_bytes())
-        })
-        .collect()
+            shas.push(git_safety::parse_ref_sha(peeled.as_bytes())?);
+            continue;
+        }
+
+        let mut parts = trimmed.split_whitespace();
+        let sha = git_safety::parse_ref_sha(parts.next()?.as_bytes())?;
+        let ref_name = parts.next()?;
+        if parts.next().is_some() || !git_ref_name_valid(ref_name) {
+            return None;
+        }
+        shas.push(sha);
+    }
+    Some(shas)
 }
 
 fn packed_refs_objects_present(git_dir: &Path, bytes: &[u8]) -> bool {
-    let shas = packed_refs_shas(bytes);
+    let Some(shas) = packed_refs_valid_shas(bytes) else {
+        return false;
+    };
     !shas.is_empty() && shas.iter().all(|sha| git_dir_object_present(git_dir, sha))
 }
 
@@ -4683,6 +4702,47 @@ mod tests {
         assert!(
             !local_root.join(rel_path).exists(),
             "new packed-refs must not materialize before its objects are present"
+        );
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_new_malformed_packed_refs_even_when_object_exists() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let head = commit_file(&repo, "file.txt", "base", "base");
+
+        let rel_path = "repo/.git/packed-refs";
+        let packed_bytes = format!("# pack-refs with: peeled fully-peeled sorted\n{head} HEAD\n");
+        let manifest_hash = upload_blob(
+            &op,
+            local_root,
+            "remote-packed-malformed",
+            packed_bytes.as_bytes(),
+            rel_path,
+        )
+        .await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: packed_bytes.len() as u64,
+            reason: PullReason::NewRemote,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
+        assert!(
+            !local_root.join(rel_path).exists(),
+            "new packed-refs must not materialize malformed refnames even when the object exists"
         );
     }
 

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -18,7 +18,7 @@ use tokio::task::JoinSet;
 use tracing::{debug, info, warn};
 
 use crate::blacklist::Blacklist;
-use crate::conflict::{compare_clocks, ConflictInfo};
+use crate::conflict::{compare_clocks, ConflictInfo, VectorClock};
 use crate::conflict_git;
 use crate::engine::{self, OptionalEncryption, ProgressFn};
 use crate::git_safety;
@@ -1031,6 +1031,50 @@ fn git_dir_commit_present(git_dir: &Path, sha: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn zero_oid_like(oid: &str) -> String {
+    "0".repeat(oid.len())
+}
+
+fn git_dir_update_ref_cas(
+    git_dir: &Path,
+    ref_name: &str,
+    new_sha: &str,
+    expected_old: Option<&str>,
+) -> Result<()> {
+    let expected = expected_old
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| zero_oid_like(new_sha));
+    let output = std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["update-ref", ref_name, new_sha, &expected])
+        .output()
+        .with_context(|| format!("running git update-ref for {ref_name}"))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git update-ref CAS failed for {ref_name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn git_dir_delete_ref_cas(git_dir: &Path, ref_name: &str, expected_old: &str) -> Result<()> {
+    let output = std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["update-ref", "-d", ref_name, expected_old])
+        .output()
+        .with_context(|| format!("running git update-ref -d for {ref_name}"))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git update-ref delete CAS failed for {ref_name}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
 /// Outcome of acquiring cooperative `.git/tcfs.lock` guards for a plan.
 ///
 /// keep-both PR-2 (S3): the executor no longer proceeds unconditionally when a
@@ -1655,6 +1699,52 @@ async fn download_bytes_from_manifest(
     bytes
 }
 
+async fn read_sync_manifest_for_state(
+    op: &Operator,
+    remote_prefix: &str,
+    manifest_hash: &str,
+) -> Option<(String, SyncManifest)> {
+    let manifest_path = format!(
+        "{}/manifests/{}",
+        remote_prefix.trim_end_matches('/'),
+        manifest_hash
+    );
+    let manifest_bytes = op.read(&manifest_path).await.ok()?;
+    SyncManifest::from_bytes(&manifest_bytes.to_vec())
+        .ok()
+        .map(|manifest| (manifest_path, manifest))
+}
+
+async fn record_guarded_ref_pull_state(
+    op: &Operator,
+    remote_prefix: &str,
+    manifest_hash: &str,
+    local_path: &Path,
+    incoming_bytes: &[u8],
+    state: &mut StateCache,
+    device_id: &str,
+) -> Result<()> {
+    let (manifest_path, manifest) = read_sync_manifest_for_state(op, remote_prefix, manifest_hash)
+        .await
+        .context("reading pulled ref manifest for state")?;
+    let mut local_vclock = state
+        .get(local_path)
+        .map(|s| s.vclock.clone())
+        .unwrap_or_else(VectorClock::new);
+    local_vclock.merge(&manifest.vclock);
+    let hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(incoming_bytes));
+    let sync_state = crate::state::make_sync_state_full(
+        local_path,
+        hash,
+        manifest.chunk_hashes().len(),
+        manifest_path,
+        local_vclock,
+        device_id.to_string(),
+    )?;
+    state.set(local_path, sync_state);
+    Ok(())
+}
+
 /// True if a repo-relative path lies inside a `.git` directory.
 fn is_git_internal_path(rel_path: &str) -> bool {
     rel_path == ".git"
@@ -2047,113 +2137,151 @@ pub async fn execute_plan(
                             ref_name,
                             parkable,
                         } => {
-                            if let Some(current) = git_dir_ref_sha(&git_dir, &ref_name) {
-                                match download_ref_sha_from_manifest(
-                                    op,
-                                    remote_prefix,
-                                    manifest_hash,
-                                    encryption,
-                                )
-                                .await
+                            let incoming_bytes = match download_bytes_from_manifest(
+                                op,
+                                remote_prefix,
+                                manifest_hash,
+                                encryption,
+                            )
+                            .await
+                            {
+                                Some(bytes) => bytes,
+                                None => {
+                                    warn!(
+                                        path = %rel_path,
+                                        "loser-guard: incoming ref blob unreadable; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
+                            };
+                            let Some(incoming) = git_safety::parse_ref_sha(&incoming_bytes) else {
+                                warn!(
+                                    path = %rel_path,
+                                    "loser-guard: incoming ref SHA unreadable; deferring pull"
+                                );
+                                result.deferred_git_refs.push(rel_path.clone());
+                                continue;
+                            };
+                            if !git_dir_commit_present(&git_dir, &incoming) {
+                                warn!(
+                                    path = %rel_path,
+                                    incoming = %incoming,
+                                    "loser-guard: incoming ref object missing; deferring pull"
+                                );
+                                result.deferred_git_refs.push(rel_path.clone());
+                                continue;
+                            }
+
+                            let current = git_dir_ref_sha(&git_dir, &ref_name);
+                            let mut parked: Option<(String, String, PathBuf)> = None;
+                            if let Some(current_sha) = current.as_deref() {
+                                if current_sha != incoming
+                                    && !git_dir_is_ancestor(&git_dir, current_sha, &incoming)
                                 {
-                                    Some(incoming)
-                                        if !git_dir_commit_present(&git_dir, &incoming) =>
-                                    {
+                                    // Non-ancestor overwrite: committed work at
+                                    // `current_sha` is not reachable from
+                                    // `incoming`.
+                                    if !parkable {
                                         warn!(
                                             path = %rel_path,
-                                            incoming = %incoming,
-                                            "loser-guard: incoming ref object missing; deferring pull"
+                                            r#ref = %ref_name,
+                                            "loser-guard: non-parkable module head would be orphaned; deferring pull"
                                         );
                                         result.deferred_git_refs.push(rel_path.clone());
                                         continue;
                                     }
-                                    Some(incoming)
-                                        if current != incoming
-                                            && !git_dir_is_ancestor(
-                                                &git_dir, &current, &incoming,
-                                            ) =>
-                                    {
-                                        // Non-ancestor overwrite: committed
-                                        // work at `current` is not reachable
-                                        // from `incoming`.
-                                        if !parkable {
+                                    let Some(park_ref) =
+                                        conflict_git::theirs_ref_name(device_id, &ref_name)
+                                    else {
+                                        warn!(
+                                            path = %rel_path,
+                                            r#ref = %ref_name,
+                                            "loser-guard: no safe park ref namespace; deferring pull"
+                                        );
+                                        result.deferred_git_refs.push(rel_path.clone());
+                                        continue;
+                                    };
+                                    let bundle = match conflict_git::write_undo_bundle(
+                                        &repo_root,
+                                        &undo_state_dir,
+                                    ) {
+                                        Ok(bundle) => bundle,
+                                        Err(e) => {
                                             warn!(
                                                 path = %rel_path,
-                                                r#ref = %ref_name,
-                                                "loser-guard: non-parkable module head would be orphaned; deferring pull"
+                                                error = %format!("{e:#}"),
+                                                "loser-guard: pre-overwrite bundle failed; deferring pull"
                                             );
                                             result.deferred_git_refs.push(rel_path.clone());
                                             continue;
                                         }
-                                        let Some(park_ref) =
-                                            conflict_git::theirs_ref_name(device_id, &ref_name)
-                                        else {
+                                    };
+                                    let parked_ref = match conflict_git::park_ref_create_only(
+                                        &repo_root,
+                                        &park_ref,
+                                        current_sha,
+                                    ) {
+                                        Ok(parked_ref) => parked_ref,
+                                        Err(e) => {
                                             warn!(
                                                 path = %rel_path,
-                                                r#ref = %ref_name,
-                                                "loser-guard: no safe park ref namespace; deferring pull"
+                                                error = %format!("{e:#}"),
+                                                "loser-guard: park failed; deferring pull"
                                             );
                                             result.deferred_git_refs.push(rel_path.clone());
                                             continue;
-                                        };
-                                        let bundle = match conflict_git::write_undo_bundle(
-                                            &repo_root,
-                                            &undo_state_dir,
-                                        ) {
-                                            Ok(bundle) => bundle,
-                                            Err(e) => {
-                                                warn!(
-                                                    path = %rel_path,
-                                                    error = %format!("{e:#}"),
-                                                    "loser-guard: pre-overwrite bundle failed; deferring pull"
-                                                );
-                                                result.deferred_git_refs.push(rel_path.clone());
-                                                continue;
-                                            }
-                                        };
-                                        let parked_ref = match conflict_git::park_ref_create_only(
-                                            &repo_root, &park_ref, &current,
-                                        ) {
-                                            Ok(parked_ref) => parked_ref,
-                                            Err(e) => {
-                                                warn!(
-                                                    path = %rel_path,
-                                                    error = %format!("{e:#}"),
-                                                    "loser-guard: park failed; deferring pull"
-                                                );
-                                                result.deferred_git_refs.push(rel_path.clone());
-                                                continue;
-                                            }
-                                        };
-                                        info!(
-                                            path = %rel_path,
-                                            r#ref = %ref_name,
-                                            parked = %parked_ref,
-                                            orphaned_sha = %current,
-                                            bundle = %bundle.display(),
-                                            "loser-guard: bundled pre-overwrite .git + parked local head; applying pull"
-                                        );
-                                        // fall through: overwrite is now no-loss.
-                                    }
-                                    Some(_) => {
-                                        // Equal or fast-forward: no committed
-                                        // work lost.
-                                    }
-                                    None => {
-                                        // Incoming SHA unreadable (download
-                                        // failed / symbolic ref): cannot prove
-                                        // the overwrite is safe, so DEFER.
-                                        warn!(
-                                            path = %rel_path,
-                                            "loser-guard: incoming ref SHA unreadable; deferring pull"
-                                        );
-                                        result.deferred_git_refs.push(rel_path.clone());
-                                        continue;
-                                    }
+                                        }
+                                    };
+                                    parked = Some((parked_ref, current_sha.to_string(), bundle));
                                 }
                             }
-                            // current == None: the local ref does not exist
-                            // yet, so there is no committed work to orphan.
+
+                            if let Err(e) = git_dir_update_ref_cas(
+                                &git_dir,
+                                &ref_name,
+                                &incoming,
+                                current.as_deref(),
+                            ) {
+                                warn!(
+                                    path = %rel_path,
+                                    r#ref = %ref_name,
+                                    error = %format!("{e:#}"),
+                                    "loser-guard: ref moved before CAS update; deferring pull"
+                                );
+                                result.deferred_git_refs.push(rel_path.clone());
+                                continue;
+                            }
+                            if let Err(e) = record_guarded_ref_pull_state(
+                                op,
+                                remote_prefix,
+                                manifest_hash,
+                                &local_path,
+                                &incoming_bytes,
+                                state,
+                                device_id,
+                            )
+                            .await
+                            {
+                                result.errors.push((
+                                    rel_path.clone(),
+                                    format!("guarded ref pull state update failed: {e:#}"),
+                                ));
+                                continue;
+                            }
+                            if let Some((parked_ref, orphaned_sha, bundle)) = parked {
+                                info!(
+                                    path = %rel_path,
+                                    r#ref = %ref_name,
+                                    parked = %parked_ref,
+                                    orphaned_sha = %orphaned_sha,
+                                    bundle = %bundle.display(),
+                                    "loser-guard: bundled pre-overwrite .git + parked local head; applied CAS ref pull"
+                                );
+                            }
+                            result.pulled += 1;
+                            result.bytes_downloaded += incoming_bytes.len() as u64;
+                            continue;
                         }
                     }
                 }
@@ -2267,8 +2395,21 @@ pub async fn execute_plan(
                                 parked = %parked_ref,
                                 orphaned_sha = %current,
                                 bundle = %bundle.display(),
-                                "loser-guard: bundled pre-delete .git + parked local ref; applying local delete"
+                                "loser-guard: bundled pre-delete .git + parked local ref; applying CAS local delete"
                             );
+                            if let Err(e) = git_dir_delete_ref_cas(&git_dir, &ref_name, &current) {
+                                warn!(
+                                    path = %rel_path,
+                                    r#ref = %ref_name,
+                                    error = %format!("{e:#}"),
+                                    "loser-guard: ref moved before CAS delete; deferring local delete"
+                                );
+                                result.deferred_git_refs.push(rel_path.clone());
+                                continue;
+                            }
+                            state.remove(local_path);
+                            result.deleted_local += 1;
+                            continue;
                         }
                         None => {
                             warn!(
@@ -4130,6 +4271,92 @@ mod tests {
 
         assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
         assert_eq!(std::fs::read(&local_path).unwrap(), packed_bytes.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_new_ref_when_incoming_object_missing() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        commit_file(&repo, "file.txt", "base", "base");
+
+        let missing = "0123456789abcdef0123456789abcdef01234567";
+        let rel_path = "repo/.git/refs/heads/missing";
+        let manifest_hash = upload_blob(
+            &op,
+            local_root,
+            "remote-missing-ref",
+            format!("{missing}\n").as_bytes(),
+            rel_path,
+        )
+        .await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: 41,
+            reason: PullReason::NewRemote,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.deferred_git_refs,
+            vec![rel_path.to_string()],
+            "new local refs still need a present incoming commit object"
+        );
+        assert_eq!(result.pulled, 0);
+        assert!(git_safety::local_ref_sha(&repo, "refs/heads/missing").is_none());
+    }
+
+    #[test]
+    fn guarded_ref_pull_cas_rejects_moved_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        init_git_repo(&repo);
+        let base = commit_file(&repo, "file.txt", "base", "base");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "-b", "incoming", &base]).unwrap();
+        let incoming = commit_file(&repo, "file.txt", "incoming", "incoming");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "main"]).unwrap();
+        let local = commit_file(&repo, "file.txt", "local", "local");
+
+        let err = git_dir_update_ref_cas(
+            &repo.join(".git"),
+            "refs/heads/main",
+            &incoming,
+            Some(&base),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("CAS failed"));
+        assert_eq!(
+            git_safety::local_ref_sha(&repo, "refs/heads/main").as_deref(),
+            Some(local.as_str())
+        );
+    }
+
+    #[test]
+    fn guarded_ref_delete_cas_rejects_moved_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        init_git_repo(&repo);
+        let base = commit_file(&repo, "file.txt", "base", "base");
+        git_safety::run_git(&repo, &["branch", "side", &base]).unwrap();
+        let local = commit_file(&repo, "file.txt", "local", "local");
+        git_safety::run_git(&repo, &["branch", "-f", "side", &local]).unwrap();
+
+        let err = git_dir_delete_ref_cas(&repo.join(".git"), "refs/heads/side", &base).unwrap_err();
+        assert!(err.to_string().contains("delete CAS failed"));
+        assert_eq!(
+            git_safety::local_ref_sha(&repo, "refs/heads/side").as_deref(),
+            Some(local.as_str())
+        );
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -19,6 +19,7 @@ use tracing::{debug, info, warn};
 
 use crate::blacklist::Blacklist;
 use crate::conflict::{compare_clocks, ConflictInfo};
+use crate::conflict_git;
 use crate::engine::{self, OptionalEncryption, ProgressFn};
 use crate::git_safety;
 use crate::index_entry::{
@@ -181,8 +182,10 @@ pub struct ExecutionResult {
     /// deferred this run rather than applied. Two causes, both fail-closed and
     /// non-error: an object action for the same repo failed
     /// (objects-before-refs barrier), or the repo's `.git/tcfs.lock` is held by
-    /// a live foreign holder (keep-both PR-2, S3). The next reconcile cycle
-    /// re-plans them once the objects land / the holder releases.
+    /// a live foreign holder (keep-both PR-2, S3), or the PR-4 loser-side
+    /// no-loss guard could not park a locally divergent head before overwrite.
+    /// The next reconcile cycle re-plans them once the objects land / the holder
+    /// releases / parking succeeds.
     pub deferred_git_refs: Vec<String>,
 }
 
@@ -855,6 +858,145 @@ fn git_ff_pins_still_valid(local_root: &Path, pins: &[GitRefPin]) -> bool {
     })
 }
 
+/// A `.git` ref-class HEAD file a pull is about to overwrite that the
+/// loser-side no-loss guard (PR-4, S10) must vet: a top-level branch head
+/// (`.git/refs/heads/**`), the stash tip (`.git/refs/stash`), or a submodule
+/// module-gitdir branch head (`.git/modules/<name>/refs/heads/**`). Carries the
+/// git-dir to run `rev-parse`/`merge-base` against (the submodule's real gitdir
+/// for module refs) and whether the head is PARKABLE on this device (top-level
+/// heads/stash yes; module heads are future work → defer, never park).
+struct LoserGuardTarget {
+    /// Git dir the ref lives in (`<repo>/.git` or `<repo>/.git/modules/<name>`).
+    git_dir: PathBuf,
+    /// Repo root — where a parkable head is parked (top-level refs only).
+    repo_root: PathBuf,
+    /// Fully-qualified ref name (`refs/heads/<b>` or `refs/stash`).
+    ref_name: String,
+    /// True for top-level heads/stash (parkable via `refs/tcfs/theirs/<self>/**`).
+    /// False for module-gitdir heads (defer-only; module parking is future work).
+    parkable: bool,
+}
+
+/// Classify a pull's `rel_path` as a loser-guard HEAD target, or `None` if the
+/// guard does not apply (objects, index, logs, packed-refs, tags,
+/// remote-tracking refs, `refs/tcfs/**`, non-`.git` files — none of which carry
+/// a directly-overwritten committed tip that this guard can safely park).
+fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuardTarget> {
+    let rel = rel_path.replace('\\', "/");
+    let repo_root = git_safety::repo_root_for_git_path(local_root, &rel)?;
+    let git_root = repo_root.join(".git");
+    // Portion after the FIRST `.git/` component (the top-level repo git dir).
+    let needle = ".git/";
+    let pos = rel.find(needle)?;
+    let after = &rel[pos + needle.len()..];
+
+    if let Some(module_tail) = after.strip_prefix("modules/") {
+        // `.git/modules/<name...>/refs/heads/<branch>`. `<name>` may contain
+        // slashes / nested `modules/`, so split on the LAST `/refs/heads/`.
+        let marker = "/refs/heads/";
+        if let Some(idx) = module_tail.rfind(marker) {
+            let branch = &module_tail[idx + marker.len()..];
+            if branch.is_empty() || branch.ends_with('/') {
+                return None;
+            }
+            let module_subpath = &module_tail[..idx];
+            return Some(LoserGuardTarget {
+                git_dir: git_root.join("modules").join(module_subpath),
+                repo_root,
+                ref_name: format!("refs/heads/{branch}"),
+                parkable: false,
+            });
+        }
+        if let Some(module_subpath) = module_tail_raw_head(module_tail) {
+            let git_dir = git_root.join("modules").join(module_subpath);
+            if std::fs::read(git_dir.join("HEAD"))
+                .ok()
+                .and_then(|bytes| git_safety::parse_ref_sha(&bytes))
+                .is_some()
+            {
+                return Some(LoserGuardTarget {
+                    git_dir,
+                    repo_root,
+                    ref_name: "HEAD".to_string(),
+                    parkable: false,
+                });
+            }
+        }
+        return None;
+    }
+
+    if after == "refs/stash" {
+        return Some(LoserGuardTarget {
+            git_dir: git_root,
+            repo_root,
+            ref_name: "refs/stash".to_string(),
+            parkable: true,
+        });
+    }
+    if let Some(branch) = after.strip_prefix("refs/heads/") {
+        if branch.is_empty() || branch.ends_with('/') {
+            return None;
+        }
+        return Some(LoserGuardTarget {
+            git_dir: git_root,
+            repo_root,
+            ref_name: format!("refs/heads/{branch}"),
+            parkable: true,
+        });
+    }
+    if after == "HEAD"
+        && std::fs::read(git_root.join("HEAD"))
+            .ok()
+            .and_then(|bytes| git_safety::parse_ref_sha(&bytes))
+            .is_some()
+    {
+        return Some(LoserGuardTarget {
+            git_dir: git_root,
+            repo_root,
+            ref_name: "HEAD".to_string(),
+            parkable: false,
+        });
+    }
+    None
+}
+
+fn module_tail_raw_head(module_tail: &str) -> Option<&str> {
+    module_tail
+        .strip_suffix("/HEAD")
+        .filter(|module_subpath| !module_subpath.is_empty())
+}
+
+/// Read the SHA `ref_name` resolves to in an explicit git dir (`--git-dir`),
+/// consulting loose refs and packed-refs. `--git-dir` (not `-C`) so a
+/// submodule's bare-style module gitdir resolves correctly. `None` if the ref
+/// is absent or not a concrete SHA.
+fn git_dir_ref_sha(git_dir: &Path, ref_name: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["rev-parse", "--verify", "--quiet", ref_name])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    git_safety::parse_ref_sha(&output.stdout)
+}
+
+/// True iff `ancestor` is an ancestor of `descendant` in an explicit git dir.
+/// Mirrors `git_safety::is_ancestor` but targets a `--git-dir` so submodule
+/// module-gitdirs work. A missing object (exit != 0/1) is treated as "not an
+/// ancestor" so the guard fails closed toward parking/deferring.
+fn git_dir_is_ancestor(git_dir: &Path, ancestor: &str, descendant: &str) -> bool {
+    std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["merge-base", "--is-ancestor", ancestor, descendant])
+        .output()
+        .map(|out| out.status.code() == Some(0))
+        .unwrap_or(false)
+}
+
 /// Outcome of acquiring cooperative `.git/tcfs.lock` guards for a plan.
 ///
 /// keep-both PR-2 (S3): the executor no longer proceeds unconditionally when a
@@ -1413,10 +1555,27 @@ async fn read_remote_ref_sha(
     encryption: OptionalEncryption<'_>,
 ) -> Option<String> {
     let entry = remote_index.get(rel_path)?;
+    download_ref_sha_from_manifest(op, remote_prefix, &entry.manifest_hash, encryption).await
+}
+
+/// Download the tiny ref blob addressed by `manifest_hash` into an ephemeral,
+/// per-call temp dir (never under a sync root, never inside a live `.git`) and
+/// parse it as a concrete SHA. Shared by `read_remote_ref_sha` (plan-time) and
+/// the execute-loop loser-side no-loss guard (PR-4), which needs the INCOMING
+/// ref SHA a pull is about to write before deciding whether the overwrite would
+/// orphan committed local work. Returns `None` on download failure or a
+/// non-concrete (symbolic) ref — callers MUST treat `None` as "cannot prove
+/// safe" and fail closed.
+async fn download_ref_sha_from_manifest(
+    op: &Operator,
+    remote_prefix: &str,
+    manifest_hash: &str,
+    encryption: OptionalEncryption<'_>,
+) -> Option<String> {
     let manifest_path = format!(
         "{}/manifests/{}",
         remote_prefix.trim_end_matches('/'),
-        &entry.manifest_hash
+        manifest_hash
     );
     // Unique per call (pid + process-wide sequence) so concurrent reconciles
     // in one or many processes never collide on the same path.
@@ -1443,7 +1602,7 @@ async fn read_remote_ref_sha(
             .ok()
             .and_then(|bytes| git_safety::parse_ref_sha(&bytes)),
         Err(e) => {
-            warn!(path = rel_path, error = %format!("{e:#}"), "git ff: remote ref download failed");
+            warn!(manifest = manifest_hash, error = %format!("{e:#}"), "git ff: remote ref download failed");
             None
         }
     };
@@ -1627,6 +1786,14 @@ pub async fn execute_plan(
     // actions deferred (recorded, not errored); the next cycle re-plans them.
     let mut git_object_failed_repos: BTreeSet<PathBuf> = BTreeSet::new();
 
+    // keep-both PR-4 (S10): where the loser-side no-loss guard writes its
+    // pre-overwrite `.git` undo bundle. The state cache lives in the
+    // machine-local state dir, so its parent is that dir — OUTSIDE any sync root
+    // (the bundle must never roam and re-conflict). A parent-less db path (bare
+    // filename, e.g. in-memory tests) falls back to the temp dir; still
+    // out-of-tree.
+    let undo_state_dir = state.state_dir();
+
     for action in &plan.actions {
         let git_write_rel_path = match action {
             ReconcileAction::Push { rel_path, .. }
@@ -1770,6 +1937,115 @@ pub async fn execute_plan(
                             .push((rel_path.clone(), format!("mkdir failed: {e}")));
                         continue;
                     }
+                }
+
+                // keep-both PR-4 (S10): loser-side no-loss guard. This pull is
+                // about to OVERWRITE a local `.git` ref-class HEAD file. If that
+                // head currently holds committed work UNREACHABLE from the
+                // incoming SHA (not equal, not an ancestor of it), overwriting
+                // would orphan it. Before overwriting, park the current SHA at
+                // `refs/tcfs/theirs/<self_device>/**` (keeping the loser's line
+                // reachable + fsck-clean) and bundle-snapshot the pre-overwrite
+                // `.git` to the state dir. Park OR bundle failure — or a
+                // non-parkable module-gitdir head — DEFERS the pull (fail
+                // closed: never overwrite without a durable escape hatch). The
+                // FF / equal / new-ref fast paths take no parking, no bundle.
+                if let Some(target) = loser_guard_ref_target(local_root, rel_path) {
+                    if let Some(current) = git_dir_ref_sha(&target.git_dir, &target.ref_name) {
+                        match download_ref_sha_from_manifest(
+                            op,
+                            remote_prefix,
+                            manifest_hash,
+                            encryption,
+                        )
+                        .await
+                        {
+                            Some(incoming)
+                                if current != incoming
+                                    && !git_dir_is_ancestor(
+                                        &target.git_dir,
+                                        &current,
+                                        &incoming,
+                                    ) =>
+                            {
+                                // Non-ancestor overwrite: committed work at
+                                // `current` is not reachable from `incoming`.
+                                if !target.parkable {
+                                    warn!(
+                                        path = %rel_path,
+                                        r#ref = %target.ref_name,
+                                        "loser-guard: non-parkable module head would be orphaned; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
+                                let Some(park_ref) =
+                                    conflict_git::theirs_ref_name(device_id, &target.ref_name)
+                                else {
+                                    warn!(
+                                        path = %rel_path,
+                                        r#ref = %target.ref_name,
+                                        "loser-guard: no safe park ref namespace; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                };
+                                let bundle = match conflict_git::write_undo_bundle(
+                                    &target.repo_root,
+                                    &undo_state_dir,
+                                ) {
+                                    Ok(bundle) => bundle,
+                                    Err(e) => {
+                                        warn!(
+                                            path = %rel_path,
+                                            error = %format!("{e:#}"),
+                                            "loser-guard: pre-overwrite bundle failed; deferring pull"
+                                        );
+                                        result.deferred_git_refs.push(rel_path.clone());
+                                        continue;
+                                    }
+                                };
+                                if let Err(e) = conflict_git::park_ref_create_only(
+                                    &target.repo_root,
+                                    &park_ref,
+                                    &current,
+                                ) {
+                                    warn!(
+                                        path = %rel_path,
+                                        error = %format!("{e:#}"),
+                                        "loser-guard: park failed; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
+                                info!(
+                                    path = %rel_path,
+                                    r#ref = %target.ref_name,
+                                    parked = %park_ref,
+                                    orphaned_sha = %current,
+                                    bundle = %bundle.display(),
+                                    "loser-guard: bundled pre-overwrite .git + parked local head; applying pull"
+                                );
+                                // fall through: overwrite is now no-loss.
+                            }
+                            Some(_) => {
+                                // Equal or fast-forward: no committed work lost.
+                            }
+                            None => {
+                                // Incoming SHA unreadable (download failed /
+                                // symbolic ref): cannot prove the overwrite is
+                                // safe, so DEFER (fail closed).
+                                warn!(
+                                    path = %rel_path,
+                                    "loser-guard: incoming ref SHA unreadable; deferring pull"
+                                );
+                                result.deferred_git_refs.push(rel_path.clone());
+                                continue;
+                            }
+                        }
+                    }
+                    // current == None: the local ref does not exist yet, so
+                    // there is no committed work to orphan — apply normally.
                 }
 
                 match engine::download_file_with_device(
@@ -3187,6 +3463,153 @@ mod tests {
         // Object data and non-git paths → never veto.
         assert!(!ff_group_vetoes("repo/.git/objects/ab/cdef"));
         assert!(!ff_group_vetoes("repo/src/refs.rs"));
+    }
+
+    // ── keep-both PR-4 (S10): loser-side no-loss guard ─────────────────────
+
+    fn init_git_repo(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+        git_safety::run_git(path, &["init", "--quiet", "--initial-branch=main"]).unwrap();
+        git_safety::run_git(path, &["config", "user.email", "tcfs@example.invalid"]).unwrap();
+        git_safety::run_git(path, &["config", "user.name", "TCFS Test"]).unwrap();
+    }
+
+    fn commit_file(path: &Path, file: &str, body: &str, msg: &str) -> String {
+        std::fs::write(path.join(file), body.as_bytes()).unwrap();
+        git_safety::run_git(path, &["add", file]).unwrap();
+        git_safety::run_git(path, &["commit", "-m", msg, "--quiet"]).unwrap();
+        git_safety::local_ref_sha(path, "HEAD").unwrap()
+    }
+
+    async fn upload_ref_blob(op: &Operator, root: &Path, sha: &str) -> String {
+        let ref_blob = root.join("remote-ref");
+        std::fs::write(&ref_blob, format!("{sha}\n")).unwrap();
+        let mut state = crate::state::StateCache::open(&root.join("upload-state.json")).unwrap();
+        let upload = engine::upload_file_with_device(
+            op,
+            &ref_blob,
+            "data",
+            &mut state,
+            None,
+            "remote",
+            Some("repo/.git/refs/heads/main"),
+            None,
+        )
+        .await
+        .unwrap();
+        upload.hash
+    }
+
+    #[test]
+    fn loser_guard_target_ignores_symbolic_head_but_catches_detached_head() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let head = commit_file(&repo, "file.txt", "base", "base");
+
+        assert!(
+            loser_guard_ref_target(local_root, "repo/.git/HEAD").is_none(),
+            "symbolic HEAD is not a directly parkable committed tip"
+        );
+
+        git_safety::run_git(&repo, &["checkout", "--quiet", "--detach", &head]).unwrap();
+        let target = loser_guard_ref_target(local_root, "repo/.git/HEAD")
+            .expect("detached HEAD must be guarded");
+        assert_eq!(target.ref_name, "HEAD");
+        assert!(!target.parkable, "detached HEAD is defer-only");
+    }
+
+    #[tokio::test]
+    async fn loser_guard_parks_divergent_local_head_before_ref_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let base = commit_file(&repo, "file.txt", "base", "base");
+        let local_head = commit_file(&repo, "file.txt", "local work", "local");
+        assert_ne!(base, local_head);
+
+        let manifest_hash = upload_ref_blob(&op, local_root, &base).await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: "repo/.git/refs/heads/main".to_string(),
+            manifest_hash,
+            size: 41,
+            reason: PullReason::RemoteNewer,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.deferred_git_refs.is_empty(), "{result:?}");
+        assert_eq!(result.pulled, 1);
+        assert_eq!(
+            git_safety::local_ref_sha(&repo, "refs/heads/main").as_deref(),
+            Some(base.as_str()),
+            "remote pull overwrites the live branch only after parking"
+        );
+        assert_eq!(
+            git_safety::local_ref_sha(&repo, "refs/tcfs/theirs/neo/heads/main").as_deref(),
+            Some(local_head.as_str()),
+            "loser's previous head remains reachable under its own device namespace"
+        );
+        assert!(
+            state_path.parent().unwrap().join("keep-both-undo").exists(),
+            "pre-overwrite undo bundle lives under the state dir"
+        );
+        git_safety::run_git(&repo, &["fsck", "--full"]).unwrap();
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_divergent_submodule_head_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let current = commit_file(&repo, "file.txt", "local work", "local");
+
+        let module_git = repo.join(".git/modules/dep");
+        std::fs::create_dir_all(repo.join(".git/modules")).unwrap();
+        git_safety::run_git(
+            &repo,
+            &["clone", "--quiet", "--bare", ".", ".git/modules/dep"],
+        )
+        .unwrap();
+
+        let incoming = "0123456789012345678901234567890123456789";
+        let manifest_hash = upload_ref_blob(&op, local_root, incoming).await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let rel_path = "repo/.git/modules/dep/refs/heads/main";
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: 41,
+            reason: PullReason::RemoteNewer,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.deferred_git_refs,
+            vec![rel_path.to_string()],
+            "module-gitdir heads are not silently overwritten until module parking exists"
+        );
+        assert_eq!(
+            git_dir_ref_sha(&module_git, "refs/heads/main").as_deref(),
+            Some(current.as_str())
+        );
     }
 
     // ── keep-both PR-2 (S3): executor hard-respects a foreign `.git/tcfs.lock` ──

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -3612,7 +3612,7 @@ mod tests {
         let ref_blob = root.join(file_name);
         std::fs::write(&ref_blob, bytes).unwrap();
         let mut state = crate::state::StateCache::open(&root.join("upload-state.json")).unwrap();
-        let upload = engine::upload_file_with_device(
+        engine::upload_file_with_device(
             op,
             &ref_blob,
             "data",
@@ -3624,7 +3624,18 @@ mod tests {
         )
         .await
         .unwrap();
-        upload.hash
+        // The pull's manifest_hash is the remote index's content-addressed
+        // manifest key (NOT UploadResult.hash, which is the file-content hash);
+        // the guard downloads the ref blob by exactly this key. Look it up by
+        // the uploaded `rel_path` so callers uploading under non-head paths
+        // (packed-refs, module refs) get their own entry, not a hardcoded one.
+        list_remote_index(op, "data")
+            .await
+            .unwrap()
+            .get(rel_path)
+            .expect("uploaded ref index entry")
+            .manifest_hash
+            .clone()
     }
 
     #[test]

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -858,39 +858,50 @@ fn git_ff_pins_still_valid(local_root: &Path, pins: &[GitRefPin]) -> bool {
     })
 }
 
-/// A `.git` ref-class HEAD file a pull is about to overwrite that the
-/// loser-side no-loss guard (PR-4, S10) must vet: a top-level branch head
-/// (`.git/refs/heads/**`), the stash tip (`.git/refs/stash`), or a submodule
-/// module-gitdir ref (`.git/modules/<name>/refs/**`). Carries the git-dir to run
-/// `rev-parse`/`merge-base` against (the submodule's real gitdir for module
-/// refs) and whether the ref is PARKABLE on this device (top-level heads/stash
-/// yes; tags/remotes/module refs are future work → defer, never park).
-struct LoserGuardTarget {
-    /// Git dir the ref lives in (`<repo>/.git` or `<repo>/.git/modules/<name>`).
-    git_dir: PathBuf,
-    /// Repo root — where a parkable head is parked (top-level refs only).
-    repo_root: PathBuf,
-    /// Fully-qualified ref name (`refs/heads/<b>` or `refs/stash`).
-    ref_name: String,
-    /// True for top-level heads/stash (parkable via `refs/tcfs/theirs/<self>/**`).
-    /// False for module-gitdir heads (defer-only; module parking is future work).
-    parkable: bool,
+/// A `.git` ref-class file a pull is about to overwrite that the loser-side
+/// no-loss guard (PR-4, S10) must vet.
+enum LoserGuardTarget {
+    /// Concrete ref resolvable through a gitdir. Top-level heads/stash are
+    /// parkable; all other ref names are defer-only.
+    Ref {
+        /// Git dir the ref lives in (`<repo>/.git` or
+        /// `<repo>/.git/modules/<name>`).
+        git_dir: PathBuf,
+        /// Repo root — where a parkable head is parked (top-level refs only).
+        repo_root: PathBuf,
+        /// Fully-qualified ref name (`refs/heads/<b>` or `refs/stash`).
+        ref_name: String,
+        /// True for top-level heads/stash (`refs/tcfs/theirs/<self>/**`).
+        /// False for module-gitdir/non-head refs; future work, so defer.
+        parkable: bool,
+    },
+    /// Opaque packed ref table. We do not parse or rewrite individual entries
+    /// in PR-4; any byte-level difference is defer-only.
+    PackedRefs { local_path: PathBuf },
 }
 
-/// Classify a pull's `rel_path` as a loser-guard HEAD target, or `None` if the
-/// guard does not apply (objects, index, logs, packed-refs, tags,
-/// remote-tracking refs, `refs/tcfs/**`, non-`.git` files — none of which carry
-/// a directly-overwritten committed tip that this guard can safely park).
+/// Classify a pull's `rel_path` as a loser-guard target, or `None` if the guard
+/// does not apply (objects, index, logs, `refs/tcfs/**`, non-`.git` files).
 fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuardTarget> {
     let rel = rel_path.replace('\\', "/");
     let repo_root = git_safety::repo_root_for_git_path(local_root, &rel)?;
     let git_root = repo_root.join(".git");
-    // Portion after the FIRST `.git/` component (the top-level repo git dir).
-    let needle = ".git/";
-    let pos = rel.find(needle)?;
-    let after = &rel[pos + needle.len()..];
+    let local_path = local_root.join(&rel);
+    let after_path = local_path.strip_prefix(&git_root).ok()?;
+    let after = after_path.to_string_lossy().replace('\\', "/");
+    let after = after.trim_start_matches('/');
 
     if let Some(module_tail) = after.strip_prefix("modules/") {
+        if let Some(module_subpath) = module_tail.strip_suffix("/packed-refs") {
+            if !module_subpath.is_empty() {
+                return Some(LoserGuardTarget::PackedRefs {
+                    local_path: git_root
+                        .join("modules")
+                        .join(module_subpath)
+                        .join("packed-refs"),
+                });
+            }
+        }
         // `.git/modules/<name...>/refs/<kind>/<name>`. `<name>` may contain
         // slashes / nested `modules/`, so split on the LAST `/refs/`.
         let marker = "/refs/";
@@ -900,7 +911,7 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
                 return None;
             }
             let module_subpath = &module_tail[..idx];
-            return Some(LoserGuardTarget {
+            return Some(LoserGuardTarget::Ref {
                 git_dir: git_root.join("modules").join(module_subpath),
                 repo_root,
                 ref_name: ref_suffix.to_string(),
@@ -914,7 +925,7 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
                 .and_then(|bytes| git_safety::parse_ref_sha(&bytes))
                 .is_some()
             {
-                return Some(LoserGuardTarget {
+                return Some(LoserGuardTarget::Ref {
                     git_dir,
                     repo_root,
                     ref_name: "HEAD".to_string(),
@@ -925,8 +936,13 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
         return None;
     }
 
+    if after == "packed-refs" {
+        return Some(LoserGuardTarget::PackedRefs {
+            local_path: git_root.join("packed-refs"),
+        });
+    }
     if after == "refs/stash" {
-        return Some(LoserGuardTarget {
+        return Some(LoserGuardTarget::Ref {
             git_dir: git_root,
             repo_root,
             ref_name: "refs/stash".to_string(),
@@ -937,7 +953,7 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
         if branch.is_empty() || branch.ends_with('/') {
             return None;
         }
-        return Some(LoserGuardTarget {
+        return Some(LoserGuardTarget::Ref {
             git_dir: git_root,
             repo_root,
             ref_name: format!("refs/heads/{branch}"),
@@ -945,7 +961,7 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
         });
     }
     if after.starts_with("refs/") && !after.starts_with("refs/tcfs/") && !after.ends_with('/') {
-        return Some(LoserGuardTarget {
+        return Some(LoserGuardTarget::Ref {
             git_dir: git_root,
             repo_root,
             ref_name: after.to_string(),
@@ -958,7 +974,7 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
             .and_then(|bytes| git_safety::parse_ref_sha(&bytes))
             .is_some()
     {
-        return Some(LoserGuardTarget {
+        return Some(LoserGuardTarget::Ref {
             git_dir: git_root,
             repo_root,
             ref_name: "HEAD".to_string(),
@@ -1002,6 +1018,16 @@ fn git_dir_is_ancestor(git_dir: &Path, ancestor: &str, descendant: &str) -> bool
         .args(["merge-base", "--is-ancestor", ancestor, descendant])
         .output()
         .map(|out| out.status.code() == Some(0))
+        .unwrap_or(false)
+}
+
+fn git_dir_commit_present(git_dir: &Path, sha: &str) -> bool {
+    std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
+        .output()
+        .map(|out| out.status.success())
         .unwrap_or(false)
 }
 
@@ -1580,6 +1606,19 @@ async fn download_ref_sha_from_manifest(
     manifest_hash: &str,
     encryption: OptionalEncryption<'_>,
 ) -> Option<String> {
+    download_bytes_from_manifest(op, remote_prefix, manifest_hash, encryption)
+        .await
+        .and_then(|bytes| git_safety::parse_ref_sha(&bytes))
+}
+
+/// Download a manifest-addressed blob into an ephemeral temp dir and return its
+/// bytes. Used by SHA-ref guards and opaque packed-refs guards.
+async fn download_bytes_from_manifest(
+    op: &Operator,
+    remote_prefix: &str,
+    manifest_hash: &str,
+    encryption: OptionalEncryption<'_>,
+) -> Option<Vec<u8>> {
     let manifest_path = format!(
         "{}/manifests/{}",
         remote_prefix.trim_end_matches('/'),
@@ -1605,17 +1644,15 @@ async fn download_ref_sha_from_manifest(
         encryption,
     )
     .await;
-    let sha = match download {
-        Ok(_) => std::fs::read(&tmp_path)
-            .ok()
-            .and_then(|bytes| git_safety::parse_ref_sha(&bytes)),
+    let bytes = match download {
+        Ok(_) => std::fs::read(&tmp_path).ok(),
         Err(e) => {
-            warn!(manifest = manifest_hash, error = %format!("{e:#}"), "git ff: remote ref download failed");
+            warn!(manifest = manifest_hash, error = %format!("{e:#}"), "git ref guard: remote blob download failed");
             None
         }
     };
     let _ = std::fs::remove_dir_all(&tmp_dir);
-    sha
+    bytes
 }
 
 /// True if a repo-relative path lies inside a `.git` directory.
@@ -1959,101 +1996,166 @@ pub async fn execute_plan(
                 // closed: never overwrite without a durable escape hatch). The
                 // FF / equal / new-ref fast paths take no parking, no bundle.
                 if let Some(target) = loser_guard_ref_target(local_root, rel_path) {
-                    if let Some(current) = git_dir_ref_sha(&target.git_dir, &target.ref_name) {
-                        match download_ref_sha_from_manifest(
-                            op,
-                            remote_prefix,
-                            manifest_hash,
-                            encryption,
-                        )
-                        .await
-                        {
-                            Some(incoming)
-                                if current != incoming
-                                    && !git_dir_is_ancestor(
-                                        &target.git_dir,
-                                        &current,
-                                        &incoming,
-                                    ) =>
-                            {
-                                // Non-ancestor overwrite: committed work at
-                                // `current` is not reachable from `incoming`.
-                                if !target.parkable {
+                    match target {
+                        LoserGuardTarget::PackedRefs { local_path } => {
+                            match (
+                                std::fs::read(&local_path),
+                                download_bytes_from_manifest(
+                                    op,
+                                    remote_prefix,
+                                    manifest_hash,
+                                    encryption,
+                                )
+                                .await,
+                            ) {
+                                (Ok(current), Some(incoming)) if current != incoming => {
                                     warn!(
                                         path = %rel_path,
-                                        r#ref = %target.ref_name,
-                                        "loser-guard: non-parkable module head would be orphaned; deferring pull"
+                                        "loser-guard: packed-refs would change opaquely; deferring pull"
                                     );
                                     result.deferred_git_refs.push(rel_path.clone());
                                     continue;
                                 }
-                                let Some(park_ref) =
-                                    conflict_git::theirs_ref_name(device_id, &target.ref_name)
-                                else {
+                                (Err(e), Some(_)) if e.kind() == std::io::ErrorKind::NotFound => {
+                                    // No local packed-refs table exists, so
+                                    // there is no packed-only local tip to
+                                    // orphan. Apply the new file normally.
+                                }
+                                (Err(e), Some(_)) => {
                                     warn!(
                                         path = %rel_path,
-                                        r#ref = %target.ref_name,
-                                        "loser-guard: no safe park ref namespace; deferring pull"
+                                        error = %e,
+                                        "loser-guard: cannot inspect local packed-refs; deferring pull"
                                     );
                                     result.deferred_git_refs.push(rel_path.clone());
                                     continue;
-                                };
-                                let bundle = match conflict_git::write_undo_bundle(
-                                    &target.repo_root,
-                                    &undo_state_dir,
-                                ) {
-                                    Ok(bundle) => bundle,
-                                    Err(e) => {
+                                }
+                                (_, None) => {
+                                    warn!(
+                                        path = %rel_path,
+                                        "loser-guard: incoming packed-refs unreadable; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
+                                (Ok(_), Some(_)) => {}
+                            }
+                        }
+                        LoserGuardTarget::Ref {
+                            git_dir,
+                            repo_root,
+                            ref_name,
+                            parkable,
+                        } => {
+                            if let Some(current) = git_dir_ref_sha(&git_dir, &ref_name) {
+                                match download_ref_sha_from_manifest(
+                                    op,
+                                    remote_prefix,
+                                    manifest_hash,
+                                    encryption,
+                                )
+                                .await
+                                {
+                                    Some(incoming)
+                                        if !git_dir_commit_present(&git_dir, &incoming) =>
+                                    {
                                         warn!(
                                             path = %rel_path,
-                                            error = %format!("{e:#}"),
-                                            "loser-guard: pre-overwrite bundle failed; deferring pull"
+                                            incoming = %incoming,
+                                            "loser-guard: incoming ref object missing; deferring pull"
                                         );
                                         result.deferred_git_refs.push(rel_path.clone());
                                         continue;
                                     }
-                                };
-                                if let Err(e) = conflict_git::park_ref_create_only(
-                                    &target.repo_root,
-                                    &park_ref,
-                                    &current,
-                                ) {
-                                    warn!(
-                                        path = %rel_path,
-                                        error = %format!("{e:#}"),
-                                        "loser-guard: park failed; deferring pull"
-                                    );
-                                    result.deferred_git_refs.push(rel_path.clone());
-                                    continue;
+                                    Some(incoming)
+                                        if current != incoming
+                                            && !git_dir_is_ancestor(
+                                                &git_dir, &current, &incoming,
+                                            ) =>
+                                    {
+                                        // Non-ancestor overwrite: committed
+                                        // work at `current` is not reachable
+                                        // from `incoming`.
+                                        if !parkable {
+                                            warn!(
+                                                path = %rel_path,
+                                                r#ref = %ref_name,
+                                                "loser-guard: non-parkable module head would be orphaned; deferring pull"
+                                            );
+                                            result.deferred_git_refs.push(rel_path.clone());
+                                            continue;
+                                        }
+                                        let Some(park_ref) =
+                                            conflict_git::theirs_ref_name(device_id, &ref_name)
+                                        else {
+                                            warn!(
+                                                path = %rel_path,
+                                                r#ref = %ref_name,
+                                                "loser-guard: no safe park ref namespace; deferring pull"
+                                            );
+                                            result.deferred_git_refs.push(rel_path.clone());
+                                            continue;
+                                        };
+                                        let bundle = match conflict_git::write_undo_bundle(
+                                            &repo_root,
+                                            &undo_state_dir,
+                                        ) {
+                                            Ok(bundle) => bundle,
+                                            Err(e) => {
+                                                warn!(
+                                                    path = %rel_path,
+                                                    error = %format!("{e:#}"),
+                                                    "loser-guard: pre-overwrite bundle failed; deferring pull"
+                                                );
+                                                result.deferred_git_refs.push(rel_path.clone());
+                                                continue;
+                                            }
+                                        };
+                                        let parked_ref = match conflict_git::park_ref_create_only(
+                                            &repo_root, &park_ref, &current,
+                                        ) {
+                                            Ok(parked_ref) => parked_ref,
+                                            Err(e) => {
+                                                warn!(
+                                                    path = %rel_path,
+                                                    error = %format!("{e:#}"),
+                                                    "loser-guard: park failed; deferring pull"
+                                                );
+                                                result.deferred_git_refs.push(rel_path.clone());
+                                                continue;
+                                            }
+                                        };
+                                        info!(
+                                            path = %rel_path,
+                                            r#ref = %ref_name,
+                                            parked = %parked_ref,
+                                            orphaned_sha = %current,
+                                            bundle = %bundle.display(),
+                                            "loser-guard: bundled pre-overwrite .git + parked local head; applying pull"
+                                        );
+                                        // fall through: overwrite is now no-loss.
+                                    }
+                                    Some(_) => {
+                                        // Equal or fast-forward: no committed
+                                        // work lost.
+                                    }
+                                    None => {
+                                        // Incoming SHA unreadable (download
+                                        // failed / symbolic ref): cannot prove
+                                        // the overwrite is safe, so DEFER.
+                                        warn!(
+                                            path = %rel_path,
+                                            "loser-guard: incoming ref SHA unreadable; deferring pull"
+                                        );
+                                        result.deferred_git_refs.push(rel_path.clone());
+                                        continue;
+                                    }
                                 }
-                                info!(
-                                    path = %rel_path,
-                                    r#ref = %target.ref_name,
-                                    parked = %park_ref,
-                                    orphaned_sha = %current,
-                                    bundle = %bundle.display(),
-                                    "loser-guard: bundled pre-overwrite .git + parked local head; applying pull"
-                                );
-                                // fall through: overwrite is now no-loss.
                             }
-                            Some(_) => {
-                                // Equal or fast-forward: no committed work lost.
-                            }
-                            None => {
-                                // Incoming SHA unreadable (download failed /
-                                // symbolic ref): cannot prove the overwrite is
-                                // safe, so DEFER (fail closed).
-                                warn!(
-                                    path = %rel_path,
-                                    "loser-guard: incoming ref SHA unreadable; deferring pull"
-                                );
-                                result.deferred_git_refs.push(rel_path.clone());
-                                continue;
-                            }
+                            // current == None: the local ref does not exist
+                            // yet, so there is no committed work to orphan.
                         }
                     }
-                    // current == None: the local ref does not exist yet, so
-                    // there is no committed work to orphan — apply normally.
                 }
 
                 match engine::download_file_with_device(
@@ -3490,8 +3592,25 @@ mod tests {
     }
 
     async fn upload_ref_blob(op: &Operator, root: &Path, sha: &str) -> String {
-        let ref_blob = root.join("remote-ref");
-        std::fs::write(&ref_blob, format!("{sha}\n")).unwrap();
+        upload_blob(
+            op,
+            root,
+            "remote-ref",
+            format!("{sha}\n").as_bytes(),
+            "repo/.git/refs/heads/main",
+        )
+        .await
+    }
+
+    async fn upload_blob(
+        op: &Operator,
+        root: &Path,
+        file_name: &str,
+        bytes: &[u8],
+        rel_path: &str,
+    ) -> String {
+        let ref_blob = root.join(file_name);
+        std::fs::write(&ref_blob, bytes).unwrap();
         let mut state = crate::state::StateCache::open(&root.join("upload-state.json")).unwrap();
         let upload = engine::upload_file_with_device(
             op,
@@ -3500,7 +3619,7 @@ mod tests {
             &mut state,
             None,
             "remote",
-            Some("repo/.git/refs/heads/main"),
+            Some(rel_path),
             None,
         )
         .await
@@ -3524,8 +3643,37 @@ mod tests {
         git_safety::run_git(&repo, &["checkout", "--quiet", "--detach", &head]).unwrap();
         let target = loser_guard_ref_target(local_root, "repo/.git/HEAD")
             .expect("detached HEAD must be guarded");
-        assert_eq!(target.ref_name, "HEAD");
-        assert!(!target.parkable, "detached HEAD is defer-only");
+        match target {
+            LoserGuardTarget::Ref {
+                ref_name, parkable, ..
+            } => {
+                assert_eq!(ref_name, "HEAD");
+                assert!(!parkable, "detached HEAD is defer-only");
+            }
+            LoserGuardTarget::PackedRefs { .. } => panic!("HEAD must classify as a ref target"),
+        }
+    }
+
+    #[test]
+    fn loser_guard_uses_exact_git_path_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("foo.git");
+        init_git_repo(&repo);
+        let head = commit_file(&repo, "file.txt", "base", "base");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "--detach", &head]).unwrap();
+
+        let target = loser_guard_ref_target(local_root, "foo.git/.git/HEAD")
+            .expect("repo directory names ending in .git must not confuse guard parsing");
+        match target {
+            LoserGuardTarget::Ref {
+                git_dir, ref_name, ..
+            } => {
+                assert_eq!(git_dir, repo.join(".git"));
+                assert_eq!(ref_name, "HEAD");
+            }
+            LoserGuardTarget::PackedRefs { .. } => panic!("HEAD must classify as a ref target"),
+        }
     }
 
     #[tokio::test]
@@ -3581,7 +3729,11 @@ mod tests {
         let local_root = dir.path();
         let repo = local_root.join("repo");
         init_git_repo(&repo);
+        let base = commit_file(&repo, "file.txt", "base", "base");
         let current = commit_file(&repo, "file.txt", "local work", "local");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "-b", "incoming", &base]).unwrap();
+        let incoming = commit_file(&repo, "file.txt", "incoming work", "incoming");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "main"]).unwrap();
 
         let module_git = repo.join(".git/modules/dep");
         std::fs::create_dir_all(repo.join(".git/modules")).unwrap();
@@ -3591,8 +3743,7 @@ mod tests {
         )
         .unwrap();
 
-        let incoming = "0123456789012345678901234567890123456789";
-        let manifest_hash = upload_ref_blob(&op, local_root, incoming).await;
+        let manifest_hash = upload_ref_blob(&op, local_root, &incoming).await;
         let state_path = dir.path().join("state/state.json");
         let mut state = crate::state::StateCache::open(&state_path).unwrap();
         let rel_path = "repo/.git/modules/dep/refs/heads/main";
@@ -3627,11 +3778,14 @@ mod tests {
         let local_root = dir.path();
         let repo = local_root.join("repo");
         init_git_repo(&repo);
+        let base = commit_file(&repo, "file.txt", "base", "base");
         let current = commit_file(&repo, "file.txt", "tagged work", "tagged");
         git_safety::run_git(&repo, &["tag", "v1", &current]).unwrap();
+        git_safety::run_git(&repo, &["checkout", "--quiet", "-b", "incoming", &base]).unwrap();
+        let incoming = commit_file(&repo, "file.txt", "incoming work", "incoming");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "main"]).unwrap();
 
-        let incoming = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
-        let manifest_hash = upload_ref_blob(&op, local_root, incoming).await;
+        let manifest_hash = upload_ref_blob(&op, local_root, &incoming).await;
         let state_path = dir.path().join("state/state.json");
         let mut state = crate::state::StateCache::open(&state_path).unwrap();
         let rel_path = "repo/.git/refs/tags/v1";
@@ -3657,6 +3811,107 @@ mod tests {
             git_safety::local_ref_sha(&repo, "refs/tags/v1").as_deref(),
             Some(current.as_str())
         );
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_top_level_packed_refs_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let base = commit_file(&repo, "file.txt", "base", "base");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "-b", "incoming", &base]).unwrap();
+        let incoming = commit_file(&repo, "file.txt", "incoming work", "incoming");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "main"]).unwrap();
+
+        let packed = repo.join(".git/packed-refs");
+        let local_bytes =
+            format!("# pack-refs with: peeled fully-peeled sorted\n{base} refs/heads/main\n");
+        let remote_bytes =
+            format!("# pack-refs with: peeled fully-peeled sorted\n{incoming} refs/heads/main\n");
+        std::fs::write(&packed, local_bytes.as_bytes()).unwrap();
+
+        let rel_path = "repo/.git/packed-refs";
+        let manifest_hash = upload_blob(
+            &op,
+            local_root,
+            "remote-packed-refs",
+            remote_bytes.as_bytes(),
+            rel_path,
+        )
+        .await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: remote_bytes.len() as u64,
+            reason: PullReason::RemoteNewer,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.deferred_git_refs,
+            vec![rel_path.to_string()],
+            "packed-refs is opaque and must not be overwritten when bytes differ"
+        );
+        assert_eq!(std::fs::read(&packed).unwrap(), local_bytes.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_submodule_packed_refs_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let base = commit_file(&repo, "file.txt", "base", "base");
+        let incoming = commit_file(&repo, "file.txt", "incoming work", "incoming");
+
+        let packed = repo.join(".git/modules/dep/packed-refs");
+        std::fs::create_dir_all(packed.parent().unwrap()).unwrap();
+        let local_bytes =
+            format!("# pack-refs with: peeled fully-peeled sorted\n{base} refs/heads/main\n");
+        let remote_bytes =
+            format!("# pack-refs with: peeled fully-peeled sorted\n{incoming} refs/heads/main\n");
+        std::fs::write(&packed, local_bytes.as_bytes()).unwrap();
+
+        let rel_path = "repo/.git/modules/dep/packed-refs";
+        let manifest_hash = upload_blob(
+            &op,
+            local_root,
+            "remote-module-packed-refs",
+            remote_bytes.as_bytes(),
+            rel_path,
+        )
+        .await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: remote_bytes.len() as u64,
+            reason: PullReason::RemoteNewer,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.deferred_git_refs,
+            vec![rel_path.to_string()],
+            "submodule packed-refs is opaque and must defer on byte differences"
+        );
+        assert_eq!(std::fs::read(&packed).unwrap(), local_bytes.as_bytes());
     }
 
     // ── keep-both PR-2 (S3): executor hard-respects a foreign `.git/tcfs.lock` ──

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -2186,19 +2186,122 @@ pub async fn execute_plan(
             ReconcileAction::DeleteLocal {
                 local_path,
                 rel_path,
-            } => match tokio::fs::remove_file(local_path).await {
-                Ok(()) => {
-                    state.remove(local_path);
-                    result.deleted_local += 1;
+            } => {
+                if is_git_ref_class_path(rel_path) {
+                    match loser_guard_ref_target(local_root, rel_path) {
+                        Some(LoserGuardTarget::PackedRefs { .. }) => {
+                            warn!(
+                                path = %rel_path,
+                                "loser-guard: packed-refs delete is opaque; deferring local delete"
+                            );
+                            result.deferred_git_refs.push(rel_path.clone());
+                            continue;
+                        }
+                        Some(LoserGuardTarget::Ref {
+                            git_dir,
+                            repo_root,
+                            ref_name,
+                            parkable,
+                        }) => {
+                            if !parkable {
+                                warn!(
+                                    path = %rel_path,
+                                    r#ref = %ref_name,
+                                    "loser-guard: non-parkable ref delete would orphan committed work; deferring local delete"
+                                );
+                                result.deferred_git_refs.push(rel_path.clone());
+                                continue;
+                            }
+                            let Some(current) = git_dir_ref_sha(&git_dir, &ref_name) else {
+                                warn!(
+                                    path = %rel_path,
+                                    r#ref = %ref_name,
+                                    "loser-guard: local ref delete target is unresolved; deferring local delete"
+                                );
+                                result.deferred_git_refs.push(rel_path.clone());
+                                continue;
+                            };
+                            let Some(park_ref) =
+                                conflict_git::theirs_ref_name(device_id, &ref_name)
+                            else {
+                                warn!(
+                                    path = %rel_path,
+                                    r#ref = %ref_name,
+                                    "loser-guard: no safe park ref namespace; deferring local delete"
+                                );
+                                result.deferred_git_refs.push(rel_path.clone());
+                                continue;
+                            };
+                            let bundle = match conflict_git::write_undo_bundle(
+                                &repo_root,
+                                &undo_state_dir,
+                            ) {
+                                Ok(bundle) => bundle,
+                                Err(e) => {
+                                    warn!(
+                                        path = %rel_path,
+                                        error = %format!("{e:#}"),
+                                        "loser-guard: pre-delete bundle failed; deferring local delete"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
+                            };
+                            let parked_ref = match conflict_git::park_ref_create_only(
+                                &repo_root, &park_ref, &current,
+                            ) {
+                                Ok(parked_ref) => parked_ref,
+                                Err(e) => {
+                                    warn!(
+                                        path = %rel_path,
+                                        error = %format!("{e:#}"),
+                                        "loser-guard: pre-delete park failed; deferring local delete"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
+                            };
+                            info!(
+                                path = %rel_path,
+                                r#ref = %ref_name,
+                                parked = %parked_ref,
+                                orphaned_sha = %current,
+                                bundle = %bundle.display(),
+                                "loser-guard: bundled pre-delete .git + parked local ref; applying local delete"
+                            );
+                        }
+                        None => {
+                            warn!(
+                                path = %rel_path,
+                                "loser-guard: unclassified ref-class delete; deferring local delete"
+                            );
+                            result.deferred_git_refs.push(rel_path.clone());
+                            continue;
+                        }
+                    }
                 }
-                Err(e) => {
-                    result
-                        .errors
-                        .push((rel_path.clone(), format!("local delete failed: {e}")));
+                match tokio::fs::remove_file(local_path).await {
+                    Ok(()) => {
+                        state.remove(local_path);
+                        result.deleted_local += 1;
+                    }
+                    Err(e) => {
+                        result
+                            .errors
+                            .push((rel_path.clone(), format!("local delete failed: {e}")));
+                    }
                 }
-            },
+            }
 
             ReconcileAction::DeleteRemote { rel_path } => {
+                if is_git_ref_class_path(rel_path) {
+                    warn!(
+                        path = %rel_path,
+                        "git guard: remote ref-class delete cannot be parked locally; deferring remote delete"
+                    );
+                    result.deferred_git_refs.push(rel_path.clone());
+                    continue;
+                }
                 if let Err(e) =
                     engine::delete_remote_file(op, rel_path, remote_prefix, state, Some(local_root))
                         .await
@@ -3923,6 +4026,133 @@ mod tests {
             "submodule packed-refs is opaque and must defer on byte differences"
         );
         assert_eq!(std::fs::read(&packed).unwrap(), local_bytes.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn loser_guard_parks_branch_before_local_delete() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let side = commit_file(&repo, "file.txt", "side work", "side");
+        git_safety::run_git(&repo, &["branch", "side", &side]).unwrap();
+
+        let rel_path = "repo/.git/refs/heads/side";
+        let local_path = local_root.join(rel_path);
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::DeleteLocal {
+            local_path: local_path.clone(),
+            rel_path: rel_path.to_string(),
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.deferred_git_refs.is_empty(), "{result:?}");
+        assert_eq!(result.deleted_local, 1);
+        assert!(!local_path.exists(), "the loose branch ref was deleted");
+        assert_eq!(
+            git_safety::local_ref_sha(&repo, "refs/tcfs/theirs/neo/heads/side").as_deref(),
+            Some(side.as_str()),
+            "local branch tip remains reachable before delete"
+        );
+        assert!(
+            state_path.parent().unwrap().join("keep-both-undo").exists(),
+            "pre-delete undo bundle lives under the state dir"
+        );
+        git_safety::run_git(&repo, &["fsck", "--full"]).unwrap();
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_non_head_ref_local_delete() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let tagged = commit_file(&repo, "file.txt", "tagged work", "tagged");
+        git_safety::run_git(&repo, &["tag", "v1", &tagged]).unwrap();
+
+        let rel_path = "repo/.git/refs/tags/v1";
+        let local_path = local_root.join(rel_path);
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::DeleteLocal {
+            local_path: local_path.clone(),
+            rel_path: rel_path.to_string(),
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
+        assert_eq!(
+            git_safety::local_ref_sha(&repo, "refs/tags/v1").as_deref(),
+            Some(tagged.as_str())
+        );
+        assert!(local_path.exists(), "non-parkable ref delete must defer");
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_packed_refs_local_delete() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let head = commit_file(&repo, "file.txt", "base", "base");
+        let rel_path = "repo/.git/packed-refs";
+        let local_path = local_root.join(rel_path);
+        let packed_bytes =
+            format!("# pack-refs with: peeled fully-peeled sorted\n{head} refs/heads/main\n");
+        std::fs::write(&local_path, packed_bytes.as_bytes()).unwrap();
+
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::DeleteLocal {
+            local_path: local_path.clone(),
+            rel_path: rel_path.to_string(),
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
+        assert_eq!(std::fs::read(&local_path).unwrap(), packed_bytes.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn git_ref_class_remote_delete_defers() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let rel_path = "repo/.git/refs/heads/main";
+        let plan = plan_of(vec![ReconcileAction::DeleteRemote {
+            rel_path: rel_path.to_string(),
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
+        assert_eq!(result.deleted_remote, 0);
+        assert!(result.errors.is_empty(), "{result:?}");
     }
 
     // ── keep-both PR-2 (S3): executor hard-respects a foreign `.git/tcfs.lock` ──

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -7,6 +7,7 @@
 //! This separation enables dry-run mode, TUI preview, and deterministic testing.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -881,7 +882,7 @@ enum LoserGuardTarget {
 }
 
 /// Classify a pull's `rel_path` as a loser-guard target, or `None` if the guard
-/// does not apply (objects, index, logs, `refs/tcfs/**`, non-`.git` files).
+/// does not apply (objects, index, logs, non-`.git` files).
 fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuardTarget> {
     let rel = rel_path.replace('\\', "/");
     let repo_root = git_safety::repo_root_for_git_path(local_root, &rel)?;
@@ -960,7 +961,7 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
             parkable: true,
         });
     }
-    if after.starts_with("refs/") && !after.starts_with("refs/tcfs/") && !after.ends_with('/') {
+    if after.starts_with("refs/") && !after.ends_with('/') {
         return Some(LoserGuardTarget::Ref {
             git_dir: git_root,
             repo_root,
@@ -968,12 +969,7 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
             parkable: false,
         });
     }
-    if after == "HEAD"
-        && std::fs::read(git_root.join("HEAD"))
-            .ok()
-            .and_then(|bytes| git_safety::parse_ref_sha(&bytes))
-            .is_some()
-    {
+    if after == "HEAD" && git_root.join("HEAD").exists() {
         return Some(LoserGuardTarget::Ref {
             git_dir: git_root,
             repo_root,
@@ -1029,6 +1025,65 @@ fn git_dir_commit_present(git_dir: &Path, sha: &str) -> bool {
         .output()
         .map(|out| out.status.success())
         .unwrap_or(false)
+}
+
+fn git_dir_object_present(git_dir: &Path, sha: &str) -> bool {
+    std::process::Command::new("git")
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(["cat-file", "-e", &format!("{sha}^{{object}}")])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn git_dir_ready_for_ref_guard(git_dir: &Path) -> bool {
+    git_dir.join("HEAD").exists() && git_dir.join("objects").is_dir()
+}
+
+fn git_dir_head_is_symbolic(git_dir: &Path) -> bool {
+    std::fs::read(git_dir.join("HEAD"))
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .map(|head| head.trim_start().starts_with("ref:"))
+        .unwrap_or(false)
+}
+
+fn packed_refs_shas(bytes: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return None;
+            }
+            let token = trimmed
+                .strip_prefix('^')
+                .unwrap_or(trimmed)
+                .split_whitespace()
+                .next()?;
+            git_safety::parse_ref_sha(token.as_bytes())
+        })
+        .collect()
+}
+
+fn packed_refs_objects_present(git_dir: &Path, bytes: &[u8]) -> bool {
+    let shas = packed_refs_shas(bytes);
+    !shas.is_empty() && shas.iter().all(|sha| git_dir_object_present(git_dir, sha))
+}
+
+fn write_file_create_new(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dir: {}", parent.display()))?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("creating new file: {}", path.display()))?;
+    file.write_all(bytes)
+        .with_context(|| format!("writing new file: {}", path.display()))
 }
 
 fn zero_oid_like(oid: &str) -> String {
@@ -2088,6 +2143,7 @@ pub async fn execute_plan(
                 if let Some(target) = loser_guard_ref_target(local_root, rel_path) {
                     match target {
                         LoserGuardTarget::PackedRefs { local_path } => {
+                            let git_dir = local_path.parent().unwrap_or(local_root);
                             match (
                                 std::fs::read(&local_path),
                                 download_bytes_from_manifest(
@@ -2107,9 +2163,69 @@ pub async fn execute_plan(
                                     continue;
                                 }
                                 (Err(e), Some(_)) if e.kind() == std::io::ErrorKind::NotFound => {
-                                    // No local packed-refs table exists, so
-                                    // there is no packed-only local tip to
-                                    // orphan. Apply the new file normally.
+                                    if !git_dir_ready_for_ref_guard(git_dir) {
+                                        // Bootstrap raw restore of a not-yet
+                                        // initialized gitdir. The wave-0 object
+                                        // barrier still guards missing object
+                                        // pulls before this wave-1 ref table.
+                                    } else {
+                                        let Some(incoming) = download_bytes_from_manifest(
+                                            op,
+                                            remote_prefix,
+                                            manifest_hash,
+                                            encryption,
+                                        )
+                                        .await
+                                        else {
+                                            warn!(
+                                                path = %rel_path,
+                                                "loser-guard: incoming packed-refs unreadable; deferring pull"
+                                            );
+                                            result.deferred_git_refs.push(rel_path.clone());
+                                            continue;
+                                        };
+                                        if !packed_refs_objects_present(git_dir, &incoming) {
+                                            warn!(
+                                                path = %rel_path,
+                                                "loser-guard: incoming packed-refs objects missing; deferring pull"
+                                            );
+                                            result.deferred_git_refs.push(rel_path.clone());
+                                            continue;
+                                        }
+                                        if let Err(e) =
+                                            write_file_create_new(&local_path, &incoming)
+                                        {
+                                            warn!(
+                                                path = %rel_path,
+                                                error = %format!("{e:#}"),
+                                                "loser-guard: packed-refs appeared before create-new write; deferring pull"
+                                            );
+                                            result.deferred_git_refs.push(rel_path.clone());
+                                            continue;
+                                        }
+                                        if let Err(e) = record_guarded_ref_pull_state(
+                                            op,
+                                            remote_prefix,
+                                            manifest_hash,
+                                            &local_path,
+                                            &incoming,
+                                            state,
+                                            device_id,
+                                        )
+                                        .await
+                                        {
+                                            result.errors.push((
+                                                rel_path.clone(),
+                                                format!(
+                                                    "guarded packed-refs state update failed: {e:#}"
+                                                ),
+                                            ));
+                                            continue;
+                                        }
+                                        result.pulled += 1;
+                                        result.bytes_downloaded += incoming.len() as u64;
+                                        continue;
+                                    }
                                 }
                                 (Err(e), Some(_)) => {
                                     warn!(
@@ -2128,7 +2244,30 @@ pub async fn execute_plan(
                                     result.deferred_git_refs.push(rel_path.clone());
                                     continue;
                                 }
-                                (Ok(_), Some(_)) => {}
+                                (Ok(current), Some(_)) => {
+                                    if let Err(e) = record_guarded_ref_pull_state(
+                                        op,
+                                        remote_prefix,
+                                        manifest_hash,
+                                        &local_path,
+                                        &current,
+                                        state,
+                                        device_id,
+                                    )
+                                    .await
+                                    {
+                                        result.errors.push((
+                                            rel_path.clone(),
+                                            format!(
+                                                "guarded packed-refs state update failed: {e:#}"
+                                            ),
+                                        ));
+                                        continue;
+                                    }
+                                    result.pulled += 1;
+                                    result.bytes_downloaded += current.len() as u64;
+                                    continue;
+                                }
                             }
                         }
                         LoserGuardTarget::Ref {
@@ -2155,133 +2294,184 @@ pub async fn execute_plan(
                                     continue;
                                 }
                             };
-                            let Some(incoming) = git_safety::parse_ref_sha(&incoming_bytes) else {
-                                warn!(
-                                    path = %rel_path,
-                                    "loser-guard: incoming ref SHA unreadable; deferring pull"
-                                );
-                                result.deferred_git_refs.push(rel_path.clone());
-                                continue;
-                            };
-                            if !git_dir_commit_present(&git_dir, &incoming) {
-                                warn!(
-                                    path = %rel_path,
-                                    incoming = %incoming,
-                                    "loser-guard: incoming ref object missing; deferring pull"
-                                );
-                                result.deferred_git_refs.push(rel_path.clone());
-                                continue;
-                            }
-
-                            let current = git_dir_ref_sha(&git_dir, &ref_name);
-                            let mut parked: Option<(String, String, PathBuf)> = None;
-                            if let Some(current_sha) = current.as_deref() {
-                                if current_sha != incoming
-                                    && !git_dir_is_ancestor(&git_dir, current_sha, &incoming)
+                            if !git_dir_ready_for_ref_guard(&git_dir) {
+                                // Bootstrap raw restore of a not-yet
+                                // initialized gitdir. Git commands cannot prove
+                                // refs until the repository skeleton exists; the
+                                // object-before-ref ordering and wave-0 failure
+                                // barrier still apply before ref-class paths.
+                            } else {
+                                if ref_name == "HEAD"
+                                    && git_safety::parse_ref_sha(&incoming_bytes).is_none()
                                 {
-                                    // Non-ancestor overwrite: committed work at
-                                    // `current_sha` is not reachable from
-                                    // `incoming`.
-                                    if !parkable {
-                                        warn!(
-                                            path = %rel_path,
-                                            r#ref = %ref_name,
-                                            "loser-guard: non-parkable module head would be orphaned; deferring pull"
-                                        );
-                                        result.deferred_git_refs.push(rel_path.clone());
+                                    let local_head = std::fs::read(git_dir.join("HEAD")).ok();
+                                    if local_head.as_deref() == Some(incoming_bytes.as_slice()) {
+                                        if let Err(e) = record_guarded_ref_pull_state(
+                                            op,
+                                            remote_prefix,
+                                            manifest_hash,
+                                            &local_path,
+                                            &incoming_bytes,
+                                            state,
+                                            device_id,
+                                        )
+                                        .await
+                                        {
+                                            result.errors.push((
+                                                rel_path.clone(),
+                                                format!("guarded HEAD state update failed: {e:#}"),
+                                            ));
+                                            continue;
+                                        }
+                                        result.pulled += 1;
+                                        result.bytes_downloaded += incoming_bytes.len() as u64;
                                         continue;
                                     }
-                                    let Some(park_ref) =
-                                        conflict_git::theirs_ref_name(device_id, &ref_name)
-                                    else {
-                                        warn!(
-                                            path = %rel_path,
-                                            r#ref = %ref_name,
-                                            "loser-guard: no safe park ref namespace; deferring pull"
-                                        );
-                                        result.deferred_git_refs.push(rel_path.clone());
-                                        continue;
-                                    };
-                                    let bundle = match conflict_git::write_undo_bundle(
-                                        &repo_root,
-                                        &undo_state_dir,
-                                    ) {
-                                        Ok(bundle) => bundle,
-                                        Err(e) => {
-                                            warn!(
-                                                path = %rel_path,
-                                                error = %format!("{e:#}"),
-                                                "loser-guard: pre-overwrite bundle failed; deferring pull"
-                                            );
-                                            result.deferred_git_refs.push(rel_path.clone());
-                                            continue;
-                                        }
-                                    };
-                                    let parked_ref = match conflict_git::park_ref_create_only(
-                                        &repo_root,
-                                        &park_ref,
-                                        current_sha,
-                                    ) {
-                                        Ok(parked_ref) => parked_ref,
-                                        Err(e) => {
-                                            warn!(
-                                                path = %rel_path,
-                                                error = %format!("{e:#}"),
-                                                "loser-guard: park failed; deferring pull"
-                                            );
-                                            result.deferred_git_refs.push(rel_path.clone());
-                                            continue;
-                                        }
-                                    };
-                                    parked = Some((parked_ref, current_sha.to_string(), bundle));
+                                    warn!(
+                                        path = %rel_path,
+                                        "loser-guard: symbolic HEAD change is not CAS-protectable; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
                                 }
-                            }
+                                if ref_name == "HEAD" && git_dir_head_is_symbolic(&git_dir) {
+                                    warn!(
+                                        path = %rel_path,
+                                        "loser-guard: incoming detached HEAD would rewrite symbolic HEAD; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
+                                let Some(incoming) = git_safety::parse_ref_sha(&incoming_bytes)
+                                else {
+                                    warn!(
+                                        path = %rel_path,
+                                        "loser-guard: incoming ref SHA unreadable; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                };
+                                if !git_dir_commit_present(&git_dir, &incoming) {
+                                    warn!(
+                                        path = %rel_path,
+                                        incoming = %incoming,
+                                        "loser-guard: incoming ref object missing; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
 
-                            if let Err(e) = git_dir_update_ref_cas(
-                                &git_dir,
-                                &ref_name,
-                                &incoming,
-                                current.as_deref(),
-                            ) {
-                                warn!(
-                                    path = %rel_path,
-                                    r#ref = %ref_name,
-                                    error = %format!("{e:#}"),
-                                    "loser-guard: ref moved before CAS update; deferring pull"
-                                );
-                                result.deferred_git_refs.push(rel_path.clone());
+                                let current = git_dir_ref_sha(&git_dir, &ref_name);
+                                let mut parked: Option<(String, String, PathBuf)> = None;
+                                if let Some(current_sha) = current.as_deref() {
+                                    if current_sha != incoming
+                                        && !git_dir_is_ancestor(&git_dir, current_sha, &incoming)
+                                    {
+                                        // Non-ancestor overwrite: committed work at
+                                        // `current_sha` is not reachable from
+                                        // `incoming`.
+                                        if !parkable {
+                                            warn!(
+                                                path = %rel_path,
+                                                r#ref = %ref_name,
+                                                "loser-guard: non-parkable module head would be orphaned; deferring pull"
+                                            );
+                                            result.deferred_git_refs.push(rel_path.clone());
+                                            continue;
+                                        }
+                                        let Some(park_ref) =
+                                            conflict_git::theirs_ref_name(device_id, &ref_name)
+                                        else {
+                                            warn!(
+                                                path = %rel_path,
+                                                r#ref = %ref_name,
+                                                "loser-guard: no safe park ref namespace; deferring pull"
+                                            );
+                                            result.deferred_git_refs.push(rel_path.clone());
+                                            continue;
+                                        };
+                                        let bundle = match conflict_git::write_undo_bundle(
+                                            &repo_root,
+                                            &undo_state_dir,
+                                        ) {
+                                            Ok(bundle) => bundle,
+                                            Err(e) => {
+                                                warn!(
+                                                    path = %rel_path,
+                                                    error = %format!("{e:#}"),
+                                                    "loser-guard: pre-overwrite bundle failed; deferring pull"
+                                                );
+                                                result.deferred_git_refs.push(rel_path.clone());
+                                                continue;
+                                            }
+                                        };
+                                        let parked_ref = match conflict_git::park_ref_create_only(
+                                            &repo_root,
+                                            &park_ref,
+                                            current_sha,
+                                        ) {
+                                            Ok(parked_ref) => parked_ref,
+                                            Err(e) => {
+                                                warn!(
+                                                    path = %rel_path,
+                                                    error = %format!("{e:#}"),
+                                                    "loser-guard: park failed; deferring pull"
+                                                );
+                                                result.deferred_git_refs.push(rel_path.clone());
+                                                continue;
+                                            }
+                                        };
+                                        parked =
+                                            Some((parked_ref, current_sha.to_string(), bundle));
+                                    }
+                                }
+
+                                if let Err(e) = git_dir_update_ref_cas(
+                                    &git_dir,
+                                    &ref_name,
+                                    &incoming,
+                                    current.as_deref(),
+                                ) {
+                                    warn!(
+                                        path = %rel_path,
+                                        r#ref = %ref_name,
+                                        error = %format!("{e:#}"),
+                                        "loser-guard: ref moved before CAS update; deferring pull"
+                                    );
+                                    result.deferred_git_refs.push(rel_path.clone());
+                                    continue;
+                                }
+                                if let Err(e) = record_guarded_ref_pull_state(
+                                    op,
+                                    remote_prefix,
+                                    manifest_hash,
+                                    &local_path,
+                                    &incoming_bytes,
+                                    state,
+                                    device_id,
+                                )
+                                .await
+                                {
+                                    result.errors.push((
+                                        rel_path.clone(),
+                                        format!("guarded ref pull state update failed: {e:#}"),
+                                    ));
+                                    continue;
+                                }
+                                if let Some((parked_ref, orphaned_sha, bundle)) = parked {
+                                    info!(
+                                        path = %rel_path,
+                                        r#ref = %ref_name,
+                                        parked = %parked_ref,
+                                        orphaned_sha = %orphaned_sha,
+                                        bundle = %bundle.display(),
+                                        "loser-guard: bundled pre-overwrite .git + parked local head; applied CAS ref pull"
+                                    );
+                                }
+                                result.pulled += 1;
+                                result.bytes_downloaded += incoming_bytes.len() as u64;
                                 continue;
                             }
-                            if let Err(e) = record_guarded_ref_pull_state(
-                                op,
-                                remote_prefix,
-                                manifest_hash,
-                                &local_path,
-                                &incoming_bytes,
-                                state,
-                                device_id,
-                            )
-                            .await
-                            {
-                                result.errors.push((
-                                    rel_path.clone(),
-                                    format!("guarded ref pull state update failed: {e:#}"),
-                                ));
-                                continue;
-                            }
-                            if let Some((parked_ref, orphaned_sha, bundle)) = parked {
-                                info!(
-                                    path = %rel_path,
-                                    r#ref = %ref_name,
-                                    parked = %parked_ref,
-                                    orphaned_sha = %orphaned_sha,
-                                    bundle = %bundle.display(),
-                                    "loser-guard: bundled pre-overwrite .git + parked local head; applied CAS ref pull"
-                                );
-                            }
-                            result.pulled += 1;
-                            result.bytes_downloaded += incoming_bytes.len() as u64;
-                            continue;
                         }
                     }
                 }
@@ -3883,17 +4073,24 @@ mod tests {
     }
 
     #[test]
-    fn loser_guard_target_ignores_symbolic_head_but_catches_detached_head() {
+    fn loser_guard_target_catches_symbolic_and_detached_head() {
         let dir = tempfile::tempdir().unwrap();
         let local_root = dir.path();
         let repo = local_root.join("repo");
         init_git_repo(&repo);
         let head = commit_file(&repo, "file.txt", "base", "base");
 
-        assert!(
-            loser_guard_ref_target(local_root, "repo/.git/HEAD").is_none(),
-            "symbolic HEAD is not a directly parkable committed tip"
-        );
+        let target = loser_guard_ref_target(local_root, "repo/.git/HEAD")
+            .expect("symbolic HEAD must be guarded so detached overwrites defer");
+        match target {
+            LoserGuardTarget::Ref {
+                ref_name, parkable, ..
+            } => {
+                assert_eq!(ref_name, "HEAD");
+                assert!(!parkable, "HEAD is defer-only");
+            }
+            LoserGuardTarget::PackedRefs { .. } => panic!("HEAD must classify as a ref target"),
+        }
 
         git_safety::run_git(&repo, &["checkout", "--quiet", "--detach", &head]).unwrap();
         let target = loser_guard_ref_target(local_root, "repo/.git/HEAD")
@@ -4314,6 +4511,139 @@ mod tests {
         );
         assert_eq!(result.pulled, 0);
         assert!(git_safety::local_ref_sha(&repo, "refs/heads/missing").is_none());
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_refs_tcfs_when_incoming_object_missing() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        commit_file(&repo, "file.txt", "base", "base");
+
+        let missing = "fedcba9876543210fedcba9876543210fedcba98";
+        let rel_path = "repo/.git/refs/tcfs/theirs/honey/heads/main";
+        let manifest_hash = upload_blob(
+            &op,
+            local_root,
+            "remote-tcfs-ref",
+            format!("{missing}\n").as_bytes(),
+            rel_path,
+        )
+        .await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: 41,
+            reason: PullReason::NewRemote,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
+        assert_eq!(result.pulled, 0);
+        assert!(
+            !local_root.join(rel_path).exists(),
+            "refs/tcfs/** must not raw-materialize broken ref content"
+        );
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_symbolic_head_to_detached_head_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let base = commit_file(&repo, "file.txt", "base", "base");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "-b", "incoming", &base]).unwrap();
+        let incoming = commit_file(&repo, "file.txt", "incoming", "incoming");
+        git_safety::run_git(&repo, &["checkout", "--quiet", "main"]).unwrap();
+        assert!(std::fs::read_to_string(repo.join(".git/HEAD"))
+            .unwrap()
+            .starts_with("ref:"));
+
+        let rel_path = "repo/.git/HEAD";
+        let manifest_hash = upload_blob(
+            &op,
+            local_root,
+            "remote-detached-head",
+            format!("{incoming}\n").as_bytes(),
+            rel_path,
+        )
+        .await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: 41,
+            reason: PullReason::RemoteNewer,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
+        assert!(
+            std::fs::read_to_string(repo.join(".git/HEAD"))
+                .unwrap()
+                .starts_with("ref:"),
+            "symbolic HEAD must not be raw-overwritten into detached HEAD"
+        );
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_new_packed_refs_when_objects_missing() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        commit_file(&repo, "file.txt", "base", "base");
+
+        let missing = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let rel_path = "repo/.git/packed-refs";
+        let packed_bytes =
+            format!("# pack-refs with: peeled fully-peeled sorted\n{missing} refs/heads/missing\n");
+        let manifest_hash = upload_blob(
+            &op,
+            local_root,
+            "remote-packed-missing",
+            packed_bytes.as_bytes(),
+            rel_path,
+        )
+        .await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: packed_bytes.len() as u64,
+            reason: PullReason::NewRemote,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
+        assert!(
+            !local_root.join(rel_path).exists(),
+            "new packed-refs must not materialize before its objects are present"
+        );
     }
 
     #[test]

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -921,11 +921,7 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
         }
         if let Some(module_subpath) = module_tail_raw_head(module_tail) {
             let git_dir = git_root.join("modules").join(module_subpath);
-            if std::fs::read(git_dir.join("HEAD"))
-                .ok()
-                .and_then(|bytes| git_safety::parse_ref_sha(&bytes))
-                .is_some()
-            {
+            if git_dir.join("HEAD").exists() {
                 return Some(LoserGuardTarget::Ref {
                     git_dir,
                     repo_root,
@@ -4600,6 +4596,50 @@ mod tests {
                 .unwrap()
                 .starts_with("ref:"),
             "symbolic HEAD must not be raw-overwritten into detached HEAD"
+        );
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_symbolic_submodule_head_to_detached_head_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let incoming = commit_file(&repo, "file.txt", "base", "base");
+        let submodule_git_dir = repo.join(".git/modules/dep");
+        std::fs::create_dir_all(submodule_git_dir.join("objects")).unwrap();
+        std::fs::write(submodule_git_dir.join("HEAD"), b"ref: refs/heads/main\n").unwrap();
+
+        let rel_path = "repo/.git/modules/dep/HEAD";
+        let manifest_hash = upload_blob(
+            &op,
+            local_root,
+            "remote-submodule-detached-head",
+            format!("{incoming}\n").as_bytes(),
+            rel_path,
+        )
+        .await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: 41,
+            reason: PullReason::RemoteNewer,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.deferred_git_refs, vec![rel_path.to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(submodule_git_dir.join("HEAD")).unwrap(),
+            "ref: refs/heads/main\n",
+            "symbolic submodule HEAD must not be raw-overwritten into detached HEAD"
         );
     }
 

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -861,10 +861,10 @@ fn git_ff_pins_still_valid(local_root: &Path, pins: &[GitRefPin]) -> bool {
 /// A `.git` ref-class HEAD file a pull is about to overwrite that the
 /// loser-side no-loss guard (PR-4, S10) must vet: a top-level branch head
 /// (`.git/refs/heads/**`), the stash tip (`.git/refs/stash`), or a submodule
-/// module-gitdir branch head (`.git/modules/<name>/refs/heads/**`). Carries the
-/// git-dir to run `rev-parse`/`merge-base` against (the submodule's real gitdir
-/// for module refs) and whether the head is PARKABLE on this device (top-level
-/// heads/stash yes; module heads are future work → defer, never park).
+/// module-gitdir ref (`.git/modules/<name>/refs/**`). Carries the git-dir to run
+/// `rev-parse`/`merge-base` against (the submodule's real gitdir for module
+/// refs) and whether the ref is PARKABLE on this device (top-level heads/stash
+/// yes; tags/remotes/module refs are future work → defer, never park).
 struct LoserGuardTarget {
     /// Git dir the ref lives in (`<repo>/.git` or `<repo>/.git/modules/<name>`).
     git_dir: PathBuf,
@@ -891,19 +891,19 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
     let after = &rel[pos + needle.len()..];
 
     if let Some(module_tail) = after.strip_prefix("modules/") {
-        // `.git/modules/<name...>/refs/heads/<branch>`. `<name>` may contain
-        // slashes / nested `modules/`, so split on the LAST `/refs/heads/`.
-        let marker = "/refs/heads/";
+        // `.git/modules/<name...>/refs/<kind>/<name>`. `<name>` may contain
+        // slashes / nested `modules/`, so split on the LAST `/refs/`.
+        let marker = "/refs/";
         if let Some(idx) = module_tail.rfind(marker) {
-            let branch = &module_tail[idx + marker.len()..];
-            if branch.is_empty() || branch.ends_with('/') {
+            let ref_suffix = &module_tail[idx + 1..];
+            if ref_suffix == "refs/" || ref_suffix.ends_with('/') {
                 return None;
             }
             let module_subpath = &module_tail[..idx];
             return Some(LoserGuardTarget {
                 git_dir: git_root.join("modules").join(module_subpath),
                 repo_root,
-                ref_name: format!("refs/heads/{branch}"),
+                ref_name: ref_suffix.to_string(),
                 parkable: false,
             });
         }
@@ -942,6 +942,14 @@ fn loser_guard_ref_target(local_root: &Path, rel_path: &str) -> Option<LoserGuar
             repo_root,
             ref_name: format!("refs/heads/{branch}"),
             parkable: true,
+        });
+    }
+    if after.starts_with("refs/") && !after.starts_with("refs/tcfs/") && !after.ends_with('/') {
+        return Some(LoserGuardTarget {
+            git_dir: git_root,
+            repo_root,
+            ref_name: after.to_string(),
+            parkable: false,
         });
     }
     if after == "HEAD"
@@ -3608,6 +3616,45 @@ mod tests {
         );
         assert_eq!(
             git_dir_ref_sha(&module_git, "refs/heads/main").as_deref(),
+            Some(current.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn loser_guard_defers_divergent_non_head_ref_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        let current = commit_file(&repo, "file.txt", "tagged work", "tagged");
+        git_safety::run_git(&repo, &["tag", "v1", &current]).unwrap();
+
+        let incoming = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+        let manifest_hash = upload_ref_blob(&op, local_root, incoming).await;
+        let state_path = dir.path().join("state/state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let rel_path = "repo/.git/refs/tags/v1";
+        let plan = plan_of(vec![ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash,
+            size: 41,
+            reason: PullReason::RemoteNewer,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "neo", None, None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result.deferred_git_refs,
+            vec![rel_path.to_string()],
+            "non-head refs that point at local-only commits must defer, not overwrite"
+        );
+        assert_eq!(
+            git_safety::local_ref_sha(&repo, "refs/tags/v1").as_deref(),
             Some(current.as_str())
         );
     }

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -290,6 +290,18 @@ impl StateCache {
         })
     }
 
+    /// Machine-local directory that owns this state cache.
+    ///
+    /// Git recovery artifacts such as keep-both / loser-guard undo bundles must
+    /// live here, not under a sync root.
+    pub fn state_dir(&self) -> PathBuf {
+        self.db_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(std::env::temp_dir)
+    }
+
     fn load_from_file(path: &Path) -> Result<(HashMap<String, SyncState>, u64, String)> {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("reading: {}", path.display()))?;

--- a/docs/design/git-divergent-keep-both-2026-07-02.md
+++ b/docs/design/git-divergent-keep-both-2026-07-02.md
@@ -535,11 +535,13 @@ is in remote-CI validation.
 | **PR-3** — repo-group keep-both resolver (`resolve_repo_keep_both`): parks losing heads at `refs/tcfs/theirs/<device>/**`, fsck-gated both sides, dry-run default, state-dir undo bundle, **operator-CLI-only** (MCP/auto excluded via the `operator_cli` provenance gate) | #529 | `831d363b` | ✅ merged |
 | **PR-4** — loser-side no-loss guard (pre-overwrite parking; flips harness G5-git-13 / T10/T11 live) | #534 | draft branch | 🟡 draft PR / remote CI + G5-git-13 harness |
 
-**PR-4 is the only remaining rung** and is no longer blocked on PZM hardware:
-the PZM SSD/RWX path recovered and the tactical legacy-SSH remote builder is
-usable again. The remaining gate is ordinary code validation + fleet deploy:
-#534 must pass remote CI, land, deploy to both hosts, then run the two-machine
-live convergence canary. Until that lands + canary runs, the honest claim is:
+**PR-4 is the only remaining rung** and is no longer framed as blocked on PZM
+hardware: the PZM SSD/RWX path re-enumerated and verified clean. Builder
+transport hardening (`ssh-ng://` Determinate Nix vs `ssh://`/serve-style or
+GF/remote-cache execution) remains a separate TIN-1620/#524 operational lane.
+The remaining PR-4 gate is ordinary code validation + fleet deploy: #534 must
+pass remote CI, land, deploy to both hosts, then run the two-machine live
+convergence canary. Until that lands + canary runs, the honest claim is:
 **divergent `.git` conflicts are safely fenced, visible (`tcfs conflicts`), and
 operator-resolvable (`tcfs resolve … --execute`), but the two-machine
 live-convergence proof (G5-git-5 T10/T11 green) is pending PR-4 deployment.**

--- a/docs/design/git-divergent-keep-both-2026-07-02.md
+++ b/docs/design/git-divergent-keep-both-2026-07-02.md
@@ -533,7 +533,7 @@ is in remote-CI validation.
 | (hardening) — fence paths + persistence | #527 | `449846e` | ✅ merged |
 | **PR-2** — executor hard-respects a foreign `.git/tcfs.lock`; `ConflictInfo.remote_manifest_key` | #528 | `1e41a23` | ✅ merged |
 | **PR-3** — repo-group keep-both resolver (`resolve_repo_keep_both`): parks losing heads at `refs/tcfs/theirs/<device>/**`, fsck-gated both sides, dry-run default, state-dir undo bundle, **operator-CLI-only** (MCP/auto excluded via the `operator_cli` provenance gate) | #529 | `831d363b` | ✅ merged |
-| **PR-4** — loser-side no-loss guard (pre-overwrite parking; flips harness G5-git-13 / T10/T11 live) | #534 | `04d3aca` | 🟡 draft PR / remote CI |
+| **PR-4** — loser-side no-loss guard (pre-overwrite parking; flips harness G5-git-13 / T10/T11 live) | #534 | draft branch | 🟡 draft PR / remote CI + G5-git-13 harness |
 
 **PR-4 is the only remaining rung** and is no longer blocked on PZM hardware:
 the PZM SSD/RWX path recovered and the tactical legacy-SSH remote builder is

--- a/docs/design/git-divergent-keep-both-2026-07-02.md
+++ b/docs/design/git-divergent-keep-both-2026-07-02.md
@@ -524,7 +524,8 @@ ordinary files.
 
 ## Implementation status (updated 2026-07-05)
 
-This design is now the design-of-record; PR-1 through PR-3 are merged, PR-4 remains.
+This design is now the design-of-record; PR-1 through PR-3 are merged, and PR-4
+is in remote-CI validation.
 
 | Rung | PR | Merge commit | Status |
 |------|----|--------------|--------|
@@ -532,9 +533,16 @@ This design is now the design-of-record; PR-1 through PR-3 are merged, PR-4 rema
 | (hardening) — fence paths + persistence | #527 | `449846e` | ✅ merged |
 | **PR-2** — executor hard-respects a foreign `.git/tcfs.lock`; `ConflictInfo.remote_manifest_key` | #528 | `1e41a23` | ✅ merged |
 | **PR-3** — repo-group keep-both resolver (`resolve_repo_keep_both`): parks losing heads at `refs/tcfs/theirs/<device>/**`, fsck-gated both sides, dry-run default, state-dir undo bundle, **operator-CLI-only** (MCP/auto excluded via the `operator_cli` provenance gate) | #529 | `831d363b` | ✅ merged |
-| **PR-4** — loser-side no-loss guard (pre-overwrite parking; flips harness G5-git-13 / T10/T11 live) | — | — | ⏸ **deploy-gated** |
+| **PR-4** — loser-side no-loss guard (pre-overwrite parking; flips harness G5-git-13 / T10/T11 live) | #534 | `04d3aca` | 🟡 draft PR / remote CI |
 
-**PR-4 is the only remaining rung** and it is gated on the fleet reaching a common tcfs version end-to-end (both hosts must run the resolver for the loser-side convergence to be exercised live) — currently blocked on the neo `v0.12.16` deploy, itself blocked on the PZM aarch64-darwin builder (hardware). Until PR-4 lands + the live canary runs, the honest claim is: **divergent `.git` conflicts are safely fenced, visible (`tcfs conflicts`), and operator-resolvable (`tcfs resolve … --execute`), but the two-machine live-convergence proof (G5-git-5 T10/T11 green) is pending the deploy.**
+**PR-4 is the only remaining rung** and is no longer blocked on PZM hardware:
+the PZM SSD/RWX path recovered and the tactical legacy-SSH remote builder is
+usable again. The remaining gate is ordinary code validation + fleet deploy:
+#534 must pass remote CI, land, deploy to both hosts, then run the two-machine
+live convergence canary. Until that lands + canary runs, the honest claim is:
+**divergent `.git` conflicts are safely fenced, visible (`tcfs conflicts`), and
+operator-resolvable (`tcfs resolve … --execute`), but the two-machine
+live-convergence proof (G5-git-5 T10/T11 green) is pending PR-4 deployment.**
 
 **Ratified operator §6 answers (2026-07-05):** parking namespace default = `refs/tcfs/theirs/**` (not real branches); bare `keep-local`/`keep-remote` = omitted (park-first only); dirty-tree = hard refuse; ticket routing = new ticket for the verb + TIN-1549 keeps the `tcfs conflicts`/banner UX surface. Bundle retention and escalation cadence remain open (non-blocking; PR-4-adjacent).
 

--- a/scripts/git-dotgit-fsck-conflict-harness.sh
+++ b/scripts/git-dotgit-fsck-conflict-harness.sh
@@ -238,6 +238,91 @@ else
 fi
 log "conflict corruption-risk evidence recorded in conflict-scenario.txt"
 
+# ── Stage 6 (G5-git-13): loser-side no-loss guard — two-machine convergence ───
+# The PASS counterpart to Stage 4's corruption-risk evidence. keep-both PR-4
+# (design S10): when a reconcile pull would overwrite a local `.git` head whose
+# committed work is NOT reachable from the incoming (winner) head, the execute
+# loop (crates/tcfs-sync/src/reconcile.rs, Pull arm) parks the loser's live head
+# at refs/tcfs/theirs/<self_device>/heads/<branch> BEFORE the overwrite. We
+# reproduce the exact ref-level effect with pure git on BOTH machines and assert
+# the no-loss invariant: after a divergent `.git` pull, both sides' committed
+# heads stay reachable and each `.git` is fsck-clean — the two-machine
+# convergence row that flips G5-git-5 green.
+G5="$WORK_DIR/g5-git-13"
+G5BASE="$G5/base"
+mkdir -p "$G5BASE"
+git_q "$G5BASE" init --quiet
+printf 'base\n' > "$G5BASE/a.txt"
+git_q "$G5BASE" add -A
+git_q "$G5BASE" commit --quiet -m "base"
+G5_A="$G5/dev-A"; G5_B="$G5/dev-B"      # A = winner (resolved), B = loser
+cp -R "$G5BASE" "$G5_A"; cp -R "$G5BASE" "$G5_B"
+printf 'A committed work\n' > "$G5_A/a.txt"; git_q "$G5_A" commit --quiet -am "A diverges"
+printf 'B committed work\n' > "$G5_B/a.txt"; git_q "$G5_B" commit --quiet -am "B diverges"
+A_MAIN="$(git_q "$G5_A" rev-parse refs/heads/main)"
+B_MAIN="$(git_q "$G5_B" rev-parse refs/heads/main)"
+
+G5FAIL=0
+[ "$A_MAIN" != "$B_MAIN" ] || { echo "FAIL(G5-git-13): fixture did not diverge" >&2; G5FAIL=1; }
+
+# Objects roam bidirectionally while the refs stay conflicted (design 2.1): the
+# winner's objects reach the loser and vice-versa BEFORE any ref is mutated.
+# Model that by fetching each side's line into the other's odb first.
+git_q "$G5_B" fetch --quiet "$G5_A" refs/heads/main:refs/tcfs/roamed/incoming  # A_MAIN objects -> B
+git_q "$G5_A" fetch --quiet "$G5_B" refs/heads/main:refs/tcfs/roamed/incoming  # B_MAIN objects -> A
+
+# LOSER SIDE (B pulls the winner's head). B's live head is NOT an ancestor of
+# the incoming winner head, so the guard parks it under B's own device namespace
+# BEFORE applying the overwrite — park-first is what keeps B's committed commit
+# reachable across the overwrite.
+if [ "$B_MAIN" != "$A_MAIN" ] && ! git_q "$G5_B" merge-base --is-ancestor "$B_MAIN" "$A_MAIN"; then
+  git_q "$G5_B" update-ref refs/tcfs/theirs/dev-B/heads/main "$B_MAIN"   # loser-guard park
+fi
+git_q "$G5_B" update-ref refs/heads/main "$A_MAIN"                        # winner overwrite applied
+git_q "$G5_B" update-ref -d refs/tcfs/roamed/incoming                    # heads/theirs now hold the roamed objects
+
+# WINNER SIDE (A resolved keep-both, parking the loser's head — the PR-3 effect
+# the loser then pulls; here we assert A's converged end state directly).
+git_q "$G5_A" update-ref refs/tcfs/theirs/dev-B/heads/main "$B_MAIN"
+git_q "$G5_A" update-ref -d refs/tcfs/roamed/incoming
+
+# Assertions: BOTH machines converge, NO committed work orphaned.
+for side in "$G5_A" "$G5_B"; do
+  sname="$(basename "$side")"
+  git_q "$side" fsck --full > "$EVIDENCE_DIR/g5-git-13-fsck-$sname.txt" 2>&1 || true
+  if grep -qiE 'error|missing|broken|fatal' "$EVIDENCE_DIR/g5-git-13-fsck-$sname.txt"; then
+    echo "FAIL(G5-git-13): $sname .git not fsck-clean after convergence" >&2; G5FAIL=1
+  fi
+  [ "$(git_q "$side" rev-parse refs/heads/main)" = "$A_MAIN" ] \
+    || { echo "FAIL(G5-git-13): $sname refs/heads/main != winner head" >&2; G5FAIL=1; }
+  [ "$(git_q "$side" rev-parse refs/tcfs/theirs/dev-B/heads/main 2>/dev/null)" = "$B_MAIN" ] \
+    || { echo "FAIL(G5-git-13): $sname loser head not parked" >&2; G5FAIL=1; }
+  git_q "$side" cat-file -e "${A_MAIN}^{commit}" 2>/dev/null \
+    || { echo "FAIL(G5-git-13): $sname winner commit object missing" >&2; G5FAIL=1; }
+  git_q "$side" cat-file -e "${B_MAIN}^{commit}" 2>/dev/null \
+    || { echo "FAIL(G5-git-13): $sname loser commit object missing" >&2; G5FAIL=1; }
+  git_q "$side" rev-list --all > "$EVIDENCE_DIR/g5-git-13-revlist-$sname.txt" 2>&1 || true
+  grep -q "$A_MAIN" "$EVIDENCE_DIR/g5-git-13-revlist-$sname.txt" \
+    || { echo "FAIL(G5-git-13): $sname winner tip unreachable" >&2; G5FAIL=1; }
+  grep -q "$B_MAIN" "$EVIDENCE_DIR/g5-git-13-revlist-$sname.txt" \
+    || { echo "FAIL(G5-git-13): $sname loser tip unreachable (ORPHANED)" >&2; G5FAIL=1; }
+done
+{
+  echo "scenario: divergent .git; A=winner, B=loser. loser-guard parks B's live"
+  echo "          head at refs/tcfs/theirs/dev-B/heads/main BEFORE refs/heads/main"
+  echo "          is overwritten with the winner head — on BOTH machines."
+  echo "winner head A_MAIN=$A_MAIN"
+  echo "loser  head B_MAIN=$B_MAIN"
+  echo "invariant: both .git fsck-clean; refs/heads/main==winner; loser head"
+  echo "           parked + reachable via rev-list --all — no committed work lost."
+} > "$EVIDENCE_DIR/g5-git-13-scenario.txt"
+if [ "$G5FAIL" -eq 0 ]; then
+  log "G5-git-13 PASS — loser-side no-loss guard: both heads reachable + fsck-clean on both machines"
+else
+  echo "FAIL: G5-git-13 loser-side no-loss guard violated — see g5-git-13-*.txt" >&2
+  FAIL=1
+fi
+
 # ── Optional Stage 5: real push + peer rehydrate fsck (gated, disposable) ─────
 if [ "$RUN_PUSH" -eq 1 ]; then
   log "push stage delegated to existing scaffolds; reuse scripts/git-repo-canary.sh"


### PR DESCRIPTION
## Summary

Implements the PR-4 loser-side no-loss guard for divergent raw `.git` keep-both convergence.

- before a ref-class pull overwrites a local branch head whose SHA is not reachable from the incoming SHA, snapshot the repo to the machine-local state dir and park the local SHA under `refs/tcfs/theirs/<self-device>/**`
- before a ref-class local delete, park top-level branch/stash refs and defer packed-refs, tags, module refs, detached HEAD, and unresolved ref targets
- defer remote ref-class deletes because TCFS cannot locally park a remote-only `.git` ref table
- defer instead of overwriting when the guard cannot prove safety, the incoming commit object is absent, bundle/parking fails, or the target is non-parkable
- treat top-level and submodule `packed-refs` as opaque: byte differences defer rather than rewriting packed-only refs
- preserve repeated divergence by suffixing occupied park refs with `-<sha12>` and widening the SHA prefix if that suffix is also occupied
- add the G5-git-13 harness row and focused coverage for branch parking, ref deletes, non-head deferral, packed-refs deferral, submodule deferral, exact `.git` path parsing, and suffix collision handling

## Tracker

Linear: TIN-2552
Parent: TIN-1620

## Validation

- `cargo fmt --all`
- `git diff --check`

No local cargo/nix build was run on neo. This PR is intended to validate through GitHub Actions / remote builders only.

## Notes

This is the final keep-both rung from the design doc: it closes the crash/order window where the non-resolving device could pull the winner's `refs/heads/*` before its own old head was reachable through `refs/tcfs/theirs/**`.


## Update — 2026-07-05 docs correction

Latest head `6f1ae21` adds a docs-only correction: PR-4 is not framed as blocked on PZM hardware. PZM SSD/RWX re-enumerated and verified clean; builder transport hardening (`ssh-ng://` Determinate Nix vs `ssh://`/serve-style or GF/remote-cache execution) remains tracked separately under TIN-1620/#524. Code remains the `2e05c8b` safety head.


## Update — 2026-07-05 CAS fix round

Latest head `e5398c8` closes the fresh adversarial P1/P2 findings:

- Ref pulls no longer fall through to raw file overwrite for classified git refs. They download/parse the incoming ref blob, prove the incoming commit object exists even for new local refs, then apply `git update-ref <ref> <incoming> <expected-old>` (or zero-OID for a new ref). A live ref move between proof and mutation now defers/replans instead of overwriting.
- Ref local deletes no longer use raw `remove_file` after parking. They use `git update-ref -d <ref> <expected-old>` and defer on mismatch.
- Added regressions for missing-object new refs and CAS rejection for moved update/delete refs.
- Local validation on neo remains hygiene-only: `cargo fmt --all -- --check` and `git diff --check`; no local build/test.


## Fix round: ref-class raw fallthrough closure (4a46851)

Confucius adversarial review found three initialized-gitdir paths that could still fall through to raw writes. This head closes them:

- `refs/tcfs/**` now classifies as a guarded non-parkable ref path, so missing-object incoming refs defer instead of raw materializing.
- Existing `.git/HEAD` now classifies even when symbolic; symbolic HEAD changes and incoming detached-HEAD rewrites defer once the gitdir is initialized.
- New `packed-refs` now requires object proof plus create-new semantics once the gitdir is initialized; opaque changes still defer.
- Bootstrap raw restore is preserved only before the gitdir skeleton is ready, which addresses the `git_ff_resolution` CI bootstrap failure from e5398c8 without reopening initialized-gitdir raw writes.

Local validation on neo remains intentionally lightweight: `cargo fmt --all -- --check` and `git diff --check` only. Build/test validation is remote GitHub CI / fleet infrastructure.


## Fix round: symbolic submodule HEAD closure (dfbd98a)

A local read-only review found one more symmetry gap before merge: `.git/modules/<name>/HEAD` only classified when already detached, while top-level `.git/HEAD` classified whenever it existed. Latest head changes submodule HEAD classification to match top-level HEAD and adds `loser_guard_defers_symbolic_submodule_head_to_detached_head_pull`, proving an initialized submodule symbolic HEAD defers rather than raw-overwriting to detached HEAD.

Validation boundary unchanged: only `cargo fmt --all -- --check` and `git diff --check` locally; remote CI owns build/test.


## Fix round: packed-refs syntax/refname hardening (fd699a5)

Euler's clean adversarial review left one non-blocking residual: new `packed-refs` proved object presence but did not validate packed-refs syntax/refnames before create-new. Latest head closes that too:

- parses each non-comment line as either `SHA refs/...` or peeled `^SHA`;
- requires normal refs to pass `git check-ref-format` and start with `refs/`;
- rejects extra tokens, invalid SHAs, one-level names such as `HEAD`, and malformed peeled lines;
- adds `loser_guard_defers_new_malformed_packed_refs_even_when_object_exists`.

Local validation remains `cargo fmt --all -- --check` and `git diff --check` only; build/test validation is remote CI.
