### PR TITLE
fix(sync): ACL-probe ENOTSUP is Nix sandbox seccomp; keep fail-closed, narrow nix checkPhase skips (TIN-2853)

### DIFF
--- a/crates/tcfs-sync/src/path_acl.rs
+++ b/crates/tcfs-sync/src/path_acl.rs
@@ -118,6 +118,20 @@ mod linux {
         Present,
     }
 
+    /// Only ENODATA proves the ACL is absent; every other errno fails closed.
+    ///
+    /// ENOTSUP/EOPNOTSUPP in particular must NOT be treated as "no ACL". It
+    /// means the POSIX ACL surface could not be inspected here, not that no
+    /// write-granting ACL exists:
+    ///   - network filesystems (NFS/CIFS) report EOPNOTSUPP for
+    ///     `system.posix_acl_*` while still enforcing server-side NFSv4/rich
+    ///     ACLs that can grant writes, and
+    ///   - the Nix Linux build sandbox installs a seccomp filter that fails
+    ///     the entire xattr syscall family with ENOTSUP (so an ACL applied
+    ///     from outside the sandbox would be invisible to this probe).
+    /// On local ACL-supporting filesystems (verified: XFS, kernel 6.19) the
+    /// probes genuinely return ENODATA when no ACL is set, so fail-closed
+    /// here does not reject ordinary trusted paths (TIN-2853).
     fn classify_probe_result(
         result: libc::ssize_t,
         errno: Option<i32>,
@@ -264,6 +278,10 @@ mod linux {
                 Ok(ProbeOutcome::Absent)
             );
             assert!(classify_probe_result(-1, Some(libc::EACCES)).is_err());
+            // ENOTSUP is an undetermined ACL surface (seccomp-filtered xattr
+            // in the Nix sandbox, NFS/CIFS with non-POSIX ACLs), never proof
+            // of absence. It must stay fail-closed (TIN-2853).
+            assert!(classify_probe_result(-1, Some(libc::EOPNOTSUPP)).is_err());
         }
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -77,19 +77,43 @@
         # Pre-build workspace deps (shared across all crate builds for caching)
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
+        # The Linux Nix build sandbox cannot faithfully run tests that
+        # exercise tcfs's fail-closed trusted-path/ACL validators, for two
+        # environment reasons verified at syscall level (TIN-2853):
+        #   1. Nix's sandbox seccomp filter fails the entire xattr syscall
+        #      family with ENOTSUP (upstream linux-derivation-builder.cc:
+        #      "Prevent builders from using EAs or ACLs"), so the POSIX ACL
+        #      probe in tcfs-sync's path_acl can never reach the filesystem
+        #      and correctly fails closed.
+        #   2. The sandbox user namespace maps a single uid, so every
+        #      ancestor above /build (/, /nix/store, /tmp) appears as
+        #      overflowuid 65534 and is rejected by the euid-or-root
+        #      ancestor-ownership validator.
+        # Rather than disabling whole checkPhases, skip exactly the affected
+        # tests; the checked-in lists under nix/checks/ document each one.
+        # Darwin runs the full suites (empty flags).
+        linuxSandboxSkipFlags = skipFile:
+          pkgs.lib.optionalString pkgs.stdenv.isLinux (
+            let
+              names = builtins.filter
+                (line: line != "" && !pkgs.lib.hasPrefix "#" line)
+                (pkgs.lib.splitString "\n" (builtins.readFile skipFile));
+            in
+            "-- " + pkgs.lib.concatMapStringsSep " " (name: "--skip ${name}") names
+          );
+
         # Build individual crates as separate derivations
         tcfsd = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
           pname = "tcfsd";
           # Registered-root safety tests create real fixture repositories.
