### PR TITLE
tcfs-sync: record Conflict for out-of-band-diverged refs (TIN-2584)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -5329,8 +5329,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let local_path = dir.path().join("main");
         std::fs::write(&local_path, b"unchanged\n").unwrap();
-        let local_hash =
-            tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_file(&local_path).unwrap());
+        let local_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_file(&local_path).unwrap());
         let tracked = tin2584_state(&local_hash, tin2584_vclock(&[("neo", 1)]));
 
         let config = ReconcileConfig::default();

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -1271,7 +1271,39 @@ async fn classify_path(
         },
 
         // Was synced, now deleted from remote — delete locally if configured
-        (Some(local_path), None, Some(_tracked_state)) => {
+        (Some(local_path), None, Some(tracked_state)) => {
+            // TIN-2584 (race): a peer's freshly-pushed ref index entry may not
+            // yet be visible in the bulk remote LIST that fed `remote` (S3
+            // read-after-write LIST lag — observed live at +0.5s after a push).
+            // A ref that also diverged locally then lands here and, with the
+            // default `delete_local_orphans = false`, is classified `UpToDate`:
+            // a SILENT no-op that freezes the divergence (conflicts stays 0).
+            //
+            // If a ref-class path's live content differs from its tracked hash,
+            // do NOT no-op it: route it through the engine's conflict-aware push
+            // instead. The push path re-resolves this exact remote index key via
+            // a direct GET (stronger read-after-write than the bulk LIST that
+            // missed it) and either records a Conflict (remote concurrently
+            // ahead) or uploads (remote genuinely dropped the ref) — never a
+            // silent freeze, never a blind clobber. The hash-equal case keeps
+            // the existing orphan behavior below.
+            if is_git_ref_class_path(rel_path) {
+                let diverged = tcfs_chunks::hash_file(local_path)
+                    .map(|h| tcfs_chunks::hash_to_hex(&h) != tracked_state.blake3)
+                    .unwrap_or(false);
+                if diverged {
+                    warn!(
+                        path = %rel_path,
+                        "TIN-2584: divergent git ref with remote index entry momentarily \
+                         absent; routing to conflict-aware push instead of a silent no-op"
+                    );
+                    return ReconcileAction::Push {
+                        local_path: local_path.clone(),
+                        rel_path: rel_path.to_string(),
+                        reason: PushReason::LocalNewer,
+                    };
+                }
+            }
             if config.delete_local_orphans {
                 ReconcileAction::DeleteLocal {
                     local_path: local_path.clone(),
@@ -1354,7 +1386,7 @@ async fn compare_both_exist(
     };
 
     // Get local vector clock from tracked state
-    let local_vclock = tracked.map(|s| s.vclock.clone()).unwrap_or_default();
+    let mut local_vclock = tracked.map(|s| s.vclock.clone()).unwrap_or_default();
 
     // Fetch remote manifest for its vector clock and hash
     let manifest_path = format!(
@@ -1386,6 +1418,39 @@ async fn compare_both_exist(
     };
 
     let remote_device = remote_manifest.written_by.as_str();
+
+    // TIN-2584: reconcile against an out-of-band local divergence. A ref file
+    // rewritten by `git commit` (e.g. `.git/refs/heads/main`) never ticks the
+    // TCFS vclock, so a diverged local file carries its stale, last-synced clock
+    // into classification. When the remote has since advanced, that stale clock
+    // is strictly dominated by the remote's — so `compare_clocks` reads the
+    // divergence as `RemoteNewer` and the incoming pull path silently parks it
+    // with NO `ConflictInfo` recorded (`tcfs conflicts` stays empty, keep-both
+    // has nothing to act on). Model the local divergence as an independent edit
+    // by ticking a CLONE of the clock (mirrors `engine.rs`
+    // `local_edit_inferred -> tick`): {neo:1} vs remote {neo:2} becomes
+    // {neo:1,honey:1} vs {neo:2} — incomparable — which classifies as a Conflict
+    // that the record arm surfaces.
+    //
+    // Narrowed to the strictly-dominated (`Ordering::Less`) case on purpose:
+    //  * Equal-clock divergence already classifies as Conflict, and ticking it
+    //    would promote the local side to LocalNewer — which for a divergent
+    //    NON-head ref (tag / submodule head / detached HEAD) would defeat the
+    //    fail-closed fast-forward veto (git_ff_resolution BLOCKER-1/3).
+    //  * Greater/None already classify correctly (LocalNewer / Conflict); a tick
+    //    there only drifts the clock.
+    // The tick lands only on the comparison clone; the state entry's stored
+    // clock is untouched, so re-recording the conflict each cycle stays
+    // idempotent (no per-cycle clock growth). `reclassify_git_ff_conflicts` is
+    // unaffected — it decides on git SHA ancestry, not on these clocks.
+    if let Some(tracked_state) = tracked {
+        if tracked_state.blake3 != local_hash
+            && local_vclock.partial_cmp_vc(&remote_manifest.vclock)
+                == Some(std::cmp::Ordering::Less)
+        {
+            local_vclock.tick(device_id);
+        }
+    }
 
     let outcome = compare_clocks(
         &local_vclock,
@@ -5033,6 +5098,257 @@ mod tests {
                 &acq.foreign_locked_repos
             ),
             "ref-class writes proceed once the stale lock is stolen"
+        );
+    }
+
+    // ── TIN-2584: out-of-band divergent ref classification ───────────────────
+
+    /// Write a v2 manifest with an explicit vclock + file_hash so a classifier
+    /// test can pin the remote side's clock exactly, with no push/pull round
+    /// trip. `hash` is the manifest storage key the `RemoteIndexEntry` points at.
+    async fn seed_manifest_vclock(
+        op: &Operator,
+        prefix: &str,
+        hash: &str,
+        file_hash: &str,
+        vclock_json: &str,
+        written_by: &str,
+    ) {
+        let body = format!(
+            r#"{{"version":2,"file_hash":"{file_hash}","file_size":41,"chunks":[],"vclock":{vclock_json},"written_by":"{written_by}","written_at":0}}"#
+        );
+        op.write(&format!("{prefix}/manifests/{hash}"), body.into_bytes())
+            .await
+            .unwrap();
+    }
+
+    fn tin2584_state(blake3: &str, vclock: VectorClock) -> SyncState {
+        SyncState {
+            blake3: blake3.to_string(),
+            size: 41,
+            mtime: 0,
+            chunk_count: 1,
+            remote_path: String::new(),
+            last_synced: 0,
+            vclock,
+            device_id: String::new(),
+            conflict: None,
+            status: crate::state::FileSyncStatus::default(),
+        }
+    }
+
+    fn tin2584_vclock(pairs: &[(&str, u64)]) -> VectorClock {
+        let mut vc = VectorClock::new();
+        for (dev, n) in pairs {
+            for _ in 0..*n {
+                vc.tick(dev);
+            }
+        }
+        vc
+    }
+
+    /// ROOT + AMPLIFIER: a ref rewritten out-of-band carries a stale clock the
+    /// remote strictly dominates. Left untouched it classifies as `RemoteNewer`
+    /// (silent park, no ConflictInfo); the divergence tick must instead make it
+    /// a recorded `Conflict`.
+    #[tokio::test]
+    async fn tin2584_dominated_out_of_band_divergence_records_conflict() {
+        let op = memory_op();
+        let prefix = "data";
+        let rel = "repo/.git/refs/heads/main";
+
+        // Remote head has advanced to {neo:2} with fresh content.
+        seed_manifest_vclock(
+            &op,
+            prefix,
+            "remotehash",
+            "remotecontenthash",
+            r#"{"clocks":{"neo":2}}"#,
+            "neo",
+        )
+        .await;
+        let remote_entry = RemoteIndexEntry::new("remotehash", 41, 1);
+
+        // Local ref diverged out-of-band; tracked clock is the stale {neo:1}
+        // (strictly dominated by {neo:2}) and its blake3 no longer matches.
+        let dir = tempfile::TempDir::new().unwrap();
+        let local_path = dir.path().join("main");
+        std::fs::write(&local_path, b"honey-divergent\n").unwrap();
+        let tracked = tin2584_state("baselinehash", tin2584_vclock(&[("neo", 1)]));
+
+        let config = ReconcileConfig::default();
+        let action = classify_path(
+            rel,
+            Some(&local_path),
+            Some(&remote_entry),
+            Some(&tracked),
+            &op,
+            prefix,
+            "honey",
+            &config,
+        )
+        .await;
+
+        assert!(
+            matches!(action, ReconcileAction::Conflict { .. }),
+            "dominated out-of-band divergence must record a Conflict (not RemoteNewer), got {action:?}"
+        );
+    }
+
+    /// Narrowing guard: an EQUAL-clock divergence is already a `Conflict` (the
+    /// fail-closed FF-veto precondition). The divergence tick must NOT promote
+    /// it to `LocalNewer`, or a divergent non-head ref would be force-pushed.
+    #[tokio::test]
+    async fn tin2584_equal_clock_divergence_stays_conflict() {
+        let op = memory_op();
+        let prefix = "data";
+        let rel = "repo/.git/refs/tags/v1";
+
+        seed_manifest_vclock(
+            &op,
+            prefix,
+            "rh",
+            "remotecontenthash",
+            r#"{"clocks":{"neo":1}}"#,
+            "neo",
+        )
+        .await;
+        let remote_entry = RemoteIndexEntry::new("rh", 41, 1);
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let local_path = dir.path().join("v1");
+        std::fs::write(&local_path, b"local-divergent-tag\n").unwrap();
+        let tracked = tin2584_state("baselinehash", tin2584_vclock(&[("neo", 1)]));
+
+        let config = ReconcileConfig::default();
+        let action = classify_path(
+            rel,
+            Some(&local_path),
+            Some(&remote_entry),
+            Some(&tracked),
+            &op,
+            prefix,
+            "honey",
+            &config,
+        )
+        .await;
+
+        assert!(
+            matches!(action, ReconcileAction::Conflict { .. }),
+            "equal-clock divergence must stay Conflict (never promoted to LocalNewer), got {action:?}"
+        );
+    }
+
+    /// A ref whose tracked clock STRICTLY DOMINATES the remote is genuinely
+    /// local-newer and must still `Push` (the tick never fires here — no clock
+    /// drift, no spurious conflict).
+    #[tokio::test]
+    async fn tin2584_local_clock_ahead_ref_stays_push() {
+        let op = memory_op();
+        let prefix = "data";
+        let rel = "repo/.git/refs/heads/main";
+
+        seed_manifest_vclock(
+            &op,
+            prefix,
+            "rh",
+            "remotecontenthash",
+            r#"{"clocks":{"neo":1}}"#,
+            "neo",
+        )
+        .await;
+        let remote_entry = RemoteIndexEntry::new("rh", 41, 1);
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let local_path = dir.path().join("main");
+        std::fs::write(&local_path, b"local-ahead\n").unwrap();
+        let tracked = tin2584_state("baselinehash", tin2584_vclock(&[("neo", 2)]));
+
+        let config = ReconcileConfig::default();
+        let action = classify_path(
+            rel,
+            Some(&local_path),
+            Some(&remote_entry),
+            Some(&tracked),
+            &op,
+            prefix,
+            "honey",
+            &config,
+        )
+        .await;
+
+        assert!(
+            matches!(action, ReconcileAction::Push { .. }),
+            "a ref whose tracked clock strictly dominates remote must Push, got {action:?}"
+        );
+    }
+
+    /// RACE arm `(Some, None, Some)`: the peer's freshly-pushed index entry is
+    /// momentarily absent from the LIST. A ref that ALSO diverged locally must
+    /// not become a silent `UpToDate` no-op — it routes to a conflict-aware
+    /// `Push` instead.
+    #[tokio::test]
+    async fn tin2584_divergent_ref_remote_index_absent_is_not_uptodate() {
+        let op = memory_op();
+        let rel = "repo/.git/refs/heads/main";
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let local_path = dir.path().join("main");
+        std::fs::write(&local_path, b"diverged\n").unwrap();
+        let tracked = tin2584_state("baselinehash", tin2584_vclock(&[("neo", 1)]));
+
+        // delete_local_orphans = false — the pre-fix silent-no-op path.
+        let config = ReconcileConfig::default();
+        let action = classify_path(
+            rel,
+            Some(&local_path),
+            None,
+            Some(&tracked),
+            &op,
+            "data",
+            "honey",
+            &config,
+        )
+        .await;
+
+        assert!(
+            matches!(action, ReconcileAction::Push { .. }),
+            "a divergent ref with a momentarily-absent remote entry must not be a silent \
+             UpToDate no-op, got {action:?}"
+        );
+    }
+
+    /// Companion to the race arm: an UNCHANGED ref (live hash == tracked) whose
+    /// remote entry is momentarily absent must stay `UpToDate` — no re-push
+    /// churn for a file that did not diverge.
+    #[tokio::test]
+    async fn tin2584_unchanged_ref_remote_index_absent_stays_uptodate() {
+        let op = memory_op();
+        let rel = "repo/.git/refs/heads/main";
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let local_path = dir.path().join("main");
+        std::fs::write(&local_path, b"unchanged\n").unwrap();
+        let local_hash =
+            tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_file(&local_path).unwrap());
+        let tracked = tin2584_state(&local_hash, tin2584_vclock(&[("neo", 1)]));
+
+        let config = ReconcileConfig::default();
+        let action = classify_path(
+            rel,
+            Some(&local_path),
+            None,
+            Some(&tracked),
+            &op,
+            "data",
+            "honey",
+            &config,
+        )
+        .await;
+
+        assert!(
+            matches!(action, ReconcileAction::UpToDate { .. }),
+            "an unchanged ref with a momentarily-absent remote entry must stay UpToDate, got {action:?}"
         );
     }
 }

--- a/crates/tcfs-sync/tests/git_ff_resolution.rs
+++ b/crates/tcfs-sync/tests/git_ff_resolution.rs
@@ -2041,3 +2041,168 @@ async fn git_ff_divergent_detached_head_vetoes_whole_group() {
     drop(a_state);
     drop(s_state);
 }
+
+/// TIN-2584 (canary shape): a head ref rewritten out-of-band on `honey` carries
+/// a stale vclock that the remote (advanced by `neo`) STRICTLY DOMINATES. Before
+/// the fix, `compare_clocks` reads `{neo:1}` vs `{neo:2}` as `RemoteNewer` and
+/// the incoming pull path silently parks the divergence — `tcfs conflicts` stays
+/// empty. The divergence tick must instead classify it as a `Conflict` that the
+/// record arm surfaces, with ZERO writes to the diverged ref.
+///
+/// `raw_no_ff_config()` keeps the FF reclassifier OFF so the Conflict can ONLY
+/// originate at the vclock layer (the divergence tick) — not a reclassification.
+#[tokio::test]
+async fn git_out_of_band_dominated_ref_records_conflict() {
+    if !git_available() {
+        eprintln!("git not available; skipping git_out_of_band_dominated_ref_records_conflict");
+        return;
+    }
+
+    let op = memory_operator();
+    let prefix = "test/tin2584-canary";
+    let blacklist = raw_blacklist();
+    let ff = ff_config();
+
+    // Seed S at C0; raw-push the whole tree.
+    let s_tmp = TempDir::new().unwrap();
+    let s_repo = s_tmp.path().join("repo");
+    std::fs::create_dir_all(&s_repo).unwrap();
+    init_repo_c0(&s_repo);
+    let mut s_state = StateCache::open(&s_tmp.path().join("s.db")).unwrap();
+    let collect = raw_collect_config();
+    push_tree_with_device(
+        &op,
+        &s_repo,
+        prefix,
+        &mut s_state,
+        None,
+        "device-s",
+        Some(&collect),
+        None,
+    )
+    .await
+    .expect("seed raw push");
+    s_state.flush().unwrap();
+
+    // honey and neo both pull C0 (each adopts the remote head clock).
+    let honey_tmp = TempDir::new().unwrap();
+    let honey_repo = honey_tmp.path().join("repo");
+    std::fs::create_dir_all(&honey_repo).unwrap();
+    let mut honey_state = pull_into(
+        &op,
+        &honey_repo,
+        prefix,
+        "device-honey",
+        &honey_tmp.path().join("honey.db"),
+        &blacklist,
+        &ff,
+    )
+    .await;
+
+    let neo_tmp = TempDir::new().unwrap();
+    let neo_repo = neo_tmp.path().join("repo");
+    std::fs::create_dir_all(&neo_repo).unwrap();
+    let mut neo_state = pull_into(
+        &op,
+        &neo_repo,
+        prefix,
+        "device-neo",
+        &neo_tmp.path().join("neo.db"),
+        &blacklist,
+        &ff,
+    )
+    .await;
+
+    // neo commits C1 and pushes (FF over C0) — the remote head clock advances to
+    // strictly dominate honey's still-{...s:1} tracked clock.
+    commit_and_sync(
+        &op,
+        &neo_repo,
+        prefix,
+        "device-neo",
+        &mut neo_state,
+        &blacklist,
+        &ff,
+        "from_neo.txt",
+        b"neo-c1\n",
+        "C1 on neo",
+    )
+    .await;
+
+    // honey commits its OWN divergent sibling out-of-band (never resyncs), so
+    // its tracked head clock stays dominated while the ref content diverges.
+    commit(&honey_repo, "from_honey.txt", b"honey-c1\n", "C1 on honey");
+    // Force the same-second, same-size (41-byte) ref rewrite the canary hit, so
+    // classification must trust the content hash, not stat granularity.
+    pin_mtime_to_cached_second(&honey_state, &honey_repo, ".git/refs/heads/main");
+
+    let head_manifest_before = list_remote_index(&op, prefix)
+        .await
+        .expect("remote index before")
+        .get(".git/refs/heads/main")
+        .expect("remote head ref entry")
+        .manifest_hash
+        .clone();
+
+    // honey reconciles with the FF reclassifier OFF: the only route to a Conflict
+    // is the divergence tick.
+    let no_ff = raw_no_ff_config();
+    let honey_plan = reconcile(
+        &op,
+        &honey_repo,
+        prefix,
+        &honey_state,
+        "device-honey",
+        &blacklist,
+        &no_ff,
+        None,
+    )
+    .await
+    .expect("honey reconcile plan");
+
+    assert!(
+        git_conflicts(&honey_plan)
+            .iter()
+            .any(|c| c.ends_with(".git/refs/heads/main")),
+        "TIN-2584: the dominated out-of-band divergence must record a head-ref Conflict, got {:?}",
+        git_conflicts(&honey_plan)
+    );
+    assert!(
+        !git_ref_pull(&honey_plan),
+        "TIN-2584: the divergence must NOT be classified as a silent RemoteNewer pull"
+    );
+
+    // Execute: the conflict is recorded and the remote head ref is untouched.
+    let honey_exec = execute_plan(
+        &honey_plan,
+        &op,
+        &honey_repo,
+        prefix,
+        &mut honey_state,
+        "device-honey",
+        None,
+        None,
+    )
+    .await
+    .expect("honey execute");
+    honey_state.flush().unwrap();
+    assert!(
+        honey_exec.conflicts_recorded >= 1,
+        "TIN-2584: the head-ref conflict must be recorded so keep-both can act"
+    );
+
+    let head_manifest_after = list_remote_index(&op, prefix)
+        .await
+        .expect("remote index after")
+        .get(".git/refs/heads/main")
+        .expect("remote head ref entry after")
+        .manifest_hash
+        .clone();
+    assert_eq!(
+        head_manifest_before, head_manifest_after,
+        "TIN-2584: recording the conflict must not write the diverged head ref"
+    );
+
+    drop(s_state);
+    drop(neo_state);
+}


### PR DESCRIPTION
## TIN-2584: out-of-band-diverged refs never record a Conflict

### Defect (traced at `origin/main` e5d913d)

A `.git/refs/heads/*` file rewritten out-of-band by `git commit` never ticks the TCFS vclock, so the diverged file carries its stale, last-synced clock into reconciliation. Three layers turned that into a silent, invisible divergence:

1. **ROOT** — `compare_both_exist` (`crates/tcfs-sync/src/reconcile.rs`) freshly hashes the local file but read the tracked vclock verbatim (`let local_vclock = tracked.map(|s| s.vclock.clone())`). The fresh hash was never compared against `tracked.blake3`, so a locally-diverged ref was classified on its stale, possibly-dominated clock.
2. **AMPLIFIER** — `compare_clocks` (`crates/tcfs-sync/src/conflict.rs:205-214`): with differing hashes, `{neo:1}` vs `{neo:2}` = `Ordering::Less` → `RemoteNewer`; `Conflict` fires only on `Equal | None`. A diverged-but-dominated ref was structurally unreachable as a `Conflict`, so the incoming pull path parked it with **no `ConflictInfo` recorded** — `tcfs conflicts` stayed empty and `tcfs resolve keep-both` had nothing to act on.
3. **RACE** — `classify_path`'s `(Some, None, Some)` arm (`reconcile.rs`) classified `UpToDate` even when the live local hash ≠ `tracked.blake3`: a diverged ref became a silent no-op whenever the peer's freshly-pushed index entry was not yet visible in the bulk LIST (S3 read-after-write lag, observed live at +0.5s after the peer's push).

### Canary provenance (neo/honey, 2026-07-07)

Baseline `{neo:1}` pulled to honey; honey commits; neo commits `{neo:2}` and pushes; honey reconciles 0.5s later → `pushed=1 pulled=4 conflicts=0`, ref state frozen at baseline blake3 `bc0807b8` / `{neo:1}`. Divergence invisible on both hosts.

### Fix (mirrors `engine.rs:1554` `local_edit_inferred -> tick`)

1. **`compare_both_exist`** — when `tracked.blake3 != live local hash` **and** the tracked clock is strictly dominated by the remote (`Ordering::Less`), tick a **clone** of the clock before `compare_clocks`. `{neo:1}` → `{neo:1,honey:1}`, incomparable with `{neo:2}` → `Conflict`, recorded → keep-both works. The tick lands only on the comparison clone; the stored state clock is untouched, so re-recording each cycle stays idempotent. `reclassify_git_ff_conflicts` decides on `git merge-base --is-ancestor` (git SHAs), not clocks, so it is unaffected.
2. **`(Some, None, Some)` arm** — a ref-class path whose live content diverges from `tracked` routes to a **conflict-aware `Push`** instead of a silent `UpToDate`. The engine push path re-resolves the exact index key via a direct GET (stronger read-after-write than the bulk LIST that missed it) and records a `Conflict` (remote concurrently ahead) or uploads (remote genuinely dropped it) — never a silent freeze, never a blind clobber. The hash-equal case keeps the existing orphan behavior.

### Deliberate deviation from the prescribed fix shape

The ticket prescribed ticking whenever `tracked.blake3 != local_hash` (unconditionally). I **narrowed the tick to the strictly-dominated (`Ordering::Less`) case**. The unconditional tick also fires on the **equal-clock** divergence and promotes a divergent **non-head** ref (tag / submodule head / detached HEAD) from `Conflict` to `LocalNewer` → `Push`, which defeats the fail-closed fast-forward veto and breaks three security-regression tests (`git_ff_divergent_tag_vetoes_whole_group`, `git_ff_divergent_submodule_ref_vetoes_whole_group`, `git_ff_divergent_detached_head_vetoes_whole_group`). Those tests rely on an equal-clock divergent ref **staying** a `Conflict`. Narrowing to `Less`:

- fixes the exact TIN-2584 defect (the dominated case that was mis-read as `RemoteNewer` / silently parked);
- leaves the equal-clock divergence as-is — it was already a recorded `Conflict`, which is the FF-veto precondition **and** already satisfies TIN-2584's acceptance (divergence recorded, not silent);
- changes **zero** existing test behavior — no security guard modified;
- keeps the blast radius minimal for a `.git` write path.

### Test evidence (`cargo test -p tcfs-sync`, hermetic: `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null`)

New tests:
- 5 hermetic classifier unit tests in `reconcile.rs`: `dominated -> Conflict`, `equal-clock -> stays Conflict` (no LocalNewer promotion), `local-clock-ahead -> Push`, `remote-absent + diverged -> not UpToDate (Push)`, `remote-absent + unchanged -> UpToDate`.
- 1 integration test in `git_ff_resolution.rs`: `git_out_of_band_dominated_ref_records_conflict` — the canary shape end-to-end (dominated head ref → Conflict recorded, zero writes to the ref), FF reclassifier **off** so the Conflict can only originate at the vclock layer.

```
lib:                 test result: ok. 267 passed; 0 failed; 0 ignored
  (incl. tin2584 subset) test result: ok. 5 passed; 0 failed

git_ff_resolution:   test result: ok. 13 passed; 0 failed
  test git_ff_divergent_tag_vetoes_whole_group ... ok
  test git_ff_divergent_submodule_ref_vetoes_whole_group ... ok
  test git_ff_divergent_detached_head_vetoes_whole_group ... ok
  test git_ff_converges_push_then_pull ... ok
  test git_divergent_stays_conflict ... ok
  test git_ff_concurrent_clocks_push_uploads_and_converges ... ok
  test git_ff_remote_ahead_concurrent_clocks_reclassifies_to_pull ... ok
  test git_ff_push_defers_when_local_ref_moves_after_plan ... ok
  test git_ff_pull_skips_when_local_ref_moves_after_plan ... ok
  test git_object_failure_bars_ref_actions_sequential ... ok
  test git_object_failure_bars_ref_pull_concurrent ... ok
  test git_ff_planning_fabricates_nothing_under_root ... ok
  test git_out_of_band_dominated_ref_records_conflict ... ok   <-- new

full suite:          exit 0 (all integration suites green: e2e_*, push_pull,
                     resolve_conflict, two_device_sync, symlink, state_cache, ...)
```

`cargo clippy -p tcfs-sync --tests`: clean apart from one **pre-existing** warning at `reconcile.rs` `.unwrap_or_else(VectorClock::new)` (present verbatim on `origin/main`, in code this PR does not touch).

> **Do NOT merge yet** — this is a `.git` write path and warrants an adversarial review pass first.

---

This PR owns `crates/tcfs-sync` — coordinate before stacking commits (AGENTS.md Agent Coordination).
