### PR TITLE
fix(state): CLI/daemon state-path convergence + conflict-preserving boot purge (TIN-2657)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1003,18 +1003,9 @@ async fn build_operator(config: &tcfs_core::config::TcfsConfig) -> Result<openda
     .context("building storage operator")
 }
 
-/// Expand `~` in path to the user's home directory
-fn expand_tilde(path: &Path) -> PathBuf {
-    let s = path.to_string_lossy();
-    if let Some(rest) = s.strip_prefix("~/") {
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .unwrap_or_default();
-        PathBuf::from(format!("{}/{}", home, rest))
-    } else {
-        path.to_path_buf()
-    }
-}
+// `~`-expansion lives in tcfs-core so the CLI and daemon expand identically
+// (TIN-2657 adversarial gate, Fix B).
+use tcfs_core::config::expand_tilde;
 
 /// Resolve the state cache path: CLI flag > config > default user data dir
 fn resolve_state_path(

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -120,7 +120,9 @@ enum Commands {
         /// Remote prefix in the bucket (default: derived from local path name)
         #[arg(long, short = 'p')]
         prefix: Option<String>,
-        /// Path to the sync state cache JSON file (overrides config)
+        /// Path to the sync state cache JSON file (overrides config).
+        /// `.db` paths are normalized to their `.json` sibling — the file the
+        /// daemon owns — so the CLI and daemon always act on the same cache.
         #[arg(long, env = "TCFS_STATE_PATH")]
         state: Option<PathBuf>,
     },
@@ -136,7 +138,9 @@ enum Commands {
         /// Remote prefix to look up chunks (default: derived from manifest path)
         #[arg(long, short = 'p')]
         prefix: Option<String>,
-        /// Path to the sync state cache JSON file (overrides config)
+        /// Path to the sync state cache JSON file (overrides config).
+        /// `.db` paths are normalized to their `.json` sibling — the file the
+        /// daemon owns — so the CLI and daemon always act on the same cache.
         #[arg(long, env = "TCFS_STATE_PATH")]
         state: Option<PathBuf>,
     },
@@ -146,7 +150,9 @@ enum Commands {
     SyncStatus {
         /// Path to check (default: current directory)
         path: Option<PathBuf>,
-        /// Path to the sync state cache JSON file (overrides config)
+        /// Path to the sync state cache JSON file (overrides config).
+        /// `.db` paths are normalized to their `.json` sibling — the file the
+        /// daemon owns — so the CLI and daemon always act on the same cache.
         #[arg(long, env = "TCFS_STATE_PATH")]
         state: Option<PathBuf>,
     },
@@ -295,7 +301,9 @@ enum Commands {
         /// Actually execute the plan (default: dry-run)
         #[arg(long)]
         execute: bool,
-        /// Path to the sync state cache JSON file (overrides config)
+        /// Path to the sync state cache JSON file (overrides config).
+        /// `.db` paths are normalized to their `.json` sibling — the file the
+        /// daemon owns — so the CLI and daemon always act on the same cache.
         #[arg(long, env = "TCFS_STATE_PATH")]
         state: Option<PathBuf>,
     },
@@ -317,7 +325,9 @@ enum Commands {
         /// Remote prefix override
         #[arg(long, short = 'p')]
         prefix: Option<String>,
-        /// Path to the sync state cache JSON file (overrides config)
+        /// Path to the sync state cache JSON file (overrides config).
+        /// `.db` paths are normalized to their `.json` sibling — the file the
+        /// daemon owns — so the CLI and daemon always act on the same cache.
         #[arg(long, env = "TCFS_STATE_PATH")]
         state: Option<PathBuf>,
     },
@@ -348,7 +358,9 @@ enum Commands {
         /// Emit machine-readable JSON instead of the human summary
         #[arg(long)]
         json: bool,
-        /// Path to the sync state cache JSON file (overrides config)
+        /// Path to the sync state cache JSON file (overrides config).
+        /// `.db` paths are normalized to their `.json` sibling — the file the
+        /// daemon owns — so the CLI and daemon always act on the same cache.
         #[arg(long, env = "TCFS_STATE_PATH")]
         state: Option<PathBuf>,
     },
@@ -1010,7 +1022,11 @@ fn resolve_state_path(
     override_path: Option<&Path>,
 ) -> PathBuf {
     if let Some(p) = override_path {
-        return p.to_path_buf();
+        // Normalize the override to the canonical `.json` sibling so a
+        // `--state …/state.db` (or `TCFS_STATE_PATH`) input resolves to the
+        // exact file the daemon owns. `.with_extension("json")` is idempotent
+        // for `.json` inputs, so explicit `.json` overrides are unchanged.
+        return expand_tilde(p).with_extension("json");
     }
     // Config uses state_db (designed for RocksDB in Phase 4); for JSON Phase 2
     // we derive a sibling .json file
@@ -7255,6 +7271,108 @@ mod tests {
         config.sync.sync_root = Some(sync_root.to_path_buf());
         config.sync.state_db = sync_root.join("state.db");
         config
+    }
+
+    // ── TIN-2657: CLI/daemon state-path convergence ──────────────────────────
+
+    #[test]
+    fn resolve_state_path_override_db_equals_default() {
+        // THE TIN-2657 regression guard: a `--state …/state.db` override must
+        // resolve to the *same* file as the config default (the daemon-owned
+        // `state.json`). On the pre-fix `return p.to_path_buf()` this fails,
+        // because the override stayed `…/state.db` while the default derived
+        // `…/state.json` — the split that orphaned writes and hid conflicts.
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("tree");
+        let config = test_config(&sync_root); // state_db = sync_root/state.db
+        let db_literal = config.sync.state_db.clone(); // …/state.db
+
+        let via_override = resolve_state_path(&config, Some(&db_literal));
+        let via_default = resolve_state_path(&config, None);
+
+        assert_eq!(
+            via_override, via_default,
+            "override `.db` must resolve to the same file as the default"
+        );
+        assert_eq!(
+            via_default.extension().and_then(|e| e.to_str()),
+            Some("json"),
+            "canonical state path is always `.json`"
+        );
+    }
+
+    #[test]
+    fn resolve_state_path_json_override_idempotent_and_tilde_expands() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(&dir.path().join("tree"));
+
+        // An explicit `.json` override is idempotent under normalization.
+        let json_override = dir.path().join("reconcile/root-a.json");
+        assert_eq!(
+            resolve_state_path(&config, Some(&json_override)),
+            json_override,
+            "`.json` override must pass through unchanged"
+        );
+
+        // A `~`-prefixed override is expanded, and `.db` still normalizes to
+        // `.json`. Read HOME rather than mutate it, so parallel tests can't race.
+        let home = std::env::var("HOME").expect("HOME set in test env");
+        let tilde = std::path::PathBuf::from("~/tcfs-tin2657/state.db");
+        assert_eq!(
+            resolve_state_path(&config, Some(&tilde)),
+            std::path::PathBuf::from(format!("{home}/tcfs-tin2657/state.json")),
+            "tilde expands and `.db` normalizes to `.json`"
+        );
+    }
+
+    #[test]
+    fn cli_write_via_db_override_visible_to_daemon_json_read() {
+        // CLI writes through a `--state …/state.db` override; the daemon reads
+        // at `config.sync.state_db.with_extension("json")`. Post-fix they are
+        // the same file, so the write is visible.
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("tree");
+        std::fs::create_dir_all(&sync_root).unwrap();
+        let file = sync_root.join("doc.txt");
+        std::fs::write(&file, b"hello").unwrap();
+        let config = test_config(&sync_root);
+
+        let cli_path = resolve_state_path(&config, Some(&config.sync.state_db));
+        let mut cli_state = tcfs_sync::state::StateCache::open(&cli_path).unwrap();
+        seed_tracked_file(&mut cli_state, &file, "data/index/doc.txt");
+        cli_state.flush().unwrap();
+
+        let daemon_path = config.sync.state_db.with_extension("json");
+        assert_eq!(cli_path, daemon_path, "CLI and daemon resolve one file");
+        let daemon_state = tcfs_sync::state::StateCache::open(&daemon_path).unwrap();
+        assert!(
+            daemon_state.get(&file).is_some(),
+            "CLI write must be visible to the daemon read"
+        );
+    }
+
+    #[test]
+    fn daemon_write_json_visible_to_cli_db_override_read() {
+        // The reverse: the daemon writes at the canonical `.json`; a CLI
+        // invocation using `--state …/state.db` must still see it.
+        let dir = tempfile::tempdir().unwrap();
+        let sync_root = dir.path().join("tree");
+        std::fs::create_dir_all(&sync_root).unwrap();
+        let file = sync_root.join("doc.txt");
+        std::fs::write(&file, b"hello").unwrap();
+        let config = test_config(&sync_root);
+
+        let daemon_path = config.sync.state_db.with_extension("json");
+        let mut daemon_state = tcfs_sync::state::StateCache::open(&daemon_path).unwrap();
+        seed_tracked_file(&mut daemon_state, &file, "data/index/doc.txt");
+        daemon_state.flush().unwrap();
+
+        let cli_path = resolve_state_path(&config, Some(&config.sync.state_db));
+        let cli_state = tcfs_sync::state::StateCache::open(&cli_path).unwrap();
+        assert!(
+            cli_state.get(&file).is_some(),
+            "daemon write must be visible to a `--state …/state.db` CLI read"
+        );
     }
 
     #[test]

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -579,6 +579,25 @@ impl Default for FuseConfig {
     }
 }
 
+/// Expand a leading `~/` in `path` to the user's home directory (`HOME`, then
+/// `USERPROFILE`). Any other path is returned unchanged.
+///
+/// Config defaults carry literal `~` paths (e.g. `sync.state_db`) and the
+/// config loader performs no normalization, so every consumer that touches the
+/// filesystem must expand first — otherwise a `~/…` value resolves to a
+/// CWD-relative `./~/…`. Shared here so the CLI and daemon expand identically.
+pub fn expand_tilde(path: &std::path::Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    if let Some(rest) = s.strip_prefix("~/") {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_default();
+        PathBuf::from(format!("{}/{}", home, rest))
+    } else {
+        path.to_path_buf()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -238,7 +238,10 @@ pub struct SyncConfig {
     pub nats_token: Option<String>,
     /// Path to a custom CA certificate for NATS TLS verification
     pub nats_ca_cert: Option<PathBuf>,
-    /// RocksDB state cache path
+    /// State cache path. The key is named `state_db` for the (future) RocksDB
+    /// Phase 4 backend, but the live JSON cache is the `.json` sibling of this
+    /// path: both the daemon and the CLI derive `state_db.with_extension("json")`,
+    /// so a `…/state.db` value resolves to `…/state.json`.
     pub state_db: PathBuf,
     /// Worker thread count (0 = cpu_count)
     pub workers: usize,

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -604,6 +604,13 @@ impl StateCache {
         let before = self.entries.len();
 
         self.entries.retain(|key, state| {
+            // Never drop an entry that carries an unresolved conflict, whatever
+            // its prefix. Cross-prefix roam (e.g. `git-roam/*`) records a
+            // conflict under a non-default prefix; purging it on boot would
+            // silently delete the record before the operator can resolve it.
+            if state.conflict.is_some() {
+                return true;
+            }
             // Keep entries whose remote_path starts with the expected prefix
             if !state.remote_path.starts_with(&prefix_slash) {
                 return false;
@@ -2048,5 +2055,95 @@ mod tests {
         cache.flush_if_stale(Duration::ZERO).unwrap();
         assert!(!cache.dirty);
         assert!(path.exists());
+    }
+
+    #[test]
+    fn purge_stale_preserves_unresolved_conflicts_across_prefixes() {
+        // TIN-2657/TIN-2658: boot-time purge must never drop an entry that
+        // carries an unresolved conflict, even when its remote_path lives under
+        // a foreign prefix (e.g. the `git-roam/*` roam record). A plain foreign
+        // non-conflict entry is still dropped.
+        let dir = tempfile::tempdir().unwrap();
+        let mut cache = StateCache::open(&dir.path().join("state.json")).unwrap();
+
+        // In-prefix ordinary entry — kept.
+        cache.set(
+            std::path::Path::new("/sync/keep.txt"),
+            SyncState {
+                blake3: "a".into(),
+                size: 1,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "data/index/keep.txt".into(),
+                last_synced: 0,
+                vclock: VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: None,
+                status: FileSyncStatus::Synced,
+            },
+        );
+        // Foreign-prefix entry carrying an unresolved conflict — must survive.
+        cache.set(
+            std::path::Path::new("/sync/repo/.git/HEAD"),
+            SyncState {
+                blake3: "b".into(),
+                size: 1,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "git-roam/repo/.git/HEAD".into(),
+                last_synced: 0,
+                vclock: VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: Some(crate::conflict::ConflictInfo {
+                    rel_path: "repo/.git/HEAD".into(),
+                    local_vclock: VectorClock::new(),
+                    remote_vclock: VectorClock::new(),
+                    local_blake3: "b".into(),
+                    remote_blake3: "c".into(),
+                    local_device: "neo".into(),
+                    remote_device: "honey".into(),
+                    detected_at: 0,
+                    times_recorded: 1,
+                    remote_manifest_key: None,
+                }),
+                status: FileSyncStatus::Conflict,
+            },
+        );
+        // Foreign-prefix ordinary entry with no conflict — must be dropped.
+        cache.set(
+            std::path::Path::new("/sync/foreign.txt"),
+            SyncState {
+                blake3: "d".into(),
+                size: 1,
+                mtime: 0,
+                chunk_count: 1,
+                remote_path: "git-roam/foreign.txt".into(),
+                last_synced: 0,
+                vclock: VectorClock::new(),
+                device_id: "neo".into(),
+                conflict: None,
+                status: FileSyncStatus::Synced,
+            },
+        );
+
+        let removed = cache.purge_stale("data/index");
+
+        assert_eq!(removed, 1, "only the foreign non-conflict entry is dropped");
+        assert!(
+            cache.get(std::path::Path::new("/sync/keep.txt")).is_some(),
+            "in-prefix entry retained"
+        );
+        assert!(
+            cache
+                .get(std::path::Path::new("/sync/repo/.git/HEAD"))
+                .is_some(),
+            "foreign-prefix UNRESOLVED CONFLICT must be preserved across boot"
+        );
+        assert!(
+            cache
+                .get(std::path::Path::new("/sync/foreign.txt"))
+                .is_none(),
+            "foreign-prefix non-conflict entry still purged"
+        );
     }
 }

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -311,8 +311,10 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         false
     };
 
-    // Open state cache, purge stale entries, then wrap in Arc<Mutex>
-    let state_json_path = config.sync.state_db.with_extension("json");
+    // Open state cache, purge stale entries, then wrap in Arc<Mutex>. The
+    // canonical file is the `.json` sibling of the configured `state_db`; a
+    // legacy `state.db`-only host is absorbed into it exactly once.
+    let state_json_path = absorb_legacy_state_db(&config.sync.state_db);
     let mut state_cache_inner = tcfs_sync::state::StateCache::open(&state_json_path)
         .unwrap_or_else(|e| {
             warn!("state cache open failed: {e}  (starting fresh)");
@@ -2071,6 +2073,30 @@ fn ensure_dirs(config: &TcfsConfig) {
     }
 }
 
+/// Resolve the canonical `state.json` path from the configured `state_db` and,
+/// exactly once, absorb a legacy sibling `state.db` into it.
+///
+/// The one-time absorb fires **only** when the canonical `.json` is absent and
+/// a *distinct* sibling `.db` exists — so an existing `.json` always wins
+/// untouched, with no size heuristic or merge (the live reality on hosts where
+/// both files exist). A copy failure is logged and the daemon continues, opening
+/// the still-absent `.json` fresh. Returns the `.json` path the caller opens.
+fn absorb_legacy_state_db(state_db: &std::path::Path) -> std::path::PathBuf {
+    let state_json_path = state_db.with_extension("json");
+    if !state_json_path.exists() && state_db != state_json_path.as_path() && state_db.exists() {
+        match std::fs::copy(state_db, &state_json_path) {
+            Ok(_) => info!("migrated legacy state.db → state.json"),
+            Err(e) => {
+                warn!(
+                    ?e,
+                    "state.db → state.json one-time migration failed; starting fresh"
+                )
+            }
+        }
+    }
+    state_json_path
+}
+
 #[cfg(test)]
 mod keep_both_pr1_tests {
     use super::{auto_conflict_must_defer, handle_auto_pull};
@@ -2303,5 +2329,111 @@ mod keep_both_pr1_tests {
         .await;
 
         assert!(!should_ack, "manifest/event mismatch must withhold ack");
+    }
+}
+
+#[cfg(test)]
+mod state_migration_tests {
+    use super::absorb_legacy_state_db;
+
+    /// Seed `path` (opened as a JSON cache regardless of extension) with the
+    /// given `(cache-key, remote_path)` entries and flush.
+    fn seed_state(path: &std::path::Path, entries: &[(&str, &str)]) {
+        let mut cache = tcfs_sync::state::StateCache::open(path).unwrap();
+        for (key, remote_path) in entries {
+            cache.set(
+                std::path::Path::new(key),
+                tcfs_sync::state::SyncState {
+                    blake3: "hash".into(),
+                    size: 0,
+                    mtime: 0,
+                    chunk_count: 0,
+                    remote_path: (*remote_path).into(),
+                    last_synced: 0,
+                    vclock: tcfs_sync::conflict::VectorClock::new(),
+                    device_id: "neo".into(),
+                    conflict: None,
+                    status: tcfs_sync::state::FileSyncStatus::Synced,
+                },
+            );
+        }
+        cache.flush().unwrap();
+    }
+
+    #[test]
+    fn absorb_seeds_json_from_db_only_host() {
+        // `.db`-only, no `.json`: the one-time absorb seeds `state.json` from the
+        // legacy `.db` and the daemon serves the migrated entry.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("state.db");
+        let json = dir.path().join("state.json");
+        seed_state(&db, &[("/sync/a.txt", "data/index/a.txt")]);
+        assert!(!json.exists(), "precondition: no .json yet");
+
+        let resolved = absorb_legacy_state_db(&db);
+        assert_eq!(resolved, json, "resolves to the .json sibling");
+        assert!(json.exists(), ".json must be seeded from .db");
+
+        let cache = tcfs_sync::state::StateCache::open(&resolved).unwrap();
+        assert!(
+            cache.get(std::path::Path::new("/sync/a.txt")).is_some(),
+            "migrated entry must be visible after absorb"
+        );
+    }
+
+    #[test]
+    fn absorb_leaves_existing_json_untouched_when_both_exist() {
+        // Both exist: `.json` (2 entries) wins untouched; the *different* `.db`
+        // (1 entry) is never copied in — no size heuristic, no merge.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("state.db");
+        let json = dir.path().join("state.json");
+        seed_state(&db, &[("/sync/from-db.txt", "data/index/from-db.txt")]);
+        seed_state(
+            &json,
+            &[
+                ("/sync/keep-1.txt", "data/index/keep-1.txt"),
+                ("/sync/keep-2.txt", "data/index/keep-2.txt"),
+            ],
+        );
+
+        let resolved = absorb_legacy_state_db(&db);
+        assert_eq!(resolved, json);
+
+        let cache = tcfs_sync::state::StateCache::open(&resolved).unwrap();
+        assert!(
+            cache
+                .get(std::path::Path::new("/sync/keep-1.txt"))
+                .is_some(),
+            "existing .json entry 1 must survive"
+        );
+        assert!(
+            cache
+                .get(std::path::Path::new("/sync/keep-2.txt"))
+                .is_some(),
+            "existing .json entry 2 must survive"
+        );
+        assert!(
+            cache
+                .get(std::path::Path::new("/sync/from-db.txt"))
+                .is_none(),
+            ".json must win untouched; .db content must not leak in"
+        );
+    }
+
+    #[test]
+    fn absorb_neither_present_starts_fresh() {
+        // Neither file exists: no crash, returns the `.json` path, nothing seeded.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("state.db");
+        let json = dir.path().join("state.json");
+
+        let resolved = absorb_legacy_state_db(&db);
+        assert_eq!(resolved, json);
+        assert!(!json.exists(), "no source → nothing seeded");
+
+        // Opening the still-absent `.json` starts fresh (empty cache, no crash).
+        let cache = tcfs_sync::state::StateCache::open(&resolved).unwrap();
+        assert!(cache.get(std::path::Path::new("/sync/nope.txt")).is_none());
     }
 }

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -2076,20 +2076,45 @@ fn ensure_dirs(config: &TcfsConfig) {
 /// Resolve the canonical `state.json` path from the configured `state_db` and,
 /// exactly once, absorb a legacy sibling `state.db` into it.
 ///
-/// The one-time absorb fires **only** when the canonical `.json` is absent and
-/// a *distinct* sibling `.db` exists — so an existing `.json` always wins
-/// untouched, with no size heuristic or merge (the live reality on hosts where
-/// both files exist). A copy failure is logged and the daemon continues, opening
-/// the still-absent `.json` fresh. Returns the `.json` path the caller opens.
+/// `state_db` is `~`-expanded first (config defaults carry a literal `~` and
+/// the loader does no normalization; without expansion the absorb would write
+/// a CWD-relative `./~/…`). The one-time absorb fires **only** when the
+/// canonical `.json` is absent and a *distinct* sibling `.db` exists — so an
+/// existing `.json` always wins untouched, with no size heuristic or merge
+/// (the live reality on hosts where both files exist).
+///
+/// The absorb is atomic and validated (mirrors the `StateCache::flush()`
+/// write-tmp-then-rename idiom): copy to `state.json.tmp`, parse-validate the
+/// temp through the real `StateCache` load path, then `rename` into place. A
+/// direct copy onto the canonical path could be truncated mid-copy (ENOSPC is
+/// documented fleet history), permanently satisfying the `!exists()` guard
+/// while failing every subsequent open. On ANY copy/parse/rename failure the
+/// temp is removed, the source `.db` is left untouched, and the daemon
+/// continues fresh with a `warn!`. Returns the `.json` path the caller opens.
 fn absorb_legacy_state_db(state_db: &std::path::Path) -> std::path::PathBuf {
+    let state_db = tcfs_core::config::expand_tilde(state_db);
     let state_json_path = state_db.with_extension("json");
-    if !state_json_path.exists() && state_db != state_json_path.as_path() && state_db.exists() {
-        match std::fs::copy(state_db, &state_json_path) {
-            Ok(_) => info!("migrated legacy state.db → state.json"),
+    if !state_json_path.exists() && state_db != state_json_path && state_db.exists() {
+        let tmp_path = {
+            let mut name = state_json_path.clone().into_os_string();
+            name.push(".tmp");
+            std::path::PathBuf::from(name)
+        };
+        let migrate = || -> Result<()> {
+            std::fs::copy(&state_db, &tmp_path)?;
+            // Parse-validate through the real load path so the temp is only
+            // installed if the daemon's own open() would accept it.
+            tcfs_sync::state::StateCache::open(&tmp_path)?;
+            std::fs::rename(&tmp_path, &state_json_path)?;
+            Ok(())
+        };
+        match migrate() {
+            Ok(()) => info!("migrated legacy state.db → state.json"),
             Err(e) => {
+                let _ = std::fs::remove_file(&tmp_path);
                 warn!(
                     ?e,
-                    "state.db → state.json one-time migration failed; starting fresh"
+                    "state.db → state.json one-time migration failed; starting fresh (source .db left untouched)"
                 )
             }
         }
@@ -2435,5 +2460,96 @@ mod state_migration_tests {
         // Opening the still-absent `.json` starts fresh (empty cache, no crash).
         let cache = tcfs_sync::state::StateCache::open(&resolved).unwrap();
         assert!(cache.get(std::path::Path::new("/sync/nope.txt")).is_none());
+    }
+
+    #[test]
+    fn absorb_recovers_from_interrupted_prior_migration() {
+        // Adversarial gate Fix A: a stale corrupt/truncated `state.json.tmp`
+        // left by an interrupted prior migration must not poison the retry.
+        // The canonical `.json` may only appear when the freshly copied temp
+        // parse-validates, and the temp must be gone afterwards (renamed away).
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("state.db");
+        let json = dir.path().join("state.json");
+        let tmp = dir.path().join("state.json.tmp");
+        seed_state(&db, &[("/sync/a.txt", "data/index/a.txt")]);
+        std::fs::write(&tmp, b"{\"entries\": {\"trunc").unwrap(); // simulated ENOSPC remnant
+
+        let resolved = absorb_legacy_state_db(&db);
+
+        assert_eq!(resolved, json);
+        assert!(json.exists(), "retry over a stale temp must still migrate");
+        assert!(!tmp.exists(), "temp must be consumed by the rename");
+        let cache = tcfs_sync::state::StateCache::open(&resolved).unwrap();
+        assert!(
+            cache.get(std::path::Path::new("/sync/a.txt")).is_some(),
+            "canonical .json carries the validated .db content"
+        );
+    }
+
+    #[test]
+    fn absorb_declines_corrupt_db_source_and_cleans_temp() {
+        // Adversarial gate Fix A: a corrupt `.db` source must never be
+        // installed as the canonical `.json`. The temp is removed, the source
+        // `.db` is left byte-identical, and no canonical file appears — so the
+        // `!exists()` guard keeps retrying on later boots instead of being
+        // permanently defeated by a truncated canonical file.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("state.db");
+        let json = dir.path().join("state.json");
+        let tmp = dir.path().join("state.json.tmp");
+        let garbage: &[u8] = b"{\"last_nats_seq\": 7, \"entries\": {\"/sync/a.t"; // truncated JSON
+        std::fs::write(&db, garbage).unwrap();
+
+        let resolved = absorb_legacy_state_db(&db);
+
+        assert_eq!(resolved, json);
+        assert!(
+            !json.exists(),
+            "corrupt source must not produce a canonical .json"
+        );
+        assert!(!tmp.exists(), "failed migration must clean up its temp");
+        assert_eq!(
+            std::fs::read(&db).unwrap(),
+            garbage,
+            "source .db must be left untouched for manual recovery"
+        );
+    }
+
+    #[test]
+    fn absorb_expands_tilde_in_configured_state_db() {
+        // Adversarial gate Fix B: SyncConfig::default() carries a literal
+        // `~/.local/share/tcfsd/state.db` and the config loader does zero
+        // normalization; absorb must target the $HOME-expanded path, never a
+        // CWD-relative `./~/…`. Guarded with a temp HOME (set + restored).
+        let home_dir = tempfile::tempdir().unwrap();
+        let saved_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", home_dir.path());
+
+        let expanded_db = home_dir.path().join("tcfsd-tin2657/state.db");
+        std::fs::create_dir_all(expanded_db.parent().unwrap()).unwrap();
+        seed_state(&expanded_db, &[("/sync/a.txt", "data/index/a.txt")]);
+
+        let resolved = absorb_legacy_state_db(std::path::Path::new("~/tcfsd-tin2657/state.db"));
+
+        // Restore HOME before asserting so a panic can't leak the temp value.
+        match saved_home {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+
+        let expected_json = home_dir.path().join("tcfsd-tin2657/state.json");
+        assert_eq!(
+            resolved, expected_json,
+            "absorb must resolve under $HOME, not CWD-relative ./~/…"
+        );
+        assert!(
+            expected_json.exists(),
+            "migration must land at the expanded path"
+        );
+        assert!(
+            !std::path::Path::new("~").exists(),
+            "no literal ./~ directory may be created"
+        );
     }
 }

--- a/docs/ops/current-workstream-truth-2026-07-06.md
+++ b/docs/ops/current-workstream-truth-2026-07-06.md
@@ -57,7 +57,7 @@ part of the truth:
   unusable over ssh). Resolve was exercised via the repo-precedent
   `require_session=false` bypass window, re-locked immediately after.
 - **TIN-2657 — OPEN:** the daemon remaps `sync.state_db` → `state.json`
-  (`crates/tcfs-daemon/src/daemon.rs:315`), so the CLI and daemon act on
+  (`crates/tcfsd/src/daemon.rs:315`), so the CLI and daemon act on
   different files — this is why the operator resolve VERB returned 0 refs even
   post-#541.
 


### PR DESCRIPTION
## TIN-2657 — CLI/daemon state-path convergence + conflict-preserving boot purge

The daemon and CLI agreed on `state.json` only for the *config-default* path. A
`--state <…/state.db>` override (and the `--state`-less `tcfs resolve`) resolved
verbatim to `…/state.db`, so the CLI read a different file than the daemon —
orphaning writes and making conflicts unreachable to `tcfs resolve` (live:
honey **TIN-2658**, the `git-roam-tool-daemon` 6-path conflict returned 0 refs).

### Approach

| Alternative | Verdict |
|---|---|
| Honor `config.sync.state_db` verbatim (drop `.with_extension`) | **Rejected — regression + silent data loss.** `StateCache::open` always uses `serde_json`; `state.db` is absent on every existing install → boots to an empty cache, losing all synced-file records, vclocks, and the TIN-2658 conflict record. Re-opens the daemon-reads-`.db`/CLI-reads-`.json` split #58/#59 already fixed. |
| Rename config key `state_db` → `state_path` | **Rejected — huge blast radius, no convergence benefit.** The key and literal `.db` are load-bearing across every fleet config and a dozen scripts; renaming needs a fleet migration and still doesn't fix the override-skips-normalization seam. |
| **Normalize override + guarded absorb (chosen)** | CLI and daemon converge on one `.json` for *every* input; existing `state.json` untouched; TIN-2658 records stay where the daemon already reads them; zero fleet steps; config key and `.db` defaults keep working. |

Three behavioral changes:

- **R1 — one path rule** (`tcfs-cli` `resolve_state_path`): the `--state`/`TCFS_STATE_PATH`
  override is normalized with `expand_tilde(p).with_extension("json")`, exactly
  like the config default. `.with_extension("json")` is idempotent for `.json`
  inputs, so `--state …/state.db` → `…/state.json` (the daemon's file) while an
  explicit `…/foo.json` passes through unchanged. Daemon/worker were already
  canonical and are unchanged.
- **R2 — absorb-on-boot (guarded)** (`tcfsd`): at boot, *only if* the canonical
  `state.json` is absent **and** a distinct sibling `state.db` exists, seed
  `state.json` from `state.db` once (copy). When both exist (honey/neo reality)
  `.json` always wins — no migration, no merge, no size heuristic. Copy failure
  is warn-and-continue.
- **Purge guard** (`tcfs-sync` `purge_stale`): the boot purge now never drops an
  entry carrying an unresolved conflict (`state.conflict.is_some()`), whatever
  its prefix. Previously any restart silently deleted TIN-2658's `git-roam/*`
  conflict record (foreign prefix) before it could be resolved.

Plus doc/comment truthing: `config.rs` `state_db` doc-comment now describes the
`.json`-sibling reality; the stale `crates/tcfs-daemon/...` path in
`docs/ops/current-workstream-truth-2026-07-06.md` → `crates/tcfsd/src/daemon.rs`.

### Tests

- `resolve_state_path_override_db_equals_default` — **the regression guard**:
  a `--state …/state.db` override resolves to the same file as the default.
  Verified revert-proof (fails on the pre-fix `return p.to_path_buf()`).
- `resolve_state_path_json_override_idempotent_and_tilde_expands` — `.json`
  passes through unchanged; `~/…/state.db` expands + normalizes to `.json`.
- `cli_write_via_db_override_visible_to_daemon_json_read` and
  `daemon_write_json_visible_to_cli_db_override_read` — both round trips.
- `absorb_seeds_json_from_db_only_host`, `absorb_leaves_existing_json_untouched_when_both_exist`,
  `absorb_neither_present_starts_fresh` — the R2 migration branches.
- `purge_stale_preserves_unresolved_conflicts_across_prefixes` — a foreign-prefix
  unresolved conflict survives the boot purge while a foreign non-conflict entry
  is still dropped.

### Scope

Refs **TIN-2657** (this fix) and **TIN-2658** (the conflict this unblocks for
`tcfs resolve`). Explicit non-goals kept out: `StateBackend`/`RocksDbStateCache`
dead code, the `state_db` config-key name, fleet TOMLs/scripts, `grpc.rs`, and
resolver-strategy code. The reconcile per-root isolation → `tcfs resolve`
routing gap remains TIN-2658 proper, flagged not fixed here.

Adversarial review gate to follow before merge — do not merge on green alone.