-          nativeCheckInputs = [ pkgs.git ];
-          # Linux Nix user namespaces expose sandbox-owned ancestors as uid
-          # 65534 and report ENOTSUP for POSIX ACL probes. Those semantics are
-          # intentionally rejected by tcfsd's production path validator, so a
-          # sandbox check cannot faithfully exercise the state-cache tests.
-          # Keep the fail-closed validator unchanged; Linux unit tests run in
-          # the ordinary Cargo CI lane, while Darwin retains this checkPhase.
-          doCheck = !pkgs.stdenv.isLinux;
+          # gitMinimal (not pkgs.git) keeps the docbook/full-git doc chain out
+          # of the check closure, matching tcfs-cli below.
+          nativeCheckInputs = [ pkgs.gitMinimal ];
+          # Skip only the trusted-path/ACL validator tests that the Linux
+          # sandbox cannot faithfully run (see linuxSandboxSkipFlags above and
+          # the list's header for the full analysis, TIN-2853).
+          cargoTestExtraArgs = linuxSandboxSkipFlags ./nix/checks/linux-sandbox-skip-tcfsd.txt;
           # Vendor OpenSSL on macOS to avoid dyld Team ID mismatch
           # when launchd loads the binary (Nix store openssl has different
           # code signature than the daemon binary).
@@ -105,12 +129,10 @@
           # keep-both CLI tests (TIN-2658) run real `git` repos in checkPhase;
           # the build sandbox has no ambient git.
           nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.gitMinimal ];
-          # Stable-root CLI tests exercise the same fail-closed ancestry and
-          # ACL checks as tcfsd. Linux Nix user namespaces expose sandbox
-          # ancestors as uid 65534 and cannot faithfully run those checks;
-          # ordinary Linux Cargo CI remains authoritative, while Darwin keeps
-          # the derivation checkPhase.
-          doCheck = !pkgs.stdenv.isLinux;
+          # Skip only the trusted-path/ACL validator tests that the Linux
+          # sandbox cannot faithfully run (see linuxSandboxSkipFlags above and
+          # the list's header for the full analysis, TIN-2853).
+          cargoTestExtraArgs = linuxSandboxSkipFlags ./nix/checks/linux-sandbox-skip-tcfs-cli.txt;
           meta.mainProgram = "tcfs";
         });
 

--- a/nix/checks/linux-sandbox-skip-tcfs-cli.txt
+++ b/nix/checks/linux-sandbox-skip-tcfs-cli.txt
@@ -1,0 +1,26 @@
+# Tests skipped in the LINUX Nix-sandbox checkPhase only (TIN-2853).
+# Same two sandbox environment properties as linux-sandbox-skip-tcfsd.txt
+# (seccomp ENOTSUP on the xattr family; single-uid userns making all
+# ancestors overflowuid 65534). Every test below passes natively; ordinary
+# Linux Cargo CI remains authoritative for them.
+#
+# Regenerate: empty this file, `nix build .#tcfs-cli` on a Linux builder,
+# and copy the FAILED test names from the check-phase log.
+tests::cli_directory_push_and_status_detect_modified_file
+tests::cli_directory_push_preserves_symlink_when_configured
+tests::cli_pull_after_peer_delete_recreate_over_unsynced_stub_uses_recreated_remote
+tests::cli_pull_after_unsync_hydrates_latest_remote_and_removes_stub
+tests::cli_pull_by_file_path_without_dest_writes_to_file_path
+tests::cli_push_status_pull_workflow_round_trips_file
+tests::cli_sync_status_reports_explicit_sync_state
+tests::cli_unsync_directory_converts_clean_tracked_descendants
+tests::cli_unsync_directory_force_converts_dirty_with_tracked_metadata
+tests::cli_unsync_directory_refuses_dirty_descendants_without_force
+tests::cli_unsync_force_rejects_untracked_file
+tests::cli_unsync_force_uses_tracked_remote_metadata
+tests::cli_unsync_marks_not_synced_and_reports_via_real_and_stub_paths
+tests::cli_write_via_db_override_visible_to_daemon_json_read
+tests::daemon_write_json_visible_to_cli_db_override_read
+tests::direct_manifest_fixed_rel_path_is_rejected_before_destination_or_cache_mutation
+tests::explicit_state_writers_fail_before_operator_work_when_locked
+unsync_flips_status_before_destructive_ops

