### PR TITLE
docs(ops): TIN-2856 credential-rotation ceremony runbook (freeze-safe prep)

### DIFF
--- a/docs/ops/tin2856-credential-rotation-ceremony-2026-07-16.md
+++ b/docs/ops/tin2856-credential-rotation-ceremony-2026-07-16.md
@@ -119,14 +119,14 @@ host before rotating (Phase 0 inventory).
     (TIN-2306 stop-rule is next; see the TIN-2306 runbook and its `[CRED]` convention,
     docs/ops/tin2306-stop-rule-runbook-2026-07-14.md, PR #554).
 
-## Operator decisions (interviewed before the secret gates run)
+## Operator decisions — RATIFIED (2026-07-16 interview)
 
-| # | Decision | Options |
+| # | Decision | Ruling |
 |---|---|---|
-| D1 | Fleet GitHub credential shape | fine-grained PAT (fast) vs GitHub App (durable custody; TIN-2801 notes App custody owed for dispatch tokens) |
-| D2 | Forward-secrecy scope | none (accept old-content exposure to the leaked passphrase) / sensitive prefixes / all prefixes (cost from 0.5 dry-run) |
-| D3 | iOS re-issue timing | inside Phase 2 window vs deferred attended session (device offline risk) |
-| D4 | Ceremony window | single attended window for Phases 1+2 vs GitHub leg early + passphrase leg in its own window |
+| D1 | Fleet GitHub credential shape | **Fine-grained PAT**, scoped to org repos + read:packages + workflow as needed. GitHub-App custody for dispatch tokens stays a separate follow-up (TIN-2801). |
+| D2 | Forward-secrecy scope | **None — rewrap only.** Residual accepted: old content remains decryptable to the leaked passphrase only if pre-rotation manifests also leaked; exposure boundary was execution telemetry and no manifest leak is in evidence. Step 2.7 is skipped; step 0.5 sizing optional. |
+| D3 | iOS re-issue timing | Folded into D4's single window (attended). |
+| D4 | Ceremony window | **One combined attended window** for Phases 1+2, once #557 and the `--new-key-file` PR (#558) are green and reviewed. The same window also restores neo's YubiKey-dependent surfaces (GPG signing, SSH-to-GitHub), both broken since the 2026-07-15 crash. |
 
 ## Related runbooks (linked, not duplicated)
 

--- a/docs/ops/tin2856-credential-rotation-ceremony-2026-07-16.md
+++ b/docs/ops/tin2856-credential-rotation-ceremony-2026-07-16.md
@@ -61,10 +61,11 @@ host before rotating (Phase 0 inventory).
 ### Phase 0 — stage during freeze (all `[PREP-SAFE-NOW]`)
 
 0.1 Confirm freeze posture: `LAB_DEPLOY_FREEZE` set; lab#825 gate live.
-0.2 Land `tcfs rotate-key --new-key-file` (tummycrypt PR; merge ≠ deploy; **no tag or
+0.2 Land `tcfs rotate-key --new-key-file` — **PR #558** (merge ≠ deploy; **no tag or
     release under the freeze**). Fallback if not landed: pending-file pre-seed above.
-0.3 Fix lab `docs/operations/tcfs-fileprovider-deploy.md` — replace the "`cat` the key
-    file" instruction with metadata-only checks (lab PR).
+0.3 ~~Fix lab `docs/operations/tcfs-fileprovider-deploy.md` `cat` guidance~~ —
+    **already corrected on lab main** (verified 2026-07-16: the doc now forbids `cat`/
+    xtrace/pretty-printers on the key material; landed via lab#844's containment slice).
 0.4 Read-only inventory on each host (neo/honey/bumble): file modes and presence for
     every row above; `launchctl` posture for TIN-1954 (redacted output only); confirm
     no host is on the passphrase-Argon2id or FP-mnemonic derivation path.

--- a/docs/ops/tin2856-credential-rotation-ceremony-2026-07-16.md
+++ b/docs/ops/tin2856-credential-rotation-ceremony-2026-07-16.md
@@ -1,0 +1,140 @@
+# TIN-2856 Credential-Rotation Ceremony — Runbook (2026-07-16)
+
+**Status:** DESIGNED-ONLY (ceremony not yet executed; this document is the plan).
+**Owner:** operator (Jess). Agents may stage `[PREP-SAFE-NOW]` steps; every
+`[SECRET-GATE]` step is operator-executed, attended, and interviewed before it runs.
+**Incident:** TIN-2856 (TCFS encryption passphrase exposed to agent execution logs via
+`bash -x` inheriting `TCFS_ENCRYPTION_KEY_FILE`, 2026-07-14), child of TIN-2801
+(PR lab#721 shell-expanded env leak). Fold-ins: the dead fleet GitHub token
+(TIN-2801 comment `42205716`), stale LaunchAgent exposure (TIN-1954), and the
+QR-invite plaintext caveat (TIN-1424 — the new passphrase inherits the same QR
+weakness until that ticket closes).
+**Freeze:** `LAB_DEPLOY_FREEZE` + nix-deploy gate (lab#825) stay in force until
+TIN-2801 closes. This ceremony is itself the unfreezing act for the TCFS legs; it
+blocks TIN-2306, TIN-2658 close-out, TIN-1903/1904, TIN-1620, TIN-1546.
+
+This runbook does not restate the incident analysis — see TIN-2856's description and
+its 2026-07-14 consumer-map comment, and TIN-2801's per-provider ledger. It defines
+the *order of operations* and the *safety invariants*.
+
+## The one invariant that can fork the fleet
+
+The deployed unlock wrapper (lab `nix/home-manager/tummycrypt.nix`, unlock section)
+derives the daemon master key as **SHA-256 of the passphrase-file bytes** and
+**re-derives it on every unlock**. `tcfs rotate-key` as shipped mints its new key from
+a mnemonic or `--password` via Argon2id + random salt. Rotating with a minted key
+therefore diverges from what the wrapper re-derives at next login → **split-key
+fleet** (explicitly forbidden by TIN-2856's acceptance).
+
+Rule: **the new master key MUST equal SHA-256(new SOPS passphrase file bytes,
+byte-for-byte, including any trailing newline).** Two ways to satisfy it:
+
+1. `tcfs rotate-key --new-key-file <path>` — exact-key input
+   (staged for this ceremony; see Phase 0).
+2. Fallback with the shipped binary only: pre-seed the resume path — write the
+   wrapper-derived key into `.master.key.rotate-pending` (0600) with a matching
+   `.master.key.rotate-state.json`; `prepare_key_rotation` then consumes it.
+
+Three passphrase→key derivations coexist and must stay convergent through the
+ceremony: wrapper = SHA-256(file bytes); daemon/CLI `passphrase_file` fallback =
+Argon2id + `crypto.kdf_salt` (`crates/tcfsd/src/daemon.rs`,
+`crates/tcfs-crypto/src/recovery.rs`); FileProvider-direct = key/base64/mnemonic/
+Argon2id + `encryption_salt` (`crates/tcfs-file-provider/src/direct.rs`). The fleet's
+live path is the wrapper one; verify the other two are not silently in use on any
+host before rotating (Phase 0 inventory).
+
+## Credential inventory (paths and mechanisms only — never values)
+
+| Material | Where | Mechanism |
+|---|---|---|
+| TCFS passphrase (leaked) | lab SOPS `nix/secrets/common.yaml` → `tcfs/encryption_passphrase`; materialized at `~/.config/sops-nix/secrets/tcfs/encryption_passphrase` (0400) | sops-nix; exported as `TCFS_ENCRYPTION_KEY_FILE` |
+| Derived master key | `~/.local/state/tcfsd/master.key` (0600) | wrapper SHA-256(file bytes); `crypto.master_key_file` in `~/.config/tcfs/config.toml`; daemon auto-loads |
+| FP plaintext embed | `~/.config/tcfs/fileprovider/config.json` (0600) | regenerated each HM activation with `encryption_passphrase` + `encryption_salt` |
+| Keychain | macOS service `tcfs`: `master-key`, `device-identity`, `session-token` (`crates/tcfs-secrets/src/keychain.rs`) | check existence during inventory; do not print |
+| iOS | Keychain + QR bootstrap payload (TIN-1424) | attended re-issue lane |
+| Fleet GitHub token (dead) | lab SOPS `api.github_token` → `~/.config/sops-nix/secrets/api/github_token`; `GH_TOKEN`/`GITHUB_TOKEN` via secret-vars; `/etc/nix/nix.custom.conf` `access-tokens` (root-owned); Actions `PERSONAL_PAT`, Dependabot, dispatch-token set | old token revoked 2026-07-13; interim = operator keyring OAuth; durable fix owed = least-privilege fleet credential |
+| Operator TOTP vault | `~/.local/state/tcfs-operator/tcfs-totp.kdbx` + `.keyx` | not implicated; frozen-class ceremonies only |
+| Stray path propagation | `dev.tinyland.prompt-pulse` LaunchAgent carries the key-file path (non-consumer); `/Library/LaunchAgents/io.tinyland.tcfsd` staleness (TIN-1954) | retire in Phase 2 step 16 |
+
+## Ceremony
+
+### Phase 0 — stage during freeze (all `[PREP-SAFE-NOW]`)
+
+0.1 Confirm freeze posture: `LAB_DEPLOY_FREEZE` set; lab#825 gate live.
+0.2 Land `tcfs rotate-key --new-key-file` (tummycrypt PR; merge ≠ deploy; **no tag or
+    release under the freeze**). Fallback if not landed: pending-file pre-seed above.
+0.3 Fix lab `docs/operations/tcfs-fileprovider-deploy.md` — replace the "`cat` the key
+    file" instruction with metadata-only checks (lab PR).
+0.4 Read-only inventory on each host (neo/honey/bumble): file modes and presence for
+    every row above; `launchctl` posture for TIN-1954 (redacted output only); confirm
+    no host is on the passphrase-Argon2id or FP-mnemonic derivation path.
+0.5 Optional sizing: `tcfs key rotate <prefix>` (dry-run by default) to estimate
+    forward-secrecy re-encryption cost for candidate prefixes.
+
+### Phase 1 — GitHub token leg (first: restores evidence capture)
+
+1.1 `[SECRET-GATE]` Mint the least-privilege fleet credential (fine-grained PAT vs
+    GitHub App — operator decision D1 below).
+1.2 `[SECRET-GATE]` `sops` edit `api.github_token`; HM switch **neo → honey → pzm**
+    (folds the owed runtime convergence); root-edit `/etc/nix/nix.custom.conf`
+    `access-tokens`; update `PERSONAL_PAT`/Dependabot/dispatch secrets; restart MCP
+    consumers. (Note lab branch `security/credential-rotation-20260715` already stages
+    a `common.yaml` refresh — rebase or supersede, don't double-project.)
+1.3 Verify: `gh api /user` 200 with the new credential on each host; private flake
+    fetch OK; old fingerprint absent from runtime env everywhere.
+
+### Phase 2 — TCFS passphrase leg (the unfreezing act)
+
+2.1 `[SECRET-GATE]` Generate the new passphrase offline; `sops` edit
+    `tcfs/encryption_passphrase`; **do not HM-switch yet**.
+2.2 `[SECRET-GATE]` Derive the new master exactly as the wrapper does
+    (SHA-256 of the *file bytes*); stage as `rotate-key` input.
+2.3 Quiesce honey/bumble sync — single writer during manifest rewrite.
+2.4 `[SECRET-GATE]` On neo:
+    `tcfs rotate-key --old-key-file ~/.local/state/tcfsd/master.key --new-key-file …`
+    Expect **zero** per-device/keyless skips (fleet `wrap_mode=master`); any skip is a
+    stop-the-line finding. Resumable via the pending/state files if interrupted.
+2.5 `[SECRET-GATE]` Per host neo → honey → bumble: HM switch (new passphrase
+    materializes → wrapper re-derives `master.key` → FP `config.json` regenerates);
+    iOS re-issue via the attended lane (TIN-1424 caveat applies to the new QR).
+2.6 Verify per host: daemon unlock + encrypted round-trip; **negative test — the old
+    derived key must be rejected**; capture the evidence packet
+    (docs/release/evidence/ convention).
+2.7 `[SECRET-GATE]` Decision D2: forward secrecy — master rotate re-wraps key-wrapping
+    only; content keys are unchanged, so pre-rotation manifest copies + the leaked
+    passphrase still decrypt old content. Run
+    `tcfs key rotate <prefix> --rotate-keys` for prefixes whose pre-rotation manifests
+    may persist anywhere untrusted.
+2.8 Retire: purge stale derived-key/FP-config copies; drop the `prompt-pulse` key-file
+    path and resolve TIN-1954's LaunchAgent posture; sweep retained execution
+    artifacts for any second passphrase copy; record the retention/deletion boundary
+    (TIN-2856 acceptance).
+
+### Phase 3 — close-out
+
+3.1 Close TIN-2856 (rotation owner clears the child).
+3.2 Remaining TIN-2801 gates: Stripe live-key dashboard roll `[SECRET-GATE,
+    operator-only]` + the residual provider list in the TIN-2801 ledger.
+3.3 TIN-2801 → Done; delete `LAB_DEPLOY_FREEZE`; resume the gate ladder
+    (TIN-2306 stop-rule is next; see the TIN-2306 runbook and its `[CRED]` convention,
+    docs/ops/tin2306-stop-rule-runbook-2026-07-14.md, PR #554).
+
+## Operator decisions (interviewed before the secret gates run)
+
+| # | Decision | Options |
+|---|---|---|
+| D1 | Fleet GitHub credential shape | fine-grained PAT (fast) vs GitHub App (durable custody; TIN-2801 notes App custody owed for dispatch tokens) |
+| D2 | Forward-secrecy scope | none (accept old-content exposure to the leaked passphrase) / sensitive prefixes / all prefixes (cost from 0.5 dry-run) |
+| D3 | iOS re-issue timing | inside Phase 2 window vs deferred attended session (device offline risk) |
+| D4 | Ceremony window | single attended window for Phases 1+2 vs GitHub leg early + passphrase leg in its own window |
+
+## Related runbooks (linked, not duplicated)
+
+- docs/ops/tin2306-stop-rule-runbook-2026-07-14.md (PR #554) — downstream gate; source
+  of the `[CRED]` gating convention.
+- lab `docs/operations/token-rotation.md` — Attic-specific and flagged inaccurate for
+  the stateless-JWT reality (TIN-2814 / lab#822); pattern reference only.
+- lab `docs/operations/tailscale-api-key-rotation.md` (TIN-2639 lane, separate),
+  `step-ca-root-rotation-dr.md`, `SECRETS_SCHEMA.md`.
+- docs/ops/per-device-crypto-migration-2026-06-06.md and
+  docs/ops/onprem-authority-recovery.md — wrap-mode/authority context.

--- a/docs/release/evidence/tin2856-phase04-inventory-20260716T0850Z/inventory.md
+++ b/docs/release/evidence/tin2856-phase04-inventory-20260716T0850Z/inventory.md
@@ -1,0 +1,64 @@
+# TIN-2856 Phase 0.4 — Fleet Credential Inventory
+
+- **Mode**: STRICTLY READ-ONLY, METADATA-ONLY. No secret values were read, printed, or collected. Only paths, existence, octal modes, sizes (bytes), and mtimes.
+- **Date collected**: 2026-07-16 (local neo time; honey/bumble timestamps in -0400)
+- **Hosts**: neo (macOS, local), honey (Linux, ssh), bumble (Linux, ssh)
+- **Runbook**: tummycrypt PR #557 rotation-ceremony, Phase 0.4
+
+## Anomaly flags
+
+| # | Severity | Anomaly |
+|---|----------|---------|
+| A1 | ~~HIGH~~ **FALSE POSITIVE** | `~/.config/tcfs/config.toml` "777" on honey/bumble was the **symlink's** mode (stat without -L). Verified with `stat -L` + `readlink -f`: both are home-manager store symlinks → `/nix/store/*-hm_tcfsconfig.toml`, target mode **444 read-only** (honey 1460 B, bumble 1459 B). Not writable by anyone. |
+| A2 | ~~MED~~ **FALSE POSITIVE** | Same on neo: "755" was the symlink (`lrwxr-xr-x` → `/nix/store/*-home-manager-files/.config/tcfs/config.toml`); target mode **444**, 1555 B. |
+| A3 | MED | TIN-1954 propagation STILL PRESENT: `dev.tinyland.prompt-pulse.plist` contains 2 matches for `TCFS_ENCRYPTION_KEY_FILE|encryption_passphrase` — env var `TCFS_ENCRYPTION_KEY_FILE` is set to the sops-nix `encryption_passphrase` path (path only; value not read). |
+| A4 | INFO | neo Keychain: all three `tcfs` generic-password entries (`master-key`, `device-identity`, `session-token`) **absent** (security exit 44 = item not found). If the runbook expects Keychain-backed material on neo, this is a gap; if file-based is canonical, it is clean posture. |
+| A5 | INFO | Dual tcfsd LaunchAgent plists on neo: root-owned `/Library/LaunchAgents/io.tinyland.tcfsd.plist` (644, 629 B, May 16) coexists with user `~/Library/LaunchAgents/dev.tinyland.tcfsd.plist`. Possible stale system-level agent. |
+| — | PASS | Derivation path uniform fleet-wide: all 3 hosts use `master_key_file` only (wrapper SHA-256 path); **zero** `passphrase_file` or `kdf_salt` keys present anywhere. |
+| — | PASS | All key-material files at expected modes/sizes: passphrase 0400/155 B, master.key 0600/32 B, github_token 0400/40 B on all hosts. tcfsd alive on all hosts. |
+
+## neo (macOS, local)
+
+| Item | Path | Exists | Mode | Size (B) | mtime | Notes |
+|---|---|---|---|---|---|---|
+| sops passphrase | `~/.config/sops-nix/secrets/tcfs/encryption_passphrase` | yes | 400 | 155 | 2026-07-15 22:31:30 | expected 0400 — OK |
+| daemon master key | `~/.local/state/tcfsd/master.key` | yes | 600 | 32 | 2026-07-15 22:32:24 | expected 0600/32 B — OK |
+| tcfs config | `~/.config/tcfs/config.toml` | yes | **755** | 87 | 2026-07-14 14:30:20 | **A2** wrong mode |
+| fileprovider config | `~/.config/tcfs/fileprovider/config.json` | yes | 600 | 490 | 2026-07-14 14:30:36 | macOS-only, expected present |
+| github token | `~/.config/sops-nix/secrets/api/github_token` | yes | 400 | 40 | 2026-07-15 22:31:30 | OK |
+
+- config.toml keys present: `master_key_file = <redacted>` (only key; no `passphrase_file`, no `kdf_salt`) → **master_key_file path — compliant**
+- Keychain (existence-only, no `-g`): `master-key` exit 44 (absent), `device-identity` exit 44 (absent), `session-token` exit 44 (absent) — **A4**
+- LaunchAgents:
+  - `/Library/LaunchAgents/`: `io.tinyland.tcfsd.plist` (rw-r--r--, root, 629 B, May 16) — **A5**
+  - `~/Library/LaunchAgents/`: `dev.tinyland.prompt-pulse.plist`, `dev.tinyland.tcfs-mcp-reaper.plist`, `dev.tinyland.tcfsd-health.plist`, `dev.tinyland.tcfsd-reconcile-claude-projects.plist`, `dev.tinyland.tcfsd-reconcile-git-roam-tool-daemon.plist`, `dev.tinyland.tcfsd.plist`
+  - `dev.tinyland.prompt-pulse.plist` (444, 8810 B, 2026-07-14 09:48:44): grep count for `TCFS_ENCRYPTION_KEY_FILE|encryption_passphrase` = **2** — **A3**. Redacted lines: `<key>TCFS_ENCRYPTION_KEY_FILE</key>` / `<string><path-redacted: sops-nix encryption_passphrase path></string>`
+- `/etc/nix/nix.custom.conf`: `access-tokens` line count = **1** (readable without sudo)
+- Daemon: `tcfsd` **alive**
+
+## honey (Linux)
+
+| Item | Path | Exists | Mode | Size (B) | mtime | Notes |
+|---|---|---|---|---|---|---|
+| sops passphrase | `~/.config/sops-nix/secrets/tcfs/encryption_passphrase` | yes | 400 | 155 | 2026-07-16 04:16:08 -0400 | OK |
+| daemon master key | `~/.local/state/tcfsd/master.key` | yes | 600 | 32 | 2026-07-14 04:44:12 -0400 | OK |
+| tcfs config | `~/.config/tcfs/config.toml` | yes | **777** | 87 | 2026-07-14 04:43:42 -0400 | **A1** world-writable |
+| fileprovider config | `~/.config/tcfs/fileprovider/config.json` | **no** | — | — | — | absent as expected (Linux) |
+| github token | `~/.config/sops-nix/secrets/api/github_token` | yes | 400 | 40 | 2026-07-16 04:16:08 -0400 | OK |
+
+- config.toml keys present: `master_key_file = <redacted>` only → **master_key_file path — compliant**
+- Daemon: `tcfsd` **alive**
+
+## bumble (Linux)
+
+| Item | Path | Exists | Mode | Size (B) | mtime | Notes |
+|---|---|---|---|---|---|---|
+| sops passphrase | `~/.config/sops-nix/secrets/tcfs/encryption_passphrase` | yes | 400 | 155 | 2026-07-14 04:48:58 -0400 | OK |
+| daemon master key | `~/.local/state/tcfsd/master.key` | yes | 600 | 32 | 2026-07-14 04:48:59 -0400 | OK |
+| tcfs config | `~/.config/tcfs/config.toml` | yes | **777** | 87 | 2026-07-14 04:48:48 -0400 | **A1** world-writable |
+| fileprovider config | `~/.config/tcfs/fileprovider/config.json` | **no** | — | — | — | absent as expected (Linux) |
+| github token | `~/.config/sops-nix/secrets/api/github_token` | yes | 400 | 40 | 2026-07-14 04:48:58 -0400 | OK |
+
+- config.toml keys present: `master_key_file = <redacted>` only → **master_key_file path — compliant**
+- Daemon: `tcfsd` **alive**
+- Collection note: bumble's remote shell is fish; POSIX loop syntax fails over ssh — inventory used loop-free stat.


### PR DESCRIPTION
## What

Adds `docs/ops/tin2856-credential-rotation-ceremony-2026-07-16.md` — the operator runbook for the credential-rotation ceremony that clears the fleet freeze (TIN-2856 leaked TCFS passphrase, child of TIN-2801; folds in the dead fleet GitHub token per TIN-2801 comment `42205716`).

Prep-safe under the freeze: docs only, no tag, no release, no deploy-lane change.

## Why now

TIN-2856 blocks TIN-2306, TIN-2658 close-out, TIN-1903/1904, TIN-1620, TIN-1546 — the 2026-07-15 movement review concluded rotation is the program's actual next rung (operator-ratified). This runbook stages every non-secret step and marks every `[SECRET-GATE]` the operator must execute attended.

## Key content

- **The fork invariant**: the deployed unlock wrapper re-derives the daemon master key as SHA-256(passphrase file bytes) on every unlock, so the rotation's new master MUST be supplied exactly — a `rotate-key`-minted (Argon2id) key forks the fleet at next login. Companion PR (in prep) adds `tcfs rotate-key --new-key-file`; the runbook also documents the pending-file pre-seed fallback for the shipped binary.
- Credential inventory (paths/mechanisms only — no values), including the FP plaintext embed, Keychain entries, `/etc/nix/nix.custom.conf` access-tokens, and the stray `prompt-pulse` key-file path (TIN-1954 fold-in).
- Phased ceremony: Phase 0 prep during freeze → Phase 1 GitHub-token leg (restores evidence capture, folds the owed honey/pzm runtime convergence) → Phase 2 passphrase leg with negative-test verification and evidence packet → Phase 3 close-out and freeze lift.
- Operator decision table D1–D4 (credential shape, forward-secrecy scope, iOS re-issue timing, ceremony window) — interviewed before any secret gate runs.

## Notes

- Commit is unsigned: post-crash the YubiKey PIN cache is empty and signing hangs; GitHub's merge commit will be web-flow signed on merge.
- Links, not restatement: incident analysis stays in TIN-2856/TIN-2801; adjacent runbooks (TIN-2306 stop-rule #554, lab token-rotation docs) are linked with their known-inaccuracy flags.

Linear: TIN-2856, TIN-2801
