### PR TITLE
docs: pointer fixes + spine enumeration from big-picture synthesis (D-2..D-7)

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,6 +1,9 @@
 exclude = [
   "^https://github.com/tinyland-inc/tummycrypt/compare",
   "^https://github.com/tinyland-inc/remote-juggler",
+  # Private repos: unauthenticated/repo-scoped link checks see 404.
+  "^https://github.com/tinyland-inc/rockies",
+  "^https://github.com/Jesssullivan/prompts-enqueue",
   "^https://nix-cache.fuzzy-dev.tinyland.dev",
   "^https://docs.tummycrypt.io",
   "^https://developer.apple.com/documentation/fskit$",

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -38,6 +38,8 @@ not need a manual copy step.
 One full repository has a proven `neo → honey` roam, and automatic divergent
 keep-both has a two-host live proof. Arbitrary repositories, sessions, and
 linked worktrees remain outside the claim.
+Live production status of the .git conflict gate: see
+[ops/current.md](ops/current.md) (TIN-2658).
 
 ### Hydrate and release space
 
@@ -66,13 +68,13 @@ TCFS is one range in a larger remote-first system:
 
 | Program or component | Responsibility |
 | --- | --- |
-| **Cordillera** | Remote-everything umbrella and cross-project product program |
-| **Rockies** | OS composition, host policy, enrollment, and fleet rollout |
+| **[Cordillera](https://linear.app/tinyland/initiative/cordillera-tinyland-remote-everything-program-15f56b187c19)** | Remote-everything umbrella and cross-project product program |
+| **[Rockies](https://github.com/tinyland-inc/rockies)** | OS composition, host policy, enrollment, and fleet rollout |
 | **TCFS** | Encrypted persistent state, roam, hydration, conflict safety, and local unsync |
 | **SSH / cmux** | Terminal and live-process transport |
 | **IDE routing** | Host-aware editor connection and cwd mapping |
-| **GloriousFlywheel** | Remote build and execution substrate |
-| **prompts-enqueue** | Prompt and context library; not the file transport or dispatcher |
+| **[GloriousFlywheel](https://github.com/tinyland-inc/GloriousFlywheel)** | Remote build and execution substrate |
+| **[prompts-enqueue](https://github.com/Jesssullivan/prompts-enqueue)** | Prompt and context library; not the file transport or dispatcher |
 | **APFS / FUSE / FileProvider / NFS / CFAPI** | Platform substrates and client surfaces |
 
 APFS is therefore neither a TCFS competitor nor proof of TCFS performance. It

--- a/docs/ops/current.md
+++ b/docs/ops/current.md
@@ -105,9 +105,15 @@ The full ceremony and root invariants are in
    second cycle.
 9. **Fleet coherence.** Bring sting to the selected release and root topology;
    leave Bumble as the tracker-defined formal third-host acceptance.
-10. **Truth cleanup.** Keep the five-document product spine current and rebase
-   or supersede stale vision PR
-   [#543](https://github.com/Jesssullivan/tummycrypt/pull/543).
+10. **Truth cleanup.** Keep the five-document product spine current:
+   [docs/VISION.md](../VISION.md), [docs/PRODUCT.md](../PRODUCT.md),
+   docs/ops/current.md (this document),
+   [docs/platform-support.md](../platform-support.md), and
+   [docs/release/evidence/README.md](../release/evidence/README.md). Stale
+   vision PR [#543](https://github.com/Jesssullivan/tummycrypt/pull/543)
+   closed unmerged; the vision landed via
+   [#549](https://github.com/Jesssullivan/tummycrypt/pull/549)
+   (commit `3e86016`).
 
 ## Gates that remain red
 

--- a/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
+++ b/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
@@ -1,3 +1,5 @@
+> Superseded for live status by [docs/ops/current.md](current.md) — retained as a dated record.
+
 # TCFS Large Workdir → Daily Driver Sequencing - 2026-05-30
 
 Status: operator-directed re-sequencing of the `TIN-1617` large-workdir

--- a/docs/ops/product-reality-and-priority.md
+++ b/docs/ops/product-reality-and-priority.md
@@ -1,3 +1,5 @@
+> Superseded for live status by [docs/ops/current.md](current.md) — retained as a dated record.
+
 # Product Reality And Priority
 
 > 2026-07-06 update: this document is historical posture, not the current

--- a/docs/release/evidence/README.md
+++ b/docs/release/evidence/README.md
@@ -80,3 +80,16 @@ former exhaustive May 2026 table at commit
 
 Do not delete or edit packet contents as documentation cleanup. Add a new packet
 or update this ledger when a stronger proof lands.
+
+## Packets after 2026-05-31
+
+Later proof records increasingly live in Linear rather than this tree:
+
+- The forward-roam zero-diff `neo → honey` proof (2026-06-09) and the G5
+  divergent keep-both closure (2026-07-08) are recorded under
+  [TIN-1620](https://linear.app/tinyland/issue/TIN-1620).
+- The TIN-2658 production-loop work (2026-07-14) is recorded on
+  [TIN-2658](https://linear.app/tinyland/issue/TIN-2658).
+- Untagged v0.12.15 ([#514](https://github.com/Jesssullivan/tummycrypt/pull/514))
+  and v0.12.16 ([#522](https://github.com/Jesssullivan/tummycrypt/pull/522))
+  shipped roam-critical work that is not visible in `gh release list`.

--- a/docs/rfc/0001-fleet-sync-integration.md
+++ b/docs/rfc/0001-fleet-sync-integration.md
@@ -1,3 +1,5 @@
+> Superseded for live status by [docs/ops/current.md](../ops/current.md) — retained as a dated record.
+
 # RFC 0001: Fleet Sync Integration for Lab Machines
 
 **Status**: Implemented (v0.3.0)


### PR DESCRIPTION
Pointer-shaped doc fixes from the big-picture synthesis. No content restatement — links only.

- **D-2** `docs/VISION.md`: the bounded keep-both claim now points to [ops/current.md](docs/ops/current.md) (TIN-2658) for live production status of the .git conflict gate.
- **D-3** `docs/VISION.md` ranges table: Cordillera, Rockies, GloriousFlywheel, and prompts-enqueue cells are now navigable links; wording unchanged.
- **D-4** `docs/release/evidence/README.md`: "Packets after 2026-05-31" addendum — later proof records live under TIN-1620 (2026-06-09 zero-diff roam, 2026-07-08 G5 keep-both closure) and TIN-2658 (2026-07-14 production loop); notes untagged v0.12.15 (#514) and v0.12.16 (#522) shipped roam-critical work invisible to `gh release list`.
- **D-5** staleness banners pointing to `docs/ops/current.md` prepended to `docs/ops/product-reality-and-priority.md`, `docs/rfc/0001-fleet-sync-integration.md`, and `docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md`.
- **D-6** `docs/ops/current.md` item 10: #543 closed unmerged — pointer corrected to the vision landing via #549 (commit `3e86016`).
- **D-7** `docs/ops/current.md` item 10: five-document product spine enumerated (VISION, PRODUCT, ops/current, platform-support, release/evidence README); all five verified present at `origin/main`.

Deviation: `.lychee.toml` gained excludes for `tinyland-inc/rockies` and `Jesssullivan/prompts-enqueue` — both are private, so the docs link check (repo-scoped token) would 404 on the new D-3 links; follows the existing `remote-juggler` exclusion pattern.
