### PR TITLE
docs: record current TCFS workstream truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Operational policy: [`docs/ops/remote-governance.md`](docs/ops/remote-governance
 ## Reality And Wayfinding
 
 - Current proof posture: [docs/ops/product-reality-and-priority.md](docs/ops/product-reality-and-priority.md)
+- Current workstream truth:
+  [docs/ops/current-workstream-truth-2026-07-06.md](docs/ops/current-workstream-truth-2026-07-06.md)
 - Feature/objective matrix: [docs/ops/feature-objective-matrix-2026-05-09.md](docs/ops/feature-objective-matrix-2026-05-09.md)
 - Next fleet parity sprint: [docs/ops/fleet-parity-sprint-plan-2026-05-09.md](docs/ops/fleet-parity-sprint-plan-2026-05-09.md)
 - Lazy traversal QA matrix: [docs/ops/lazy-traversal-qa-permutation-matrix-2026-05-09.md](docs/ops/lazy-traversal-qa-permutation-matrix-2026-05-09.md)
@@ -92,6 +94,9 @@ Operational policy: [`docs/ops/remote-governance.md`](docs/ops/remote-governance
   in-progress state is PROVEN (2026-06-09), evidence
   `docs/release/evidence/repo-roam-canary-20260609/`. See
   [Roam an in-progress repo across machines](#roam-an-in-progress-repo-across-machines).
+- Build substrate rule: do not use `neo` for heavy local builds. Use remote CI
+  or the fleet build substrate; PZM/Nix offload is tactical, while the durable
+  direction is the GloriousFlywheel/RBE/Darwin substrate lane.
 
 ## Roam an in-progress repo across machines
 

--- a/docs/ops/current-workstream-truth-2026-07-06.md
+++ b/docs/ops/current-workstream-truth-2026-07-06.md
@@ -1,0 +1,63 @@
+# Current TCFS Workstream Truth, 2026-07-06
+
+This note is the current operator-facing checkpoint for TCFS daily-driver work.
+Older evidence packets remain useful provenance, but do not treat them as the
+active blocker list.
+
+## Build Substrate
+
+Do not use `neo` for heavy local builds. If a change needs expensive Rust,
+Nix, or Darwin validation, use remote CI or the repo/fleet build substrate.
+
+`petting-zoo-mini` may be useful as a bounded Darwin lab endpoint, but it is
+not the durable answer to `neo` build pressure. The durable direction is the
+GloriousFlywheel/RBE/Darwin substrate lane. Nix offload to PZM is tactical and
+must fail loud when unavailable.
+
+## Keep-Both / Repo Roam
+
+The fast-forward `.git` case is closed by #513 and live evidence. The divergent
+keep-both ladder is split:
+
+- PR-1 through PR-3 are merged: per-file `.git` resolve is fenced, the executor
+  respects foreign `.git/tcfs.lock`, `tcfs conflicts` exists, and the
+  operator-only repo keep-both resolver parks the peer side under
+  `refs/tcfs/theirs/**`.
+- PR-4 is the active loser-side no-loss guard work: before a ref pull can
+  overwrite a divergent local branch, TCFS must park the old local head and keep
+  an undo bundle in the machine-local state dir. This is tracked by TIN-2552
+  and PR #534.
+
+Until PR-4 is merged, deployed, and live-canary proven, do not claim the
+divergent two-machine G5-git-13/T10/T11 convergence row green.
+
+## PZM / TCC / SSD
+
+The PZM external SSD is not the current proof blocker when directory-health and
+transport checks are green. Recent observed healthy shape:
+
+- TinylandSSD and `/nix` are APFS volumes on the external SSD container.
+- Directory traversal over SSH completes for `/Volumes/TinylandSSD` and the
+  Tinyland-owned subtree.
+- The ASM236X enclosure enumerates at 10Gbps.
+
+The remaining PZM risk is context-specific macOS policy, not basic SSD
+enumeration: TCC/PPPC/FDA, launchd execution, Nix/profile/dyld reads, code
+identity, and the exposed become password rotation. Finder access is useful
+evidence, but it does not prove launchd, SSH, or Nix-store dynamic execution
+contexts.
+
+## Per-Device Crypto
+
+Do not resurrect #517 as a merge candidate. It is closed, stale provenance for
+the fresh `tcfs key rotate <prefix>` rebuild. The active direction is TIN-2551
+under TIN-1417: per-prefix FileKey rotation, real revocation semantics, and
+the staged `master -> dual -> per_device` live proof path.
+
+## Documentation Hygiene
+
+Archived packets may mention source-built binaries on `neo`, old Finder
+read-timeout blockers, or PZM hardware-gated conclusions. Treat those as dated
+evidence unless a current runbook explicitly promotes them. Current docs should
+point here or to the relevant Linear issue before making new daily-driver
+claims.

--- a/docs/ops/lab-host-acceptance-matrix.md
+++ b/docs/ops/lab-host-acceptance-matrix.md
@@ -22,7 +22,7 @@ Use only hosts that are operationally real today.
 | --- | --- | --- | --- |
 | `honey` | canonical Linux control point | high-volume push/pull, daemon/service checks, conflict and stress lanes, Linux-first operator truth | none beyond normal fleet drift |
 | `neo` | canonical release-adjacent Darwin lane | package upgrade proof, live `neo-honey` smoke, regression reproduction on the maintainer workstation | not a good target for destructive “fresh machine” cleanup |
-| `petting-zoo-mini` | canonical headless Darwin endpoint | FileProvider packaging presence, Darwin daemon parity, Linux-to-Darwin and Darwin-to-Linux operator acceptance, end-user-ish desktop surface checks | external SSD, PPPC, and MDM work can interfere; preflight first |
+| `petting-zoo-mini` | canonical headless Darwin endpoint | FileProvider packaging presence, Darwin daemon parity, Linux-to-Darwin and Darwin-to-Linux operator acceptance, end-user-ish desktop surface checks | preflight TCC/PPPC/FDA, launchd/Nix/profile/dyld execution context, SSD directory health, and password-rotation state first |
 | `sting` | none yet | none until it is real | blocked on lab-side hardware stabilization and onboarding; do not treat it as an acceptance target |
 
 ## Lane Map
@@ -101,8 +101,10 @@ Minimum reset contract per host:
 For `petting-zoo-mini`, add one more gate:
 
 6. Confirm the host-specific Darwin workstream is not already degraded.
-   - PPPC / MDM expectations are known
-   - external SSD rollout is not currently in a bad state if the acceptance lane depends on it
+   - TCC / PPPC / FDA expectations are known for the execution context under test
+   - launchd, SSH, Nix/profile, and dyld contexts are not assumed from Finder access alone
+   - external SSD directory health is green if the acceptance lane depends on it
+   - exposed become credentials have been rotated before relying on sudo-backed probes
    - the machine is not already under runner or storage distress
 
 ## Current Operator Commands


### PR DESCRIPTION
## Summary
- add a current TCFS workstream truth note for the July 6 daily-driver frontier
- point README wayfinding at the current note and state the no-heavy-neo-build rule
- tighten PZM lab acceptance preflight around TCC/PPPC/FDA, launchd/Nix/dyld contexts, SSD directory health, and password rotation

## Validation
- git diff --check

## Notes
This is intentionally separate from #534 so the keep-both PR-4 code gate does not restart remote CI.