### PR TITLE
docs: remove residual TCFS frontier drift

### DIFF
--- a/docs/ops/current-workstream-truth-2026-07-06.md
+++ b/docs/ops/current-workstream-truth-2026-07-06.md
@@ -40,12 +40,13 @@ divergent two-machine G5-git-13/T10/T11 convergence row green.
 
 ## PZM / TCC / SSD
 
-The PZM external SSD is healthy at the block/APFS/Finder layer, but that is not
-enough for TCFS offload. Current lab probes show SSH child enumeration still
-times out under `/nix` and `/Volumes/TinylandSSD/tinyland`, and denial logs show
-System Policy/FDA decisions involving shell and Nix-store paths. Finder access
-is useful evidence, but it does not prove launchd, SSH, Nix/dyld, runner,
-daemon, or remote-builder contexts.
+The PZM external SSD can be visible and browsable at the block/APFS/Finder
+layer, but that is not enough for TCFS offload. Current lab probes show SSH
+child enumeration still times out under `/nix` and
+`/Volumes/TinylandSSD/tinyland`, and denial logs show System Policy/FDA
+decisions involving shell and Nix-store paths. Finder access is useful evidence,
+but it does not prove launchd, SSH, Nix/dyld, runner, daemon, or remote-builder
+contexts.
 
 Before any TCFS deploy uses PZM again, lab must pass the read-only recovery
 gate: directory-health, Nix execution-context probes, denial-log check, and

--- a/docs/ops/dotgit-as-files-conflict-corruption-2026-06-08.md
+++ b/docs/ops/dotgit-as-files-conflict-corruption-2026-06-08.md
@@ -125,12 +125,11 @@ For `TIN-1620` / G5 the live-repo conflict and rollback proof must add, for
 - **G5-git-4 (dirty-child refusal incl. `.git`):** `tcfs unsync <repo>` with a
   dirty `.git` child (e.g. a fresh commit not yet synced) **refuses** without
   `--force`. No silent loss, no partial dehydration.