--- a/nix/checks/linux-sandbox-skip-tcfsd.txt
+++ b/nix/checks/linux-sandbox-skip-tcfsd.txt
@@ -1,0 +1,131 @@
+# Tests skipped in the LINUX Nix-sandbox checkPhase only (TIN-2853).
+#
+# These tests exercise tcfs's fail-closed trusted-path/ACL validators,
+# which cannot pass inside the Linux Nix build sandbox for two environment
+# reasons (verified at syscall level on sting, kernel 6.19/XFS):
+#   1. Nix's sandbox seccomp filter fails the whole xattr syscall family
+#      with ENOTSUP ("Prevent builders from using EAs or ACLs", upstream
+#      src/libstore/linux/build/linux-derivation-builder.cc), so the POSIX
+#      ACL probe (tcfs-sync path_acl.rs) can never reach the filesystem and
+#      correctly fails closed.
+#   2. The sandbox user namespace maps a single uid, so every ancestor above
+#      /build (/, /nix/store, /tmp) appears as overflowuid 65534 and is
+#      rejected by the euid-or-root ancestor-ownership validator
+#      (conflict_git.rs validate_trusted_configured_path).
+# Natively (outside the sandbox) every test below passes; ordinary Linux
+# Cargo CI remains authoritative for them.
+#
+# Regenerate: empty this file, `nix build .#tcfsd` on a Linux builder, and
+# copy the FAILED test names from the check-phase log.
+# Entries are passed as `--skip <name>` (substring match on the full test
+# path), one per line; '#' comments and blank lines are ignored.
+daemon::invite_redemption_startup_tests::first_start_allows_missing_invite_redemption_store
+daemon::invite_redemption_startup_tests::restart_fails_closed_on_corrupt_invite_redemption_store
+daemon::invite_redemption_startup_tests::restart_fails_closed_on_unsafe_invite_redemption_store
+daemon::keep_both_pr1_tests::auto_download_failure_withholds_ack_signal
+daemon::keep_both_pr1_tests::auto_download_flush_failure_rolls_back_in_memory_state
+daemon::keep_both_pr1_tests::auto_download_uses_current_index_when_event_metadata_is_stale
+daemon::keep_both_pr1_tests::auto_pull_acknowledges_read_only_up_to_date_git_internal_path
+daemon::keep_both_pr1_tests::auto_pull_classifies_the_current_snapshot_not_a_delayed_event
+daemon::keep_both_pr1_tests::auto_pull_defers_new_git_internal_path_without_hydration_or_cache_advance
+daemon::keep_both_pr1_tests::auto_pull_defers_remote_newer_git_internal_path_without_mutation
+daemon::keep_both_pr1_tests::auto_pull_persists_git_conflict_and_withholds_ack_for_grouped_reconcile
+daemon::keep_both_pr1_tests::auto_pull_preserves_an_existing_untracked_local_file
+daemon::keep_both_pr1_tests::auto_pull_preserves_unsynced_local_bytes_and_records_conflict
+daemon::keep_both_pr1_tests::auto_pull_tie_break_uses_the_current_manifest_writer
+daemon::keep_both_pr1_tests::conflict_resolved_flush_failure_rolls_back_and_withholds_ack
+daemon::keep_both_pr1_tests::conflict_resolved_uses_indexed_clock_not_notification_metadata
+daemon::keep_both_pr1_tests::crash_after_staging_rename_replays_original_bytes
+daemon::keep_both_pr1_tests::daemon_lifetime_lock_rejects_second_instance_and_releases_on_drop
+daemon::keep_both_pr1_tests::git_conflict_flush_failure_withholds_ack_signal
+daemon::keep_both_pr1_tests::on_demand_threshold_uses_the_current_manifest_size
+daemon::keep_both_pr1_tests::pending_delete_replay_never_overwrites_recreated_original
+daemon::keep_both_pr1_tests::private_daemon_data_dir_is_owner_only_and_rejects_unsafe_existing_mode
+daemon::keep_both_pr1_tests::remote_delete_acks_git_internal_path_after_grouped_reconcile_converges
+daemon::keep_both_pr1_tests::remote_delete_acks_when_local_and_cache_are_already_absent
+daemon::keep_both_pr1_tests::remote_delete_commits_matching_tracked_file_and_cache_together
+daemon::keep_both_pr1_tests::remote_delete_defers_git_internal_path_without_per_file_mutation
+daemon::keep_both_pr1_tests::remote_delete_flush_failure_restores_file_and_in_memory_cache
+daemon::keep_both_pr1_tests::remote_delete_never_policy_acknowledges_without_mutation
+daemon::keep_both_pr1_tests::remote_delete_preserves_edit_without_persisting_forged_event_clock
+daemon::keep_both_pr1_tests::remote_delete_preserves_untracked_local_file_as_conflict
+daemon::keep_both_pr1_tests::remote_delete_treats_missing_tracked_file_as_conflict
+daemon::keep_both_pr1_tests::remote_delete_without_tombstone_never_removes_matching_tracked_file
+daemon::keep_both_pr1_tests::watcher_only_file_deleted_cannot_erase_live_remote_index_or_local_peer
+daemon::state_migration_tests::absorb_expands_tilde_in_configured_state_db
+daemon::state_migration_tests::absorb_ignores_unrelated_stale_legacy_temp
+daemon::state_migration_tests::absorb_leaves_existing_json_untouched_when_both_exist
+daemon::state_migration_tests::absorb_neither_present_starts_fresh
+daemon::state_migration_tests::absorb_repairs_valid_backup_before_promoting_legacy_authority
+daemon::state_migration_tests::absorb_seeds_json_from_db_only_host
+daemon::state_migration_tests::absorb_treats_dangling_canonical_symlink_as_present_and_fail_closed
+grpc::tests::auth_complete_enroll_allows_self_or_admin_session
+grpc::tests::auth_enroll_allows_self_or_admin_session
+grpc::tests::auth_revoke_requires_admin_session
+grpc::tests::auth_status_locked_by_default
+grpc::tests::auth_unlock_then_lock_roundtrip
+grpc::tests::auth_unlock_wrong_key_size_fails
+grpc::tests::credential_status_empty
+grpc::tests::device_enroll_rejects_invalid_public_key_before_claiming_invite
+grpc::tests::device_enroll_rejects_reused_invite
+grpc::tests::device_enroll_wraps_bootstrap_to_joining_device_key
+grpc::tests::diagnostics_empty_state
+grpc::tests::file_provider_pull_exact_miss_never_uses_same_filename_elsewhere
+grpc::tests::file_provider_pull_exact_rejects_stale_before_manifest_corruption
+grpc::tests::file_provider_pull_exact_requires_version_and_marks_empty_content
+grpc::tests::hydrate_exact_index_miss_never_uses_same_filename_elsewhere
+grpc::tests::hydrate_rejects_custom_master_key_through_symlinked_directory_alias
+grpc::tests::hydrate_rejects_fixed_targets_before_storage_or_cache_access
+grpc::tests::hydrate_rejects_stub_origin_for_a_different_local_path
+grpc::tests::hydrate_stale_stub_uses_current_exact_index
+grpc::tests::list_files_uses_live_remote_namespace_and_cache_only_for_bound_metadata
+grpc::tests::mount_missing_required_fields_returns_error_response
+grpc::tests::mount_rejects_duplicate_active_mountpoint
+grpc::tests::mount_requires_initialized_operator
+grpc::tests::primary_resolution_permissions_match_strategy_before_state_lookup
+grpc::tests::primary_uds_serves_when_fileprovider_socket_bind_fails
+grpc::tests::pull_only_primary_keep_remote_is_retired_without_mutation
+grpc::tests::pull_rejects_fixed_logical_paths_before_storage_or_cache_access
+grpc::tests::pull_rejects_fixed_rel_discovered_during_resolution_before_cache_or_write
+grpc::tests::pull_rejects_outside_root_and_custom_master_key_alias_without_mutation
+grpc::tests::push_then_pull_streams_complete_successfully_over_uds
+grpc::tests::registered_root_auth_bypass_fails_before_route_lookup
+grpc::tests::registered_root_cache_and_git_metadata_fences_fail_closed
+grpc::tests::registered_root_execute_obeys_inspect_only_policy
+grpc::tests::registered_root_inspect_and_execute_share_isolated_cache
+grpc::tests::registered_root_peer_canonicalization_errors_fail_closed
+grpc::tests::registered_root_rejects_local_root_alias_below_writable_parent
+grpc::tests::registered_root_rejects_state_directory_alias_below_writable_parent
+grpc::tests::registered_root_rejects_writable_state_ancestor
+grpc::tests::registered_root_resolution_permissions_match_mode_before_route_lookup
+grpc::tests::registered_root_retires_unrooted_primary_per_file_mutation
+grpc::tests::registered_root_rootless_repo_rejects_route_and_retired_files_are_uniform
+grpc::tests::registered_root_rootless_resolve_rejects_symlink_alias_and_missing_child
+grpc::tests::registered_root_rootless_restricted_session_cannot_probe_enrollment
+grpc::tests::registered_root_state_cache_rejects_hardlinks_and_primary_inode_alias
+grpc::tests::registered_root_state_directory_rejects_canonical_named_alias
+grpc::tests::registered_root_unauthorized_id_is_indistinguishable_from_unknown
+grpc::tests::registered_root_unknown_id_does_not_enumerate_enrollment
+grpc::tests::resolve_conflict_defer_allowed_on_git_internal_path
+grpc::tests::resolve_conflict_invalid_resolution
+grpc::tests::resolve_conflict_repo_git_keep_both_requires_operator_cli
+grpc::tests::resolve_conflict_retires_git_internal_path_before_classification
+grpc::tests::resolve_conflict_retires_normal_per_file_mutations
+grpc::tests::resolve_conflict_retires_symlink_alias_without_classification
+grpc::tests::resolve_conflict_retires_without_consulting_stored_git_path
+grpc::tests::status_rechecks_live_storage_health
+grpc::tests::status_returns_version
+grpc::tests::sync_status_reports_explicit_conflict_state
+grpc::tests::sync_status_reports_pending_for_modified_tracked_file
+grpc::tests::sync_status_surfaces_needs_sync_error_instead_of_synced
+grpc::tests::sync_status_unknown_path
+grpc::tests::unmount_requires_mountpoint
+grpc::tests::unsync_waits_for_active_path_lock
+grpc::tests::watch_rejects_partial_cache_catch_up_without_advancing_anchor
+mark_conflict_inserts_entry_when_missing
+mark_conflict_preserves_existing_entry_fields
+needs_sync_errors_on_missing_path
+sync_status_does_not_report_synced_when_needs_sync_errs
+sync_status_reports_pending_on_ok_some
+sync_status_reports_synced_on_ok_none
+sync_status_returns_entry_status_when_not_synced


