### PR TITLE
docs: refresh TCFS keep-both and PZM truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 > Under active development. Not yet stable. Expect breaking changes.
 
-Current release: `v0.12.14` (tagged); `v0.12.15` is pending on `main`. The
-Homebrew tap is stale at `0.12.12` and that formula skips symlinks.
+Current release: `v0.12.14` (tagged); workspace `main` is `0.12.16` and carries
+the merged `.git` fast-forward and divergent keep-both code paths, but the
+post-PR-4 divergent keep-both fleet deploy/canary is still pending. The Homebrew
+tap is stale at `0.12.12` and that formula skips symlinks.
 
 Self-hosted encrypted file sync with on-demand hydration. The Linux FUSE mounted
 view is host-proven for clean-name traversal, hydrate-on-open, mounted

--- a/docs/design/git-divergent-keep-both-2026-07-02.md
+++ b/docs/design/git-divergent-keep-both-2026-07-02.md
@@ -1,6 +1,7 @@
 # Divergent `.git` keep-both: operator resolution for genuinely diverged repos
 
-- **Status:** DRAFT — pending operator review
+- **Status:** Design-of-record — PR-1 through PR-4 are merged; live divergent
+  fleet canary pending deploy
 - **Date:** 2026-07-02
 - **Code baseline:** all `file:line` references verified at `origin/main` `c40f075` (#513 merged)
 - **Predecessors:** #513 (`.git`-aware FF conflict resolution), #506 harness
@@ -524,8 +525,8 @@ ordinary files.
 
 ## Implementation status (updated 2026-07-05)
 
-This design is now the design-of-record; PR-1 through PR-3 are merged, and PR-4
-is in remote-CI validation.
+This design is now the design-of-record; PR-1 through PR-4 are merged. The
+remaining work is fleet deploy plus the live divergent keep-both canary.
 
 | Rung | PR | Merge commit | Status |
 |------|----|--------------|--------|
@@ -533,18 +534,15 @@ is in remote-CI validation.
 | (hardening) — fence paths + persistence | #527 | `449846e` | ✅ merged |
 | **PR-2** — executor hard-respects a foreign `.git/tcfs.lock`; `ConflictInfo.remote_manifest_key` | #528 | `1e41a23` | ✅ merged |
 | **PR-3** — repo-group keep-both resolver (`resolve_repo_keep_both`): parks losing heads at `refs/tcfs/theirs/<device>/**`, fsck-gated both sides, dry-run default, state-dir undo bundle, **operator-CLI-only** (MCP/auto excluded via the `operator_cli` provenance gate) | #529 | `831d363b` | ✅ merged |
-| **PR-4** — loser-side no-loss guard (pre-overwrite parking; flips harness G5-git-13 / T10/T11 live) | #534 | draft branch | 🟡 draft PR / remote CI + G5-git-13 harness |
+| **PR-4** — loser-side no-loss guard (pre-overwrite parking; flips harness G5-git-13 / T10/T11 live after deploy/canary) | #534 | `4c61da4` | ✅ merged |
 
-**PR-4 is the only remaining rung** and is no longer framed as blocked on PZM
-hardware: the PZM SSD/RWX path re-enumerated and verified clean. Builder
-transport hardening (`ssh-ng://` Determinate Nix vs `ssh://`/serve-style or
-GF/remote-cache execution) remains a separate TIN-1620/#524 operational lane.
-The remaining PR-4 gate is ordinary code validation + fleet deploy: #534 must
-pass remote CI, land, deploy to both hosts, then run the two-machine live
-convergence canary. Until that lands + canary runs, the honest claim is:
+**PR-4 is merged, not live-proven.** The remaining gate is deploy + canary:
+builds must not run locally on neo, and PZM cannot be used for TCFS offload
+until lab's PZM directory-health/Nix-context/denial-log/remote-builder verifier
+passes again. Until deploy + canary run, the honest claim is:
 **divergent `.git` conflicts are safely fenced, visible (`tcfs conflicts`), and
 operator-resolvable (`tcfs resolve … --execute`), but the two-machine
-live-convergence proof (G5-git-5 T10/T11 green) is pending PR-4 deployment.**
+live-convergence proof (G5-git-5 T10/T11 green) is pending.**
 
 **Ratified operator §6 answers (2026-07-05):** parking namespace default = `refs/tcfs/theirs/**` (not real branches); bare `keep-local`/`keep-remote` = omitted (park-first only); dirty-tree = hard refuse; ticket routing = new ticket for the verb + TIN-1549 keeps the `tcfs conflicts`/banner UX surface. Bundle retention and escalation cadence remain open (non-blocking; PR-4-adjacent).
 

--- a/docs/ops/current-workstream-truth-2026-07-06.md
+++ b/docs/ops/current-workstream-truth-2026-07-06.md
@@ -11,8 +11,9 @@ Nix, or Darwin validation, use remote CI or the repo/fleet build substrate.
 
 `petting-zoo-mini` may be useful as a bounded Darwin lab endpoint, but it is
 not the durable answer to `neo` build pressure. The durable direction is the
-GloriousFlywheel/RBE/Darwin substrate lane. Nix offload to PZM is tactical and
-must fail loud when unavailable.
+GloriousFlywheel/RBE/Darwin substrate lane. Nix offload to PZM is tactical, must
+fail loud when unavailable, and is currently not accepted for TCFS deploy work
+until the lab verifier says it is healthy again.
 
 ## Keep-Both / Repo Roam
 
@@ -39,19 +40,17 @@ divergent two-machine G5-git-13/T10/T11 convergence row green.
 
 ## PZM / TCC / SSD
 
-The PZM external SSD is not the current proof blocker when directory-health and
-transport checks are green. Recent observed healthy shape:
+The PZM external SSD is healthy at the block/APFS/Finder layer, but that is not
+enough for TCFS offload. Current lab probes show SSH child enumeration still
+times out under `/nix` and `/Volumes/TinylandSSD/tinyland`, and denial logs show
+System Policy/FDA decisions involving shell and Nix-store paths. Finder access
+is useful evidence, but it does not prove launchd, SSH, Nix/dyld, runner,
+daemon, or remote-builder contexts.
 
-- TinylandSSD and `/nix` are APFS volumes on the external SSD container.
-- Directory traversal over SSH completes for `/Volumes/TinylandSSD` and the
-  Tinyland-owned subtree.
-- The ASM236X enclosure enumerates at 10Gbps.
-
-The remaining PZM risk is context-specific macOS policy, not basic SSD
-enumeration: TCC/PPPC/FDA, launchd execution, Nix/profile/dyld reads, code
-identity, and the exposed become password rotation. Finder access is useful
-evidence, but it does not prove launchd, SSH, or Nix-store dynamic execution
-contexts.
+Before any TCFS deploy uses PZM again, lab must pass the read-only recovery
+gate: directory-health, Nix execution-context probes, denial-log check, and
+`just nix-remote-builder-verify --live --strict`. Keep `TIN-2521`
+become-password rotation separate and required.
 
 ## Per-Device Crypto
 

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -1,5 +1,15 @@
 # Product Reality And Priority
 
+> 2026-07-06 update: this document is historical posture, not the current
+> daily-driver blocker list. Current workspace `main` is `0.12.16`; #513
+> fast-forward `.git` resolution is merged and live-proven; #534 loser-side
+> no-loss guard is merged; the remaining G5-git-5 divergent keep-both gate is
+> fleet deploy plus the live neo<->honey canary in
+> `docs/release/evidence/divergent-keep-both-canary-PLAN.md`. Do not use this
+> May release-candidate text to justify local neo builds or PZM offload while
+> PZM's SSH/launchd/Nix contexts are failing directory-health/System Policy
+> probes.
+
 As of May 19, 2026, `tummycrypt` is in a much better state operationally than
 its remaining gaps might suggest.
 

--- a/docs/release/evidence/bidirectional-ff-canary-20260705T225429Z/RESULTS.md
+++ b/docs/release/evidence/bidirectional-ff-canary-20260705T225429Z/RESULTS.md
@@ -8,7 +8,10 @@ via #513's fast-forward resolver where the 2026-06-09 canary stalled at 5 confli
 - neo: macOS, tcfs 0.12.16 (hm gen 417), reconcile invokes tcfs-cli-0.12.16 (lab pin 19ae294 ⊇ #513/c40f075)
 - honey: Rocky 10, tcfs 0.12.16
 - Both hosts on #513 FF resolution; raw `.git`-as-files (sync_git_dirs=true, git_sync_mode=raw); disposable prefix `git-roam/bidi-ff-*`
-- PZM aarch64-darwin builder recovered same day (TCC-prompt clear + reboot restored SSH-context /nix access; forced offload build verified).
+- PZM aarch64-darwin builder evidence from this day is superseded by later
+  2026-07-06 lab probes: Finder/APFS can look healthy while SSH directory
+  health still times out and System Policy/FDA denies shell/Nix-store paths.
+  Do not use this packet as current PZM builder acceptance.
 
 ## Result — both directions converge, zero conflicts
 | Step | Action | Outcome |
@@ -30,5 +33,7 @@ here in BOTH directions on the deployed fleet: **"the machine doesn't matter" �
 commit on either host, resume on the other, byte-exact + fsck-clean, zero manual
 intervention.**
 
-Remaining: divergent (non-FF) keep-both = PR-3 (#529) merged, PR-4 (loser-guard)
-is the last rung. This canary is the FF acceptance (harness G5-git-9/-11 class).
+Remaining: divergent (non-FF) keep-both code is merged through PR-4 (#534), but
+the post-PR-4 fleet deploy and divergent live canary are still pending. This
+packet remains the FF acceptance (harness G5-git-9/-11 class), not the divergent
+T10/T11 proof.

--- a/docs/release/evidence/repo-roam-canary-20260609/RESULTS.md
+++ b/docs/release/evidence/repo-roam-canary-20260609/RESULTS.md
@@ -6,3 +6,10 @@ R0 source fingerprint (neo): 5b24b9f95065576e4f664141fe837e8e1d9e4586c2a5765720b
 R1 neo PUSH: 126 pushed, 0 errors (raw .git incl objects/index/refs/logs+stash + working tree)
 R2 honey PULL + compare: honey fingerprint = 5b24b9f9... IDENTICAL → dev-env-zero-diff=PASS (T13-Z), fsck clean both sides. Branch/staged/unstaged/untracked/stash all roamed exact.
 R3 bidirectional (honey commit→neo): honey reconcile = 5 conflicts, 0 pushed → G5-git-5 concurrent-.git gate CONFIRMED expected-fail (AutoResolver not .git-aware). Forward roam clean; concurrent bidirectional needs .git-aware conflict resolution (future work) or unsync/rehydrate safe-handoff.
+
+2026-07-06 supersession note: the fast-forward half of this expected-fail was
+closed by #513 and live-proven in
+`docs/release/evidence/bidirectional-ff-canary-20260705T225429Z/RESULTS.md`.
+The divergent keep-both code path is merged through #534, but still needs fleet
+deploy and the live divergent canary before this historical expected-fail can be
+treated as fully green.


### PR DESCRIPTION
## Summary
- update README/current truth surfaces for workspace 0.12.16 and the merged-but-not-deployed keep-both PR-4 state
- mark PZM as not accepted for TCFS offload until lab directory-health, Nix context, denial-log, and remote-builder verifier gates pass again
- cross-link old repo-roam expected-fail evidence to the later FF proof while keeping divergent T10/T11 pending deploy/canary

Linear: TIN-1620, TIN-2552, TIN-1908

## Validation
- `git diff --check`
- stale-truth grep for old PR-4 draft/PZM-green phrases

No local builds or Rust tests; docs-only truth correction under the no-local-neo-build constraint.