-- **G5-git-5 (concurrent-write corruption row):** the per-file `.git` conflict
-  interleave under `conflict_mode=auto` must be **detected** — `git fsck` reports
-  the half-applied ref. Until resolution is made `.git`-aware (resolve a repo's
-  `.git/*` as one unit, or fall back to bundle on `.git` conflict), this row is
-  expected to FAIL and stands as the corruption-risk gate that must be closed
-  before G5 can claim concurrent-edit safety.
+- **G5-git-5 (concurrent-write corruption row):** historical red row for per-file
+  `.git` conflict interleaves under `conflict_mode=auto`. The row is superseded
+  by the merged `.git`-aware FF and divergent keep-both stack (#513, #529, #534),
+  but fleet acceptance still requires a post-#534 deploy and live divergent
+  keep-both canary before claiming two-host concurrent-edit safety.
 
 ## Harness
 

--- a/docs/ops/ghost-device-revocation-safety-2026-07-02.md
+++ b/docs/ops/ghost-device-revocation-safety-2026-07-02.md
@@ -39,7 +39,7 @@ FileProvider bring-up lanes and have no corresponding physical device.
 |---|---|
 | `master` (current fleet state) | **No cryptographic effect.** Content carries only the master wrap; every holder of the master key decrypts regardless of registry state. Revocation here is registry hygiene. |
 | `dual` (EXPAND) | Ghosts are dropped from every recipient set built after the local revoke (`active_devices()` filter); new `wrapped_file_keys` exclude them. Master wrap still present, so no read denial yet. |
-| `per_device` (CONTRACT) | True denial of NEW content. Historical content stays readable to any holder of previously-wrapped keys until `tcfs key rotate <prefix> --rotate-keys` (TIN-1899, landed). |
+| `per_device` (CONTRACT) | True denial of NEW content. Historical content stays readable to any holder of previously-wrapped keys until the fresh `tcfs key rotate <prefix> --rotate-keys` rebuild is implemented and proven under TIN-2551. Do not treat the closed #517 / TIN-1899 branch as landed production truth. |
 
 ## Why this is on the critical path anyway (the roll-call coupling)
 

--- a/docs/ops/lab-host-acceptance-matrix.md
+++ b/docs/ops/lab-host-acceptance-matrix.md
@@ -22,7 +22,7 @@ Use only hosts that are operationally real today.
 | --- | --- | --- | --- |
 | `honey` | canonical Linux control point | high-volume push/pull, daemon/service checks, conflict and stress lanes, Linux-first operator truth | none beyond normal fleet drift |
 | `neo` | canonical release-adjacent Darwin lane | package upgrade proof, live `neo-honey` smoke, regression reproduction on the maintainer workstation | not a good target for destructive “fresh machine” cleanup |
-| `petting-zoo-mini` | canonical headless Darwin endpoint | FileProvider packaging presence, Darwin daemon parity, Linux-to-Darwin and Darwin-to-Linux operator acceptance, end-user-ish desktop surface checks | preflight TCC/PPPC/FDA, launchd/Nix/profile/dyld execution context, SSD directory health, and password-rotation state first |
+| `petting-zoo-mini` | bounded Darwin/FileProvider lab endpoint | FileProvider packaging presence, Darwin daemon parity, and targeted end-user-ish desktop surface checks after health gates pass | not accepted as TCFS offload or broad operator-acceptance host until TCC/PPPC/FDA, launchd/Nix/profile/dyld execution context, SSD directory health, strict remote-builder verification, and password-rotation state pass |
 | `sting` | none yet | none until it is real | blocked on lab-side hardware stabilization and onboarding; do not treat it as an acceptance target |
 
 ## Lane Map

--- a/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
+++ b/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
@@ -10,11 +10,11 @@ Tracker: `TIN-1617` (epic). New sub-issues: `TIN-1736`, `TIN-1737`,
 not the current frontier. Since it was written, the neo↔honey live repo path has
 advanced materially: fast-forward `.git` conflict resolution landed, the
 bidirectional FF handoff canary has live evidence under `TIN-1620`, and the
-divergent keep-both ladder has PR-1/PR-2/PR-3 merged with PR-4 still
-deploy-gated. The current stop rule is no broad `~/git` or home takeover until
-two small repos clear R0-R5 both directions and the remaining divergent no-loss
-guard is deployed and proven. Per-device forward secrecy remains gated on the
-fresh `tcfs key rotate` rebuild tracked by `TIN-2551`.
+divergent keep-both ladder has PR-1/PR-2/PR-3 plus PR-4/#534 merged. The current
+stop rule is no broad `~/git` or home takeover until two small repos clear R0-R5
+both directions and the merged divergent no-loss stack is deployed and proven by
+the live canary. Per-device forward secrecy remains gated on the fresh
+`tcfs key rotate` rebuild tracked by `TIN-2551`.
 
 This document does not replace
 [large-workdir-onboarding-design-2026-05-25.md](large-workdir-onboarding-design-2026-05-25.md);

--- a/docs/ops/repo-roam-test-plan-2026-06-08.md
+++ b/docs/ops/repo-roam-test-plan-2026-06-08.md
@@ -356,11 +356,11 @@ The live-repo packet must add five raw-mode `.git` rows (these are the
   fsck-clean, byte-exact repo (the R3 fingerprint compare proves this).
 - **G5-git-4 DIRTY-CHILD REFUSAL** — `tcfs unsync` with a dirty `.git` child
   refuses without `--force`; no partial dehydration (row T6).
-- **G5-git-5 CONCURRENT-WRITE CORRUPTION** — the per-file `.git` conflict interleave
-  under `conflict_mode=auto` MUST be detected by `git fsck` (invalid sha1 pointer).
-  **Until conflict resolution is made `.git`-aware, G5-git-5 is EXPECTED TO FAIL**
-  and stands as the corruption gate that must close before G5 can claim
-  concurrent-edit safety.
+- **G5-git-5 CONCURRENT-WRITE CORRUPTION** — historical red row for per-file
+  `.git` conflict interleaves under `conflict_mode=auto`. This row has been
+  superseded by the merged `.git`-aware FF and divergent keep-both stack (#513,
+  #529, #534). It is not green for fleet acceptance until a post-#534 deploy and
+  the live divergent keep-both canary prove no-loss behavior on two hosts.
 
 **Safe handoff rule:** the `tcfs unsync <repo>` flip-flop is the correct primitive —
 do not let two machines hold the same `.git` hydrated+writable at once. Quiesce git

--- a/docs/release/evidence/divergent-keep-both-canary-PLAN.md
+++ b/docs/release/evidence/divergent-keep-both-canary-PLAN.md
@@ -9,13 +9,9 @@
 
 ## 0. Grounding — what is actually true right now (read this first)
 
-This plan was drafted from a working tree on `facet6/dotgit-conflict-corruption-harness`,
-which is **70 commits behind `origin/main`** (merge-base `f9fb683`). Several source
-files this runbook depends on (the design doc, the harness script's Stage 6, the
-`tcfs conflicts`/`resolve` CLI surface, the loser-guard in `reconcile.rs`) only exist
-on `origin/main` — they were read via `git show origin/main:<path>`, not the local
-worktree. **Fetch/rebase this branch onto current `origin/main` before running any
-step below**, or run everything from a fresh `origin/main` checkout.
+This plan is maintained from current `origin/main`. Run it only from a fresh
+checkout that contains #513, #529, and #534, and after the lab/fleet deploy has
+installed a build newer than merge commit `4c61da4`.
 
 ### Surprises vs. the task brief
 
@@ -24,24 +20,20 @@ step below**, or run everything from a fresh `origin/main` checkout.
    (`tcfs: loser-side no-loss guard for git keep-both (TIN-2552)`). The brief's
    premise ("once merged...") is already satisfied on `origin/main` — what is
    **not** yet true is fleet deployment (see below).
-2. **`docs/ops/repo-roam-test-plan-2026-06-08.md` does not exist in this branch's
-   working tree** (only on `origin/main`, added at `f295748`). Its §7/T10/T11 rows
-   are quoted from `origin/main`'s copy in §1 below.
-3. **The FF canary evidence is not named `bidirectional-ff-canary-*` in the local
-   tree** — it's at `docs/release/evidence/bidirectional-ff-canary-20260705T225429Z/RESULTS.md`
-   on `origin/main` (not yet present locally). Its structure is mirrored in §5/§6.
-4. **`docs/ops/current-workstream-truth-2026-07-06.md` (origin/main, added same day
-   as #534 in PR #535) still describes PR-4 as "the active loser-side no-loss guard
-   work"** — i.e. the docs commit that's supposed to be the current operator
-   checkpoint is already one PR stale relative to `origin/main`'s own history. Trust
-   `gh pr view 534` over that prose.
-5. **Neither `tcfs resolve` nor `tcfs conflicts --json`'s CLI surface has the
+2. **The repo-roam test plan and FF canary evidence are now present on main.** Use
+   `docs/ops/repo-roam-test-plan-2026-06-08.md` for the G5/T10/T11 rows and
+   `docs/release/evidence/bidirectional-ff-canary-20260705T225429Z/RESULTS.md`
+   as the fast-forward baseline.
+3. **`docs/ops/current-workstream-truth-2026-07-06.md` is the current operator
+   checkpoint.** It says #534 is merged, but the fleet deployment and divergent
+   live canary are still pending.
+4. **Neither `tcfs resolve` nor `tcfs conflicts --json`'s CLI surface has the
    `--theirs-as-branch`, `--allow-dirty`, or `--restore-undo` flags** that
    `docs/design/git-divergent-keep-both-2026-07-02.md` describes as UX skin (§2.2,
    §2.3 step 10). Only `tcfs resolve <path> --strategy keep-both [--execute]` and
    `tcfs conflicts [--json] [--state <path>]` shipped. Undo restoration is a manual
    `git bundle` operation (§8 below), not a CLI flag.
-6. **Architectural gotcha (verified live, not in any doc): `tcfs resolve` talks
+5. **Architectural gotcha (verified live, not in any doc): `tcfs resolve` talks
    only to the running daemon over gRPC, and the daemon's `ResolveConflict`
    handler resolves against the daemon's OWN configured `sync.state_db`** — it does
    **not** accept a `--state` override (unlike `tcfs conflicts`, which does). The
@@ -57,14 +49,14 @@ step below**, or run everything from a fresh `origin/main` checkout.
    `sync.state_db` path** (§2), not an isolated file, or `tcfs resolve` will see
    zero conflicts and the whole canary silently no-ops. Verify this live with the
    dry-run sanity check in §4 before trusting `--execute`.
-7. **Fleet is on tcfs 0.12.16 on both hosts** (verified live: `tcfs --version` on
+6. **Fleet is on tcfs 0.12.16 on both hosts** (verified live: `tcfs --version` on
    neo and `ssh jess@honey 'tcfs --version'` both return `tcfs 0.12.16`) — matching
    the FF canary's fleet line. `Cargo.toml` on `origin/main` is **still** `0.12.16`
    (unreleased, no version bump yet for #534/#535), and the binary has no embedded
    build SHA (`tcfs --version` prints only the semver). **A version number alone
    cannot distinguish pre-#534 from post-#534 fleet builds** — see §0.1 for the
    actual check.
-8. Both hosts' deployed `config.toml` already have `sync.sync_git_dirs = true` and
+7. Both hosts' deployed `config.toml` already have `sync.sync_git_dirs = true` and
    `sync.git_sync_mode = "raw"` **globally** (verified: `cat ~/.config/tcfs/config.toml`
    on neo, `ssh jess@honey cat ~/.config/tcfs/config.toml` on honey). No config
    change is needed for raw `.git`-as-files mode.


### PR DESCRIPTION
## Summary

Refresh residual TCFS frontier docs after #513/#529/#534/#537 so the current stop rule is consistent across older packets and runbooks.

## Changes

- mark PR-4/#534 as merged but still deploy/canary pending
- soften PZM language from hardware/Finder healthy to not accepted for TCFS offload until lab gates pass
- move key-rotation language from closed #517/TIN-1899 to TIN-2551
- supersede old G5-git-5 expected-red wording with post-#534 deploy/canary gating

## Test plan

- [x] git diff --check
- [x] targeted stale-phrase grep over docs/ops and divergent keep-both canary plan
- [ ] task test passes locally — not run; docs-only, and neo-local heavy builds are intentionally avoided
- [ ] task lint passes locally — not run; docs-only, and neo-local heavy builds are intentionally avoided
- [x] Verified affected functionality manually

## Checklist

- [x] Docs updated
- [x] CHANGELOG.md updated (not applicable)
- [x] No secrets or credentials in diff

Linear: TIN-1620, TIN-2552, TIN-2551
