### PR TITLE
fix(config): redact diagnostic output and parse errors (TIN-2860)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ intent rather than the current supported/proven surface.
   strip userinfo, path, query, and fragment components. CLI, MCP, and daemon
   parse failures no longer echo offending TOML source lines into operator
   output or system logs.
+- CLI-generated signed enrollment invites now carry only the URL-normalized
+  HTTP(S) origin in `storage_endpoint`; userinfo, path, query, and fragment are
+  omitted, malformed or unsupported schemes fail closed, and bucket and remote
+  prefix remain dedicated fields.
 - Credential-bearing S3/SeaweedFS clients now require HTTPS by default across
   daemon, CLI, direct mount, and FileProvider operator construction. Plaintext
   compatibility requires an explicit development/test opt-in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ intent rather than the current supported/proven surface.
   `--state` cache mutations with daemon-side registered-root operations before
   constructing storage clients. These remain legacy mutation routes, not
   named-root authorization surfaces; only `conflicts --state` is diagnostic.
+- CLI and MCP configuration display now replaces the inline NATS token with a
+  `nats_token_configured` boolean. Displayed endpoint URLs are origin-only and
+  strip userinfo, path, query, and fragment components. CLI, MCP, and daemon
+  parse failures no longer echo offending TOML source lines into operator
+  output or system logs.
 - Credential-bearing S3/SeaweedFS clients now require HTTPS by default across
   daemon, CLI, direct mount, and FileProvider operator construction. Plaintext
   compatibility requires an explicit development/test opt-in.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,6 +5233,7 @@ dependencies = [
  "prost",
  "protoc-bin-vendored",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "toml 0.8.23",
@@ -5240,6 +5241,7 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ serde_json = { version = "1" }
 toml = { version = "0.8" }
 unicode-normalization = { version = "0.1" }
 unicode-casefold = { version = "0.2" }
+url = { version = "2" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -20,6 +20,7 @@ use serde::Serialize;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
+use tcfs_core::config::sanitize_http_endpoint_for_display;
 
 #[cfg(unix)]
 use tonic::metadata::MetadataValue;
@@ -655,7 +656,7 @@ enum TrashAction {
 
 #[derive(Subcommand, Debug)]
 enum ConfigAction {
-    /// Print the active configuration (merged defaults + config file)
+    /// Print a redacted diagnostic view (not suitable for config reuse)
     Show,
     /// Render the macOS FileProvider bootstrap JSON from the active config
     Fileprovider {
@@ -1012,7 +1013,12 @@ async fn load_config(path: &Path) -> Result<tcfs_core::config::TcfsConfig> {
         let content = tokio::fs::read_to_string(path)
             .await
             .with_context(|| format!("reading config: {}", path.display()))?;
-        toml::from_str(&content).with_context(|| format!("parsing config: {}", path.display()))
+        toml::from_str(&content).map_err(|_| {
+            anyhow::anyhow!(
+                "parsing config {} failed; check TOML syntax and field types",
+                path.display()
+            )
+        })
     } else {
         Ok(tcfs_core::config::TcfsConfig::default())
     }
@@ -1488,13 +1494,14 @@ async fn cmd_push_with_operator(
     let remote_prefix = prefix
         .map(|s| s.trim_end_matches('/').to_string())
         .unwrap_or_else(|| config.storage.resolved_prefix().to_string());
+    let storage_endpoint_display = sanitize_http_endpoint_for_display(&config.storage.endpoint);
 
     println!(
         "Pushing {} → {}:{} (endpoint: {}{})",
         local.display(),
         config.storage.bucket,
         remote_prefix,
-        config.storage.endpoint,
+        storage_endpoint_display,
         if device_id.is_empty() {
             String::new()
         } else {
@@ -2300,9 +2307,10 @@ async fn run_storage_canary_with_operator(
 ) -> Result<StorageCanaryReport> {
     let key = storage_canary_key(prefix, nonce);
     let list_prefix = storage_canary_list_prefix(prefix);
+    let endpoint_display = sanitize_http_endpoint_for_display(&config.storage.endpoint);
     let payload = format!(
         "tcfs storage canary\nendpoint={}\nbucket={}\nprefix={}\nkey={}\nnonce={}\n",
-        config.storage.endpoint, config.storage.bucket, prefix, key, nonce
+        endpoint_display, config.storage.bucket, prefix, key, nonce
     )
     .into_bytes();
 
@@ -2364,7 +2372,7 @@ async fn run_storage_canary_with_operator(
     };
 
     Ok(StorageCanaryReport {
-        endpoint: config.storage.endpoint.clone(),
+        endpoint: endpoint_display,
         bucket: config.storage.bucket.clone(),
         prefix: prefix.to_string(),
         key,
@@ -3328,7 +3336,7 @@ async fn cmd_status(config: &tcfs_core::config::TcfsConfig) -> Result<()> {
     }
     println!(
         "  storage:       {} [{}]",
-        status.storage_endpoint,
+        sanitize_http_endpoint_for_display(&status.storage_endpoint),
         if status.storage_ok {
             "ok"
         } else {
@@ -3581,18 +3589,27 @@ async fn connect_daemon_with_token(
 // ── `tcfs config show` ────────────────────────────────────────────────────────
 
 fn cmd_config_show(config: &tcfs_core::config::TcfsConfig, config_path: &Path) -> Result<()> {
-    if config_path.exists() {
-        println!("# Configuration from: {}", config_path.display());
+    print!("{}", render_config_show(config, config_path)?);
+    Ok(())
+}
+
+fn render_config_show(
+    config: &tcfs_core::config::TcfsConfig,
+    config_path: &Path,
+) -> Result<String> {
+    let source = if config_path.exists() {
+        format!("# Configuration from: {}", config_path.display())
     } else {
-        println!(
+        format!(
             "# Configuration: defaults (no file at {})",
             config_path.display()
-        );
-    }
-    println!();
-    let rendered = toml::to_string_pretty(config).context("serializing config to TOML")?;
-    print!("{rendered}");
-    Ok(())
+        )
+    };
+    let rendered =
+        toml::to_string_pretty(&config.redacted()).context("serializing config to TOML")?;
+    Ok(format!(
+        "# Redacted diagnostic view; not suitable for reuse as configuration\n{source}\n\n{rendered}"
+    ))
 }
 
 async fn cmd_config_fileprovider(
@@ -3821,7 +3838,11 @@ async fn cmd_mount(
 
             match resp {
                 Ok(r) if r.get_ref().success => {
-                    println!("Mounted via daemon: {} → {}", remote, mountpoint.display());
+                    println!(
+                        "Mounted via daemon: {} → {}",
+                        mount_remote_endpoint_for_display(remote),
+                        mountpoint.display()
+                    );
                     return Ok(());
                 }
                 Ok(r) => {
@@ -3872,10 +3893,8 @@ async fn cmd_mount(
 
     let backend = if use_nfs { "NFS loopback" } else { "FUSE" };
     println!(
-        "Mounting {}:{} (prefix: {}) → {} [{}]",
-        endpoint,
-        bucket,
-        if prefix.is_empty() { "(root)" } else { &prefix },
+        "Mounting {} → {} [{}]",
+        sanitize_http_endpoint_for_display(&endpoint),
         mountpoint.display(),
         backend,
     );
@@ -4004,6 +4023,12 @@ async fn cmd_mount(
         .await
         .context("FUSE mount failed")
     }
+}
+
+fn mount_remote_endpoint_for_display(remote: &str) -> String {
+    tcfs_storage::parse_remote_spec(remote)
+        .map(|(endpoint, _, _)| sanitize_http_endpoint_for_display(&endpoint))
+        .unwrap_or_else(|_| sanitize_http_endpoint_for_display(remote))
 }
 
 // ── `tcfs unmount` ───────────────────────────────────────────────────────────
@@ -5758,6 +5783,23 @@ async fn cmd_auth_revoke(
 // ── `tcfs device invite` ─────────────────────────────────────────────────
 
 #[cfg(unix)]
+fn populate_invite_routing_metadata(
+    invite: &mut tcfs_auth::enrollment::EnrollmentInvite,
+    config: &tcfs_core::config::TcfsConfig,
+) -> Result<()> {
+    invite.storage_endpoint = Some(
+        tcfs_core::config::http_endpoint_origin(&config.storage.endpoint).ok_or_else(|| {
+            anyhow::anyhow!(
+                "storage endpoint must be an absolute HTTP(S) URL before creating a device invite"
+            )
+        })?,
+    );
+    invite.storage_bucket = Some(config.storage.bucket.clone());
+    invite.remote_prefix = Some(config.storage.resolved_prefix().to_string());
+    Ok(())
+}
+
+#[cfg(unix)]
 async fn cmd_device_invite(
     config: &tcfs_core::config::TcfsConfig,
     expiry_hours: u64,
@@ -5809,9 +5851,7 @@ async fn cmd_device_invite(
 
     // Include non-secret routing metadata. Secret bootstrap material is brokered
     // by tcfsd during DeviceEnroll and wrapped to the joining device public key.
-    invite.storage_endpoint = Some(config.storage.endpoint.clone());
-    invite.storage_bucket = Some(config.storage.bucket.clone());
-    invite.remote_prefix = Some(config.storage.resolved_prefix().to_string());
+    populate_invite_routing_metadata(&mut invite, config)?;
 
     invite.refresh_signature(&signing_key);
 
@@ -5827,7 +5867,8 @@ async fn cmd_device_invite(
     println!("Expires: {} hours from now", expiry_hours);
     println!(
         "Storage: {} (bucket: {})",
-        config.storage.endpoint, config.storage.bucket
+        sanitize_http_endpoint_for_display(&config.storage.endpoint),
+        config.storage.bucket
     );
     println!("Credentials: not embedded in invite; daemon wraps bootstrap during enrollment");
     println!(
@@ -7705,7 +7746,7 @@ async fn cmd_reconcile(
     println!(
         "Reconciling {} ↔ {}:{}/",
         local_root.display(),
-        config.storage.endpoint,
+        sanitize_http_endpoint_for_display(&config.storage.endpoint),
         remote_prefix
     );
 
@@ -8865,6 +8906,218 @@ mod tests {
             .is_err(),
             "a named root must never be combined with a client state path"
         );
+    }
+
+    #[test]
+    fn config_show_never_serializes_nats_token_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "# display source marker\n").unwrap();
+
+        let mut config = tcfs_core::config::TcfsConfig::default();
+        let token = "TIN2860-left-sentinel.middle-sentinel.right-sentinel";
+        config.sync.nats_token = Some(token.into());
+        config.storage.endpoint =
+            "https://s3-user:S3-secret@storage.example.test:8333/S3-path-secret?signature=S3-query#S3-fragment"
+                .into();
+        config.sync.nats_url =
+            "nats://nats-user:NATS-secret@nats.example.test:4222/NATS-path-secret?token=NATS-query#NATS-fragment"
+                .into();
+        config.daemon.fileprovider_endpoint = Some(
+            "https://fp-user:FP-secret@fp.example.test/FP-path-secret?token=FP-query#FP-fragment"
+                .into(),
+        );
+        let output = render_config_show(&config, &config_path).unwrap();
+
+        for forbidden in [
+            token,
+            "TIN2860-left-sentinel",
+            "middle-sentinel",
+            "right-sentinel",
+            "s3-user",
+            "S3-secret",
+            "S3-path-secret",
+            "S3-query",
+            "S3-fragment",
+            "nats-user",
+            "NATS-secret",
+            "NATS-path-secret",
+            "NATS-query",
+            "NATS-fragment",
+            "fp-user",
+            "FP-secret",
+            "FP-path-secret",
+            "FP-query",
+            "FP-fragment",
+        ] {
+            assert!(
+                !output.contains(forbidden),
+                "CLI config output leaked token material: {output}"
+            );
+        }
+
+        let (_, rendered) = output
+            .split_once("\n\n")
+            .expect("config output must separate its source header from TOML");
+        let value: toml::Value =
+            toml::from_str(rendered).expect("CLI config output must remain valid TOML");
+        assert_eq!(value["sync"]["nats_token_configured"].as_bool(), Some(true));
+        assert!(value["sync"].get("nats_token").is_none());
+        assert_eq!(
+            value["storage"]["endpoint"].as_str(),
+            Some("https://storage.example.test:8333")
+        );
+        assert_eq!(
+            value["sync"]["nats_url"].as_str(),
+            Some("nats://nats.example.test:4222")
+        );
+        assert_eq!(
+            value["daemon"]["fileprovider_endpoint"].as_str(),
+            Some("https://fp.example.test")
+        );
+        assert!(
+            output.contains("# Redacted diagnostic view; not suitable for reuse as configuration")
+        );
+    }
+
+    #[test]
+    fn mount_display_is_origin_only() {
+        let remote = "seaweedfs+https://mount-user:MOUNT-secret@storage.example.test:8333/bucket/MOUNT-path?token=MOUNT-query#MOUNT-fragment";
+        let rendered = mount_remote_endpoint_for_display(remote);
+        assert_eq!(rendered, "https://storage.example.test:8333");
+        for forbidden in [
+            "mount-user",
+            "MOUNT-secret",
+            "bucket",
+            "MOUNT-path",
+            "MOUNT-query",
+            "MOUNT-fragment",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "mount display leaked {forbidden}: {rendered}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn device_invite_routing_metadata_is_origin_only() {
+        use tcfs_auth::enrollment::EnrollmentInvite;
+        use tcfs_auth::session::DevicePermissions;
+
+        let signing_key = [7_u8; tcfs_crypto::KEY_SIZE];
+        let mut config = tcfs_core::config::TcfsConfig::default();
+        config.storage.endpoint =
+            "https://invite-user:INVITE-secret@storage.example.test:8333/INVITE-path?token=INVITE-query#INVITE-fragment"
+                .into();
+        config.storage.bucket = "invite-bucket".into();
+        config.storage.remote_prefix = Some("invite-prefix".into());
+
+        let mut invite = EnrollmentInvite::new(
+            "source-device",
+            &signing_key,
+            1,
+            DevicePermissions::default(),
+        );
+        populate_invite_routing_metadata(&mut invite, &config).unwrap();
+        invite.refresh_signature(&signing_key);
+
+        let encoded = invite.encode_compact().unwrap();
+        let decoded = EnrollmentInvite::decode_compact(&encoded).unwrap();
+        assert_eq!(
+            decoded.storage_endpoint.as_deref(),
+            Some("https://storage.example.test:8333")
+        );
+        assert_eq!(decoded.storage_bucket.as_deref(), Some("invite-bucket"));
+        assert_eq!(decoded.remote_prefix.as_deref(), Some("invite-prefix"));
+        for forbidden in [
+            "invite-user",
+            "INVITE-secret",
+            "INVITE-path",
+            "INVITE-query",
+            "INVITE-fragment",
+        ] {
+            assert!(
+                !decoded
+                    .storage_endpoint
+                    .as_deref()
+                    .unwrap()
+                    .contains(forbidden),
+                "decoded invite leaked {forbidden}: {decoded:?}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn device_invite_rejects_invalid_endpoint_without_echoing_input() {
+        use tcfs_auth::enrollment::EnrollmentInvite;
+        use tcfs_auth::session::DevicePermissions;
+
+        let signing_key = [7_u8; tcfs_crypto::KEY_SIZE];
+        for endpoint in [
+            "not-an-endpoint-with-INVALID-secret?token=INVALID-query",
+            "ftp://invite-user:FTP-secret@storage.example.test/FTP-path?token=FTP-query",
+        ] {
+            let mut config = tcfs_core::config::TcfsConfig::default();
+            config.storage.endpoint = endpoint.into();
+            let mut invite = EnrollmentInvite::new(
+                "source-device",
+                &signing_key,
+                1,
+                DevicePermissions::default(),
+            );
+
+            let rendered = populate_invite_routing_metadata(&mut invite, &config)
+                .unwrap_err()
+                .to_string();
+            assert!(invite.storage_endpoint.is_none());
+            assert!(invite.storage_bucket.is_none());
+            assert!(invite.remote_prefix.is_none());
+            for forbidden in [
+                "INVALID-secret",
+                "INVALID-query",
+                "invite-user",
+                "FTP-secret",
+                "FTP-path",
+                "FTP-query",
+            ] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "invite validation error leaked {forbidden}: {rendered}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn load_config_parse_error_never_echoes_offending_source_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let malformed = r#"
+[sync]
+nats_token = ["TIN2860-malformed-left", "malformed-middle", "malformed-right"]
+"#;
+        std::fs::write(&config_path, malformed).unwrap();
+
+        let error = load_config(&config_path)
+            .await
+            .expect_err("malformed token type must fail config loading");
+        let rendered = format!("{error:#}");
+
+        for forbidden in [
+            "TIN2860-malformed-left",
+            "malformed-middle",
+            "malformed-right",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "CLI parse error leaked config source material: {rendered}"
+            );
+        }
+        assert!(rendered.contains(&config_path.display().to_string()));
+        assert!(rendered.contains("check TOML syntax and field types"));
     }
 
     #[test]
@@ -10390,7 +10643,10 @@ enabled = false
     #[tokio::test]
     async fn storage_canary_writes_reads_deletes_and_verifies() {
         let dir = tempfile::tempdir().unwrap();
-        let config = test_config(dir.path());
+        let mut config = test_config(dir.path());
+        config.storage.endpoint =
+            "https://canary-user:CANARY-secret@storage.example.test:8333/CANARY-path?signature=CANARY-query#CANARY-fragment"
+                .into();
         let op = memory_op();
 
         let report = run_storage_canary_with_operator(
@@ -10406,6 +10662,20 @@ enabled = false
 
         assert_eq!(report.key, "data/.tcfs-canary/test-nonce.txt");
         assert_eq!(report.list_prefix, "data/");
+        assert_eq!(report.endpoint, "https://storage.example.test:8333");
+        for forbidden in [
+            "canary-user",
+            "CANARY-secret",
+            "CANARY-path",
+            "CANARY-query",
+            "CANARY-fragment",
+        ] {
+            assert!(
+                !report.endpoint.contains(forbidden),
+                "canary report leaked {forbidden}: {}",
+                report.endpoint
+            );
+        }
         assert!(report.listed);
         assert!(report.list_count >= 1);
         assert!(report.deleted);

--- a/crates/tcfs-core/Cargo.toml
+++ b/crates/tcfs-core/Cargo.toml
@@ -12,11 +12,13 @@ toml = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 
 [build-dependencies]

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use url::{Host, Url};
 
 /// Top-level daemon configuration (loaded from tcfs.toml)
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -17,6 +18,500 @@ pub struct TcfsConfig {
     /// Warn if the config file is world-readable (default: true)
     #[serde(default = "default_true")]
     pub config_file_mode_check: bool,
+}
+
+/// Configuration view safe for operator and diagnostic display surfaces.
+///
+/// This deliberately does not implement `Deserialize` and does not replace
+/// [`TcfsConfig`]'s runtime/persistence serialization. The current config
+/// schema has one inline credential, `sync.nats_token`. Endpoint outputs are
+/// origin-only (scheme, normalized host/IP, and parsed non-default port) and
+/// strip userinfo, path, query, and fragment components. Credential/key paths
+/// and the KDF salt are configuration metadata rather than secret contents.
+/// Keep each display section allowlisted so future runtime fields do not enter
+/// a diagnostic serializer by default.
+#[derive(Debug, Serialize)]
+pub struct RedactedConfig<'a> {
+    daemon: RedactedDaemonConfig<'a>,
+    storage: RedactedStorageConfig<'a>,
+    secrets: RedactedSecretsConfig<'a>,
+    sync: RedactedSyncConfig<'a>,
+    fuse: RedactedFuseConfig<'a>,
+    crypto: RedactedCryptoConfig<'a>,
+    sops: RedactedSopsConfig<'a>,
+    auth: RedactedAuthConfig<'a>,
+    config_file_mode_check: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedDaemonConfig<'a> {
+    socket: &'a PathBuf,
+    fileprovider_socket: &'a Option<PathBuf>,
+    fileprovider_endpoint: Option<String>,
+    listen: &'a Option<String>,
+    metrics_addr: &'a Option<String>,
+    log_level: &'a str,
+    log_format: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedStorageConfig<'a> {
+    endpoint: String,
+    region: &'a str,
+    bucket: &'a str,
+    remote_prefix: &'a Option<String>,
+    credentials_file: &'a Option<PathBuf>,
+    enforce_tls: bool,
+    ca_cert_path: &'a Option<PathBuf>,
+    max_concurrent_ops: usize,
+    s3_connect_timeout_secs: u64,
+    s3_pool_idle_timeout_secs: u64,
+    s3_pool_max_idle_per_host: usize,
+    s3_http1_only: bool,
+    max_upload_bytes_per_sec: u64,
+    max_download_bytes_per_sec: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedSecretsConfig<'a> {
+    age_identity: &'a Option<PathBuf>,
+    kdbx_path: &'a Option<PathBuf>,
+    sops_dir: &'a Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedSyncConfig<'a> {
+    nats_url: String,
+    nats_tls: bool,
+    nats_token_configured: bool,
+    nats_ca_cert: &'a Option<PathBuf>,
+    state_db: &'a PathBuf,
+    workers: usize,
+    max_retries: u32,
+    device_identity: &'a Option<PathBuf>,
+    device_name: &'a Option<String>,
+    conflict_mode: &'a str,
+    sync_git_dirs: bool,
+    git_sync_mode: &'a str,
+    sync_hidden_dirs: bool,
+    exclude_patterns: &'a [String],
+    sync_symlinks: bool,
+    sync_empty_dirs: bool,
+    sync_root: &'a Option<PathBuf>,
+    auto_unsync_max_age_secs: u64,
+    auto_unsync_interval_secs: u64,
+    auto_unsync_dry_run: bool,
+    auto_unsync_disk_pressure_pct: f64,
+    auto_unsync_max_per_sweep: usize,
+    auto_download_threshold: u64,
+    trash_enabled: bool,
+    trash_retention_secs: u64,
+    reconcile_interval_secs: u64,
+    orphan_chunk_cleanup_grace_secs: u64,
+    roots: BTreeMap<&'a str, RedactedRegisteredRootConfig<'a>>,
+    root_state_dir: &'a Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedRegisteredRootConfig<'a> {
+    local_root: &'a PathBuf,
+    remote_prefix: &'a str,
+    state_path: &'a PathBuf,
+    policy: &'a RegisteredRootPolicy,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedFuseConfig<'a> {
+    negative_cache_ttl_secs: u64,
+    cache_dir: &'a PathBuf,
+    cache_max_mb: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedCryptoConfig<'a> {
+    enabled: bool,
+    argon2_mem_cost_kib: u32,
+    argon2_time_cost: u32,
+    argon2_parallelism: u32,
+    master_key_file: &'a Option<PathBuf>,
+    device_identity: &'a Option<PathBuf>,
+    passphrase_file: &'a Option<PathBuf>,
+    kdf_salt: &'a Option<String>,
+    wrap_mode: &'a WrapMode,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedSopsConfig<'a> {
+    enabled: bool,
+    sops_dir: &'a PathBuf,
+    sync_prefix: &'a str,
+    machine_id: &'a Option<String>,
+    backup_dir: &'a PathBuf,
+    watch: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedAuthConfig<'a> {
+    enabled: bool,
+    require_session: bool,
+    session_expiry_hours: u64,
+    methods: &'a [String],
+    totp: RedactedAuthTotpConfig<'a>,
+    webauthn: RedactedAuthWebAuthnConfig<'a>,
+    enrollment: RedactedAuthEnrollmentConfig,
+    rate_limit: RedactedAuthRateLimitConfig,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedAuthTotpConfig<'a> {
+    issuer: &'a str,
+    digits: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedAuthWebAuthnConfig<'a> {
+    relying_party_id: &'a str,
+    relying_party_name: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedAuthEnrollmentConfig {
+    qr_code: bool,
+    auto_discovery: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedAuthRateLimitConfig {
+    max_attempts: u32,
+    lockout_secs: u64,
+    backoff_multiplier: u32,
+}
+
+const REDACTED_INVALID_ENDPOINT: &str = "<invalid-or-non-base-url:redacted>";
+
+/// Return an HTTP(S) endpoint safe for terminal, log, status, and diagnostic output.
+///
+/// The result contains only the parsed scheme, normalized host/IP, and
+/// non-default port. Invalid or unsupported values become a constant so raw
+/// credential-bearing input is never echoed while reporting an error.
+pub fn sanitize_http_endpoint_for_display(raw: &str) -> String {
+    sanitize_endpoint_for_display(raw, &["http", "https"])
+}
+
+/// Return the origin of an absolute HTTP(S) endpoint for functional metadata.
+///
+/// Unlike [`sanitize_http_endpoint_for_display`], invalid values return
+/// `None` instead of a display placeholder. Callers can therefore fail closed
+/// before signing or serializing routing metadata that must remain usable.
+pub fn http_endpoint_origin(raw: &str) -> Option<String> {
+    endpoint_origin(raw, &["http", "https"])
+}
+
+/// Return a NATS endpoint safe for terminal, log, status, and diagnostic output.
+///
+/// The result contains only the parsed scheme, normalized host/IP, and
+/// non-default port. Invalid or unsupported values become a constant so raw
+/// credential-bearing input is never echoed while reporting an error.
+pub fn sanitize_nats_endpoint_for_display(raw: &str) -> String {
+    sanitize_endpoint_for_display(raw, &["nats", "tls"])
+}
+
+/// Preserve only a URL's scheme, normalized host/IP, and parsed non-default port.
+///
+/// Userinfo, path, query, and fragment components are intentionally omitted.
+/// Unparseable, hostless, opaque, relative, and unsupported-scheme values are
+/// represented by a constant because echoing any raw component would recreate
+/// the credential leak this display contract prevents.
+fn sanitize_endpoint_for_display(raw: &str, allowed_schemes: &[&str]) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+
+    endpoint_origin(raw, allowed_schemes).unwrap_or_else(|| REDACTED_INVALID_ENDPOINT.to_owned())
+}
+
+fn endpoint_origin(raw: &str, allowed_schemes: &[&str]) -> Option<String> {
+    let Ok(endpoint) = Url::parse(raw) else {
+        return None;
+    };
+    if endpoint.cannot_be_a_base() || !allowed_schemes.contains(&endpoint.scheme()) {
+        return None;
+    }
+
+    let host = match endpoint.host() {
+        Some(Host::Domain(host)) => host.to_owned(),
+        Some(Host::Ipv4(host)) => host.to_string(),
+        Some(Host::Ipv6(host)) => format!("[{host}]"),
+        None => return None,
+    };
+    let port = endpoint
+        .port()
+        .map(|port| format!(":{port}"))
+        .unwrap_or_default();
+    Some(format!("{}://{host}{port}", endpoint.scheme()))
+}
+
+impl TcfsConfig {
+    /// Borrow a serialization-only view that omits inline credentials.
+    pub fn redacted(&self) -> RedactedConfig<'_> {
+        // These patterns are intentionally exhaustive: adding a runtime config
+        // field must force an explicit decision about diagnostic display.
+        let TcfsConfig {
+            daemon,
+            storage,
+            secrets,
+            sync,
+            fuse,
+            crypto,
+            sops,
+            auth,
+            config_file_mode_check,
+        } = self;
+
+        let DaemonConfig {
+            socket,
+            fileprovider_socket,
+            fileprovider_endpoint,
+            listen,
+            metrics_addr,
+            log_level,
+            log_format,
+        } = daemon;
+        let StorageConfig {
+            endpoint,
+            region,
+            bucket,
+            remote_prefix,
+            credentials_file,
+            enforce_tls,
+            ca_cert_path,
+            max_concurrent_ops,
+            s3_connect_timeout_secs,
+            s3_pool_idle_timeout_secs,
+            s3_pool_max_idle_per_host,
+            s3_http1_only,
+            max_upload_bytes_per_sec,
+            max_download_bytes_per_sec,
+        } = storage;
+        let SecretsConfig {
+            age_identity,
+            kdbx_path,
+            sops_dir: secrets_sops_dir,
+        } = secrets;
+        let SyncConfig {
+            nats_url,
+            nats_tls,
+            nats_token,
+            nats_ca_cert,
+            state_db,
+            workers,
+            max_retries,
+            device_identity: sync_device_identity,
+            device_name,
+            conflict_mode,
+            sync_git_dirs,
+            git_sync_mode,
+            sync_hidden_dirs,
+            exclude_patterns,
+            sync_symlinks,
+            sync_empty_dirs,
+            sync_root,
+            auto_unsync_max_age_secs,
+            auto_unsync_interval_secs,
+            auto_unsync_dry_run,
+            auto_unsync_disk_pressure_pct,
+            auto_unsync_max_per_sweep,
+            auto_download_threshold,
+            trash_enabled,
+            trash_retention_secs,
+            reconcile_interval_secs,
+            orphan_chunk_cleanup_grace_secs,
+            roots,
+            root_state_dir,
+        } = sync;
+        let FuseConfig {
+            negative_cache_ttl_secs,
+            cache_dir,
+            cache_max_mb,
+        } = fuse;
+        let CryptoConfig {
+            enabled: crypto_enabled,
+            argon2_mem_cost_kib,
+            argon2_time_cost,
+            argon2_parallelism,
+            master_key_file,
+            device_identity: crypto_device_identity,
+            passphrase_file,
+            kdf_salt,
+            wrap_mode,
+        } = crypto;
+        let SopsConfig {
+            enabled: sops_enabled,
+            sops_dir,
+            sync_prefix,
+            machine_id,
+            backup_dir,
+            watch,
+        } = sops;
+        let AuthConfig {
+            enabled: auth_enabled,
+            require_session,
+            session_expiry_hours,
+            methods,
+            totp,
+            webauthn,
+            enrollment,
+            rate_limit,
+        } = auth;
+        let AuthTotpConfig { issuer, digits } = totp;
+        let AuthWebAuthnConfig {
+            relying_party_id,
+            relying_party_name,
+        } = webauthn;
+        let AuthEnrollmentConfig {
+            qr_code,
+            auto_discovery,
+        } = enrollment;
+        let AuthRateLimitConfig {
+            max_attempts,
+            lockout_secs,
+            backoff_multiplier,
+        } = rate_limit;
+        let redacted_roots = roots
+            .iter()
+            .map(|(root_id, root)| {
+                let RegisteredRootConfig {
+                    local_root,
+                    remote_prefix,
+                    state_path,
+                    policy,
+                } = root;
+                (
+                    root_id.as_str(),
+                    RedactedRegisteredRootConfig {
+                        local_root,
+                        remote_prefix,
+                        state_path,
+                        policy,
+                    },
+                )
+            })
+            .collect();
+
+        RedactedConfig {
+            daemon: RedactedDaemonConfig {
+                socket,
+                fileprovider_socket,
+                fileprovider_endpoint: fileprovider_endpoint
+                    .as_deref()
+                    .map(sanitize_http_endpoint_for_display),
+                listen,
+                metrics_addr,
+                log_level,
+                log_format,
+            },
+            storage: RedactedStorageConfig {
+                endpoint: sanitize_http_endpoint_for_display(endpoint),
+                region,
+                bucket,
+                remote_prefix,
+                credentials_file,
+                enforce_tls: *enforce_tls,
+                ca_cert_path,
+                max_concurrent_ops: *max_concurrent_ops,
+                s3_connect_timeout_secs: *s3_connect_timeout_secs,
+                s3_pool_idle_timeout_secs: *s3_pool_idle_timeout_secs,
+                s3_pool_max_idle_per_host: *s3_pool_max_idle_per_host,
+                s3_http1_only: *s3_http1_only,
+                max_upload_bytes_per_sec: *max_upload_bytes_per_sec,
+                max_download_bytes_per_sec: *max_download_bytes_per_sec,
+            },
+            secrets: RedactedSecretsConfig {
+                age_identity,
+                kdbx_path,
+                sops_dir: secrets_sops_dir,
+            },
+            sync: RedactedSyncConfig {
+                nats_url: sanitize_nats_endpoint_for_display(nats_url),
+                nats_tls: *nats_tls,
+                nats_token_configured: nats_token.is_some(),
+                nats_ca_cert,
+                state_db,
+                workers: *workers,
+                max_retries: *max_retries,
+                device_identity: sync_device_identity,
+                device_name,
+                conflict_mode,
+                sync_git_dirs: *sync_git_dirs,
+                git_sync_mode,
+                sync_hidden_dirs: *sync_hidden_dirs,
+                exclude_patterns,
+                sync_symlinks: *sync_symlinks,
+                sync_empty_dirs: *sync_empty_dirs,
+                sync_root,
+                auto_unsync_max_age_secs: *auto_unsync_max_age_secs,
+                auto_unsync_interval_secs: *auto_unsync_interval_secs,
+                auto_unsync_dry_run: *auto_unsync_dry_run,
+                auto_unsync_disk_pressure_pct: *auto_unsync_disk_pressure_pct,
+                auto_unsync_max_per_sweep: *auto_unsync_max_per_sweep,
+                auto_download_threshold: *auto_download_threshold,
+                trash_enabled: *trash_enabled,
+                trash_retention_secs: *trash_retention_secs,
+                reconcile_interval_secs: *reconcile_interval_secs,
+                orphan_chunk_cleanup_grace_secs: *orphan_chunk_cleanup_grace_secs,
+                roots: redacted_roots,
+                root_state_dir,
+            },
+            fuse: RedactedFuseConfig {
+                negative_cache_ttl_secs: *negative_cache_ttl_secs,
+                cache_dir,
+                cache_max_mb: *cache_max_mb,
+            },
+            crypto: RedactedCryptoConfig {
+                enabled: *crypto_enabled,
+                argon2_mem_cost_kib: *argon2_mem_cost_kib,
+                argon2_time_cost: *argon2_time_cost,
+                argon2_parallelism: *argon2_parallelism,
+                master_key_file,
+                device_identity: crypto_device_identity,
+                passphrase_file,
+                kdf_salt,
+                wrap_mode,
+            },
+            sops: RedactedSopsConfig {
+                enabled: *sops_enabled,
+                sops_dir,
+                sync_prefix,
+                machine_id,
+                backup_dir,
+                watch: *watch,
+            },
+            auth: RedactedAuthConfig {
+                enabled: *auth_enabled,
+                require_session: *require_session,
+                session_expiry_hours: *session_expiry_hours,
+                methods,
+                totp: RedactedAuthTotpConfig {
+                    issuer,
+                    digits: *digits,
+                },
+                webauthn: RedactedAuthWebAuthnConfig {
+                    relying_party_id,
+                    relying_party_name,
+                },
+                enrollment: RedactedAuthEnrollmentConfig {
+                    qr_code: *qr_code,
+                    auto_discovery: *auto_discovery,
+                },
+                rate_limit: RedactedAuthRateLimitConfig {
+                    max_attempts: *max_attempts,
+                    lockout_secs: *lockout_secs,
+                    backoff_multiplier: *backoff_multiplier,
+                },
+            },
+            config_file_mode_check: *config_file_mode_check,
+        }
+    }
 }
 
 /// Authentication and session configuration
@@ -1020,6 +1515,205 @@ state_path = "/run/tcfsd/reconcile/docs.json"
         assert_eq!(config.daemon.socket, parsed.daemon.socket);
         assert_eq!(config.storage.endpoint, parsed.storage.endpoint);
         assert_eq!(config.sync.nats_url, parsed.sync.nats_url);
+    }
+
+    #[test]
+    fn raw_config_roundtrip_retains_nats_token_but_redacted_view_omits_it() {
+        const TOKEN: &str = "raw-roundtrip-token-sentinel";
+
+        let mut config = TcfsConfig::default();
+        config.sync.nats_token = Some(TOKEN.into());
+
+        let raw = toml::to_string(&config).unwrap();
+        assert!(raw.contains("nats_token"));
+        assert!(raw.contains(TOKEN));
+
+        let parsed: TcfsConfig = toml::from_str(&raw).unwrap();
+        assert_eq!(parsed.sync.nats_token.as_deref(), Some(TOKEN));
+
+        let redacted = toml::to_string(&config.redacted()).unwrap();
+        assert!(!redacted.contains(TOKEN));
+        let redacted: toml::Value = toml::from_str(&redacted).unwrap();
+        assert!(redacted["sync"].get("nats_token").is_none());
+        assert_eq!(
+            redacted["sync"]["nats_token_configured"].as_bool(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn redacted_view_explicitly_serializes_registered_root_metadata() {
+        let mut config = TcfsConfig::default();
+        config.sync.root_state_dir = Some(PathBuf::from("/var/lib/tcfs/reconcile"));
+        config.sync.roots.insert(
+            "work-root".into(),
+            RegisteredRootConfig {
+                local_root: PathBuf::from("/srv/work"),
+                remote_prefix: "roots/work".into(),
+                state_path: PathBuf::from("/var/lib/tcfs/reconcile/work.json"),
+                policy: RegisteredRootPolicy::Resolve,
+            },
+        );
+
+        let toml_rendered = toml::to_string(&config.redacted()).unwrap();
+        let toml_value: toml::Value = toml::from_str(&toml_rendered).unwrap();
+        let root = &toml_value["sync"]["roots"]["work-root"];
+        assert_eq!(root["local_root"].as_str(), Some("/srv/work"));
+        assert_eq!(root["remote_prefix"].as_str(), Some("roots/work"));
+        assert_eq!(
+            root["state_path"].as_str(),
+            Some("/var/lib/tcfs/reconcile/work.json")
+        );
+        assert_eq!(root["policy"].as_str(), Some("resolve"));
+        assert_eq!(
+            toml_value["sync"]["root_state_dir"].as_str(),
+            Some("/var/lib/tcfs/reconcile")
+        );
+
+        let json_value = serde_json::to_value(config.redacted()).unwrap();
+        assert_eq!(
+            json_value["sync"]["roots"]["work-root"]["remote_prefix"].as_str(),
+            Some("roots/work")
+        );
+        assert_eq!(
+            json_value["sync"]["roots"]["work-root"]["local_root"].as_str(),
+            Some("/srv/work")
+        );
+        assert_eq!(
+            json_value["sync"]["roots"]["work-root"]["state_path"].as_str(),
+            Some("/var/lib/tcfs/reconcile/work.json")
+        );
+        assert_eq!(
+            json_value["sync"]["roots"]["work-root"]["policy"].as_str(),
+            Some("resolve")
+        );
+        assert_eq!(
+            json_value["sync"]["root_state_dir"].as_str(),
+            Some("/var/lib/tcfs/reconcile")
+        );
+    }
+
+    #[test]
+    fn redacted_view_sanitizes_url_credentials_and_unparseable_values() {
+        let mut config = TcfsConfig::default();
+        config.storage.endpoint =
+            "https://s3-user:S3-secret@storage.example.test:8333/S3-path-secret?signature=S3-query#S3-fragment"
+                .into();
+        config.sync.nats_url =
+            "nats://nats-user:NATS-secret@nats.example.test:4222/NATS-path-secret?token=NATS-query#NATS-fragment"
+                .into();
+        config.daemon.fileprovider_endpoint = Some(
+            "https://fp-user:FP-secret@fp.example.test/FP-path-secret?token=FP-query#FP-fragment"
+                .into(),
+        );
+        config.sync.nats_token = Some("inline-token-sentinel".into());
+
+        let rendered = toml::to_string(&config.redacted()).unwrap();
+        for forbidden in [
+            "s3-user",
+            "S3-secret",
+            "S3-path-secret",
+            "S3-query",
+            "S3-fragment",
+            "nats-user",
+            "NATS-secret",
+            "NATS-path-secret",
+            "NATS-query",
+            "NATS-fragment",
+            "fp-user",
+            "FP-secret",
+            "FP-path-secret",
+            "FP-query",
+            "FP-fragment",
+            "inline-token-sentinel",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "leaked {forbidden}: {rendered}"
+            );
+        }
+
+        let value: toml::Value = toml::from_str(&rendered).unwrap();
+        assert_eq!(
+            value["storage"]["endpoint"].as_str(),
+            Some("https://storage.example.test:8333")
+        );
+        assert_eq!(
+            value["sync"]["nats_url"].as_str(),
+            Some("nats://nats.example.test:4222")
+        );
+        assert_eq!(
+            value["daemon"]["fileprovider_endpoint"].as_str(),
+            Some("https://fp.example.test")
+        );
+        assert_eq!(value["sync"]["nats_token_configured"].as_bool(), Some(true));
+        assert!(value["sync"].get("nats_token").is_none());
+
+        config.storage.endpoint = "host-with-secret=S3-unparseable-sentinel".into();
+        config.sync.nats_url = "host-with-secret=NATS-unparseable-sentinel".into();
+        let rendered = toml::to_string(&config.redacted()).unwrap();
+        assert!(!rendered.contains("S3-unparseable-sentinel"));
+        assert!(!rendered.contains("NATS-unparseable-sentinel"));
+        let value: toml::Value = toml::from_str(&rendered).unwrap();
+        assert_eq!(
+            value["storage"]["endpoint"].as_str(),
+            Some(REDACTED_INVALID_ENDPOINT)
+        );
+        assert_eq!(
+            value["sync"]["nats_url"].as_str(),
+            Some(REDACTED_INVALID_ENDPOINT)
+        );
+    }
+
+    #[test]
+    fn endpoint_display_contract_is_origin_only_and_scheme_bounded() {
+        assert_eq!(
+            sanitize_http_endpoint_for_display(
+                "https://user%40name:pass%3Aword@example.test:8333/%50%41%54%48_SECRET?sig=QUERY_SECRET#FRAGMENT_SECRET",
+            ),
+            "https://example.test:8333"
+        );
+        assert_eq!(
+            sanitize_nats_endpoint_for_display(
+                "nats://user:pass@nats.example.test:4222/PATH_SECRET?token=QUERY_SECRET",
+            ),
+            "nats://nats.example.test:4222"
+        );
+        assert_eq!(
+            sanitize_http_endpoint_for_display("https://[2001:db8::1]:8333/private"),
+            "https://[2001:db8::1]:8333"
+        );
+        assert_eq!(
+            sanitize_http_endpoint_for_display("https://safe.example.test:8443/"),
+            "https://safe.example.test:8443"
+        );
+        assert_eq!(
+            sanitize_http_endpoint_for_display("/relative/PATH_SECRET?token=QUERY_SECRET"),
+            REDACTED_INVALID_ENDPOINT
+        );
+        assert_eq!(
+            sanitize_http_endpoint_for_display("mailto:OPAQUE_SECRET@example.test"),
+            REDACTED_INVALID_ENDPOINT
+        );
+        assert_eq!(
+            sanitize_nats_endpoint_for_display("nats:///MISSING_HOST_SECRET"),
+            REDACTED_INVALID_ENDPOINT
+        );
+        assert_eq!(
+            sanitize_http_endpoint_for_display("://MALFORMED_SECRET"),
+            REDACTED_INVALID_ENDPOINT
+        );
+        assert_eq!(
+            sanitize_http_endpoint_for_display("ftp://user:pass@example.test/DISALLOWED_SECRET",),
+            REDACTED_INVALID_ENDPOINT
+        );
+        assert_eq!(
+            http_endpoint_origin(
+                "https://user:pass@example.test:8333/private?token=secret#fragment",
+            ),
+            Some("https://example.test:8333".to_string())
+        );
+        assert_eq!(http_endpoint_origin("not-an-endpoint"), None);
     }
 
     #[test]

--- a/crates/tcfs-core/src/proto/tcfs.proto
+++ b/crates/tcfs-core/src/proto/tcfs.proto
@@ -46,6 +46,7 @@ message Empty {}
 message StatusRequest {}
 message StatusResponse {
   string version = 1;
+  // Diagnostic origin only: userinfo, path, query, and fragment are stripped.
   string storage_endpoint = 2;
   bool storage_ok = 3;
   bool nats_ok = 4;

--- a/crates/tcfs-mcp/src/server.rs
+++ b/crates/tcfs-mcp/src/server.rs
@@ -10,6 +10,7 @@ use rmcp::{
     schemars, tool, tool_handler, tool_router, ServerHandler,
 };
 
+use tcfs_core::config::sanitize_http_endpoint_for_display;
 use tcfs_core::proto::{
     tcfs_daemon_client::TcfsDaemonClient, Empty, PullRequest, StatusRequest, SyncStatusRequest,
 };
@@ -99,7 +100,9 @@ impl TcfsMcp {
                     let s = resp.into_inner();
                     serde_json::json!({
                         "version": s.version,
-                        "storage_endpoint": s.storage_endpoint,
+                        "storage_endpoint": sanitize_http_endpoint_for_display(
+                            &s.storage_endpoint
+                        ),
                         "storage_ok": s.storage_ok,
                         "nats_ok": s.nats_ok,
                         "active_mounts": s.active_mounts,
@@ -136,7 +139,7 @@ impl TcfsMcp {
         }
     }
 
-    #[tool(description = "Show tcfs configuration (daemon, storage, sync, fuse, crypto sections)")]
+    #[tool(description = "Show a redacted tcfs diagnostic configuration view")]
     async fn config_show(&self) -> String {
         let path = self
             .config_path
@@ -146,15 +149,25 @@ impl TcfsMcp {
 
         match std::fs::read_to_string(&path) {
             Ok(contents) => match toml::from_str::<tcfs_core::config::TcfsConfig>(&contents) {
-                Ok(config) => match serde_json::to_string_pretty(&config) {
+                Ok(config) => match serde_json::to_string_pretty(&config.redacted()) {
                     Ok(json) => json,
-                    Err(e) => format!("{{\"error\": \"serialize config: {e}\"}}"),
+                    Err(_) => serde_json::json!({
+                        "error": "serializing redacted config failed",
+                    })
+                    .to_string(),
                 },
-                Err(e) => {
-                    format!("{{\"error\": \"parse config at {}: {e}\"}}", path.display())
-                }
+                Err(_) => serde_json::json!({
+                    "error": format!(
+                        "parse config at {} failed; check TOML syntax and field types",
+                        path.display()
+                    ),
+                })
+                .to_string(),
             },
-            Err(e) => format!("{{\"error\": \"read config at {}: {e}\"}}", path.display()),
+            Err(e) => serde_json::json!({
+                "error": format!("read config at {} failed: {e}", path.display()),
+            })
+            .to_string(),
         }
     }
 
@@ -442,7 +455,9 @@ mod tests {
             self.calls.lock().await.status_calls += 1;
             Ok(Response::new(StatusResponse {
                 version: "0.12.0-test".into(),
-                storage_endpoint: "http://seaweedfs:8333".into(),
+                storage_endpoint:
+                    "https://status-user:STATUS-secret@storage.example.test:8333/STATUS-path?signature=STATUS-query#STATUS-fragment"
+                        .into(),
                 storage_ok: true,
                 nats_ok: false,
                 active_mounts: 2,
@@ -698,6 +713,25 @@ mod tests {
         assert_eq!(value["version"], "0.12.0-test");
         assert_eq!(value["device_id"], "device-123");
         assert_eq!(value["active_mounts"], 2);
+        assert_eq!(
+            value["storage_endpoint"],
+            "https://storage.example.test:8333"
+        );
+        for forbidden in [
+            "status-user",
+            "STATUS-secret",
+            "STATUS-path",
+            "STATUS-query",
+            "STATUS-fragment",
+        ] {
+            assert!(
+                !value["storage_endpoint"]
+                    .as_str()
+                    .unwrap()
+                    .contains(forbidden),
+                "MCP daemon status leaked {forbidden}: {value}"
+            );
+        }
         assert_eq!(harness.calls.lock().await.status_calls, 1);
 
         harness.shutdown().await;
@@ -735,9 +769,110 @@ mod tests {
 
         assert_eq!(value["storage"]["bucket"], "bucket-a");
         assert_eq!(value["sync"]["conflict_mode"], "keep_local");
+        assert_eq!(value["sync"]["nats_token_configured"], false);
+        assert!(value["sync"].get("nats_token").is_none());
         assert!(value.get("daemon").is_some());
         assert!(value.get("fuse").is_some());
         assert!(value.get("crypto").is_some());
+    }
+
+    #[test]
+    fn config_show_never_serializes_nats_token_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let mut config = tcfs_core::config::TcfsConfig::default();
+        let token = "TIN2860-left-sentinel.middle-sentinel.right-sentinel";
+        config.sync.nats_token = Some(token.into());
+        config.storage.endpoint =
+            "https://s3-user:S3-secret@storage.example.test:8333/S3-path-secret?signature=S3-query#S3-fragment"
+                .into();
+        config.sync.nats_url =
+            "nats://nats-user:NATS-secret@nats.example.test:4222/NATS-path-secret?token=NATS-query#NATS-fragment"
+                .into();
+        config.daemon.fileprovider_endpoint = Some(
+            "https://fp-user:FP-secret@fp.example.test/FP-path-secret?token=FP-query#FP-fragment"
+                .into(),
+        );
+        std::fs::write(&config_path, toml::to_string(&config).unwrap()).unwrap();
+
+        let mcp = TcfsMcp::new(PathBuf::from("/tmp/unused.sock"), Some(config_path));
+        let output = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(mcp.config_show());
+
+        for forbidden in [
+            token,
+            "TIN2860-left-sentinel",
+            "middle-sentinel",
+            "right-sentinel",
+            "s3-user",
+            "S3-secret",
+            "S3-path-secret",
+            "S3-query",
+            "S3-fragment",
+            "nats-user",
+            "NATS-secret",
+            "NATS-path-secret",
+            "NATS-query",
+            "NATS-fragment",
+            "fp-user",
+            "FP-secret",
+            "FP-path-secret",
+            "FP-query",
+            "FP-fragment",
+        ] {
+            assert!(
+                !output.contains(forbidden),
+                "MCP config output leaked token material: {output}"
+            );
+        }
+
+        let value: serde_json::Value =
+            serde_json::from_str(&output).expect("MCP config output must remain valid JSON");
+        assert_eq!(value["sync"]["nats_token_configured"], true);
+        assert!(value["sync"].get("nats_token").is_none());
+        assert_eq!(
+            value["storage"]["endpoint"],
+            "https://storage.example.test:8333"
+        );
+        assert_eq!(value["sync"]["nats_url"], "nats://nats.example.test:4222");
+        assert_eq!(
+            value["daemon"]["fileprovider_endpoint"],
+            "https://fp.example.test"
+        );
+    }
+
+    #[test]
+    fn config_show_parse_error_never_echoes_offending_source_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let malformed = r#"
+[sync]
+nats_token = ["TIN2860-malformed-left", "malformed-middle", "malformed-right"]
+"#;
+        std::fs::write(&config_path, malformed).unwrap();
+
+        let mcp = TcfsMcp::new(PathBuf::from("/tmp/unused.sock"), Some(config_path.clone()));
+        let output = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(mcp.config_show());
+
+        for forbidden in [
+            "TIN2860-malformed-left",
+            "malformed-middle",
+            "malformed-right",
+        ] {
+            assert!(
+                !output.contains(forbidden),
+                "MCP parse error leaked config source material: {output}"
+            );
+        }
+
+        let value: serde_json::Value =
+            serde_json::from_str(&output).expect("MCP parse failure must remain valid JSON");
+        let error = value["error"].as_str().expect("error string");
+        assert!(error.contains(&config_path.display().to_string()));
+        assert!(error.contains("check TOML syntax and field types"));
     }
 
     #[tokio::test]

--- a/crates/tcfs-storage/src/health.rs
+++ b/crates/tcfs-storage/src/health.rs
@@ -45,12 +45,11 @@ pub struct HealthCheckReport {
 
 /// Typed storage health probe failure.
 #[derive(Debug, thiserror::Error)]
-#[error("storage health check {kind} at {path} after {elapsed_ms} ms: {message}")]
+#[error("storage health check {kind} at {path} after {elapsed_ms} ms")]
 pub struct HealthCheckError {
     kind: HealthCheckFailureKind,
     path: String,
     elapsed_ms: u128,
-    message: String,
     backend_kind: Option<String>,
 }
 
@@ -71,12 +70,11 @@ impl HealthCheckError {
         self.backend_kind.as_deref()
     }
 
-    fn timeout(path: &str, timeout: Duration, elapsed: Duration) -> Self {
+    fn timeout(path: &str, _timeout: Duration, elapsed: Duration) -> Self {
         Self {
             kind: HealthCheckFailureKind::Timeout,
             path: path.to_string(),
             elapsed_ms: elapsed.as_millis(),
-            message: format!("timed out after {timeout:?}"),
             backend_kind: None,
         }
     }
@@ -94,7 +92,6 @@ impl HealthCheckError {
             kind,
             path: path.to_string(),
             elapsed_ms: elapsed.as_millis(),
-            message: err.to_string(),
             backend_kind: Some(backend_kind),
         }
     }
@@ -275,6 +272,33 @@ mod tests {
 
         assert_eq!(err.kind(), HealthCheckFailureKind::RateLimited);
         assert_eq!(err.backend_kind(), Some("RateLimited"));
+    }
+
+    #[test]
+    fn backend_error_display_never_echoes_backend_message() {
+        let err = HealthCheckError::from_opendal(
+            "tenant-a/",
+            Duration::from_millis(9),
+            opendal::Error::new(
+                opendal::ErrorKind::Unexpected,
+                "https://user:HEALTH-secret@storage.example.test/HEALTH-path?token=HEALTH-query",
+            ),
+        );
+
+        let rendered = err.to_string();
+        assert!(rendered.contains("backend_error"));
+        for forbidden in [
+            "user",
+            "HEALTH-secret",
+            "storage.example.test",
+            "HEALTH-path",
+            "HEALTH-query",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "health error leaked {forbidden}: {rendered}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tcfs-storage/src/lib.rs
+++ b/crates/tcfs-storage/src/lib.rs
@@ -35,15 +35,14 @@ pub fn parse_remote_spec(spec: &str) -> anyhow::Result<(String, String, String)>
         ("http", rest)
     } else {
         anyhow::bail!(
-            "remote spec must start with seaweedfs://, seaweedfs+http://, or seaweedfs+https:// — got: {}",
-            spec
+            "remote spec must start with seaweedfs://, seaweedfs+http://, or seaweedfs+https://"
         );
     };
 
     // Split host:port from /bucket[/prefix]
     let slash = rest
         .find('/')
-        .ok_or_else(|| anyhow::anyhow!("remote spec must include /bucket — got: {}", spec))?;
+        .ok_or_else(|| anyhow::anyhow!("remote spec must include /bucket"))?;
 
     let host = &rest[..slash]; // e.g. "dees-appu-bearts:8333"
     let path = &rest[slash + 1..]; // e.g. "tcfs-test" or "tcfs-test/subdir"
@@ -51,7 +50,7 @@ pub fn parse_remote_spec(spec: &str) -> anyhow::Result<(String, String, String)>
     // First path component = bucket, remainder = prefix
     let (bucket, prefix) = path.split_once('/').unwrap_or((path, ""));
     if bucket.is_empty() {
-        anyhow::bail!("remote spec must include a bucket — got: {}", spec);
+        anyhow::bail!("remote spec must include a bucket");
     }
 
     Ok((
@@ -125,5 +124,28 @@ mod tests {
     #[test]
     fn test_parse_remote_spec_empty_bucket() {
         assert!(parse_remote_spec("seaweedfs://host:8333/").is_err());
+    }
+
+    #[test]
+    fn parse_remote_spec_errors_never_echo_caller_input() {
+        for spec in [
+            "custom-secret://user:SCHEME-secret@host/bucket?token=SCHEME-query",
+            "seaweedfs+https://user:NO-BUCKET-secret@host",
+            "seaweedfs+https://user:EMPTY-secret@host/",
+        ] {
+            let rendered = format!("{:#}", parse_remote_spec(spec).unwrap_err());
+            for forbidden in [
+                "custom-secret",
+                "SCHEME-secret",
+                "SCHEME-query",
+                "NO-BUCKET-secret",
+                "EMPTY-secret",
+            ] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "remote-spec error leaked {forbidden}: {rendered}"
+                );
+            }
+        }
     }
 }

--- a/crates/tcfs-storage/src/operator.rs
+++ b/crates/tcfs-storage/src/operator.rs
@@ -6,6 +6,7 @@ use opendal::{ErrorKind, Operator};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::Duration;
+use tcfs_core::config::sanitize_http_endpoint_for_display;
 
 /// Minimal config needed to build an operator
 /// (full config lives in tcfs-core's StorageConfig)
@@ -571,11 +572,12 @@ pub async fn ensure_conditional_write_semantics(op: &Operator, prefix: &str) -> 
 }
 
 fn validate_endpoint_transport(cfg: &StorageConfig) -> Result<()> {
+    let endpoint_display = sanitize_http_endpoint_for_display(&cfg.endpoint);
     let endpoint = reqwest::Url::parse(&cfg.endpoint)
-        .with_context(|| format!("parsing S3 endpoint URL {}", cfg.endpoint))?;
+        .with_context(|| format!("parsing S3 endpoint URL {endpoint_display}"))?;
 
     if let Some(warning) = insecure_transport_warning(endpoint.scheme(), cfg.allow_insecure_http) {
-        tracing::warn!(endpoint = %cfg.endpoint, "{warning}");
+        tracing::warn!(endpoint = %endpoint_display, "{warning}");
     }
 
     match endpoint.scheme() {
@@ -583,11 +585,11 @@ fn validate_endpoint_transport(cfg: &StorageConfig) -> Result<()> {
         "http" if cfg.allow_insecure_http => Ok(()),
         "http" => anyhow::bail!(
             "S3 endpoint uses plaintext HTTP ({}). Use an HTTPS endpoint. For isolated development or tests only, explicitly set storage.enforce_tls = false (tcfs config) or allow_insecure_http = true (low-level client).",
-            cfg.endpoint
+            endpoint_display
         ),
-        scheme => anyhow::bail!(
-            "unsupported S3 endpoint scheme {scheme:?} in {}; HTTPS is required",
-            cfg.endpoint
+        _ => anyhow::bail!(
+            "unsupported S3 endpoint scheme in {}; HTTPS is required",
+            endpoint_display
         ),
     }
 }
@@ -1381,6 +1383,50 @@ mod tests {
 
         let err = build_operator(&cfg).unwrap_err();
         assert!(err.to_string().contains("plaintext HTTP"), "{err:#}");
+    }
+
+    #[test]
+    fn endpoint_transport_errors_never_echo_credential_bearing_input() {
+        for endpoint in [
+            "not-a-url-with-MALFORMED-secret?token=MALFORMED-query",
+            "http://plain-user:PLAIN-secret@plain.example.test:8333/PLAIN-path?token=PLAIN-query#PLAIN-fragment",
+            "ftp://ftp-user:FTP-secret@ftp.example.test/FTP-path?token=FTP-query#FTP-fragment",
+            "custom-secret://custom-user:CUSTOM-secret@custom.example.test/CUSTOM-path?token=CUSTOM-query#CUSTOM-fragment",
+        ] {
+            let cfg = StorageConfig {
+                endpoint: endpoint.into(),
+                access_key_id: "test-key".into(),
+                secret_access_key: "test-secret".into(),
+                ..Default::default()
+            };
+
+            let rendered = format!("{:#}", validate_endpoint_transport(&cfg).unwrap_err());
+            for forbidden in [
+                "MALFORMED-secret",
+                "MALFORMED-query",
+                "plain-user",
+                "PLAIN-secret",
+                "PLAIN-path",
+                "PLAIN-query",
+                "PLAIN-fragment",
+                "ftp-user",
+                "FTP-secret",
+                "FTP-path",
+                "FTP-query",
+                "FTP-fragment",
+                "custom-secret",
+                "custom-user",
+                "CUSTOM-secret",
+                "CUSTOM-path",
+                "CUSTOM-query",
+                "CUSTOM-fragment",
+            ] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "transport error leaked {forbidden}: {rendered}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/tcfs-sync/src/nats.rs
+++ b/crates/tcfs-sync/src/nats.rs
@@ -25,6 +25,7 @@ mod inner {
     use tracing::{debug, error, info, warn};
 
     use crate::conflict::VectorClock;
+    use tcfs_core::config::sanitize_nats_endpoint_for_display;
 
     // ── Stream / consumer names ───────────────────────────────────────────────
 
@@ -206,16 +207,19 @@ mod inner {
     pub fn resolve_nats_url(url: &str, require_tls: bool) -> String {
         if require_tls && url.starts_with("nats://") {
             let upgraded = url.replacen("nats://", "tls://", 1);
+            let original_display = sanitize_nats_endpoint_for_display(url);
+            let upgraded_display = sanitize_nats_endpoint_for_display(&upgraded);
             warn!(
-                original = url,
-                upgraded = %upgraded,
+                original = %original_display,
+                upgraded = %upgraded_display,
                 "NATS: upgrading to TLS (nats_tls=true)"
             );
             upgraded
         } else {
             if !require_tls && !url.starts_with("tls://") {
+                let url_display = sanitize_nats_endpoint_for_display(url);
                 warn!(
-                    url,
+                    url = %url_display,
                     "NATS: connecting without TLS — credentials transmitted in plaintext"
                 );
             }
@@ -229,20 +233,29 @@ mod inner {
         /// If `require_tls` is true and the URL uses `nats://`, it is upgraded to `tls://`.
         pub async fn connect(url: &str, require_tls: bool, token: Option<&str>) -> Result<Self> {
             let effective_url = resolve_nats_url(url, require_tls);
+            let effective_url_display = sanitize_nats_endpoint_for_display(&effective_url);
 
             let client = if let Some(tok) = token {
                 info!("NATS: connecting with token auth");
                 async_nats::ConnectOptions::with_token(tok.to_string())
                     .connect(&effective_url)
                     .await
-                    .map_err(|e| anyhow::anyhow!("connecting to NATS at {effective_url}: {e}"))?
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "connecting to NATS at {effective_url_display} failed; check endpoint, TLS, and credentials"
+                        )
+                    })?
             } else {
                 async_nats::connect(&effective_url)
                     .await
-                    .map_err(|e| anyhow::anyhow!("connecting to NATS at {effective_url}: {e}"))?
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "connecting to NATS at {effective_url_display} failed; check endpoint, TLS, and credentials"
+                        )
+                    })?
             };
 
-            info!("NATS: connected to {effective_url}");
+            info!("NATS: connected to {effective_url_display}");
             let js = jetstream::new(client);
             Ok(NatsClient { js })
         }
@@ -836,6 +849,25 @@ mod inner {
         fn tls_url_preserved_when_tls_not_required() {
             let url = resolve_nats_url("tls://nats.example.com:4222", false);
             assert_eq!(url, "tls://nats.example.com:4222");
+        }
+
+        #[test]
+        fn nats_display_url_omits_credentials_and_routing_components() {
+            let raw = "nats://nats-user:NATS-secret@nats.example.test:4222/NATS-path?token=NATS-query#NATS-fragment";
+            let display = sanitize_nats_endpoint_for_display(raw);
+            assert_eq!(display, "nats://nats.example.test:4222");
+            for forbidden in [
+                "nats-user",
+                "NATS-secret",
+                "NATS-path",
+                "NATS-query",
+                "NATS-fragment",
+            ] {
+                assert!(
+                    !display.contains(forbidden),
+                    "leaked {forbidden}: {display}"
+                );
+            }
         }
 
         #[tokio::test]

--- a/crates/tcfs-tui/src/ui/widgets/config.rs
+++ b/crates/tcfs-tui/src/ui/widgets/config.rs
@@ -3,6 +3,7 @@ use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Frame;
+use tcfs_core::config::{sanitize_http_endpoint_for_display, sanitize_nats_endpoint_for_display};
 
 use crate::app::App;
 
@@ -25,7 +26,8 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     kv(&mut lines, "Log Format", &c.daemon.log_format);
 
     section_header(&mut lines, "Storage");
-    kv(&mut lines, "Endpoint", &c.storage.endpoint);
+    let storage_endpoint = sanitize_http_endpoint_for_display(&c.storage.endpoint);
+    kv(&mut lines, "Endpoint", &storage_endpoint);
     kv(&mut lines, "Region", &c.storage.region);
     kv(&mut lines, "Bucket", &c.storage.bucket);
     kv(
@@ -64,7 +66,8 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     );
 
     section_header(&mut lines, "Sync");
-    kv(&mut lines, "NATS URL", &c.sync.nats_url);
+    let nats_url = sanitize_nats_endpoint_for_display(&c.sync.nats_url);
+    kv(&mut lines, "NATS URL", &nats_url);
     kv(
         &mut lines,
         "NATS TLS",

--- a/crates/tcfs-tui/src/ui/widgets/dashboard.rs
+++ b/crates/tcfs-tui/src/ui/widgets/dashboard.rs
@@ -3,6 +3,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Sparkline};
 use ratatui::Frame;
+use tcfs_core::config::sanitize_http_endpoint_for_display;
 
 use crate::app::App;
 
@@ -66,7 +67,7 @@ fn draw_status_card(f: &mut Frame, app: &App, area: Rect) {
                 ]),
                 Line::from(vec![
                     Span::styled("  Endpoint: ", Style::default().fg(Color::DarkGray)),
-                    Span::raw(&s.storage_endpoint),
+                    Span::raw(sanitize_http_endpoint_for_display(&s.storage_endpoint)),
                 ]),
                 Line::from(vec![
                     Span::styled("  Storage:  ", Style::default().fg(Color::DarkGray)),

--- a/crates/tcfsd/src/config_loader.rs
+++ b/crates/tcfsd/src/config_loader.rs
@@ -21,5 +21,44 @@ pub async fn load_config(path: &Path) -> Result<TcfsConfig> {
     let content = tokio::fs::read_to_string(path)
         .await
         .map_err(|e| anyhow::anyhow!("reading config {}: {e}", path.display()))?;
-    toml::from_str(&content).map_err(|e| anyhow::anyhow!("parsing config {}: {e}", path.display()))
+    toml::from_str(&content).map_err(|_| {
+        anyhow::anyhow!(
+            "parsing config {} failed; check TOML syntax and field types",
+            path.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn parse_error_never_echoes_offending_source_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let malformed = r#"
+[sync]
+nats_token = ["TIN2860-malformed-left", "malformed-middle", "malformed-right"]
+"#;
+        std::fs::write(&config_path, malformed).unwrap();
+
+        let error = load_config(&config_path)
+            .await
+            .expect_err("malformed token type must fail daemon config loading");
+        let rendered = format!("{error:#}");
+
+        for forbidden in [
+            "TIN2860-malformed-left",
+            "malformed-middle",
+            "malformed-right",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "daemon parse error leaked config source material: {rendered}"
+            );
+        }
+        assert!(rendered.contains(&config_path.display().to_string()));
+        assert!(rendered.contains("check TOML syntax and field types"));
+    }
 }

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -5,7 +5,9 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use tcfs_core::config::TcfsConfig;
+use tcfs_core::config::{
+    sanitize_http_endpoint_for_display, sanitize_nats_endpoint_for_display, TcfsConfig,
+};
 use tcfs_sync::conflict::ConflictResolver;
 use tracing::{debug, error, info, warn};
 
@@ -550,6 +552,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
 
     // Build storage operator and verify connectivity
     let mut operator: Option<opendal::Operator> = None;
+    let storage_endpoint_display = sanitize_http_endpoint_for_display(&config.storage.endpoint);
     let storage_ok = if let Some(s3) = cred_store.read().await.as_ref().and_then(|c| c.s3.as_ref())
     {
         let op = tcfs_storage::operator::build_from_core_config(
@@ -561,7 +564,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         match tcfs_storage::check_health_for_prefix_detailed(&op, storage_prefix).await {
             Ok(report) => {
                 info!(
-                    endpoint = %config.storage.endpoint,
+                    endpoint = %storage_endpoint_display,
                     prefix = %storage_prefix,
                     health_path = %report.path,
                     elapsed_ms = report.elapsed_ms,
@@ -573,7 +576,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
             }
             Err(e) => {
                 warn!(
-                    endpoint = %config.storage.endpoint,
+                    endpoint = %storage_endpoint_display,
                     prefix = %storage_prefix,
                     health_kind = %e.kind(),
                     health_path = %e.path(),
@@ -1231,9 +1234,11 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         } else {
             if let Ok(ref env_url) = std::env::var("TCFS_NATS_URL") {
                 if env_url != nats_url {
+                    let config_url_display = sanitize_nats_endpoint_for_display(nats_url);
+                    let env_url_display = sanitize_nats_endpoint_for_display(env_url);
                     warn!(
-                        config_url = %nats_url,
-                        env_url = %env_url,
+                        config_url = %config_url_display,
+                        env_url = %env_url_display,
                         "TCFS_NATS_URL env var differs from config — using config value"
                     );
                 }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -17,7 +17,9 @@ use crate::cred_store::SharedCredStore;
 
 use base64::Engine;
 use secrecy::ExposeSecret;
-use tcfs_core::config::{RegisteredRootConfig, RegisteredRootPolicy, TcfsConfig};
+use tcfs_core::config::{
+    sanitize_http_endpoint_for_display, RegisteredRootConfig, RegisteredRootPolicy, TcfsConfig,
+};
 use tcfs_core::proto::{
     tcfs_daemon_server::{TcfsDaemon, TcfsDaemonServer},
     *,
@@ -2043,7 +2045,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
 
         Ok(tonic::Response::new(StatusResponse {
             version: env!("CARGO_PKG_VERSION").into(),
-            storage_endpoint: self.storage_endpoint.clone(),
+            storage_endpoint: sanitize_http_endpoint_for_display(&self.storage_endpoint),
             storage_ok,
             nats_ok: self.nats_ok.load(std::sync::atomic::Ordering::Relaxed),
             active_mounts: mount_count,
@@ -2110,16 +2112,6 @@ impl TcfsDaemon for TcfsDaemonImpl {
             })?;
         }
 
-        let use_nfs = req.options.iter().any(|o| o == "nfs");
-        let backend = if use_nfs { "NFS loopback" } else { "FUSE" };
-
-        info!(
-            mountpoint = %req.mountpoint,
-            remote = %req.remote,
-            backend = %backend,
-            "spawning mount"
-        );
-
         // Get the storage operator from daemon state
         let op = {
             let guard = self.operator.lock().await;
@@ -2129,8 +2121,18 @@ impl TcfsDaemon for TcfsDaemonImpl {
         };
 
         // Parse prefix from remote spec
-        let (_endpoint, _bucket, prefix) = tcfs_storage::parse_remote_spec(&req.remote)
+        let (endpoint, _bucket, prefix) = tcfs_storage::parse_remote_spec(&req.remote)
             .map_err(|e| tonic::Status::invalid_argument(format!("bad remote spec: {e}")))?;
+        let endpoint_display = sanitize_http_endpoint_for_display(&endpoint);
+        let use_nfs = req.options.iter().any(|o| o == "nfs");
+        let backend = if use_nfs { "NFS loopback" } else { "FUSE" };
+
+        info!(
+            mountpoint = %req.mountpoint,
+            endpoint = %endpoint_display,
+            backend = %backend,
+            "spawning mount"
+        );
 
         let mp = mountpoint.clone();
         let cache_dir = self.config.fuse.cache_dir.clone();
@@ -2142,7 +2144,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
         if use_nfs {
             // NFS loopback (fallback — use --nfs flag or "nfs" option)
             let mount_handle = tokio::spawn(async move {
-                tracing::info!("NFS mount task starting (prefix={prefix})");
+                tracing::info!("NFS mount task starting");
                 match tcfs_nfs::serve_and_mount(tcfs_nfs::NfsMountConfig {
                     op,
                     prefix,
@@ -2225,7 +2227,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
 
             let vfs_sender = self.vfs_tx.clone();
             let mount_handle = tokio::spawn(async move {
-                tracing::info!("FUSE mount task starting (prefix={prefix})");
+                tracing::info!("FUSE mount task starting");
                 match tcfs_fuse::mount(
                     tcfs_fuse::MountConfig {
                         op,
@@ -5802,7 +5804,10 @@ mod tests {
 
     #[tokio::test]
     async fn status_returns_version() {
-        let daemon = test_daemon();
+        let mut daemon = test_daemon();
+        daemon.storage_endpoint =
+            "https://status-user:STATUS-secret@storage.example.test:8333/STATUS-path?signature=STATUS-query#STATUS-fragment"
+                .into();
         let resp = daemon
             .status(tonic::Request::new(StatusRequest {}))
             .await
@@ -5812,6 +5817,20 @@ mod tests {
         assert_eq!(resp.version, env!("CARGO_PKG_VERSION"));
         assert_eq!(resp.device_id, "test-device-id");
         assert_eq!(resp.device_name, "test-device");
+        assert_eq!(resp.storage_endpoint, "https://storage.example.test:8333");
+        for forbidden in [
+            "status-user",
+            "STATUS-secret",
+            "STATUS-path",
+            "STATUS-query",
+            "STATUS-fragment",
+        ] {
+            assert!(
+                !resp.storage_endpoint.contains(forbidden),
+                "status endpoint leaked {forbidden}: {}",
+                resp.storage_endpoint
+            );
+        }
         assert!(!resp.storage_ok);
         assert!(!resp.nats_ok);
         assert_eq!(resp.active_mounts, 0);


### PR DESCRIPTION
Linear: TIN-2860

## Summary

Introduce one explicit, allowlisted `TcfsConfig::redacted()` contract for operator and diagnostic surfaces. The current schema's sole inline credential, `sync.nats_token`, is never serialized by that contract; output instead reports `nats_token_configured`. HTTP(S) and NATS endpoints are reduced to URL-normalized origins, and CLI/MCP/daemon TOML config parse failures retain the file path plus actionable guidance without echoing source lines.

This is source-only under the TIN-2856 fleet freeze. No live credentials were read, and no fleet deployment, activation, enrollment ceremony, resolver operation, TOTP flow, reconciliation, or crypto rotation was performed.

## Changes

- Add an exhaustive `TcfsConfig::redacted()` serializer that:
  - omits inline NATS bearer bytes;
  - reports only whether NATS authentication is configured;
  - explicitly retains registered-root and `root_state_dir` metadata;
  - requires a deliberate display decision when future config fields are added.
- Sanitize HTTP(S) and NATS endpoints to URL-normalized origins, removing userinfo, path, query, and fragment components; custom or malformed schemes fail closed.
- Use the shared contract in CLI and MCP config display while preserving valid TOML and JSON output.
- Replace CLI, MCP, and daemon TOML parse details with path-bearing generic guidance that does not echo source lines.
- Apply defense-in-depth sanitization to daemon status, CLI/MCP/TUI status, storage canary reports, storage/NATS diagnostics, mount output, and storage health errors.
- Prevent mount-spec validation errors and daemon mount logs from reproducing raw caller-controlled endpoint or prefix material.
- Restrict CLI-created signed `EnrollmentInvite.storage_endpoint` metadata to a valid HTTP(S) origin and fail closed on invalid or unsupported endpoints without echoing input.
- Document the diagnostic and signed-invite compatibility contract in the changelog and status protobuf comment.
- Add sentinel coverage for token fragments, URL credentials, paths, queries, fragments, malformed config lines, invalid invite endpoints, and backend error messages.

## Boundary

Runtime config parsing semantics, full config persistence, initialization, and config-file writers are unchanged.

The signed-invite change is deliberately disclosed as functional exported metadata. Newly CLI-generated invites transitively supply an origin-only storage endpoint to wrapped `EnrollmentBootstrap` and the legacy `DeviceEnrollResponse.storage_endpoint` field because the daemon prefers invite metadata. Legacy/manually created invites and fallback configuration may still carry full functional URLs. There are no direct DeviceEnroll schema, daemon enrollment-handler, or FileProvider code changes, and path-based endpoint semantics are not claimed as preserved.

Credential/key paths, bucket and prefix identifiers, and the KDF salt remain visible as deliberately classified configuration metadata; secret contents do not. MCP-to-daemon session metadata remains separate.

## Test plan

Validated on Sting with Rust 1.93 at exact signed head `490cca1d64c234840024dc2cbd4aacc65f110deb`:

- [x] `cargo fmt --all -- --check`
- [x] Locked workspace metadata resolution
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] Focused CLI, MCP, daemon, core-config, storage, NATS, mount, canary, invite, and parse-error sentinel tests
- [x] `cargo build --workspace --locked`
- [x] `cargo test --workspace --locked`
- [x] `cargo test -p tcfs-sync --features nats,crypto --locked`
- [x] `cargo build -p tcfsd --features k8s-worker --locked`
- [x] `cargo build -p tcfs-cli --no-default-features --locked`
- [x] `cargo check -p tcfs-tui --all-targets --locked`
- [x] `git diff --check` and changed-file conflict-marker check
- [x] Targeted Gitleaks scan of the complete diff
- [x] Exact-head CI

Fresh independent read-only security and acceptance reviews found no remaining actionable leak through the reviewed diagnostic, terminal, log, status, or RPC-error surfaces and mapped every Linear acceptance item to tests. This was not a professional security audit; functional legacy/manual enrollment payloads and MCP session propagation remain outside its claim boundary.

## Checklist

- [x] Docs updated for changed operator-visible behavior
- [x] `CHANGELOG.md` updated, including signed-invite compatibility
- [x] No secrets or credentials in the diff
- [ ] Live manual verification — intentionally not performed under TIN-2856

