### PR TITLE
fix(storage): require HTTPS by default (TIN-2854)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,8 @@ AWS_SECRET_ACCESS_KEY=admin
 # ── Local dev stack overrides ────────────────────────────────────────────────
 # SeaweedFS S3 endpoint (default: docker-compose local stack)
 # TCFS_S3_ENDPOINT=http://localhost:8333
+# The repo-managed config/tcfs.example.toml explicitly sets enforce_tls=false
+# for this isolated local stack. Runtime defaults otherwise require TLS.
 
 # NATS JetStream URL (default: docker-compose local stack)
 # TCFS_NATS_URL=nats://localhost:4222
@@ -48,7 +50,9 @@ AWS_SECRET_ACCESS_KEY=admin
 # TCFS_METRICS_ADDR=127.0.0.1:9100
 
 # ── Production SeaweedFS (uncomment to target real infra) ────────────────────
-# TCFS_S3_ENDPOINT=http://dees-appu-bearts:8333
+# TCFS_S3_ENDPOINT=https://seaweedfs.example.com:8333
+# Set storage.enforce_tls=true (the default) and configure ca_cert_path when
+# the endpoint uses a private CA.
 # AWS_ACCESS_KEY_ID=jess
 # AWS_SECRET_ACCESS_KEY=<your-real-secret-key>
 

--- a/.github/workflows/ci-live-storage.yml
+++ b/.github/workflows/ci-live-storage.yml
@@ -43,6 +43,8 @@ env:
   # Override defaults baked into fleet_live.rs (which point at tailnet MagicDNS)
   TCFS_E2E_LIVE: "1"
   TCFS_S3_ENDPOINT: "http://127.0.0.1:8333"
+  # Explicit test-only opt-in for the job-local compose endpoint.
+  TCFS_STORAGE_ALLOW_INSECURE_HTTP: "true"
   TCFS_S3_BUCKET: "tcfs"
   TCFS_NATS_URL: "nats://127.0.0.1:4222"
   # Keep infra failures cheap in CI; the production default is 300s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ intent rather than the current supported/proven surface.
 
 ## [Unreleased]
 
+### Security
+
+- Credential-bearing S3/SeaweedFS clients now require HTTPS by default across
+  daemon, CLI, direct mount, and FileProvider operator construction. Plaintext
+  compatibility requires an explicit development/test opt-in.
+
 ## [0.12.17] - 2026-07-09
 
 > **Version-truth note (TIN-2684):** the version strings `0.12.15` and

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -138,6 +138,7 @@ tasks:
       - task: lazy:test-macos-fileprovider-lab-gatekeeper-override
       - task: lazy:test-asc-fileprovider-lab-provision
       - task: lazy:test-fileprovider-provision
+      - task: lazy:test-ios-bootstrap-qr
       - task: lazy:test-fileprovider-surface-contract
       - task: lazy:test-release-workflow-fileprovider
       - task: lazy:test-release-workflow-container
@@ -1239,6 +1240,13 @@ tasks:
     desc: Regression-test FileProvider config provisioning metadata
     cmds:
       - bash scripts/test-fileprovider-provision-config.sh
+
+  lazy:test-ios-bootstrap-qr:
+    desc: Regression-test iOS bootstrap QR storage transport validation
+    cmds:
+      - bash -n swift/ios/Scripts/gen-bootstrap-qr.sh scripts/test-ios-bootstrap-qr.sh
+      - shellcheck scripts/test-ios-bootstrap-qr.sh
+      - bash scripts/test-ios-bootstrap-qr.sh
 
   lazy:test-fileprovider-surface-contract:
     desc: Regression-test FileProvider decorations, progress, and custom action contract

--- a/config/tcfs.example.toml
+++ b/config/tcfs.example.toml
@@ -14,8 +14,14 @@ log_level = "info"       # trace, debug, info, warn, error
 log_format = "json"      # json, text
 
 [storage]
