### PR TITLE
fix(cli): sanitize git_head_oneline repo spawn (TIN-2853)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -8157,8 +8157,12 @@ fn group_conflicts(items: &[(String, tcfs_sync::conflict::ConflictInfo)]) -> Vec
 
 /// Resolve a repo's current HEAD to `<shortsha> <summary>` via
 /// `git log --oneline -1`, or `None` when the repo/HEAD cannot be read.
+///
+/// Spawned through the tcfs-sync sanitizer so repository-local configuration
+/// (hooks, `log.showSignature` + `gpg.program`) synced from another device can
+/// never execute code on the machine listing conflicts (TIN-2853).
 fn git_head_oneline(repo_root: &Path) -> Option<String> {
-    let out = std::process::Command::new("git")
+    let out = tcfs_sync::git_safety::sanitized_git_readonly_command()
         .args(["-C", &repo_root.to_string_lossy(), "log", "--oneline", "-1"])
         .output()
         .ok()?;
@@ -12088,6 +12092,91 @@ enabled = false
         assert!(
             summary.contains("WARNING: NO per-device forward secrecy"),
             "empty-recipient PerDevice must warn rather than reassure: {summary}"
+        );
+    }
+
+    /// TIN-2853: `tcfs conflicts` summarizes repo HEADs with `git log`. A
+    /// roamed repository can arm `log.showSignature=true` plus
+    /// `gpg.program=<attacker binary>` in its synced `.git/config`, which an
+    /// unsanitized `git log` executes. The sanitized spawn must return the
+    /// same benign summary while never running the repository-configured
+    /// program.
+    #[cfg(unix)]
+    #[test]
+    fn git_head_oneline_does_not_execute_repository_gpg_program() {
+        use std::os::unix::fs::PermissionsExt;
+
+        fn run_git(repo: &Path, args: &[&str]) {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(repo)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "--quiet", "--initial-branch=main"]);
+        run_git(&repo, &["config", "user.email", "tcfs@example.invalid"]);
+        run_git(&repo, &["config", "user.name", "TCFS Test"]);
+
+        // The armed program doubles as a fake signer (SIG_CREATED status plus
+        // a signature block, the shape `git commit -S` expects) so the fixture
+        // commit carries a signature for `git log` to verify.
+        let gpg = dir.path().join("evil-gpg");
+        let sentinel = dir.path().join("evil-gpg.ran");
+        std::fs::write(
+            &gpg,
+            format!(
+                "#!/bin/sh\n\
+                 printf ran > \"{}\"\n\
+                 printf '[GNUPG:] SIG_CREATED \\n' >&2\n\
+                 printf -- '-----BEGIN PGP SIGNATURE-----\\nfake\\n-----END PGP SIGNATURE-----\\n'\n",
+                sentinel.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&gpg, std::fs::Permissions::from_mode(0o700)).unwrap();
+        run_git(&repo, &["config", "gpg.program", gpg.to_str().unwrap()]);
+        run_git(&repo, &["config", "log.showSignature", "true"]);
+
+        std::fs::write(repo.join("file.txt"), b"base\n").unwrap();
+        run_git(&repo, &["add", "file.txt"]);
+        run_git(&repo, &["commit", "--quiet", "-S", "-m", "base"]);
+        assert!(
+            sentinel.exists(),
+            "signing through the armed gpg.program did not run it"
+        );
+        std::fs::remove_file(&sentinel).unwrap();
+
+        // Prove the fixture is armed: an ordinary `git log` executes the
+        // repository-configured gpg.program via log.showSignature.
+        let control = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(["log", "--oneline", "-1"])
+            .output()
+            .unwrap();
+        assert!(
+            control.status.success(),
+            "ordinary git log failed: {}",
+            String::from_utf8_lossy(&control.stderr)
+        );
+        assert!(sentinel.exists(), "the armed control did not run");
+        std::fs::remove_file(&sentinel).unwrap();
+
+        let head = git_head_oneline(&repo).expect("sanitized HEAD read must succeed");
+        assert!(head.contains("base"), "unexpected oneline output: {head}");
+        assert!(
+            !sentinel.exists(),
+            "git_head_oneline must not execute the repository-configured gpg.program"
         );
     }
 }

