### PR TITLE
fix(sync): satisfy Rust 1.93 strict Clippy (TIN-2853)

### DIFF
--- a/crates/tcfs-sync/src/path_acl.rs
+++ b/crates/tcfs-sync/src/path_acl.rs
@@ -82,11 +82,7 @@ fn metadata_identity(metadata: &std::fs::Metadata) -> (u64, u64, u32) {
     #[allow(clippy::unnecessary_cast)]
     let file_type = metadata.mode() & (libc::S_IFMT as u32);
 
-    (
-        metadata.dev(),
-        metadata.ino(),
-        file_type,
-    )
+    (metadata.dev(), metadata.ino(), file_type)
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/tcfs-sync/src/path_acl.rs
+++ b/crates/tcfs-sync/src/path_acl.rs
@@ -81,7 +81,7 @@ fn metadata_identity(metadata: &std::fs::Metadata) -> (u64, u64, u32) {
     (
         metadata.dev(),
         metadata.ino(),
-        metadata.mode() & libc::S_IFMT as u32,
+        metadata.mode() & libc::S_IFMT,
     )
 }
 
@@ -129,6 +129,7 @@ mod linux {
     ///   - the Nix Linux build sandbox installs a seccomp filter that fails
     ///     the entire xattr syscall family with ENOTSUP (so an ACL applied
     ///     from outside the sandbox would be invisible to this probe).
+    ///
     /// On local ACL-supporting filesystems (verified: XFS, kernel 6.19) the
     /// probes genuinely return ENODATA when no ACL is set, so fail-closed
     /// here does not reject ordinary trusted paths (TIN-2853).

--- a/crates/tcfs-sync/src/path_acl.rs
+++ b/crates/tcfs-sync/src/path_acl.rs
@@ -78,10 +78,14 @@ fn c_path(path: &Path) -> Result<std::ffi::CString> {
 fn metadata_identity(metadata: &std::fs::Metadata) -> (u64, u64, u32) {
     use std::os::unix::fs::MetadataExt;
 
+    // Darwin exposes S_IFMT as u16, while Linux exposes it as u32.
+    #[allow(clippy::unnecessary_cast)]
+    let file_type = metadata.mode() & (libc::S_IFMT as u32);
+
     (
         metadata.dev(),
         metadata.ino(),
-        metadata.mode() & libc::S_IFMT,
+        file_type,
     )
 }
 


### PR DESCRIPTION
Linear: TIN-2853

## Summary

Follow-up to #560. Strict workspace Clippy on the repository-pinned Rust 1.93 toolchain identifies two lint-only issues in the ACL-probe helper and documentation.

`libc::S_IFMT` is `u32` on Linux but `u16` on Darwin. The identity mask therefore retains its cross-platform `u32` conversion behind one narrowly scoped, documented Clippy allowance. The rustdoc list also receives the paragraph separator required by `doc_lazy_continuation`. Runtime behavior is unchanged.

## Changes

- Document the platform-dependent `S_IFMT` width and isolate the required Darwin-compatible cast behind a let-local Clippy allowance.
- Separate the ACL-probe list from its following paragraph in rustdoc.
- Limit the diff to `crates/tcfs-sync/src/path_acl.rs`.

## Test plan

Validated on Sting at exact signed head `ea14195736e300199cf312d384b3a7f754d3bb8c`:

- [x] Pinned Rust/Cargo 1.93
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test -p tcfs-sync --locked path_acl` (2 passed)
- [x] Targeted Gitleaks diff scan
- [x] Refreshed exact-head CI, including macOS/iOS compilation

The first CI pass on `115e194` correctly caught that simply removing the cast breaks Darwin (`S_IFMT` is `u16`). The current head restores the required conversion while keeping strict Linux Clippy green.

## Safety boundary

Source-only lint correction. No TCFS deployment, enrollment, resolver/TOTP action, reconciliation, credential handling, or crypto ceremony was performed. The TIN-2856 live-ceremony freeze remains in force.

## Checklist

- [x] Docs updated (if user-facing behavior changed) — not applicable; only rustdoc formatting changed
- [x] CHANGELOG.md updated (if applicable) — not applicable; no behavior change
- [x] No secrets or credentials in diff