### PR DESCRIPTION
## Root cause (TIN-2853): the ENOTSUP is Nix's sandbox seccomp filter, not the probe and not the filesystem

Verdict: **(ii) genuine environment property** — with a corrected premise. The
POSIX-ACL probe in `crates/tcfs-sync/src/path_acl.rs` is implemented correctly
and does NOT fail on sting natively.

### Syscall-level evidence

Native probes on sting (kernel 6.19.5-9.xr.el10; `/tmp` and `/srv/fast-local`
are both XFS — `/tmp` is not tmpfs on sting), via ctypes against the exact
mechanism the code uses (`lgetxattr`/`fgetxattr`, NULL buffer, size 0):

```
lgetxattr system.posix_acl_access  size=0   -> r=-1 errno=61 ENODATA   (no ACL set)
fgetxattr system.posix_acl_access  size=0   -> r=-1 errno=61 ENODATA   (O_RDONLY|O_NOFOLLOW|O_NONBLOCK fd)
lgetxattr system.posix_acl_access  size=0   -> r=44 errno=0            (after setfacl -m u:jess:r)
```

Same for directories and for `system.posix_acl_default`. ENOTSUP never appears
natively; `setfacl`/`getfacl` round-trip fine, and no ancestor of the test
paths carries an extended ACL. Full native suites at origin/main (929bbf1) on
sting: tcfs-sync 431 lib tests + all integration targets, tcfsd 166 tests,
tcfs-cli 132 tests — 0 failures. The "2 failing state tests on sting" premise
did not reproduce at this commit.