--- a/crates/tcfs-sync/src/git_safety.rs
+++ b/crates/tcfs-sync/src/git_safety.rs
@@ -67,6 +67,19 @@ pub(crate) fn sanitized_git_command() -> std::process::Command {
         .arg("core.logAllRefUpdates=false")
         .arg("-c")
         .arg("core.sharedRepository=0");
+    // `git log`/`git show` honor repository-local `log.showSignature`, which
+    // executes the repository-configured `gpg.program` to verify signatures.
+    // A roamed repository must never choose an executable for us: disable
+    // signature display outright and point both signature programs at the
+    // null device so any residual verification path fails closed instead of
+    // running attacker-controlled code.
+    command
+        .arg("-c")
+        .arg("log.showSignature=false")
+        .arg("-c")
+        .arg(format!("gpg.program={null_device}"))
+        .arg("-c")
+        .arg(format!("gpg.ssh.program={null_device}"));
     // Git creates loose refs and lock files using the process umask. tcfsd
     // must not let an inherited permissive service umask turn a sanitized
     // `update-ref` into group/world-writable repository metadata. Apply this
@@ -86,6 +99,17 @@ pub(crate) fn sanitized_git_command() -> std::process::Command {
         }
     }
     command
+}
+
+/// Build a sanitized Git command for read-only inspection of an
+/// operator-supplied repository (e.g. `tcfs conflicts` summarizing a repo's
+/// HEAD). Same boundary as the internal sanitized builder: repository-routing
+/// environment is stripped and repository-configured executables (hooks,
+/// fsmonitor, `gpg.program`) can never run. Callers must keep the spawned
+/// subcommand read-only; mutation paths stay inside this crate behind the
+/// lock- and CAS-guarded helpers.
+pub fn sanitized_git_readonly_command() -> std::process::Command {
+    sanitized_git_command()
 }
 
 /// Relative path (under the repo working root) where the TCFS git bundle is
@@ -732,6 +756,9 @@ mod tests {
         assert!(args.iter().any(|arg| arg == "tag.gpgSign=false"));
         assert!(args.iter().any(|arg| arg == "core.logAllRefUpdates=false"));
         assert!(args.iter().any(|arg| arg == "core.sharedRepository=0"));
+        assert!(args.iter().any(|arg| arg == "log.showSignature=false"));
+        assert!(args.iter().any(|arg| arg.starts_with("gpg.program=")));
+        assert!(args.iter().any(|arg| arg.starts_with("gpg.ssh.program=")));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

TIN-2853 follow-up (Linear comment 26441afb): `git_head_oneline` in `tcfs-cli` was the last raw production git spawn — `tcfs conflicts` summarized repo HEADs with a bare `std::process::Command::new("git") log --oneline -1`. An attacker-synced `.git/config` arming `[log] showSignature = true` + `[gpg] program = /tmp/evil` would make that spawn execute the attacker's program on the machine listing conflicts.

This routes the spawn through the existing `tcfs-sync` sanitizer and hardens the sanitizer so the signature-verification path fails closed for every caller.

## Changes

- `crates/tcfs-sync/src/git_safety.rs`: harden the common sanitized builder with `-c log.showSignature=false` and point `gpg.program` / `gpg.ssh.program` at the null device (fail-closed if any residual verification path is ever reached). Extend the builder unit test to assert the new args.
- `crates/tcfs-sync/src/git_safety.rs`: add `sanitized_git_readonly_command()`, a minimal public read-only variant for operator-facing CLI reads (the internal builder stays `pub(crate)`).
- `crates/tcfs-cli/src/main.rs`: `git_head_oneline` now spawns through `tcfs_sync::git_safety::sanitized_git_readonly_command()`; identical args and stdout parsing, so benign-repo behavior is unchanged.
- Regression test `git_head_oneline_does_not_execute_repository_gpg_program` (armed-fixture style, mirroring `sanitized_git_dir_updates_do_not_run_repository_hooks`): arms `log.showSignature` + `gpg.program` with a sentinel-writing fake gpg, signs the fixture commit through it, proves an ordinary `git log` executes the armed program, then asserts `git_head_oneline` returns the same HEAD summary with the sentinel absent.

No existing sanitized caller verifies signatures (subcommand set is bundle/config/merge-base/rev-list/rev-parse/status/update-ref and signing was already forced off), so the hardening changes no current behavior.

## Test plan

- [x] `cargo test -p tcfs-cli -p tcfs-sync --locked` passes on the Linux build box (rustc 1.93.0, git 2.51.2)
- [x] `tests::git_head_oneline_does_not_execute_repository_gpg_program` passes; its in-test armed control (a raw `git -C <repo> log --oneline -1`, i.e. exactly the pre-fix spawn) proves the fixture executes the armed `gpg.program`, and the sanitized call does not
- [x] `git_safety::tests::sanitized_git_command_removes_repository_routing_environment` extended and passing

## Checklist

- [ ] Docs updated (if user-facing behavior changed) — n/a, internal hardening
- [ ] CHANGELOG.md updated (if applicable) — n/a
- [x] No secrets or credentials in diff
