### PR TITLE
tcfs-sync: flip entry.status to Conflict on plan-path conflict record (TIN-2652)

### DIFF
--- a/crates/tcfs-sync/src/conflict_git.rs
+++ b/crates/tcfs-sync/src/conflict_git.rs
@@ -1072,4 +1072,98 @@ mod tests {
         );
         run_git(&winner, &["fsck", "--full"]).expect("fsck clean after idempotent re-run");
     }
+
+    /// TIN-2652 seam regression: the test that was missing and would have caught
+    /// the live no-op. Record a divergent head-ref conflict through the REAL plan
+    /// path (`reconcile::execute_plan`'s `Conflict` arm), then assert
+    /// `collect_repo_conflicts` — the keep-both resolver's candidate scan — yields
+    /// exactly one `Park` candidate for `refs/heads/main`. Before the status flip,
+    /// the plan-recorded entry stayed `Synced`; `collect_repo_conflicts` skipped
+    /// it (`status != Conflict`) and keep-both silently resolved nothing.
+    #[tokio::test]
+    async fn tin2652_plan_recorded_conflict_is_a_keep_both_park_candidate() {
+        use crate::conflict::{ConflictInfo, VectorClock};
+        use crate::reconcile::{execute_plan, ReconcileAction, ReconcilePlan, ReconcileSummary};
+
+        let op = Operator::new(Memory::default()).unwrap().finish();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_repo(&repo);
+        commit(&repo, "file.txt", "base", "base");
+        let ref_path = repo.join(".git/refs/heads/main");
+        assert!(
+            ref_path.exists(),
+            "base commit must create the loose head ref"
+        );
+
+        // Tracked head ref starts fully Synced — the live canary shape.
+        let rel = "repo/.git/refs/heads/main";
+        let mut local = VectorClock::new();
+        local.tick("honey");
+        let mut remote = VectorClock::new();
+        remote.tick("neo");
+        remote.tick("neo");
+        let mut state = StateCache::open(&local_root.join("state.json")).unwrap();
+        state.set(
+            &ref_path,
+            crate::state::SyncState {
+                blake3: "baselinehash".into(),
+                size: 41,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/manifests/head".into(),
+                last_synced: 0,
+                vclock: local.clone(),
+                device_id: "honey".into(),
+                conflict: None,
+                status: FileSyncStatus::Synced,
+            },
+        );
+
+        // Record the conflict through the real plan-execution path.
+        let plan = ReconcilePlan {
+            actions: vec![ReconcileAction::Conflict {
+                rel_path: rel.into(),
+                info: ConflictInfo {
+                    rel_path: rel.into(),
+                    local_vclock: local.clone(),
+                    remote_vclock: remote,
+                    local_blake3: "baselinehash".into(),
+                    remote_blake3: "remotehash".into(),
+                    local_device: "honey".into(),
+                    remote_device: "neo".into(),
+                    detected_at: 1,
+                    times_recorded: 0,
+                    // Park candidates REQUIRE the remote manifest key.
+                    remote_manifest_key: Some("data/manifests/remotehead".into()),
+                },
+            }],
+            summary: ReconcileSummary::default(),
+            device_id: "honey".into(),
+            generated_at: 0,
+        };
+        let exec = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "honey", None, None,
+        )
+        .await
+        .expect("execute plan");
+        assert_eq!(exec.conflicts_recorded, 1, "one conflict must be recorded");
+
+        // The seam: the keep-both resolver's candidate scan must see it.
+        let repo_root = repo.canonicalize().unwrap();
+        let candidates = collect_repo_conflicts(&state, &repo_root).expect("collect candidates");
+        assert_eq!(
+            candidates.len(),
+            1,
+            "TIN-2652: exactly one keep-both candidate for the plan-recorded head-ref conflict, \
+             got {candidates:?}"
+        );
+        match &candidates[0].kind {
+            GitConflictKind::Park { head_ref, .. } => {
+                assert_eq!(head_ref, "refs/heads/main");
+            }
+            other => panic!("head ref must be a Park candidate, got {other:?}"),
+        }
+    }
 }

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -27,7 +27,7 @@ use crate::index_entry::{
     manifest_key, parse_index_entry_record, resolve_visible_index_entry, RemoteIndexEntry,
 };
 use crate::manifest::{SymlinkManifest, SyncManifest};