-# SeaweedFS S3 gateway endpoint
-endpoint = "http://dees-appu-bearts:8333"
+# Local docker-compose SeaweedFS endpoint. Plaintext is accepted only because
+# this repository-managed development config opts in explicitly below.
+endpoint = "http://localhost:8333"
+enforce_tls = false
+# Production must use an authenticated HTTPS endpoint and enforce_tls = true.
+# endpoint = "https://seaweedfs.example.com:8333"
+# enforce_tls = true
+# ca_cert_path = "/etc/tcfs/certs/seaweedfs-ca.pem"
 region = "us-east-1"
 bucket = "tcfs"
 # Path to SOPS-encrypted credential file (loaded at startup)

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -3102,6 +3102,7 @@ async fn cmd_mount(
         bucket: bucket.clone(),
         access_key_id: access_key,
         secret_access_key: secret_key,
+        allow_insecure_http: !config.storage.enforce_tls,
         s3_connect_timeout_secs: config.storage.s3_connect_timeout_secs,
         s3_pool_idle_timeout_secs: config.storage.s3_pool_idle_timeout_secs,
         s3_pool_max_idle_per_host: config.storage.s3_pool_max_idle_per_host,
@@ -4057,6 +4058,8 @@ fn write_init_config(
 #[derive(Debug, Serialize, PartialEq, Eq)]
 struct FileProviderInitConfig {
     s3_endpoint: String,
+    /// Explicit compatibility opt-in for isolated plaintext development S3.
+    allow_insecure_http: bool,
     s3_bucket: String,
     s3_access: String,
     s3_secret: String,
@@ -4113,6 +4116,7 @@ fn build_fileprovider_init_config(
     };
     FileProviderInitConfig {
         s3_endpoint: config.storage.endpoint.clone(),
+        allow_insecure_http: !config.storage.enforce_tls,
         s3_bucket: config.storage.bucket.clone(),
         s3_access: s3.access_key_id.clone(),
         s3_secret: s3.secret_access_key.expose_secret().to_string(),
@@ -7450,6 +7454,7 @@ mod tests {
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
         assert_eq!(rendered.s3_endpoint, "https://s3.example.test");
+        assert!(!rendered.allow_insecure_http);
         assert_eq!(rendered.s3_bucket, "tcfs-smoke");
         assert_eq!(rendered.s3_access, "access-key");
         assert_eq!(rendered.s3_secret, "secret-key");
@@ -7467,10 +7472,36 @@ mod tests {
 
         let json = serde_json::to_value(&rendered).unwrap();
         assert_eq!(json["s3_secret"], "secret-key");
+        assert_eq!(json["allow_insecure_http"], false);
         assert_eq!(
             json["master_key_file"].as_str(),
             Some(master_key_path.to_string_lossy().as_ref())
         );
+    }
+
+    #[test]
+    fn build_fileprovider_init_config_carries_explicit_http_opt_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = test_config(dir.path());
+        config.storage.endpoint = "http://localhost:8333".into();
+        config.storage.enforce_tls = false;
+        let s3 = tcfs_secrets::S3Credentials {
+            access_key_id: "access-key".into(),
+            secret_access_key: secrecy::SecretString::from("secret-key".to_string()),
+            endpoint: config.storage.endpoint.clone(),
+            region: config.storage.region.clone(),
+        };
+
+        let rendered = build_fileprovider_init_config(
+            &config,
+            &s3,
+            &dir.path().join("master.key"),
+            "device-1",
+        );
+        let json = serde_json::to_value(&rendered).unwrap();
+
+        assert!(rendered.allow_insecure_http);
+        assert_eq!(json["allow_insecure_http"], true);
     }
 
     #[test]

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -179,7 +179,9 @@ pub struct StorageConfig {
     pub remote_prefix: Option<String>,
     /// SOPS credential file path
     pub credentials_file: Option<PathBuf>,
-    /// Enforce HTTPS for S3 connections (warn/error on HTTP endpoints)
+    /// Enforce HTTPS for S3 connections (default: true).
+    /// Set false only for an explicitly isolated development/test endpoint.
+    #[serde(default = "default_true")]
     pub enforce_tls: bool,
     /// Path to a custom CA certificate for S3 TLS verification
     pub ca_cert_path: Option<PathBuf>,
@@ -522,7 +524,7 @@ impl Default for StorageConfig {
             bucket: "tcfs".into(),
             remote_prefix: None,
             credentials_file: None,
-            enforce_tls: false,
+            enforce_tls: true,
             ca_cert_path: None,
             max_concurrent_ops: 0,
             s3_connect_timeout_secs: 0,
@@ -685,7 +687,7 @@ argon2_parallelism = 8
         );
         assert_eq!(config.daemon.log_level, "info");
         assert_eq!(config.storage.endpoint, "http://localhost:8333");
-        assert!(!config.storage.enforce_tls);
+        assert!(config.storage.enforce_tls);
         assert_eq!(config.storage.bucket, "tcfs");
         assert_eq!(config.storage.max_concurrent_ops, 0);
         assert_eq!(config.storage.s3_connect_timeout_secs, 0);
@@ -710,6 +712,10 @@ endpoint = "http://192.168.1.100:8333"
 
         // Overridden
         assert_eq!(config.storage.endpoint, "http://192.168.1.100:8333");
+        assert!(
+            config.storage.enforce_tls,
+            "an HTTP endpoint must not silently disable the TLS default"
+        );
         // Defaults
         assert_eq!(config.storage.region, "us-east-1");
         assert_eq!(config.storage.bucket, "tcfs");
@@ -743,6 +749,17 @@ endpoint = "http://192.168.1.100:8333"
             config.nats_tls,
             "nats_tls must default to true for security"
         );
+    }
+
+    #[test]
+    fn storage_plaintext_http_requires_explicit_opt_in() {
+        let toml_str = r#"
+[storage]
+endpoint = "http://localhost:8333"
+enforce_tls = false
+"#;
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.storage.enforce_tls);
     }
 
     #[test]

--- a/crates/tcfs-file-provider/src/storage_bounds.rs
+++ b/crates/tcfs-file-provider/src/storage_bounds.rs
@@ -2,6 +2,7 @@ use tcfs_storage::operator::StorageConfig;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct StorageTransportBounds {
+    pub allow_insecure_http: Option<bool>,
     pub max_concurrent_ops: Option<usize>,
     pub s3_connect_timeout_secs: Option<u64>,
     pub s3_pool_idle_timeout_secs: Option<u64>,
@@ -12,6 +13,7 @@ pub(crate) struct StorageTransportBounds {
 impl StorageTransportBounds {
     fn merge_missing(self, fallback: Self) -> Self {
         Self {
+            allow_insecure_http: self.allow_insecure_http.or(fallback.allow_insecure_http),
             max_concurrent_ops: self.max_concurrent_ops.or(fallback.max_concurrent_ops),
             s3_connect_timeout_secs: self
                 .s3_connect_timeout_secs
@@ -27,6 +29,9 @@ impl StorageTransportBounds {
     }
 
     fn apply_to_storage_config(self, config: &mut StorageConfig) {
+        if let Some(value) = self.allow_insecure_http {
+            config.allow_insecure_http = value;
+        }
         if let Some(value) = self.s3_connect_timeout_secs {
             config.s3_connect_timeout_secs = value;
         }
@@ -56,14 +61,19 @@ pub(crate) fn build_operator_from_json(config: &serde_json::Value) -> Option<ope
         return None;
     }
 
-    build_operator_from_parts(
+    match build_operator_from_parts(
         endpoint.to_string(),
         bucket.to_string(),
         access.to_string(),
         secret.to_string(),
         bounds_from_json_and_env(config),
-    )
-    .ok()
+    ) {
+        Ok(operator) => Some(operator),
+        Err(error) => {
+            tracing::error!(%error, "FileProvider storage operator rejected");
+            None
+        }
+    }
 }
 
 #[cfg_attr(not(feature = "uniffi"), allow(dead_code))]
@@ -108,6 +118,10 @@ fn bounds_from_json_and_env(config: &serde_json::Value) -> StorageTransportBound
 
 fn bounds_from_json(config: &serde_json::Value) -> StorageTransportBounds {
     StorageTransportBounds {
+        allow_insecure_http: json_bool(
+            config,
+            &["allow_insecure_http", "storage_allow_insecure_http"],
+        ),
         max_concurrent_ops: json_usize(
             config,
             &["max_concurrent_ops", "storage_max_concurrent_ops"],
@@ -136,6 +150,7 @@ fn bounds_from_json(config: &serde_json::Value) -> StorageTransportBounds {
 
 fn bounds_from_env() -> StorageTransportBounds {
     StorageTransportBounds {
+        allow_insecure_http: env_bool("TCFS_STORAGE_ALLOW_INSECURE_HTTP"),
         max_concurrent_ops: env_usize("TCFS_STORAGE_MAX_CONCURRENT_OPS"),
         s3_connect_timeout_secs: env_u64("TCFS_STORAGE_S3_CONNECT_TIMEOUT_SECS"),
         s3_pool_idle_timeout_secs: env_u64("TCFS_STORAGE_S3_POOL_IDLE_TIMEOUT_SECS"),
@@ -203,6 +218,7 @@ mod tests {
     #[test]
     fn parses_storage_bounds_from_json() {
         let config = serde_json::json!({
+            "allow_insecure_http": false,
             "max_concurrent_ops": "7",
             "s3_connect_timeout_secs": 5,
             "s3_pool_idle_timeout_secs": "13",
@@ -213,6 +229,7 @@ mod tests {
         assert_eq!(
             bounds_from_json(&config),
             StorageTransportBounds {
+                allow_insecure_http: Some(false),
                 max_concurrent_ops: Some(7),
                 s3_connect_timeout_secs: Some(5),
                 s3_pool_idle_timeout_secs: Some(13),
@@ -225,6 +242,7 @@ mod tests {
     #[test]
     fn json_bounds_accept_storage_prefixed_keys_and_explicit_false() {
         let config = serde_json::json!({
+            "storage_allow_insecure_http": true,
             "storage_max_concurrent_ops": 4,
             "storage_s3_connect_timeout_secs": "6",
             "storage_s3_pool_idle_timeout_secs": "0",
@@ -235,6 +253,7 @@ mod tests {
         assert_eq!(
             bounds_from_json(&config),
             StorageTransportBounds {
+                allow_insecure_http: Some(true),
                 max_concurrent_ops: Some(4),
                 s3_connect_timeout_secs: Some(6),
                 s3_pool_idle_timeout_secs: Some(0),
@@ -242,5 +261,30 @@ mod tests {
                 s3_http1_only: Some(false),
             }
         );
+    }
+
+    #[test]
+    fn direct_operator_rejects_plaintext_without_explicit_opt_in() {
+        let config = serde_json::json!({
+            "s3_endpoint": "http://localhost:8333",
+            "s3_bucket": "tcfs",
+            "s3_access": "test-access",
+            "s3_secret": "test-secret"
+        });
+
+        assert!(build_operator_from_json(&config).is_none());
+    }
+
+    #[test]
+    fn direct_operator_allows_explicit_plaintext_dev_opt_in() {
+        let config = serde_json::json!({
+            "s3_endpoint": "http://localhost:8333",
+            "s3_bucket": "tcfs",
+            "s3_access": "test-access",
+            "s3_secret": "test-secret",
+            "allow_insecure_http": true
+        });
+
+        assert!(build_operator_from_json(&config).is_some());
     }
 }

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -14,6 +14,9 @@ use secrecy::SecretString;
 /// Configuration for the TCFS provider.
 ///
 /// On iOS, these values come from the Keychain via the Swift layer.
+/// `s3_endpoint` must use HTTPS. This record intentionally exposes no
+/// plaintext opt-in; lower-level development tests can use the process-only
+/// `TCFS_STORAGE_ALLOW_INSECURE_HTTP` escape hatch.
 #[derive(uniffi::Record)]
 pub struct ProviderConfig {
     pub s3_endpoint: String,
@@ -1082,7 +1085,7 @@ mod tests {
 
     fn test_provider() -> Arc<TcfsProviderHandle> {
         TcfsProviderHandle::new(ProviderConfig {
-            s3_endpoint: "http://127.0.0.1:8333".into(),
+            s3_endpoint: "https://127.0.0.1:8333".into(),
             s3_bucket: "tcfs-test".into(),
             access_key: "test-access".into(),
             s3_secret: "test-secret".into(),

--- a/crates/tcfs-storage/src/lib.rs
+++ b/crates/tcfs-storage/src/lib.rs
@@ -14,7 +14,8 @@ pub use operator::{build_operator, StorageConfig};
 /// Parse a remote spec like `seaweedfs://host:port/bucket[/prefix]`.
 ///
 /// `seaweedfs://` is retained as the historical HTTP form for local/dev
-/// endpoints. Use `seaweedfs+https://` for production-like TLS endpoints.
+/// endpoints and still requires the caller's explicit insecure-HTTP opt-in.
+/// Use `seaweedfs+https://` for production TLS endpoints.
 ///
 /// Returns `(endpoint, bucket, prefix)` where:
 /// - endpoint: `http://host:port` or `https://host:port`

--- a/crates/tcfs-storage/src/operator.rs
+++ b/crates/tcfs-storage/src/operator.rs
@@ -15,6 +15,11 @@ pub struct StorageConfig {
     pub bucket: String,
     pub access_key_id: String,
     pub secret_access_key: String,
+    /// Permit credentials to be sent over plaintext HTTP.
+    ///
+    /// This is intentionally false by default. Callers may enable it only for
+    /// isolated development or test endpoints.
+    pub allow_insecure_http: bool,
     pub s3_connect_timeout_secs: u64,
     pub s3_pool_idle_timeout_secs: u64,
     pub s3_pool_max_idle_per_host: usize,
@@ -30,6 +35,7 @@ impl Default for StorageConfig {
             bucket: "tcfs".to_string(),
             access_key_id: String::new(),
             secret_access_key: String::new(),
+            allow_insecure_http: false,
             s3_connect_timeout_secs: 0,
             s3_pool_idle_timeout_secs: 0,
             s3_pool_max_idle_per_host: 0,
@@ -51,6 +57,8 @@ pub fn build_operator(cfg: &StorageConfig) -> Result<Operator> {
 ///
 /// If `max_concurrent > 0`, applies `ConcurrentLimitLayer` to cap inflight S3 ops.
 pub fn build_operator_with_limits(cfg: &StorageConfig, max_concurrent: usize) -> Result<Operator> {
+    validate_endpoint_transport(cfg)?;
+
     // opendal 0.55: S3 builder uses consuming pattern (methods take `self`, return `Self`).
     let mut builder = opendal::services::S3::default()
         .endpoint(&cfg.endpoint)
@@ -94,18 +102,63 @@ pub fn build_operator_with_limits(cfg: &StorageConfig, max_concurrent: usize) ->
     Ok(op)
 }
 
-fn build_s3_http_client(cfg: &StorageConfig) -> Result<Option<HttpClient>> {
-    let custom_client_requested = cfg.s3_connect_timeout_secs > 0
-        || cfg.s3_pool_idle_timeout_secs > 0
-        || cfg.s3_pool_max_idle_per_host > 0
-        || cfg.s3_http1_only
-        || cfg.ca_cert_path.is_some();
+fn validate_endpoint_transport(cfg: &StorageConfig) -> Result<()> {
+    let endpoint = reqwest::Url::parse(&cfg.endpoint)
+        .with_context(|| format!("parsing S3 endpoint URL {}", cfg.endpoint))?;
 
-    if !custom_client_requested {
-        return Ok(None);
+    if let Some(warning) = insecure_transport_warning(endpoint.scheme(), cfg.allow_insecure_http) {
+        tracing::warn!(endpoint = %cfg.endpoint, "{warning}");
     }
 
-    let mut builder = reqwest::Client::builder();
+    match endpoint.scheme() {
+        "https" => Ok(()),
+        "http" if cfg.allow_insecure_http => Ok(()),
+        "http" => anyhow::bail!(
+            "S3 endpoint uses plaintext HTTP ({}). Use an HTTPS endpoint. For isolated development or tests only, explicitly set storage.enforce_tls = false (tcfs config) or allow_insecure_http = true (low-level client).",
+            cfg.endpoint
+        ),
+        scheme => anyhow::bail!(
+            "unsupported S3 endpoint scheme {scheme:?} in {}; HTTPS is required",
+            cfg.endpoint
+        ),
+    }
+}
+
+fn insecure_transport_warning(scheme: &str, allow_insecure_http: bool) -> Option<&'static str> {
+    if !allow_insecure_http {
+        return None;
+    }
+    match scheme {
+        "http" => Some(
+            "S3 endpoint uses explicitly allowed plaintext HTTP; credentials are transmitted \
+             unencrypted. This mode is for isolated development and tests only.",
+        ),
+        "https" => Some(
+            "S3 insecure-HTTP compatibility is enabled for an HTTPS endpoint; the first hop uses \
+             TLS, but redirects may downgrade to plaintext HTTP. Disable this development/test \
+             opt-in to enforce HTTPS for the complete request chain.",
+        ),
+        _ => None,
+    }
+}
+
+fn build_s3_http_client(cfg: &StorageConfig) -> Result<Option<HttpClient>> {
+    // OpenDAL requires redirect support, while reqwest's default policy also
+    // permits an HTTPS endpoint to redirect to plaintext HTTP. Install a
+    // bounded policy for every operator so `allow_insecure_http = false`
+    // covers the complete request chain, not only the configured first hop.
+    let allow_insecure_http = cfg.allow_insecure_http;
+    let redirect_policy = reqwest::redirect::Policy::custom(move |attempt| {
+        if attempt.previous().len() >= 10 {
+            return attempt.error("too many S3 redirects");
+        }
+        if redirect_scheme_allowed(attempt.url().scheme(), allow_insecure_http) {
+            attempt.follow()
+        } else {
+            attempt.error("S3 redirect to insecure or unsupported transport rejected")
+        }
+    });
+    let mut builder = reqwest::Client::builder().redirect(redirect_policy);
     if let Some(path) = &cfg.ca_cert_path {
         let pem = std::fs::read(path)
             .with_context(|| format!("reading S3 CA certificate {}", path.display()))?;
@@ -136,35 +189,26 @@ fn build_s3_http_client(cfg: &StorageConfig) -> Result<Option<HttpClient>> {
             .ca_cert_path
             .as_ref()
             .map(|path| path.display().to_string()),
-        "S3 HTTP client controls enabled"
+        allow_insecure_http = cfg.allow_insecure_http,
+        "S3 HTTP client security and transport controls enabled"
     );
     Ok(Some(HttpClient::with(client)))
 }
 
+fn redirect_scheme_allowed(scheme: &str, allow_insecure_http: bool) -> bool {
+    scheme == "https" || (allow_insecure_http && scheme == "http")
+}
+
 /// Build an operator from tcfs-core config + loaded credentials.
 ///
-/// If `enforce_tls` is true and the endpoint uses HTTP, this returns an error.
-/// Otherwise, a warning is logged for non-HTTPS endpoints.
+/// HTTPS is required by default. A plaintext HTTP endpoint is accepted only
+/// when the core config explicitly sets `enforce_tls = false` for isolated
+/// development or tests.
 pub fn build_from_core_config(
     storage: &tcfs_core::config::StorageConfig,
     access_key_id: &str,
     secret_access_key: &str,
 ) -> Result<Operator> {
-    if storage.endpoint.starts_with("http://") {
-        if storage.enforce_tls {
-            anyhow::bail!(
-                "S3 endpoint uses plaintext HTTP ({}), but enforce_tls is enabled. \
-                 Use an HTTPS endpoint or set storage.enforce_tls = false for local development.",
-                storage.endpoint
-            );
-        }
-        tracing::warn!(
-            endpoint = %storage.endpoint,
-            "S3 endpoint uses plaintext HTTP — credentials are transmitted unencrypted. \
-             Set storage.enforce_tls = true and use HTTPS in production."
-        );
-    }
-
     build_operator_with_limits(
         &StorageConfig {
             endpoint: storage.endpoint.clone(),
@@ -172,6 +216,7 @@ pub fn build_from_core_config(
             bucket: storage.bucket.clone(),
             access_key_id: access_key_id.to_string(),
             secret_access_key: secret_access_key.to_string(),
+            allow_insecure_http: !storage.enforce_tls,
             s3_connect_timeout_secs: storage.s3_connect_timeout_secs,
             s3_pool_idle_timeout_secs: storage.s3_pool_idle_timeout_secs,
             s3_pool_max_idle_per_host: storage.s3_pool_max_idle_per_host,
@@ -187,9 +232,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_operator_valid() {
+    fn test_build_operator_https_valid() {
         let cfg = StorageConfig {
-            endpoint: "http://localhost:8333".to_string(),
+            endpoint: "https://localhost:8333".to_string(),
             region: "us-east-1".to_string(),
             bucket: "test-bucket".to_string(),
             access_key_id: "test-key".to_string(),
@@ -201,6 +246,32 @@ mod tests {
     }
 
     #[test]
+    fn test_build_operator_rejects_http_by_default() {
+        let cfg = StorageConfig {
+            endpoint: "http://localhost:8333".to_string(),
+            access_key_id: "test-key".to_string(),
+            secret_access_key: "test-secret".to_string(),
+            ..Default::default()
+        };
+
+        let err = build_operator(&cfg).unwrap_err();
+        assert!(err.to_string().contains("plaintext HTTP"), "{err:#}");
+    }
+
+    #[test]
+    fn test_build_operator_allows_explicit_insecure_http() {
+        let cfg = StorageConfig {
+            endpoint: "http://localhost:8333".to_string(),
+            access_key_id: "test-key".to_string(),
+            secret_access_key: "test-secret".to_string(),
+            allow_insecure_http: true,
+            ..Default::default()
+        };
+
+        assert!(build_operator(&cfg).is_ok());
+    }
+
+    #[test]
     fn test_build_operator_with_s3_http_controls() {
         let cfg = StorageConfig {
             endpoint: "https://s3.example.com".to_string(),
@@ -208,6 +279,7 @@ mod tests {
             bucket: "test-bucket".to_string(),
             access_key_id: "test-key".to_string(),
             secret_access_key: "test-secret".to_string(),
+            allow_insecure_http: false,
             s3_connect_timeout_secs: 5,
             s3_pool_idle_timeout_secs: 15,
             s3_pool_max_idle_per_host: 4,
@@ -223,6 +295,31 @@ mod tests {
             build_operator_with_limits(&cfg, 4).is_ok(),
             "operator construction should succeed with S3 HTTP controls and concurrency limits"
         );
+    }
+
+    #[test]
+    fn strict_redirect_policy_rejects_tls_downgrade() {
+        assert!(redirect_scheme_allowed("https", false));
+        assert!(!redirect_scheme_allowed("http", false));
+        assert!(!redirect_scheme_allowed("file", false));
+    }
+
+    #[test]
+    fn explicit_dev_opt_in_allows_http_redirects_only() {
+        assert!(redirect_scheme_allowed("https", true));
+        assert!(redirect_scheme_allowed("http", true));
+        assert!(!redirect_scheme_allowed("file", true));
+    }
+
+    #[test]
+    fn insecure_opt_in_warns_for_plaintext_and_https_downgrade_risk() {
+        let plaintext = insecure_transport_warning("http", true).unwrap();
+        let downgrade = insecure_transport_warning("https", true).unwrap();
+
+        assert!(plaintext.contains("credentials are transmitted"));
+        assert!(downgrade.contains("redirects may downgrade"));
+        assert_ne!(plaintext, downgrade);
+        assert!(insecure_transport_warning("https", false).is_none());
     }
 
     #[test]
@@ -248,8 +345,8 @@ mod tests {
     }
 
     #[test]
-    fn test_build_from_core_config_http_warning() {
-        // HTTP endpoint with enforce_tls=false should succeed (but log warning)
+    fn test_build_from_core_config_http_explicit_dev_opt_in() {
+        // HTTP endpoint with explicit enforce_tls=false should succeed (and warn).
         let storage = tcfs_core::config::StorageConfig {
             endpoint: "http://localhost:8333".into(),
             enforce_tls: false,
@@ -271,7 +368,7 @@ mod tests {
         assert!(result.is_err(), "HTTP + enforce_tls must fail");
         assert!(
             result.unwrap_err().to_string().contains("enforce_tls"),
-            "error message should mention enforce_tls"
+            "error message should mention the plaintext transport"
         );
     }
 

--- a/crates/tcfsd/tests/config_test.rs
+++ b/crates/tcfsd/tests/config_test.rs
@@ -30,6 +30,7 @@ socket = "/tmp/test-tcfsd.sock"
 
 [storage]
 endpoint = "http://localhost:8333"
+enforce_tls = false
 bucket = "test-bucket"
 
 [sync]
@@ -53,6 +54,7 @@ enabled = false
         .await
         .expect("valid TOML should parse");
     assert_eq!(config.storage.bucket, "test-bucket");
+    assert!(!config.storage.enforce_tls);
     assert_eq!(
         config.daemon.socket,
         std::path::PathBuf::from("/tmp/test-tcfsd.sock")

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -124,14 +124,26 @@ cargo clippy --workspace --all-targets --fix  # Auto-fix lints
 # This runs docker-compose with the local dev infrastructure
 task dev
 
-# In another terminal, run the daemon
-cargo run -p tcfsd
+# In another terminal, copy the annotated development config. It explicitly
+# opts the isolated local SeaweedFS endpoint into plaintext HTTP.
+DEV_CONFIG="${TMPDIR:-/tmp}/tcfs-dev.toml"
+cp config/tcfs.example.toml "$DEV_CONFIG"
+# Edit the copied file to use writable socket/state/cache paths and either
+# remove credentials_file or point it at your development credentials.
+${EDITOR:-vi} "$DEV_CONFIG"
+
+# Run the daemon and every CLI command against that same config.
+cargo run -p tcfsd -- --config "$DEV_CONFIG"
 
 # Use the CLI
-cargo run -p tcfs-cli -- status
-cargo run -p tcfs-cli -- push /path/to/files
-cargo run -p tcfs-cli -- mount seaweedfs://localhost:8333/tcfs /tmp/tcfs-mount
+cargo run -p tcfs-cli -- --config "$DEV_CONFIG" status
+cargo run -p tcfs-cli -- --config "$DEV_CONFIG" push /path/to/files
+cargo run -p tcfs-cli -- --config "$DEV_CONFIG" mount seaweedfs://localhost:8333/tcfs /tmp/tcfs-mount
 ```
+
+The example's `storage.enforce_tls = false` is only for the job-local
+development stack. Use an HTTPS endpoint and retain the secure default for any
+shared, remote, or fleet environment.
 
 ## Pull Request Guidelines
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,6 +17,17 @@ task docs:pdf
 
 tcfs encrypts all file content client-side before upload using XChaCha20-Poly1305 with per-file keys derived via HKDF from a master key. The master key is protected by Argon2id key derivation with BIP-39 mnemonic recovery. Credentials are managed through a layered chain: SOPS/age encrypted files, KeePassXC databases, or environment variables. Device identity uses age keypairs with BLAKE3 fingerprints, stored in an S3-backed registry. All chunk data is content-addressed (BLAKE3) ensuring integrity verification on every read.
 
+Credential-bearing S3 clients require an `https://` endpoint by default. The
+daemon/CLI compatibility escape hatch, `storage.enforce_tls = false`, and the
+macOS direct-client JSON setting, `allow_insecure_http = true`, are explicit
+development/test opt-ins. The iOS UniFFI `ProviderConfig` intentionally has no
+plaintext field; its lower-level test escape hatch is the process environment
+variable `TCFS_STORAGE_ALLOW_INSECURE_HTTP=true`. None of these opt-ins may be
+used for production or fleet reconciliation. Custom private trust roots via
+`storage.ca_cert_path` are supported by daemon/CLI/core operator paths. Direct
+FileProvider paths currently require a publicly WebPKI-trusted chain;
+sandbox-safe private-CA/PEM propagation remains open.
+
 ## Quick Reference
 
 See the [Security PDF](https://github.com/Jesssullivan/tummycrypt/actions/workflows/docs.yml) for full details including:

--- a/docs/ops/storage-posture-production-gate.md
+++ b/docs/ops/storage-posture-production-gate.md
@@ -12,6 +12,19 @@ endpoint TLS posture, and the credential scope used for the run. It does not
 prove broad directory ownership, multitenancy, lost-device recovery, or long
 soak behavior.
 
+Source invariant: credential-bearing S3 operator construction requires HTTPS
+by default. Plaintext compatibility now requires the explicit
+development/test opt-in `storage.enforce_tls = false` (or
+`allow_insecure_http = true` in macOS direct-client JSON). The iOS UniFFI
+`ProviderConfig` remains HTTPS-only; only its lower-level process environment
+recognizes `TCFS_STORAGE_ALLOW_INSECURE_HTTP=true` for tests. This fail-closed
+source default does not itself provision a fleet TLS hostname, install its
+trust chain, or prove a live read/write path. `storage.ca_cert_path` reaches
+daemon/CLI/core operators; direct FileProvider paths currently require a
+publicly WebPKI-trusted chain, and sandbox-safe private-CA/PEM propagation
+remains open. The HTTPS canary evidence below remains valid and is distinct
+from the still-open neo/honey runtime migration.
+
 For the production posture packet, the canary should also include a negative
 scope probe by setting `scope_deny_prefix` to a prefix outside the credential
 policy. The workflow passes that to `tcfs storage canary

--- a/docs/tex/security.tex
+++ b/docs/tex/security.tex
@@ -170,8 +170,18 @@ enforce_tls = true
 ca_cert_path = "/etc/tcfs/certs/ca.pem"
 \end{lstlisting}
 
-When \code{enforce\_tls = true}, HTTP endpoints produce an error at startup.
-When \code{false} (default), HTTP endpoints produce a warning.
+HTTPS enforcement defaults to true. Credential-bearing HTTP endpoints fail
+closed across daemon, CLI, direct mount, and FileProvider operator
+construction. Setting \code{enforce\_tls = false} is an explicit compatibility
+opt-in for isolated development and tests; the lower-level direct-client
+equivalent for macOS JSON is \code{allow\_insecure\_http = true}. The iOS
+UniFFI \code{ProviderConfig} has no plaintext field; only the lower-level test
+process environment recognizes
+\code{TCFS\_STORAGE\_ALLOW\_INSECURE\_HTTP=true}. These modes produce a warning
+and must not be used for production or fleet reconciliation.
+\code{ca\_cert\_path} applies to daemon, CLI, and core operator paths. Direct
+FileProvider paths currently require a publicly WebPKI-trusted chain;
+sandbox-safe private-CA/PEM propagation remains open.
 
 \subsection{NATS}
 

--- a/nix/modules/tcfs-daemon.nix
+++ b/nix/modules/tcfs-daemon.nix
@@ -8,7 +8,7 @@
 #     configFile = "/etc/tcfs/config.toml";
 #     credentialsFile = "/etc/tcfs/age-identity.txt";
 #     mounts = [
-#       { remote = "seaweedfs://dees-appu-bearts:8333/bucket"; local = "/mnt/tcfs"; }
+#       { remote = "seaweedfs+https://seaweedfs.example.com/bucket"; local = "/mnt/tcfs"; }
 #     ];
 #   };
 #

--- a/nix/modules/tcfs-user.nix
+++ b/nix/modules/tcfs-user.nix
@@ -9,7 +9,7 @@
 #     syncRoot = "~/tcfs";
 #     natsUrl = "nats://nats-tcfs:4222";
 #     mounts = [
-#       { remote = "seaweedfs://host/bucket"; local = "~/tcfs"; }
+#       { remote = "seaweedfs+https://seaweedfs.example.com/bucket"; local = "~/tcfs"; }
 #     ];
 #   };
 #

--- a/scripts/test-fileprovider-provision-config.sh
+++ b/scripts/test-fileprovider-provision-config.sh
@@ -24,6 +24,7 @@ fileprovider_endpoint = "http://127.0.0.1:19101"
 
 [storage]
 endpoint = "http://example.invalid:8333"
+enforce_tls = false
 bucket = "tcfs"
 remote_prefix = "data"
 
@@ -46,6 +47,7 @@ jq -e \
   --arg master_key_file "$MASTER_KEY_FILE" \
   '
     .s3_endpoint == $endpoint and
+    .allow_insecure_http == true and
     .s3_bucket == $bucket and
     .s3_access == $access and
     .s3_secret == $secret and
@@ -57,6 +59,7 @@ jq -e \
   ' "$OUTPUT_JSON" >/dev/null
 
 grep -Fq "Master key file: present" "${TMPDIR}/provision.out"
+grep -Fq "Insecure HTTP allowed: true" "${TMPDIR}/provision.out"
 grep -Fq "Endpoint: http://127.0.0.1:19101" "${TMPDIR}/provision.out"
 grep -Fq "Also written to $APP_GROUP_JSON" "${TMPDIR}/provision.out"
 grep -Fq "TCFS_FILEPROVIDER_APP_GROUP_COPY_TIMEOUT" "$SCRIPT"
@@ -81,5 +84,21 @@ if [[ -e "$APP_GROUP_JSON" ]]; then
   printf 'expected skip mode not to write %s\n' "$APP_GROUP_JSON" >&2
   exit 1
 fi
+
+STRICT_CONFIG_TOML="${TMPDIR}/tcfs-strict.toml"
+cat >"$STRICT_CONFIG_TOML" <<EOF
+[storage]
+endpoint = "http://example.invalid:8333"
+bucket = "tcfs"
+EOF
+
+if HOME="$HOME_DIR" \
+    AWS_ACCESS_KEY_ID="test-access" \
+    AWS_SECRET_ACCESS_KEY="test-secret" \
+    bash "$SCRIPT" "$STRICT_CONFIG_TOML" >"${TMPDIR}/strict.out" 2>"${TMPDIR}/strict.err"; then
+  printf 'expected plaintext config without explicit opt-in to fail\n' >&2
+  exit 1
+fi
+grep -Fq "requires explicit 'enforce_tls = false'" "${TMPDIR}/strict.err"
 
 printf 'FileProvider provision config tests passed\n'

--- a/scripts/test-git-repo-restore-proof.sh
+++ b/scripts/test-git-repo-restore-proof.sh
@@ -65,6 +65,7 @@ EOF
 cat >"$CONFIG" <<'EOF'
 [storage]
 endpoint = "http://example.invalid"
+enforce_tls = false
 bucket = "tcfs"
 remote_prefix = "git-repo-canary-fixture"
 

--- a/scripts/test-honey-backbone-preflight.sh
+++ b/scripts/test-honey-backbone-preflight.sh
@@ -32,6 +32,7 @@ mkdir -p "$FAKE_BIN" "$FAKE_HOME/.config/tcfs"
 cat >"$FAKE_HOME/.config/tcfs/config.toml" <<'EOF'
 [storage]
 endpoint = "http://seaweedfs-tcfs:8333"
+enforce_tls = false
 secret = "do-not-leak"
 [sync]
 nats_url = "nats://nats-tcfs:4222"
@@ -127,6 +128,7 @@ OUT
     cat <<'OUT'
 [storage]
 endpoint = "http://10.245.93.143:8333"
+enforce_tls = false
 secret = "remote-secret"
 [sync]
 nats_url = "nats://10.245.131.232:4222"

--- a/scripts/test-ios-bootstrap-qr.sh
+++ b/scripts/test-ios-bootstrap-qr.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/swift/ios/Scripts/gen-bootstrap-qr.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-ios-bootstrap-qr-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+HOME_DIR="$TMPDIR/home"
+CONFIG="$HOME_DIR/.config/tcfs/config.toml"
+ACCESS_FILE="$TMPDIR/access"
+SECRET_FILE="$TMPDIR/secret"
+FAKE_BIN="$TMPDIR/fake-bin"
+NO_QR_BIN="$TMPDIR/no-qr-bin"
+mkdir -p "$(dirname "$CONFIG")" "$FAKE_BIN" "$NO_QR_BIN"
+printf 'test-access\n' >"$ACCESS_FILE"
+printf 'test-secret\n' >"$SECRET_FILE"
+
+cat >"$FAKE_BIN/qrencode" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+[[ -n "$output" ]]
+cat >"${TCFS_QR_CAPTURE:?}"
+printf 'fake-png\n' >"$output"
+EOF
+cat >"$FAKE_BIN/open" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN/qrencode" "$FAKE_BIN/open"
+
+for command_name in cat date grep head hostname sed tr; do
+  ln -s "$(command -v "$command_name")" "$NO_QR_BIN/$command_name"
+done
+
+run_generator() {
+  local test_path="${TCFS_TEST_PATH:-$FAKE_BIN:/usr/bin:/bin}"
+  # Start from an empty environment so no inherited TCFS/AWS credential
+  # channel can influence the fixture-backed generator invocation.
+  env -i \
+    HOME="$HOME_DIR" \
+    PATH="$test_path" \
+    TMPDIR="$TMPDIR" \
+    TCFS_S3_ACCESS_KEY_FILE="$ACCESS_FILE" \
+    TCFS_S3_SECRET_KEY_FILE="$SECRET_FILE" \
+    "$@" \
+    /bin/bash "$SCRIPT" ios-test
+}
+
+file_mode() {
+  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
+cat >"$CONFIG" <<'EOF'
+[storage]
+endpoint = "http://example.invalid:8333"
+bucket = "tcfs"
+EOF
+if run_generator >"$TMPDIR/http.out" 2>"$TMPDIR/http.err"; then
+  printf 'expected iOS bootstrap generation to reject HTTP\n' >&2
+  exit 1
+fi
+grep -Fq 'must use https://' "$TMPDIR/http.err"
+
+# An explicit HTTPS endpoint is the migration override for a legacy HTTP config.
+OVERRIDE_CAPTURE="$TMPDIR/override.json"
+if ! run_generator \
+    TCFS_S3_ENDPOINT=https://override-storage.example.invalid \
+    TCFS_QR_CAPTURE="$OVERRIDE_CAPTURE" \
+    >"$TMPDIR/override.out" 2>"$TMPDIR/override.err"; then
+  cat "$TMPDIR/override.err" >&2
+  exit 1
+fi
+grep -Fq '"s3_endpoint":"https://override-storage.example.invalid"' "$OVERRIDE_CAPTURE"
+grep -Fq 'Endpoint: https://override-storage.example.invalid' "$TMPDIR/override.out"
+
+cat >"$CONFIG" <<'EOF'
+[storage]
+endpoint = "https://storage.example.invalid"
+bucket = "tcfs"
+EOF
+HTTPS_CAPTURE="$TMPDIR/https.json"
+run_generator TCFS_QR_CAPTURE="$HTTPS_CAPTURE" >"$TMPDIR/https.out"
+grep -Fq 'Endpoint: https://storage.example.invalid' "$TMPDIR/https.out"
+grep -Fq '"s3_endpoint":"https://storage.example.invalid"' "$HTTPS_CAPTURE"
+if grep -Fq 'test-secret' "$TMPDIR/https.out"; then
+  printf 'credential leaked to generator stdout\n' >&2
+  exit 1
+fi
+ARTIFACT=$(sed -n 's/^==> QR code saved to: //p' "$TMPDIR/https.out")
+[[ -f "$ARTIFACT" ]]
+[[ "$(file_mode "$ARTIFACT")" == "600" ]]
+[[ "$(file_mode "$(dirname "$ARTIFACT")")" == "700" ]]
+[[ "$(file_mode "$HTTPS_CAPTURE")" == "600" ]]
+
+cat >"$CONFIG" <<'EOF'
+[storage]
+endpoint = "https://user:do-not-log@example.invalid"
+bucket = "tcfs"
+EOF
+if run_generator >"$TMPDIR/userinfo.out" 2>"$TMPDIR/userinfo.err"; then
+  printf 'expected iOS bootstrap generation to reject URL userinfo\n' >&2
+  exit 1
+fi
+grep -Fq 'without userinfo, query, or fragment' "$TMPDIR/userinfo.err"
+if grep -Fq 'do-not-log' "$TMPDIR/userinfo.err"; then
+  printf 'credential-bearing endpoint leaked to generator error\n' >&2
+  exit 1
+fi
+
+rm "$CONFIG"
+if run_generator >"$TMPDIR/missing.out" 2>"$TMPDIR/missing.err"; then
+  printf 'expected iOS bootstrap generation to require an endpoint\n' >&2
+  exit 1
+fi
+grep -Fq 'an HTTPS storage endpoint is required' "$TMPDIR/missing.err"
+
+ENV_CAPTURE="$TMPDIR/env-https.json"
+run_generator \
+  TCFS_S3_ENDPOINT=https://env-storage.example.invalid \
+  TCFS_QR_CAPTURE="$ENV_CAPTURE" \
+  >"$TMPDIR/env-https.out"
+grep -Fq 'Endpoint: https://env-storage.example.invalid' "$TMPDIR/env-https.out"
+
+cat >"$CONFIG" <<'EOF'
+[storage]
+endpoint = "https://storage.example.invalid"
+bucket = "tcfs"
+EOF
+if TCFS_TEST_PATH="$NO_QR_BIN" run_generator \
+    >"$TMPDIR/no-qr.out" 2>"$TMPDIR/no-qr.err"; then
+  printf 'expected generator to fail safely without qrencode\n' >&2
+  exit 1
+fi
+grep -Fq 'refusing to print credential-bearing bootstrap JSON' "$TMPDIR/no-qr.err"
+if grep -Fq 'test-secret' "$TMPDIR/no-qr.out" "$TMPDIR/no-qr.err"; then
+  printf 'credential leaked when qrencode was unavailable\n' >&2
+  exit 1
+fi
+
+printf 'iOS bootstrap QR transport tests passed\n'

--- a/scripts/test-macos-fileprovider-preflight.sh
+++ b/scripts/test-macos-fileprovider-preflight.sh
@@ -107,7 +107,7 @@ mkdir -p \
   "$(dirname "$CONFIG_PATH")" \
   "$(dirname "$FILEPROVIDER_CONFIG")"
 
-printf '[storage]\nendpoint = "http://example.invalid:8333"\nbucket = "tcfs"\n' >"$CONFIG_PATH"
+printf '[storage]\nendpoint = "http://example.invalid:8333"\nenforce_tls = false\nbucket = "tcfs"\n' >"$CONFIG_PATH"
 printf '{"socket_path":"/tmp/tcfs-fileprovider.sock"}\n' >"$FILEPROVIDER_CONFIG"
 write_info_plist "$APP_PATH/Contents/Info.plist" "io.tinyland.tcfs"
 write_info_plist "$APP_PATH/Contents/Extensions/TCFSFileProvider.appex/Contents/Info.plist" "io.tinyland.tcfs.fileprovider"

--- a/scripts/test-macos-postinstall-smoke.sh
+++ b/scripts/test-macos-postinstall-smoke.sh
@@ -88,6 +88,7 @@ mkdir -p \
 cat >"$CONFIG_PATH" <<EOF
 [storage]
 endpoint = "http://example.invalid:8333"
+enforce_tls = false
 bucket = "tcfs"
 
 [sync]

--- a/swift/fileprovider/provision-config.sh
+++ b/swift/fileprovider/provision-config.sh
@@ -33,6 +33,12 @@ extract_toml() {
     grep -E "^[[:space:]]*$1[[:space:]]*=" "$CONFIG_TOML" 2>/dev/null | head -1 | sed -E 's/.*=[[:space:]]*"([^"]*)".*/\1/' || true
 }
 
+extract_toml_bool() {
+    grep -E "^[[:space:]]*$1[[:space:]]*=" "$CONFIG_TOML" 2>/dev/null \
+        | head -1 \
+        | sed -E 's/.*=[[:space:]]*(true|false).*/\1/' || true
+}
+
 copy_app_group_config() {
     local src="$1"
     local dst="$2"
@@ -63,6 +69,7 @@ copy_app_group_config() {
 }
 
 S3_ENDPOINT="$(extract_toml endpoint)"
+STORAGE_ENFORCE_TLS="$(extract_toml_bool enforce_tls)"
 S3_BUCKET="$(extract_toml bucket)"
 REMOTE_PREFIX="$(extract_toml remote_prefix)"
 DEVICE_ID="$(extract_toml device_id)"
@@ -71,7 +78,27 @@ DAEMON_SOCKET="$(extract_toml fileprovider_socket)"
 DAEMON_ENDPOINT="$(extract_toml fileprovider_endpoint)"
 MASTER_KEY_FILE="$(extract_toml master_key_file)"
 
-S3_ENDPOINT="${S3_ENDPOINT:-http://212.2.245.145:8333}"
+if [ -z "$S3_ENDPOINT" ]; then
+    echo "ERROR: storage.endpoint is required for FileProvider provisioning" >&2
+    exit 1
+fi
+
+ALLOW_INSECURE_HTTP=false
+case "$S3_ENDPOINT" in
+    https://*) ;;
+    http://*)
+        if [ "$STORAGE_ENFORCE_TLS" != "false" ]; then
+            echo "ERROR: plaintext storage.endpoint requires explicit 'enforce_tls = false' for isolated development/testing" >&2
+            exit 1
+        fi
+        ALLOW_INSECURE_HTTP=true
+        ;;
+    *)
+        echo "ERROR: storage.endpoint must use https:// (or explicit development-only http://)" >&2
+        exit 1
+        ;;
+esac
+
 S3_BUCKET="${S3_BUCKET:-tcfs}"
 DEVICE_ID="${DEVICE_ID:-${DEVICE_NAME:-$(hostname -s)}}"
 REMOTE_PREFIX="${REMOTE_PREFIX:-devices/$DEVICE_ID}"
@@ -118,6 +145,7 @@ if [ -n "$DAEMON_ENDPOINT" ] && [ -n "$MASTER_KEY_FILE" ]; then
 cat > "$CONFIG_JSON" <<CONFIGEOF
 {
   "s3_endpoint": "$S3_ENDPOINT",
+  "allow_insecure_http": $ALLOW_INSECURE_HTTP,
   "s3_bucket": "$S3_BUCKET",
   "s3_access": "$S3_ACCESS",
   "s3_secret": "$S3_SECRET",
@@ -131,6 +159,7 @@ elif [ -n "$DAEMON_ENDPOINT" ]; then
 cat > "$CONFIG_JSON" <<CONFIGEOF
 {
   "s3_endpoint": "$S3_ENDPOINT",
+  "allow_insecure_http": $ALLOW_INSECURE_HTTP,
   "s3_bucket": "$S3_BUCKET",
   "s3_access": "$S3_ACCESS",
   "s3_secret": "$S3_SECRET",
@@ -143,6 +172,7 @@ elif [ -n "$DAEMON_SOCKET" ] && [ -n "$MASTER_KEY_FILE" ]; then
 cat > "$CONFIG_JSON" <<CONFIGEOF
 {
   "s3_endpoint": "$S3_ENDPOINT",
+  "allow_insecure_http": $ALLOW_INSECURE_HTTP,
   "s3_bucket": "$S3_BUCKET",
   "s3_access": "$S3_ACCESS",
   "s3_secret": "$S3_SECRET",
@@ -156,6 +186,7 @@ elif [ -n "$DAEMON_SOCKET" ]; then
 cat > "$CONFIG_JSON" <<CONFIGEOF
 {
   "s3_endpoint": "$S3_ENDPOINT",
+  "allow_insecure_http": $ALLOW_INSECURE_HTTP,
   "s3_bucket": "$S3_BUCKET",
   "s3_access": "$S3_ACCESS",
   "s3_secret": "$S3_SECRET",
@@ -168,6 +199,7 @@ elif [ -n "$MASTER_KEY_FILE" ]; then
 cat > "$CONFIG_JSON" <<CONFIGEOF
 {
   "s3_endpoint": "$S3_ENDPOINT",
+  "allow_insecure_http": $ALLOW_INSECURE_HTTP,
   "s3_bucket": "$S3_BUCKET",
   "s3_access": "$S3_ACCESS",
   "s3_secret": "$S3_SECRET",
@@ -180,6 +212,7 @@ else
 cat > "$CONFIG_JSON" <<CONFIGEOF
 {
   "s3_endpoint": "$S3_ENDPOINT",
+  "allow_insecure_http": $ALLOW_INSECURE_HTTP,
   "s3_bucket": "$S3_BUCKET",
   "s3_access": "$S3_ACCESS",
   "s3_secret": "$S3_SECRET",
@@ -193,6 +226,7 @@ chmod 600 "$CONFIG_JSON"
 
 echo "==> Config written to $CONFIG_JSON"
 echo "    Endpoint: $S3_ENDPOINT"
+echo "    Insecure HTTP allowed: $ALLOW_INSECURE_HTTP"
 echo "    Bucket:   $S3_BUCKET"
 echo "    Device:   $DEVICE_ID"
 echo "    Prefix:   $REMOTE_PREFIX"

--- a/swift/ios/HostApp/AuthView.swift
+++ b/swift/ios/HostApp/AuthView.swift
@@ -157,9 +157,12 @@ class AuthViewModel: ObservableObject {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
 
-            // Decode invite directly — no provider needed (credentials come FROM the invite)
+            // The current UniFFI API exposes invite parsing on a provider
+            // handle. Construction does not contact storage, so use a reserved
+            // HTTPS placeholder until credentials come FROM the invite.
             let config = ProviderConfig(
-                s3Endpoint: "", s3Bucket: "", accessKey: "", s3Secret: "",
+                s3Endpoint: "https://invite-parser.invalid", s3Bucket: "invite-parser",
+                accessKey: "unused", s3Secret: "unused",
                 remotePrefix: "default", deviceId: "pending",
                 encryptionPassphrase: "", encryptionSalt: ""
             )
@@ -171,6 +174,12 @@ class AuthViewModel: ObservableObject {
                 DispatchQueue.main.async {
                     self.isLoading = false
                     if result.success {
+                        if !result.storageEndpoint.isEmpty,
+                           !BootstrapConfig.isSecureStorageEndpoint(result.storageEndpoint) {
+                            self.errorMessage = "Enrollment invite returned an unsupported storage endpoint. TCFS on iOS requires HTTPS."
+                            authLogger.error("Rejected invite credentials with non-HTTPS storage endpoint")
+                            return
+                        }
                         // Auto-configure: save brokered credentials to keychain
                         if !result.storageEndpoint.isEmpty, let vm = tcfsViewModel {
                             vm.saveConfig(

--- a/swift/ios/HostApp/HostApp.swift
+++ b/swift/ios/HostApp/HostApp.swift
@@ -21,7 +21,7 @@ struct TCFSApp: App {
 
     private func handleDeepLink(_ url: URL) {
         guard url.scheme == "tcfs" else {
-            hostLogger.warning("Ignoring URL with unknown scheme: \(url.absoluteString)")
+            hostLogger.warning("Ignoring URL with unknown scheme: \(url.scheme ?? "nil")")
             return
         }
 
@@ -33,14 +33,14 @@ struct TCFSApp: App {
         case "enroll":
             handleEnrollLink(url)
         default:
-            hostLogger.warning("Unrecognized deep link host: \(host ?? "nil") in \(url.absoluteString)")
+            hostLogger.warning("Unrecognized deep link host: \(host ?? "nil") (scheme=\(url.scheme ?? "nil"))")
         }
     }
 
     private func handleBootstrapLink(_ url: URL) {
         // BootstrapConfig.parse() already handles tcfs://bootstrap?data=<base64>
         guard let config = BootstrapConfig.parse(url.absoluteString) else {
-            hostLogger.error("Failed to parse bootstrap deep link: \(url.absoluteString)")
+            hostLogger.error("Rejected invalid bootstrap deep link; storage endpoint must use HTTPS")
             return
         }
 
@@ -58,14 +58,14 @@ struct TCFSApp: App {
             salt: config.encryption_salt ?? ""
         )
 
-        hostLogger.info("Bootstrap config saved via deep link (endpoint=\(config.s3_endpoint))")
+        hostLogger.info("Bootstrap config saved via deep link")
     }
 
     private func handleEnrollLink(_ url: URL) {
         // Extract the data query parameter, matching QRScannerView's parsing
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let dataParam = components.queryItems?.first(where: { $0.name == "data" })?.value else {
-            hostLogger.error("Enroll deep link missing 'data' parameter: \(url.absoluteString)")
+            hostLogger.error("Enroll deep link missing data parameter")
             return
         }
 

--- a/swift/ios/HostApp/QREnrollmentView.swift
+++ b/swift/ios/HostApp/QREnrollmentView.swift
@@ -11,7 +11,7 @@ private let enrollLogger = Logger(subsystem: "io.tinyland.tcfs.ios", category: "
 /// ```json
 /// {
 ///   "type": "tcfs-bootstrap",
-///   "s3_endpoint": "http://212.2.245.145:8333",
+///   "s3_endpoint": "https://storage.example.com",
 ///   "s3_bucket": "tcfs",
 ///   "access_key": "...",
 ///   "s3_secret": "...",
@@ -66,6 +66,8 @@ struct BootstrapConfig: Codable {
 
     /// Try to parse from a scanned QR string.
     /// Supports: raw JSON, base64-encoded JSON, or `tcfs://bootstrap?data=<base64>` deep link.
+    /// All accepted payloads require an HTTPS storage endpoint so no caller can
+    /// save credentials that the iOS FileProvider will later reject.
     static func parse(_ raw: String) -> BootstrapConfig? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -97,7 +99,11 @@ struct BootstrapConfig: Codable {
 
     private static func decodeJSON(_ json: String) -> BootstrapConfig? {
         guard let data = json.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(BootstrapConfig.self, from: data)
+        guard let config = try? JSONDecoder().decode(BootstrapConfig.self, from: data),
+              isSecureStorageEndpoint(config.s3_endpoint) else {
+            return nil
+        }
+        return config
     }
 
     private static func decodeBase64(_ encoded: String) -> BootstrapConfig? {
@@ -107,11 +113,26 @@ struct BootstrapConfig: Codable {
             // Pad if needed
             let padded = candidate.padding(toLength: ((candidate.count + 3) / 4) * 4, withPad: "=", startingAt: 0)
             if let data = Data(base64Encoded: padded),
-               let config = try? JSONDecoder().decode(BootstrapConfig.self, from: data) {
+               let config = try? JSONDecoder().decode(BootstrapConfig.self, from: data),
+               isSecureStorageEndpoint(config.s3_endpoint) {
                 return config
             }
         }
         return nil
+    }
+
+    static func isSecureStorageEndpoint(_ endpoint: String) -> Bool {
+        guard let components = URLComponents(string: endpoint),
+              components.scheme?.lowercased() == "https",
+              let host = components.host,
+              !host.isEmpty,
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil else {
+            return false
+        }
+        return true
     }
 }
 
@@ -323,12 +344,12 @@ struct QREnrollmentView: View {
         scannedData = value
         isProcessing = true
 
-        enrollLogger.info("QR scanned: \(value.prefix(50))...")
+        enrollLogger.info("Enrollment QR scanned (payload bytes=\(value.utf8.count))")
 
         guard let config = BootstrapConfig.parse(value) else {
             DispatchQueue.main.async {
                 isProcessing = false
-                errorMessage = "QR code is not a valid TCFS bootstrap config.\n\nExpected JSON with s3_endpoint, s3_bucket, access_key, s3_secret."
+                errorMessage = "QR code is not a valid TCFS bootstrap config.\n\nExpected JSON with an https:// s3_endpoint, s3_bucket, access_key, and s3_secret."
             }
             return
         }
@@ -379,7 +400,7 @@ struct QREnrollmentView: View {
             salt: config.encryption_salt ?? ""
         )
 
-        enrollLogger.info("Bootstrap config saved to keychain (endpoint=\(config.s3_endpoint), bucket=\(config.s3_bucket))")
+        enrollLogger.info("Bootstrap config saved to keychain")
 
         DispatchQueue.main.async {
             isProcessing = false

--- a/swift/ios/HostApp/QRScannerView.swift
+++ b/swift/ios/HostApp/QRScannerView.swift
@@ -219,7 +219,7 @@ struct QRScannerView: View {
         isProcessing = true
 
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        scannerLogger.info("QR scanned: \(trimmed.prefix(30))...")
+        scannerLogger.info("QR scanned (payload bytes=\(trimmed.utf8.count))")
 
         // Route based on payload type to avoid sending raw JSON to base64 decoder.
         // Bootstrap configs (raw JSON or tcfs://bootstrap deep links) must be parsed
@@ -238,7 +238,7 @@ struct QRScannerView: View {
             } else {
                 DispatchQueue.main.async {
                     self.isProcessing = false
-                    self.errorMessage = "QR contains JSON but is not a valid TCFS bootstrap config or enrollment invite.\n\nExpected fields: s3_endpoint, s3_bucket, access_key, s3_secret."
+                    self.errorMessage = "QR contains JSON but is not a valid TCFS bootstrap config or enrollment invite.\n\nBootstrap storage endpoints must use https://."
                 }
             }
             return
@@ -268,7 +268,7 @@ struct QRScannerView: View {
         } else {
             DispatchQueue.main.async {
                 self.isProcessing = false
-                self.errorMessage = "Invalid bootstrap QR code. Could not decode configuration data."
+                self.errorMessage = "Invalid bootstrap QR code. The payload must decode successfully and its storage endpoint must use https://."
             }
         }
     }
@@ -296,7 +296,7 @@ struct QRScannerView: View {
             salt: config.encryption_salt ?? ""
         )
 
-        scannerLogger.info("Bootstrap config saved via scanner (endpoint=\(config.s3_endpoint))")
+        scannerLogger.info("Bootstrap config saved via scanner")
 
         DispatchQueue.main.async {
             self.isProcessing = false

--- a/swift/ios/Scripts/gen-bootstrap-qr.sh
+++ b/swift/ios/Scripts/gen-bootstrap-qr.sh
@@ -2,11 +2,13 @@
 # Generate a TCFS bootstrap QR code for iOS device enrollment.
 #
 # Usage:
-#   ./gen-bootstrap-qr.sh                    # uses sops-nix secrets from current host
+#   TCFS_S3_ENDPOINT=https://storage.example.com ./gen-bootstrap-qr.sh
+#                                             # uses sops-nix secrets from current host
 #   ./gen-bootstrap-qr.sh --device-id myphone
 #
 # Requires: qrencode (brew install qrencode)
 set -euo pipefail
+umask 077
 
 DEVICE_ID="${1:-ios-$(hostname -s | tr '[:upper:]' '[:lower:]')}"
 
@@ -34,12 +36,32 @@ fi
 
 # Read endpoint + bucket from tcfs config
 CONFIG="${HOME}/.config/tcfs/config.toml"
+CONFIG_ENDPOINT=""
+CONFIG_BUCKET=""
 if [ -f "$CONFIG" ]; then
-    ENDPOINT=$(grep '^endpoint' "$CONFIG" | head -1 | sed 's/.*= *"//;s/".*//')
-    BUCKET=$(grep '^bucket' "$CONFIG" | head -1 | sed 's/.*= *"//;s/".*//')
-else
-    ENDPOINT="${TCFS_S3_ENDPOINT:-http://212.2.245.145:8333}"
-    BUCKET="tcfs"
+    CONFIG_ENDPOINT=$(grep '^endpoint' "$CONFIG" | head -1 | sed 's/.*= *"//;s/".*//' || true)
+    CONFIG_BUCKET=$(grep '^bucket' "$CONFIG" | head -1 | sed 's/.*= *"//;s/".*//' || true)
+fi
+ENDPOINT="${TCFS_S3_ENDPOINT:-$CONFIG_ENDPOINT}"
+BUCKET="${TCFS_S3_BUCKET:-${CONFIG_BUCKET:-tcfs}}"
+
+if [ -z "$ENDPOINT" ]; then
+    echo "ERROR: an HTTPS storage endpoint is required; set TCFS_S3_ENDPOINT or configure storage.endpoint" >&2
+    exit 1
+fi
+case "$ENDPOINT" in
+    https://*) ;;
+    *)
+        echo "ERROR: iOS bootstrap storage endpoint must use https://" >&2
+        exit 1
+        ;;
+esac
+ENDPOINT_AUTHORITY="${ENDPOINT#https://}"
+ENDPOINT_AUTHORITY="${ENDPOINT_AUTHORITY%%/*}"
+if [ -z "$ENDPOINT_AUTHORITY" ] || [[ "$ENDPOINT_AUTHORITY" == *"@"* ]] || \
+   [[ "$ENDPOINT" == *"?"* ]] || [[ "$ENDPOINT" == *"#"* ]]; then
+    echo "ERROR: iOS bootstrap storage endpoint must be an HTTPS URL without userinfo, query, or fragment" >&2
+    exit 1
 fi
 
 # Read encryption passphrase from sops-nix secret file (optional — plaintext mode if absent)
@@ -51,7 +73,7 @@ fi
 # Read encryption salt: env var > config.toml [crypto] section > empty (plaintext mode)
 ENCRYPTION_SALT="${TCFS_ENCRYPTION_SALT:-}"
 if [ -z "$ENCRYPTION_SALT" ] && [ -f "$CONFIG" ]; then
-    ENCRYPTION_SALT=$(grep '^salt' "$CONFIG" | head -1 | sed 's/.*= *"//;s/".*//')
+    ENCRYPTION_SALT=$(grep '^salt' "$CONFIG" | head -1 | sed 's/.*= *"//;s/".*//' || true)
 fi
 
 # Build encryption JSON fields (omitted entirely if passphrase is empty)
@@ -115,21 +137,22 @@ else
 fi
 echo ""
 
-if command -v qrencode &>/dev/null; then
-    OUT="/tmp/tcfs-bootstrap-qr.png"
-    echo "$JSON" | qrencode -o "$OUT" -s 8 -l H
-    echo "==> QR code saved to: $OUT"
+if ! command -v qrencode &>/dev/null; then
+    echo "ERROR: qrencode is required; refusing to print credential-bearing bootstrap JSON" >&2
+    echo "Install it with 'brew install qrencode' (macOS) or your system package manager." >&2
+    exit 1
+fi
 
-    # Try to open it
-    if command -v open &>/dev/null; then
-        open "$OUT"
-    elif command -v xdg-open &>/dev/null; then
-        xdg-open "$OUT"
-    fi
-else
-    echo "==> Install qrencode to generate QR image:"
-    echo "    brew install qrencode"
-    echo ""
-    echo "==> Raw JSON (paste into any QR generator):"
-    echo "$JSON"
+OUT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tcfs-bootstrap-qr.XXXXXX")
+chmod 700 "$OUT_DIR"
+OUT="$OUT_DIR/bootstrap.png"
+printf '%s\n' "$JSON" | qrencode -o "$OUT" -s 8 -l H
+chmod 600 "$OUT"
+echo "==> QR code saved to: $OUT"
+
+# Try to open it
+if command -v open &>/dev/null; then
+    open "$OUT"
+elif command -v xdg-open &>/dev/null; then
+    xdg-open "$OUT"
 fi

--- a/tests/e2e/tests/fleet_live.rs
+++ b/tests/e2e/tests/fleet_live.rs
@@ -10,6 +10,7 @@
 //! Run:
 //!   TCFS_E2E_LIVE=1 \
 //!   TCFS_S3_ENDPOINT=http://seaweedfs-tcfs:8333 \
+//!   TCFS_STORAGE_ALLOW_INSECURE_HTTP=true \
 //!   TCFS_S3_BUCKET=tcfs \
 //!   AWS_ACCESS_KEY_ID=<from k8s secret seaweedfs-admin> \
 //!   AWS_SECRET_ACCESS_KEY=<from k8s secret seaweedfs-admin> \
@@ -45,7 +46,7 @@ fn s3_endpoint() -> String {
 }
 
 fn broken_s3_endpoint() -> String {
-    std::env::var("TCFS_S3_BROKEN_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:1".into())
+    std::env::var("TCFS_S3_BROKEN_ENDPOINT").unwrap_or_else(|_| "https://127.0.0.1:1".into())
 }
 
 fn s3_bucket() -> String {
@@ -54,6 +55,24 @@ fn s3_bucket() -> String {
 
 fn nats_url() -> String {
     std::env::var("TCFS_NATS_URL").unwrap_or_else(|_| "nats://nats-tcfs:4222".into())
+}
+
+fn parse_explicit_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" => Some(true),
+        "0" | "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn storage_allow_insecure_http() -> bool {
+    const NAME: &str = "TCFS_STORAGE_ALLOW_INSECURE_HTTP";
+    match std::env::var(NAME) {
+        Ok(value) => parse_explicit_bool(&value)
+            .unwrap_or_else(|| panic!("{NAME} must be one of true, false, 1, or 0; got {value:?}")),
+        Err(std::env::VarError::NotPresent) => false,
+        Err(error) => panic!("reading {NAME}: {error}"),
+    }
 }
 
 fn sample_state_event(
@@ -167,10 +186,28 @@ fn live_operator_for_endpoint(endpoint: &str) -> Option<opendal::Operator> {
         bucket,
         access_key_id: access,
         secret_access_key: secret,
+        allow_insecure_http: storage_allow_insecure_http(),
         ..Default::default()
     };
 
-    tcfs_storage::operator::build_operator(&config).ok()
+    Some(
+        tcfs_storage::operator::build_operator(&config).unwrap_or_else(|error| {
+            panic!(
+                "S3 operator rejected endpoint {endpoint}: {error:#}. Set \
+             TCFS_STORAGE_ALLOW_INSECURE_HTTP=true only for an isolated \
+             development/test HTTP endpoint."
+            )
+        }),
+    )
+}
+
+#[test]
+fn insecure_http_env_parser_is_explicit_and_false_by_default() {
+    assert_eq!(parse_explicit_bool("true"), Some(true));
+    assert_eq!(parse_explicit_bool("1"), Some(true));
+    assert_eq!(parse_explicit_bool(" false "), Some(false));
+    assert_eq!(parse_explicit_bool("0"), Some(false));
+    assert_eq!(parse_explicit_bool("yes"), None);
 }
 
 async fn cleanup_upload_objects(


### PR DESCRIPTION
## Outcome

- Requires HTTPS by default in core, daemon, CLI, and direct FileProvider storage construction.
- Rejects HTTPS-to-HTTP redirect downgrades unless an explicit development-only compatibility flag is enabled.
- Carries an explicit strict boolean through generated FileProvider JSON so ambient environment cannot weaken a strict config.
- Rejects insecure iOS bootstrap and invite endpoints before credentials are saved.
- Makes QR generation fail closed, secret-safe, and permission-bounded; the regression harness runs from an empty environment.

## Validation

- Rust format and diff checks
- Core, storage, FileProvider, CLI, daemon-config, and non-live E2E parser tests
- FileProvider tests with UniFFI enabled
- Changed-package Clippy with warnings denied
- FileProvider provisioning and iOS bootstrap shell regressions
- Independent adversarial review: P0 none, P1 none

## Claim boundary

This is source-only transport hardening. It does not provision a fleet TLS endpoint, deploy to Neo or Honey, or prove a live migration canary. Direct FileProvider private-CA propagation and secure signed enrollment remain separate follow-ups. The active credential-incident freeze remains in force.

Linear: TIN-2854