Inside the Nix Linux build sandbox (probe derivation, same XFS bind-mounted at
`/build`, `Seccomp: 2` with 1 filter installed, Determinate Nix 3.18.0):

```
lgetxattr /build/probe-file system.posix_acl_access  -> r=-1 errno=95 ENOTSUP
fgetxattr /build/probe-file system.posix_acl_access  -> r=-1 errno=95 ENOTSUP
setxattr  /build/probe-file user.tin2853             -> ENOTSUP        (even user.* on a builder-owned file)
```

This matches upstream Nix `src/libstore/linux/build/linux-derivation-builder.cc`,
which seccomp-filters the entire xattr syscall family to `ENOTSUP`
(`getxattr/lgetxattr/fgetxattr/setxattr/lsetxattr/fsetxattr/listxattr/...`):

> Prevent builders from using EAs or ACLs. Not all filesystems
> support these, and they're not allowed in the Nix store because
> they're not representable in the NAR serialisation.

So inside any sandboxed Linux nix build the ACL probe can never reach the
filesystem. A second, independent sandbox property compounds it: the sandbox
user namespace maps a single uid (`uid_map: 1000 30001 1`), so every ancestor
above `/build` (`/`, `/nix/store`, `/tmp`) appears as overflowuid 65534, which
`validate_trusted_configured_path` (each ancestor must be euid- or root-owned)
rightly rejects.