-use crate::state::{StateCache, StateCacheBackend, SyncState};
+use crate::state::{FileSyncStatus, StateCache, StateCacheBackend, SyncState};
 
 const REMOTE_INDEX_READ_CONCURRENCY: usize = 32;
 const REMOTE_PULL_CONCURRENCY: usize = 16;
@@ -2751,6 +2751,16 @@ pub async fn execute_plan(
                     // unchanged so the recorded conflict carries the key a future
                     // PR-3 resolve verb needs to fetch the remote ref SHA.
                     updated.conflict = Some(info);
+                    // TIN-2652: the conflict payload and the entry status must
+                    // move together. Recording only the `ConflictInfo` left the
+                    // entry at its prior `Synced` status, so `tcfs conflicts`
+                    // (which scans `.conflict` presence via `StateCache::conflicts`)
+                    // surfaced it while `collect_repo_conflicts`
+                    // (conflict_git.rs, filters on `status == Conflict`) skipped
+                    // it -> `tcfs resolve --strategy keep-both` silently no-oped.
+                    // Mirror the engine push path (engine.rs) and
+                    // `StateCache::mark_conflict`, both of which flip status here.
+                    updated.status = FileSyncStatus::Conflict;
                     state.set(Path::new(&key_owned), updated);
                 }
                 result.conflicts_recorded += 1;
@@ -5348,6 +5358,98 @@ mod tests {
         assert!(
             matches!(action, ReconcileAction::UpToDate { .. }),
             "an unchanged ref with a momentarily-absent remote entry must stay UpToDate, got {action:?}"
+        );
+    }
+
+    /// TIN-2652 (fix seam): the plan-path `ReconcileAction::Conflict` arm records
+    /// the `ConflictInfo` but MUST also flip `entry.status` to `Conflict`. The
+    /// live canary shipped 5 head-ref conflicts whose `.conflict` payload was
+    /// complete yet whose `status` was still `synced`, so `collect_repo_conflicts`
+    /// (which filters on `status == Conflict`) skipped them and
+    /// `tcfs resolve --strategy keep-both` silently no-oped. Drive the real
+    /// `execute_plan` Conflict arm (the TIN-2584 divergent-ref shape) and assert
+    /// BOTH fields move together — payload present AND status == Conflict.
+    #[tokio::test]
+    async fn tin2652_plan_conflict_record_flips_status_to_conflict() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        let repo = local_root.join("repo");
+        init_git_repo(&repo);
+        // A base commit materializes `.git/refs/heads/main` on disk so the state
+        // key canonicalizes against a real parent, matching the daemon.
+        commit_file(&repo, "file.txt", "base", "base");
+        let ref_path = repo.join(".git/refs/heads/main");
+        assert!(
+            ref_path.exists(),
+            "base commit must create the loose head ref"
+        );
+
+        // Seed the tracked entry exactly as the live canary carried it: a fully
+        // `Synced` head ref, no conflict recorded yet.
+        let rel = "repo/.git/refs/heads/main";
+        let mut local = VectorClock::new();
+        local.tick("honey");
+        let mut remote = VectorClock::new();
+        remote.tick("neo");
+        remote.tick("neo");
+        let mut state = crate::state::StateCache::open(&local_root.join("state.json")).unwrap();
+        state.set(
+            &ref_path,
+            SyncState {
+                blake3: "baselinehash".into(),
+                size: 41,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/manifests/head".into(),
+                last_synced: 0,
+                vclock: local.clone(),
+                device_id: "honey".into(),
+                conflict: None,
+                status: FileSyncStatus::Synced,
+            },
+        );
+
+        let info = ConflictInfo {
+            rel_path: rel.into(),
+            local_vclock: local,
+            remote_vclock: remote,
+            local_blake3: "baselinehash".into(),
+            remote_blake3: "remotehash".into(),
+            local_device: "honey".into(),
+            remote_device: "neo".into(),
+            detected_at: 1,
+            times_recorded: 0,
+            remote_manifest_key: Some("data/manifests/remotehead".into()),
+        };
+        let plan = plan_of(vec![ReconcileAction::Conflict {
+            rel_path: rel.into(),
+            info,
+        }]);
+
+        let result = execute_plan(
+            &plan, &op, local_root, "data", &mut state, "honey", None, None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            result.conflicts_recorded, 1,
+            "the plan must record exactly one conflict"
+        );
+
+        let (_, entry) = state
+            .get_by_rel_path(rel)
+            .expect("the recorded conflict entry must be present");
+        assert!(
+            entry.conflict.is_some(),
+            "TIN-2652: the ConflictInfo payload must be recorded"
+        );
+        assert_eq!(
+            entry.status,
+            FileSyncStatus::Conflict,
+            "TIN-2652: recording a plan-path conflict must flip status to Conflict \
+             (payload + status move together), got {:?}",
+            entry.status
         );
     }
 }


