### PR TITLE
release: cut v0.12.17 — first tagged release since v0.12.14 (TIN-2684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ historical release intent rather than the current supported/proven surface.
 
 ## [Unreleased]
 
+## [0.12.17] - 2026-07-09
+
+> **Version-truth note (TIN-2684):** the version strings `0.12.15` and
+> `0.12.16` were deployed to fleet hosts from untagged main builds but were
+> never released or tagged; their changes are folded into this release. This
+> is the first tagged release since `v0.12.14`.
+
+### Added
+
+- **`.git`-as-files bidirectional conflict safety (G5-git-5, TIN-1620) is
+  proven end-to-end**: worktree/gitfile fence (#526), foreign-lock respect +
+  `remote_manifest_key` (#528), keep-both resolver parking losing refs under
+  `refs/tcfs/theirs/<device>/**` (#529), and the loser-side no-loss guard with
+  verified undo bundles (#534). Divergent convergence proven live on a
+  two-host canary — all six G5-git-13 criteria (#542).
+- **Off-neo darwin closure CI** (#524): every push to main builds and
+  publishes the full aarch64-darwin closure (including `tcfsd`) from hosted
+  macOS CI (~40 min) for fleet substitution.
+- One-time **legacy state absorb**: a `.db`-only host migrates its state file
+  to the canonical `state.json` atomically (temp + parse-validate + rename)
+  at daemon boot (#545).
+
+### Fixed
+
+- **Out-of-band `git commit` never ticked the vector clock**, making real
+  divergence structurally unreachable as a conflict (TIN-2584, #540).
+- **Plan-path conflicts were recorded with `status="synced"`**, leaving the
+  keep-both resolver blind to them (TIN-2652, #541).
+- **CLI `--state` overrides and the daemon now converge on one state file**:
+  overrides are tilde-expanded and normalized to the `.json` sibling the
+  daemon actually reads; boot-time `purge_stale` never drops entries with
+  unresolved conflicts (TIN-2657, #545).
+- FileProvider backends read Dual/v2 manifests via master-wrap fallback
+  (TIN-1898).
+- Zero-diff roam fidelity: mtime preservation and opt-in symlink convergence
+  (#508 lineage).
+
 ### Changed
 
 - **Per-device file-key wrapping is now a tri-state `crypto.wrap_mode`**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-auth"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-chunks"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cli"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cloudfilter"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-core"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "prost",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-crypto"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "aes-siv",
  "age",
@@ -5269,7 +5269,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-dbus"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-e2e"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5304,7 +5304,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-file-provider"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-fuse"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-mcp"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5372,7 +5372,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-nfs"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-secrets"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5422,7 +5422,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sops"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-storage"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sync"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "age",
  "anyhow",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-tui"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-vfs"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "tcfsd"
-version = "0.12.16"
+version = "0.12.17"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.16"
+version = "0.12.17"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version cut: workspace 0.12.16 → 0.12.17, changelog section absorbing [Unreleased] + everything since v0.12.14, lockfile refresh.

**Version-truth (TIN-2684):** declares 0.12.15/0.12.16 as deployed-but-never-released strings folded into this release, ending the tag-build vs main-build ambiguity. On merge: tag `v0.12.17` on the merge commit + GitHub release with the changelog section.

Carries (since v0.12.14): keep-both ladder #526/#528/#529/#534 + G5 evidence #542, TIN-2584 #540, TIN-2652 #541, TIN-2657 #545, TIN-1898 FP dual-read, #508 zero-diff fidelity, #524 darwin closure CI, wrap_mode tri-state (TIN-1417 groundwork).

Deploy plan after tag: lab flake bump → honey/bumble/sting nix-switch → neo via CI-closure substitution (#524 path) — then the TIN-2658 live resolve.