### Why the probe must stay fail-closed on ENOTSUP

Treating ENOTSUP as "no ACL" would be fail-open exactly where it matters:
- the seccomp case above — an ACL set from outside the sandbox would be
  invisible to the probe;
- NFS/CIFS report EOPNOTSUPP for `system.posix_acl_*` while enforcing
  server-side NFSv4/rich ACLs that can grant writes.

### Changes

- `path_acl.rs`: document the ENOTSUP fail-closed constraint at
  `classify_probe_result` and pin it with an explicit
  `EOPNOTSUPP -> Err` contract assertion. No behavioral change.
- `flake.nix`: restore the Linux checkPhase for tcfsd and tcfs-cli (replacing
  the blanket `doCheck = !isLinux` from b063323/e7117f0) with per-test
  `--skip` lists checked in under `nix/checks/`, enumerated from real
  sandbox check runs (`--no-fail-fast`):
  - tcfsd: 110 skips (103 lib + 7 integration; every failure signature is
    `configured path component must be owned by effective uid 1000 or root,
    got uid 65534: /` or the downstream state-cache open), **56 tests
    restored** to the Linux sandbox checkPhase (previously 0).
  - tcfs-cli: 18 skips, **114 tests restored** (previously 0).
  - Substring-collision between skip entries and passing test names checked
    programmatically: none.
  - New sandbox-incompatible tests fail the Linux build loudly and must be
    added to the list consciously; each file's header documents how to
    regenerate.
- `flake.nix`: tcfsd `nativeCheckInputs` switched `pkgs.git` ->
  `pkgs.gitMinimal` (parity with tcfs-cli). During enumeration the full-git
  path rebuilt opensp/docbook2X/git-2.52 from source (cache misses) including
  git's own test suite — gitMinimal drops that chain from the check closure.
- Noted per the task: `.#tcfsd` does NOT depend on chromium; the
  mermaid-cli/chromium chain is devShell-only and never blocked these builds.

### Verification (all on sting)

Native, at this branch (rustc 1.93.0 pinned, `TMPDIR=/srv/fast-local/jess/tmp`,
`GIT_CONFIG_GLOBAL=/tmp/git-test-config`):

```
cargo test -p tcfs-sync --lib path_acl   -> 2 passed (incl. new EOPNOTSUPP contract assertion)
cargo test -p tcfs-sync --lib state::    -> 47 passed
cargo test -p tcfs-sync                  -> 431 lib + all integration targets, 0 failed
cargo fmt -p tcfs-sync -- --check        -> clean
```

Sandboxed, at this branch (tinyland cache down; cache.nixos.org substitution only):

```
nix build .#tcfsd     -> exit 0; lib 42 passed / 103 filtered (skips);
                         config_test 5, ensure_dirs_test 7, metrics_test 2 passed;
                         grpc_sync_status_errors 5 + watcher_conflict_no_entry 2 filtered
nix build .#tcfs-cli  -> exit 0; lib 94 passed / 17 filtered;
                         cli_parsing_test 20 passed; unsync ordering 1 filtered
```

Enumeration runs (blanket exclusion temporarily lifted, `--no-fail-fast`):
tcfsd 103/145 lib + 7 integration FAILED, tcfs-cli 17/111 lib + 1 integration
FAILED — every failure with the uid-65534 ancestor signature; those exact
names are the checked-in skip lists.