### PR DESCRIPTION
## Defect (TIN-2652)

The reconcile **plan-path** `ReconcileAction::Conflict` arm (`crates/tcfs-sync/src/reconcile.rs`) recorded the `ConflictInfo` payload but never set `entry.status = FileSyncStatus::Conflict`.

Two consumers read the recorded conflict differently:

- `tcfs conflicts` enumerates via `StateCache::conflicts`, which scans `.conflict` **presence** — so the conflict *was listed*.
- The keep-both resolver's `collect_repo_conflicts` (`conflict_git.rs`) filters on `entry.status != FileSyncStatus::Conflict { continue; }` — so it saw **zero** candidates.

Net effect: `tcfs resolve --strategy keep-both` **silently no-oped** on every plan-recorded conflict.

**Live canary evidence:** 5 head-ref conflict entries all at `status:"synced"` with complete `.conflict` objects.

## Fix (one line)

Mirror the engine PUSH path (`engine.rs`, which sets both `conflict` and `status`) and `StateCache::mark_conflict` (whose doc-comment states *"Conflict payload and status must move together"*): flip `updated.status = FileSyncStatus::Conflict` when the plan arm records the payload.

## Audit results

Grepped every `.conflict = …` write across `crates/tcfs-sync` **and** `crates/tcfsd`. Six writing sites; **only the reconcile plan arm omitted the status flip**:

| Site | Sets status? | Verdict |
|------|-------------|---------|
| `reconcile.rs` plan Conflict arm | ❌ → **now ✅** | the bug, fixed |
| `engine.rs` push path | ✅ | correct (reference) |
| `state.rs` `mark_conflict` | ✅ | correct (canonical helper, #540) |
| `tcfsd/grpc.rs` + `tcfsd/daemon.rs` watchers | ✅ (via `mark_conflict`) | correct; outside this lane |
| `state.rs` `resolve_conflict` / `resolve_conflict_by_cache_key` (clearing) | ✅ restores `Synced` | correct; left intact |

## Test evidence

Two regression tests added:

- `reconcile::tests::tin2652_plan_conflict_record_flips_status_to_conflict` — drives the real `execute_plan` Conflict arm on the TIN-2584 divergent-ref shape; asserts the state entry has **both** `.conflict` present **and** `status == Conflict`.
- `conflict_git::tests::tin2652_plan_recorded_conflict_is_a_keep_both_park_candidate` — the missing **seam** test: records via the real plan path, then asserts `collect_repo_conflicts` returns **exactly one Park candidate** for `refs/heads/main`. This is the test that would have caught the live no-op.

```
cargo test -p tcfs-sync   (GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null)
...
test conflict_git::tests::tin2652_plan_recorded_conflict_is_a_keep_both_park_candidate ... ok
test reconcile::tests::tin2652_plan_conflict_record_flips_status_to_conflict ... ok
test result: ok. 269 passed; 0 failed   (lib, incl. tin2584_* 5/5)
test result: ok. 13 passed; 0 failed    (git_ff_resolution, incl. git_out_of_band_dominated_ref_records_conflict)
...
394 passed, 0 failed across all 23 test binaries
```

No `Cargo.toml` / `Cargo.lock` change — deny status inherited from #540 (crossbeam bump already green).

## Canary provenance

Reproduces the repo-roam canary defect: 5 diverged head-ref conflicts recorded by the reconcile plan path stayed at `status:"synced"`, making `keep-both` a no-op. This PR flips them to `Conflict` at the record site so the resolver enumerates them.

## Lane claim

**This PR owns `crates/tcfs-sync` — coordinate before stacking commits.**

DO NOT merge without operator sign-off.
