### PR TITLE
feat(sync): bind registered-root reconcile control state (TIN-2864)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - tinyland-dind
+    - tinyland-nix

--- a/.github/workflows/ci-live-storage.yml
+++ b/.github/workflows/ci-live-storage.yml
@@ -1,16 +1,11 @@
 name: CI Live Storage
 
-# TIN-1421: real-storage CI lane.
-#
-# Brings up SeaweedFS + NATS via the project's existing docker-compose stack
-# inside the job container, then runs `cargo test -p tcfs-e2e --test fleet_live`
-# with TCFS_E2E_LIVE=1. This is the single highest-leverage QA investment from
-# the 2026-05-18 audit: today PRs can land broken sync paths and ci.yml stays
-# green because the live-fleet tests are operator-only on neo/honey/yoga.
-#
-# The compose stack is a subset of `task dev` (masters + volume + filer + nats —
-# no prometheus/grafana since those aren't on the test path). Same images, same
-# config, so a green CI run carries the same authority as a green local run.
+# TIN-2538: live-storage proof is valid only on the shared GloriousFlywheel
+# DinD capability lane with immutable service images and the TIN-3127
+# public-read-only Nix front door. Public-only applies to Attic authentication:
+# the pinned helper may retain the repository-scoped contents:read GitHub token
+# for Nix source fetches. A missing personal-owner binding queues this job; it
+# never falls back to hosted execution.
 
 on:
   pull_request:
@@ -22,6 +17,8 @@ on:
       - "docker-compose.yml"
       - "config/**"
       - ".github/workflows/ci-live-storage.yml"
+      - "scripts/test-ci-authority-contract.py"
+      - "config/ci-authority-policy.json"
   push:
     branches: [main]
     paths:
@@ -32,63 +29,96 @@ on:
       - "docker-compose.yml"
       - "config/**"
       - ".github/workflows/ci-live-storage.yml"
+      - "scripts/test-ci-authority-contract.py"
+      - "config/ci-authority-policy.json"
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ci-live-storage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: "1.93.0"
-  # Override defaults baked into fleet_live.rs (which point at tailnet MagicDNS)
+  ATTIC_TOKEN: ""
   TCFS_E2E_LIVE: "1"
   TCFS_S3_ENDPOINT: "http://127.0.0.1:8333"
-  # Explicit test-only opt-in for the job-local compose endpoint.
   TCFS_STORAGE_ALLOW_INSECURE_HTTP: "true"
   TCFS_S3_BUCKET: "tcfs"
   TCFS_NATS_URL: "nats://127.0.0.1:4222"
-  # Keep infra failures cheap in CI; the production default is 300s.
   TCFS_UPLOAD_CHUNK_TIMEOUT_SECS: "30"
   AWS_ACCESS_KEY_ID: "admin"
   AWS_SECRET_ACCESS_KEY: "admin"
 
 jobs:
   fleet-live:
-    name: fleet_live tests against compose-managed SeaweedFS + NATS
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
+    name: fleet_live on GloriousFlywheel DinD
+    runs-on: tinyland-dind
+    timeout-minutes: 35
 
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
-      - name: Cache cargo registry + target
-        uses: Swatinem/rust-cache@v2
+      - name: Verify exact checked out revision
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Require the preinstalled GF Nix runtime
+        run: command -v nix
+
+      - name: Attach GloriousFlywheel public-read-only DinD cache runtime
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@TIN_3127_SIGNED_MERGE_REVISION_PENDING
+        env:
+          GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          ATTIC_TOKEN: ""
         with:
-          shared-key: ci-live-storage-${{ runner.os }}
-          workspaces: ". -> target"
+          attic-enabled: "true"
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-read-only: "true"
+          attic-public-read-site: tcfs-live-storage
+          push-cache: "false"
+          require-cache-push: "false"
+          command: |
+            set -euo pipefail
+            test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+            test "${ATTIC_TOKEN:-}" = ""
+            test -n "${DOCKER_HOST:-}"
+            test -n "${ATTIC_SERVER:-}"
+            test "${ATTIC_CACHE:-}" = main
+            test -n "${ATTIC_PUBLIC_KEY:-}"
+            test -n "${BAZEL_REMOTE_CACHE:-}"
+            test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
+            test "${NIX_USER_CONF_FILES:-}" = /dev/null
+            test "${NETRC:-}" = /dev/null
+            test "$(nix config show netrc-file)" = /dev/null
+            nix config show extra-substituters |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+            docker version
+            docker info
 
-      - name: Write CI compose override
-        # Keep CI on the repo-managed dev stack, with narrow overrides for
-        # image-version realities that currently make a fresh runner fail
-        # before tcfs is under test:
-        #
-        # - SeaweedFS: the shared stack uses `-max=0` for the volume server.
-        #   Current SeaweedFS can then report "No writable volumes" for the
-        #   S3 bucket collection. Give the CI volume server room to create
-        #   collection volumes.
-        # - NATS: the shared stack passes `--max_payload 8MB`; current
-        #   nats:2.10-alpine rejects that CLI flag.
+      - name: Write immutable CI compose override
         run: |
           set -euo pipefail
           mkdir -p .github/compose-overrides
           cat > .github/compose-overrides/ci.yml <<'EOF'
           services:
+            seaweed-master-1:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+            seaweed-master-2:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+            seaweed-master-3:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
             seaweed-volume:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
               command: >
                 volume
                 -mserver=seaweed-master-1:9333,seaweed-master-2:9333,seaweed-master-3:9333
@@ -99,7 +129,10 @@ jobs:
                 -max=32
                 -ip=seaweed-volume
                 -ip.bind=0.0.0.0
+            seaweed-filer:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
             nats:
+              image: nats:2.10.29-alpine3.22@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
               command: >
                 --name tcfs-nats
                 --jetstream
@@ -107,7 +140,7 @@ jobs:
                 --http_port 8222
           EOF
 
-      - name: Bring up compose-managed SeaweedFS + NATS
+      - name: Bring up compose-managed SeaweedFS and NATS
         run: |
           set -euo pipefail
           docker compose -f docker-compose.yml -f .github/compose-overrides/ci.yml up -d \
@@ -120,10 +153,6 @@ jobs:
         run: |
           set -euo pipefail
           for i in $(seq 1 60); do
-            # -s silent, -o discard body, -w just the http code. NO -f, since -f
-            # suppresses --write-out on HTTP error responses (SeaweedFS S3 returns
-            # 403 from `/` without credentials, which is the correct "service up"
-            # signal but would silence the code under -f).
             CODE="$(curl -s -m 5 -o /dev/null -w "%{http_code}" "${TCFS_S3_ENDPOINT}/" || echo "000")"
             case "$CODE" in
               200|301|302|307|403|404)
@@ -132,7 +161,8 @@ jobs:
                 ;;
             esac
             echo "waiting for SeaweedFS S3 (attempt $i/60, last code: $CODE)..."
-            sleep 2
+            sleep 2 &
+            wait $!
           done
           echo "::error::SeaweedFS S3 did not become reachable at ${TCFS_S3_ENDPOINT}" >&2
           docker compose logs seaweed-filer | tail -80 || true
@@ -148,52 +178,38 @@ jobs:
               exit 0
             fi
             echo "waiting for NATS ($i/30)..."
-            sleep 1
+            sleep 1 &
+            wait $!
           done
           echo "::error::NATS did not become healthy" >&2
           docker compose logs nats | tail -80 || true
           exit 1
 
-      - name: Create S3 bucket (if not auto-created)
+      - name: Create S3 bucket
         run: |
           set -euo pipefail
-          # SeaweedFS S3 auto-creates buckets on PUT for admin identities, but
-          # do an explicit create with awscli to surface auth/config issues
-          # before the cargo test step.
-          aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
-              s3api create-bucket --bucket "${TCFS_S3_BUCKET}" \
-              --region us-east-1 2>&1 \
+          nix develop --accept-flake-config .#default --command \
+            aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
+                s3api create-bucket --bucket "${TCFS_S3_BUCKET}" \
+                --region us-east-1 2>&1 \
             | tee /tmp/bucket-create.log || true
-          aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
-              s3api head-bucket --bucket "${TCFS_S3_BUCKET}"
-          echo "S3 bucket '${TCFS_S3_BUCKET}' reachable"
+          nix develop --accept-flake-config .#default --command \
+            aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
+                s3api head-bucket --bucket "${TCFS_S3_BUCKET}"
 
       - name: Run fleet_live tests
         run: |
-          set -euo pipefail
-          cargo test -p tcfs-e2e --test fleet_live -- --nocapture
-        env:
-          # Re-export so the test process sees env from `env:` above
-          # (cargo test inherits the workflow env; this is belt-and-suspenders).
-          TCFS_E2E_LIVE: "1"
+          nix develop --accept-flake-config .#default --command \
+            cargo test -p tcfs-e2e --test fleet_live --locked -- --nocapture
 
-      - name: Collect compose logs on failure
+      - name: Print compose logs on failure
         if: failure()
         run: |
-          mkdir -p /tmp/compose-logs
           for svc in seaweed-master-1 seaweed-master-2 seaweed-master-3 seaweed-volume seaweed-filer nats; do
-            docker compose logs "$svc" > "/tmp/compose-logs/${svc}.log" 2>&1 || true
+            echo "===== ${svc} ====="
+            docker compose logs --no-color "$svc" | tail -200 || true
           done
-
-      - name: Upload compose logs artifact
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: compose-logs-${{ github.run_id }}
-          path: /tmp/compose-logs/
-          retention-days: 7
 
       - name: Tear down compose stack
         if: always()
-        run: |
-          docker compose down -v --remove-orphans || true
+        run: docker compose down -v --remove-orphans || true

--- a/.github/workflows/ci-live-storage.yml
+++ b/.github/workflows/ci-live-storage.yml
@@ -75,7 +75,7 @@ jobs:
         run: command -v nix
 
       - name: Attach GloriousFlywheel public-read-only DinD cache runtime
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@TIN_3127_SIGNED_MERGE_REVISION_PENDING
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,238 +6,163 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUST_TOOLCHAIN: 1.93.0
-  GITLEAKS_VERSION: 8.30.1
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
+  # TIN-3127 public-read-only applies to Attic authentication. The pinned
+  # helper may separately retain the contents:read GitHub token for Nix source
+  # fetches; checked-out PR code receives no Attic token or inherited netrc.
+  ATTIC_TOKEN: ""
 
 jobs:
-  check:
-    name: Build + Lint + Test
-    runs-on: ubuntu-latest
+  linux-source:
+    name: Linux source authority (GloriousFlywheel)
+    runs-on: tinyland-nix
+    timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-
-      - name: Free hosted runner disk
-        run: |
-          set -euo pipefail
-          df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
-          df -h /
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            protobuf-compiler \
-            libfuse3-dev \
-            pkg-config \
-            libssl-dev
-
-      - name: Verify Cargo.lock is consistent
-        run: cargo check --workspace --locked
-
-      - name: cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: FileProvider surface contract
-        run: bash scripts/test-fileprovider-surface-contract.sh
-
-      - name: cargo clippy
-        run: cargo clippy --workspace --all-targets
-
-      - name: cargo test
-        run: cargo test --workspace
-
-      - name: cargo test tcfs-sync (nats + crypto features)
-        run: cargo test -p tcfs-sync --features nats,crypto
-
-      - name: Feature-isolated consumer tests
-        run: |
-          cargo test -p tcfs-file-provider --no-default-features --features grpc --locked
-          cargo test -p tcfs-file-provider --no-default-features --features uniffi --locked
-          cargo test -p tcfs-dbus --features grpc --locked
-
-      - name: Wire-up integration tests (prove modules are connected)
-        run: |
-          cargo test -p tcfs-e2e --test blacklist_wireup -- --nocapture
-          cargo test -p tcfs-e2e --test reconcile_wireup -- --nocapture
-
-      - name: Trim incremental artifacts before final builds
-        run: |
-          set -euo pipefail
-          du -sh target || true
-          find target -type d -name incremental -prune -exec rm -rf {} +
-          du -sh target || true
-          df -h .
-
-      - name: Build workspace (default features)
-        run: cargo build --workspace
-
-      - name: Build tcfsd (k8s-worker feature)
-        run: cargo build -p tcfsd --features k8s-worker
-
-      - name: Build tcfs CLI (no FUSE — macOS/Windows compat)
-        run: cargo build -p tcfs-cli --no-default-features
-
-  cloudfilter-windows:
-    name: CloudFilter compile (Windows)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-
-      - name: Compile Windows CloudFilter targets
-        run: cargo check -p tcfs-cloudfilter --all-targets --locked
-
-  nix:
-    name: Nix Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.tinyland.dev/main
-            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
-
-      - name: Verify runner Nix toolchain
-        run: nix --version
-
-      - name: Nix flake check
-        run: nix flake check --accept-flake-config
-
-      - name: Verify devShell Rust version
-        run: |
-          VERSION="$(nix develop --accept-flake-config --command rustc --version)"
-          echo "$VERSION"
-          echo "$VERSION" | grep -q "1.93.0"
-
-      - name: Build tcfsd
-        run: nix build --accept-flake-config --fallback .#tcfsd
-
-      - name: Build tcfs-cli
-        run: nix build --accept-flake-config --fallback .#tcfs-cli
-
-      - name: Build tcfs-tui
-        run: nix build --accept-flake-config --fallback .#tcfs-tui
-
-      - name: Build tcfs-mcp
-        run: nix build --accept-flake-config --fallback .#tcfs-mcp
-
-  fileprovider-staticlib:
-    name: FileProvider staticlib (macOS)
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-
-      - name: Build staticlib
-        run: cargo build -p tcfs-file-provider --release
-
-      - name: Verify staticlib exists
-        run: |
-          test -f target/release/libtcfs_file_provider.a
-          echo "staticlib size: $(du -h target/release/libtcfs_file_provider.a | cut -f1)"
-
-      - name: Verify cbindgen header
-        run: |
-          HEADER=$(find target -name tcfs_file_provider.h | head -1)
-          test -n "$HEADER"
-          grep -q "tcfs_provider_new" "$HEADER"
-          grep -q "tcfs_provider_upload" "$HEADER"
-          grep -q "tcfs_provider_delete" "$HEADER"
-          echo "header: $HEADER"
-
-      - name: Check gRPC backend compiles
-        run: cargo check -p tcfs-file-provider --no-default-features --features grpc
-
-  ios-typecheck:
-    name: iOS FileProvider typecheck
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          targets: aarch64-apple-ios-sim
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-
-      - name: Build iOS staticlib + type-check Swift
-        run: bash swift/ios/Scripts/build-ios.sh --simulator
-
-  deny:
-    name: cargo-deny
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-      - name: Install cargo-deny build dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends build-essential
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
-      - name: cargo deny check
-        run: cargo deny check
-
-  secret-scan:
-    name: Secret Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Install gitleaks
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact checked out revision
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Require the preinstalled GF Nix runtime
+        run: command -v nix
+
+      - name: Attach GloriousFlywheel public-read-only cache runtime
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@TIN_3127_SIGNED_MERGE_REVISION_PENDING
+        env:
+          GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          ATTIC_TOKEN: ""
+        with:
+          attic-enabled: "true"
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-read-only: "true"
+          attic-public-read-site: tcfs-linux-source
+          push-cache: "false"
+          require-cache-push: "false"
+          command: |
+            set -euo pipefail
+            test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+            test "${ATTIC_TOKEN:-}" = ""
+            test -n "${ATTIC_SERVER:-}"
+            test "${ATTIC_CACHE:-}" = main
+            test -n "${ATTIC_PUBLIC_KEY:-}"
+            test -n "${BAZEL_REMOTE_CACHE:-}"
+            test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
+            test "${NIX_USER_CONF_FILES:-}" = /dev/null
+            test "${NETRC:-}" = /dev/null
+            test "$(nix config show netrc-file)" = /dev/null
+            nix config show extra-substituters |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+
+      - name: Build, lint, test, and scan in the repo toolchain
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
         run: |
-          curl --retry 5 --retry-all-errors --retry-delay 2 -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | sudo tar xz -C /usr/local/bin gitleaks
-      - name: Scan for secrets
+          # shellcheck disable=SC2016 # Expanded by the inner repo-toolchain shell.
+          nix develop --accept-flake-config .#default --command bash -euo pipefail -c '
+            python3 scripts/test-ci-authority-contract.py
+            cargo check --workspace --locked
+            cargo fmt --all -- --check
+            bash scripts/test-fileprovider-surface-contract.sh
+            cargo clippy --workspace --all-targets --locked -- -D warnings
+            cargo test --workspace --locked
+            cargo test -p tcfs-sync --features nats,crypto --locked
+            cargo test -p tcfs-file-provider --no-default-features --features grpc --locked
+            cargo test -p tcfs-file-provider --no-default-features --features uniffi --locked
+            cargo test -p tcfs-dbus --features grpc --locked
+            cargo test -p tcfs-e2e --test blacklist_wireup --locked -- --nocapture
+            cargo test -p tcfs-e2e --test reconcile_wireup --locked -- --nocapture
+            cargo build --workspace --locked
+            cargo build -p tcfsd --features k8s-worker --locked
+            cargo build -p tcfs-cli --no-default-features --locked
+            cargo deny check
+            if [ -n "$BASE_SHA" ]; then
+              gitleaks git --config .gitleaks.toml --redact --log-opts="$BASE_SHA..HEAD"
+            else
+              gitleaks git --config .gitleaks.toml --redact
+            fi
+          '
+
+  windows-cross:
+    name: Windows CFAPI cross-check (source-only)
+    runs-on: tinyland-nix
+    timeout-minutes: 45
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact checked out revision
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Require the preinstalled GF Nix runtime
+        run: command -v nix
+
+      - name: Attach GloriousFlywheel public-read-only cache runtime
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@TIN_3127_SIGNED_MERGE_REVISION_PENDING
+        env:
+          GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          ATTIC_TOKEN: ""
+        with:
+          attic-enabled: "true"
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-read-only: "true"
+          attic-public-read-site: tcfs-windows-cross
+          push-cache: "false"
+          require-cache-push: "false"
+          command: |
+            set -euo pipefail
+            test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+            test "${ATTIC_TOKEN:-}" = ""
+            test -n "${ATTIC_SERVER:-}"
+            test "${ATTIC_CACHE:-}" = main
+            test -n "${ATTIC_PUBLIC_KEY:-}"
+            test -n "${BAZEL_REMOTE_CACHE:-}"
+            test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
+            test "${NIX_USER_CONF_FILES:-}" = /dev/null
+            test "${NETRC:-}" = /dev/null
+            test "$(nix config show netrc-file)" = /dev/null
+            nix config show extra-substituters |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+
+      - name: Type-check the Windows CFAPI surface from sanctioned Linux compute
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            gitleaks detect --source . --config .gitleaks.toml --log-opts="${{ github.event.pull_request.base.sha }}..HEAD" --verbose
-          else
-            gitleaks detect --source . --config .gitleaks.toml --verbose
-          fi
+          nix develop --accept-flake-config .#default --command \
+            cargo check -p tcfs-cloudfilter \
+              --target x86_64-pc-windows-gnu \
+              --all-targets \
+              --locked
+
+  darwin-authority-held:
+    name: HELD - native Darwin and iOS authority
+    runs-on: tinyland-nix
+    timeout-minutes: 5
+    steps:
+      - name: Hold until the authorized GF Darwin worker is proved
+        run: |
+          echo "::error title=Darwin authority held::TIN-2998 has not yet proved an authorized native Apple Silicon GF worker. Linux cross-compilation is not a substitute for FileProvider or iOS native proof."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: command -v nix
 
       - name: Attach GloriousFlywheel public-read-only cache runtime
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@TIN_3127_SIGNED_MERGE_REVISION_PENDING
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""
@@ -122,7 +122,7 @@ jobs:
         run: command -v nix
 
       - name: Attach GloriousFlywheel public-read-only cache runtime
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@TIN_3127_SIGNED_MERGE_REVISION_PENDING
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   push:
     branches: [main, dev, "sid/**", "1-*"]
+  # Stacked PRs require the same exact-head authority as main-bound PRs.
   pull_request:
-    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/container-runtime-smoke.yml
+++ b/.github/workflows/container-runtime-smoke.yml
@@ -29,6 +29,7 @@ concurrency:
 
 jobs:
   runtime-smoke:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Runtime smoke (${{ matrix.platform }})
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   check-links:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Check Links
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +33,7 @@ jobs:
           fail: true
 
   build-pdf:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Build PDFs
     runs-on: ubuntu-latest
     steps:
@@ -50,10 +52,10 @@ jobs:
           path: dist/docs/*.pdf
 
   deploy:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: [check-links]
-    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/homebrew-install-smoke.yml
+++ b/.github/workflows/homebrew-install-smoke.yml
@@ -44,6 +44,7 @@ concurrency:
 
 jobs:
   install-smoke:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Homebrew ${{ github.event.inputs.smoke_mode }} smoke
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 25

--- a/.github/workflows/linux-package-container-smoke.yml
+++ b/.github/workflows/linux-package-container-smoke.yml
@@ -46,7 +46,7 @@ concurrency:
 jobs:
   package-container-smoke:
     name: ${{ matrix.surface }}
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     strategy:

--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -70,7 +70,7 @@ permissions:
 jobs:
   package-postinstall:
     name: Linux package post-install smoke
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 30
     environment: ${{ github.event.inputs.smoke_environment }}

--- a/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
+++ b/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   notarized-pkg-proof:
     name: Build, notarize, staple, and assess .pkg
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 120
     steps:

--- a/.github/workflows/macos-fileprovider-testing-mode-pkg.yml
+++ b/.github/workflows/macos-fileprovider-testing-mode-pkg.yml
@@ -60,7 +60,7 @@ env:
 jobs:
   build-testing-mode-pkg:
     name: Build testing-mode .pkg
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -105,7 +105,7 @@ permissions:
 jobs:
   pkg-postinstall:
     name: macOS .pkg post-install smoke
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 40
     environment: ${{ github.event.inputs.smoke_environment }}

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,11 +1,5 @@
-# Nix CI with Attic binary cache push
-#
-# Builds all tcfs packages with Nix and pushes results to the
-# tinyland Attic binary cache. Consuming machines can then
-# `nix profile install` or `nix build` with near-instant cache hits.
-#
-# Required secrets:
-#   ATTIC_TOKEN — obtained from `attic login tinyland <server> <token>`
+# TIN-2538: Nix proof is cache-read-only on the shared GloriousFlywheel Nix
+# capability lane. Publication remains a separately authorized standing path.
 
 name: Nix CI
 
@@ -16,161 +10,77 @@ on:
     branches: [main, dev]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+# TIN-3127 public-read-only applies to Attic authentication. The pinned helper
+# may separately retain the contents:read GitHub token for Nix source fetches.
 env:
-  # Public Attic endpoint shared with flake.nix and other workflows.
-  ATTIC_SERVER: https://nix-cache.tinyland.dev
-  ATTIC_CACHE: main
+  ATTIC_TOKEN: ""
+
+concurrency:
+  group: nix-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  flake-check:
-    name: Flake Check
-    runs-on: ubuntu-latest
+  nix-linux:
+    name: Nix Linux source authority (GloriousFlywheel)
+    runs-on: tinyland-nix
+    timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.tinyland.dev/main
-            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
-      - name: Verify runner Nix toolchain
-        run: nix --version
+      - name: Verify exact checked out revision
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
 
-      - name: Nix flake check
-        run: nix flake check --accept-flake-config
+      - name: Require the preinstalled GF Nix runtime
+        run: command -v nix
 
-  build-linux-x86_64:
-    name: Build Linux x86_64
-    runs-on: ubuntu-latest
-    needs: flake-check
+      - name: Check and build through the public-read-only GloriousFlywheel Nix front door
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@TIN_3127_SIGNED_MERGE_REVISION_PENDING
+        env:
+          GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          ATTIC_TOKEN: ""
+        with:
+          attic-enabled: "true"
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-read-only: "true"
+          attic-public-read-site: tcfs-nix-linux
+          push-cache: "false"
+          require-cache-push: "false"
+          command: |
+            set -euo pipefail
+            test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+            test "${ATTIC_TOKEN:-}" = ""
+            test -n "${ATTIC_SERVER:-}"
+            test "${ATTIC_CACHE:-}" = main
+            test -n "${ATTIC_PUBLIC_KEY:-}"
+            test -n "${BAZEL_REMOTE_CACHE:-}"
+            test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
+            test "${NIX_USER_CONF_FILES:-}" = /dev/null
+            test "${NETRC:-}" = /dev/null
+            test "$(nix config show netrc-file)" = /dev/null
+            nix config show extra-substituters |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+            nix flake check --accept-flake-config
+            for package in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
+              nix build --accept-flake-config --fallback ".#${package}"
+            done
+
+  nix-darwin-authority-held:
+    name: HELD - native aarch64-darwin Nix authority
+    runs-on: tinyland-nix
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.tinyland.dev/main
-            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
-
-      - name: Verify runner cache endpoints
+      - name: Hold until the authorized GF Darwin worker is proved
         run: |
-          echo "ATTIC_SERVER=${ATTIC_SERVER}"
-          echo "ATTIC_CACHE=${ATTIC_CACHE}"
-          echo "BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:-unset}"
-
-      - name: Configure Attic
-        run: |
-          nix profile install nixpkgs#attic-client
-          if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland "${{ env.ATTIC_SERVER }}" "${{ secrets.ATTIC_TOKEN }}"
-            attic use "${{ env.ATTIC_CACHE }}" || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> "$GITHUB_ENV"
-          else
-            echo "::warning::ATTIC_TOKEN not set, skipping cache push"
-            echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
-          fi
-
-      - name: Build tcfsd
-        run: nix build --accept-flake-config --fallback .#tcfsd
-
-      - name: Build tcfs-cli
-        run: nix build --accept-flake-config --fallback .#tcfs-cli
-
-      - name: Build tcfs-tui
-        run: nix build --accept-flake-config --fallback .#tcfs-tui
-
-      - name: Build tcfs-mcp
-        run: nix build --accept-flake-config --fallback .#tcfs-mcp
-
-      - name: Push to Attic
-        if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
-        run: |
-          for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
-            nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
-            attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
-          done
-
-  build-macos-aarch64:
-    name: Build macOS aarch64
-    runs-on: macos-14
-    # Hard stop well under the 6h hosted-runner ceiling: a wedged job must fail
-    # loud with hours to spare, not silently eat the whole window (both prior
-    # runs of this job died at exactly 6h00m inside "Set up FlakeHub Cache").
-    timeout-minutes: 300
-    needs: flake-check
-    # id-token: write is required for FlakeHub Cache OIDC push (below).
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.tinyland.dev/main
-            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
-
-      # FlakeHub Cache is the canonical nix cache the fleet substitutes from
-      # (lab nix/home-manager/nix.nix: "Attic replaced by FlakeHub"; macbook-neo
-      # trusts cache.flakehub.com). This action sets up a post-build push hook so
-      # EVERY darwin store path built below is published to FlakeHub Cache — which
-      # is what lets neo `nix-switch` SUBSTITUTE the aarch64-darwin closure
-      # (incl. tcfsd) instead of ever compiling locally. Requires this repo to be
-      # enrolled in FlakeHub Cache; no-ops with a warning if not yet enrolled.
-      # continue-on-error alone is not enough: when un-enrolled this action can
-      # HANG rather than fail (observed twice: job cancelled at exactly the 6h
-      # ceiling with every build step still skipped) — timeout-minutes converts
-      # the hang into the warning this comment always assumed.
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@main
-        timeout-minutes: 10
-        continue-on-error: true
-
-      - name: Configure Attic
-        run: |
-          nix profile install nixpkgs#attic-client
-          if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland "${{ env.ATTIC_SERVER }}" "${{ secrets.ATTIC_TOKEN }}"
-            attic use "${{ env.ATTIC_CACHE }}" || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> "$GITHUB_ENV"
-          else
-            echo "::warning::ATTIC_TOKEN not set, skipping cache push"
-            echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
-          fi
-
-      # NOTE: the aarch64-darwin DAEMON closure (tcfsd/tcfsd-app/staticlib) was
-      # previously NOT built here — only cli/tui/mcp — so macbook-neo could not
-      # substitute a new tcfsd and silently fell back to a LOCAL compile
-      # (2026-07-04 incident: a full day of neo compilation). Build the full set
-      # here on the GitHub macos-14 runner (off-neo, off-PZM) so the whole
-      # darwin closure lands in the caches and neo only ever substitutes.
-      - name: Build tcfs-cli (no FUSE on macOS)
-        run: nix build --accept-flake-config --fallback .#tcfs-cli
-
-      - name: Build tcfs-tui
-        run: nix build --accept-flake-config --fallback .#tcfs-tui
-
-      - name: Build tcfs-mcp
-        run: nix build --accept-flake-config --fallback .#tcfs-mcp
-
-      - name: Build tcfsd (daemon)
-        run: nix build --accept-flake-config --fallback .#tcfsd
-
-      - name: Build tcfsd-app (FileProvider app bundle)
-        run: nix build --accept-flake-config --fallback .#tcfsd-app
-
-      - name: Build tcfs-file-provider-staticlib
-        run: nix build --accept-flake-config --fallback .#tcfs-file-provider-staticlib
-
-      - name: Push to Attic
-        if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
-        run: |
-          for pkg in tcfs-cli tcfs-tui tcfs-mcp tcfsd tcfsd-app tcfs-file-provider-staticlib; do
-            nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
-            attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
-          done
+          echo "::error title=Darwin Nix authority held::TIN-2998 has not yet proved an authorized native Apple Silicon GF worker. Linux evaluation or cross-compilation cannot publish a Darwin closure."
+          exit 1

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: command -v nix
 
       - name: Check and build through the public-read-only GloriousFlywheel Nix front door
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@TIN_3127_SIGNED_MERGE_REVISION_PENDING
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -6,8 +6,8 @@ name: Nix CI
 on:
   push:
     branches: [main, dev]
+  # Stacked PRs require the same exact-head authority as main-bound PRs.
   pull_request:
-    branches: [main, dev]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nix-profile-install-smoke.yml
+++ b/.github/workflows/nix-profile-install-smoke.yml
@@ -46,6 +46,7 @@ concurrency:
 
 jobs:
   profile-install-smoke:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Nix profile install smoke
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
   # ── Plan release ──────────────────────────────────────────────────────────
 
   plan:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Plan release
     runs-on: ubuntu-latest
     outputs:
@@ -106,6 +107,7 @@ jobs:
   # ── Build client binaries ─────────────────────────────────────────────────
 
   build-binaries:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: plan
@@ -466,6 +468,7 @@ jobs:
   # ── Build container image (k8s-worker) ────────────────────────────────────
 
   build-image:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Build container image
     runs-on: ubuntu-latest
     needs: plan
@@ -526,6 +529,7 @@ jobs:
   # ── Nix build + Attic cache push ─────────────────────────────────────────
 
   nix-build:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Nix Build + Attic Push
     runs-on: ubuntu-latest
     needs: plan
@@ -568,6 +572,7 @@ jobs:
   # ── Generate installer scripts ────────────────────────────────────────────
 
   generate-installers:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Generate installer scripts
     runs-on: ubuntu-latest
     needs: plan
@@ -663,6 +668,7 @@ jobs:
   # ── Build FileProvider extension (macOS) ──────────────────────────────────
 
   build-fileprovider:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Build FileProvider (macOS)
     runs-on: macos-14
     needs: plan
@@ -820,11 +826,7 @@ jobs:
     name: Build macOS installer (.pkg)
     runs-on: macos-14
     needs: [plan, build-binaries, build-fileprovider]
-    if: |
-      success() && (
-        startsWith(github.ref, 'refs/tags/v') ||
-        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
-      )
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -949,11 +951,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [plan, build-binaries, generate-installers, build-fileprovider, build-pkg]
-    if: |
-      success() && (
-        startsWith(github.ref, 'refs/tags/v') ||
-        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
-      )
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
 
     steps:
       - name: Download all artifacts
@@ -1084,11 +1082,7 @@ jobs:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
     needs: [plan, create-release]
-    if: |
-      success() && (
-        startsWith(github.ref, 'refs/tags/v') ||
-        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
-      )
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/storage-large-restore-canary.yml
+++ b/.github/workflows/storage-large-restore-canary.yml
@@ -109,7 +109,7 @@ permissions:
 jobs:
   large-restore:
     name: Large push + restore
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 180
     environment: ${{ github.event.inputs.smoke_environment }}

--- a/.github/workflows/storage-posture-canary.yml
+++ b/.github/workflows/storage-posture-canary.yml
@@ -49,7 +49,7 @@ permissions:
 jobs:
   storage-canary:
     name: Scoped storage canary
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 20
     environment: ${{ github.event.inputs.smoke_environment }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5482,6 +5482,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "static_assertions",
  "tcfs-chunks",
  "tcfs-core",
  "tcfs-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ proptest = { version = "1" }
 tempfile = { version = "3" }
 tokio-test = { version = "0.4" }
 divan = { version = "0.1" }
+static_assertions = { version = "1" }
 
 [profile.release]
 opt-level = 3

--- a/Justfile
+++ b/Justfile
@@ -154,6 +154,10 @@ linux-package-container-workflow-test:
 storage-large-restore-workflow-test:
     @bash scripts/test-storage-large-restore-canary-workflow.sh
 
+# Fail-closed first-party CI runner/cache/action/image authority contract
+ci-authority-contract-test:
+    @python3 scripts/test-ci-authority-contract.py
+
 # Regression test the storage large restore SLO evaluator
 storage-large-restore-slo-test:
     @bash scripts/test-evaluate-storage-large-restore-slo.sh

--- a/config/ci-authority-policy.json
+++ b/config/ci-authority-policy.json
@@ -1,13 +1,8 @@
 {
   "version": 1,
   "issue": "TIN-2538",
-  "gloriousflywheel_revision": "TIN_3127_SIGNED_MERGE_REVISION_PENDING",
+  "gloriousflywheel_revision": "693574567f9b879486782f1fb7f432c54a2fe294",
   "checkout_revision": "3d3c42e5aac5ba805825da76410c181273ba90b1",
-  "promotion_hold": {
-    "issue": "TIN-3127",
-    "required_revision": "signed merge revision containing the reviewed public-read-only Attic nix-job contract",
-    "reason": "origin/main at eb50ca7da6cce315867de963bef2184cfd924b26 does not contain the required action inputs or credential stripping"
-  },
   "live_proof_hold": {
     "issue": "TIN-3120",
     "reason": "the Jess personal-owner listener and multi-capability binding are absent; GitHub-hosted capacity is never a fallback"
@@ -128,7 +123,6 @@
     }
   ],
   "blocked_prerequisites": {
-    "public_read_only_attic_action": "TIN-3127",
     "multi_capability_personal_owner_binding": "TIN-3120",
     "native_darwin_worker": "TIN-2998",
     "native_windows_runtime_and_installer": "TIN-1569"

--- a/config/ci-authority-policy.json
+++ b/config/ci-authority-policy.json
@@ -1,0 +1,136 @@
+{
+  "version": 1,
+  "issue": "TIN-2538",
+  "gloriousflywheel_revision": "TIN_3127_SIGNED_MERGE_REVISION_PENDING",
+  "checkout_revision": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+  "promotion_hold": {
+    "issue": "TIN-3127",
+    "required_revision": "signed merge revision containing the reviewed public-read-only Attic nix-job contract",
+    "reason": "origin/main at eb50ca7da6cce315867de963bef2184cfd924b26 does not contain the required action inputs or credential stripping"
+  },
+  "live_proof_hold": {
+    "issue": "TIN-3120",
+    "reason": "the Jess personal-owner listener and multi-capability binding are absent; GitHub-hosted capacity is never a fallback"
+  },
+  "credential_boundary": {
+    "attic": "public-read-only; ATTIC_TOKEN empty; inherited netrc disabled",
+    "github": "repository-scoped contents:read token may remain available to Nix source fetches",
+    "claim": "not globally credential-free"
+  },
+  "protected_proof": [
+    {
+      "path": ".github/workflows/ci.yml",
+      "jobs": {
+        "linux-source": "tinyland-nix",
+        "windows-cross": "tinyland-nix",
+        "darwin-authority-held": "tinyland-nix"
+      },
+      "held_jobs": {
+        "darwin-authority-held": "TIN-2998"
+      },
+      "front_door": "nix-job",
+      "topology_sha256": "b3ac6ee0b7d459b845f15425cd2dcbdc93ed56b55d5528e7abd6060629553d1a"
+    },
+    {
+      "path": ".github/workflows/ci-live-storage.yml",
+      "jobs": {
+        "fleet-live": "tinyland-dind"
+      },
+      "held_jobs": {},
+      "front_door": "nix-job",
+      "topology_sha256": "074e1789a31482a3a4abad5f06daf1919200be8be1712ba5898405cae0bf685a"
+    },
+    {
+      "path": ".github/workflows/nix-ci.yml",
+      "jobs": {
+        "nix-linux": "tinyland-nix",
+        "nix-darwin-authority-held": "tinyland-nix"
+      },
+      "held_jobs": {
+        "nix-darwin-authority-held": "TIN-2998"
+      },
+      "front_door": "nix-job",
+      "topology_sha256": "7d0ff6c0cf8b5b2579982fc33083b9bc24b1c31f83db0dc1a8c747e3b165beba"
+    }
+  ],
+  "disabled_legacy_workflows": [
+    {
+      "path": ".github/workflows/container-runtime-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "6553b96d17d0d0fe1398755915321a0dec6c6a819fda7345069b0844a88304a0"
+    },
+    {
+      "path": ".github/workflows/docs.yml",
+      "owner": "TIN-2538",
+      "triggers": ["push", "pull_request", "workflow_dispatch"],
+      "topology_sha256": "d6d955a2af4e130c5e275738169c7b64a571501cb013e239c4545fc5cc71106e"
+    },
+    {
+      "path": ".github/workflows/homebrew-install-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "ad242cd50c5404859d90e743cf1050d202c68bd9077f00f60e3faae07cec4bf6"
+    },
+    {
+      "path": ".github/workflows/linux-package-container-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["pull_request", "workflow_dispatch"],
+      "topology_sha256": "6fe6fc413c9e4e35e39de26c62d06bce965a0bf7d6ca30c5a1c4bf8f426289d5"
+    },
+    {
+      "path": ".github/workflows/linux-postinstall-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "686e918b85b24af7f26970378b1379dc6ded8f7f1e13c7fbde89969614a3e156"
+    },
+    {
+      "path": ".github/workflows/macos-fileprovider-pkg-notarization-proof.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "06e45748ac285d6d16d9011f10085609850e9d3cb4b5780625c5eb6f7fbceec3"
+    },
+    {
+      "path": ".github/workflows/macos-fileprovider-testing-mode-pkg.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "b57dbf2e61e2a320ec9209a90d47dabf1f3db12f46a9dbabbf5be472a2a3f901"
+    },
+    {
+      "path": ".github/workflows/macos-postinstall-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "ddce25f9c5f5b6265a7122b3ad38a04be29207073ce9d17711b9247d3102d947"
+    },
+    {
+      "path": ".github/workflows/nix-profile-install-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "a8cfae7d6a7f488cfd0b3aa81d55c5f4e3ca824d9dfdeb07a278ea8df3572d77"
+    },
+    {
+      "path": ".github/workflows/release.yml",
+      "owner": "TIN-2538",
+      "triggers": ["push", "workflow_dispatch"],
+      "topology_sha256": "3fbf7f2e159f084591e8841b0056a5ac2aef13a9f99fedf9ecce19c9b277acad"
+    },
+    {
+      "path": ".github/workflows/storage-large-restore-canary.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "05be76ed05cd025a1adaad7e94809905e8b9e2af52a08b854101585d17fe1326"
+    },
+    {
+      "path": ".github/workflows/storage-posture-canary.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "7e5bf0304a248e5783371a5607cc4c44f09bf749c2c797489b8ab87b319e92a1"
+    }
+  ],
+  "blocked_prerequisites": {
+    "public_read_only_attic_action": "TIN-3127",
+    "multi_capability_personal_owner_binding": "TIN-3120",
+    "native_darwin_worker": "TIN-2998",
+    "native_windows_runtime_and_installer": "TIN-1569"
+  }
+}

--- a/config/ci-authority-policy.json
+++ b/config/ci-authority-policy.json
@@ -23,8 +23,9 @@
       "held_jobs": {
         "darwin-authority-held": "TIN-2998"
       },
+      "pull_request_all_bases": true,
       "front_door": "nix-job",
-      "topology_sha256": "b3ac6ee0b7d459b845f15425cd2dcbdc93ed56b55d5528e7abd6060629553d1a"
+      "topology_sha256": "ec523770d2806d967dfb64af00191c7f68bb6242fc2239c4e5bd626bd78acd49"
     },
     {
       "path": ".github/workflows/ci-live-storage.yml",
@@ -32,6 +33,7 @@
         "fleet-live": "tinyland-dind"
       },
       "held_jobs": {},
+      "pull_request_all_bases": true,
       "front_door": "nix-job",
       "topology_sha256": "074e1789a31482a3a4abad5f06daf1919200be8be1712ba5898405cae0bf685a"
     },
@@ -44,8 +46,9 @@
       "held_jobs": {
         "nix-darwin-authority-held": "TIN-2998"
       },
+      "pull_request_all_bases": true,
       "front_door": "nix-job",
-      "topology_sha256": "7d0ff6c0cf8b5b2579982fc33083b9bc24b1c31f83db0dc1a8c747e3b165beba"
+      "topology_sha256": "f9549d2e0f06e98b752e279f7777b6c7394faff6f760cb87fac5b638d0372e39"
     }
   ],
   "disabled_legacy_workflows": [

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1337,6 +1337,41 @@ impl RootStateContractV1 {
             Self::ImmutablePrimarySemanticExactV1 => "immutable-primary-semantic-exact-v1",
         }
     }
+
+    /// Maximum exact byte length of one accepted state primary.
+    pub const fn max_primary_bytes(self) -> u64 {
+        match self {
+            Self::ImmutablePrimarySemanticExactV1 => 64 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum generated namespace-claim observations before deduplication.
+    pub const fn max_generated_claim_observations(self) -> u64 {
+        match self {
+            Self::ImmutablePrimarySemanticExactV1 => 4_000_000,
+        }
+    }
+
+    /// Maximum exact-plus-folded bytes across generated state claims.
+    pub const fn max_generated_claim_bytes(self) -> u64 {
+        match self {
+            Self::ImmutablePrimarySemanticExactV1 => 1024 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum compatible unique namespace claims retained from state.
+    pub const fn max_retained_unique_claims(self) -> u64 {
+        match self {
+            Self::ImmutablePrimarySemanticExactV1 => 2_000_000,
+        }
+    }
+
+    /// Maximum exact-plus-folded bytes retained for unique state claims.
+    pub const fn max_retained_unique_claim_bytes(self) -> u64 {
+        match self {
+            Self::ImmutablePrimarySemanticExactV1 => 512 * 1024 * 1024,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1987,6 +2022,11 @@ struct RegisteredRootPlanContractFingerprintFieldsV1 {
     local_snapshot_max_regular_file_bytes: u64,
     local_snapshot_max_total_hashed_bytes: u64,
     local_snapshot_hash_buffer_bytes: u64,
+    state_max_primary_bytes: u64,
+    state_max_generated_claim_observations: u64,
+    state_max_generated_claim_bytes: u64,
+    state_max_retained_unique_claims: u64,
+    state_max_retained_unique_claim_bytes: u64,
     remote_max_listing_rows_per_pass: u64,
     remote_max_listing_key_bytes_per_pass: u64,
     remote_max_storage_key_bytes: u64,
@@ -2050,6 +2090,11 @@ fn registered_root_plan_contract_fingerprint_fields_v1(
         local_snapshot_max_regular_file_bytes: contract.local_snapshot.max_regular_file_bytes(),
         local_snapshot_max_total_hashed_bytes: contract.local_snapshot.max_total_hashed_bytes(),
         local_snapshot_hash_buffer_bytes: contract.local_snapshot.hash_buffer_bytes(),
+        state_max_primary_bytes: contract.state.max_primary_bytes(),
+        state_max_generated_claim_observations: contract.state.max_generated_claim_observations(),
+        state_max_generated_claim_bytes: contract.state.max_generated_claim_bytes(),
+        state_max_retained_unique_claims: contract.state.max_retained_unique_claims(),
+        state_max_retained_unique_claim_bytes: contract.state.max_retained_unique_claim_bytes(),
         remote_max_listing_rows_per_pass: contract.remote.max_listing_rows_per_pass(),
         remote_max_listing_key_bytes_per_pass: contract.remote.max_listing_key_bytes_per_pass(),
         remote_max_storage_key_bytes: contract.remote.max_storage_key_bytes(),
@@ -2097,7 +2142,7 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
 ) -> RegisteredRootPlanContractFingerprintV1 {
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.registered-root-plan-contract.b3v1",
-        fields.canonical_names.len() + 30,
+        fields.canonical_names.len() + 35,
     );
     for (tag, value) in fields.canonical_names {
         encoder.field(tag, value.as_bytes());
@@ -2129,6 +2174,28 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
             encoder.field(
                 "local_snapshot_hash_buffer_bytes",
                 &fields.local_snapshot_hash_buffer_bytes.to_be_bytes(),
+            );
+        }
+        if tag == "state_policy" {
+            encoder.field(
+                "state_max_primary_bytes",
+                &fields.state_max_primary_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "state_max_generated_claim_observations",
+                &fields.state_max_generated_claim_observations.to_be_bytes(),
+            );
+            encoder.field(
+                "state_max_generated_claim_bytes",
+                &fields.state_max_generated_claim_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "state_max_retained_unique_claims",
+                &fields.state_max_retained_unique_claims.to_be_bytes(),
+            );
+            encoder.field(
+                "state_max_retained_unique_claim_bytes",
+                &fields.state_max_retained_unique_claim_bytes.to_be_bytes(),
             );
         }
         if tag == "remote_observation_model" {
@@ -3321,6 +3388,12 @@ resolution_policy = "inspect-only"
             contract.state_contract(),
             RootStateContractV1::ImmutablePrimarySemanticExactV1
         );
+        let state = contract.state_contract();
+        assert_eq!(state.max_primary_bytes(), 64 * 1024 * 1024);
+        assert_eq!(state.max_generated_claim_observations(), 4_000_000);
+        assert_eq!(state.max_generated_claim_bytes(), 1024 * 1024 * 1024);
+        assert_eq!(state.max_retained_unique_claims(), 2_000_000);
+        assert_eq!(state.max_retained_unique_claim_bytes(), 512 * 1024 * 1024);
         assert_eq!(
             contract.remote_contract(),
             RootRemoteContractV1::RawCommittedManifestBoundV1
@@ -3402,7 +3475,7 @@ resolution_policy = "inspect-only"
         );
         assert_eq!(
             fingerprint.to_string(),
-            "b3v1:0a3dbb43186967c1978104b72a5dbc750ba913842b1c491267def62f8db05d1f"
+            "b3v1:aabbbd421e6d9d487b59e244faa8d8a1ebf75311ec7cfa2dd7954b5a960850c4"
         );
     }
 
@@ -3450,6 +3523,14 @@ resolution_policy = "inspect-only"
             8 * 1024 * 1024 * 1024 * 1024
         );
         assert_eq!(fields.local_snapshot_hash_buffer_bytes, 64 * 1024);
+        assert_eq!(fields.state_max_primary_bytes, 64 * 1024 * 1024);
+        assert_eq!(fields.state_max_generated_claim_observations, 4_000_000);
+        assert_eq!(fields.state_max_generated_claim_bytes, 1024 * 1024 * 1024);
+        assert_eq!(fields.state_max_retained_unique_claims, 2_000_000);
+        assert_eq!(
+            fields.state_max_retained_unique_claim_bytes,
+            512 * 1024 * 1024
+        );
         assert_eq!(fields.remote_max_listing_rows_per_pass, 4_000_000);
         assert_eq!(
             fields.remote_max_listing_key_bytes_per_pass,
@@ -3572,6 +3653,25 @@ resolution_policy = "inspect-only"
             baseline,
             fingerprint_registered_root_plan_contract_fields_v1(observation_model_mutation)
         );
+
+        macro_rules! assert_state_resource_is_bound {
+            ($field:ident) => {{
+                let mut mutation = fields;
+                mutation.$field += 1;
+                assert_ne!(
+                    baseline,
+                    fingerprint_registered_root_plan_contract_fields_v1(mutation),
+                    "state contract fingerprint omitted {}",
+                    stringify!($field)
+                );
+            }};
+        }
+
+        assert_state_resource_is_bound!(state_max_primary_bytes);
+        assert_state_resource_is_bound!(state_max_generated_claim_observations);
+        assert_state_resource_is_bound!(state_max_generated_claim_bytes);
+        assert_state_resource_is_bound!(state_max_retained_unique_claims);
+        assert_state_resource_is_bound!(state_max_retained_unique_claim_bytes);
 
         macro_rules! assert_remote_resource_is_bound {
             ($field:ident) => {{

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1,3 +1,4 @@
+use crate::fixed_ingress::{FixedIngressPolicySchemaFingerprintV1, FixedIngressPolicyV1};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
@@ -1037,11 +1038,12 @@ impl RootHiddenPathPolicyV1 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RootExclusionPolicyV1 {
-    /// Exactly the config-independent checks implemented by
-    /// `Blacklist::check_fixed_ingress_path_components`.
+    /// Exactly the config-independent checks owned by
+    /// [`FixedIngressPolicyV1`].
     ///
-    /// Changing that function's membership or semantics requires a new
-    /// profile/policy version and canonical name.
+    /// The profile settings fingerprint also binds that policy's schema
+    /// fingerprint, so changing membership, matcher semantics, labels, or
+    /// order changes profile identity even if this canonical name is retained.
     FixedIngressPathComponentsV1,
 }
 
@@ -1540,22 +1542,31 @@ impl fmt::Debug for RegisteredRootPlanContractFingerprintV1 {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RootProfileSettingsFingerprintFieldsV1 {
+    canonical_names: [(&'static str, &'static str); 7],
+    fixed_ingress_schema: FixedIngressPolicySchemaFingerprintV1,
+}
+
 fn root_profile_settings_fingerprint_fields_v1(
     profile: RootProfileV1,
     settings: RootProfileSettingsV1,
-) -> [(&'static str, &'static str); 7] {
-    [
-        ("profile", profile.canonical_name()),
-        ("hidden_path_policy", settings.hidden_paths.canonical_name()),
-        ("exclusion_policy", settings.exclusions.canonical_name()),
-        ("git_policy", settings.git.canonical_name()),
-        ("symlink_policy", settings.symlinks.canonical_name()),
-        (
-            "empty_directory_policy",
-            settings.empty_directories.canonical_name(),
-        ),
-        ("metadata_policy", settings.metadata.canonical_name()),
-    ]
+) -> RootProfileSettingsFingerprintFieldsV1 {
+    RootProfileSettingsFingerprintFieldsV1 {
+        canonical_names: [
+            ("profile", profile.canonical_name()),
+            ("hidden_path_policy", settings.hidden_paths.canonical_name()),
+            ("exclusion_policy", settings.exclusions.canonical_name()),
+            ("git_policy", settings.git.canonical_name()),
+            ("symlink_policy", settings.symlinks.canonical_name()),
+            (
+                "empty_directory_policy",
+                settings.empty_directories.canonical_name(),
+            ),
+            ("metadata_policy", settings.metadata.canonical_name()),
+        ],
+        fixed_ingress_schema: FixedIngressPolicyV1::strict_v1().schema_fingerprint(),
+    }
 }
 
 fn fingerprint_root_profile_settings_v1(
@@ -1565,11 +1576,15 @@ fn fingerprint_root_profile_settings_v1(
     let fields = root_profile_settings_fingerprint_fields_v1(profile, settings);
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.root-profile-settings.b3v1",
-        fields.len(),
+        fields.canonical_names.len() + 1,
     );
-    for (tag, value) in fields {
+    for (tag, value) in fields.canonical_names {
         encoder.field(tag, value.as_bytes());
     }
+    encoder.field(
+        "fixed_ingress_policy_schema",
+        fields.fixed_ingress_schema.as_bytes(),
+    );
     RootProfileSettingsFingerprintV1(encoder.finish())
 }
 
@@ -2550,19 +2565,20 @@ resolution_policy = "inspect-only"
         assert_ne!(git_fingerprint, agent_fingerprint);
         assert_eq!(
             git_fingerprint.to_string(),
-            "b3v1:ceedf3bc0437f2dce0ae5228efd0b5949dafaf47bbd23f99a27eb9183c8ee794"
+            "b3v1:9aa6b15f0ef417e3d05ce69509a73f122aa0dc82c2b5f67da35168609f2145b2"
         );
         assert_eq!(
             agent_fingerprint.to_string(),
-            "b3v1:86c7ae197c9b320a8cf93bd7559d6352ee4b9dceded70f9249dc9deba4918294"
+            "b3v1:cd9e9cc1c9bd0359d273861d84f3145347df6a61defbe229664ff27e450b6351"
         );
     }
 
     #[test]
     fn root_profile_fingerprint_schema_binds_every_policy_field() {
         let git = RootProfileV1::GitRawV1.policy();
+        let git_fields = root_profile_settings_fingerprint_fields_v1(git.profile(), git.settings());
         assert_eq!(
-            root_profile_settings_fingerprint_fields_v1(git.profile(), git.settings(),),
+            git_fields.canonical_names,
             [
                 ("profile", "git-raw-v1"),
                 ("hidden_path_policy", "include-v1"),
@@ -2573,10 +2589,20 @@ resolution_policy = "inspect-only"
                 ("metadata_policy", "regular-file-manifest-mode-and-mtime-v1",),
             ]
         );
+        assert_eq!(
+            git_fields.fixed_ingress_schema,
+            FixedIngressPolicyV1::strict_v1().schema_fingerprint()
+        );
+        assert_eq!(
+            git.settings().exclusion_policy().canonical_name(),
+            FixedIngressPolicyV1::strict_v1().canonical_name()
+        );
 
         let agent = RootProfileV1::AgentStaticV1.policy();
+        let agent_fields =
+            root_profile_settings_fingerprint_fields_v1(agent.profile(), agent.settings());
         assert_eq!(
-            root_profile_settings_fingerprint_fields_v1(agent.profile(), agent.settings(),),
+            agent_fields.canonical_names,
             [
                 ("profile", "agent-static-v1"),
                 ("hidden_path_policy", "include-v1"),
@@ -2586,6 +2612,14 @@ resolution_policy = "inspect-only"
                 ("empty_directory_policy", "ignore-v1"),
                 ("metadata_policy", "regular-file-manifest-mode-and-mtime-v1",),
             ]
+        );
+        assert_eq!(
+            agent_fields.fixed_ingress_schema,
+            FixedIngressPolicyV1::strict_v1().schema_fingerprint()
+        );
+        assert_eq!(
+            git_fields.fixed_ingress_schema,
+            agent_fields.fixed_ingress_schema
         );
     }
 

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1017,6 +1017,8 @@ impl RootProfileV1 {
                 Self::AgentStaticV1 => RootGitPolicyV1::ExcludedV1,
             },
             symlinks: RootSymlinkPolicyV1::PreserveExactTargetV1,
+            hardlinks: RootHardlinkPolicyV1::RejectV1,
+            special_files: RootSpecialFilePolicyV1::RejectV1,
             empty_directories: RootEmptyDirectoryPolicyV1::IgnoreV1,
             metadata: RootMetadataPolicyV1::RegularFileManifestModeAndMtimeV1,
         }
@@ -1086,6 +1088,34 @@ impl RootSymlinkPolicyV1 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootHardlinkPolicyV1 {
+    /// Reject multiply linked regular files rather than collapsing identity.
+    RejectV1,
+}
+
+impl RootHardlinkPolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::RejectV1 => "reject-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootSpecialFilePolicyV1 {
+    /// Reject sockets, devices, FIFOs, and other non-file entry kinds.
+    RejectV1,
+}
+
+impl RootSpecialFilePolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::RejectV1 => "reject-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RootEmptyDirectoryPolicyV1 {
     IgnoreV1,
 }
@@ -1127,6 +1157,8 @@ pub struct RootProfileSettingsV1 {
     exclusions: RootExclusionPolicyV1,
     git: RootGitPolicyV1,
     symlinks: RootSymlinkPolicyV1,
+    hardlinks: RootHardlinkPolicyV1,
+    special_files: RootSpecialFilePolicyV1,
     empty_directories: RootEmptyDirectoryPolicyV1,
     metadata: RootMetadataPolicyV1,
 }
@@ -1146,6 +1178,14 @@ impl RootProfileSettingsV1 {
 
     pub const fn symlink_policy(self) -> RootSymlinkPolicyV1 {
         self.symlinks
+    }
+
+    pub const fn hardlink_policy(self) -> RootHardlinkPolicyV1 {
+        self.hardlinks
+    }
+
+    pub const fn special_file_policy(self) -> RootSpecialFilePolicyV1 {
+        self.special_files
     }
 
     pub const fn empty_directory_policy(self) -> RootEmptyDirectoryPolicyV1 {
@@ -1192,6 +1232,82 @@ impl RootPathContractV1 {
     pub const fn canonical_name(self) -> &'static str {
         match self {
             Self::PortableNfcCaseFoldV1 => "portable-nfc-case-fold-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootMountBoundaryPolicyV1 {
+    /// Reject every descendant mount boundary, including same-filesystem bind
+    /// mounts. Device-ID equality alone does not satisfy this policy.
+    SameMountNoCrossingV1,
+}
+
+impl RootMountBoundaryPolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::SameMountNoCrossingV1 => "same-mount-no-crossing-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootLocalSnapshotContractV1 {
+    /// Walk and read through no-follow descriptors, then prove both entry
+    /// identity and content identity remained stable.
+    DescriptorRelativeIdentityContentIdentityV1,
+}
+
+impl RootLocalSnapshotContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => {
+                "descriptor-relative-identity-content-identity-v1"
+            }
+        }
+    }
+
+    /// Mount containment required while walking the enrolled root.
+    pub const fn mount_boundary_policy(self) -> RootMountBoundaryPolicyV1 {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => {
+                RootMountBoundaryPolicyV1::SameMountNoCrossingV1
+            }
+        }
+    }
+
+    /// Maximum number of path components beneath the enrolled root.
+    pub const fn max_depth(self) -> u32 {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => 256,
+        }
+    }
+
+    /// Maximum retained entry count for one complete snapshot.
+    pub const fn max_entries(self) -> u64 {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => 1_000_000,
+        }
+    }
+
+    /// Maximum combined byte length of all retained canonical paths.
+    pub const fn max_retained_path_bytes(self) -> u64 {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => 256 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum byte length of one preserved symlink target.
+    pub const fn max_symlink_target_bytes(self) -> u64 {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => 1023,
+        }
+    }
+
+    /// Fixed regular-file hashing buffer size.
+    pub const fn hash_buffer_bytes(self) -> u64 {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => 64 * 1024,
         }
     }
 }
@@ -1284,6 +1400,7 @@ impl RootCompletenessContractV1 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RegisteredRootPlanContractV1 {
     path: RootPathContractV1,
+    local_snapshot: RootLocalSnapshotContractV1,
     state: RootStateContractV1,
     remote: RootRemoteContractV1,
     causality: RootCausalityContractV1,
@@ -1296,6 +1413,8 @@ impl RegisteredRootPlanContractV1 {
     pub const fn strict_v1() -> Self {
         Self {
             path: RootPathContractV1::PortableNfcCaseFoldV1,
+            local_snapshot:
+                RootLocalSnapshotContractV1::DescriptorRelativeIdentityContentIdentityV1,
             state: RootStateContractV1::ImmutablePrimarySemanticExactV1,
             remote: RootRemoteContractV1::RawCommittedManifestBoundV1,
             causality: RootCausalityContractV1::TypedVectorClockV1,
@@ -1307,6 +1426,10 @@ impl RegisteredRootPlanContractV1 {
 
     pub const fn path_contract(self) -> RootPathContractV1 {
         self.path
+    }
+
+    pub const fn local_snapshot_contract(self) -> RootLocalSnapshotContractV1 {
+        self.local_snapshot
     }
 
     pub const fn state_contract(self) -> RootStateContractV1 {
@@ -1544,7 +1667,7 @@ impl fmt::Debug for RegisteredRootPlanContractFingerprintV1 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RootProfileSettingsFingerprintFieldsV1 {
-    canonical_names: [(&'static str, &'static str); 7],
+    canonical_names: [(&'static str, &'static str); 9],
     fixed_ingress_schema: FixedIngressPolicySchemaFingerprintV1,
 }
 
@@ -1559,6 +1682,11 @@ fn root_profile_settings_fingerprint_fields_v1(
             ("exclusion_policy", settings.exclusions.canonical_name()),
             ("git_policy", settings.git.canonical_name()),
             ("symlink_policy", settings.symlinks.canonical_name()),
+            ("hardlink_policy", settings.hardlinks.canonical_name()),
+            (
+                "special_file_policy",
+                settings.special_files.canonical_name(),
+            ),
             (
                 "empty_directory_policy",
                 settings.empty_directories.canonical_name(),
@@ -1569,11 +1697,9 @@ fn root_profile_settings_fingerprint_fields_v1(
     }
 }
 
-fn fingerprint_root_profile_settings_v1(
-    profile: RootProfileV1,
-    settings: RootProfileSettingsV1,
+fn fingerprint_root_profile_settings_fields_v1(
+    fields: RootProfileSettingsFingerprintFieldsV1,
 ) -> RootProfileSettingsFingerprintV1 {
-    let fields = root_profile_settings_fingerprint_fields_v1(profile, settings);
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.root-profile-settings.b3v1",
         fields.canonical_names.len() + 1,
@@ -1588,33 +1714,101 @@ fn fingerprint_root_profile_settings_v1(
     RootProfileSettingsFingerprintV1(encoder.finish())
 }
 
-fn fingerprint_registered_root_plan_contract_v1(
+fn fingerprint_root_profile_settings_v1(
+    profile: RootProfileV1,
+    settings: RootProfileSettingsV1,
+) -> RootProfileSettingsFingerprintV1 {
+    fingerprint_root_profile_settings_fields_v1(root_profile_settings_fingerprint_fields_v1(
+        profile, settings,
+    ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RegisteredRootPlanContractFingerprintFieldsV1 {
+    canonical_names: [(&'static str, &'static str); 9],
+    local_snapshot_max_depth: u32,
+    local_snapshot_max_entries: u64,
+    local_snapshot_max_retained_path_bytes: u64,
+    local_snapshot_max_symlink_target_bytes: u64,
+    local_snapshot_hash_buffer_bytes: u64,
+}
+
+fn registered_root_plan_contract_fingerprint_fields_v1(
     contract: RegisteredRootPlanContractV1,
+) -> RegisteredRootPlanContractFingerprintFieldsV1 {
+    RegisteredRootPlanContractFingerprintFieldsV1 {
+        canonical_names: [
+            ("path_policy", contract.path.canonical_name()),
+            (
+                "local_snapshot_policy",
+                contract.local_snapshot.canonical_name(),
+            ),
+            (
+                "local_snapshot_mount_boundary_policy",
+                contract
+                    .local_snapshot
+                    .mount_boundary_policy()
+                    .canonical_name(),
+            ),
+            ("state_policy", contract.state.canonical_name()),
+            ("remote_policy", contract.remote.canonical_name()),
+            ("causality_policy", contract.causality.canonical_name()),
+            ("action_policy", contract.actions.canonical_name()),
+            ("ordering_policy", contract.ordering.canonical_name()),
+            (
+                "completeness_policy",
+                contract.completeness.canonical_name(),
+            ),
+        ],
+        local_snapshot_max_depth: contract.local_snapshot.max_depth(),
+        local_snapshot_max_entries: contract.local_snapshot.max_entries(),
+        local_snapshot_max_retained_path_bytes: contract.local_snapshot.max_retained_path_bytes(),
+        local_snapshot_max_symlink_target_bytes: contract.local_snapshot.max_symlink_target_bytes(),
+        local_snapshot_hash_buffer_bytes: contract.local_snapshot.hash_buffer_bytes(),
+    }
+}
+
+fn fingerprint_registered_root_plan_contract_fields_v1(
+    fields: RegisteredRootPlanContractFingerprintFieldsV1,
 ) -> RegisteredRootPlanContractFingerprintV1 {
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.registered-root-plan-contract.b3v1",
-        7,
+        fields.canonical_names.len() + 5,
     );
-    encoder.field("path_policy", contract.path.canonical_name().as_bytes());
-    encoder.field("state_policy", contract.state.canonical_name().as_bytes());
-    encoder.field("remote_policy", contract.remote.canonical_name().as_bytes());
-    encoder.field(
-        "causality_policy",
-        contract.causality.canonical_name().as_bytes(),
-    );
-    encoder.field(
-        "action_policy",
-        contract.actions.canonical_name().as_bytes(),
-    );
-    encoder.field(
-        "ordering_policy",
-        contract.ordering.canonical_name().as_bytes(),
-    );
-    encoder.field(
-        "completeness_policy",
-        contract.completeness.canonical_name().as_bytes(),
-    );
+    for (tag, value) in fields.canonical_names {
+        encoder.field(tag, value.as_bytes());
+        if tag == "local_snapshot_policy" {
+            encoder.field(
+                "local_snapshot_max_depth",
+                &fields.local_snapshot_max_depth.to_be_bytes(),
+            );
+            encoder.field(
+                "local_snapshot_max_entries",
+                &fields.local_snapshot_max_entries.to_be_bytes(),
+            );
+            encoder.field(
+                "local_snapshot_max_retained_path_bytes",
+                &fields.local_snapshot_max_retained_path_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "local_snapshot_max_symlink_target_bytes",
+                &fields.local_snapshot_max_symlink_target_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "local_snapshot_hash_buffer_bytes",
+                &fields.local_snapshot_hash_buffer_bytes.to_be_bytes(),
+            );
+        }
+    }
     RegisteredRootPlanContractFingerprintV1(encoder.finish())
+}
+
+fn fingerprint_registered_root_plan_contract_v1(
+    contract: RegisteredRootPlanContractV1,
+) -> RegisteredRootPlanContractFingerprintV1 {
+    fingerprint_registered_root_plan_contract_fields_v1(
+        registered_root_plan_contract_fingerprint_fields_v1(contract),
+    )
 }
 
 impl RootSpecV1Config {
@@ -2539,6 +2733,11 @@ resolution_policy = "inspect-only"
                 settings.symlink_policy(),
                 RootSymlinkPolicyV1::PreserveExactTargetV1
             );
+            assert_eq!(settings.hardlink_policy(), RootHardlinkPolicyV1::RejectV1);
+            assert_eq!(
+                settings.special_file_policy(),
+                RootSpecialFilePolicyV1::RejectV1
+            );
             assert_eq!(
                 settings.empty_directory_policy(),
                 RootEmptyDirectoryPolicyV1::IgnoreV1
@@ -2565,11 +2764,11 @@ resolution_policy = "inspect-only"
         assert_ne!(git_fingerprint, agent_fingerprint);
         assert_eq!(
             git_fingerprint.to_string(),
-            "b3v1:9aa6b15f0ef417e3d05ce69509a73f122aa0dc82c2b5f67da35168609f2145b2"
+            "b3v1:3f7b636df0abf0081df3dee914c678444f880d6de7e66717e5f6acdcb6a6f447"
         );
         assert_eq!(
             agent_fingerprint.to_string(),
-            "b3v1:cd9e9cc1c9bd0359d273861d84f3145347df6a61defbe229664ff27e450b6351"
+            "b3v1:d71f461619660b8e88a2bcbc299e0bb88c91ba2112a75621b9c58e148d08d0e4"
         );
     }
 
@@ -2585,6 +2784,8 @@ resolution_policy = "inspect-only"
                 ("exclusion_policy", "fixed-ingress-path-components-v1"),
                 ("git_policy", "standalone-raw-with-fast-forward-proof-v1",),
                 ("symlink_policy", "preserve-exact-target-v1"),
+                ("hardlink_policy", "reject-v1"),
+                ("special_file_policy", "reject-v1"),
                 ("empty_directory_policy", "ignore-v1"),
                 ("metadata_policy", "regular-file-manifest-mode-and-mtime-v1",),
             ]
@@ -2609,6 +2810,8 @@ resolution_policy = "inspect-only"
                 ("exclusion_policy", "fixed-ingress-path-components-v1"),
                 ("git_policy", "excluded-v1"),
                 ("symlink_policy", "preserve-exact-target-v1"),
+                ("hardlink_policy", "reject-v1"),
+                ("special_file_policy", "reject-v1"),
                 ("empty_directory_policy", "ignore-v1"),
                 ("metadata_policy", "regular-file-manifest-mode-and-mtime-v1",),
             ]
@@ -2624,12 +2827,46 @@ resolution_policy = "inspect-only"
     }
 
     #[test]
+    fn root_profile_fingerprint_binds_hardlink_and_special_file_policies() {
+        let policy = RootProfileV1::GitRawV1.policy();
+        let fields =
+            root_profile_settings_fingerprint_fields_v1(policy.profile(), policy.settings());
+        let baseline = fingerprint_root_profile_settings_fields_v1(fields);
+
+        for (index, mutation) in [
+            (5, "allow-hardlinks-test-v0"),
+            (6, "allow-special-files-test-v0"),
+        ] {
+            let mut mutated = fields;
+            mutated.canonical_names[index].1 = mutation;
+            assert_ne!(
+                baseline,
+                fingerprint_root_profile_settings_fields_v1(mutated)
+            );
+        }
+    }
+
+    #[test]
     fn registered_root_plan_contract_is_fixed_and_digest_bound() {
         let contract = RegisteredRootPlanContractV1::strict_v1();
         assert_eq!(
             contract.path_contract(),
             RootPathContractV1::PortableNfcCaseFoldV1
         );
+        let local_snapshot = contract.local_snapshot_contract();
+        assert_eq!(
+            local_snapshot,
+            RootLocalSnapshotContractV1::DescriptorRelativeIdentityContentIdentityV1
+        );
+        assert_eq!(
+            local_snapshot.mount_boundary_policy(),
+            RootMountBoundaryPolicyV1::SameMountNoCrossingV1
+        );
+        assert_eq!(local_snapshot.max_depth(), 256);
+        assert_eq!(local_snapshot.max_entries(), 1_000_000);
+        assert_eq!(local_snapshot.max_retained_path_bytes(), 256 * 1024 * 1024);
+        assert_eq!(local_snapshot.max_symlink_target_bytes(), 1023);
+        assert_eq!(local_snapshot.hash_buffer_bytes(), 64 * 1024);
         assert_eq!(
             contract.state_contract(),
             RootStateContractV1::ImmutablePrimarySemanticExactV1
@@ -2663,7 +2900,92 @@ resolution_policy = "inspect-only"
         );
         assert_eq!(
             fingerprint.to_string(),
-            "b3v1:6d2d9204424755f56559ba85b5e8596f1b1ab74e357989be4907f4976b9c2d50"
+            "b3v1:af0bce82d5ebee4249f45ad7824e9e12a7628ffb4ec764c1865d079b1fac4d6a"
+        );
+    }
+
+    #[test]
+    fn registered_root_plan_fingerprint_schema_binds_local_snapshot_resources() {
+        let contract = RegisteredRootPlanContractV1::strict_v1();
+        let fields = registered_root_plan_contract_fingerprint_fields_v1(contract);
+        assert_eq!(
+            fields.canonical_names,
+            [
+                ("path_policy", "portable-nfc-case-fold-v1"),
+                (
+                    "local_snapshot_policy",
+                    "descriptor-relative-identity-content-identity-v1",
+                ),
+                (
+                    "local_snapshot_mount_boundary_policy",
+                    "same-mount-no-crossing-v1",
+                ),
+                ("state_policy", "immutable-primary-semantic-exact-v1"),
+                ("remote_policy", "raw-committed-manifest-bound-v1"),
+                ("causality_policy", "typed-vector-clock-v1"),
+                ("action_policy", "plan-only-no-delete-v1"),
+                ("ordering_policy", "relative-path-kind-proof-v1"),
+                ("completeness_policy", "complete-or-no-digest-v1"),
+            ]
+        );
+        assert_eq!(fields.local_snapshot_max_depth, 256);
+        assert_eq!(fields.local_snapshot_max_entries, 1_000_000);
+        assert_eq!(
+            fields.local_snapshot_max_retained_path_bytes,
+            256 * 1024 * 1024
+        );
+        assert_eq!(fields.local_snapshot_max_symlink_target_bytes, 1023);
+        assert_eq!(fields.local_snapshot_hash_buffer_bytes, 64 * 1024);
+
+        let baseline = fingerprint_registered_root_plan_contract_fields_v1(fields);
+
+        let mut policy_mutation = fields;
+        policy_mutation.canonical_names[1].1 = "path-open-content-only-test-v0";
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(policy_mutation)
+        );
+
+        let mut mount_policy_mutation = fields;
+        mount_policy_mutation.canonical_names[2].1 = "device-id-only-test-v0";
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(mount_policy_mutation)
+        );
+
+        let mut depth_mutation = fields;
+        depth_mutation.local_snapshot_max_depth += 1;
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(depth_mutation)
+        );
+
+        let mut entries_mutation = fields;
+        entries_mutation.local_snapshot_max_entries += 1;
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(entries_mutation)
+        );
+
+        let mut path_bytes_mutation = fields;
+        path_bytes_mutation.local_snapshot_max_retained_path_bytes += 1;
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(path_bytes_mutation)
+        );
+
+        let mut target_bytes_mutation = fields;
+        target_bytes_mutation.local_snapshot_max_symlink_target_bytes += 1;
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(target_bytes_mutation)
+        );
+
+        let mut buffer_bytes_mutation = fields;
+        buffer_bytes_mutation.local_snapshot_hash_buffer_bytes += 1;
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(buffer_bytes_mutation)
         );
     }
 

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1407,6 +1407,34 @@ impl RootRemoteObservationModelV1 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootRemoteCompletenessAuthorityV1 {
+    /// One conditionally updated current HEAD selects an immutable,
+    /// content-addressed catalog root whose ordered pages enumerate the exact
+    /// registered-root reconcile metadata corpus: every index, every namespace
+    /// reservation, and exactly the manifests referenced by that metadata.
+    /// Chunks, staging objects, probes, and the catalog's own objects are
+    /// outside this corpus. Generic object-store listings are diagnostic only
+    /// and cannot contribute completeness authority.
+    ///
+    /// This contract is not satisfied merely by publishing catalog objects.
+    /// Every namespace writer must be fenced behind the HEAD CAS protocol, and
+    /// the initial catalog must be bootstrapped from externally established
+    /// complete truth rather than from an ordinary LIST. The selected HEAD
+    /// proves closure only at that exact revision; current-namespace authority
+    /// also requires linearizable current-HEAD reads or an externally trusted
+    /// monotonic high-water mark that rejects replay and rollback.
+    ImmutableCatalogHeadClosureV1,
+}
+
+impl RootRemoteCompletenessAuthorityV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::ImmutableCatalogHeadClosureV1 => "immutable-catalog-head-closure-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RootRemoteContractV1 {
     RawCommittedManifestBoundV1,
 }
@@ -1427,6 +1455,18 @@ impl RootRemoteContractV1 {
         match self {
             Self::RawCommittedManifestBoundV1 => {
                 RootRemoteObservationModelV1::TwoListedUniverseBoundPassesNonAtomicV1
+            }
+        }
+    }
+
+    /// The only remote source permitted to satisfy complete-or-no-digest.
+    ///
+    /// The repeated LIST model above remains useful drift evidence, but it
+    /// cannot be promoted into this authority even when both passes match.
+    pub const fn completeness_authority(self) -> RootRemoteCompletenessAuthorityV1 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => {
+                RootRemoteCompletenessAuthorityV1::ImmutableCatalogHeadClosureV1
             }
         }
     }
@@ -1623,6 +1663,71 @@ impl RootRemoteContractV1 {
     pub const fn max_remote_vector_clock_entries(self) -> u64 {
         match self {
             Self::RawCommittedManifestBoundV1 => 4096,
+        }
+    }
+
+    /// Maximum canonical bytes in the mutable catalog HEAD.
+    pub const fn max_catalog_head_object_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 16 * 1024,
+        }
+    }
+
+    /// Maximum canonical bytes in one immutable catalog root.
+    pub const fn max_catalog_root_object_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum canonical bytes in one immutable catalog page.
+    pub const fn max_catalog_page_object_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 16 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum immutable pages referenced by one catalog root.
+    pub const fn max_catalog_pages(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4096,
+        }
+    }
+
+    /// Maximum physical namespace objects named by one catalog page.
+    pub const fn max_catalog_entries_per_page(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4096,
+        }
+    }
+
+    /// Maximum physical namespace objects named by the complete catalog.
+    pub const fn max_catalog_entries(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 3_000_000,
+        }
+    }
+
+    /// Maximum combined storage-key bytes retained from all catalog entries.
+    pub const fn max_catalog_entry_key_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 512 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum combined version and ETag bytes retained from catalog object
+    /// bindings, including root, pages, and named namespace objects.
+    pub const fn max_catalog_binding_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 512 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum aggregate canonical bytes read for the immutable catalog root
+    /// and all pages. The mutable HEAD is charged separately.
+    pub const fn max_catalog_closure_object_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4 * 1024 * 1024 * 1024,
         }
     }
 }
@@ -2014,7 +2119,7 @@ fn fingerprint_root_profile_settings_v1(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RegisteredRootPlanContractFingerprintFieldsV1 {
-    canonical_names: [(&'static str, &'static str); 10],
+    canonical_names: [(&'static str, &'static str); 11],
     local_snapshot_max_depth: u32,
     local_snapshot_max_entries: u64,
     local_snapshot_max_retained_path_bytes: u64,
@@ -2050,6 +2155,15 @@ struct RegisteredRootPlanContractFingerprintFieldsV1 {
     remote_max_manifest_chunk_entries: u64,
     remote_max_manifest_wrapped_key_entries: u64,
     remote_max_remote_vector_clock_entries: u64,
+    remote_max_catalog_head_object_bytes: u64,
+    remote_max_catalog_root_object_bytes: u64,
+    remote_max_catalog_page_object_bytes: u64,
+    remote_max_catalog_pages: u64,
+    remote_max_catalog_entries_per_page: u64,
+    remote_max_catalog_entries: u64,
+    remote_max_catalog_entry_key_bytes: u64,
+    remote_max_catalog_binding_bytes: u64,
+    remote_max_catalog_closure_object_bytes: u64,
 }
 
 fn registered_root_plan_contract_fingerprint_fields_v1(
@@ -2074,6 +2188,10 @@ fn registered_root_plan_contract_fingerprint_fields_v1(
             (
                 "remote_observation_model",
                 contract.remote.observation_model().canonical_name(),
+            ),
+            (
+                "remote_completeness_authority",
+                contract.remote.completeness_authority().canonical_name(),
             ),
             ("causality_policy", contract.causality.canonical_name()),
             ("action_policy", contract.actions.canonical_name()),
@@ -2134,6 +2252,15 @@ fn registered_root_plan_contract_fingerprint_fields_v1(
         remote_max_manifest_chunk_entries: contract.remote.max_manifest_chunk_entries(),
         remote_max_manifest_wrapped_key_entries: contract.remote.max_manifest_wrapped_key_entries(),
         remote_max_remote_vector_clock_entries: contract.remote.max_remote_vector_clock_entries(),
+        remote_max_catalog_head_object_bytes: contract.remote.max_catalog_head_object_bytes(),
+        remote_max_catalog_root_object_bytes: contract.remote.max_catalog_root_object_bytes(),
+        remote_max_catalog_page_object_bytes: contract.remote.max_catalog_page_object_bytes(),
+        remote_max_catalog_pages: contract.remote.max_catalog_pages(),
+        remote_max_catalog_entries_per_page: contract.remote.max_catalog_entries_per_page(),
+        remote_max_catalog_entries: contract.remote.max_catalog_entries(),
+        remote_max_catalog_entry_key_bytes: contract.remote.max_catalog_entry_key_bytes(),
+        remote_max_catalog_binding_bytes: contract.remote.max_catalog_binding_bytes(),
+        remote_max_catalog_closure_object_bytes: contract.remote.max_catalog_closure_object_bytes(),
     }
 }
 
@@ -2142,7 +2269,7 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
 ) -> RegisteredRootPlanContractFingerprintV1 {
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.registered-root-plan-contract.b3v1",
-        fields.canonical_names.len() + 35,
+        fields.canonical_names.len() + 44,
     );
     for (tag, value) in fields.canonical_names {
         encoder.field(tag, value.as_bytes());
@@ -2306,6 +2433,44 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
             encoder.field(
                 "remote_max_remote_vector_clock_entries",
                 &fields.remote_max_remote_vector_clock_entries.to_be_bytes(),
+            );
+        }
+        if tag == "remote_completeness_authority" {
+            encoder.field(
+                "remote_max_catalog_head_object_bytes",
+                &fields.remote_max_catalog_head_object_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_root_object_bytes",
+                &fields.remote_max_catalog_root_object_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_page_object_bytes",
+                &fields.remote_max_catalog_page_object_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_pages",
+                &fields.remote_max_catalog_pages.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_entries_per_page",
+                &fields.remote_max_catalog_entries_per_page.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_entries",
+                &fields.remote_max_catalog_entries.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_entry_key_bytes",
+                &fields.remote_max_catalog_entry_key_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_binding_bytes",
+                &fields.remote_max_catalog_binding_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_closure_object_bytes",
+                &fields.remote_max_catalog_closure_object_bytes.to_be_bytes(),
             );
         }
     }
@@ -3403,6 +3568,10 @@ resolution_policy = "inspect-only"
             remote.observation_model(),
             RootRemoteObservationModelV1::TwoListedUniverseBoundPassesNonAtomicV1
         );
+        assert_eq!(
+            remote.completeness_authority(),
+            RootRemoteCompletenessAuthorityV1::ImmutableCatalogHeadClosureV1
+        );
         assert_eq!(remote.observation_model().pass_count(), 2);
         assert_eq!(remote.listing_page_request_limit(), 1000);
         assert_eq!(remote.max_concurrent_bound_reads(), 8);
@@ -3450,6 +3619,18 @@ resolution_policy = "inspect-only"
         assert_eq!(remote.max_manifest_chunk_entries(), 262_144);
         assert_eq!(remote.max_manifest_wrapped_key_entries(), 4096);
         assert_eq!(remote.max_remote_vector_clock_entries(), 4096);
+        assert_eq!(remote.max_catalog_head_object_bytes(), 16 * 1024);
+        assert_eq!(remote.max_catalog_root_object_bytes(), 4 * 1024 * 1024);
+        assert_eq!(remote.max_catalog_page_object_bytes(), 16 * 1024 * 1024);
+        assert_eq!(remote.max_catalog_pages(), 4096);
+        assert_eq!(remote.max_catalog_entries_per_page(), 4096);
+        assert_eq!(remote.max_catalog_entries(), 3_000_000);
+        assert_eq!(remote.max_catalog_entry_key_bytes(), 512 * 1024 * 1024);
+        assert_eq!(remote.max_catalog_binding_bytes(), 512 * 1024 * 1024);
+        assert_eq!(
+            remote.max_catalog_closure_object_bytes(),
+            4 * 1024 * 1024 * 1024
+        );
         assert_eq!(
             contract.causality_contract(),
             RootCausalityContractV1::TypedVectorClockV1
@@ -3475,7 +3656,7 @@ resolution_policy = "inspect-only"
         );
         assert_eq!(
             fingerprint.to_string(),
-            "b3v1:aabbbd421e6d9d487b59e244faa8d8a1ebf75311ec7cfa2dd7954b5a960850c4"
+            "b3v1:8767d0b8866f8c319f16e816a1996e2a7b638fe01ba972ed28dd2075345f9b6f"
         );
     }
 
@@ -3500,6 +3681,10 @@ resolution_policy = "inspect-only"
                 (
                     "remote_observation_model",
                     "two-listed-universe-bound-passes-non-atomic-v1",
+                ),
+                (
+                    "remote_completeness_authority",
+                    "immutable-catalog-head-closure-v1",
                 ),
                 ("causality_policy", "typed-vector-clock-v1"),
                 ("action_policy", "plan-only-no-delete-v1"),
@@ -3568,6 +3753,21 @@ resolution_policy = "inspect-only"
         assert_eq!(
             fields.remote_max_retained_unique_claim_bytes_per_pass,
             512 * 1024 * 1024
+        );
+        assert_eq!(fields.remote_max_catalog_head_object_bytes, 16 * 1024);
+        assert_eq!(fields.remote_max_catalog_root_object_bytes, 4 * 1024 * 1024);
+        assert_eq!(
+            fields.remote_max_catalog_page_object_bytes,
+            16 * 1024 * 1024
+        );
+        assert_eq!(fields.remote_max_catalog_pages, 4096);
+        assert_eq!(fields.remote_max_catalog_entries_per_page, 4096);
+        assert_eq!(fields.remote_max_catalog_entries, 3_000_000);
+        assert_eq!(fields.remote_max_catalog_entry_key_bytes, 512 * 1024 * 1024);
+        assert_eq!(fields.remote_max_catalog_binding_bytes, 512 * 1024 * 1024);
+        assert_eq!(
+            fields.remote_max_catalog_closure_object_bytes,
+            4 * 1024 * 1024 * 1024
         );
         assert_eq!(
             fields.remote_max_bound_object_bytes_per_pass,
@@ -3654,6 +3854,13 @@ resolution_policy = "inspect-only"
             fingerprint_registered_root_plan_contract_fields_v1(observation_model_mutation)
         );
 
+        let mut completeness_authority_mutation = fields;
+        completeness_authority_mutation.canonical_names[6].1 = "listing-equality-authority-test-v0";
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(completeness_authority_mutation)
+        );
+
         macro_rules! assert_state_resource_is_bound {
             ($field:ident) => {{
                 let mut mutation = fields;
@@ -3709,6 +3916,15 @@ resolution_policy = "inspect-only"
         assert_remote_resource_is_bound!(remote_max_manifest_chunk_entries);
         assert_remote_resource_is_bound!(remote_max_manifest_wrapped_key_entries);
         assert_remote_resource_is_bound!(remote_max_remote_vector_clock_entries);
+        assert_remote_resource_is_bound!(remote_max_catalog_head_object_bytes);
+        assert_remote_resource_is_bound!(remote_max_catalog_root_object_bytes);
+        assert_remote_resource_is_bound!(remote_max_catalog_page_object_bytes);
+        assert_remote_resource_is_bound!(remote_max_catalog_pages);
+        assert_remote_resource_is_bound!(remote_max_catalog_entries_per_page);
+        assert_remote_resource_is_bound!(remote_max_catalog_entries);
+        assert_remote_resource_is_bound!(remote_max_catalog_entry_key_bytes);
+        assert_remote_resource_is_bound!(remote_max_catalog_binding_bytes);
+        assert_remote_resource_is_bound!(remote_max_catalog_closure_object_bytes);
     }
 
     #[test]

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fmt;
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 use url::{Host, Url};
@@ -990,6 +991,349 @@ impl RootProfileV1 {
             Self::AgentStaticV1 => "agent-static-v1",
         }
     }
+
+    /// Immutable planning policy carried by this profile version.
+    ///
+    /// Registered-root planning must not inherit mutable primary-root
+    /// collection or deletion settings. A profile name therefore expands to
+    /// one closed bundle whose settings and fingerprint cannot be paired with
+    /// a different profile.
+    pub fn policy(self) -> RootProfilePolicyV1 {
+        let settings = self.settings();
+        RootProfilePolicyV1 {
+            profile: self,
+            settings,
+            settings_fingerprint: fingerprint_root_profile_settings_v1(self, settings),
+        }
+    }
+
+    fn settings(self) -> RootProfileSettingsV1 {
+        RootProfileSettingsV1 {
+            hidden_paths: RootHiddenPathPolicyV1::IncludeV1,
+            exclusions: RootExclusionPolicyV1::FixedIngressPathComponentsV1,
+            git: match self {
+                Self::GitRawV1 => RootGitPolicyV1::StandaloneRawWithFastForwardProofV1,
+                Self::AgentStaticV1 => RootGitPolicyV1::ExcludedV1,
+            },
+            symlinks: RootSymlinkPolicyV1::PreserveExactTargetV1,
+            empty_directories: RootEmptyDirectoryPolicyV1::IgnoreV1,
+            metadata: RootMetadataPolicyV1::RegularFileManifestModeAndMtimeV1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootHiddenPathPolicyV1 {
+    IncludeV1,
+}
+
+impl RootHiddenPathPolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::IncludeV1 => "include-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootExclusionPolicyV1 {
+    /// Exactly the config-independent checks implemented by
+    /// `Blacklist::check_fixed_ingress_path_components`.
+    ///
+    /// Changing that function's membership or semantics requires a new
+    /// profile/policy version and canonical name.
+    FixedIngressPathComponentsV1,
+}
+
+impl RootExclusionPolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::FixedIngressPathComponentsV1 => "fixed-ingress-path-components-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootGitPolicyV1 {
+    ExcludedV1,
+    StandaloneRawWithFastForwardProofV1,
+}
+
+impl RootGitPolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::ExcludedV1 => "excluded-v1",
+            Self::StandaloneRawWithFastForwardProofV1 => {
+                "standalone-raw-with-fast-forward-proof-v1"
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootSymlinkPolicyV1 {
+    PreserveExactTargetV1,
+}
+
+impl RootSymlinkPolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::PreserveExactTargetV1 => "preserve-exact-target-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootEmptyDirectoryPolicyV1 {
+    IgnoreV1,
+}
+
+impl RootEmptyDirectoryPolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::IgnoreV1 => "ignore-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootMetadataPolicyV1 {
+    /// Bind regular-file mode and mtime from its manifest.
+    ///
+    /// Symlink target semantics are governed separately by
+    /// `RootSymlinkPolicyV1`; V1 does not claim symlink metadata fidelity.
+    RegularFileManifestModeAndMtimeV1,
+}
+
+impl RootMetadataPolicyV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::RegularFileManifestModeAndMtimeV1 => "regular-file-manifest-mode-and-mtime-v1",
+        }
+    }
+}
+
+/// Closed operational settings for one registered-root profile generation.
+///
+/// These are deliberately not deserialized from host configuration. Changing
+/// any value requires a new profile version so a plan digest cannot retain the
+/// same policy identity while silently changing collection or deletion
+/// semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RootProfileSettingsV1 {
+    hidden_paths: RootHiddenPathPolicyV1,
+    exclusions: RootExclusionPolicyV1,
+    git: RootGitPolicyV1,
+    symlinks: RootSymlinkPolicyV1,
+    empty_directories: RootEmptyDirectoryPolicyV1,
+    metadata: RootMetadataPolicyV1,
+}
+
+impl RootProfileSettingsV1 {
+    pub const fn hidden_path_policy(self) -> RootHiddenPathPolicyV1 {
+        self.hidden_paths
+    }
+
+    pub const fn exclusion_policy(self) -> RootExclusionPolicyV1 {
+        self.exclusions
+    }
+
+    pub const fn git_policy(self) -> RootGitPolicyV1 {
+        self.git
+    }
+
+    pub const fn symlink_policy(self) -> RootSymlinkPolicyV1 {
+        self.symlinks
+    }
+
+    pub const fn empty_directory_policy(self) -> RootEmptyDirectoryPolicyV1 {
+        self.empty_directories
+    }
+
+    pub const fn metadata_policy(self) -> RootMetadataPolicyV1 {
+        self.metadata
+    }
+}
+
+/// Closed profile/settings/fingerprint bundle for registered-root planning.
+///
+/// The fields are private so a caller cannot pair one profile's settings with
+/// another profile's fingerprint. Planners accept `RootProfileV1` and derive
+/// this bundle rather than accepting its components independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RootProfilePolicyV1 {
+    profile: RootProfileV1,
+    settings: RootProfileSettingsV1,
+    settings_fingerprint: RootProfileSettingsFingerprintV1,
+}
+
+impl RootProfilePolicyV1 {
+    pub const fn profile(self) -> RootProfileV1 {
+        self.profile
+    }
+
+    pub const fn settings(self) -> RootProfileSettingsV1 {
+        self.settings
+    }
+
+    pub const fn settings_fingerprint(self) -> RootProfileSettingsFingerprintV1 {
+        self.settings_fingerprint
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootPathContractV1 {
+    PortableNfcCaseFoldV1,
+}
+
+impl RootPathContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::PortableNfcCaseFoldV1 => "portable-nfc-case-fold-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootStateContractV1 {
+    ImmutablePrimarySemanticExactV1,
+}
+
+impl RootStateContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::ImmutablePrimarySemanticExactV1 => "immutable-primary-semantic-exact-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootRemoteContractV1 {
+    RawCommittedManifestBoundV1,
+}
+
+impl RootRemoteContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::RawCommittedManifestBoundV1 => "raw-committed-manifest-bound-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootCausalityContractV1 {
+    TypedVectorClockV1,
+}
+
+impl RootCausalityContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::TypedVectorClockV1 => "typed-vector-clock-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootActionContractV1 {
+    PlanOnlyNoDeleteV1,
+}
+
+impl RootActionContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::PlanOnlyNoDeleteV1 => "plan-only-no-delete-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootOrderingContractV1 {
+    /// Sort by canonical relative-path bytes, then entry-kind discriminant,
+    /// then proof bytes. V1 planners must reject paths that do not have one
+    /// unambiguous portable canonical form before applying this ordering.
+    RelativePathKindProofV1,
+}
+
+impl RootOrderingContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::RelativePathKindProofV1 => "relative-path-kind-proof-v1",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootCompletenessContractV1 {
+    CompleteOrNoDigestV1,
+}
+
+impl RootCompletenessContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::CompleteOrNoDigestV1 => "complete-or-no-digest-v1",
+        }
+    }
+}
+
+/// Fixed semantic contract for the first registered-root planner.
+///
+/// The fields are private so callers cannot weaken an individual dimension or
+/// manufacture an unreviewed contract while retaining the V1 type name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisteredRootPlanContractV1 {
+    path: RootPathContractV1,
+    state: RootStateContractV1,
+    remote: RootRemoteContractV1,
+    causality: RootCausalityContractV1,
+    actions: RootActionContractV1,
+    ordering: RootOrderingContractV1,
+    completeness: RootCompletenessContractV1,
+}
+
+impl RegisteredRootPlanContractV1 {
+    pub const fn strict_v1() -> Self {
+        Self {
+            path: RootPathContractV1::PortableNfcCaseFoldV1,
+            state: RootStateContractV1::ImmutablePrimarySemanticExactV1,
+            remote: RootRemoteContractV1::RawCommittedManifestBoundV1,
+            causality: RootCausalityContractV1::TypedVectorClockV1,
+            actions: RootActionContractV1::PlanOnlyNoDeleteV1,
+            ordering: RootOrderingContractV1::RelativePathKindProofV1,
+            completeness: RootCompletenessContractV1::CompleteOrNoDigestV1,
+        }
+    }
+
+    pub const fn path_contract(self) -> RootPathContractV1 {
+        self.path
+    }
+
+    pub const fn state_contract(self) -> RootStateContractV1 {
+        self.state
+    }
+
+    pub const fn remote_contract(self) -> RootRemoteContractV1 {
+        self.remote
+    }
+
+    pub const fn causality_contract(self) -> RootCausalityContractV1 {
+        self.causality
+    }
+
+    pub const fn action_contract(self) -> RootActionContractV1 {
+        self.actions
+    }
+
+    pub const fn ordering_contract(self) -> RootOrderingContractV1 {
+        self.ordering
+    }
+
+    pub const fn completeness_contract(self) -> RootCompletenessContractV1 {
+        self.completeness
+    }
+
+    pub fn fingerprint(self) -> RegisteredRootPlanContractFingerprintV1 {
+        fingerprint_registered_root_plan_contract_v1(self)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1098,6 +1442,164 @@ fn update_root_fingerprint_field(hasher: &mut blake3::Hasher, tag: &str, value: 
 
 fn finish_root_fingerprint(hasher: blake3::Hasher) -> String {
     format!("b3v1:{}", hasher.finalize().to_hex())
+}
+
+const CANONICAL_ROOT_FINGERPRINT_SCHEMA_V1: u32 = 1;
+
+struct CanonicalRootFingerprintEncoderV1 {
+    hasher: blake3::Hasher,
+    expected_fields: u32,
+    encoded_fields: u32,
+}
+
+impl CanonicalRootFingerprintEncoderV1 {
+    fn new(domain: &'static str, expected_fields: usize) -> Self {
+        let expected_fields = u32::try_from(expected_fields)
+            .expect("canonical root fingerprint field count must fit u32");
+        let mut hasher = blake3::Hasher::new_derive_key(domain);
+        hasher.update(&CANONICAL_ROOT_FINGERPRINT_SCHEMA_V1.to_be_bytes());
+        hasher.update(&expected_fields.to_be_bytes());
+        Self {
+            hasher,
+            expected_fields,
+            encoded_fields: 0,
+        }
+    }
+
+    fn field(&mut self, tag: &'static str, value: &[u8]) {
+        let tag_len =
+            u32::try_from(tag.len()).expect("canonical root fingerprint tag length must fit u32");
+        let value_len = u64::try_from(value.len())
+            .expect("canonical root fingerprint value length must fit u64");
+        self.hasher.update(&tag_len.to_be_bytes());
+        self.hasher.update(tag.as_bytes());
+        self.hasher.update(&value_len.to_be_bytes());
+        self.hasher.update(value);
+        self.encoded_fields = self
+            .encoded_fields
+            .checked_add(1)
+            .expect("canonical root fingerprint field count overflow");
+    }
+
+    fn finish(self) -> [u8; 32] {
+        assert_eq!(
+            self.encoded_fields, self.expected_fields,
+            "canonical root fingerprint field count does not match its schema"
+        );
+        *self.hasher.finalize().as_bytes()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RootProfileSettingsFingerprintV1([u8; 32]);
+
+impl RootProfileSettingsFingerprintV1 {
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for RootProfileSettingsFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("b3v1:")?;
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for RootProfileSettingsFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "RootProfileSettingsFingerprintV1({self})")
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RegisteredRootPlanContractFingerprintV1([u8; 32]);
+
+impl RegisteredRootPlanContractFingerprintV1 {
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for RegisteredRootPlanContractFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("b3v1:")?;
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for RegisteredRootPlanContractFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "RegisteredRootPlanContractFingerprintV1({self})")
+    }
+}
+
+fn root_profile_settings_fingerprint_fields_v1(
+    profile: RootProfileV1,
+    settings: RootProfileSettingsV1,
+) -> [(&'static str, &'static str); 7] {
+    [
+        ("profile", profile.canonical_name()),
+        ("hidden_path_policy", settings.hidden_paths.canonical_name()),
+        ("exclusion_policy", settings.exclusions.canonical_name()),
+        ("git_policy", settings.git.canonical_name()),
+        ("symlink_policy", settings.symlinks.canonical_name()),
+        (
+            "empty_directory_policy",
+            settings.empty_directories.canonical_name(),
+        ),
+        ("metadata_policy", settings.metadata.canonical_name()),
+    ]
+}
+
+fn fingerprint_root_profile_settings_v1(
+    profile: RootProfileV1,
+    settings: RootProfileSettingsV1,
+) -> RootProfileSettingsFingerprintV1 {
+    let fields = root_profile_settings_fingerprint_fields_v1(profile, settings);
+    let mut encoder = CanonicalRootFingerprintEncoderV1::new(
+        "tinyland.tcfs.root-profile-settings.b3v1",
+        fields.len(),
+    );
+    for (tag, value) in fields {
+        encoder.field(tag, value.as_bytes());
+    }
+    RootProfileSettingsFingerprintV1(encoder.finish())
+}
+
+fn fingerprint_registered_root_plan_contract_v1(
+    contract: RegisteredRootPlanContractV1,
+) -> RegisteredRootPlanContractFingerprintV1 {
+    let mut encoder = CanonicalRootFingerprintEncoderV1::new(
+        "tinyland.tcfs.registered-root-plan-contract.b3v1",
+        7,
+    );
+    encoder.field("path_policy", contract.path.canonical_name().as_bytes());
+    encoder.field("state_policy", contract.state.canonical_name().as_bytes());
+    encoder.field("remote_policy", contract.remote.canonical_name().as_bytes());
+    encoder.field(
+        "causality_policy",
+        contract.causality.canonical_name().as_bytes(),
+    );
+    encoder.field(
+        "action_policy",
+        contract.actions.canonical_name().as_bytes(),
+    );
+    encoder.field(
+        "ordering_policy",
+        contract.ordering.canonical_name().as_bytes(),
+    );
+    encoder.field(
+        "completeness_policy",
+        contract.completeness.canonical_name().as_bytes(),
+    );
+    RegisteredRootPlanContractFingerprintV1(encoder.finish())
 }
 
 impl RootSpecV1Config {
@@ -1997,6 +2499,191 @@ resolution_policy = "inspect-only"
         assert_ne!(local_path_only, state_path_only);
         assert_eq!(identity, spec.identity_fingerprint("work"));
         assert_ne!(identity, spec.identity_fingerprint("other-work"));
+    }
+
+    #[test]
+    fn versioned_root_profile_settings_are_closed_and_typed() {
+        let git_policy = RootProfileV1::GitRawV1.policy();
+        let agent_policy = RootProfileV1::AgentStaticV1.policy();
+        let git = git_policy.settings();
+        let agent = agent_policy.settings();
+
+        assert_eq!(git_policy.profile(), RootProfileV1::GitRawV1);
+        assert_eq!(agent_policy.profile(), RootProfileV1::AgentStaticV1);
+
+        for settings in [git, agent] {
+            assert_eq!(
+                settings.hidden_path_policy(),
+                RootHiddenPathPolicyV1::IncludeV1
+            );
+            assert_eq!(
+                settings.exclusion_policy(),
+                RootExclusionPolicyV1::FixedIngressPathComponentsV1
+            );
+            assert_eq!(
+                settings.symlink_policy(),
+                RootSymlinkPolicyV1::PreserveExactTargetV1
+            );
+            assert_eq!(
+                settings.empty_directory_policy(),
+                RootEmptyDirectoryPolicyV1::IgnoreV1
+            );
+            assert_eq!(
+                settings.metadata_policy(),
+                RootMetadataPolicyV1::RegularFileManifestModeAndMtimeV1
+            );
+        }
+        assert_eq!(
+            git.git_policy(),
+            RootGitPolicyV1::StandaloneRawWithFastForwardProofV1
+        );
+        assert_eq!(agent.git_policy(), RootGitPolicyV1::ExcludedV1);
+
+        let git_fingerprint = git_policy.settings_fingerprint();
+        let agent_fingerprint = agent_policy.settings_fingerprint();
+        assert_eq!(git_fingerprint.as_bytes().len(), 32);
+        assert_eq!(agent_fingerprint.as_bytes().len(), 32);
+        assert_eq!(
+            git_fingerprint,
+            RootProfileV1::GitRawV1.policy().settings_fingerprint()
+        );
+        assert_ne!(git_fingerprint, agent_fingerprint);
+        assert_eq!(
+            git_fingerprint.to_string(),
+            "b3v1:ceedf3bc0437f2dce0ae5228efd0b5949dafaf47bbd23f99a27eb9183c8ee794"
+        );
+        assert_eq!(
+            agent_fingerprint.to_string(),
+            "b3v1:86c7ae197c9b320a8cf93bd7559d6352ee4b9dceded70f9249dc9deba4918294"
+        );
+    }
+
+    #[test]
+    fn root_profile_fingerprint_schema_binds_every_policy_field() {
+        let git = RootProfileV1::GitRawV1.policy();
+        assert_eq!(
+            root_profile_settings_fingerprint_fields_v1(git.profile(), git.settings(),),
+            [
+                ("profile", "git-raw-v1"),
+                ("hidden_path_policy", "include-v1"),
+                ("exclusion_policy", "fixed-ingress-path-components-v1"),
+                ("git_policy", "standalone-raw-with-fast-forward-proof-v1",),
+                ("symlink_policy", "preserve-exact-target-v1"),
+                ("empty_directory_policy", "ignore-v1"),
+                ("metadata_policy", "regular-file-manifest-mode-and-mtime-v1",),
+            ]
+        );
+
+        let agent = RootProfileV1::AgentStaticV1.policy();
+        assert_eq!(
+            root_profile_settings_fingerprint_fields_v1(agent.profile(), agent.settings(),),
+            [
+                ("profile", "agent-static-v1"),
+                ("hidden_path_policy", "include-v1"),
+                ("exclusion_policy", "fixed-ingress-path-components-v1"),
+                ("git_policy", "excluded-v1"),
+                ("symlink_policy", "preserve-exact-target-v1"),
+                ("empty_directory_policy", "ignore-v1"),
+                ("metadata_policy", "regular-file-manifest-mode-and-mtime-v1",),
+            ]
+        );
+    }
+
+    #[test]
+    fn registered_root_plan_contract_is_fixed_and_digest_bound() {
+        let contract = RegisteredRootPlanContractV1::strict_v1();
+        assert_eq!(
+            contract.path_contract(),
+            RootPathContractV1::PortableNfcCaseFoldV1
+        );
+        assert_eq!(
+            contract.state_contract(),
+            RootStateContractV1::ImmutablePrimarySemanticExactV1
+        );
+        assert_eq!(
+            contract.remote_contract(),
+            RootRemoteContractV1::RawCommittedManifestBoundV1
+        );
+        assert_eq!(
+            contract.causality_contract(),
+            RootCausalityContractV1::TypedVectorClockV1
+        );
+        assert_eq!(
+            contract.action_contract(),
+            RootActionContractV1::PlanOnlyNoDeleteV1
+        );
+        assert_eq!(
+            contract.ordering_contract(),
+            RootOrderingContractV1::RelativePathKindProofV1
+        );
+        assert_eq!(
+            contract.completeness_contract(),
+            RootCompletenessContractV1::CompleteOrNoDigestV1
+        );
+
+        let fingerprint = contract.fingerprint();
+        assert_eq!(fingerprint.as_bytes().len(), 32);
+        assert_eq!(
+            fingerprint,
+            RegisteredRootPlanContractV1::strict_v1().fingerprint()
+        );
+        assert_eq!(
+            fingerprint.to_string(),
+            "b3v1:6d2d9204424755f56559ba85b5e8596f1b1ab74e357989be4907f4976b9c2d50"
+        );
+    }
+
+    #[test]
+    fn canonical_root_fingerprint_framing_separates_fields_and_domains() {
+        fn encode(domain: &'static str, fields: &[(&'static str, &[u8])]) -> [u8; 32] {
+            let mut encoder = CanonicalRootFingerprintEncoderV1::new(domain, fields.len());
+            for (tag, value) in fields {
+                encoder.field(tag, value);
+            }
+            encoder.finish()
+        }
+
+        let left = encode("tinyland.tcfs.test-framing.b3v1", &[("a", b"bc")]);
+        let right = encode("tinyland.tcfs.test-framing.b3v1", &[("ab", b"c")]);
+        let other_domain = encode("tinyland.tcfs.test-domain.b3v1", &[("a", b"bc")]);
+        let ordered = encode(
+            "tinyland.tcfs.test-ordering.b3v1",
+            &[("first", b"one"), ("second", b"two")],
+        );
+        let permuted = encode(
+            "tinyland.tcfs.test-ordering.b3v1",
+            &[("second", b"two"), ("first", b"one")],
+        );
+        let mutated = encode(
+            "tinyland.tcfs.test-ordering.b3v1",
+            &[("first", b"one"), ("second", b"too")],
+        );
+
+        assert_eq!(
+            blake3::Hash::from_bytes(left).to_hex().to_string(),
+            "dee4f6c7d62fc770a28b56121139daa070b3f8a42cd89a65d916dbbb9ecbcc00"
+        );
+        assert_eq!(
+            blake3::Hash::from_bytes(right).to_hex().to_string(),
+            "155a944066efbd250f2d5dc9d88a2f7d023c4fc792fc34c62e2012e7243e06eb"
+        );
+        assert_eq!(
+            blake3::Hash::from_bytes(other_domain).to_hex().to_string(),
+            "419c248d4d7f18324fad3a54a9f1af1b6defec6e0336d94b21034c0907b586a2"
+        );
+        assert_ne!(left, right);
+        assert_ne!(left, other_domain);
+        assert_ne!(ordered, permuted);
+        assert_ne!(ordered, mutated);
+    }
+
+    #[test]
+    #[should_panic(expected = "canonical root fingerprint field count does not match its schema")]
+    fn canonical_root_fingerprint_rejects_declared_field_count_mismatch() {
+        let mut encoder =
+            CanonicalRootFingerprintEncoderV1::new("tinyland.tcfs.test-count.b3v1", 2);
+        encoder.field("only", b"one");
+        let _ = encoder.finish();
     }
 
     #[test]

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1304,6 +1304,20 @@ impl RootLocalSnapshotContractV1 {
         }
     }
 
+    /// Maximum byte length of one regular file admitted for hashing.
+    pub const fn max_regular_file_bytes(self) -> u64 {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => 1024 * 1024 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum aggregate regular-file bytes hashed for one snapshot.
+    pub const fn max_total_hashed_bytes(self) -> u64 {
+        match self {
+            Self::DescriptorRelativeIdentityContentIdentityV1 => 8 * 1024 * 1024 * 1024 * 1024,
+        }
+    }
+
     /// Fixed regular-file hashing buffer size.
     pub const fn hash_buffer_bytes(self) -> u64 {
         match self {
@@ -1730,6 +1744,8 @@ struct RegisteredRootPlanContractFingerprintFieldsV1 {
     local_snapshot_max_entries: u64,
     local_snapshot_max_retained_path_bytes: u64,
     local_snapshot_max_symlink_target_bytes: u64,
+    local_snapshot_max_regular_file_bytes: u64,
+    local_snapshot_max_total_hashed_bytes: u64,
     local_snapshot_hash_buffer_bytes: u64,
 }
 
@@ -1764,6 +1780,8 @@ fn registered_root_plan_contract_fingerprint_fields_v1(
         local_snapshot_max_entries: contract.local_snapshot.max_entries(),
         local_snapshot_max_retained_path_bytes: contract.local_snapshot.max_retained_path_bytes(),
         local_snapshot_max_symlink_target_bytes: contract.local_snapshot.max_symlink_target_bytes(),
+        local_snapshot_max_regular_file_bytes: contract.local_snapshot.max_regular_file_bytes(),
+        local_snapshot_max_total_hashed_bytes: contract.local_snapshot.max_total_hashed_bytes(),
         local_snapshot_hash_buffer_bytes: contract.local_snapshot.hash_buffer_bytes(),
     }
 }
@@ -1773,7 +1791,7 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
 ) -> RegisteredRootPlanContractFingerprintV1 {
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.registered-root-plan-contract.b3v1",
-        fields.canonical_names.len() + 5,
+        fields.canonical_names.len() + 7,
     );
     for (tag, value) in fields.canonical_names {
         encoder.field(tag, value.as_bytes());
@@ -1793,6 +1811,14 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
             encoder.field(
                 "local_snapshot_max_symlink_target_bytes",
                 &fields.local_snapshot_max_symlink_target_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "local_snapshot_max_regular_file_bytes",
+                &fields.local_snapshot_max_regular_file_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "local_snapshot_max_total_hashed_bytes",
+                &fields.local_snapshot_max_total_hashed_bytes.to_be_bytes(),
             );
             encoder.field(
                 "local_snapshot_hash_buffer_bytes",
@@ -2866,6 +2892,14 @@ resolution_policy = "inspect-only"
         assert_eq!(local_snapshot.max_entries(), 1_000_000);
         assert_eq!(local_snapshot.max_retained_path_bytes(), 256 * 1024 * 1024);
         assert_eq!(local_snapshot.max_symlink_target_bytes(), 1023);
+        assert_eq!(
+            local_snapshot.max_regular_file_bytes(),
+            1024 * 1024 * 1024 * 1024
+        );
+        assert_eq!(
+            local_snapshot.max_total_hashed_bytes(),
+            8 * 1024 * 1024 * 1024 * 1024
+        );
         assert_eq!(local_snapshot.hash_buffer_bytes(), 64 * 1024);
         assert_eq!(
             contract.state_contract(),
@@ -2900,7 +2934,7 @@ resolution_policy = "inspect-only"
         );
         assert_eq!(
             fingerprint.to_string(),
-            "b3v1:af0bce82d5ebee4249f45ad7824e9e12a7628ffb4ec764c1865d079b1fac4d6a"
+            "b3v1:db9a3d9899a427c952789afdd850d6ffafca84770b99d6f02d3efcca6b3a0327"
         );
     }
 
@@ -2935,6 +2969,14 @@ resolution_policy = "inspect-only"
             256 * 1024 * 1024
         );
         assert_eq!(fields.local_snapshot_max_symlink_target_bytes, 1023);
+        assert_eq!(
+            fields.local_snapshot_max_regular_file_bytes,
+            1024 * 1024 * 1024 * 1024
+        );
+        assert_eq!(
+            fields.local_snapshot_max_total_hashed_bytes,
+            8 * 1024 * 1024 * 1024 * 1024
+        );
         assert_eq!(fields.local_snapshot_hash_buffer_bytes, 64 * 1024);
 
         let baseline = fingerprint_registered_root_plan_contract_fields_v1(fields);
@@ -2979,6 +3021,20 @@ resolution_policy = "inspect-only"
         assert_ne!(
             baseline,
             fingerprint_registered_root_plan_contract_fields_v1(target_bytes_mutation)
+        );
+
+        let mut regular_file_bytes_mutation = fields;
+        regular_file_bytes_mutation.local_snapshot_max_regular_file_bytes += 1;
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(regular_file_bytes_mutation)
+        );
+
+        let mut total_hashed_bytes_mutation = fields;
+        total_hashed_bytes_mutation.local_snapshot_max_total_hashed_bytes += 1;
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(total_hashed_bytes_mutation)
         );
 
         let mut buffer_bytes_mutation = fields;

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1009,13 +1009,15 @@ impl RootProfileV1 {
     }
 
     fn settings(self) -> RootProfileSettingsV1 {
+        let git = match self {
+            Self::GitRawV1 => RootGitPolicyV1::StandaloneRawWithFastForwardProofV1,
+            Self::AgentStaticV1 => RootGitPolicyV1::ExcludedV1,
+        };
         RootProfileSettingsV1 {
             hidden_paths: RootHiddenPathPolicyV1::IncludeV1,
             exclusions: RootExclusionPolicyV1::FixedIngressPathComponentsV1,
-            git: match self {
-                Self::GitRawV1 => RootGitPolicyV1::StandaloneRawWithFastForwardProofV1,
-                Self::AgentStaticV1 => RootGitPolicyV1::ExcludedV1,
-            },
+            git,
+            git_observation: git.observation_contract(),
             symlinks: RootSymlinkPolicyV1::PreserveExactTargetV1,
             hardlinks: RootHardlinkPolicyV1::RejectV1,
             special_files: RootSpecialFilePolicyV1::RejectV1,
@@ -1070,6 +1072,130 @@ impl RootGitPolicyV1 {
             Self::StandaloneRawWithFastForwardProofV1 => {
                 "standalone-raw-with-fast-forward-proof-v1"
             }
+        }
+    }
+
+    pub const fn observation_contract(self) -> RootGitObservationContractV1 {
+        match self {
+            Self::ExcludedV1 => RootGitObservationContractV1::ExcludedV1,
+            Self::StandaloneRawWithFastForwardProofV1 => {
+                RootGitObservationContractV1::TwoPassRefsAndSymrefsV1
+            }
+        }
+    }
+}
+
+/// Closed resource and stability contract for observing Git ref topology.
+///
+/// The operational variant describes one bounded `for-each-ref`-style
+/// observation. Both passes must produce identical canonical ref/symref
+/// records; V1 never retries until a stable result appears. The bounds apply
+/// to inventory-A inputs and retained command output; writer fencing and
+/// same-principal swap/restore during a child process are outside this
+/// source-only contract. OID lengths are the byte lengths of their hexadecimal
+/// command-output representations.
+///
+/// `ExcludedV1` is a distinct, fingerprinted policy. Its numeric accessors
+/// return zero to represent non-applicability, not an executable zero-budget
+/// observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootGitObservationContractV1 {
+    ExcludedV1,
+    TwoPassRefsAndSymrefsV1,
+}
+
+impl RootGitObservationContractV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::ExcludedV1 => "excluded-v1",
+            Self::TwoPassRefsAndSymrefsV1 => "two-pass-refs-and-symrefs-v1",
+        }
+    }
+
+    pub const fn is_applicable(self) -> bool {
+        match self {
+            Self::ExcludedV1 => false,
+            Self::TwoPassRefsAndSymrefsV1 => true,
+        }
+    }
+
+    /// Maximum refs retained by one complete observation pass.
+    pub const fn max_refs(self) -> u64 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 1_000_000,
+        }
+    }
+
+    /// Maximum bytes in one ref name or symbolic-ref target.
+    pub const fn max_ref_or_symref_bytes(self) -> u64 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 1023,
+        }
+    }
+
+    /// Maximum aggregate bytes retained for canonical ref/symref records.
+    pub const fn max_retained_bytes(self) -> u64 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 256 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum stdout accepted from one Git observation command.
+    pub const fn max_command_stdout_bytes(self) -> u64 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 320 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum repository-local Git config bytes accepted by inventory A.
+    pub const fn max_config_file_bytes(self) -> u64 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 1024 * 1024,
+        }
+    }
+
+    /// Maximum `.git/HEAD` bytes accepted by inventory A, including syntax and
+    /// newline.
+    pub const fn max_head_file_bytes(self) -> u64 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 1029,
+        }
+    }
+
+    /// Exact number of complete observation passes.
+    pub const fn pass_count(self) -> u8 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 2,
+        }
+    }
+
+    /// Number of retries allowed after either pass or equality proof fails.
+    pub const fn retry_count(self) -> u8 {
+        match self {
+            Self::ExcludedV1 | Self::TwoPassRefsAndSymrefsV1 => 0,
+        }
+    }
+
+    /// SHA-1 object ID length in hexadecimal command-output bytes.
+    pub const fn sha1_oid_hex_bytes(self) -> u8 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 40,
+        }
+    }
+
+    /// SHA-256 object ID length in hexadecimal command-output bytes.
+    pub const fn sha256_oid_hex_bytes(self) -> u8 {
+        match self {
+            Self::ExcludedV1 => 0,
+            Self::TwoPassRefsAndSymrefsV1 => 64,
         }
     }
 }
@@ -1156,6 +1282,7 @@ pub struct RootProfileSettingsV1 {
     hidden_paths: RootHiddenPathPolicyV1,
     exclusions: RootExclusionPolicyV1,
     git: RootGitPolicyV1,
+    git_observation: RootGitObservationContractV1,
     symlinks: RootSymlinkPolicyV1,
     hardlinks: RootHardlinkPolicyV1,
     special_files: RootSpecialFilePolicyV1,
@@ -1174,6 +1301,10 @@ impl RootProfileSettingsV1 {
 
     pub const fn git_policy(self) -> RootGitPolicyV1 {
         self.git
+    }
+
+    pub const fn git_observation_contract(self) -> RootGitObservationContractV1 {
+        self.git_observation
     }
 
     pub const fn symlink_policy(self) -> RootSymlinkPolicyV1 {
@@ -2061,8 +2192,18 @@ impl fmt::Debug for RegisteredRootPlanContractFingerprintV1 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RootProfileSettingsFingerprintFieldsV1 {
-    canonical_names: [(&'static str, &'static str); 9],
+    canonical_names: [(&'static str, &'static str); 10],
     fixed_ingress_schema: FixedIngressPolicySchemaFingerprintV1,
+    git_observation_max_refs: u64,
+    git_observation_max_ref_or_symref_bytes: u64,
+    git_observation_max_retained_bytes: u64,
+    git_observation_max_command_stdout_bytes: u64,
+    git_observation_max_config_file_bytes: u64,
+    git_observation_max_head_file_bytes: u64,
+    git_observation_pass_count: u8,
+    git_observation_retry_count: u8,
+    git_observation_sha1_oid_hex_bytes: u8,
+    git_observation_sha256_oid_hex_bytes: u8,
 }
 
 fn root_profile_settings_fingerprint_fields_v1(
@@ -2075,6 +2216,10 @@ fn root_profile_settings_fingerprint_fields_v1(
             ("hidden_path_policy", settings.hidden_paths.canonical_name()),
             ("exclusion_policy", settings.exclusions.canonical_name()),
             ("git_policy", settings.git.canonical_name()),
+            (
+                "git_observation_contract",
+                settings.git_observation.canonical_name(),
+            ),
             ("symlink_policy", settings.symlinks.canonical_name()),
             ("hardlink_policy", settings.hardlinks.canonical_name()),
             (
@@ -2088,6 +2233,18 @@ fn root_profile_settings_fingerprint_fields_v1(
             ("metadata_policy", settings.metadata.canonical_name()),
         ],
         fixed_ingress_schema: FixedIngressPolicyV1::strict_v1().schema_fingerprint(),
+        git_observation_max_refs: settings.git_observation.max_refs(),
+        git_observation_max_ref_or_symref_bytes: settings.git_observation.max_ref_or_symref_bytes(),
+        git_observation_max_retained_bytes: settings.git_observation.max_retained_bytes(),
+        git_observation_max_command_stdout_bytes: settings
+            .git_observation
+            .max_command_stdout_bytes(),
+        git_observation_max_config_file_bytes: settings.git_observation.max_config_file_bytes(),
+        git_observation_max_head_file_bytes: settings.git_observation.max_head_file_bytes(),
+        git_observation_pass_count: settings.git_observation.pass_count(),
+        git_observation_retry_count: settings.git_observation.retry_count(),
+        git_observation_sha1_oid_hex_bytes: settings.git_observation.sha1_oid_hex_bytes(),
+        git_observation_sha256_oid_hex_bytes: settings.git_observation.sha256_oid_hex_bytes(),
     }
 }
 
@@ -2096,7 +2253,7 @@ fn fingerprint_root_profile_settings_fields_v1(
 ) -> RootProfileSettingsFingerprintV1 {
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.root-profile-settings.b3v1",
-        fields.canonical_names.len() + 1,
+        fields.canonical_names.len() + 11,
     );
     for (tag, value) in fields.canonical_names {
         encoder.field(tag, value.as_bytes());
@@ -2104,6 +2261,48 @@ fn fingerprint_root_profile_settings_fields_v1(
     encoder.field(
         "fixed_ingress_policy_schema",
         fields.fixed_ingress_schema.as_bytes(),
+    );
+    encoder.field(
+        "git_observation_max_refs",
+        &fields.git_observation_max_refs.to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_max_ref_or_symref_bytes",
+        &fields.git_observation_max_ref_or_symref_bytes.to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_max_retained_bytes",
+        &fields.git_observation_max_retained_bytes.to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_max_command_stdout_bytes",
+        &fields
+            .git_observation_max_command_stdout_bytes
+            .to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_max_config_file_bytes",
+        &fields.git_observation_max_config_file_bytes.to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_max_head_file_bytes",
+        &fields.git_observation_max_head_file_bytes.to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_pass_count",
+        &fields.git_observation_pass_count.to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_retry_count",
+        &fields.git_observation_retry_count.to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_sha1_oid_hex_bytes",
+        &fields.git_observation_sha1_oid_hex_bytes.to_be_bytes(),
+    );
+    encoder.field(
+        "git_observation_sha256_oid_hex_bytes",
+        &fields.git_observation_sha256_oid_hex_bytes.to_be_bytes(),
     );
     RootProfileSettingsFingerprintV1(encoder.finish())
 }
@@ -3426,6 +3625,47 @@ resolution_policy = "inspect-only"
             RootGitPolicyV1::StandaloneRawWithFastForwardProofV1
         );
         assert_eq!(agent.git_policy(), RootGitPolicyV1::ExcludedV1);
+        let git_observation = git.git_observation_contract();
+        assert_eq!(
+            git_observation,
+            RootGitObservationContractV1::TwoPassRefsAndSymrefsV1
+        );
+        assert_eq!(git.git_policy().observation_contract(), git_observation);
+        assert!(git_observation.is_applicable());
+        assert_eq!(git_observation.max_refs(), 1_000_000);
+        assert_eq!(git_observation.max_ref_or_symref_bytes(), 1023);
+        assert_eq!(git_observation.max_retained_bytes(), 256 * 1024 * 1024);
+        assert_eq!(
+            git_observation.max_command_stdout_bytes(),
+            320 * 1024 * 1024
+        );
+        assert_eq!(git_observation.max_config_file_bytes(), 1024 * 1024);
+        assert_eq!(git_observation.max_head_file_bytes(), 1029);
+        assert_eq!(git_observation.pass_count(), 2);
+        assert_eq!(git_observation.retry_count(), 0);
+        assert_eq!(git_observation.sha1_oid_hex_bytes(), 40);
+        assert_eq!(git_observation.sha256_oid_hex_bytes(), 64);
+
+        let excluded_observation = agent.git_observation_contract();
+        assert_eq!(
+            excluded_observation,
+            RootGitObservationContractV1::ExcludedV1
+        );
+        assert_eq!(
+            agent.git_policy().observation_contract(),
+            excluded_observation
+        );
+        assert!(!excluded_observation.is_applicable());
+        assert_eq!(excluded_observation.max_refs(), 0);
+        assert_eq!(excluded_observation.max_ref_or_symref_bytes(), 0);
+        assert_eq!(excluded_observation.max_retained_bytes(), 0);
+        assert_eq!(excluded_observation.max_command_stdout_bytes(), 0);
+        assert_eq!(excluded_observation.max_config_file_bytes(), 0);
+        assert_eq!(excluded_observation.max_head_file_bytes(), 0);
+        assert_eq!(excluded_observation.pass_count(), 0);
+        assert_eq!(excluded_observation.retry_count(), 0);
+        assert_eq!(excluded_observation.sha1_oid_hex_bytes(), 0);
+        assert_eq!(excluded_observation.sha256_oid_hex_bytes(), 0);
 
         let git_fingerprint = git_policy.settings_fingerprint();
         let agent_fingerprint = agent_policy.settings_fingerprint();
@@ -3438,11 +3678,11 @@ resolution_policy = "inspect-only"
         assert_ne!(git_fingerprint, agent_fingerprint);
         assert_eq!(
             git_fingerprint.to_string(),
-            "b3v1:3f7b636df0abf0081df3dee914c678444f880d6de7e66717e5f6acdcb6a6f447"
+            "b3v1:97275abb42108c673d31e1358c55ec7c83ce665fc367c5cf9a3c685c5301e043"
         );
         assert_eq!(
             agent_fingerprint.to_string(),
-            "b3v1:d71f461619660b8e88a2bcbc299e0bb88c91ba2112a75621b9c58e148d08d0e4"
+            "b3v1:92f2569ed6fc3379b2710c0abc11d28da9b7ed1e970a971a06d4675b519c619d"
         );
     }
 
@@ -3457,6 +3697,7 @@ resolution_policy = "inspect-only"
                 ("hidden_path_policy", "include-v1"),
                 ("exclusion_policy", "fixed-ingress-path-components-v1"),
                 ("git_policy", "standalone-raw-with-fast-forward-proof-v1",),
+                ("git_observation_contract", "two-pass-refs-and-symrefs-v1",),
                 ("symlink_policy", "preserve-exact-target-v1"),
                 ("hardlink_policy", "reject-v1"),
                 ("special_file_policy", "reject-v1"),
@@ -3468,6 +3709,25 @@ resolution_policy = "inspect-only"
             git_fields.fixed_ingress_schema,
             FixedIngressPolicyV1::strict_v1().schema_fingerprint()
         );
+        assert_eq!(git_fields.git_observation_max_refs, 1_000_000);
+        assert_eq!(git_fields.git_observation_max_ref_or_symref_bytes, 1023);
+        assert_eq!(
+            git_fields.git_observation_max_retained_bytes,
+            256 * 1024 * 1024
+        );
+        assert_eq!(
+            git_fields.git_observation_max_command_stdout_bytes,
+            320 * 1024 * 1024
+        );
+        assert_eq!(
+            git_fields.git_observation_max_config_file_bytes,
+            1024 * 1024
+        );
+        assert_eq!(git_fields.git_observation_max_head_file_bytes, 1029);
+        assert_eq!(git_fields.git_observation_pass_count, 2);
+        assert_eq!(git_fields.git_observation_retry_count, 0);
+        assert_eq!(git_fields.git_observation_sha1_oid_hex_bytes, 40);
+        assert_eq!(git_fields.git_observation_sha256_oid_hex_bytes, 64);
         assert_eq!(
             git.settings().exclusion_policy().canonical_name(),
             FixedIngressPolicyV1::strict_v1().canonical_name()
@@ -3483,6 +3743,7 @@ resolution_policy = "inspect-only"
                 ("hidden_path_policy", "include-v1"),
                 ("exclusion_policy", "fixed-ingress-path-components-v1"),
                 ("git_policy", "excluded-v1"),
+                ("git_observation_contract", "excluded-v1"),
                 ("symlink_policy", "preserve-exact-target-v1"),
                 ("hardlink_policy", "reject-v1"),
                 ("special_file_policy", "reject-v1"),
@@ -3494,6 +3755,16 @@ resolution_policy = "inspect-only"
             agent_fields.fixed_ingress_schema,
             FixedIngressPolicyV1::strict_v1().schema_fingerprint()
         );
+        assert_eq!(agent_fields.git_observation_max_refs, 0);
+        assert_eq!(agent_fields.git_observation_max_ref_or_symref_bytes, 0);
+        assert_eq!(agent_fields.git_observation_max_retained_bytes, 0);
+        assert_eq!(agent_fields.git_observation_max_command_stdout_bytes, 0);
+        assert_eq!(agent_fields.git_observation_max_config_file_bytes, 0);
+        assert_eq!(agent_fields.git_observation_max_head_file_bytes, 0);
+        assert_eq!(agent_fields.git_observation_pass_count, 0);
+        assert_eq!(agent_fields.git_observation_retry_count, 0);
+        assert_eq!(agent_fields.git_observation_sha1_oid_hex_bytes, 0);
+        assert_eq!(agent_fields.git_observation_sha256_oid_hex_bytes, 0);
         assert_eq!(
             git_fields.fixed_ingress_schema,
             agent_fields.fixed_ingress_schema
@@ -3508,14 +3779,89 @@ resolution_policy = "inspect-only"
         let baseline = fingerprint_root_profile_settings_fields_v1(fields);
 
         for (index, mutation) in [
-            (5, "allow-hardlinks-test-v0"),
-            (6, "allow-special-files-test-v0"),
+            (6, "allow-hardlinks-test-v0"),
+            (7, "allow-special-files-test-v0"),
         ] {
             let mut mutated = fields;
             mutated.canonical_names[index].1 = mutation;
             assert_ne!(
                 baseline,
                 fingerprint_root_profile_settings_fields_v1(mutated)
+            );
+        }
+    }
+
+    #[test]
+    fn root_profile_fingerprint_binds_git_observation_contract_and_bounds() {
+        let policy = RootProfileV1::GitRawV1.policy();
+        let fields =
+            root_profile_settings_fingerprint_fields_v1(policy.profile(), policy.settings());
+        let baseline = fingerprint_root_profile_settings_fields_v1(fields);
+
+        let mut contract_mutation = fields;
+        contract_mutation.canonical_names[4].1 = "one-pass-refs-test-v0";
+        assert_ne!(
+            baseline,
+            fingerprint_root_profile_settings_fields_v1(contract_mutation)
+        );
+
+        let mutations = [
+            {
+                let mut mutation = fields;
+                mutation.git_observation_max_refs += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_max_ref_or_symref_bytes += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_max_retained_bytes += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_max_command_stdout_bytes += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_max_config_file_bytes += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_max_head_file_bytes += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_pass_count += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_retry_count += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_sha1_oid_hex_bytes += 1;
+                mutation
+            },
+            {
+                let mut mutation = fields;
+                mutation.git_observation_sha256_oid_hex_bytes += 1;
+                mutation
+            },
+        ];
+
+        for mutation in mutations {
+            assert_ne!(
+                baseline,
+                fingerprint_root_profile_settings_fields_v1(mutation)
             );
         }
     }

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1079,21 +1079,23 @@ impl RootGitPolicyV1 {
         match self {
             Self::ExcludedV1 => RootGitObservationContractV1::ExcludedV1,
             Self::StandaloneRawWithFastForwardProofV1 => {
-                RootGitObservationContractV1::TwoPassRefsAndSymrefsV1
+                RootGitObservationContractV1::TwoPassImmutableRawMetadataV1
             }
         }
     }
 }
 
-/// Closed resource and stability contract for observing Git ref topology.
+/// Closed resource and stability contract for capturing raw Git metadata.
 ///
-/// The operational variant describes one bounded `for-each-ref`-style
-/// observation. Both passes must produce identical canonical ref/symref
-/// records; V1 never retries until a stable result appears. The bounds apply
-/// to inventory-A inputs and retained command output; writer fencing and
-/// same-principal swap/restore during a child process are outside this
-/// source-only contract. OID lengths are the byte lengths of their hexadecimal
-/// command-output representations.
+/// The operational variant retains one bounded, process-owned shadow of the
+/// inventory-A config, HEAD, packed refs, and loose refs. Config syntax is
+/// interpreted only from those captured bytes and ref/HEAD topology is derived
+/// twice without reopening live Git metadata. Both derivations must be exact;
+/// inventory C and the held root/`.git` descriptors still have to revalidate
+/// before the shadow can be promoted.
+/// Object kind, ancestry, fast-forward, and enduring writer exclusion are not
+/// part of this source-only contract. OID lengths are the byte lengths of their
+/// hexadecimal raw-metadata representations.
 ///
 /// `ExcludedV1` is a distinct, fingerprinted policy. Its numeric accessors
 /// return zero to represent non-applicability, not an executable zero-budget
@@ -1101,21 +1103,21 @@ impl RootGitPolicyV1 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RootGitObservationContractV1 {
     ExcludedV1,
-    TwoPassRefsAndSymrefsV1,
+    TwoPassImmutableRawMetadataV1,
 }
 
 impl RootGitObservationContractV1 {
     pub const fn canonical_name(self) -> &'static str {
         match self {
             Self::ExcludedV1 => "excluded-v1",
-            Self::TwoPassRefsAndSymrefsV1 => "two-pass-refs-and-symrefs-v1",
+            Self::TwoPassImmutableRawMetadataV1 => "two-pass-immutable-raw-metadata-v1",
         }
     }
 
     pub const fn is_applicable(self) -> bool {
         match self {
             Self::ExcludedV1 => false,
-            Self::TwoPassRefsAndSymrefsV1 => true,
+            Self::TwoPassImmutableRawMetadataV1 => true,
         }
     }
 
@@ -1123,7 +1125,7 @@ impl RootGitObservationContractV1 {
     pub const fn max_refs(self) -> u64 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 1_000_000,
+            Self::TwoPassImmutableRawMetadataV1 => 1_000_000,
         }
     }
 
@@ -1131,23 +1133,28 @@ impl RootGitObservationContractV1 {
     pub const fn max_ref_or_symref_bytes(self) -> u64 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 1023,
+            Self::TwoPassImmutableRawMetadataV1 => 1023,
         }
     }
 
-    /// Maximum aggregate bytes retained for canonical ref/symref records.
+    /// Maximum aggregate payload bytes in one effective raw-ref map or one
+    /// derived canonical ref/symref set.
+    ///
+    /// This is not a peak-RSS claim. The immutable raw config, HEAD, and
+    /// packed-ref inputs retain their independently bounded payloads, and
+    /// bounded intermediate maps can coexist during an exact derivation.
     pub const fn max_retained_bytes(self) -> u64 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 256 * 1024 * 1024,
+            Self::TwoPassImmutableRawMetadataV1 => 256 * 1024 * 1024,
         }
     }
 
-    /// Maximum stdout accepted from one Git observation command.
+    /// Maximum captured packed-ref or config-query output bytes.
     pub const fn max_command_stdout_bytes(self) -> u64 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 320 * 1024 * 1024,
+            Self::TwoPassImmutableRawMetadataV1 => 320 * 1024 * 1024,
         }
     }
 
@@ -1155,7 +1162,7 @@ impl RootGitObservationContractV1 {
     pub const fn max_config_file_bytes(self) -> u64 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 1024 * 1024,
+            Self::TwoPassImmutableRawMetadataV1 => 1024 * 1024,
         }
     }
 
@@ -1164,22 +1171,22 @@ impl RootGitObservationContractV1 {
     pub const fn max_head_file_bytes(self) -> u64 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 1029,
+            Self::TwoPassImmutableRawMetadataV1 => 1029,
         }
     }
 
-    /// Exact number of complete observation passes.
+    /// Exact number of canonical derivations from the immutable shadow.
     pub const fn pass_count(self) -> u8 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 2,
+            Self::TwoPassImmutableRawMetadataV1 => 2,
         }
     }
 
-    /// Number of retries allowed after either pass or equality proof fails.
+    /// Number of retries allowed after capture or validation fails.
     pub const fn retry_count(self) -> u8 {
         match self {
-            Self::ExcludedV1 | Self::TwoPassRefsAndSymrefsV1 => 0,
+            Self::ExcludedV1 | Self::TwoPassImmutableRawMetadataV1 => 0,
         }
     }
 
@@ -1187,7 +1194,7 @@ impl RootGitObservationContractV1 {
     pub const fn sha1_oid_hex_bytes(self) -> u8 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 40,
+            Self::TwoPassImmutableRawMetadataV1 => 40,
         }
     }
 
@@ -1195,7 +1202,7 @@ impl RootGitObservationContractV1 {
     pub const fn sha256_oid_hex_bytes(self) -> u8 {
         match self {
             Self::ExcludedV1 => 0,
-            Self::TwoPassRefsAndSymrefsV1 => 64,
+            Self::TwoPassImmutableRawMetadataV1 => 64,
         }
     }
 }
@@ -3628,7 +3635,7 @@ resolution_policy = "inspect-only"
         let git_observation = git.git_observation_contract();
         assert_eq!(
             git_observation,
-            RootGitObservationContractV1::TwoPassRefsAndSymrefsV1
+            RootGitObservationContractV1::TwoPassImmutableRawMetadataV1
         );
         assert_eq!(git.git_policy().observation_contract(), git_observation);
         assert!(git_observation.is_applicable());
@@ -3678,7 +3685,7 @@ resolution_policy = "inspect-only"
         assert_ne!(git_fingerprint, agent_fingerprint);
         assert_eq!(
             git_fingerprint.to_string(),
-            "b3v1:97275abb42108c673d31e1358c55ec7c83ce665fc367c5cf9a3c685c5301e043"
+            "b3v1:99d9d7a2f881738c36b8ad518fe6138c2243b3cc5bcf466029f7db8e25f2f9c4"
         );
         assert_eq!(
             agent_fingerprint.to_string(),
@@ -3697,7 +3704,10 @@ resolution_policy = "inspect-only"
                 ("hidden_path_policy", "include-v1"),
                 ("exclusion_policy", "fixed-ingress-path-components-v1"),
                 ("git_policy", "standalone-raw-with-fast-forward-proof-v1",),
-                ("git_observation_contract", "two-pass-refs-and-symrefs-v1",),
+                (
+                    "git_observation_contract",
+                    "two-pass-immutable-raw-metadata-v1",
+                ),
                 ("symlink_policy", "preserve-exact-target-v1"),
                 ("hardlink_policy", "reject-v1"),
                 ("special_file_policy", "reject-v1"),

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1340,6 +1340,38 @@ impl RootStateContractV1 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootRemoteObservationModelV1 {
+    /// Exactly two exhaustive passes over each listed key universe independently
+    /// identity-bind every index, marker, reservation, and referenced manifest
+    /// object. The passes must have identical keys, bindings, bytes, and strict
+    /// semantics. A mismatch proves observed drift; equality still does not
+    /// provide transaction or globally atomic namespace snapshot isolation.
+    ///
+    /// Each sequential, non-overlapping pass lists index then reservation keys,
+    /// validates and sorts both keysets, binds every index and reservation
+    /// object, derives and deduplicates committed manifest keys, then binds
+    /// those manifests. Errors fail the observation; V1 never retries until a
+    /// stable result appears.
+    TwoListedUniverseBoundPassesNonAtomicV1,
+}
+
+impl RootRemoteObservationModelV1 {
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::TwoListedUniverseBoundPassesNonAtomicV1 => {
+                "two-listed-universe-bound-passes-non-atomic-v1"
+            }
+        }
+    }
+
+    pub const fn pass_count(self) -> u8 {
+        match self {
+            Self::TwoListedUniverseBoundPassesNonAtomicV1 => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RootRemoteContractV1 {
     RawCommittedManifestBoundV1,
 }
@@ -1348,6 +1380,214 @@ impl RootRemoteContractV1 {
     pub const fn canonical_name(self) -> &'static str {
         match self {
             Self::RawCommittedManifestBoundV1 => "raw-committed-manifest-bound-v1",
+        }
+    }
+
+    /// Observation mechanics available from generic S3-compatible backends.
+    ///
+    /// This model is intentionally weaker than the registered-root plan's
+    /// `CompleteOrNoDigestV1` completeness contract. A stable observation is
+    /// evidence, not authority to mint a plan digest.
+    pub const fn observation_model(self) -> RootRemoteObservationModelV1 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => {
+                RootRemoteObservationModelV1::TwoListedUniverseBoundPassesNonAtomicV1
+            }
+        }
+    }
+
+    /// Requested backend page limit for each streaming namespace listing.
+    ///
+    /// OpenDAL exposes this as a backend hint, never as a safety boundary. The
+    /// independent total-row and total-key-byte ceilings remain authoritative.
+    pub const fn listing_page_request_limit(self) -> u32 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 1000,
+        }
+    }
+
+    /// Maximum concurrent identity-bound object reads.
+    ///
+    /// This and [`Self::listing_page_request_limit`] are acquisition-only
+    /// tuning. They cannot change canonical output, incompleteness rules, or
+    /// any acceptance ceiling and therefore are not fingerprint fields.
+    pub const fn max_concurrent_bound_reads(self) -> u32 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 8,
+        }
+    }
+
+    /// Maximum rows emitted by both backend listers in one pass.
+    ///
+    /// Every row counts before mode/path validation, filtering, or duplicate
+    /// detection, including synthetic directories and malformed rows.
+    pub const fn max_listing_rows_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4_000_000,
+        }
+    }
+
+    /// Maximum raw key bytes emitted by both backend listers in one pass.
+    ///
+    /// As with rows, bytes count before any validation or filtering.
+    pub const fn max_listing_key_bytes_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 1024 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum byte length of every emitted or constructed storage key.
+    ///
+    /// This also bounds the remote prefix because it is a strict key prefix.
+    pub const fn max_storage_key_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 1024,
+        }
+    }
+
+    /// Maximum physical non-directory index objects observed in one pass.
+    pub const fn max_index_observations_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 1_000_000,
+        }
+    }
+
+    /// Maximum combined byte length of retained physical index keys per pass.
+    pub const fn max_retained_index_key_bytes_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 256 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum physical namespace-reservation objects observed in one pass.
+    pub const fn max_reservation_observations_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 2_000_000,
+        }
+    }
+
+    /// Maximum combined byte length of retained reservation keys per pass.
+    pub const fn max_retained_reservation_key_bytes_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 256 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum byte length of one exact raw index object.
+    pub const fn max_index_object_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 1024 * 1024,
+        }
+    }
+
+    /// Maximum byte length of one exact committed manifest object.
+    pub const fn max_manifest_object_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 16 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum byte length of one exact namespace-reservation object.
+    pub const fn max_reservation_object_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 16 * 1024,
+        }
+    }
+
+    /// Maximum byte length of one strict logical namespace path.
+    pub const fn max_logical_path_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 1024,
+        }
+    }
+
+    /// Maximum UTF-8 byte length of one portable logical path component.
+    pub const fn max_logical_component_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 255,
+        }
+    }
+
+    /// Maximum component depth of one strict logical namespace path.
+    pub const fn max_logical_path_depth(self) -> u32 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 256,
+        }
+    }
+
+    /// Maximum generated namespace-claim observations in one pass.
+    ///
+    /// Every derived claim counts before alias/role compatibility
+    /// deduplication.
+    pub const fn max_generated_claim_observations_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4_000_000,
+        }
+    }
+
+    /// Maximum exact-plus-folded bytes across generated claims in one pass.
+    ///
+    /// Every derived claim counts before alias/role compatibility deduplication.
+    pub const fn max_generated_claim_bytes_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 1024 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum unique compatible claims retained in one pass.
+    pub const fn max_retained_unique_claims_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 2_000_000,
+        }
+    }
+
+    /// Maximum exact-plus-folded bytes retained for unique claims in one pass.
+    pub const fn max_retained_unique_claim_bytes_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 512 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum aggregate bytes from all identity-bound object reads in one
+    /// pass. Every actual body read counts before retention.
+    pub const fn max_bound_object_bytes_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 8 * 1024 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum byte length of one retained version or ETag identity token.
+    pub const fn max_binding_token_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4096,
+        }
+    }
+
+    /// Maximum combined retained version and ETag bytes in one pass.
+    pub const fn max_retained_binding_bytes_per_pass(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 512 * 1024 * 1024,
+        }
+    }
+
+    /// Maximum chunk-address entries decoded from one strict manifest.
+    pub const fn max_manifest_chunk_entries(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 262_144,
+        }
+    }
+
+    /// Maximum per-device wrapped-key entries decoded from one manifest.
+    pub const fn max_manifest_wrapped_key_entries(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4096,
+        }
+    }
+
+    /// Maximum vector-clock entries decoded from one remote object.
+    pub const fn max_remote_vector_clock_entries(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 4096,
         }
     }
 }
@@ -1739,7 +1979,7 @@ fn fingerprint_root_profile_settings_v1(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RegisteredRootPlanContractFingerprintFieldsV1 {
-    canonical_names: [(&'static str, &'static str); 9],
+    canonical_names: [(&'static str, &'static str); 10],
     local_snapshot_max_depth: u32,
     local_snapshot_max_entries: u64,
     local_snapshot_max_retained_path_bytes: u64,
@@ -1747,6 +1987,29 @@ struct RegisteredRootPlanContractFingerprintFieldsV1 {
     local_snapshot_max_regular_file_bytes: u64,
     local_snapshot_max_total_hashed_bytes: u64,
     local_snapshot_hash_buffer_bytes: u64,
+    remote_max_listing_rows_per_pass: u64,
+    remote_max_listing_key_bytes_per_pass: u64,
+    remote_max_storage_key_bytes: u64,
+    remote_max_index_observations_per_pass: u64,
+    remote_max_retained_index_key_bytes_per_pass: u64,
+    remote_max_reservation_observations_per_pass: u64,
+    remote_max_retained_reservation_key_bytes_per_pass: u64,
+    remote_max_index_object_bytes: u64,
+    remote_max_manifest_object_bytes: u64,
+    remote_max_reservation_object_bytes: u64,
+    remote_max_logical_path_bytes: u64,
+    remote_max_logical_component_bytes: u64,
+    remote_max_logical_path_depth: u32,
+    remote_max_generated_claim_observations_per_pass: u64,
+    remote_max_generated_claim_bytes_per_pass: u64,
+    remote_max_retained_unique_claims_per_pass: u64,
+    remote_max_retained_unique_claim_bytes_per_pass: u64,
+    remote_max_bound_object_bytes_per_pass: u64,
+    remote_max_binding_token_bytes: u64,
+    remote_max_retained_binding_bytes_per_pass: u64,
+    remote_max_manifest_chunk_entries: u64,
+    remote_max_manifest_wrapped_key_entries: u64,
+    remote_max_remote_vector_clock_entries: u64,
 }
 
 fn registered_root_plan_contract_fingerprint_fields_v1(
@@ -1768,6 +2031,10 @@ fn registered_root_plan_contract_fingerprint_fields_v1(
             ),
             ("state_policy", contract.state.canonical_name()),
             ("remote_policy", contract.remote.canonical_name()),
+            (
+                "remote_observation_model",
+                contract.remote.observation_model().canonical_name(),
+            ),
             ("causality_policy", contract.causality.canonical_name()),
             ("action_policy", contract.actions.canonical_name()),
             ("ordering_policy", contract.ordering.canonical_name()),
@@ -1783,6 +2050,45 @@ fn registered_root_plan_contract_fingerprint_fields_v1(
         local_snapshot_max_regular_file_bytes: contract.local_snapshot.max_regular_file_bytes(),
         local_snapshot_max_total_hashed_bytes: contract.local_snapshot.max_total_hashed_bytes(),
         local_snapshot_hash_buffer_bytes: contract.local_snapshot.hash_buffer_bytes(),
+        remote_max_listing_rows_per_pass: contract.remote.max_listing_rows_per_pass(),
+        remote_max_listing_key_bytes_per_pass: contract.remote.max_listing_key_bytes_per_pass(),
+        remote_max_storage_key_bytes: contract.remote.max_storage_key_bytes(),
+        remote_max_index_observations_per_pass: contract.remote.max_index_observations_per_pass(),
+        remote_max_retained_index_key_bytes_per_pass: contract
+            .remote
+            .max_retained_index_key_bytes_per_pass(),
+        remote_max_reservation_observations_per_pass: contract
+            .remote
+            .max_reservation_observations_per_pass(),
+        remote_max_retained_reservation_key_bytes_per_pass: contract
+            .remote
+            .max_retained_reservation_key_bytes_per_pass(),
+        remote_max_index_object_bytes: contract.remote.max_index_object_bytes(),
+        remote_max_manifest_object_bytes: contract.remote.max_manifest_object_bytes(),
+        remote_max_reservation_object_bytes: contract.remote.max_reservation_object_bytes(),
+        remote_max_logical_path_bytes: contract.remote.max_logical_path_bytes(),
+        remote_max_logical_component_bytes: contract.remote.max_logical_component_bytes(),
+        remote_max_logical_path_depth: contract.remote.max_logical_path_depth(),
+        remote_max_generated_claim_observations_per_pass: contract
+            .remote
+            .max_generated_claim_observations_per_pass(),
+        remote_max_generated_claim_bytes_per_pass: contract
+            .remote
+            .max_generated_claim_bytes_per_pass(),
+        remote_max_retained_unique_claims_per_pass: contract
+            .remote
+            .max_retained_unique_claims_per_pass(),
+        remote_max_retained_unique_claim_bytes_per_pass: contract
+            .remote
+            .max_retained_unique_claim_bytes_per_pass(),
+        remote_max_bound_object_bytes_per_pass: contract.remote.max_bound_object_bytes_per_pass(),
+        remote_max_binding_token_bytes: contract.remote.max_binding_token_bytes(),
+        remote_max_retained_binding_bytes_per_pass: contract
+            .remote
+            .max_retained_binding_bytes_per_pass(),
+        remote_max_manifest_chunk_entries: contract.remote.max_manifest_chunk_entries(),
+        remote_max_manifest_wrapped_key_entries: contract.remote.max_manifest_wrapped_key_entries(),
+        remote_max_remote_vector_clock_entries: contract.remote.max_remote_vector_clock_entries(),
     }
 }
 
@@ -1791,7 +2097,7 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
 ) -> RegisteredRootPlanContractFingerprintV1 {
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.registered-root-plan-contract.b3v1",
-        fields.canonical_names.len() + 7,
+        fields.canonical_names.len() + 30,
     );
     for (tag, value) in fields.canonical_names {
         encoder.field(tag, value.as_bytes());
@@ -1823,6 +2129,116 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
             encoder.field(
                 "local_snapshot_hash_buffer_bytes",
                 &fields.local_snapshot_hash_buffer_bytes.to_be_bytes(),
+            );
+        }
+        if tag == "remote_observation_model" {
+            encoder.field(
+                "remote_max_listing_rows_per_pass",
+                &fields.remote_max_listing_rows_per_pass.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_listing_key_bytes_per_pass",
+                &fields.remote_max_listing_key_bytes_per_pass.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_storage_key_bytes",
+                &fields.remote_max_storage_key_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_index_observations_per_pass",
+                &fields.remote_max_index_observations_per_pass.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_retained_index_key_bytes_per_pass",
+                &fields
+                    .remote_max_retained_index_key_bytes_per_pass
+                    .to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_reservation_observations_per_pass",
+                &fields
+                    .remote_max_reservation_observations_per_pass
+                    .to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_retained_reservation_key_bytes_per_pass",
+                &fields
+                    .remote_max_retained_reservation_key_bytes_per_pass
+                    .to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_index_object_bytes",
+                &fields.remote_max_index_object_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_manifest_object_bytes",
+                &fields.remote_max_manifest_object_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_reservation_object_bytes",
+                &fields.remote_max_reservation_object_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_logical_path_bytes",
+                &fields.remote_max_logical_path_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_logical_component_bytes",
+                &fields.remote_max_logical_component_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_logical_path_depth",
+                &fields.remote_max_logical_path_depth.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_generated_claim_observations_per_pass",
+                &fields
+                    .remote_max_generated_claim_observations_per_pass
+                    .to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_generated_claim_bytes_per_pass",
+                &fields
+                    .remote_max_generated_claim_bytes_per_pass
+                    .to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_retained_unique_claims_per_pass",
+                &fields
+                    .remote_max_retained_unique_claims_per_pass
+                    .to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_retained_unique_claim_bytes_per_pass",
+                &fields
+                    .remote_max_retained_unique_claim_bytes_per_pass
+                    .to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_bound_object_bytes_per_pass",
+                &fields.remote_max_bound_object_bytes_per_pass.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_binding_token_bytes",
+                &fields.remote_max_binding_token_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_retained_binding_bytes_per_pass",
+                &fields
+                    .remote_max_retained_binding_bytes_per_pass
+                    .to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_manifest_chunk_entries",
+                &fields.remote_max_manifest_chunk_entries.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_manifest_wrapped_key_entries",
+                &fields.remote_max_manifest_wrapped_key_entries.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_remote_vector_clock_entries",
+                &fields.remote_max_remote_vector_clock_entries.to_be_bytes(),
             );
         }
     }
@@ -2909,6 +3325,58 @@ resolution_policy = "inspect-only"
             contract.remote_contract(),
             RootRemoteContractV1::RawCommittedManifestBoundV1
         );
+        let remote = contract.remote_contract();
+        assert_eq!(
+            remote.observation_model(),
+            RootRemoteObservationModelV1::TwoListedUniverseBoundPassesNonAtomicV1
+        );
+        assert_eq!(remote.observation_model().pass_count(), 2);
+        assert_eq!(remote.listing_page_request_limit(), 1000);
+        assert_eq!(remote.max_concurrent_bound_reads(), 8);
+        assert_eq!(remote.max_listing_rows_per_pass(), 4_000_000);
+        assert_eq!(remote.max_listing_key_bytes_per_pass(), 1024 * 1024 * 1024);
+        assert_eq!(remote.max_storage_key_bytes(), 1024);
+        assert_eq!(remote.max_index_observations_per_pass(), 1_000_000);
+        assert_eq!(
+            remote.max_retained_index_key_bytes_per_pass(),
+            256 * 1024 * 1024
+        );
+        assert_eq!(remote.max_reservation_observations_per_pass(), 2_000_000);
+        assert_eq!(
+            remote.max_retained_reservation_key_bytes_per_pass(),
+            256 * 1024 * 1024
+        );
+        assert_eq!(remote.max_index_object_bytes(), 1024 * 1024);
+        assert_eq!(remote.max_manifest_object_bytes(), 16 * 1024 * 1024);
+        assert_eq!(remote.max_reservation_object_bytes(), 16 * 1024);
+        assert_eq!(remote.max_logical_path_bytes(), 1024);
+        assert_eq!(remote.max_logical_component_bytes(), 255);
+        assert_eq!(remote.max_logical_path_depth(), 256);
+        assert_eq!(
+            remote.max_generated_claim_observations_per_pass(),
+            4_000_000
+        );
+        assert_eq!(
+            remote.max_generated_claim_bytes_per_pass(),
+            1024 * 1024 * 1024
+        );
+        assert_eq!(remote.max_retained_unique_claims_per_pass(), 2_000_000);
+        assert_eq!(
+            remote.max_retained_unique_claim_bytes_per_pass(),
+            512 * 1024 * 1024
+        );
+        assert_eq!(
+            remote.max_bound_object_bytes_per_pass(),
+            8 * 1024 * 1024 * 1024
+        );
+        assert_eq!(remote.max_binding_token_bytes(), 4096);
+        assert_eq!(
+            remote.max_retained_binding_bytes_per_pass(),
+            512 * 1024 * 1024
+        );
+        assert_eq!(remote.max_manifest_chunk_entries(), 262_144);
+        assert_eq!(remote.max_manifest_wrapped_key_entries(), 4096);
+        assert_eq!(remote.max_remote_vector_clock_entries(), 4096);
         assert_eq!(
             contract.causality_contract(),
             RootCausalityContractV1::TypedVectorClockV1
@@ -2934,12 +3402,12 @@ resolution_policy = "inspect-only"
         );
         assert_eq!(
             fingerprint.to_string(),
-            "b3v1:db9a3d9899a427c952789afdd850d6ffafca84770b99d6f02d3efcca6b3a0327"
+            "b3v1:0a3dbb43186967c1978104b72a5dbc750ba913842b1c491267def62f8db05d1f"
         );
     }
 
     #[test]
-    fn registered_root_plan_fingerprint_schema_binds_local_snapshot_resources() {
+    fn registered_root_plan_fingerprint_schema_binds_acceptance_resources() {
         let contract = RegisteredRootPlanContractV1::strict_v1();
         let fields = registered_root_plan_contract_fingerprint_fields_v1(contract);
         assert_eq!(
@@ -2956,6 +3424,10 @@ resolution_policy = "inspect-only"
                 ),
                 ("state_policy", "immutable-primary-semantic-exact-v1"),
                 ("remote_policy", "raw-committed-manifest-bound-v1"),
+                (
+                    "remote_observation_model",
+                    "two-listed-universe-bound-passes-non-atomic-v1",
+                ),
                 ("causality_policy", "typed-vector-clock-v1"),
                 ("action_policy", "plan-only-no-delete-v1"),
                 ("ordering_policy", "relative-path-kind-proof-v1"),
@@ -2978,6 +3450,56 @@ resolution_policy = "inspect-only"
             8 * 1024 * 1024 * 1024 * 1024
         );
         assert_eq!(fields.local_snapshot_hash_buffer_bytes, 64 * 1024);
+        assert_eq!(fields.remote_max_listing_rows_per_pass, 4_000_000);
+        assert_eq!(
+            fields.remote_max_listing_key_bytes_per_pass,
+            1024 * 1024 * 1024
+        );
+        assert_eq!(fields.remote_max_storage_key_bytes, 1024);
+        assert_eq!(fields.remote_max_index_observations_per_pass, 1_000_000);
+        assert_eq!(
+            fields.remote_max_retained_index_key_bytes_per_pass,
+            256 * 1024 * 1024
+        );
+        assert_eq!(
+            fields.remote_max_reservation_observations_per_pass,
+            2_000_000
+        );
+        assert_eq!(
+            fields.remote_max_retained_reservation_key_bytes_per_pass,
+            256 * 1024 * 1024
+        );
+        assert_eq!(fields.remote_max_index_object_bytes, 1024 * 1024);
+        assert_eq!(fields.remote_max_manifest_object_bytes, 16 * 1024 * 1024);
+        assert_eq!(fields.remote_max_reservation_object_bytes, 16 * 1024);
+        assert_eq!(fields.remote_max_logical_path_bytes, 1024);
+        assert_eq!(fields.remote_max_logical_component_bytes, 255);
+        assert_eq!(fields.remote_max_logical_path_depth, 256);
+        assert_eq!(
+            fields.remote_max_generated_claim_observations_per_pass,
+            4_000_000
+        );
+        assert_eq!(
+            fields.remote_max_generated_claim_bytes_per_pass,
+            1024 * 1024 * 1024
+        );
+        assert_eq!(fields.remote_max_retained_unique_claims_per_pass, 2_000_000);
+        assert_eq!(
+            fields.remote_max_retained_unique_claim_bytes_per_pass,
+            512 * 1024 * 1024
+        );
+        assert_eq!(
+            fields.remote_max_bound_object_bytes_per_pass,
+            8 * 1024 * 1024 * 1024
+        );
+        assert_eq!(fields.remote_max_binding_token_bytes, 4096);
+        assert_eq!(
+            fields.remote_max_retained_binding_bytes_per_pass,
+            512 * 1024 * 1024
+        );
+        assert_eq!(fields.remote_max_manifest_chunk_entries, 262_144);
+        assert_eq!(fields.remote_max_manifest_wrapped_key_entries, 4096);
+        assert_eq!(fields.remote_max_remote_vector_clock_entries, 4096);
 
         let baseline = fingerprint_registered_root_plan_contract_fields_v1(fields);
 
@@ -3043,6 +3565,50 @@ resolution_policy = "inspect-only"
             baseline,
             fingerprint_registered_root_plan_contract_fields_v1(buffer_bytes_mutation)
         );
+
+        let mut observation_model_mutation = fields;
+        observation_model_mutation.canonical_names[5].1 = "atomic-namespace-snapshot-test-v0";
+        assert_ne!(
+            baseline,
+            fingerprint_registered_root_plan_contract_fields_v1(observation_model_mutation)
+        );
+
+        macro_rules! assert_remote_resource_is_bound {
+            ($field:ident) => {{
+                let mut mutation = fields;
+                mutation.$field += 1;
+                assert_ne!(
+                    baseline,
+                    fingerprint_registered_root_plan_contract_fields_v1(mutation),
+                    "remote contract fingerprint omitted {}",
+                    stringify!($field)
+                );
+            }};
+        }
+
+        assert_remote_resource_is_bound!(remote_max_listing_rows_per_pass);
+        assert_remote_resource_is_bound!(remote_max_listing_key_bytes_per_pass);
+        assert_remote_resource_is_bound!(remote_max_storage_key_bytes);
+        assert_remote_resource_is_bound!(remote_max_index_observations_per_pass);
+        assert_remote_resource_is_bound!(remote_max_retained_index_key_bytes_per_pass);
+        assert_remote_resource_is_bound!(remote_max_reservation_observations_per_pass);
+        assert_remote_resource_is_bound!(remote_max_retained_reservation_key_bytes_per_pass);
+        assert_remote_resource_is_bound!(remote_max_index_object_bytes);
+        assert_remote_resource_is_bound!(remote_max_manifest_object_bytes);
+        assert_remote_resource_is_bound!(remote_max_reservation_object_bytes);
+        assert_remote_resource_is_bound!(remote_max_logical_path_bytes);
+        assert_remote_resource_is_bound!(remote_max_logical_component_bytes);
+        assert_remote_resource_is_bound!(remote_max_logical_path_depth);
+        assert_remote_resource_is_bound!(remote_max_generated_claim_observations_per_pass);
+        assert_remote_resource_is_bound!(remote_max_generated_claim_bytes_per_pass);
+        assert_remote_resource_is_bound!(remote_max_retained_unique_claims_per_pass);
+        assert_remote_resource_is_bound!(remote_max_retained_unique_claim_bytes_per_pass);
+        assert_remote_resource_is_bound!(remote_max_bound_object_bytes_per_pass);
+        assert_remote_resource_is_bound!(remote_max_binding_token_bytes);
+        assert_remote_resource_is_bound!(remote_max_retained_binding_bytes_per_pass);
+        assert_remote_resource_is_bound!(remote_max_manifest_chunk_entries);
+        assert_remote_resource_is_bound!(remote_max_manifest_wrapped_key_entries);
+        assert_remote_resource_is_bound!(remote_max_remote_vector_clock_entries);
     }
 
     #[test]

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -1825,6 +1825,17 @@ impl RootRemoteContractV1 {
         }
     }
 
+    /// Maximum aggregate successor-body bytes retained by one authoritative
+    /// catalog mutation journal.
+    ///
+    /// Larger reconciles must segment their work across monotonic catalog
+    /// publications instead of retaining one process-sized transaction.
+    pub const fn max_catalog_mutation_payload_bytes(self) -> u64 {
+        match self {
+            Self::RawCommittedManifestBoundV1 => 256 * 1024 * 1024,
+        }
+    }
+
     /// Maximum immutable pages referenced by one catalog root.
     pub const fn max_catalog_pages(self) -> u64 {
         match self {
@@ -2364,6 +2375,7 @@ struct RegisteredRootPlanContractFingerprintFieldsV1 {
     remote_max_catalog_head_object_bytes: u64,
     remote_max_catalog_root_object_bytes: u64,
     remote_max_catalog_page_object_bytes: u64,
+    remote_max_catalog_mutation_payload_bytes: u64,
     remote_max_catalog_pages: u64,
     remote_max_catalog_entries_per_page: u64,
     remote_max_catalog_entries: u64,
@@ -2461,6 +2473,9 @@ fn registered_root_plan_contract_fingerprint_fields_v1(
         remote_max_catalog_head_object_bytes: contract.remote.max_catalog_head_object_bytes(),
         remote_max_catalog_root_object_bytes: contract.remote.max_catalog_root_object_bytes(),
         remote_max_catalog_page_object_bytes: contract.remote.max_catalog_page_object_bytes(),
+        remote_max_catalog_mutation_payload_bytes: contract
+            .remote
+            .max_catalog_mutation_payload_bytes(),
         remote_max_catalog_pages: contract.remote.max_catalog_pages(),
         remote_max_catalog_entries_per_page: contract.remote.max_catalog_entries_per_page(),
         remote_max_catalog_entries: contract.remote.max_catalog_entries(),
@@ -2475,7 +2490,7 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
 ) -> RegisteredRootPlanContractFingerprintV1 {
     let mut encoder = CanonicalRootFingerprintEncoderV1::new(
         "tinyland.tcfs.registered-root-plan-contract.b3v1",
-        fields.canonical_names.len() + 44,
+        fields.canonical_names.len() + 45,
     );
     for (tag, value) in fields.canonical_names {
         encoder.field(tag, value.as_bytes());
@@ -2653,6 +2668,12 @@ fn fingerprint_registered_root_plan_contract_fields_v1(
             encoder.field(
                 "remote_max_catalog_page_object_bytes",
                 &fields.remote_max_catalog_page_object_bytes.to_be_bytes(),
+            );
+            encoder.field(
+                "remote_max_catalog_mutation_payload_bytes",
+                &fields
+                    .remote_max_catalog_mutation_payload_bytes
+                    .to_be_bytes(),
             );
             encoder.field(
                 "remote_max_catalog_pages",
@@ -3978,6 +3999,10 @@ resolution_policy = "inspect-only"
         assert_eq!(remote.max_catalog_head_object_bytes(), 16 * 1024);
         assert_eq!(remote.max_catalog_root_object_bytes(), 4 * 1024 * 1024);
         assert_eq!(remote.max_catalog_page_object_bytes(), 16 * 1024 * 1024);
+        assert_eq!(
+            remote.max_catalog_mutation_payload_bytes(),
+            256 * 1024 * 1024
+        );
         assert_eq!(remote.max_catalog_pages(), 4096);
         assert_eq!(remote.max_catalog_entries_per_page(), 4096);
         assert_eq!(remote.max_catalog_entries(), 3_000_000);
@@ -4012,7 +4037,7 @@ resolution_policy = "inspect-only"
         );
         assert_eq!(
             fingerprint.to_string(),
-            "b3v1:8767d0b8866f8c319f16e816a1996e2a7b638fe01ba972ed28dd2075345f9b6f"
+            "b3v1:1118477115662bba81df3cd3e8f2250a350e1d65e62150d746448c821ce0c678"
         );
     }
 
@@ -4115,6 +4140,10 @@ resolution_policy = "inspect-only"
         assert_eq!(
             fields.remote_max_catalog_page_object_bytes,
             16 * 1024 * 1024
+        );
+        assert_eq!(
+            fields.remote_max_catalog_mutation_payload_bytes,
+            256 * 1024 * 1024
         );
         assert_eq!(fields.remote_max_catalog_pages, 4096);
         assert_eq!(fields.remote_max_catalog_entries_per_page, 4096);
@@ -4275,6 +4304,7 @@ resolution_policy = "inspect-only"
         assert_remote_resource_is_bound!(remote_max_catalog_head_object_bytes);
         assert_remote_resource_is_bound!(remote_max_catalog_root_object_bytes);
         assert_remote_resource_is_bound!(remote_max_catalog_page_object_bytes);
+        assert_remote_resource_is_bound!(remote_max_catalog_mutation_payload_bytes);
         assert_remote_resource_is_bound!(remote_max_catalog_pages);
         assert_remote_resource_is_bound!(remote_max_catalog_entries_per_page);
         assert_remote_resource_is_bound!(remote_max_catalog_entries);

--- a/crates/tcfs-core/src/fixed_ingress.rs
+++ b/crates/tcfs-core/src/fixed_ingress.rs
@@ -1,0 +1,626 @@
+//! Versioned, config-independent ingress exclusions.
+//!
+//! Registered-root plans must bind the exact deny-set used when remote
+//! payloads are admitted. Keeping that policy in `tcfs-core` gives profile
+//! fingerprints and every consumer one dependency-neutral source of truth.
+
+use std::fmt;
+use std::path::{Component, Path};
+
+/// Canonical encoding version for the fixed-ingress policy schema.
+pub const FIXED_INGRESS_POLICY_SCHEMA_VERSION_V1: u32 = 1;
+
+const FIXED_INGRESS_POLICY_FINGERPRINT_DOMAIN_V1: &str =
+    "tinyland.tcfs.fixed-ingress-policy-schema.b3v1";
+const FIXED_INGRESS_POLICY_NAME_V1: &str = "fixed-ingress-path-components-v1";
+const FIXED_INGRESS_EVALUATION_ORDER_V1: &str =
+    "path-wide-git-rules-then-component-major-security-rules-v1";
+
+const SECURITY_DIRECTORY_NAMES_V1: &[&str] = &[".ssh", ".gnupg", "sops-nix"];
+const SECURITY_EXACT_FILE_NAMES_V1: &[&str] = &[
+    ".credentials.json",
+    "auth.json",
+    ".netrc",
+    ".pgpass",
+    "master.key",
+];
+const LIVE_DATABASE_SUFFIXES_V1: &[&str] = &[
+    ".sqlite",
+    ".sqlite3",
+    ".sqlite-wal",
+    ".sqlite-shm",
+    ".db",
+    ".db-wal",
+    ".db-shm",
+];
+
+const GIT_WORKTREES_PATTERNS_V1: &[&str] = &[".git", "worktrees"];
+const GIT_LOCK_PATTERNS_V1: &[&str] = &[".git", ".lock"];
+const GIT_TCFS_UNDO_PATTERNS_V1: &[&str] = &[".git", "tcfs-undo"];
+const ROTATION_PENDING_PATTERNS_V1: &[&str] = &[".rotate-pending"];
+const ROTATION_STATE_PATTERNS_V1: &[&str] = &[".rotate-state.json"];
+const ATOMIC_WRITE_TEMP_PARAMETERS_V1: &[&str] = &[
+    ".tmp.",
+    "target-starts-with-dot",
+    "nonce-length-32",
+    "nonce-ascii-hex",
+];
+const ATOMIC_WRITE_TEMP_NONCE_LENGTH_V1: usize = 32;
+const DOTENV_PATTERNS_V1: &[&str] = &["exact:.env", "prefix:.env.", "suffix:.env"];
+
+const GIT_WORKTREES_LABELS_V1: &[&str] = &[".git/worktrees admin area"];
+const GIT_LOCK_LABELS_V1: &[&str] = &["git lockfile"];
+const GIT_TCFS_UNDO_LABELS_V1: &[&str] = &[".git/tcfs-undo bundle"];
+const ROTATION_PENDING_LABELS_V1: &[&str] = &["tcfs-rotation-pending-key"];
+const ROTATION_STATE_LABELS_V1: &[&str] = &["tcfs-rotation-state"];
+const ATOMIC_WRITE_TEMP_LABELS_V1: &[&str] = &["tcfs-atomic-write-temp"];
+const DOTENV_LABELS_V1: &[&str] = &["dotenv"];
+const LIVE_DATABASE_LABELS_V1: &[&str] = &["live-db"];
+
+/// One rule in the canonical fixed-ingress evaluation order.
+///
+/// Reordering, adding, or changing a rule is a policy-schema change and must
+/// produce a different [`FixedIngressPolicySchemaFingerprintV1`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FixedIngressRuleV1 {
+    GitWorktreesAdmin,
+    GitLockFile,
+    GitTcfsUndo,
+    SecurityDirectory,
+    SecurityExactFile,
+    MasterKeyRotationPending,
+    MasterKeyRotationState,
+    AtomicWriteTemporary,
+    Dotenv,
+    LiveDatabase,
+}
+
+impl FixedIngressRuleV1 {
+    /// Stable rule name used by the schema fingerprint.
+    pub const fn canonical_name(self) -> &'static str {
+        match self {
+            Self::GitWorktreesAdmin => "git-worktrees-admin-v1",
+            Self::GitLockFile => "git-lock-file-v1",
+            Self::GitTcfsUndo => "git-tcfs-undo-v1",
+            Self::SecurityDirectory => "security-directory-v1",
+            Self::SecurityExactFile => "security-exact-file-v1",
+            Self::MasterKeyRotationPending => "master-key-rotation-pending-v1",
+            Self::MasterKeyRotationState => "master-key-rotation-state-v1",
+            Self::AtomicWriteTemporary => "atomic-write-temporary-v1",
+            Self::Dotenv => "dotenv-v1",
+            Self::LiveDatabase => "live-database-v1",
+        }
+    }
+
+    fn schema(self) -> FixedIngressRuleSchemaV1 {
+        match self {
+            Self::GitWorktreesAdmin => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "adjacent-components-ascii-case-insensitive-v1",
+                patterns: GIT_WORKTREES_PATTERNS_V1,
+                diagnostic_labels: GIT_WORKTREES_LABELS_V1,
+            },
+            Self::GitLockFile => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "final-suffix-under-component-ascii-case-insensitive-v1",
+                patterns: GIT_LOCK_PATTERNS_V1,
+                diagnostic_labels: GIT_LOCK_LABELS_V1,
+            },
+            Self::GitTcfsUndo => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "adjacent-components-ascii-case-insensitive-v1",
+                patterns: GIT_TCFS_UNDO_PATTERNS_V1,
+                diagnostic_labels: GIT_TCFS_UNDO_LABELS_V1,
+            },
+            Self::SecurityDirectory => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "any-component-exact-ascii-case-insensitive-v1",
+                patterns: SECURITY_DIRECTORY_NAMES_V1,
+                diagnostic_labels: SECURITY_DIRECTORY_NAMES_V1,
+            },
+            Self::SecurityExactFile => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "any-component-exact-ascii-case-insensitive-v1",
+                patterns: SECURITY_EXACT_FILE_NAMES_V1,
+                diagnostic_labels: SECURITY_EXACT_FILE_NAMES_V1,
+            },
+            Self::MasterKeyRotationPending => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "any-component-suffix-ascii-case-insensitive-v1",
+                patterns: ROTATION_PENDING_PATTERNS_V1,
+                diagnostic_labels: ROTATION_PENDING_LABELS_V1,
+            },
+            Self::MasterKeyRotationState => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "any-component-suffix-ascii-case-insensitive-v1",
+                patterns: ROTATION_STATE_PATTERNS_V1,
+                diagnostic_labels: ROTATION_STATE_LABELS_V1,
+            },
+            Self::AtomicWriteTemporary => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "hidden-target-atomic-temp-shape-ascii-case-insensitive-v1",
+                patterns: ATOMIC_WRITE_TEMP_PARAMETERS_V1,
+                diagnostic_labels: ATOMIC_WRITE_TEMP_LABELS_V1,
+            },
+            Self::Dotenv => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "dotenv-family-ascii-case-insensitive-v1",
+                patterns: DOTENV_PATTERNS_V1,
+                diagnostic_labels: DOTENV_LABELS_V1,
+            },
+            Self::LiveDatabase => FixedIngressRuleSchemaV1 {
+                rule: self,
+                matcher: "any-component-suffix-ascii-case-insensitive-v1",
+                patterns: LIVE_DATABASE_SUFFIXES_V1,
+                diagnostic_labels: LIVE_DATABASE_LABELS_V1,
+            },
+        }
+    }
+}
+
+const FIXED_INGRESS_RULE_ORDER_V1: [FixedIngressRuleV1; 10] = [
+    FixedIngressRuleV1::GitWorktreesAdmin,
+    FixedIngressRuleV1::GitLockFile,
+    FixedIngressRuleV1::GitTcfsUndo,
+    FixedIngressRuleV1::SecurityDirectory,
+    FixedIngressRuleV1::SecurityExactFile,
+    FixedIngressRuleV1::MasterKeyRotationPending,
+    FixedIngressRuleV1::MasterKeyRotationState,
+    FixedIngressRuleV1::AtomicWriteTemporary,
+    FixedIngressRuleV1::Dotenv,
+    FixedIngressRuleV1::LiveDatabase,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FixedIngressRuleSchemaV1 {
+    rule: FixedIngressRuleV1,
+    matcher: &'static str,
+    patterns: &'static [&'static str],
+    diagnostic_labels: &'static [&'static str],
+}
+
+/// Typed result from the config-independent ingress deny-set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FixedIngressDenyReasonV1 {
+    rule: FixedIngressRuleV1,
+    label: &'static str,
+}
+
+impl FixedIngressDenyReasonV1 {
+    /// The canonical rule that rejected the path.
+    pub const fn rule(self) -> FixedIngressRuleV1 {
+        self.rule
+    }
+
+    /// Stable diagnostic label associated with the matching rule.
+    pub const fn label(self) -> &'static str {
+        self.label
+    }
+}
+
+/// Opaque BLAKE3 identity for the complete V1 policy schema.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FixedIngressPolicySchemaFingerprintV1([u8; 32]);
+
+impl FixedIngressPolicySchemaFingerprintV1 {
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for FixedIngressPolicySchemaFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("b3v1:")?;
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for FixedIngressPolicySchemaFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "FixedIngressPolicySchemaFingerprintV1({self})")
+    }
+}
+
+/// Immutable V1 fixed-ingress policy.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FixedIngressPolicyV1;
+
+impl FixedIngressPolicyV1 {
+    pub const fn strict_v1() -> Self {
+        Self
+    }
+
+    pub const fn canonical_name(self) -> &'static str {
+        FIXED_INGRESS_POLICY_NAME_V1
+    }
+
+    /// Rules in their canonical evaluation and fingerprint order.
+    pub const fn ordered_rules(self) -> &'static [FixedIngressRuleV1] {
+        &FIXED_INGRESS_RULE_ORDER_V1
+    }
+
+    /// Fingerprint of matcher semantics, membership, labels, and rule order.
+    pub fn schema_fingerprint(self) -> FixedIngressPolicySchemaFingerprintV1 {
+        let schemas = FIXED_INGRESS_RULE_ORDER_V1.map(FixedIngressRuleV1::schema);
+        fingerprint_fixed_ingress_schema_v1(&schemas)
+    }
+
+    /// Return the first V1 rule that rejects `path`.
+    ///
+    /// The three Git topology rules are path-wide and ordered first. Remaining
+    /// security rules are then evaluated in canonical rule order for each path
+    /// component, preserving the V1 first-match diagnostic contract.
+    pub fn classify_path(self, path: &Path) -> Option<FixedIngressDenyReasonV1> {
+        if let Some(denied) = self.ordered_rules()[..3]
+            .iter()
+            .find_map(|rule| classify_rule_v1(*rule, path))
+        {
+            return Some(denied);
+        }
+        for component in path.components() {
+            let Some(name) = normal_component_v1(component) else {
+                continue;
+            };
+            if let Some(denied) = self.ordered_rules()[3..]
+                .iter()
+                .find_map(|rule| classify_security_component_v1(*rule, name))
+            {
+                return Some(denied);
+            }
+        }
+        None
+    }
+}
+
+fn classify_rule_v1(rule: FixedIngressRuleV1, path: &Path) -> Option<FixedIngressDenyReasonV1> {
+    let label = match rule {
+        FixedIngressRuleV1::GitWorktreesAdmin => has_adjacent_components_v1(
+            path,
+            GIT_WORKTREES_PATTERNS_V1[0],
+            GIT_WORKTREES_PATTERNS_V1[1],
+        )
+        .then_some(GIT_WORKTREES_LABELS_V1[0]),
+        FixedIngressRuleV1::GitLockFile => {
+            let name = path.file_name()?.to_str()?;
+            (name.to_ascii_lowercase().ends_with(GIT_LOCK_PATTERNS_V1[1])
+                && has_component_v1(path, GIT_LOCK_PATTERNS_V1[0]))
+            .then_some(GIT_LOCK_LABELS_V1[0])
+        }
+        FixedIngressRuleV1::GitTcfsUndo => has_adjacent_components_v1(
+            path,
+            GIT_TCFS_UNDO_PATTERNS_V1[0],
+            GIT_TCFS_UNDO_PATTERNS_V1[1],
+        )
+        .then_some(GIT_TCFS_UNDO_LABELS_V1[0]),
+        FixedIngressRuleV1::SecurityDirectory
+        | FixedIngressRuleV1::SecurityExactFile
+        | FixedIngressRuleV1::MasterKeyRotationPending
+        | FixedIngressRuleV1::MasterKeyRotationState
+        | FixedIngressRuleV1::AtomicWriteTemporary
+        | FixedIngressRuleV1::Dotenv
+        | FixedIngressRuleV1::LiveDatabase => return None,
+    }?;
+    Some(FixedIngressDenyReasonV1 { rule, label })
+}
+
+fn classify_security_component_v1(
+    rule: FixedIngressRuleV1,
+    name: &str,
+) -> Option<FixedIngressDenyReasonV1> {
+    let folded = name.to_ascii_lowercase();
+    let label = match rule {
+        FixedIngressRuleV1::SecurityDirectory => {
+            first_exact_name_v1(name, SECURITY_DIRECTORY_NAMES_V1)
+        }
+        FixedIngressRuleV1::SecurityExactFile => {
+            first_exact_name_v1(name, SECURITY_EXACT_FILE_NAMES_V1)
+        }
+        FixedIngressRuleV1::MasterKeyRotationPending => folded
+            .ends_with(ROTATION_PENDING_PATTERNS_V1[0])
+            .then_some(ROTATION_PENDING_LABELS_V1[0]),
+        FixedIngressRuleV1::MasterKeyRotationState => folded
+            .ends_with(ROTATION_STATE_PATTERNS_V1[0])
+            .then_some(ROTATION_STATE_LABELS_V1[0]),
+        FixedIngressRuleV1::AtomicWriteTemporary => {
+            is_atomic_write_temp_v1(name).then_some(ATOMIC_WRITE_TEMP_LABELS_V1[0])
+        }
+        FixedIngressRuleV1::Dotenv => {
+            (folded == ".env" || folded.starts_with(".env.") || folded.ends_with(".env"))
+                .then_some(DOTENV_LABELS_V1[0])
+        }
+        FixedIngressRuleV1::LiveDatabase => LIVE_DATABASE_SUFFIXES_V1
+            .iter()
+            .any(|suffix| folded.ends_with(suffix))
+            .then_some(LIVE_DATABASE_LABELS_V1[0]),
+        FixedIngressRuleV1::GitWorktreesAdmin
+        | FixedIngressRuleV1::GitLockFile
+        | FixedIngressRuleV1::GitTcfsUndo => return None,
+    }?;
+    Some(FixedIngressDenyReasonV1 { rule, label })
+}
+
+fn normal_component_v1<'a>(component: Component<'a>) -> Option<&'a str> {
+    match component {
+        Component::Normal(name) => name.to_str(),
+        _ => None,
+    }
+}
+
+fn has_component_v1(path: &Path, expected: &str) -> bool {
+    path.components()
+        .filter_map(normal_component_v1)
+        .any(|name| name.eq_ignore_ascii_case(expected))
+}
+
+fn has_adjacent_components_v1(path: &Path, parent: &str, child: &str) -> bool {
+    let mut previous_matches = false;
+    for component in path.components() {
+        let Some(name) = normal_component_v1(component) else {
+            previous_matches = false;
+            continue;
+        };
+        if previous_matches && name.eq_ignore_ascii_case(child) {
+            return true;
+        }
+        previous_matches = name.eq_ignore_ascii_case(parent);
+    }
+    false
+}
+
+fn first_exact_name_v1(
+    name: &str,
+    expected_names: &'static [&'static str],
+) -> Option<&'static str> {
+    expected_names
+        .iter()
+        .find(|expected| name.eq_ignore_ascii_case(expected))
+        .copied()
+}
+
+fn is_atomic_write_temp_v1(name: &str) -> bool {
+    let folded = name.to_ascii_lowercase();
+    let Some((target, nonce)) = folded.rsplit_once(ATOMIC_WRITE_TEMP_PARAMETERS_V1[0]) else {
+        return false;
+    };
+    target.starts_with('.')
+        && nonce.len() == ATOMIC_WRITE_TEMP_NONCE_LENGTH_V1
+        && nonce.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn update_schema_string_v1(hasher: &mut blake3::Hasher, value: &str) {
+    let len = u32::try_from(value.len()).expect("fixed-ingress schema string length must fit u32");
+    hasher.update(&len.to_be_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn fingerprint_fixed_ingress_schema_v1(
+    schemas: &[FixedIngressRuleSchemaV1],
+) -> FixedIngressPolicySchemaFingerprintV1 {
+    let mut hasher = blake3::Hasher::new_derive_key(FIXED_INGRESS_POLICY_FINGERPRINT_DOMAIN_V1);
+    hasher.update(&FIXED_INGRESS_POLICY_SCHEMA_VERSION_V1.to_be_bytes());
+    update_schema_string_v1(&mut hasher, FIXED_INGRESS_POLICY_NAME_V1);
+    update_schema_string_v1(&mut hasher, FIXED_INGRESS_EVALUATION_ORDER_V1);
+    let rule_count =
+        u32::try_from(schemas.len()).expect("fixed-ingress schema rule count must fit u32");
+    hasher.update(&rule_count.to_be_bytes());
+    for (ordinal, schema) in schemas.iter().enumerate() {
+        let ordinal = u32::try_from(ordinal).expect("fixed-ingress rule ordinal must fit u32");
+        hasher.update(&ordinal.to_be_bytes());
+        update_schema_string_v1(&mut hasher, schema.rule.canonical_name());
+        update_schema_string_v1(&mut hasher, schema.matcher);
+        let pattern_count = u32::try_from(schema.patterns.len())
+            .expect("fixed-ingress schema pattern count must fit u32");
+        hasher.update(&pattern_count.to_be_bytes());
+        for pattern in schema.patterns {
+            update_schema_string_v1(&mut hasher, pattern);
+        }
+        let label_count = u32::try_from(schema.diagnostic_labels.len())
+            .expect("fixed-ingress schema diagnostic-label count must fit u32");
+        hasher.update(&label_count.to_be_bytes());
+        for label in schema.diagnostic_labels {
+            update_schema_string_v1(&mut hasher, label);
+        }
+    }
+    FixedIngressPolicySchemaFingerprintV1(*hasher.finalize().as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordered_rules_are_closed_and_canonical() {
+        assert_eq!(
+            FixedIngressPolicyV1::strict_v1().ordered_rules(),
+            &[
+                FixedIngressRuleV1::GitWorktreesAdmin,
+                FixedIngressRuleV1::GitLockFile,
+                FixedIngressRuleV1::GitTcfsUndo,
+                FixedIngressRuleV1::SecurityDirectory,
+                FixedIngressRuleV1::SecurityExactFile,
+                FixedIngressRuleV1::MasterKeyRotationPending,
+                FixedIngressRuleV1::MasterKeyRotationState,
+                FixedIngressRuleV1::AtomicWriteTemporary,
+                FixedIngressRuleV1::Dotenv,
+                FixedIngressRuleV1::LiveDatabase,
+            ]
+        );
+    }
+
+    #[test]
+    fn every_fixed_ingress_rule_has_a_positive_case() {
+        let policy = FixedIngressPolicyV1::strict_v1();
+        let cases = [
+            (
+                "repo/.git/worktrees/wt/HEAD",
+                FixedIngressRuleV1::GitWorktreesAdmin,
+                ".git/worktrees admin area",
+            ),
+            (
+                "repo/.git/refs/heads/main.lock",
+                FixedIngressRuleV1::GitLockFile,
+                "git lockfile",
+            ),
+            (
+                "repo/.git/tcfs-undo/history.bundle",
+                FixedIngressRuleV1::GitTcfsUndo,
+                ".git/tcfs-undo bundle",
+            ),
+            (
+                "home/.ssh/id_ed25519",
+                FixedIngressRuleV1::SecurityDirectory,
+                ".ssh",
+            ),
+            (
+                "home/.config/auth.json",
+                FixedIngressRuleV1::SecurityExactFile,
+                "auth.json",
+            ),
+            (
+                "home/.vault-key.rotate-pending",
+                FixedIngressRuleV1::MasterKeyRotationPending,
+                "tcfs-rotation-pending-key",
+            ),
+            (
+                "home/.vault-key.rotate-state.json",
+                FixedIngressRuleV1::MasterKeyRotationState,
+                "tcfs-rotation-state",
+            ),
+            (
+                "home/..vault-key.tmp.0123456789abcdef0123456789abcdef",
+                FixedIngressRuleV1::AtomicWriteTemporary,
+                "tcfs-atomic-write-temp",
+            ),
+            ("repo/service.env", FixedIngressRuleV1::Dotenv, "dotenv"),
+            (
+                "home/.codex/logs.sqlite-wal",
+                FixedIngressRuleV1::LiveDatabase,
+                "live-db",
+            ),
+        ];
+
+        for (path, expected_rule, expected_label) in cases {
+            let denied = policy
+                .classify_path(Path::new(path))
+                .unwrap_or_else(|| panic!("expected fixed-ingress denial for {path}"));
+            assert_eq!(denied.rule(), expected_rule, "wrong rule for {path}");
+            assert_eq!(denied.label(), expected_label, "wrong label for {path}");
+        }
+    }
+
+    #[test]
+    fn fixed_ingress_matching_is_ascii_case_insensitive() {
+        let policy = FixedIngressPolicyV1::strict_v1();
+        for path in [
+            "repo/.GIT/WORKTREES/wt/HEAD",
+            "repo/.GIT/INDEX.LOCK",
+            "repo/.GIT/TCFS-UNDO/history.bundle",
+            "home/.SSH/id_ed25519",
+            "home/AUTH.JSON",
+            "home/VAULT.ROTATE-PENDING",
+            "home/VAULT.ROTATE-STATE.JSON",
+            "home/.TARGET.TMP.ABCDEF0123456789ABCDEF0123456789",
+            "repo/SERVICE.ENV",
+            "home/STATE.SQLITE-WAL",
+        ] {
+            assert!(
+                policy.classify_path(Path::new(path)).is_some(),
+                "case alias must remain denied: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_ingress_near_misses_remain_admissible() {
+        let policy = FixedIngressPolicyV1::strict_v1();
+        for path in [
+            "repo/.git/worktree/wt/HEAD",
+            "repo/git/worktrees/wt/HEAD",
+            "repo/.git/index.locked",
+            "repo/index.lock",
+            "repo/.git/tcfs-undo-not/history.bundle",
+            "home/.sshd/id_ed25519",
+            "home/auth.json.bak",
+            "home/vault.rotate-pending.bak",
+            "home/vault.rotate-state.json.bak",
+            "home/visible.tmp.0123456789abcdef0123456789abcdef",
+            "home/.hidden.tmp.0123456789abcdef0123456789abcde",
+            "home/.hidden.tmp.0123456789abcdef0123456789abcdeg",
+            "repo/.envrc",
+            "repo/service.environment",
+            "home/state.sqlite4",
+            "home/data.dbf",
+        ] {
+            assert_eq!(
+                policy.classify_path(Path::new(path)),
+                None,
+                "near miss must remain admissible: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn rule_order_is_observable_and_schema_bound() {
+        let policy = FixedIngressPolicyV1::strict_v1();
+        let denied = policy
+            .classify_path(Path::new("home/.ssh/repo/.git/worktrees/wt/auth.json"))
+            .expect("multi-match path must be denied");
+        assert_eq!(denied.rule(), FixedIngressRuleV1::GitWorktreesAdmin);
+
+        let denied = policy
+            .classify_path(Path::new("home/auth.json/.ssh/id_ed25519"))
+            .expect("component-order path must be denied");
+        assert_eq!(denied.rule(), FixedIngressRuleV1::SecurityExactFile);
+
+        let schemas = FIXED_INGRESS_RULE_ORDER_V1.map(FixedIngressRuleV1::schema);
+        let mut reordered = schemas;
+        reordered.swap(0, 1);
+        assert_ne!(
+            fingerprint_fixed_ingress_schema_v1(&schemas),
+            fingerprint_fixed_ingress_schema_v1(&reordered)
+        );
+    }
+
+    #[test]
+    fn schema_fingerprint_binds_membership_and_matcher_semantics() {
+        let schemas = FIXED_INGRESS_RULE_ORDER_V1.map(FixedIngressRuleV1::schema);
+        assert_eq!(
+            ATOMIC_WRITE_TEMP_PARAMETERS_V1[2],
+            format!("nonce-length-{ATOMIC_WRITE_TEMP_NONCE_LENGTH_V1}")
+        );
+
+        let mut changed_membership = schemas;
+        changed_membership[4].patterns = &["auth.json"];
+        assert_ne!(
+            fingerprint_fixed_ingress_schema_v1(&schemas),
+            fingerprint_fixed_ingress_schema_v1(&changed_membership)
+        );
+
+        let mut changed_matcher = schemas;
+        changed_matcher[4].matcher = "any-component-prefix-ascii-case-insensitive-v1";
+        assert_ne!(
+            fingerprint_fixed_ingress_schema_v1(&schemas),
+            fingerprint_fixed_ingress_schema_v1(&changed_matcher)
+        );
+
+        let mut changed_label = schemas;
+        changed_label[4].diagnostic_labels = &["redacted-auth-file"];
+        assert_ne!(
+            fingerprint_fixed_ingress_schema_v1(&schemas),
+            fingerprint_fixed_ingress_schema_v1(&changed_label)
+        );
+    }
+
+    #[test]
+    fn fixed_ingress_schema_fingerprint_has_a_golden_identity() {
+        let fingerprint = FixedIngressPolicyV1::strict_v1().schema_fingerprint();
+        assert_eq!(fingerprint.as_bytes().len(), 32);
+        assert_eq!(
+            fingerprint.to_string(),
+            "b3v1:155e561ee22414cad8a977a8f9e1f7ed6e4efe715fa12e66966057f3f6824a70"
+        );
+    }
+}

--- a/crates/tcfs-core/src/lib.rs
+++ b/crates/tcfs-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod config;
 pub mod error;
+pub mod fixed_ingress;
 pub mod types;
 
 pub use error::{TcfsError, TcfsResult};

--- a/crates/tcfs-storage/src/lib.rs
+++ b/crates/tcfs-storage/src/lib.rs
@@ -10,10 +10,10 @@ pub use health::{
     HealthCheckError, HealthCheckFailureKind, HealthCheckReport,
 };
 pub use operator::{
-    build_operator, ensure_conditional_write_semantics,
-    memory_conditional_write_emulation_is_registered_for_tests,
+    acquire_conditional_write_semantics_receipt, build_operator,
+    ensure_conditional_write_semantics, memory_conditional_write_emulation_is_registered_for_tests,
     register_memory_conditional_write_emulation_for_tests, verify_conditional_write_semantics,
-    StorageConfig,
+    ConditionalWriteSemanticsReceipt, StorageConfig,
 };
 
 /// Parse a remote spec like `seaweedfs://host:port/bucket[/prefix]`.

--- a/crates/tcfs-storage/src/operator.rs
+++ b/crates/tcfs-storage/src/operator.rs
@@ -419,6 +419,40 @@ pub async fn verify_conditional_write_semantics(op: &Operator, prefix: &str) -> 
 
 type WeakAccessor = Weak<dyn opendal::raw::AccessDyn>;
 
+/// Opaque evidence that one exact OpenDAL accessor and canonical prefix passed
+/// the live conditional read/write semantics probe.
+///
+/// Capability flags alone are not sufficient for catalog HEAD authority: an
+/// S3-compatible endpoint may accept conditional request headers without
+/// enforcing them atomically. The receipt is deliberately non-cloneable and
+/// cannot authorize another accessor or prefix.
+pub struct ConditionalWriteSemanticsReceipt {
+    accessor: WeakAccessor,
+    prefix: String,
+}
+
+impl std::fmt::Debug for ConditionalWriteSemanticsReceipt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ConditionalWriteSemanticsReceipt")
+            .field("prefix", &self.prefix)
+            .field("accessor_alive", &self.accessor.upgrade().is_some())
+            .finish()
+    }
+}
+
+impl ConditionalWriteSemanticsReceipt {
+    /// Return whether this receipt belongs to the exact live accessor and
+    /// canonical prefix supplied by the caller.
+    pub fn authorizes(&self, op: &Operator, prefix: &str) -> Result<bool> {
+        let prefix = normalize_probe_prefix(prefix)?;
+        let accessor = Arc::downgrade(op.inner());
+        Ok(self.prefix == prefix
+            && self.accessor.upgrade().is_some()
+            && Weak::ptr_eq(&self.accessor, &accessor))
+    }
+}
+
 struct ConditionalWriteProbeRoute {
     application: WeakAccessor,
     /// Separate unthrottled accessor for the live concurrent conformance race.
@@ -569,6 +603,24 @@ pub async fn ensure_conditional_write_semantics(op: &Operator, prefix: &str) -> 
         .get_or_try_init(|| verify_conditional_write_semantics(op, &prefix))
         .await?;
     Ok(())
+}
+
+/// Verify and retain the conditional semantics required by a mutable catalog
+/// HEAD for one exact accessor and prefix.
+///
+/// The returned receipt is the only admission input accepted by the strict
+/// catalog reader. Acquiring it may perform the bounded live conformance probe;
+/// callers must therefore do so before entering a read-only planning window.
+pub async fn acquire_conditional_write_semantics_receipt(
+    op: &Operator,
+    prefix: &str,
+) -> Result<ConditionalWriteSemanticsReceipt> {
+    let prefix = normalize_probe_prefix(prefix)?;
+    ensure_conditional_write_semantics(op, &prefix).await?;
+    Ok(ConditionalWriteSemanticsReceipt {
+        accessor: Arc::downgrade(op.inner()),
+        prefix,
+    })
 }
 
 fn validate_endpoint_transport(cfg: &StorageConfig) -> Result<()> {
@@ -1079,6 +1131,28 @@ mod tests {
             error.to_string().contains("safe relative"),
             "registration must not bypass prefix validation: {error:#}"
         );
+    }
+
+    #[tokio::test]
+    async fn conditional_semantics_receipt_is_exact_accessor_and_prefix_scoped() {
+        let registered = Operator::new(opendal::services::Memory::default())
+            .unwrap()
+            .finish();
+        let unrelated = Operator::new(opendal::services::Memory::default())
+            .unwrap()
+            .finish();
+        register_memory_conditional_write_emulation_for_tests(&registered).unwrap();
+
+        let receipt = acquire_conditional_write_semantics_receipt(&registered, "/tenant/nested/")
+            .await
+            .unwrap();
+        assert!(receipt.authorizes(&registered, "tenant/nested").unwrap());
+        assert!(receipt
+            .authorizes(&registered.clone(), "/tenant/nested/")
+            .unwrap());
+        assert!(!receipt.authorizes(&registered, "tenant/other").unwrap());
+        assert!(!receipt.authorizes(&unrelated, "tenant/nested").unwrap());
+        assert!(receipt.authorizes(&registered, "tenant/../other").is_err());
     }
 
     #[test]

--- a/crates/tcfs-sync/Cargo.toml
+++ b/crates/tcfs-sync/Cargo.toml
@@ -48,3 +48,4 @@ proptest = { workspace = true }
 tokio-test = { workspace = true }
 age = { workspace = true }
 secrecy = { workspace = true }
+static_assertions = { workspace = true }

--- a/crates/tcfs-sync/Cargo.toml
+++ b/crates/tcfs-sync/Cargo.toml
@@ -16,7 +16,7 @@ opendal = { workspace = true }
 # rocksdb and async-nats are optional until Phase 4 implementation
 rocksdb = { workspace = true, optional = true }
 async-nats = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
+futures = { workspace = true }
 bytes = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 notify = { workspace = true }
@@ -37,7 +37,7 @@ tempfile = { workspace = true }
 [features]
 default = []
 # NATS JetStream messaging only (no RocksDB) — used by tcfsd k8s-worker
-nats = ["dep:async-nats", "dep:futures", "dep:bytes"]
+nats = ["dep:async-nats", "dep:bytes"]
 # E2E encryption support (XChaCha20-Poly1305 chunk encryption)
 crypto = ["dep:tcfs-crypto", "dep:base64"]
 # Full feature set including RocksDB persistent state + encryption

--- a/crates/tcfs-sync/src/blacklist.rs
+++ b/crates/tcfs-sync/src/blacklist.rs
@@ -4,6 +4,9 @@
 //! into a single `Blacklist` type with a unified `check()` method.
 
 use std::path::Path;
+use tcfs_core::fixed_ingress::{
+    FixedIngressDenyReasonV1, FixedIngressPolicyV1, FixedIngressRuleV1,
+};
 use tracing::debug;
 
 /// Why a path was excluded — useful for debug logging and diagnostics.
@@ -68,6 +71,23 @@ impl std::fmt::Display for BlacklistReason {
             BlacklistReason::GitLockFile => write!(f, "git lockfile"),
             BlacklistReason::GitTcfsUndo => write!(f, ".git/tcfs-undo bundle"),
             BlacklistReason::VfsMarker => write!(f, "VFS marker"),
+        }
+    }
+}
+
+impl From<FixedIngressDenyReasonV1> for BlacklistReason {
+    fn from(reason: FixedIngressDenyReasonV1) -> Self {
+        match reason.rule() {
+            FixedIngressRuleV1::GitWorktreesAdmin => Self::GitWorktreesAdmin,
+            FixedIngressRuleV1::GitLockFile => Self::GitLockFile,
+            FixedIngressRuleV1::GitTcfsUndo => Self::GitTcfsUndo,
+            FixedIngressRuleV1::SecurityDirectory
+            | FixedIngressRuleV1::SecurityExactFile
+            | FixedIngressRuleV1::MasterKeyRotationPending
+            | FixedIngressRuleV1::MasterKeyRotationState
+            | FixedIngressRuleV1::AtomicWriteTemporary
+            | FixedIngressRuleV1::Dotenv
+            | FixedIngressRuleV1::LiveDatabase => Self::Security(reason.label()),
         }
     }
 }
@@ -485,30 +505,9 @@ impl Blacklist {
     /// credentials/live databases, linked-worktree admin data, Git lockfiles,
     /// and legacy in-tree undo bundles are never valid hydration payloads.
     pub fn check_fixed_ingress_path_components(&self, path: &Path) -> Option<BlacklistReason> {
-        if has_git_worktrees_segment(path) {
-            return Some(BlacklistReason::GitWorktreesAdmin);
-        }
-        if is_git_lockfile_path(path) {
-            return Some(BlacklistReason::GitLockFile);
-        }
-        if has_git_tcfs_undo_segment(path) {
-            return Some(BlacklistReason::GitTcfsUndo);
-        }
-        for component in path.components() {
-            if let std::path::Component::Normal(name) = component {
-                if let Some(name_str) = name.to_str() {
-                    for &dir in SECURITY_DIRS {
-                        if name_str.eq_ignore_ascii_case(dir) {
-                            return Some(BlacklistReason::Security(dir));
-                        }
-                    }
-                    if let Some(label) = security_file_reason(name_str) {
-                        return Some(BlacklistReason::Security(label));
-                    }
-                }
-            }
-        }
-        None
+        FixedIngressPolicyV1::strict_v1()
+            .classify_path(path)
+            .map(BlacklistReason::from)
     }
 }
 
@@ -523,6 +522,33 @@ mod tests {
     fn blacklist_with_globs(patterns: &[&str]) -> Blacklist {
         let pats: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
         Blacklist::new(&pats, false, false, "bundle")
+    }
+
+    fn legacy_fixed_ingress_reference(path: &Path) -> Option<BlacklistReason> {
+        if has_git_worktrees_segment(path) {
+            return Some(BlacklistReason::GitWorktreesAdmin);
+        }
+        if is_git_lockfile_path(path) {
+            return Some(BlacklistReason::GitLockFile);
+        }
+        if has_git_tcfs_undo_segment(path) {
+            return Some(BlacklistReason::GitTcfsUndo);
+        }
+        for component in path.components() {
+            if let std::path::Component::Normal(name) = component {
+                if let Some(name) = name.to_str() {
+                    for &directory in SECURITY_DIRS {
+                        if name.eq_ignore_ascii_case(directory) {
+                            return Some(BlacklistReason::Security(directory));
+                        }
+                    }
+                    if let Some(label) = security_file_reason(name) {
+                        return Some(BlacklistReason::Security(label));
+                    }
+                }
+            }
+        }
+        None
     }
 
     #[test]
@@ -988,6 +1014,51 @@ mod tests {
                     .is_some(),
                 "case alias must remain fenced: {path}"
             );
+        }
+    }
+
+    #[test]
+    fn fixed_ingress_adapter_matches_core_policy_independent_of_config() {
+        let policy = FixedIngressPolicyV1::strict_v1();
+        let configured_patterns = vec!["*.json".to_owned(), "target/**".to_owned()];
+        let blacklists = [
+            Blacklist::default(),
+            Blacklist::new(&[], true, true, "raw"),
+            Blacklist::new(&configured_patterns, false, false, "bundle"),
+        ];
+        let corpus = [
+            "repo/.git/worktrees/wt/HEAD",
+            "repo/.git/index.lock",
+            "repo/.git/tcfs-undo/history.bundle",
+            "home/.ssh/id_ed25519",
+            "home/auth.json",
+            "home/vault.rotate-pending",
+            "home/vault.rotate-state.json",
+            "home/.vault.tmp.0123456789abcdef0123456789abcdef",
+            "repo/service.env",
+            "home/state.sqlite-wal",
+            "repo/.git/HEAD",
+            "repo/Cargo.lock",
+            "home/.envrc",
+            "home/state.dbf",
+            "repo/ordinary.json",
+            "home/auth.json/.ssh/id_ed25519",
+            "home/.ssh/repo/.git/worktrees/wt/auth.json",
+        ];
+
+        for path in corpus {
+            let path = Path::new(path);
+            let core = policy.classify_path(path).map(BlacklistReason::from);
+            let legacy = legacy_fixed_ingress_reference(path);
+            assert_eq!(core, legacy, "core policy changed V1 behavior for {path:?}");
+            let expected = policy.classify_path(path).map(BlacklistReason::from);
+            for blacklist in &blacklists {
+                assert_eq!(
+                    blacklist.check_fixed_ingress_path_components(path),
+                    expected,
+                    "adapter drift for {path:?}"
+                );
+            }
         }
     }
 

--- a/crates/tcfs-sync/src/conflict_git.rs
+++ b/crates/tcfs-sync/src/conflict_git.rs
@@ -5,8 +5,9 @@
 //! the recorded conflicts, park the remote branch heads under a TCFS namespace,
 //! verify the repository before/after, then clear the group atomically.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 
 use anyhow::{anyhow, bail, Context, Result};
 use opendal::Operator;
@@ -45,6 +46,31 @@ fn repo_git_command(
         command.current_dir(repo_root);
         Ok(command)
     }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn descriptor_rooted_sanitized_git_command(
+    directory: &std::fs::File,
+) -> Result<std::process::Command> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::process::CommandExt;
+
+    let directory = directory
+        .try_clone()
+        .context("cloning descriptor-rooted Git cwd")?;
+    let mut command = git_safety::sanitized_git_command();
+    // SAFETY: `fchdir(2)` is async-signal-safe. The callback owns the cloned
+    // descriptor, so delayed spawn cannot observe a closed/reused fd number.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fchdir(directory.as_raw_fd()) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+    Ok(command)
 }
 
 fn git_output_at(
@@ -683,6 +709,58 @@ pub struct GitRepoAnchor {
     after_conflict_state_flush: std::sync::Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
 }
 
+/// Closed set of read-only Git probes available outside this mutation module.
+///
+/// Keeping arguments closed prevents a caller from turning a held repository
+/// capability into an unguarded `update-ref` or another mutation command.
+pub(crate) enum HeldGitReadQueryV1 {
+    EffectiveConfigNames,
+    SharedRepositoryValues,
+    BareRepositoryValues,
+    ObjectFormat,
+    ForEachRef { count: u64 },
+    SymbolicHeadNoRecurse,
+    ResolvedHeadCommit,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HeldGitReadErrorV1 {
+    Failed,
+    OutputLimit,
+}
+
+pub(crate) struct HeldGitReadOutputV1 {
+    status: ExitStatus,
+    stdout: Vec<u8>,
+}
+
+impl HeldGitReadOutputV1 {
+    pub(crate) fn into_parts(self) -> (ExitStatus, Vec<u8>) {
+        (self.status, self.stdout)
+    }
+}
+
+fn drain_git_stderr_presence_v1(mut stderr: std::process::ChildStderr) -> std::io::Result<bool> {
+    let mut saw_bytes = false;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = stderr.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(saw_bytes);
+        }
+        saw_bytes = true;
+    }
+}
+
+fn terminate_held_git_read_v1(
+    child: &mut std::process::Child,
+    stderr_reader: std::thread::JoinHandle<std::io::Result<bool>>,
+) {
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = stderr_reader.join();
+}
+
 impl std::fmt::Debug for GitRepoAnchor {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
@@ -719,9 +797,47 @@ impl GitRepoAnchor {
                     canonical_root.display()
                 )
             })?;
+            Self::capture_from_authorized_root(&canonical_root, directory)
+        }
+    }
+
+    /// Build an anchor from a root descriptor that an earlier authority check
+    /// already opened and retained.
+    ///
+    /// The supplied descriptor, not a reopened pathname, becomes the worktree
+    /// capability. `.git` is opened relative to it with `O_NOFOLLOW`; the
+    /// canonical spelling is retained for identity revalidation and operator
+    /// diagnostics only.
+    pub(crate) fn capture_from_authorized_root(
+        canonical_root: &Path,
+        directory: std::fs::File,
+    ) -> Result<Self> {
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            let _ = (canonical_root, directory);
+            bail!(
+                "registered-root Git resolution requires descriptor-anchored commands on Linux or macOS"
+            );
+        }
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            let metadata = directory
+                .metadata()
+                .context("inspecting authorized repo root descriptor")?;
+            if !metadata.is_dir() {
+                bail!("authorized repo root descriptor is not a directory");
+            }
+            if !canonical_root.is_absolute() {
+                bail!(
+                    "authorized repo root spelling is not absolute: {}",
+                    canonical_root.display()
+                );
+            }
+
             let git_directory = git_safety::open_git_directory_at(&directory)?;
             let anchor = Self {
-                canonical_root,
+                canonical_root: canonical_root.to_owned(),
                 directory,
                 git_directory,
                 #[cfg(test)]
@@ -734,7 +850,11 @@ impl GitRepoAnchor {
         }
     }
 
-    fn revalidate(&self) -> Result<()> {
+    pub(crate) fn canonical_root(&self) -> &Path {
+        &self.canonical_root
+    }
+
+    pub(crate) fn revalidate(&self) -> Result<()> {
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
             bail!(
@@ -804,9 +924,9 @@ impl GitRepoAnchor {
         }
     }
 
-    /// Git command rooted in the captured worktree. This variant is for
-    /// read-only worktree/topology inspection only; mutations use
-    /// [`Self::metadata_git_command`].
+    /// Git command rooted in the captured worktree. Legacy clean-worktree
+    /// inspection uses this capability; held topology queries bind the
+    /// metadata descriptor separately.
     fn root_git_command(&self) -> Result<std::process::Command> {
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
@@ -815,26 +935,143 @@ impl GitRepoAnchor {
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            use std::os::fd::AsRawFd;
-            use std::os::unix::process::CommandExt;
-
-            let directory_fd = self.directory.as_raw_fd();
-            let mut command = git_safety::sanitized_git_command();
-            // SAFETY: `fchdir` is async-signal-safe and the descriptor remains
-            // alive for the full child spawn. Git discovery after the cwd
-            // change is read-only on this command path; root and `.git`
-            // identity are both revalidated immediately before mutation.
-            unsafe {
-                command.pre_exec(move || {
-                    if libc::fchdir(directory_fd) == 0 {
-                        Ok(())
-                    } else {
-                        Err(std::io::Error::last_os_error())
-                    }
-                });
-            }
-            Ok(command)
+            descriptor_rooted_sanitized_git_command(&self.directory)
         }
+    }
+
+    pub(crate) fn run_held_read_query(
+        &self,
+        query: HeldGitReadQueryV1,
+        stdout_limit: u64,
+    ) -> std::result::Result<HeldGitReadOutputV1, HeldGitReadErrorV1> {
+        let stdout_limit =
+            usize::try_from(stdout_limit).map_err(|_| HeldGitReadErrorV1::OutputLimit)?;
+        self.revalidate().map_err(|_| HeldGitReadErrorV1::Failed)?;
+        let mut command = self
+            .metadata_git_command()
+            .map_err(|_| HeldGitReadErrorV1::Failed)?;
+        match query {
+            HeldGitReadQueryV1::EffectiveConfigNames => {
+                command.args(["config", "--no-includes", "--null", "--name-only", "--list"]);
+            }
+            HeldGitReadQueryV1::SharedRepositoryValues => {
+                command.args([
+                    "config",
+                    "--no-includes",
+                    "--null",
+                    "--type=bool",
+                    "--get-all",
+                    "core.sharedRepository",
+                ]);
+            }
+            HeldGitReadQueryV1::BareRepositoryValues => {
+                command.args([
+                    "config",
+                    "--no-includes",
+                    "--null",
+                    "--type=bool",
+                    "--get-all",
+                    "core.bare",
+                ]);
+            }
+            HeldGitReadQueryV1::ObjectFormat => {
+                command.args(["rev-parse", "--show-object-format=storage"]);
+            }
+            HeldGitReadQueryV1::ForEachRef { count } => {
+                command.args([
+                    "for-each-ref",
+                    "--sort=refname",
+                    &format!("--count={count}"),
+                    "--format=%(refname)%00%(objectname)%00%(objecttype)%00%(symref)",
+                ]);
+            }
+            HeldGitReadQueryV1::SymbolicHeadNoRecurse => {
+                command.args(["symbolic-ref", "--quiet", "--no-recurse", "HEAD"]);
+            }
+            HeldGitReadQueryV1::ResolvedHeadCommit => {
+                command.args(["rev-parse", "--verify", "--quiet", "HEAD^{commit}"]);
+            }
+        }
+        #[cfg(windows)]
+        let null_config = "NUL";
+        #[cfg(not(windows))]
+        let null_config = "/dev/null";
+        command
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_SYSTEM", null_config)
+            .env("GIT_CONFIG_GLOBAL", null_config)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = command.spawn().map_err(|_| HeldGitReadErrorV1::Failed)?;
+        let mut stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(HeldGitReadErrorV1::Failed);
+            }
+        };
+        let stderr = match child.stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(HeldGitReadErrorV1::Failed);
+            }
+        };
+        let stderr_reader = match std::thread::Builder::new()
+            .name("tcfs-held-git-stderr".to_owned())
+            .spawn(move || drain_git_stderr_presence_v1(stderr))
+        {
+            Ok(reader) => reader,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(HeldGitReadErrorV1::Failed);
+            }
+        };
+        let mut retained = Vec::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = match stdout.read(&mut buffer) {
+                Ok(read) => read,
+                Err(_) => {
+                    terminate_held_git_read_v1(&mut child, stderr_reader);
+                    return Err(HeldGitReadErrorV1::Failed);
+                }
+            };
+            if read == 0 {
+                break;
+            }
+            let Some(next_len) = retained.len().checked_add(read) else {
+                terminate_held_git_read_v1(&mut child, stderr_reader);
+                return Err(HeldGitReadErrorV1::OutputLimit);
+            };
+            if next_len > stdout_limit || retained.try_reserve_exact(read).is_err() {
+                terminate_held_git_read_v1(&mut child, stderr_reader);
+                return Err(HeldGitReadErrorV1::OutputLimit);
+            }
+            retained.extend_from_slice(&buffer[..read]);
+        }
+        let status = match child.wait() {
+            Ok(status) => status,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stderr_reader.join();
+                return Err(HeldGitReadErrorV1::Failed);
+            }
+        };
+        match stderr_reader.join() {
+            Ok(Ok(false)) => {}
+            Ok(Ok(true)) | Ok(Err(_)) | Err(_) => return Err(HeldGitReadErrorV1::Failed),
+        }
+        self.revalidate().map_err(|_| HeldGitReadErrorV1::Failed)?;
+        Ok(HeldGitReadOutputV1 {
+            status,
+            stdout: retained,
+        })
     }
 
     fn local_ref_sha(&self, ref_name: &str) -> Option<String> {
@@ -877,29 +1114,12 @@ impl GitRepoAnchor {
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            use std::os::fd::AsRawFd;
-            use std::os::unix::process::CommandExt;
-
-            let git_directory_fd = self.git_directory.as_raw_fd();
-            let mut command = git_safety::sanitized_git_command();
+            let mut command = descriptor_rooted_sanitized_git_command(&self.git_directory)?;
             command
                 .arg("-c")
                 .arg("core.fsync=reference")
                 .env("GIT_DIR", ".")
                 .env("GIT_COMMON_DIR", ".");
-            // SAFETY: only async-signal-safe `fchdir` runs in this callback.
-            // The common sanitized builder already installs the private child
-            // umask. This metadata command set does not need a worktree and
-            // resolves all Git state from the captured `.git` cwd.
-            unsafe {
-                command.pre_exec(move || {
-                    if libc::fchdir(git_directory_fd) == 0 {
-                        Ok(())
-                    } else {
-                        Err(std::io::Error::last_os_error())
-                    }
-                });
-            }
             Ok(command)
         }
     }
@@ -2282,6 +2502,102 @@ mod tests {
                 .expect_err("redirected/shared Git topology must fail closed");
             assert!(error.to_string().contains(expected), "{error:#}");
         }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn authorized_descriptor_anchor_drives_read_only_git_observation() {
+        let temporary = tempfile::tempdir().unwrap();
+        let repo = temporary.path().join("repo");
+        init_repo(&repo);
+        let head = commit(&repo, "tracked.txt", "base\n", "base");
+        let canonical_root = repo.canonicalize().unwrap();
+        let directory = std::fs::File::open(&canonical_root).unwrap();
+
+        let anchor =
+            GitRepoAnchor::capture_from_authorized_root(&canonical_root, directory).unwrap();
+        assert_eq!(anchor.canonical_root(), canonical_root);
+        validate_standalone_repo_topology(&canonical_root).unwrap();
+
+        let output = anchor
+            .run_held_read_query(HeldGitReadQueryV1::ResolvedHeadCommit, 128)
+            .unwrap();
+        let (status, stdout) = output.into_parts();
+        assert!(status.success());
+        assert_eq!(String::from_utf8_lossy(&stdout).trim(), head);
+        anchor.revalidate().unwrap();
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn held_read_query_enforces_output_ceiling_and_stderr_policy() {
+        let committed = tempfile::tempdir().unwrap();
+        let committed_repo = committed.path().join("repo");
+        init_repo(&committed_repo);
+        let head = commit(&committed_repo, "tracked.txt", "base\n", "base");
+        let committed_root = committed_repo.canonicalize().unwrap();
+        let committed_anchor = GitRepoAnchor::capture_from_authorized_root(
+            &committed_root,
+            std::fs::File::open(&committed_root).unwrap(),
+        )
+        .unwrap();
+        let exact_limit = u64::try_from(head.len() + 1).unwrap();
+        let exact = committed_anchor
+            .run_held_read_query(HeldGitReadQueryV1::ResolvedHeadCommit, exact_limit)
+            .unwrap();
+        let (status, stdout) = exact.into_parts();
+        assert!(status.success());
+        assert_eq!(stdout, format!("{head}\n").as_bytes());
+        assert!(matches!(
+            committed_anchor
+                .run_held_read_query(HeldGitReadQueryV1::ResolvedHeadCommit, exact_limit - 1),
+            Err(HeldGitReadErrorV1::OutputLimit)
+        ));
+
+        let unborn = tempfile::tempdir().unwrap();
+        let unborn_repo = unborn.path().join("repo");
+        init_repo(&unborn_repo);
+        let unborn_root = unborn_repo.canonicalize().unwrap();
+        let unborn_anchor = GitRepoAnchor::capture_from_authorized_root(
+            &unborn_root,
+            std::fs::File::open(&unborn_root).unwrap(),
+        )
+        .unwrap();
+        let unresolved = unborn_anchor
+            .run_held_read_query(HeldGitReadQueryV1::ResolvedHeadCommit, 128)
+            .unwrap();
+        let (status, stdout) = unresolved.into_parts();
+        assert_eq!(status.code(), Some(1));
+        assert!(stdout.is_empty());
+
+        std::fs::write(committed_root.join(".git/config"), b"[broken\n").unwrap();
+        assert!(matches!(
+            committed_anchor.run_held_read_query(HeldGitReadQueryV1::EffectiveConfigNames, 1024),
+            Err(HeldGitReadErrorV1::Failed)
+        ));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn authorized_descriptor_anchor_rejects_a_different_canonical_route() {
+        let temporary = tempfile::tempdir().unwrap();
+        let authorized = temporary.path().join("authorized");
+        let different = temporary.path().join("different");
+        init_repo(&authorized);
+        init_repo(&different);
+
+        let authorized_descriptor = std::fs::File::open(&authorized).unwrap();
+        let error = GitRepoAnchor::capture_from_authorized_root(
+            &different.canonicalize().unwrap(),
+            authorized_descriptor,
+        )
+        .expect_err("the held descriptor, not the supplied route, is authoritative");
+        assert!(
+            error
+                .to_string()
+                .contains("repo root was replaced after authorization"),
+            "{error:#}"
+        );
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/tcfs-sync/src/conflict_git.rs
+++ b/crates/tcfs-sync/src/conflict_git.rs
@@ -5,9 +5,8 @@
 //! the recorded conflicts, park the remote branch heads under a TCFS namespace,
 //! verify the repository before/after, then clear the group atomically.
 
-use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::{ExitStatus, Stdio};
+use std::process::Stdio;
 
 use anyhow::{anyhow, bail, Context, Result};
 use opendal::Operator;
@@ -709,58 +708,6 @@ pub struct GitRepoAnchor {
     after_conflict_state_flush: std::sync::Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
 }
 
-/// Closed set of read-only Git probes available outside this mutation module.
-///
-/// Keeping arguments closed prevents a caller from turning a held repository
-/// capability into an unguarded `update-ref` or another mutation command.
-pub(crate) enum HeldGitReadQueryV1 {
-    EffectiveConfigNames,
-    SharedRepositoryValues,
-    BareRepositoryValues,
-    ObjectFormat,
-    ForEachRef { count: u64 },
-    SymbolicHeadNoRecurse,
-    ResolvedHeadCommit,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum HeldGitReadErrorV1 {
-    Failed,
-    OutputLimit,
-}
-
-pub(crate) struct HeldGitReadOutputV1 {
-    status: ExitStatus,
-    stdout: Vec<u8>,
-}
-
-impl HeldGitReadOutputV1 {
-    pub(crate) fn into_parts(self) -> (ExitStatus, Vec<u8>) {
-        (self.status, self.stdout)
-    }
-}
-
-fn drain_git_stderr_presence_v1(mut stderr: std::process::ChildStderr) -> std::io::Result<bool> {
-    let mut saw_bytes = false;
-    let mut buffer = [0_u8; 64 * 1024];
-    loop {
-        let read = stderr.read(&mut buffer)?;
-        if read == 0 {
-            return Ok(saw_bytes);
-        }
-        saw_bytes = true;
-    }
-}
-
-fn terminate_held_git_read_v1(
-    child: &mut std::process::Child,
-    stderr_reader: std::thread::JoinHandle<std::io::Result<bool>>,
-) {
-    let _ = child.kill();
-    let _ = child.wait();
-    let _ = stderr_reader.join();
-}
-
 impl std::fmt::Debug for GitRepoAnchor {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
@@ -924,9 +871,8 @@ impl GitRepoAnchor {
         }
     }
 
-    /// Git command rooted in the captured worktree. Legacy clean-worktree
-    /// inspection uses this capability; held topology queries bind the
-    /// metadata descriptor separately.
+    /// Git command rooted in the captured worktree for legacy clean-worktree
+    /// inspection and the separately fenced mutation path.
     fn root_git_command(&self) -> Result<std::process::Command> {
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
@@ -937,141 +883,6 @@ impl GitRepoAnchor {
         {
             descriptor_rooted_sanitized_git_command(&self.directory)
         }
-    }
-
-    pub(crate) fn run_held_read_query(
-        &self,
-        query: HeldGitReadQueryV1,
-        stdout_limit: u64,
-    ) -> std::result::Result<HeldGitReadOutputV1, HeldGitReadErrorV1> {
-        let stdout_limit =
-            usize::try_from(stdout_limit).map_err(|_| HeldGitReadErrorV1::OutputLimit)?;
-        self.revalidate().map_err(|_| HeldGitReadErrorV1::Failed)?;
-        let mut command = self
-            .metadata_git_command()
-            .map_err(|_| HeldGitReadErrorV1::Failed)?;
-        match query {
-            HeldGitReadQueryV1::EffectiveConfigNames => {
-                command.args(["config", "--no-includes", "--null", "--name-only", "--list"]);
-            }
-            HeldGitReadQueryV1::SharedRepositoryValues => {
-                command.args([
-                    "config",
-                    "--no-includes",
-                    "--null",
-                    "--type=bool",
-                    "--get-all",
-                    "core.sharedRepository",
-                ]);
-            }
-            HeldGitReadQueryV1::BareRepositoryValues => {
-                command.args([
-                    "config",
-                    "--no-includes",
-                    "--null",
-                    "--type=bool",
-                    "--get-all",
-                    "core.bare",
-                ]);
-            }
-            HeldGitReadQueryV1::ObjectFormat => {
-                command.args(["rev-parse", "--show-object-format=storage"]);
-            }
-            HeldGitReadQueryV1::ForEachRef { count } => {
-                command.args([
-                    "for-each-ref",
-                    "--sort=refname",
-                    &format!("--count={count}"),
-                    "--format=%(refname)%00%(objectname)%00%(objecttype)%00%(symref)",
-                ]);
-            }
-            HeldGitReadQueryV1::SymbolicHeadNoRecurse => {
-                command.args(["symbolic-ref", "--quiet", "--no-recurse", "HEAD"]);
-            }
-            HeldGitReadQueryV1::ResolvedHeadCommit => {
-                command.args(["rev-parse", "--verify", "--quiet", "HEAD^{commit}"]);
-            }
-        }
-        #[cfg(windows)]
-        let null_config = "NUL";
-        #[cfg(not(windows))]
-        let null_config = "/dev/null";
-        command
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env("GIT_CONFIG_SYSTEM", null_config)
-            .env("GIT_CONFIG_GLOBAL", null_config)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        let mut child = command.spawn().map_err(|_| HeldGitReadErrorV1::Failed)?;
-        let mut stdout = match child.stdout.take() {
-            Some(stdout) => stdout,
-            None => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(HeldGitReadErrorV1::Failed);
-            }
-        };
-        let stderr = match child.stderr.take() {
-            Some(stderr) => stderr,
-            None => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(HeldGitReadErrorV1::Failed);
-            }
-        };
-        let stderr_reader = match std::thread::Builder::new()
-            .name("tcfs-held-git-stderr".to_owned())
-            .spawn(move || drain_git_stderr_presence_v1(stderr))
-        {
-            Ok(reader) => reader,
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return Err(HeldGitReadErrorV1::Failed);
-            }
-        };
-        let mut retained = Vec::new();
-        let mut buffer = [0_u8; 64 * 1024];
-        loop {
-            let read = match stdout.read(&mut buffer) {
-                Ok(read) => read,
-                Err(_) => {
-                    terminate_held_git_read_v1(&mut child, stderr_reader);
-                    return Err(HeldGitReadErrorV1::Failed);
-                }
-            };
-            if read == 0 {
-                break;
-            }
-            let Some(next_len) = retained.len().checked_add(read) else {
-                terminate_held_git_read_v1(&mut child, stderr_reader);
-                return Err(HeldGitReadErrorV1::OutputLimit);
-            };
-            if next_len > stdout_limit || retained.try_reserve_exact(read).is_err() {
-                terminate_held_git_read_v1(&mut child, stderr_reader);
-                return Err(HeldGitReadErrorV1::OutputLimit);
-            }
-            retained.extend_from_slice(&buffer[..read]);
-        }
-        let status = match child.wait() {
-            Ok(status) => status,
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = stderr_reader.join();
-                return Err(HeldGitReadErrorV1::Failed);
-            }
-        };
-        match stderr_reader.join() {
-            Ok(Ok(false)) => {}
-            Ok(Ok(true)) | Ok(Err(_)) | Err(_) => return Err(HeldGitReadErrorV1::Failed),
-        }
-        self.revalidate().map_err(|_| HeldGitReadErrorV1::Failed)?;
-        Ok(HeldGitReadOutputV1 {
-            status,
-            stdout: retained,
-        })
     }
 
     fn local_ref_sha(&self, ref_name: &str) -> Option<String> {
@@ -2506,11 +2317,11 @@ mod tests {
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn authorized_descriptor_anchor_drives_read_only_git_observation() {
+    fn authorized_descriptor_anchor_revalidates_the_captured_route() {
         let temporary = tempfile::tempdir().unwrap();
         let repo = temporary.path().join("repo");
         init_repo(&repo);
-        let head = commit(&repo, "tracked.txt", "base\n", "base");
+        commit(&repo, "tracked.txt", "base\n", "base");
         let canonical_root = repo.canonicalize().unwrap();
         let directory = std::fs::File::open(&canonical_root).unwrap();
 
@@ -2519,62 +2330,7 @@ mod tests {
         assert_eq!(anchor.canonical_root(), canonical_root);
         validate_standalone_repo_topology(&canonical_root).unwrap();
 
-        let output = anchor
-            .run_held_read_query(HeldGitReadQueryV1::ResolvedHeadCommit, 128)
-            .unwrap();
-        let (status, stdout) = output.into_parts();
-        assert!(status.success());
-        assert_eq!(String::from_utf8_lossy(&stdout).trim(), head);
         anchor.revalidate().unwrap();
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    #[test]
-    fn held_read_query_enforces_output_ceiling_and_stderr_policy() {
-        let committed = tempfile::tempdir().unwrap();
-        let committed_repo = committed.path().join("repo");
-        init_repo(&committed_repo);
-        let head = commit(&committed_repo, "tracked.txt", "base\n", "base");
-        let committed_root = committed_repo.canonicalize().unwrap();
-        let committed_anchor = GitRepoAnchor::capture_from_authorized_root(
-            &committed_root,
-            std::fs::File::open(&committed_root).unwrap(),
-        )
-        .unwrap();
-        let exact_limit = u64::try_from(head.len() + 1).unwrap();
-        let exact = committed_anchor
-            .run_held_read_query(HeldGitReadQueryV1::ResolvedHeadCommit, exact_limit)
-            .unwrap();
-        let (status, stdout) = exact.into_parts();
-        assert!(status.success());
-        assert_eq!(stdout, format!("{head}\n").as_bytes());
-        assert!(matches!(
-            committed_anchor
-                .run_held_read_query(HeldGitReadQueryV1::ResolvedHeadCommit, exact_limit - 1),
-            Err(HeldGitReadErrorV1::OutputLimit)
-        ));
-
-        let unborn = tempfile::tempdir().unwrap();
-        let unborn_repo = unborn.path().join("repo");
-        init_repo(&unborn_repo);
-        let unborn_root = unborn_repo.canonicalize().unwrap();
-        let unborn_anchor = GitRepoAnchor::capture_from_authorized_root(
-            &unborn_root,
-            std::fs::File::open(&unborn_root).unwrap(),
-        )
-        .unwrap();
-        let unresolved = unborn_anchor
-            .run_held_read_query(HeldGitReadQueryV1::ResolvedHeadCommit, 128)
-            .unwrap();
-        let (status, stdout) = unresolved.into_parts();
-        assert_eq!(status.code(), Some(1));
-        assert!(stdout.is_empty());
-
-        std::fs::write(committed_root.join(".git/config"), b"[broken\n").unwrap();
-        assert!(matches!(
-            committed_anchor.run_held_read_query(HeldGitReadQueryV1::EffectiveConfigNames, 1024),
-            Err(HeldGitReadErrorV1::Failed)
-        ));
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -29,11 +29,11 @@ use crate::index_entry::{
     admit_portable_namespace_entry, manifest_key, manifest_object_id,
     read_index_entry_record_from_store, require_absent_index_entry_for_update,
     resolve_visible_index_entry, resolve_visible_index_entry_for_update,
-    validate_canonical_rel_path, validate_relative_storage_key, validate_remote_entry,
-    write_committed_index_entry_conditionally, write_directory_marker_conditionally,
-    write_immutable_manifest_object_if_absent, write_preparing_index_entry_conditionally,
-    PendingIndexEntry, PortableNamespaceRole, RemoteEntryKind, RemoteIndexEntry,
-    ResolvedIndexEntryForUpdate,
+    validate_canonical_rel_path, validate_namespace_logical_path, validate_relative_storage_key,
+    validate_remote_entry, write_committed_index_entry_conditionally,
+    write_directory_marker_conditionally, write_immutable_manifest_object_if_absent,
+    write_preparing_index_entry_conditionally, PendingIndexEntry, PortableNamespaceRole,
+    RemoteEntryKind, RemoteIndexEntry, ResolvedIndexEntryForUpdate,
 };
 use crate::manifest::{SymlinkManifest, SyncManifest};
 use crate::state::{make_sync_state_full, FileSyncStatus, StateCache, SyncState};
@@ -4182,10 +4182,14 @@ enum SymlinkRejection {
     Empty,
     /// Target contains a control character that could inject logs or metadata.
     ControlCharacter,
+    /// Target uses a backslash, whose path meaning differs across platforms.
+    NonPortableSeparator,
+    /// Target contains a normal component that has no single portable spelling.
+    NonPortableComponent,
     /// Target is an absolute path (`/etc/passwd`, `C:\...`, UNC).
     Absolute,
-    /// Target uses `..` to escape above the link's own directory (and therefore
-    /// the sync root, since the link is always created inside the root).
+    /// Target uses `..` to cross the admitted logical-root boundary (or the
+    /// link-parent boundary when an absolute caller cannot identify that root).
     Traversal,
     /// Resolved target lands on the fail-closed security deny-set
     /// (`.ssh`, `.gnupg`, dotenv, credential files, live DBs, ...).
@@ -4199,91 +4203,136 @@ impl std::fmt::Display for SymlinkRejection {
         match self {
             SymlinkRejection::Empty => write!(f, "empty target"),
             SymlinkRejection::ControlCharacter => write!(f, "control character in target"),
+            SymlinkRejection::NonPortableSeparator => {
+                write!(f, "non-portable backslash separator in target")
+            }
+            SymlinkRejection::NonPortableComponent => {
+                write!(f, "non-portable path component in target")
+            }
             SymlinkRejection::Absolute => write!(f, "absolute target"),
-            SymlinkRejection::Traversal => write!(f, "`..` escapes sync root"),
+            SymlinkRejection::Traversal => write!(f, "`..` crosses admitted root boundary"),
             SymlinkRejection::DenySet(reason) => write!(f, "deny-set: {reason}"),
             SymlinkRejection::ReservedGit => write!(f, "reserved Git metadata path"),
         }
     }
 }
 
-/// Lexically normalize `rel` (a relative path) joined onto `base`, collapsing
-/// `.` and `..` components *without touching the filesystem* (no `canonicalize`,
-/// which would follow existing links and could itself be attacker-influenced).
+/// Whether `target` begins with a Windows path prefix.
 ///
-/// Returns the number of leading `..` components that remain after collapsing —
-/// i.e. how many directory levels the path climbs *above* `base`. Zero means the
-/// resolved path stays at or below `base`. Also returns the normalized path so
-/// callers can re-run the deny-set check across every resolved component.
-fn lexical_resolve(base: &Path, rel: &Path) -> (usize, PathBuf) {
+/// This is deliberately textual rather than `Path`-based: a Linux build must
+/// reject the same drive, rooted-current-drive, UNC, and device spellings that
+/// a Windows build would reject.
+fn has_windows_path_prefix(target: &str) -> bool {
+    let bytes = target.as_bytes();
+    target.starts_with('\\')
+        || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+}
+
+#[derive(Clone, Copy)]
+enum SymlinkLinkPathKind {
+    Physical,
+    IndexedLogical,
+}
+
+/// Lexically resolve a portable `/`-separated symlink body without touching the
+/// filesystem.
+///
+/// A root-relative logical link path (the form used by indexed plans) supplies
+/// its parent depth, so `../sibling` is accepted only when it remains under that
+/// logical root. An absolute filesystem link path does not identify its sync
+/// root; those legacy restore/upload callers therefore get a zero ascent budget
+/// and retain the stricter "do not leave the link's own parent" behavior.
+fn lexical_resolve_portable_target(
+    local_path: &Path,
+    target: &str,
+    link_path_kind: SymlinkLinkPathKind,
+) -> std::result::Result<PathBuf, SymlinkRejection> {
     use std::path::Component;
 
-    // `depth` counts directory levels we currently sit *below* `base`. Pushing a
-    // normal component descends (+1); a `..` ascends. While `depth > 0` a `..`
-    // just pops the last descent; at `depth == 0` a `..` climbs above `base` and
-    // is an escape. `escapes` is the max depth above base that we ever reach.
-    let mut components: Vec<std::ffi::OsString> = Vec::new();
-    let mut depth: usize = 0;
-    let mut escapes: usize = 0;
+    let base = local_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut resolved = base.to_path_buf();
 
-    for comp in rel.components() {
-        match comp {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                if depth > 0 {
-                    depth -= 1;
-                    components.pop();
+    let root_relative_parent_depth = match link_path_kind {
+        SymlinkLinkPathKind::Physical => None,
+        SymlinkLinkPathKind::IndexedLogical => {
+            let mut depth = 0usize;
+            let mut is_root_relative = true;
+            for component in base.components() {
+                match component {
+                    Component::CurDir => {}
+                    Component::Normal(_) => depth += 1,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                        is_root_relative = false;
+                        break;
+                    }
+                }
+            }
+            is_root_relative.then_some(depth)
+        }
+    };
+
+    let mut parent_ascent_budget = root_relative_parent_depth.unwrap_or(0);
+    let mut target_descent_depth = 0usize;
+    for component in target.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                if target_descent_depth > 0 {
+                    target_descent_depth -= 1;
+                    resolved.pop();
+                } else if parent_ascent_budget > 0 {
+                    parent_ascent_budget -= 1;
+                    resolved.pop();
                 } else {
-                    escapes += 1;
+                    return Err(SymlinkRejection::Traversal);
                 }
             }
-            Component::Normal(name) => {
-                // Below base we track descent depth so a later `..` pops a real
-                // directory; once we have escaped above base (`escapes > 0`) the
-                // remaining names are recorded as the residual escape path only.
-                if escapes == 0 {
-                    depth += 1;
-                }
-                components.push(name.to_os_string());
+            name => {
+                target_descent_depth += 1;
+                resolved.push(name);
             }
-            // RootDir / Prefix should not appear here (absolute is rejected
-            // earlier), but if they do, treat conservatively as part of the path.
-            other => components.push(other.as_os_str().to_os_string()),
         }
     }
 
-    // Build the resolved path anchored at `base`, prefixed by any net escape.
-    let mut out = PathBuf::new();
-    if escapes == 0 {
-        out.push(base);
-    } else {
-        for _ in 0..escapes {
-            out.push("..");
-        }
-    }
-    for name in &components {
-        out.push(name);
-    }
-    (escapes, out)
+    Ok(resolved)
 }
 
 /// Fail-closed validation for a restored symlink target (TIN-1737).
 ///
 /// `local_path` is the would-be link location; `target` is the attacker-supplied
-/// link body. Rejects: empty, absolute, `..`-escape above the link's directory,
-/// or any resolved component hitting the security deny-set. Returns `Ok(())` for
-/// a benign in-root relative target.
+/// link body. Rejects: empty, controls, non-portable separators or prefixes,
+/// `..`-escape above the logical root, or any resolved component hitting the
+/// security deny-set. Returns `Ok(())` for a benign in-root relative target.
 ///
 /// NOTE: `create_local_symlink` does not receive the sync root, so the link's
-/// own parent directory is used as the escape boundary. This is *more* strict
-/// than "must stay within the sync root" (the link is always created inside the
-/// root), so it can refuse an otherwise-legitimate `../sibling/file` target that
-/// crosses one directory but stays in-root. That is the conservative, fail-closed
-/// trade-off; loosening it safely requires threading the real sync root down to
-/// every restore caller.
+/// own parent directory is used as the escape boundary for absolute filesystem
+/// paths. This is *more* strict than "must stay within the sync root" (the link
+/// is always created inside the root), so it can refuse an otherwise-legitimate
+/// `../sibling/file` target. Root-relative indexed paths do carry their logical
+/// parent depth and may ascend within that root.
 fn validate_restored_symlink_target(
     local_path: &Path,
     target: &str,
+) -> std::result::Result<(), SymlinkRejection> {
+    validate_symlink_target(local_path, target, SymlinkLinkPathKind::Physical)
+}
+
+pub(crate) fn validate_restored_symlink_target_for_physical_path(
+    local_path: &Path,
+    target: &str,
+) -> Result<()> {
+    validate_restored_symlink_target(local_path, target).map_err(|reason| {
+        anyhow::anyhow!(
+            "refusing symlink target at {}: {reason}",
+            local_path.display()
+        )
+    })
+}
+
+fn validate_symlink_target(
+    local_path: &Path,
+    target: &str,
+    link_path_kind: SymlinkLinkPathKind,
 ) -> std::result::Result<(), SymlinkRejection> {
     if target.is_empty() {
         return Err(SymlinkRejection::Empty);
@@ -4292,33 +4341,32 @@ fn validate_restored_symlink_target(
         return Err(SymlinkRejection::ControlCharacter);
     }
 
+    // Parse the serialized target using one portable grammar. Host-native
+    // `Path::is_absolute` / `Path::components` would interpret `C:\...` and
+    // backslashes differently on Linux, macOS, and Windows.
+    if target.starts_with('/') || has_windows_path_prefix(target) {
+        return Err(SymlinkRejection::Absolute);
+    }
+    if target.contains('\\') {
+        return Err(SymlinkRejection::NonPortableSeparator);
+    }
+    for component in target.split('/') {
+        if component.is_empty() {
+            return Err(SymlinkRejection::NonPortableComponent);
+        }
+        if component != ".git" && component.eq_ignore_ascii_case(".git") {
+            return Err(SymlinkRejection::ReservedGit);
+        }
+        if component != "."
+            && component != ".."
+            && validate_namespace_logical_path(component).is_err()
+        {
+            return Err(SymlinkRejection::NonPortableComponent);
+        }
+    }
+
     let target_path = Path::new(target);
-
-    // (a) Absolute targets are always refused: `is_absolute` is platform-correct
-    // (covers `/etc/...`, Windows drive `C:\`, and UNC `\\server\share`).
-    if target_path.is_absolute() {
-        return Err(SymlinkRejection::Absolute);
-    }
-    // Defense-in-depth: refuse a leading `/` even if a non-unix `is_absolute`
-    // ever disagreed, and refuse a Windows-style drive/UNC prefix explicitly.
-    if target.starts_with('/') || target.starts_with('\\') {
-        return Err(SymlinkRejection::Absolute);
-    }
-    if target_path
-        .components()
-        .next()
-        .is_some_and(|c| matches!(c, std::path::Component::Prefix(_)))
-    {
-        return Err(SymlinkRejection::Absolute);
-    }
-
-    let base = local_path.parent().unwrap_or_else(|| Path::new("."));
-    let (escapes, resolved) = lexical_resolve(base, target_path);
-
-    // (b) `..` escape above the link's directory (and thus the sync root).
-    if escapes > 0 {
-        return Err(SymlinkRejection::Traversal);
-    }
+    let resolved = lexical_resolve_portable_target(local_path, target, link_path_kind)?;
 
     if filesystem_path_has_reserved_git_component(local_path)
         || filesystem_path_has_reserved_git_component(&resolved)
@@ -4347,12 +4395,19 @@ fn validate_restored_symlink_target(
 /// Planning-safe wrapper for the symlink ingress/egress target policy. The
 /// attacker-controlled target is deliberately omitted from the error text.
 pub fn validate_indexed_symlink_target(local_path: &Path, target: &str) -> Result<()> {
-    validate_restored_symlink_target(local_path, target).map_err(|reason| {
-        anyhow::anyhow!(
-            "refusing symlink target at {}: {reason}",
-            local_path.display()
-        )
-    })
+    let logical_path = local_path
+        .to_str()
+        .context("indexed symlink path must be valid UTF-8")?;
+    validate_namespace_logical_path(logical_path)
+        .context("indexed symlink path must be a canonical logical relative path")?;
+    validate_symlink_target(local_path, target, SymlinkLinkPathKind::IndexedLogical).map_err(
+        |reason| {
+            anyhow::anyhow!(
+                "refusing symlink target at {}: {reason}",
+                local_path.display()
+            )
+        },
+    )
 }
 
 /// Create a restored symlink after fail-closed target validation (TIN-1737).
@@ -6981,6 +7036,31 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlink_upload_rejects_unbound_logical_parent_target() {
+        let op = memory_op();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        let nested = root.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(root.join("target.txt"), b"target").unwrap();
+        let local = nested.join("link");
+        std::os::unix::fs::symlink("../target.txt", &local).unwrap();
+        let mut state = StateCache::open(&tmp.path().join("state.json")).unwrap();
+
+        let error =
+            upload_symlink_with_device(&op, &local, "data", &mut state, "neo", "nested/link")
+                .await
+                .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("crosses admitted root boundary"),
+            "unexpected rejection: {error:#}"
+        );
+        assert!(!op.exists("data/index/nested/link").await.unwrap());
+    }
+
     #[test]
     fn typed_content_identity_never_equates_regular_file_and_symlink() {
         let clock = VectorClock::new();
@@ -7250,7 +7330,6 @@ mod tests {
         assert_eq!(winner_manifest.vclock.get("device-b"), 0);
     }
 
-    #[cfg(unix)]
     #[test]
     fn validate_restored_symlink_target_rules() {
         let link = Path::new("/sync/root/sub/link");
@@ -7288,6 +7367,151 @@ mod tests {
         assert!(validate_restored_symlink_target(link, "sibling.txt").is_ok());
         assert!(validate_restored_symlink_target(link, "./nested/file").is_ok());
         assert!(validate_restored_symlink_target(link, "a/b/c").is_ok());
+        assert!(validate_restored_symlink_target(link, "missing/broken-target").is_ok());
+    }
+
+    #[test]
+    fn validate_restored_symlink_target_uses_portable_prefix_and_separator_rules() {
+        let link = Path::new("/sync/root/sub/link");
+
+        for target in [
+            r"C:\outside",
+            "C:/outside",
+            "C:outside",
+            r"\\server\share",
+            r"\\?\C:\outside",
+            r"\\.\PhysicalDrive0",
+            r"\??\C:\outside",
+            "//server/share",
+            "//?/C:/outside",
+        ] {
+            assert!(
+                matches!(
+                    validate_restored_symlink_target(link, target),
+                    Err(SymlinkRejection::Absolute)
+                ),
+                "Windows absolute/prefix form was accepted: {target:?}"
+            );
+        }
+
+        for target in [r"dir\..\outside", r"nested\file", r"safe/inner\file"] {
+            assert!(
+                matches!(
+                    validate_restored_symlink_target(link, target),
+                    Err(SymlinkRejection::NonPortableSeparator)
+                ),
+                "backslash-bearing target was accepted: {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_restored_symlink_target_rejects_nonportable_components() {
+        let link = Path::new("/sync/root/sub/link");
+
+        for target in [
+            "nested/a:b",
+            "nested/NUL",
+            "nested/COM1.txt",
+            "nested/git~1/config",
+            "nested/.tcfs_dir/entry",
+            "nested/.TCFS_DIR/entry",
+            "nested/trailing.",
+            "nested/trailing ",
+            "nested/question?",
+            "nested/re\u{301}sume\u{301}.txt",
+            "nested//file",
+            "nested/",
+        ] {
+            assert!(
+                matches!(
+                    validate_restored_symlink_target(link, target),
+                    Err(SymlinkRejection::NonPortableComponent)
+                ),
+                "non-portable target component was accepted: {target:?}"
+            );
+        }
+
+        for target in [
+            "nested/file",
+            "nested/Résumé.txt",
+            "./nested/file",
+            "../sibling",
+        ] {
+            assert!(
+                !matches!(
+                    validate_restored_symlink_target(link, target),
+                    Err(SymlinkRejection::NonPortableComponent)
+                ),
+                "portable target component was rejected: {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_restored_symlink_target_rejects_controls_on_every_host() {
+        let link = Path::new("/sync/root/sub/link");
+
+        for target in [
+            "safe\0other",
+            "safe\nother",
+            "safe\u{1f}other",
+            "safe\u{7f}other",
+        ] {
+            assert!(
+                matches!(
+                    validate_restored_symlink_target(link, target),
+                    Err(SymlinkRejection::ControlCharacter)
+                ),
+                "control-bearing target was accepted: {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_indexed_symlink_target_resolves_against_logical_parent_depth() {
+        let nested_link = Path::new("a/b/link");
+
+        assert!(validate_indexed_symlink_target(nested_link, "../../sibling").is_ok());
+        assert!(validate_indexed_symlink_target(nested_link, "../missing/target").is_ok());
+        assert!(matches!(
+            validate_symlink_target(
+                nested_link,
+                "../../../outside",
+                SymlinkLinkPathKind::IndexedLogical
+            ),
+            Err(SymlinkRejection::Traversal)
+        ));
+        assert!(matches!(
+            validate_symlink_target(
+                nested_link,
+                "../../.git/config",
+                SymlinkLinkPathKind::IndexedLogical
+            ),
+            Err(SymlinkRejection::ReservedGit)
+        ));
+
+        // Physical destination paths do not disclose the logical sync root, so
+        // their conservative boundary remains the link's own parent.
+        assert!(matches!(
+            validate_restored_symlink_target(Path::new("/sync/root/a/b/link"), "../sibling"),
+            Err(SymlinkRejection::Traversal)
+        ));
+        assert!(matches!(
+            validate_restored_symlink_target(Path::new("sandbox/link"), "../outside"),
+            Err(SymlinkRejection::Traversal)
+        ));
+        assert!(
+            validate_indexed_symlink_target(Path::new("/sync/root/a/b/link"), "nested/file")
+                .is_err()
+        );
+        for reserved_link_path in [".tcfs_dir", "nested/.TCFS_DIR/link"] {
+            assert!(
+                validate_indexed_symlink_target(Path::new(reserved_link_path), "nested/file")
+                    .is_err(),
+                "reserved indexed link path was accepted: {reserved_link_path:?}"
+            );
+        }
     }
 
     // ── normalize_rel_path ───────────────────────────────────────────────

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -1424,6 +1424,23 @@ impl RawObjectReadBindingV1 {
     }
 }
 
+/// Storage-native identity declared by a trusted caller for one exact
+/// observational raw-object read.
+///
+/// Unlike [`RawObjectReadBindingV1`], this borrows the caller's tokens so the
+/// read path cannot silently substitute identity discovered from current
+/// storage metadata.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExpectedRawObjectBindingV1<'a> {
+    Version {
+        version: &'a str,
+        etag: Option<&'a str>,
+    },
+    Etag {
+        etag: &'a str,
+    },
+}
+
 /// Result of proving whether one exact storage object can be read by identity.
 ///
 /// `Unbound` deliberately carries no bytes: a backend without version- or
@@ -2045,6 +2062,12 @@ enum RawObjectSnapshotReadModeV1 {
     CurrentEtag,
 }
 
+#[derive(Clone, Copy)]
+enum RawObjectSnapshotSelectionV1<'a> {
+    Discover(RawObjectSnapshotReadModeV1),
+    Expected(ExpectedRawObjectBindingV1<'a>),
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("object changed after read-only snapshot stat: {object_key}")]
 pub(crate) struct RawObjectChangedDuringReadV1 {
@@ -2061,11 +2084,25 @@ pub(crate) struct RawObjectSnapshotTooLargeV1 {
     max_bytes: u64,
 }
 
-async fn read_raw_object_snapshot_with_mode_v1(
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RawObjectSnapshotInvalidMetadataReasonV1 {
+    NonFile,
+    Empty,
+    BindingToken,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("read-only object snapshot has invalid metadata ({reason:?}): {object_key}")]
+pub(crate) struct RawObjectSnapshotInvalidMetadataV1 {
+    object_key: String,
+    reason: RawObjectSnapshotInvalidMetadataReasonV1,
+}
+
+async fn read_raw_object_snapshot_with_selection_v1(
     op: &Operator,
     object_key: &str,
     max_bytes: u64,
-    mode: RawObjectSnapshotReadModeV1,
+    selection: RawObjectSnapshotSelectionV1<'_>,
 ) -> Result<Option<RawObjectReadV1>> {
     let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
     anyhow::ensure!(
@@ -2077,7 +2114,50 @@ async fn read_raw_object_snapshot_with_mode_v1(
             <= remote_contract.max_storage_key_bytes(),
         "read-only object snapshot key exceeds the registered-root storage-key bound: {object_key:?}"
     );
-    let metadata = match op.stat(object_key).await {
+    let checked_expected_binding_token = |value: &str, description: &str| -> Result<()> {
+        anyhow::ensure!(
+            !value.is_empty() && value != "null",
+            "{description} is not a valid registered-root binding token: {object_key}"
+        );
+        anyhow::ensure!(
+            u64::try_from(value.len())
+                .context("expected object binding token length does not fit u64")?
+                <= remote_contract.max_binding_token_bytes(),
+            "{description} exceeds the registered-root binding-token bound: {object_key}"
+        );
+        Ok(())
+    };
+    let capability = op.info().full_capability();
+    match selection {
+        RawObjectSnapshotSelectionV1::Expected(ExpectedRawObjectBindingV1::Version {
+            version,
+            etag,
+        }) => {
+            checked_expected_binding_token(version, "expected object version")?;
+            if let Some(etag) = etag {
+                checked_expected_binding_token(etag, "expected object ETag")?;
+            }
+            if !capability.stat_with_version || !capability.read_with_version {
+                return Ok(Some(RawObjectReadV1::Unbound));
+            }
+        }
+        RawObjectSnapshotSelectionV1::Expected(ExpectedRawObjectBindingV1::Etag { etag }) => {
+            checked_expected_binding_token(etag, "expected object ETag")?;
+            if !capability.read_with_if_match {
+                return Ok(Some(RawObjectReadV1::Unbound));
+            }
+        }
+        RawObjectSnapshotSelectionV1::Discover(_) => {}
+    }
+    let metadata_result = match selection {
+        RawObjectSnapshotSelectionV1::Expected(ExpectedRawObjectBindingV1::Version {
+            version,
+            ..
+        }) => op.stat_with(object_key).version(version).await,
+        RawObjectSnapshotSelectionV1::Expected(ExpectedRawObjectBindingV1::Etag { .. })
+        | RawObjectSnapshotSelectionV1::Discover(_) => op.stat(object_key).await,
+    };
+    let metadata = match metadata_result {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
         Err(error) => {
@@ -2085,14 +2165,20 @@ async fn read_raw_object_snapshot_with_mode_v1(
                 .with_context(|| format!("statting read-only object snapshot: {object_key}"));
         }
     };
-    anyhow::ensure!(
-        metadata.is_file(),
-        "read-only object snapshot is not a file: {object_key}"
-    );
-    anyhow::ensure!(
-        metadata.content_length() > 0,
-        "read-only object snapshot is empty: {object_key}"
-    );
+    if !metadata.is_file() {
+        return Err(RawObjectSnapshotInvalidMetadataV1 {
+            object_key: object_key.to_owned(),
+            reason: RawObjectSnapshotInvalidMetadataReasonV1::NonFile,
+        }
+        .into());
+    }
+    if metadata.content_length() == 0 {
+        return Err(RawObjectSnapshotInvalidMetadataV1 {
+            object_key: object_key.to_owned(),
+            reason: RawObjectSnapshotInvalidMetadataReasonV1::Empty,
+        }
+        .into());
+    }
     if metadata.content_length() > max_bytes {
         return Err(RawObjectSnapshotTooLargeV1 {
             object_key: object_key.to_owned(),
@@ -2102,57 +2188,122 @@ async fn read_raw_object_snapshot_with_mode_v1(
         .into());
     }
 
-    let checked_binding_token = |value: Option<&str>,
-                                 description: &str|
-     -> Result<Option<String>> {
-        let Some(value) = value.filter(|value| !value.is_empty()) else {
-            return Ok(None);
+    let checked_binding_token =
+        |value: Option<&str>, description: &str| -> Result<Option<String>> {
+            let Some(value) = value.filter(|value| !value.is_empty() && *value != "null") else {
+                return Ok(None);
+            };
+            if u64::try_from(value.len()).context("object binding token length does not fit u64")?
+                > remote_contract.max_binding_token_bytes()
+            {
+                let error: anyhow::Error = RawObjectSnapshotInvalidMetadataV1 {
+                    object_key: object_key.to_owned(),
+                    reason: RawObjectSnapshotInvalidMetadataReasonV1::BindingToken,
+                }
+                .into();
+                return Err(error).with_context(|| {
+                    format!("{description} exceeds the registered-root binding-token bound")
+                });
+            }
+            Ok(Some(value.to_owned()))
         };
-        anyhow::ensure!(
-            u64::try_from(value.len()).context("object binding token length does not fit u64")?
-                <= remote_contract.max_binding_token_bytes(),
-            "{description} exceeds the registered-root binding-token bound: {object_key}"
-        );
-        Ok(Some(value.to_owned()))
-    };
     let etag = checked_binding_token(metadata.etag(), "object ETag")?;
-    let version = checked_binding_token(metadata.version(), "object version")?
-        .filter(|version| version != "null")
-        .filter(|_| matches!(mode, RawObjectSnapshotReadModeV1::PreferVersion));
-    let capability = op.info().full_capability();
-    let version = version.filter(|_| capability.read_with_version);
+    let version = checked_binding_token(metadata.version(), "object version")?;
+    let discovered_version = version
+        .as_deref()
+        .filter(|_| {
+            matches!(
+                selection,
+                RawObjectSnapshotSelectionV1::Discover(RawObjectSnapshotReadModeV1::PreferVersion)
+            )
+        })
+        .filter(|_| capability.read_with_version)
+        .map(str::to_owned);
     let etag_for_read = etag
         .as_deref()
         .filter(|_| capability.read_with_if_match)
         .map(str::to_owned);
-    if version.is_none() && etag_for_read.is_none() {
+    if matches!(selection, RawObjectSnapshotSelectionV1::Discover(_))
+        && discovered_version.is_none()
+        && etag_for_read.is_none()
+    {
         return Ok(Some(RawObjectReadV1::Unbound));
     }
-    let (reader_result, binding) = if let Some(version) = version.as_deref() {
-        let reader = if let Some(etag) = etag_for_read.as_deref() {
-            op.reader_with(object_key)
-                .version(version)
-                .if_match(etag)
-                .await
-        } else {
-            op.reader_with(object_key).version(version).await
-        };
-        (
-            reader,
-            RawObjectReadBindingV1::Version {
-                version: version.to_owned(),
-                etag: etag.clone(),
-            },
-        )
-    } else if let Some(etag) = etag_for_read.as_deref() {
-        (
-            op.reader_with(object_key).if_match(etag).await,
-            RawObjectReadBindingV1::Etag {
-                etag: etag.to_owned(),
-            },
-        )
-    } else {
-        unreachable!("unbound storage reads return before fetching object bytes")
+    let changed_during_read = || -> anyhow::Error {
+        RawObjectChangedDuringReadV1 {
+            object_key: object_key.to_owned(),
+        }
+        .into()
+    };
+    let (reader_result, binding) = match selection {
+        RawObjectSnapshotSelectionV1::Discover(_) => {
+            if let Some(version) = discovered_version.as_deref() {
+                let reader = if let Some(etag) = etag_for_read.as_deref() {
+                    op.reader_with(object_key)
+                        .version(version)
+                        .if_match(etag)
+                        .await
+                } else {
+                    op.reader_with(object_key).version(version).await
+                };
+                (
+                    reader,
+                    RawObjectReadBindingV1::Version {
+                        version: version.to_owned(),
+                        etag: etag.clone(),
+                    },
+                )
+            } else if let Some(etag) = etag_for_read.as_deref() {
+                (
+                    op.reader_with(object_key).if_match(etag).await,
+                    RawObjectReadBindingV1::Etag {
+                        etag: etag.to_owned(),
+                    },
+                )
+            } else {
+                unreachable!("unbound storage reads return before fetching object bytes")
+            }
+        }
+        RawObjectSnapshotSelectionV1::Expected(ExpectedRawObjectBindingV1::Version {
+            version: expected_version,
+            etag: expected_etag,
+        }) => {
+            if version.as_deref() != Some(expected_version)
+                || expected_etag.is_some_and(|expected| etag.as_deref() != Some(expected))
+            {
+                return Err(changed_during_read());
+            }
+            let reader = if let Some(expected_etag) =
+                expected_etag.filter(|_| capability.read_with_if_match)
+            {
+                op.reader_with(object_key)
+                    .version(expected_version)
+                    .if_match(expected_etag)
+                    .await
+            } else {
+                op.reader_with(object_key).version(expected_version).await
+            };
+            (
+                reader,
+                RawObjectReadBindingV1::Version {
+                    version: expected_version.to_owned(),
+                    etag: expected_etag.map(str::to_owned),
+                },
+            )
+        }
+        RawObjectSnapshotSelectionV1::Expected(ExpectedRawObjectBindingV1::Etag {
+            etag: expected_etag,
+        }) => {
+            if etag.as_deref() != Some(expected_etag) {
+                return Err(changed_during_read());
+            }
+            (
+                op.reader_with(object_key).if_match(expected_etag).await,
+                RawObjectReadBindingV1::Etag {
+                    etag: expected_etag.to_owned(),
+                },
+            )
+        }
     };
 
     let reader = match reader_result {
@@ -2266,11 +2417,11 @@ pub(crate) async fn read_raw_object_snapshot_v1(
     object_key: &str,
     max_bytes: u64,
 ) -> Result<Option<RawObjectReadV1>> {
-    read_raw_object_snapshot_with_mode_v1(
+    read_raw_object_snapshot_with_selection_v1(
         op,
         object_key,
         max_bytes,
-        RawObjectSnapshotReadModeV1::PreferVersion,
+        RawObjectSnapshotSelectionV1::Discover(RawObjectSnapshotReadModeV1::PreferVersion),
     )
     .await
 }
@@ -2286,11 +2437,32 @@ pub(crate) async fn read_current_raw_object_snapshot_v1(
     object_key: &str,
     max_bytes: u64,
 ) -> Result<Option<RawObjectReadV1>> {
-    read_raw_object_snapshot_with_mode_v1(
+    read_raw_object_snapshot_with_selection_v1(
         op,
         object_key,
         max_bytes,
-        RawObjectSnapshotReadModeV1::CurrentEtag,
+        RawObjectSnapshotSelectionV1::Discover(RawObjectSnapshotReadModeV1::CurrentEtag),
+    )
+    .await
+}
+
+/// Read the exact storage identity declared by a trusted caller.
+///
+/// Version-bound declarations stat and read the named historical version.
+/// ETag-only declarations remain current-value observations and use a
+/// conditional read. Unsupported identity semantics produce `Unbound`;
+/// absence of the exact version produces `None`.
+pub(crate) async fn read_expected_raw_object_snapshot_v1(
+    op: &Operator,
+    object_key: &str,
+    max_bytes: u64,
+    expected_binding: ExpectedRawObjectBindingV1<'_>,
+) -> Result<Option<RawObjectReadV1>> {
+    read_raw_object_snapshot_with_selection_v1(
+        op,
+        object_key,
+        max_bytes,
+        RawObjectSnapshotSelectionV1::Expected(expected_binding),
     )
     .await
 }
@@ -2975,11 +3147,17 @@ mod tests {
         version: Option<String>,
     }
 
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct SnapshotTestStat {
+        version: Option<String>,
+    }
+
     #[derive(Debug)]
     struct SnapshotTestState {
         current: SnapshotTestObject,
         versions: BTreeMap<String, SnapshotTestObject>,
         replace_after_next_stat: Option<SnapshotTestObject>,
+        stats: Vec<SnapshotTestStat>,
         reads: Vec<SnapshotTestRead>,
     }
 
@@ -2990,6 +3168,18 @@ mod tests {
     }
 
     impl SnapshotTestBackend {
+        fn insert_version(&self, version: impl Into<String>, object: SnapshotTestObject) {
+            self.state
+                .lock()
+                .unwrap()
+                .versions
+                .insert(version.into(), object);
+        }
+
+        fn stats(&self) -> Vec<SnapshotTestStat> {
+            self.state.lock().unwrap().stats.clone()
+        }
+
         fn reads(&self) -> Vec<SnapshotTestRead> {
             self.state.lock().unwrap().reads.clone()
         }
@@ -3005,9 +3195,18 @@ mod tests {
             self.info.clone()
         }
 
-        async fn stat(&self, _path: &str, _: OpStat) -> opendal::Result<RpStat> {
+        async fn stat(&self, _path: &str, args: OpStat) -> opendal::Result<RpStat> {
             let mut state = self.state.lock().unwrap();
-            let observed = state.current.clone();
+            state.stats.push(SnapshotTestStat {
+                version: args.version().map(str::to_owned),
+            });
+            let observed = match args.version() {
+                Some(version) => state.versions.get(version).cloned(),
+                None => Some(state.current.clone()),
+            }
+            .ok_or_else(|| {
+                opendal::Error::new(ErrorKind::NotFound, "snapshot-test version is missing")
+            })?;
             if let Some(replacement) = state.replace_after_next_stat.take() {
                 state.current = replacement;
             }
@@ -3084,6 +3283,7 @@ mod tests {
             .set_name("snapshot-test")
             .set_native_capability(Capability {
                 stat: true,
+                stat_with_version: advertise_version,
                 read: true,
                 read_with_if_match: advertise_etag,
                 read_with_version: advertise_version,
@@ -3094,6 +3294,7 @@ mod tests {
                 current,
                 versions,
                 replace_after_next_stat: replacement,
+                stats: Vec::new(),
                 reads: Vec::new(),
             })),
             info: Arc::new(info),
@@ -3204,10 +3405,59 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
+            error
+                .downcast_ref::<super::RawObjectSnapshotInvalidMetadataV1>()
+                .is_some(),
+            "{error:#}"
+        );
+        assert!(
             format!("{error:#}").contains("binding-token bound"),
             "{error:#}"
         );
         assert!(backend.reads().is_empty());
+    }
+
+    #[tokio::test]
+    async fn raw_object_snapshot_types_empty_metadata_and_rejects_null_etag_sentinel() {
+        let (empty_op, empty_backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: Vec::new(),
+                etag: Some("etag".to_owned()),
+                version: None,
+            },
+            None,
+            false,
+            true,
+        );
+        let error = super::read_raw_object_snapshot_v1(&empty_op, "object", 16)
+            .await
+            .unwrap_err();
+        let invalid = error
+            .downcast_ref::<super::RawObjectSnapshotInvalidMetadataV1>()
+            .expect("empty metadata must retain its typed error");
+        assert_eq!(
+            invalid.reason,
+            super::RawObjectSnapshotInvalidMetadataReasonV1::Empty
+        );
+        assert!(empty_backend.reads().is_empty());
+
+        let (null_etag_op, null_etag_backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"body".to_vec(),
+                etag: Some("null".to_owned()),
+                version: None,
+            },
+            None,
+            false,
+            true,
+        );
+        assert_eq!(
+            super::read_current_raw_object_snapshot_v1(&null_etag_op, "head", 16)
+                .await
+                .unwrap(),
+            Some(super::RawObjectReadV1::Unbound)
+        );
+        assert!(null_etag_backend.reads().is_empty());
     }
 
     #[tokio::test]
@@ -3252,6 +3502,260 @@ mod tests {
                 version: Some("version-1".to_owned()),
             }]
         );
+    }
+
+    #[tokio::test]
+    async fn expected_raw_object_snapshot_reads_declared_historical_version() {
+        let (op, backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"current-v2".to_vec(),
+                etag: Some("etag-v2".to_owned()),
+                version: Some("version-v2".to_owned()),
+            },
+            None,
+            true,
+            true,
+        );
+        backend.insert_version(
+            "version-v1",
+            SnapshotTestObject {
+                bytes: b"historical-v1".to_vec(),
+                etag: Some("etag-v1".to_owned()),
+                version: Some("version-v1".to_owned()),
+            },
+        );
+
+        let snapshot = match super::read_expected_raw_object_snapshot_v1(
+            &op,
+            "object",
+            32,
+            super::ExpectedRawObjectBindingV1::Version {
+                version: "version-v1",
+                etag: Some("etag-v1"),
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        {
+            super::RawObjectReadV1::Bound(snapshot) => snapshot,
+            super::RawObjectReadV1::Unbound => panic!("expected exact version-bound snapshot"),
+        };
+        assert_eq!(snapshot.raw_bytes(), b"historical-v1");
+        assert_eq!(
+            snapshot.binding(),
+            &super::RawObjectReadBindingV1::Version {
+                version: "version-v1".to_owned(),
+                etag: Some("etag-v1".to_owned()),
+            }
+        );
+        assert_eq!(
+            backend.stats(),
+            vec![SnapshotTestStat {
+                version: Some("version-v1".to_owned()),
+            }]
+        );
+        assert_eq!(
+            backend.reads(),
+            vec![SnapshotTestRead {
+                offset: 0,
+                size: None,
+                if_match: Some("etag-v1".to_owned()),
+                version: Some("version-v1".to_owned()),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn expected_raw_object_snapshot_uses_declared_current_etag() {
+        let (op, backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"current".to_vec(),
+                etag: Some("declared-etag".to_owned()),
+                version: Some("ignored-version".to_owned()),
+            },
+            None,
+            true,
+            true,
+        );
+
+        let snapshot = match super::read_expected_raw_object_snapshot_v1(
+            &op,
+            "object",
+            32,
+            super::ExpectedRawObjectBindingV1::Etag {
+                etag: "declared-etag",
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        {
+            super::RawObjectReadV1::Bound(snapshot) => snapshot,
+            super::RawObjectReadV1::Unbound => panic!("expected exact ETag-bound snapshot"),
+        };
+        assert_eq!(snapshot.raw_bytes(), b"current");
+        assert_eq!(
+            snapshot.binding(),
+            &super::RawObjectReadBindingV1::Etag {
+                etag: "declared-etag".to_owned(),
+            }
+        );
+        assert_eq!(backend.stats(), vec![SnapshotTestStat { version: None }]);
+        assert_eq!(
+            backend.reads(),
+            vec![SnapshotTestRead {
+                offset: 0,
+                size: None,
+                if_match: Some("declared-etag".to_owned()),
+                version: None,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn expected_raw_object_snapshot_types_missing_exact_version_as_absent() {
+        let (op, backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"current-v2".to_vec(),
+                etag: Some("etag-v2".to_owned()),
+                version: Some("version-v2".to_owned()),
+            },
+            None,
+            true,
+            true,
+        );
+
+        assert!(super::read_expected_raw_object_snapshot_v1(
+            &op,
+            "object",
+            32,
+            super::ExpectedRawObjectBindingV1::Version {
+                version: "missing-v1",
+                etag: Some("etag-v1"),
+            },
+        )
+        .await
+        .unwrap()
+        .is_none());
+        assert_eq!(
+            backend.stats(),
+            vec![SnapshotTestStat {
+                version: Some("missing-v1".to_owned()),
+            }]
+        );
+        assert!(backend.reads().is_empty());
+    }
+
+    #[tokio::test]
+    async fn expected_raw_object_snapshot_types_declared_binding_mismatch() {
+        let (version_op, version_backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"current".to_vec(),
+                etag: Some("etag-current".to_owned()),
+                version: Some("current-version".to_owned()),
+            },
+            None,
+            true,
+            true,
+        );
+        version_backend.insert_version(
+            "declared-version",
+            SnapshotTestObject {
+                bytes: b"wrong-version".to_vec(),
+                etag: Some("declared-etag".to_owned()),
+                version: Some("different-version".to_owned()),
+            },
+        );
+        let error = super::read_expected_raw_object_snapshot_v1(
+            &version_op,
+            "object",
+            32,
+            super::ExpectedRawObjectBindingV1::Version {
+                version: "declared-version",
+                etag: Some("declared-etag"),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            error
+                .downcast_ref::<super::RawObjectChangedDuringReadV1>()
+                .is_some(),
+            "{error:#}"
+        );
+        assert!(version_backend.reads().is_empty());
+
+        let (etag_op, etag_backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"current".to_vec(),
+                etag: Some("actual-etag".to_owned()),
+                version: Some("declared-version".to_owned()),
+            },
+            None,
+            true,
+            true,
+        );
+        let error = super::read_expected_raw_object_snapshot_v1(
+            &etag_op,
+            "object",
+            32,
+            super::ExpectedRawObjectBindingV1::Version {
+                version: "declared-version",
+                etag: Some("expected-etag"),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            error
+                .downcast_ref::<super::RawObjectChangedDuringReadV1>()
+                .is_some(),
+            "{error:#}"
+        );
+        assert!(etag_backend.reads().is_empty());
+    }
+
+    #[tokio::test]
+    async fn expected_raw_object_snapshot_returns_unbound_without_required_semantics() {
+        let object = SnapshotTestObject {
+            bytes: b"current".to_vec(),
+            etag: Some("etag".to_owned()),
+            version: Some("version".to_owned()),
+        };
+        let (version_op, version_backend) =
+            snapshot_test_operator(object.clone(), None, false, true);
+        assert_eq!(
+            super::read_expected_raw_object_snapshot_v1(
+                &version_op,
+                "object",
+                32,
+                super::ExpectedRawObjectBindingV1::Version {
+                    version: "version",
+                    etag: Some("etag"),
+                },
+            )
+            .await
+            .unwrap(),
+            Some(super::RawObjectReadV1::Unbound)
+        );
+        assert!(version_backend.stats().is_empty());
+        assert!(version_backend.reads().is_empty());
+
+        let (etag_op, etag_backend) = snapshot_test_operator(object, None, true, false);
+        assert_eq!(
+            super::read_expected_raw_object_snapshot_v1(
+                &etag_op,
+                "object",
+                32,
+                super::ExpectedRawObjectBindingV1::Etag { etag: "etag" },
+            )
+            .await
+            .unwrap(),
+            Some(super::RawObjectReadV1::Unbound)
+        );
+        assert!(etag_backend.stats().is_empty());
+        assert!(etag_backend.reads().is_empty());
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -297,7 +297,7 @@ pub enum PortableNamespaceRole {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-struct PortableNamespaceReservationV1 {
+pub(crate) struct PortableNamespaceReservationV1 {
     version: u8,
     exact_path: String,
     folded_path: String,
@@ -316,7 +316,7 @@ impl PortableNamespaceReservationV1 {
         })
     }
 
-    fn from_json_bytes(bytes: &[u8]) -> Result<Self> {
+    pub(crate) fn from_json_bytes(bytes: &[u8]) -> Result<Self> {
         let reservation: Self =
             serde_json::from_slice(bytes).context("parsing portable namespace reservation v1")?;
         anyhow::ensure!(
@@ -334,8 +334,23 @@ impl PortableNamespaceReservationV1 {
         Ok(reservation)
     }
 
-    fn to_json_bytes(&self) -> Result<Vec<u8>> {
+    pub(crate) fn to_json_bytes(&self) -> Result<Vec<u8>> {
         serde_json::to_vec(self).context("serializing portable namespace reservation v1")
+    }
+
+    #[allow(dead_code)] // Consumed by the next full list-and-bind pass.
+    pub(crate) fn exact_path(&self) -> &str {
+        &self.exact_path
+    }
+
+    #[allow(dead_code)] // Consumed by the next full list-and-bind pass.
+    pub(crate) fn folded_path(&self) -> &str {
+        &self.folded_path
+    }
+
+    #[allow(dead_code)] // Consumed by the next full list-and-bind pass.
+    pub(crate) const fn role(&self) -> PortableNamespaceRole {
+        self.role
     }
 }
 
@@ -386,7 +401,7 @@ pub(crate) fn namespace_logical_entry_from_index_path(
     Ok((rel_path.to_owned(), PortableNamespaceRole::File))
 }
 
-fn namespace_reservation_object_id(folded_path: &str) -> String {
+pub(crate) fn namespace_reservation_object_id(folded_path: &str) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(b"tcfs-portable-namespace-reservation-v1\0");
     hasher.update(folded_path.as_bytes());
@@ -673,28 +688,7 @@ impl DeletionEvidence {
         safety_copy_key: &str,
         safety_copy_bytes: &[u8],
     ) -> Result<Self> {
-        let prefix = validate_canonical_namespace_remote_prefix(remote_prefix)?;
-        validate_canonical_rel_path(rel_path)?;
-        let trash_prefix = if prefix.is_empty() {
-            ".tcfs-trash/".to_string()
-        } else {
-            format!("{prefix}/.tcfs-trash/")
-        };
-        let remainder = safety_copy_key
-            .strip_prefix(&trash_prefix)
-            .with_context(|| {
-                format!(
-                    "trash safety-copy key is outside canonical prefix {trash_prefix:?}: {safety_copy_key:?}"
-                )
-            })?;
-        let (generation, evidence_rel_path) = remainder
-            .split_once('/')
-            .context("trash safety-copy key is missing its generation/path separator")?;
-        validate_storage_key_component(generation, "trash safety-copy generation")?;
-        anyhow::ensure!(
-            evidence_rel_path == rel_path,
-            "trash safety-copy path does not match deletion path: expected {rel_path:?}, got {evidence_rel_path:?}"
-        );
+        validate_trash_safety_copy_route(remote_prefix, rel_path, safety_copy_key)?;
 
         Ok(Self {
             safety_copy_key: safety_copy_key.to_string(),
@@ -717,6 +711,62 @@ impl DeletionEvidence {
                 safety_copy_bytes,
             )?)
     }
+}
+
+pub(crate) fn validate_trash_safety_copy_route(
+    remote_prefix: &str,
+    rel_path: &str,
+    safety_copy_key: &str,
+) -> Result<()> {
+    let prefix = validate_canonical_namespace_remote_prefix(remote_prefix)?;
+    validate_canonical_rel_path(rel_path)?;
+    let trash_prefix = if prefix.is_empty() {
+        ".tcfs-trash/".to_string()
+    } else {
+        format!("{prefix}/.tcfs-trash/")
+    };
+    let remainder = safety_copy_key
+        .strip_prefix(&trash_prefix)
+        .with_context(|| {
+            format!(
+                "trash safety-copy key is outside canonical prefix {trash_prefix:?}: {safety_copy_key:?}"
+            )
+        })?;
+    let (generation, evidence_rel_path) = remainder
+        .split_once('/')
+        .context("trash safety-copy key is missing its generation/path separator")?;
+    validate_canonical_trash_generation(generation)?;
+    anyhow::ensure!(
+        evidence_rel_path == rel_path,
+        "trash safety-copy path does not match deletion path: expected {rel_path:?}, got {evidence_rel_path:?}"
+    );
+    Ok(())
+}
+
+fn validate_canonical_trash_generation(generation: &str) -> Result<()> {
+    let (timestamp_text, uuid_text) = generation
+        .split_once('-')
+        .context("trash safety-copy generation requires timestamp and UUID")?;
+    anyhow::ensure!(
+        !timestamp_text.is_empty() && timestamp_text.bytes().all(|byte| byte.is_ascii_digit()),
+        "trash safety-copy generation timestamp must be decimal"
+    );
+    let timestamp = timestamp_text
+        .parse::<u64>()
+        .context("trash safety-copy generation timestamp does not fit u64")?;
+    anyhow::ensure!(
+        timestamp.to_string() == timestamp_text,
+        "trash safety-copy generation timestamp is not canonical"
+    );
+    let uuid =
+        uuid::Uuid::parse_str(uuid_text).context("trash safety-copy generation UUID is invalid")?;
+    anyhow::ensure!(
+        uuid.hyphenated().to_string() == uuid_text
+            && uuid.get_variant() == uuid::Variant::RFC4122
+            && uuid.get_version_num() == 4,
+        "trash safety-copy generation UUID must be canonical lowercase RFC4122 v4"
+    );
+    Ok(())
 }
 
 fn validate_deletion_evidence(evidence: &DeletionEvidence) -> Result<()> {
@@ -3684,6 +3734,27 @@ mod tests {
         let mut tampered: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         tampered["deletion_evidence"]["safety_copy_blake3"] = serde_json::json!("NOT-A-DIGEST");
         assert!(parse_index_entry_record(&serde_json::to_vec(&tampered).unwrap()).is_err());
+    }
+
+    #[test]
+    fn deletion_evidence_requires_the_canonical_v4_generation_route() {
+        let bytes = b"exact safety copy";
+        for key in [
+            "data/.tcfs-trash/123/doc.txt",
+            "data/.tcfs-trash/0123-00000000-0000-4000-8000-000000000000/doc.txt",
+            "data/.tcfs-trash/18446744073709551616-00000000-0000-4000-8000-000000000000/doc.txt",
+            "data/.tcfs-trash/123-00000000-0000-3000-8000-000000000000/doc.txt",
+            "data/.tcfs-trash/123-00000000-0000-4000-7000-000000000000/doc.txt",
+            "data/.tcfs-trash/123-00000000-0000-4000-8000-00000000000A/doc.txt",
+            "other/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/doc.txt",
+            "data/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/other.txt",
+        ] {
+            assert!(
+                super::DeletionEvidence::for_trash_generation("data", "doc.txt", key, bytes)
+                    .is_err(),
+                "accepted noncanonical evidence route {key:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Context, Result};
 use futures::TryStreamExt;
 use opendal::{ErrorKind, Operator};
 use serde::{Deserialize, Serialize};
+use tcfs_core::config::RegisteredRootPlanContractV1;
 use unicode_casefold::UnicodeCaseFold;
 use unicode_normalization::UnicodeNormalization;
 
@@ -1999,9 +2000,15 @@ pub(crate) async fn read_raw_object_snapshot_v1(
     object_key: &str,
     max_bytes: u64,
 ) -> Result<Option<RawObjectReadV1>> {
+    let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
     anyhow::ensure!(
         max_bytes > 0,
         "read-only object snapshot bound must be nonzero: {object_key}"
+    );
+    anyhow::ensure!(
+        u64::try_from(object_key.len()).context("storage key length does not fit u64")?
+            <= remote_contract.max_storage_key_bytes(),
+        "read-only object snapshot key exceeds the registered-root storage-key bound: {object_key:?}"
     );
     let metadata = match op.stat(object_key).await {
         Ok(metadata) => metadata,
@@ -2024,14 +2031,22 @@ pub(crate) async fn read_raw_object_snapshot_v1(
         "read-only object snapshot exceeds {max_bytes} bytes: {object_key}"
     );
 
-    let etag = metadata
-        .etag()
-        .filter(|etag| !etag.is_empty())
-        .map(str::to_owned);
-    let version = metadata
-        .version()
-        .filter(|version| !version.is_empty() && *version != "null")
-        .map(str::to_owned);
+    let checked_binding_token = |value: Option<&str>,
+                                 description: &str|
+     -> Result<Option<String>> {
+        let Some(value) = value.filter(|value| !value.is_empty()) else {
+            return Ok(None);
+        };
+        anyhow::ensure!(
+            u64::try_from(value.len()).context("object binding token length does not fit u64")?
+                <= remote_contract.max_binding_token_bytes(),
+            "{description} exceeds the registered-root binding-token bound: {object_key}"
+        );
+        Ok(Some(value.to_owned()))
+    };
+    let etag = checked_binding_token(metadata.etag(), "object ETag")?;
+    let version = checked_binding_token(metadata.version(), "object version")?
+        .filter(|version| version != "null");
     let capability = op.info().full_capability();
     let version = version.filter(|_| capability.read_with_version);
     let etag_for_read = etag
@@ -3031,6 +3046,42 @@ mod tests {
             .await
             .unwrap_err();
         assert!(format!("{error:#}").contains("exceeds 3 bytes"));
+    }
+
+    #[tokio::test]
+    async fn read_only_raw_object_snapshot_enforces_key_and_binding_token_bounds() {
+        let remote_contract =
+            tcfs_core::config::RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let overlong_key =
+            "k".repeat(usize::try_from(remote_contract.max_storage_key_bytes() + 1).unwrap());
+        let error = super::read_raw_object_snapshot_v1(&memory_op(), &overlong_key, 16)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("storage-key bound"),
+            "{error:#}"
+        );
+
+        let oversized_etag =
+            "e".repeat(usize::try_from(remote_contract.max_binding_token_bytes() + 1).unwrap());
+        let (op, backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"body".to_vec(),
+                etag: Some(oversized_etag),
+                version: None,
+            },
+            None,
+            false,
+            true,
+        );
+        let error = super::read_raw_object_snapshot_v1(&op, "object", 16)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("binding-token bound"),
+            "{error:#}"
+        );
+        assert!(backend.reads().is_empty());
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -365,7 +365,7 @@ pub(crate) fn validate_namespace_logical_path(rel_path: &str) -> Result<()> {
     Ok(())
 }
 
-fn namespace_claims_for_path(
+pub(crate) fn namespace_claims_for_path(
     rel_path: &str,
     leaf_role: PortableNamespaceRole,
 ) -> Result<Vec<PortableNamespaceReservationV1>> {

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -371,7 +371,7 @@ fn namespace_claims_for_path(
     Ok(claims)
 }
 
-fn namespace_logical_entry_from_index_path(
+pub(crate) fn namespace_logical_entry_from_index_path(
     rel_path: &str,
 ) -> Result<(String, PortableNamespaceRole)> {
     if let Some(parent) = rel_path
@@ -1645,7 +1645,7 @@ pub(crate) fn validate_canonical_namespace_remote_prefix(remote_prefix: &str) ->
     Ok(remote_prefix)
 }
 
-fn namespace_index_prefix(remote_prefix: &str) -> String {
+pub(crate) fn namespace_index_prefix(remote_prefix: &str) -> String {
     if remote_prefix.is_empty() {
         "index/".to_owned()
     } else {
@@ -1653,7 +1653,7 @@ fn namespace_index_prefix(remote_prefix: &str) -> String {
     }
 }
 
-fn namespace_reservation_prefix(remote_prefix: &str) -> String {
+pub(crate) fn namespace_reservation_prefix(remote_prefix: &str) -> String {
     if remote_prefix.is_empty() {
         ".tcfs-namespace/v1/".to_owned()
     } else {

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use futures::TryStreamExt;
 use opendal::{ErrorKind, Operator};
 use serde::{Deserialize, Serialize};
 use unicode_casefold::UnicodeCaseFold;
@@ -337,7 +338,7 @@ impl PortableNamespaceReservationV1 {
     }
 }
 
-fn validate_namespace_logical_path(rel_path: &str) -> Result<()> {
+pub(crate) fn validate_namespace_logical_path(rel_path: &str) -> Result<()> {
     validate_canonical_rel_path(rel_path)?;
     anyhow::ensure!(
         !rel_path
@@ -1344,6 +1345,77 @@ struct IndexEntrySnapshot {
     cas_etag: Option<String>,
 }
 
+/// Storage-native identity used to bind one observational raw-object read.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RawObjectReadBindingV1 {
+    Version {
+        version: String,
+        etag: Option<String>,
+    },
+    Etag {
+        etag: String,
+    },
+}
+
+impl RawObjectReadBindingV1 {
+    pub(crate) fn version(&self) -> Option<&str> {
+        match self {
+            Self::Version { version, .. } => Some(version),
+            Self::Etag { .. } => None,
+        }
+    }
+
+    pub(crate) fn etag(&self) -> Option<&str> {
+        match self {
+            Self::Version { etag, .. } => etag.as_deref(),
+            Self::Etag { etag } => Some(etag),
+        }
+    }
+}
+
+/// Result of proving whether one exact storage object can be read by identity.
+///
+/// `Unbound` deliberately carries no bytes: a backend without version- or
+/// ETag-bound reads cannot contribute object content to a complete plan.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RawObjectReadV1 {
+    Bound(RawObjectSnapshotV1),
+    Unbound,
+}
+
+/// Exact bytes and identity from one read-only storage-object observation.
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct RawObjectSnapshotV1 {
+    raw_bytes: Vec<u8>,
+    raw_blake3: blake3::Hash,
+    binding: RawObjectReadBindingV1,
+}
+
+impl std::fmt::Debug for RawObjectSnapshotV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RawObjectSnapshotV1")
+            .field("raw_bytes_len", &self.raw_bytes.len())
+            .field("raw_blake3", &self.raw_blake3)
+            .field("binding", &self.binding)
+            .finish()
+    }
+}
+
+impl RawObjectSnapshotV1 {
+    pub(crate) fn raw_bytes(&self) -> &[u8] {
+        &self.raw_bytes
+    }
+
+    pub(crate) const fn binding(&self) -> &RawObjectReadBindingV1 {
+        &self.binding
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<u8>, blake3::Hash, RawObjectReadBindingV1) {
+        (self.raw_bytes, self.raw_blake3, self.binding)
+    }
+}
+
 /// Exact index-object identity carried from conflict resolution into publish.
 /// Production variants are backed by storage-native conditional writes; the
 /// in-memory variant exists only so unit tests can exercise the state machine.
@@ -1561,7 +1633,7 @@ fn memory_index_write_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
-fn validate_canonical_namespace_remote_prefix(remote_prefix: &str) -> Result<&str> {
+pub(crate) fn validate_canonical_namespace_remote_prefix(remote_prefix: &str) -> Result<&str> {
     anyhow::ensure!(
         remote_prefix == remote_prefix.trim_end_matches('/'),
         "portable namespace remote prefix must be canonical without a trailing slash: {remote_prefix:?}"
@@ -1914,6 +1986,172 @@ pub(crate) async fn write_immutable_manifest_object_if_absent(
         "existing immutable manifest object does not match its byte address",
     )
     .await
+}
+
+/// Read one exact storage object without invoking compatibility recovery or
+/// any write-capability probe.
+///
+/// Version-bound reads are preferred, followed by ETag-bound reads. A backend
+/// without either identity is represented explicitly as `Unbound`; callers
+/// must not silently promote that observation into a complete plan.
+pub(crate) async fn read_raw_object_snapshot_v1(
+    op: &Operator,
+    object_key: &str,
+    max_bytes: u64,
+) -> Result<Option<RawObjectReadV1>> {
+    anyhow::ensure!(
+        max_bytes > 0,
+        "read-only object snapshot bound must be nonzero: {object_key}"
+    );
+    let metadata = match op.stat(object_key).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(anyhow::anyhow!(error))
+                .with_context(|| format!("statting read-only object snapshot: {object_key}"));
+        }
+    };
+    anyhow::ensure!(
+        metadata.is_file(),
+        "read-only object snapshot is not a file: {object_key}"
+    );
+    anyhow::ensure!(
+        metadata.content_length() > 0,
+        "read-only object snapshot is empty: {object_key}"
+    );
+    anyhow::ensure!(
+        metadata.content_length() <= max_bytes,
+        "read-only object snapshot exceeds {max_bytes} bytes: {object_key}"
+    );
+
+    let etag = metadata
+        .etag()
+        .filter(|etag| !etag.is_empty())
+        .map(str::to_owned);
+    let version = metadata
+        .version()
+        .filter(|version| !version.is_empty() && *version != "null")
+        .map(str::to_owned);
+    let capability = op.info().full_capability();
+    let version = version.filter(|_| capability.read_with_version);
+    let etag_for_read = etag
+        .as_deref()
+        .filter(|_| capability.read_with_if_match)
+        .map(str::to_owned);
+    if version.is_none() && etag_for_read.is_none() {
+        return Ok(Some(RawObjectReadV1::Unbound));
+    }
+    let (reader_result, binding) = if let Some(version) = version.as_deref() {
+        let reader = if let Some(etag) = etag_for_read.as_deref() {
+            op.reader_with(object_key)
+                .version(version)
+                .if_match(etag)
+                .await
+        } else {
+            op.reader_with(object_key).version(version).await
+        };
+        (
+            reader,
+            RawObjectReadBindingV1::Version {
+                version: version.to_owned(),
+                etag: etag.clone(),
+            },
+        )
+    } else if let Some(etag) = etag_for_read.as_deref() {
+        (
+            op.reader_with(object_key).if_match(etag).await,
+            RawObjectReadBindingV1::Etag {
+                etag: etag.to_owned(),
+            },
+        )
+    } else {
+        unreachable!("unbound storage reads return before fetching object bytes")
+    };
+
+    let reader = match reader_result {
+        Ok(reader) => reader,
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::NotFound | ErrorKind::ConditionNotMatch
+            ) =>
+        {
+            bail!("object changed after read-only snapshot stat: {object_key}");
+        }
+        Err(error) => {
+            return Err(anyhow::anyhow!(error))
+                .with_context(|| format!("reading read-only object snapshot: {object_key}"));
+        }
+    };
+    // An exact `0..stat_length` range can silently accept a truncated prefix
+    // if a broken provider reuses an ETag while the object grows. Keep the
+    // conditional identity on one open-ended reader, consume it incrementally,
+    // and retain at most max+1 bytes so growth is detected without unbounded
+    // application allocation.
+    let mut stream = match reader.into_stream(..).await {
+        Ok(stream) => stream,
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::NotFound | ErrorKind::ConditionNotMatch
+            ) =>
+        {
+            bail!("object changed after read-only snapshot stat: {object_key}");
+        }
+        Err(error) => {
+            return Err(anyhow::anyhow!(error))
+                .with_context(|| format!("opening read-only object snapshot: {object_key}"));
+        }
+    };
+    let max_plus_one = max_bytes
+        .checked_add(1)
+        .context("read-only object snapshot bound cannot be incremented")?;
+    let max_bytes_usize = usize::try_from(max_bytes)
+        .context("read-only object snapshot bound does not fit memory")?;
+    let max_plus_one_usize = usize::try_from(max_plus_one)
+        .context("read-only object snapshot detection bound does not fit memory")?;
+    let initial_capacity = usize::try_from(metadata.content_length())
+        .context("read-only object metadata length does not fit memory")?;
+    let mut raw_bytes = Vec::with_capacity(initial_capacity);
+    loop {
+        let buffer = match stream.try_next().await {
+            Ok(Some(buffer)) => buffer,
+            Ok(None) => break,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    ErrorKind::NotFound | ErrorKind::ConditionNotMatch
+                ) =>
+            {
+                bail!("object changed after read-only snapshot stat: {object_key}");
+            }
+            Err(error) => {
+                return Err(anyhow::anyhow!(error))
+                    .with_context(|| format!("streaming read-only object snapshot: {object_key}"));
+            }
+        };
+        for chunk in buffer {
+            let retained = raw_bytes.len();
+            let remaining = max_plus_one_usize.saturating_sub(retained);
+            let copy_len = remaining.min(chunk.len());
+            raw_bytes.extend_from_slice(&chunk[..copy_len]);
+            anyhow::ensure!(
+                raw_bytes.len() <= max_bytes_usize && copy_len == chunk.len(),
+                "object exceeded read-only snapshot bound while reading: {object_key}"
+            );
+        }
+    }
+    anyhow::ensure!(
+        u64::try_from(raw_bytes.len()).context("read-only object length does not fit u64")?
+            == metadata.content_length(),
+        "object length changed during read-only snapshot: {object_key}"
+    );
+    let raw_blake3 = blake3::hash(&raw_bytes);
+    Ok(Some(RawObjectReadV1::Bound(RawObjectSnapshotV1 {
+        raw_bytes,
+        raw_blake3,
+        binding,
+    })))
 }
 
 async fn read_raw_index_snapshot_from_store(
@@ -2569,13 +2807,157 @@ mod tests {
         resolve_visible_index_entry_with_hook, validate_canonical_rel_path, IndexEntryState,
         ParsedIndexEntry, PendingIndexEntry, RemoteIndexEntry, VersionedIndexEntry,
     };
+    use opendal::raw::{Access, AccessorInfo, OpRead, OpStat, RpRead, RpStat};
     use opendal::services::Memory;
-    use opendal::Operator;
+    use opendal::{Buffer, Capability, EntryMode, ErrorKind, Metadata, Operator, OperatorBuilder};
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
 
     fn memory_op() -> Operator {
         let op = Operator::new(Memory::default()).unwrap().finish();
         super::register_memory_index_emulation_for_tests(&op).unwrap();
         op
+    }
+
+    #[derive(Clone, Debug)]
+    struct SnapshotTestObject {
+        bytes: Vec<u8>,
+        etag: Option<String>,
+        version: Option<String>,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct SnapshotTestRead {
+        offset: u64,
+        size: Option<u64>,
+        if_match: Option<String>,
+        version: Option<String>,
+    }
+
+    #[derive(Debug)]
+    struct SnapshotTestState {
+        current: SnapshotTestObject,
+        versions: BTreeMap<String, SnapshotTestObject>,
+        replace_after_next_stat: Option<SnapshotTestObject>,
+        reads: Vec<SnapshotTestRead>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct SnapshotTestBackend {
+        state: Arc<Mutex<SnapshotTestState>>,
+        info: Arc<AccessorInfo>,
+    }
+
+    impl SnapshotTestBackend {
+        fn reads(&self) -> Vec<SnapshotTestRead> {
+            self.state.lock().unwrap().reads.clone()
+        }
+    }
+
+    impl Access for SnapshotTestBackend {
+        type Reader = Buffer;
+        type Writer = ();
+        type Lister = ();
+        type Deleter = ();
+
+        fn info(&self) -> Arc<AccessorInfo> {
+            self.info.clone()
+        }
+
+        async fn stat(&self, _path: &str, _: OpStat) -> opendal::Result<RpStat> {
+            let mut state = self.state.lock().unwrap();
+            let observed = state.current.clone();
+            if let Some(replacement) = state.replace_after_next_stat.take() {
+                state.current = replacement;
+            }
+            let mut metadata =
+                Metadata::new(EntryMode::FILE).with_content_length(observed.bytes.len() as u64);
+            if let Some(etag) = observed.etag {
+                metadata = metadata.with_etag(etag);
+            }
+            if let Some(version) = observed.version {
+                metadata = metadata.with_version(version);
+            }
+            Ok(RpStat::new(metadata))
+        }
+
+        async fn read(&self, _path: &str, args: OpRead) -> opendal::Result<(RpRead, Buffer)> {
+            let mut state = self.state.lock().unwrap();
+            let range = args.range();
+            state.reads.push(SnapshotTestRead {
+                offset: range.offset(),
+                size: range.size(),
+                if_match: args.if_match().map(str::to_owned),
+                version: args.version().map(str::to_owned),
+            });
+            let selected = match args.version() {
+                Some(version) => state.versions.get(version).cloned(),
+                None => Some(state.current.clone()),
+            }
+            .ok_or_else(|| {
+                opendal::Error::new(ErrorKind::NotFound, "snapshot-test version is missing")
+            })?;
+            if args
+                .if_match()
+                .is_some_and(|expected| selected.etag.as_deref() != Some(expected))
+            {
+                return Err(opendal::Error::new(
+                    ErrorKind::ConditionNotMatch,
+                    "snapshot-test rejected stale ETag",
+                ));
+            }
+
+            let start = usize::try_from(range.offset()).unwrap_or(usize::MAX);
+            let requested = range
+                .size()
+                .and_then(|size| usize::try_from(size).ok())
+                .unwrap_or(usize::MAX);
+            let end = start.saturating_add(requested).min(selected.bytes.len());
+            let bytes = if start <= end {
+                selected.bytes[start..end].to_vec()
+            } else {
+                Vec::new()
+            };
+            Ok((
+                RpRead::new().with_size(Some(bytes.len() as u64)),
+                Buffer::from(bytes),
+            ))
+        }
+    }
+
+    fn snapshot_test_operator(
+        current: SnapshotTestObject,
+        replacement: Option<SnapshotTestObject>,
+        advertise_version: bool,
+        advertise_etag: bool,
+    ) -> (Operator, SnapshotTestBackend) {
+        let mut versions = BTreeMap::new();
+        for object in std::iter::once(&current).chain(replacement.as_ref()) {
+            if let Some(version) = object.version.as_ref() {
+                versions.insert(version.clone(), object.clone());
+            }
+        }
+        let info = AccessorInfo::default();
+        info.set_scheme("snapshot-test")
+            .set_root("/")
+            .set_name("snapshot-test")
+            .set_native_capability(Capability {
+                stat: true,
+                read: true,
+                read_with_if_match: advertise_etag,
+                read_with_version: advertise_version,
+                ..Default::default()
+            });
+        let backend = SnapshotTestBackend {
+            state: Arc::new(Mutex::new(SnapshotTestState {
+                current,
+                versions,
+                replace_after_next_stat: replacement,
+                reads: Vec::new(),
+            })),
+            info: Arc::new(info),
+        };
+        (OperatorBuilder::new(backend.clone()).finish(), backend)
     }
 
     async fn write_committed_index_entry(
@@ -2619,6 +3001,197 @@ mod tests {
         .unwrap_err();
         assert!(format!("{error:#}").contains("verifying conditional-write semantics"));
         assert!(!unregistered.exists("data/index/doc.txt").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn read_only_raw_object_snapshot_is_exact_unbound_and_non_mutating() {
+        let op = memory_op();
+        assert!(super::read_raw_object_snapshot_v1(&op, "object", 1024)
+            .await
+            .unwrap()
+            .is_none());
+
+        let expected = b"raw-object-sentinel";
+        op.write("object", expected.to_vec()).await.unwrap();
+        let before = op.read("object").await.unwrap().to_vec();
+        assert_eq!(
+            super::read_raw_object_snapshot_v1(&op, "object", 1024)
+                .await
+                .unwrap(),
+            Some(super::RawObjectReadV1::Unbound)
+        );
+        assert_eq!(op.read("object").await.unwrap().to_vec(), before);
+    }
+
+    #[tokio::test]
+    async fn read_only_raw_object_snapshot_rejects_oversized_metadata_before_read() {
+        let op = memory_op();
+        op.write("object", b"five".to_vec()).await.unwrap();
+        let error = super::read_raw_object_snapshot_v1(&op, "object", 3)
+            .await
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("exceeds 3 bytes"));
+    }
+
+    #[tokio::test]
+    async fn read_only_raw_object_snapshot_prefers_version_and_pins_stat_generation() {
+        let (op, backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"old".to_vec(),
+                etag: Some("etag-1".to_owned()),
+                version: Some("version-1".to_owned()),
+            },
+            Some(SnapshotTestObject {
+                bytes: b"newer".to_vec(),
+                etag: Some("etag-2".to_owned()),
+                version: Some("version-2".to_owned()),
+            }),
+            true,
+            true,
+        );
+
+        let snapshot = match super::read_raw_object_snapshot_v1(&op, "object", 32)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            super::RawObjectReadV1::Bound(snapshot) => snapshot,
+            super::RawObjectReadV1::Unbound => panic!("expected version-bound snapshot"),
+        };
+        assert_eq!(snapshot.raw_bytes(), b"old");
+        assert_eq!(
+            snapshot.binding(),
+            &super::RawObjectReadBindingV1::Version {
+                version: "version-1".to_owned(),
+                etag: Some("etag-1".to_owned()),
+            }
+        );
+        assert_eq!(
+            backend.reads(),
+            vec![SnapshotTestRead {
+                offset: 0,
+                size: None,
+                if_match: Some("etag-1".to_owned()),
+                version: Some("version-1".to_owned()),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn read_only_raw_object_snapshot_uses_etag_and_rejects_stat_read_mutation() {
+        let stable = SnapshotTestObject {
+            bytes: b"same".to_vec(),
+            etag: Some("etag-1".to_owned()),
+            version: None,
+        };
+        let (op, _) = snapshot_test_operator(stable.clone(), None, false, true);
+        let snapshot = match super::read_raw_object_snapshot_v1(&op, "object", 16)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            super::RawObjectReadV1::Bound(snapshot) => snapshot,
+            super::RawObjectReadV1::Unbound => panic!("expected ETag-bound snapshot"),
+        };
+        assert_eq!(
+            snapshot.binding(),
+            &super::RawObjectReadBindingV1::Etag {
+                etag: "etag-1".to_owned()
+            }
+        );
+
+        let (mutated_op, _) = snapshot_test_operator(
+            stable,
+            Some(SnapshotTestObject {
+                bytes: b"diff".to_vec(),
+                etag: Some("etag-2".to_owned()),
+                version: None,
+            }),
+            false,
+            true,
+        );
+        let error = super::read_raw_object_snapshot_v1(&mutated_op, "object", 16)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("changed after read-only snapshot stat"),
+            "{error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_only_raw_object_snapshot_rejects_oversize_and_same_identity_growth() {
+        let (oversized_op, oversized_backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: vec![0; 5],
+                etag: Some("etag-1".to_owned()),
+                version: None,
+            },
+            None,
+            false,
+            true,
+        );
+        assert!(
+            super::read_raw_object_snapshot_v1(&oversized_op, "object", 4)
+                .await
+                .is_err()
+        );
+        assert!(oversized_backend.reads().is_empty());
+
+        let (bounded_op, bounded_backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: vec![0; 4],
+                etag: Some("same-etag".to_owned()),
+                version: None,
+            },
+            None,
+            false,
+            true,
+        );
+        let snapshot = super::read_raw_object_snapshot_v1(&bounded_op, "object", 4)
+            .await
+            .unwrap();
+        assert!(matches!(snapshot, Some(super::RawObjectReadV1::Bound(_))));
+        assert_eq!(
+            bounded_backend.reads(),
+            vec![SnapshotTestRead {
+                offset: 0,
+                size: None,
+                if_match: Some("same-etag".to_owned()),
+                version: None,
+            }]
+        );
+
+        let (grown_op, grown_backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: vec![0; 4],
+                etag: Some("reused-etag".to_owned()),
+                version: None,
+            },
+            Some(SnapshotTestObject {
+                bytes: vec![0; 128],
+                etag: Some("reused-etag".to_owned()),
+                version: None,
+            }),
+            false,
+            true,
+        );
+        let error = super::read_raw_object_snapshot_v1(&grown_op, "object", 4)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("exceeded read-only snapshot bound"),
+            "{error:#}"
+        );
+        assert_eq!(
+            grown_backend.reads(),
+            vec![SnapshotTestRead {
+                offset: 0,
+                size: None,
+                if_match: Some("reused-etag".to_owned()),
+                version: None,
+            }]
+        );
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/index_entry.rs
+++ b/crates/tcfs-sync/src/index_entry.rs
@@ -2039,16 +2039,33 @@ pub(crate) async fn write_immutable_manifest_object_if_absent(
     .await
 }
 
-/// Read one exact storage object without invoking compatibility recovery or
-/// any write-capability probe.
-///
-/// Version-bound reads are preferred, followed by ETag-bound reads. A backend
-/// without either identity is represented explicitly as `Unbound`; callers
-/// must not silently promote that observation into a complete plan.
-pub(crate) async fn read_raw_object_snapshot_v1(
+#[derive(Clone, Copy)]
+enum RawObjectSnapshotReadModeV1 {
+    PreferVersion,
+    CurrentEtag,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("object changed after read-only snapshot stat: {object_key}")]
+pub(crate) struct RawObjectChangedDuringReadV1 {
+    object_key: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "read-only object snapshot exceeds {max_bytes} bytes ({observed_bytes} observed): {object_key}"
+)]
+pub(crate) struct RawObjectSnapshotTooLargeV1 {
+    object_key: String,
+    observed_bytes: u64,
+    max_bytes: u64,
+}
+
+async fn read_raw_object_snapshot_with_mode_v1(
     op: &Operator,
     object_key: &str,
     max_bytes: u64,
+    mode: RawObjectSnapshotReadModeV1,
 ) -> Result<Option<RawObjectReadV1>> {
     let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
     anyhow::ensure!(
@@ -2076,10 +2093,14 @@ pub(crate) async fn read_raw_object_snapshot_v1(
         metadata.content_length() > 0,
         "read-only object snapshot is empty: {object_key}"
     );
-    anyhow::ensure!(
-        metadata.content_length() <= max_bytes,
-        "read-only object snapshot exceeds {max_bytes} bytes: {object_key}"
-    );
+    if metadata.content_length() > max_bytes {
+        return Err(RawObjectSnapshotTooLargeV1 {
+            object_key: object_key.to_owned(),
+            observed_bytes: metadata.content_length(),
+            max_bytes,
+        }
+        .into());
+    }
 
     let checked_binding_token = |value: Option<&str>,
                                  description: &str|
@@ -2096,7 +2117,8 @@ pub(crate) async fn read_raw_object_snapshot_v1(
     };
     let etag = checked_binding_token(metadata.etag(), "object ETag")?;
     let version = checked_binding_token(metadata.version(), "object version")?
-        .filter(|version| version != "null");
+        .filter(|version| version != "null")
+        .filter(|_| matches!(mode, RawObjectSnapshotReadModeV1::PreferVersion));
     let capability = op.info().full_capability();
     let version = version.filter(|_| capability.read_with_version);
     let etag_for_read = etag
@@ -2141,7 +2163,10 @@ pub(crate) async fn read_raw_object_snapshot_v1(
                 ErrorKind::NotFound | ErrorKind::ConditionNotMatch
             ) =>
         {
-            bail!("object changed after read-only snapshot stat: {object_key}");
+            return Err(RawObjectChangedDuringReadV1 {
+                object_key: object_key.to_owned(),
+            }
+            .into());
         }
         Err(error) => {
             return Err(anyhow::anyhow!(error))
@@ -2161,7 +2186,10 @@ pub(crate) async fn read_raw_object_snapshot_v1(
                 ErrorKind::NotFound | ErrorKind::ConditionNotMatch
             ) =>
         {
-            bail!("object changed after read-only snapshot stat: {object_key}");
+            return Err(RawObjectChangedDuringReadV1 {
+                object_key: object_key.to_owned(),
+            }
+            .into());
         }
         Err(error) => {
             return Err(anyhow::anyhow!(error))
@@ -2188,7 +2216,10 @@ pub(crate) async fn read_raw_object_snapshot_v1(
                     ErrorKind::NotFound | ErrorKind::ConditionNotMatch
                 ) =>
             {
-                bail!("object changed after read-only snapshot stat: {object_key}");
+                return Err(RawObjectChangedDuringReadV1 {
+                    object_key: object_key.to_owned(),
+                }
+                .into());
             }
             Err(error) => {
                 return Err(anyhow::anyhow!(error))
@@ -2200,23 +2231,68 @@ pub(crate) async fn read_raw_object_snapshot_v1(
             let remaining = max_plus_one_usize.saturating_sub(retained);
             let copy_len = remaining.min(chunk.len());
             raw_bytes.extend_from_slice(&chunk[..copy_len]);
-            anyhow::ensure!(
-                raw_bytes.len() <= max_bytes_usize && copy_len == chunk.len(),
-                "object exceeded read-only snapshot bound while reading: {object_key}"
-            );
+            if raw_bytes.len() > max_bytes_usize || copy_len != chunk.len() {
+                return Err(RawObjectChangedDuringReadV1 {
+                    object_key: object_key.to_owned(),
+                }
+                .into());
+            }
         }
     }
-    anyhow::ensure!(
-        u64::try_from(raw_bytes.len()).context("read-only object length does not fit u64")?
-            == metadata.content_length(),
-        "object length changed during read-only snapshot: {object_key}"
-    );
+    if u64::try_from(raw_bytes.len()).context("read-only object length does not fit u64")?
+        != metadata.content_length()
+    {
+        return Err(RawObjectChangedDuringReadV1 {
+            object_key: object_key.to_owned(),
+        }
+        .into());
+    }
     let raw_blake3 = blake3::hash(&raw_bytes);
     Ok(Some(RawObjectReadV1::Bound(RawObjectSnapshotV1 {
         raw_bytes,
         raw_blake3,
         binding,
     })))
+}
+
+/// Read one exact storage object without invoking compatibility recovery or
+/// any write-capability probe.
+///
+/// Version-bound reads are preferred, followed by ETag-bound reads. A backend
+/// without either identity is represented explicitly as `Unbound`; callers
+/// must not silently promote that observation into a complete plan.
+pub(crate) async fn read_raw_object_snapshot_v1(
+    op: &Operator,
+    object_key: &str,
+    max_bytes: u64,
+) -> Result<Option<RawObjectReadV1>> {
+    read_raw_object_snapshot_with_mode_v1(
+        op,
+        object_key,
+        max_bytes,
+        RawObjectSnapshotReadModeV1::PreferVersion,
+    )
+    .await
+}
+
+/// Read the current value of one mutable object by ETag.
+///
+/// Unlike [`read_raw_object_snapshot_v1`], this never selects a historical
+/// version after the initial stat. Catalog HEAD acquisition must prove that the
+/// bytes were current at the conditional read, then compare a second current
+/// read after the immutable closure is drained.
+pub(crate) async fn read_current_raw_object_snapshot_v1(
+    op: &Operator,
+    object_key: &str,
+    max_bytes: u64,
+) -> Result<Option<RawObjectReadV1>> {
+    read_raw_object_snapshot_with_mode_v1(
+        op,
+        object_key,
+        max_bytes,
+        RawObjectSnapshotReadModeV1::CurrentEtag,
+    )
+    .await
 }
 
 async fn read_raw_index_snapshot_from_store(
@@ -3179,6 +3255,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn current_raw_object_snapshot_uses_current_etag_not_historical_version() {
+        let (op, backend) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"current".to_vec(),
+                etag: Some("etag-1".to_owned()),
+                version: Some("version-1".to_owned()),
+            },
+            None,
+            true,
+            true,
+        );
+
+        let snapshot = match super::read_current_raw_object_snapshot_v1(&op, "head", 32)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            super::RawObjectReadV1::Bound(snapshot) => snapshot,
+            super::RawObjectReadV1::Unbound => panic!("expected current ETag-bound snapshot"),
+        };
+        assert_eq!(snapshot.raw_bytes(), b"current");
+        assert_eq!(
+            snapshot.binding(),
+            &super::RawObjectReadBindingV1::Etag {
+                etag: "etag-1".to_owned()
+            }
+        );
+        assert_eq!(
+            backend.reads(),
+            vec![SnapshotTestRead {
+                offset: 0,
+                size: None,
+                if_match: Some("etag-1".to_owned()),
+                version: None,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn current_raw_object_snapshot_types_current_head_movement() {
+        let (op, _) = snapshot_test_operator(
+            SnapshotTestObject {
+                bytes: b"head-a".to_vec(),
+                etag: Some("etag-a".to_owned()),
+                version: Some("version-a".to_owned()),
+            },
+            Some(SnapshotTestObject {
+                bytes: b"head-b".to_vec(),
+                etag: Some("etag-b".to_owned()),
+                version: Some("version-b".to_owned()),
+            }),
+            true,
+            true,
+        );
+        let error = super::read_current_raw_object_snapshot_v1(&op, "head", 32)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .downcast_ref::<super::RawObjectChangedDuringReadV1>()
+                .is_some(),
+            "{error:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn read_only_raw_object_snapshot_uses_etag_and_rejects_stat_read_mutation() {
         let stable = SnapshotTestObject {
             bytes: b"same".to_vec(),
@@ -3232,10 +3374,14 @@ mod tests {
             false,
             true,
         );
+        let error = super::read_raw_object_snapshot_v1(&oversized_op, "object", 4)
+            .await
+            .unwrap_err();
         assert!(
-            super::read_raw_object_snapshot_v1(&oversized_op, "object", 4)
-                .await
-                .is_err()
+            error
+                .downcast_ref::<super::RawObjectSnapshotTooLargeV1>()
+                .is_some(),
+            "{error:#}"
         );
         assert!(oversized_backend.reads().is_empty());
 
@@ -3281,7 +3427,9 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            format!("{error:#}").contains("exceeded read-only snapshot bound"),
+            error
+                .downcast_ref::<super::RawObjectChangedDuringReadV1>()
+                .is_some(),
             "{error:#}"
         );
         assert_eq!(

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -22,6 +22,11 @@ pub mod registered_reconcile;
 // list+bind work in each non-atomic source-only evidence pass.
 #[allow(dead_code)]
 pub(crate) mod registered_remote_observation;
+// Held-window composition of selected-root observation evidence. This remains
+// namespace-safety history only: it has no plan digest, action conversion, or
+// serialization surface.
+#[allow(dead_code)]
+pub(crate) mod registered_source_composition;
 pub mod scheduler;
 pub mod state;
 pub mod watcher;

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -12,6 +12,7 @@ pub mod nats;
 pub mod path_acl;
 pub mod policy;
 pub mod reconcile;
+pub mod registered_reconcile;
 pub mod scheduler;
 pub mod state;
 pub mod watcher;

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -17,6 +17,11 @@ pub mod reconcile;
 #[allow(dead_code)]
 pub(crate) mod registered_local_snapshot;
 pub mod registered_reconcile;
+// Diagnostic key-only repeated listing; never a complete namespace snapshot
+// or plan-digest input. The bound reader must discard this artifact and rerun
+// fresh list+bind work inside each complete source-only pass.
+#[allow(dead_code)]
+pub(crate) mod registered_remote_observation;
 pub mod scheduler;
 pub mod state;
 pub mod watcher;

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -17,9 +17,9 @@ pub mod reconcile;
 #[allow(dead_code)]
 pub(crate) mod registered_local_snapshot;
 pub mod registered_reconcile;
-// Diagnostic key-only repeated listing; never a complete namespace snapshot
-// or plan-digest input. The bound reader must discard this artifact and rerun
-// fresh list+bind work inside each complete source-only pass.
+// Strict remote-observation stages. The diagnostic key-only artifact is never
+// a snapshot or plan input; the bound reader independently reruns fresh
+// list+bind work in each non-atomic source-only evidence pass.
 #[allow(dead_code)]
 pub(crate) mod registered_remote_observation;
 pub mod scheduler;

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -32,9 +32,10 @@ pub(crate) mod registered_remote_observation;
 // before the artifact can satisfy complete-or-no-digest.
 #[allow(dead_code)]
 pub(crate) mod registered_remote_catalog;
-// Held-window composition of selected-root observation evidence. This remains
-// namespace-safety history only: it has no plan digest, action conversion, or
-// serialization surface.
+// Held-window composition of selected-root diagnostic and catalog-bound
+// observation evidence. Even the internally closed catalog revision lacks
+// writer-fence/bootstrap/currentness authority, so neither path has a plan
+// digest, action conversion, or serialization surface.
 #[allow(dead_code)]
 pub(crate) mod registered_source_composition;
 pub mod scheduler;

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -22,6 +22,11 @@ pub mod registered_reconcile;
 // list+bind work in each non-atomic source-only evidence pass.
 #[allow(dead_code)]
 pub(crate) mod registered_remote_observation;
+// Immutable catalog-head closure. This validates only the catalog inventory;
+// writer fencing, bootstrap truth, and every named object remain mandatory
+// before the artifact can satisfy complete-or-no-digest.
+#[allow(dead_code)]
+pub(crate) mod registered_remote_catalog;
 // Held-window composition of selected-root observation evidence. This remains
 // namespace-safety history only: it has no plan digest, action conversion, or
 // serialization surface.

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -12,6 +12,10 @@ pub mod nats;
 pub mod path_acl;
 pub mod policy;
 pub mod reconcile;
+// Internal acquisition artifact until a held root anchor revalidates inventory C
+// across state/remote reads and is the only path that can mint a complete plan.
+#[allow(dead_code)]
+pub(crate) mod registered_local_snapshot;
 pub mod registered_reconcile;
 pub mod scheduler;
 pub mod state;

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -12,6 +12,11 @@ pub mod nats;
 pub mod path_acl;
 pub mod policy;
 pub mod reconcile;
+// Descriptor-held, two-pass GitRaw topology/ref evidence. This is a bounded
+// local prerequisite only and has no digest, plan, action, or serialization
+// surface.
+#[allow(dead_code)]
+pub(crate) mod registered_git_topology;
 // Internal acquisition artifact until a held root anchor revalidates inventory C
 // across state/remote reads and is the only path that can mint a complete plan.
 #[allow(dead_code)]

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -335,8 +335,11 @@ async fn validate_pull_manifests_for_execution(
         engine::validate_indexed_manifest_entry_binding(&bytes, manifest_hash, &entry, rel_path)
             .with_context(|| format!("binding pull manifest before mutation: {manifest_path}"))?;
         if let Some(target) = expected_symlink_target.as_deref() {
-            engine::validate_indexed_symlink_target(&local_root.join(rel_path), target)
-                .with_context(|| format!("validating pull symlink target: {rel_path}"))?;
+            engine::validate_restored_symlink_target_for_physical_path(
+                &local_root.join(rel_path),
+                target,
+            )
+            .with_context(|| format!("validating pull symlink target: {rel_path}"))?;
         }
     }
     Ok(())
@@ -3516,12 +3519,15 @@ fn parse_reconcile_manifest_causality(
                 .symlink_target
                 .as_deref()
                 .context("cross-kind remote symlink index entry is missing its target")?;
-            engine::validate_indexed_symlink_target(local_path, expected_target)
+            engine::validate_restored_symlink_target_for_physical_path(local_path, expected_target)
                 .context("validating cross-kind indexed symlink target")?;
             let manifest = SymlinkManifest::from_bytes(bytes)
                 .context("parsing cross-kind remote symlink manifest")?;
-            engine::validate_indexed_symlink_target(local_path, &manifest.symlink_target)
-                .context("validating cross-kind manifest symlink target")?;
+            engine::validate_restored_symlink_target_for_physical_path(
+                local_path,
+                &manifest.symlink_target,
+            )
+            .context("validating cross-kind manifest symlink target")?;
             anyhow::ensure!(
                 manifest.symlink_target == expected_target,
                 "cross-kind remote symlink manifest target does not match index at {rel_path:?}"
@@ -3566,7 +3572,7 @@ async fn compare_both_exist_cross_kind(
                 local_path.display()
             )
         })?;
-        engine::validate_indexed_symlink_target(local_path, &target)
+        engine::validate_restored_symlink_target_for_physical_path(local_path, &target)
             .context("validating local symlink target during type transition")?;
         (
             RemoteEntryKind::Symlink,
@@ -4124,9 +4130,9 @@ async fn compare_both_exist_symlink(
     // Read the local link target without following it.
     let local_target = crate::engine::read_symlink_target_text(local_path)
         .with_context(|| format!("reading local symlink target: {}", local_path.display()))?;
-    engine::validate_indexed_symlink_target(local_path, &local_target)
+    engine::validate_restored_symlink_target_for_physical_path(local_path, &local_target)
         .context("validating local symlink target before reconciliation")?;
-    engine::validate_indexed_symlink_target(local_path, expected_target)
+    engine::validate_restored_symlink_target_for_physical_path(local_path, expected_target)
         .context("validating indexed symlink target before reconciliation")?;
     let local_hash = crate::engine::symlink_manifest_hash(&local_target);
     let local_vclock = tracked.map(|s| s.vclock.clone()).unwrap_or_default();
@@ -4156,8 +4162,11 @@ async fn compare_both_exist_symlink(
     })?;
     let remote_manifest = SymlinkManifest::from_bytes(&remote_bytes)
         .with_context(|| format!("parsing remote symlink manifest: {manifest_path}"))?;
-    engine::validate_indexed_symlink_target(local_path, &remote_manifest.symlink_target)
-        .context("validating manifest symlink target before reconciliation")?;
+    engine::validate_restored_symlink_target_for_physical_path(
+        local_path,
+        &remote_manifest.symlink_target,
+    )
+    .context("validating manifest symlink target before reconciliation")?;
     if remote_manifest.symlink_target != expected_target {
         anyhow::bail!("remote symlink manifest target does not match index at {rel_path:?}");
     }

--- a/crates/tcfs-sync/src/registered_git_topology.rs
+++ b/crates/tcfs-sync/src/registered_git_topology.rs
@@ -1,24 +1,28 @@
 //! Held, bounded Git topology evidence for one `git-raw-v1` root.
 //!
 //! This module proves only that one already-authorized local root exposed the
-//! same ordinary standalone Git topology and canonical ref set in two bounded
-//! observations around the external state/remote read window. It does not
-//! prove remote Git object semantics, fast-forward ancestry, catalog
-//! completeness/currentness, bootstrap safety, continuous stability, or
-//! writer fencing against same-principal swap/restore. The opaque artifact
-//! therefore has no digest, serialization, clone, plan, or action conversion.
+//! same ordinary standalone raw Git metadata topology derived twice from one
+//! bounded, process-owned inventory-A shadow around the external state/remote
+//! read window. No child reopens live config, HEAD, or refs. It does not prove
+//! object presence/kind, remote Git semantics, fast-forward ancestry, catalog
+//! completeness/currentness, bootstrap safety, continuous stability, or an
+//! enduring writer lease. The opaque artifact therefore has no digest,
+//! serialization, clone, plan, or action conversion.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::process::ExitStatus;
+use std::io::{Read, Write};
+use std::process::{ExitStatus, Stdio};
 
 use tcfs_core::config::{RootGitObservationContractV1, RootGitPolicyV1};
 
-use crate::conflict_git::{GitRepoAnchor, HeldGitReadErrorV1, HeldGitReadQueryV1};
+use crate::conflict_git::GitRepoAnchor;
+use crate::git_safety;
 use crate::index_entry::portable_casefold_path;
 use crate::registered_local_snapshot::{
-    PendingStrictLocalSnapshotV1, StrictInitialLocalEntryKindV1,
-    StrictLocalSnapshotIncompleteKindV1, StrictLocalSnapshotIncompleteV1,
+    PendingStrictLocalSnapshotV1, RevalidatedStrictLocalSnapshotV1, StrictInitialLocalEntryKindV1,
+    StrictLocalGitShadowWitnessV1, StrictLocalSnapshotIncompleteKindV1,
+    StrictLocalSnapshotIncompleteV1,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -31,6 +35,7 @@ pub(crate) enum StrictGitRawTopologyIncompleteKindV1 {
     ReferenceMalformed,
     ReferenceResourceLimit,
     ReferenceSetChanged,
+    ImmutableDerivationMismatch,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -72,19 +77,10 @@ pub(crate) enum StrictGitObjectFormatV1 {
     Sha256,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum StrictGitObjectKindV1 {
-    Commit,
-    Tree,
-    Blob,
-    Tag,
-}
-
 #[derive(PartialEq, Eq)]
 pub(crate) struct StrictGitRefPinV1 {
     ref_name: String,
     object_id: String,
-    object_kind: StrictGitObjectKindV1,
     symref_target: Option<String>,
 }
 
@@ -108,7 +104,6 @@ impl fmt::Debug for StrictGitRefPinV1 {
             .debug_struct("StrictGitRefPinV1")
             .field("ref_name", &self.ref_name)
             .field("object_id", &self.object_id)
-            .field("object_kind", &self.object_kind)
             .field("symref_target", &self.symref_target)
             .finish()
     }
@@ -118,7 +113,7 @@ impl fmt::Debug for StrictGitRefPinV1 {
 pub(crate) enum StrictGitHeadPinV1 {
     Symbolic {
         target: String,
-        resolved_object_id: Option<String>,
+        raw_target_object_id: Option<String>,
     },
     Detached {
         object_id: String,
@@ -133,11 +128,12 @@ impl StrictGitHeadPinV1 {
         }
     }
 
-    pub(crate) fn resolved_object_id(&self) -> Option<&str> {
+    pub(crate) fn raw_target_object_id(&self) -> Option<&str> {
         match self {
             Self::Symbolic {
-                resolved_object_id, ..
-            } => resolved_object_id.as_deref(),
+                raw_target_object_id,
+                ..
+            } => raw_target_object_id.as_deref(),
             Self::Detached { object_id } => Some(object_id),
         }
     }
@@ -148,11 +144,11 @@ impl fmt::Debug for StrictGitHeadPinV1 {
         match self {
             Self::Symbolic {
                 target,
-                resolved_object_id,
+                raw_target_object_id,
             } => formatter
                 .debug_struct("Symbolic")
                 .field("target", target)
-                .field("resolved_object_id", resolved_object_id)
+                .field("raw_target_object_id", raw_target_object_id)
                 .finish(),
             Self::Detached { object_id } => formatter
                 .debug_struct("Detached")
@@ -174,7 +170,8 @@ struct StrictGitRawTopologySnapshotV1 {
 pub(crate) struct PendingStrictGitRawTopologyV1 {
     anchor: GitRepoAnchor,
     contract: RootGitObservationContractV1,
-    metadata: GitMetadataInventoryV1,
+    local_acquisition: StrictLocalGitShadowWitnessV1,
+    shadow: GitMetadataShadowV1,
     first: StrictGitRawTopologySnapshotV1,
 }
 
@@ -241,18 +238,21 @@ pub(crate) enum StrictGitRawTopologyBeginV1 {
 }
 
 pub(crate) enum StrictGitRawTopologyFinishV1 {
-    Held(HeldStrictGitRawTopologyV1),
+    Held {
+        topology: HeldStrictGitRawTopologyV1,
+        local: RevalidatedStrictLocalSnapshotV1,
+    },
     Incomplete(StrictGitRawTopologyIncompleteV1),
 }
 
 pub(crate) fn begin_strict_git_raw_topology_v1(
-    local: &PendingStrictLocalSnapshotV1,
+    local: &mut PendingStrictLocalSnapshotV1,
 ) -> StrictGitRawTopologyBeginV1 {
     let profile = local.profile();
     let policy = profile.policy().settings().git_policy();
     let contract = policy.observation_contract();
     if policy != RootGitPolicyV1::StandaloneRawWithFastForwardProofV1
-        || !contract.is_applicable()
+        || contract != RootGitObservationContractV1::TwoPassImmutableRawMetadataV1
         || contract.pass_count() != 2
         || contract.retry_count() != 0
     {
@@ -261,6 +261,16 @@ pub(crate) fn begin_strict_git_raw_topology_v1(
             "select-git-observation-contract",
         ));
     }
+
+    let local_acquisition = match local.issue_git_shadow_witness() {
+        Some(witness) => witness,
+        None => {
+            return StrictGitRawTopologyBeginV1::Incomplete(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::CapabilityOpenFailed,
+                "issue-one-shot-local-git-shadow-witness",
+            ));
+        }
+    };
 
     let directory = match local.try_clone_root_descriptor() {
         Ok(directory) => directory,
@@ -284,13 +294,13 @@ pub(crate) fn begin_strict_git_raw_topology_v1(
         }
     };
     let limits = GitObservationLimitsV1::from(contract);
-    let metadata = match capture_initial_git_metadata_v1(local, &anchor, limits) {
-        Ok(metadata) => metadata,
+    let shadow = match capture_initial_git_metadata_v1(local, &anchor, limits) {
+        Ok(shadow) => shadow,
         Err(incomplete) => {
             return StrictGitRawTopologyBeginV1::Incomplete(incomplete);
         }
     };
-    let first = match read_topology_snapshot_v1(&anchor, &metadata, contract) {
+    let first = match read_topology_snapshot_v1(&shadow, contract) {
         Ok(snapshot) => snapshot,
         Err(incomplete) => {
             return StrictGitRawTopologyBeginV1::Incomplete(incomplete);
@@ -299,33 +309,60 @@ pub(crate) fn begin_strict_git_raw_topology_v1(
     StrictGitRawTopologyBeginV1::Pending(Box::new(PendingStrictGitRawTopologyV1 {
         anchor,
         contract,
-        metadata,
+        local_acquisition,
+        shadow,
         first,
     }))
 }
 
 impl PendingStrictGitRawTopologyV1 {
-    pub(crate) fn revalidate_after_external_reads(self) -> StrictGitRawTopologyFinishV1 {
-        let second = match read_topology_snapshot_v1(&self.anchor, &self.metadata, self.contract) {
+    /// Derive the exact topology again from the same process-owned bytes.
+    ///
+    /// The caller promotes only after inventory C. This method therefore does
+    /// not reopen live config, HEAD, or refs after the local acquisition
+    /// bracket has closed.
+    pub(crate) fn revalidate_after_external_reads(
+        self,
+        local: RevalidatedStrictLocalSnapshotV1,
+    ) -> StrictGitRawTopologyFinishV1 {
+        let Some(local) = local.bind_git_shadow_witness(self.local_acquisition) else {
+            return StrictGitRawTopologyFinishV1::Incomplete(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+                "bind-shadow-to-inventory-c-acquisition",
+            ));
+        };
+        if local.canonical_local_root() != self.anchor.canonical_root() {
+            return StrictGitRawTopologyFinishV1::Incomplete(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+                "bind-shadow-to-inventory-c-root",
+            ));
+        }
+        if self.anchor.revalidate().is_err() {
+            return StrictGitRawTopologyFinishV1::Incomplete(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+                "revalidate-git-capabilities-before-shadow-promotion",
+            ));
+        }
+        let second = match read_topology_snapshot_v1(&self.shadow, self.contract) {
             Ok(snapshot) => snapshot,
-            Err(_) => {
-                return StrictGitRawTopologyFinishV1::Incomplete(incomplete(
-                    StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
-                    "repeat-git-topology-observation",
-                ));
+            Err(incomplete) => {
+                return StrictGitRawTopologyFinishV1::Incomplete(incomplete);
             }
         };
         if self.first != second {
             return StrictGitRawTopologyFinishV1::Incomplete(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
-                "compare-git-topology-passes",
+                StrictGitRawTopologyIncompleteKindV1::ImmutableDerivationMismatch,
+                "compare-immutable-git-metadata-derivations",
             ));
         }
-        StrictGitRawTopologyFinishV1::Held(HeldStrictGitRawTopologyV1 {
-            anchor: self.anchor,
-            contract: self.contract,
-            snapshot: second,
-        })
+        StrictGitRawTopologyFinishV1::Held {
+            topology: HeldStrictGitRawTopologyV1 {
+                anchor: self.anchor,
+                contract: self.contract,
+                snapshot: second,
+            },
+            local,
+        }
     }
 }
 
@@ -362,7 +399,8 @@ enum RawLooseRefValueV1 {
     SymbolicTarget(String),
 }
 
-struct GitMetadataInventoryV1 {
+struct GitMetadataShadowV1 {
+    raw_config: Vec<u8>,
     loose_refs: BTreeMap<String, RawLooseRefValueV1>,
     packed_refs: Option<Vec<u8>>,
     raw_head: Vec<u8>,
@@ -409,7 +447,7 @@ fn capture_initial_git_metadata_v1(
     local: &PendingStrictLocalSnapshotV1,
     anchor: &GitRepoAnchor,
     limits: GitObservationLimitsV1,
-) -> Result<GitMetadataInventoryV1, StrictGitRawTopologyIncompleteV1> {
+) -> Result<GitMetadataShadowV1, StrictGitRawTopologyIncompleteV1> {
     anchor.revalidate().map_err(|_| {
         incomplete(
             StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
@@ -431,7 +469,7 @@ fn capture_initial_git_metadata_v1(
     let mut retained_bytes = 0_u64;
     let mut packed_refs = None;
     let mut raw_head = None;
-    let mut saw_config = false;
+    let mut raw_config = None;
 
     for entry in local.initial_inventory_entries() {
         let raw_path = entry.rel_path();
@@ -478,7 +516,10 @@ fn capture_initial_git_metadata_v1(
                 saw_objects_directory = entry.kind() == StrictInitialLocalEntryKindV1::Directory;
             }
             ".git/config" => {
-                if entry.kind() != StrictInitialLocalEntryKindV1::Regular || entry.size() < 0 {
+                if entry.kind() != StrictInitialLocalEntryKindV1::Regular
+                    || entry.size() < 0
+                    || raw_config.is_some()
+                {
                     return Err(incomplete(
                         StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
                         "require-regular-git-config",
@@ -496,7 +537,13 @@ fn capture_initial_git_metadata_v1(
                         "maximum-git-config-file-bytes",
                     ));
                 }
-                saw_config = true;
+                raw_config = Some(
+                    local
+                        .read_initial_regular_file_bounded(raw_path, limits.max_config_file_bytes)
+                        .map_err(|failure| {
+                            map_held_local_read_failure_v1(failure, "read-held-git-config")
+                        })?,
+                );
             }
             ".git/HEAD" => {
                 if entry.kind() != StrictInitialLocalEntryKindV1::Regular
@@ -736,7 +783,7 @@ fn capture_initial_git_metadata_v1(
     if !saw_git_directory
         || !saw_refs_directory
         || !saw_objects_directory
-        || !saw_config
+        || raw_config.is_none()
         || raw_head.is_none()
     {
         return Err(incomplete(
@@ -750,7 +797,8 @@ fn capture_initial_git_metadata_v1(
             "revalidate-after-raw-git-inventory",
         )
     })?;
-    Ok(GitMetadataInventoryV1 {
+    Ok(GitMetadataShadowV1 {
+        raw_config: raw_config.expect("validated raw config presence"),
         loose_refs,
         packed_refs,
         raw_head: raw_head.expect("validated raw HEAD presence"),
@@ -762,91 +810,244 @@ struct BoundedCommandOutputV1 {
     stdout: Vec<u8>,
 }
 
-fn run_held_git_query_v1(
-    anchor: &GitRepoAnchor,
-    query: HeldGitReadQueryV1,
-    stdout_limit: u64,
-    operation: &'static str,
-) -> Result<BoundedCommandOutputV1, StrictGitRawTopologyIncompleteV1> {
-    match anchor.run_held_read_query(query, stdout_limit) {
-        Ok(output) => {
-            let (status, stdout) = output.into_parts();
-            Ok(BoundedCommandOutputV1 { status, stdout })
-        }
-        Err(HeldGitReadErrorV1::OutputLimit) => Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
-            operation,
-        )),
-        Err(HeldGitReadErrorV1::Failed) => Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
-            operation,
-        )),
-    }
+enum CapturedConfigQueryV1 {
+    List,
+    BooleanValues(&'static str),
 }
 
-fn require_only_false_config_values_v1(
-    output: &BoundedCommandOutputV1,
-    operation: &'static str,
-) -> Result<(), StrictGitRawTopologyIncompleteV1> {
-    match output.status.code() {
-        Some(0) => {
-            let values = output.stdout.strip_suffix(&[0]).ok_or_else(|| {
-                incomplete(
-                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                    operation,
-                )
-            })?;
-            if values.is_empty()
-                || values
-                    .split(|byte| *byte == 0)
-                    .any(|value| value != b"false")
-            {
+fn terminate_captured_config_query_v1(
+    child: &mut std::process::Child,
+    input_writer: std::thread::JoinHandle<std::io::Result<()>>,
+    stderr_reader: std::thread::JoinHandle<std::io::Result<bool>>,
+) {
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = input_writer.join();
+    let _ = stderr_reader.join();
+}
+
+fn run_captured_config_query_v1(
+    raw_config: &[u8],
+    stdout_limit: u64,
+    query: CapturedConfigQueryV1,
+) -> Result<BoundedCommandOutputV1, StrictGitRawTopologyIncompleteV1> {
+    let stdout_limit = usize::try_from(stdout_limit).map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "bound-captured-git-config-output",
+        )
+    })?;
+    let mut command = git_safety::sanitized_git_command();
+    command.args(["config", "--file", "-", "--no-includes", "--null"]);
+    match query {
+        CapturedConfigQueryV1::List => {
+            command.arg("--list");
+        }
+        CapturedConfigQueryV1::BooleanValues(key) => {
+            command.args(["--type=bool", "--get-all", key]);
+        }
+    }
+    #[cfg(unix)]
+    command.current_dir("/");
+    #[cfg(not(unix))]
+    command.current_dir(std::env::temp_dir());
+    #[cfg(windows)]
+    let null_config = "NUL";
+    #[cfg(not(windows))]
+    let null_config = "/dev/null";
+    command
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_SYSTEM", null_config)
+        .env("GIT_CONFIG_GLOBAL", null_config)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+            "spawn-captured-git-config-query",
+        )
+    })?;
+    let mut stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+                "open-captured-git-config-input",
+            ));
+        }
+    };
+    let mut stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+                "open-captured-git-config-output",
+            ));
+        }
+    };
+    let mut stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+                "open-captured-git-config-errors",
+            ));
+        }
+    };
+    let config = raw_config.to_vec();
+    let input_writer = std::thread::Builder::new()
+        .name("tcfs-shadow-config-input".to_owned())
+        .spawn(move || stdin.write_all(&config))
+        .map_err(|_| {
+            let _ = child.kill();
+            let _ = child.wait();
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+                "start-captured-git-config-input",
+            )
+        })?;
+    let stderr_reader = match std::thread::Builder::new()
+        .name("tcfs-shadow-config-stderr".to_owned())
+        .spawn(move || {
+            let mut saw_bytes = false;
+            let mut buffer = [0_u8; 64 * 1024];
+            loop {
+                let read = stderr.read(&mut buffer)?;
+                if read == 0 {
+                    return Ok(saw_bytes);
+                }
+                saw_bytes = true;
+            }
+        }) {
+        Ok(reader) => reader,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = input_writer.join();
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+                "start-captured-git-config-error-reader",
+            ));
+        }
+    };
+
+    let mut retained = Vec::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = match stdout.read(&mut buffer) {
+            Ok(read) => read,
+            Err(_) => {
+                terminate_captured_config_query_v1(&mut child, input_writer, stderr_reader);
                 return Err(incomplete(
-                    StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
-                    operation,
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+                    "read-captured-git-config-output",
                 ));
             }
-            Ok(())
+        };
+        if read == 0 {
+            break;
         }
-        Some(1) if output.stdout.is_empty() => Ok(()),
-        _ => Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
-            operation,
-        )),
+        let Some(next_len) = retained.len().checked_add(read) else {
+            terminate_captured_config_query_v1(&mut child, input_writer, stderr_reader);
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "bound-captured-git-config-output",
+            ));
+        };
+        if next_len > stdout_limit || retained.try_reserve_exact(read).is_err() {
+            terminate_captured_config_query_v1(&mut child, input_writer, stderr_reader);
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "bound-captured-git-config-output",
+            ));
+        }
+        retained.extend_from_slice(&buffer[..read]);
     }
+    let status = match child.wait() {
+        Ok(status) => status,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = input_writer.join();
+            let _ = stderr_reader.join();
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+                "wait-captured-git-config-query",
+            ));
+        }
+    };
+    let input_ok = matches!(input_writer.join(), Ok(Ok(())));
+    let stderr_empty = matches!(stderr_reader.join(), Ok(Ok(false)));
+    if !input_ok || !stderr_empty {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            "run-captured-git-config-query",
+        ));
+    }
+    Ok(BoundedCommandOutputV1 {
+        status,
+        stdout: retained,
+    })
+}
+
+fn captured_config_boolean_values_are_false_v1(
+    raw_config: &[u8],
+    key: &'static str,
+    limits: GitObservationLimitsV1,
+) -> Result<bool, StrictGitRawTopologyIncompleteV1> {
+    let output = run_captured_config_query_v1(
+        raw_config,
+        limits.max_config_file_bytes,
+        CapturedConfigQueryV1::BooleanValues(key),
+    )?;
+    if !output.status.success() || output.stdout.is_empty() || !output.stdout.ends_with(&[0]) {
+        return Ok(false);
+    }
+    Ok(output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|value| !value.is_empty())
+        .all(|value| value == b"false"))
 }
 
 fn validate_bounded_git_routing_v1(
-    anchor: &GitRepoAnchor,
+    raw_config: &[u8],
     limits: GitObservationLimitsV1,
-) -> Result<(), StrictGitRawTopologyIncompleteV1> {
-    let config = run_held_git_query_v1(
-        anchor,
-        HeldGitReadQueryV1::EffectiveConfigNames,
+) -> Result<StrictGitObjectFormatV1, StrictGitRawTopologyIncompleteV1> {
+    let config = run_captured_config_query_v1(
+        raw_config,
         limits.max_command_stdout_bytes,
-        "read-bounded-effective-git-config",
-    )
-    .map_err(|failure| {
-        if failure.kind() == StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit {
-            failure
-        } else {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
-                "read-bounded-effective-git-config",
-            )
-        }
-    })?;
+        CapturedConfigQueryV1::List,
+    )?;
     if !config.status.success() || (!config.stdout.is_empty() && !config.stdout.ends_with(&[0])) {
         return Err(incomplete(
             StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
-            "read-bounded-effective-git-config",
+            "parse-captured-git-config",
         ));
     }
-    for raw_key in config
+    let mut repository_format_version: Option<Vec<u8>> = None;
+    let mut object_format: Option<Vec<u8>> = None;
+    let mut saw_core_bare = false;
+    let mut saw_core_shared_repository = false;
+    for record in config
         .stdout
         .split(|byte| *byte == 0)
-        .filter(|key| !key.is_empty())
+        .filter(|record| !record.is_empty())
     {
+        let (raw_key, value) = match record.iter().position(|byte| *byte == b'\n') {
+            Some(separator) => (&record[..separator], Some(&record[separator + 1..])),
+            None => (record, None),
+        };
         if raw_key.len() > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX) {
             return Err(incomplete(
                 StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
@@ -863,9 +1064,7 @@ fn validate_bounded_git_routing_v1(
             .to_ascii_lowercase();
         let remote_promisor = key.starts_with("remote.")
             && (key.ends_with(".promisor") || key.ends_with(".partialclonefilter"));
-        if key == "extensions.partialclone"
-            || key == "extensions.refstorage"
-            || key == "extensions.worktreeconfig"
+        if (key.starts_with("extensions.") && key != "extensions.objectformat")
             || remote_promisor
             || key == "protocol.ext.allow"
             || key == "core.alternaterefscommand"
@@ -879,57 +1078,69 @@ fn validate_bounded_git_routing_v1(
                 "reject-effective-git-config-key",
             ));
         }
+        if key == "core.bare" {
+            saw_core_bare = true;
+        }
+        if key == "core.sharedrepository" {
+            saw_core_shared_repository = true;
+        }
+        if key == "core.repositoryformatversion" {
+            if repository_format_version.is_some() || value.is_none() {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                    "require-one-repository-format-version",
+                ));
+            }
+            repository_format_version = value.map(|value| value.to_vec());
+        }
+        if key == "extensions.objectformat" {
+            if object_format.is_some() || value.is_none() {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                    "require-one-git-object-format",
+                ));
+            }
+            object_format = value.map(|value| value.to_vec());
+        }
+    }
+    if (saw_core_bare
+        && !captured_config_boolean_values_are_false_v1(raw_config, "core.bare", limits)?)
+        || (saw_core_shared_repository
+            && !captured_config_boolean_values_are_false_v1(
+                raw_config,
+                "core.sharedRepository",
+                limits,
+            )?)
+    {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            "reject-shared-or-bare-repository-config",
+        ));
     }
 
-    let shared = run_held_git_query_v1(
-        anchor,
-        HeldGitReadQueryV1::SharedRepositoryValues,
-        1024,
-        "read-bounded-shared-repository-config",
-    )
-    .map_err(|failure| {
-        if failure.kind() == StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit {
-            failure
-        } else {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
-                "read-bounded-shared-repository-config",
-            )
+    match (
+        repository_format_version.as_deref(),
+        object_format.as_deref(),
+    ) {
+        (Some(b"0"), None) => Ok(StrictGitObjectFormatV1::Sha1),
+        (Some(b"1"), Some(format)) if format.eq_ignore_ascii_case(b"sha256") => {
+            Ok(StrictGitObjectFormatV1::Sha256)
         }
-    })?;
-    require_only_false_config_values_v1(&shared, "reject-shared-repository-config")?;
-
-    let bare = run_held_git_query_v1(
-        anchor,
-        HeldGitReadQueryV1::BareRepositoryValues,
-        1024,
-        "read-bounded-bare-repository-config",
-    )
-    .map_err(|failure| {
-        if failure.kind() == StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit {
-            failure
-        } else {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
-                "read-bounded-bare-repository-config",
-            )
-        }
-    })?;
-    require_only_false_config_values_v1(&bare, "reject-bare-repository-config")?;
-
-    Ok(())
+        _ => Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            "validate-captured-git-object-format",
+        )),
+    }
 }
 
 fn read_topology_snapshot_v1(
-    anchor: &GitRepoAnchor,
-    metadata: &GitMetadataInventoryV1,
+    shadow: &GitMetadataShadowV1,
     contract: RootGitObservationContractV1,
 ) -> Result<StrictGitRawTopologySnapshotV1, StrictGitRawTopologyIncompleteV1> {
     let limits = GitObservationLimitsV1::from(contract);
-    validate_bounded_git_routing_v1(anchor, limits)?;
-    let object_format = read_object_format_v1(anchor, limits)?;
-    let refs = read_refs_v1(anchor, metadata, object_format, limits)?;
-    let head = read_head_v1(anchor, metadata, object_format, &refs, limits)?;
+    let object_format = validate_bounded_git_routing_v1(&shadow.raw_config, limits)?;
+    let refs = read_refs_v1(shadow, object_format, limits)?;
+    let head = read_head_v1(shadow, object_format, &refs, limits)?;
     Ok(StrictGitRawTopologySnapshotV1 {
         object_format,
         head,
@@ -943,32 +1154,6 @@ fn exact_single_line_v1(bytes: &[u8]) -> Option<&[u8]> {
         None
     } else {
         Some(line)
-    }
-}
-
-fn read_object_format_v1(
-    anchor: &GitRepoAnchor,
-    limits: GitObservationLimitsV1,
-) -> Result<StrictGitObjectFormatV1, StrictGitRawTopologyIncompleteV1> {
-    let output = run_held_git_query_v1(
-        anchor,
-        HeldGitReadQueryV1::ObjectFormat,
-        limits.max_command_stdout_bytes.min(32),
-        "read-git-object-format",
-    )?;
-    if !output.status.success() {
-        return Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
-            "read-git-object-format",
-        ));
-    }
-    match exact_single_line_v1(&output.stdout) {
-        Some(b"sha1") => Ok(StrictGitObjectFormatV1::Sha1),
-        Some(b"sha256") => Ok(StrictGitObjectFormatV1::Sha256),
-        _ => Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-            "parse-git-object-format",
-        )),
     }
 }
 
@@ -989,16 +1174,6 @@ fn parse_object_id_v1(
             .iter()
             .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')))
     .then(|| String::from_utf8(bytes.to_vec()).expect("validated ASCII object ID"))
-}
-
-fn parse_object_kind_v1(bytes: &[u8]) -> Option<StrictGitObjectKindV1> {
-    match bytes {
-        b"commit" => Some(StrictGitObjectKindV1::Commit),
-        b"tree" => Some(StrictGitObjectKindV1::Tree),
-        b"blob" => Some(StrictGitObjectKindV1::Blob),
-        b"tag" => Some(StrictGitObjectKindV1::Tag),
-        _ => None,
-    }
 }
 
 fn validate_ref_name_v1(value: &str, limits: GitObservationLimitsV1) -> Option<String> {
@@ -1053,162 +1228,6 @@ fn checked_retain_v1(
     Ok(())
 }
 
-#[derive(Debug)]
-struct ObservedGitRefV1 {
-    ref_name: String,
-    object_id: String,
-    object_kind: StrictGitObjectKindV1,
-    reported_symref_target: Option<String>,
-}
-
-fn parse_ref_output_v1(
-    bytes: &[u8],
-    format: StrictGitObjectFormatV1,
-    limits: GitObservationLimitsV1,
-) -> Result<Vec<ObservedGitRefV1>, StrictGitRawTopologyIncompleteV1> {
-    let mut refs = Vec::new();
-    let mut previous_ref: Option<String> = None;
-    let mut folded_refs = BTreeSet::new();
-    let mut retained_bytes = 0_u64;
-    let mut lines = bytes.split(|byte| *byte == b'\n').peekable();
-    while let Some(line) = lines.next() {
-        if line.is_empty() && lines.peek().is_none() {
-            break;
-        }
-        if line.is_empty() || line.contains(&b'\r') {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-reference-record",
-            ));
-        }
-        let mut fields = line.splitn(5, |byte| *byte == 0);
-        let Some(ref_name_bytes) = fields.next() else {
-            unreachable!("splitn always yields one field");
-        };
-        let Some(object_id_bytes) = fields.next() else {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-reference-fields",
-            ));
-        };
-        let Some(object_kind_bytes) = fields.next() else {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-reference-fields",
-            ));
-        };
-        let Some(symref_target_bytes) = fields.next() else {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-reference-fields",
-            ));
-        };
-        if fields.next().is_some() {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-reference-fields",
-            ));
-        }
-        if u64::try_from(refs.len()).unwrap_or(u64::MAX) >= limits.max_refs {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
-                "maximum-git-reference-count",
-            ));
-        }
-        if ref_name_bytes.len()
-            > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX)
-            || symref_target_bytes.len()
-                > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX)
-            || object_id_bytes.len() > usize::from(limits.sha256_oid_hex_bytes)
-            || object_kind_bytes.len() > 6
-        {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
-                "maximum-git-reference-field-bytes",
-            ));
-        }
-        let ref_name_borrowed = std::str::from_utf8(ref_name_bytes).map_err(|_| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "decode-git-reference-name",
-            )
-        })?;
-        let folded_ref = validate_ref_name_v1(ref_name_borrowed, limits).ok_or_else(|| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "validate-git-reference-name",
-            )
-        })?;
-        let ref_name = ref_name_borrowed.to_owned();
-        if previous_ref
-            .as_ref()
-            .is_some_and(|previous| previous >= &ref_name)
-            || !folded_refs.insert(folded_ref.clone())
-        {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "require-sorted-unique-git-references",
-            ));
-        }
-        let object_id = parse_object_id_v1(object_id_bytes, format, limits).ok_or_else(|| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-reference-object-id",
-            )
-        })?;
-        let object_kind = parse_object_kind_v1(object_kind_bytes).ok_or_else(|| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-reference-object-kind",
-            )
-        })?;
-        if ref_name.starts_with("refs/heads/") && object_kind != StrictGitObjectKindV1::Commit {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "require-branch-reference-commit",
-            ));
-        }
-        let reported_symref_target = if symref_target_bytes.is_empty() {
-            None
-        } else {
-            let target = std::str::from_utf8(symref_target_bytes).map_err(|_| {
-                incomplete(
-                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                    "decode-git-symref-target",
-                )
-            })?;
-            validate_ref_name_v1(target, limits).ok_or_else(|| {
-                incomplete(
-                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                    "validate-git-symref-target",
-                )
-            })?;
-            Some(target.to_owned())
-        };
-        checked_retain_v1(&mut retained_bytes, ref_name.len(), limits)?;
-        checked_retain_v1(&mut retained_bytes, folded_ref.len(), limits)?;
-        checked_retain_v1(&mut retained_bytes, object_id.len(), limits)?;
-        checked_retain_v1(&mut retained_bytes, object_kind_bytes.len(), limits)?;
-        if let Some(target) = &reported_symref_target {
-            checked_retain_v1(&mut retained_bytes, target.len(), limits)?;
-        }
-        previous_ref = Some(ref_name.clone());
-        refs.try_reserve(1).map_err(|_| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
-                "allocate-git-reference-record",
-            )
-        })?;
-        refs.push(ObservedGitRefV1 {
-            ref_name,
-            object_id,
-            object_kind,
-            reported_symref_target,
-        });
-    }
-    Ok(refs)
-}
-
 fn parse_packed_refs_v1(
     bytes: &[u8],
     format: StrictGitObjectFormatV1,
@@ -1227,9 +1246,19 @@ fn parse_packed_refs_v1(
     let mut retained_bytes = 0_u64;
     let mut previous_was_ref = false;
     let mut previous_was_peeled = false;
-    for line in bytes.split(|byte| *byte == b'\n') {
+    let records = &bytes[..bytes.len() - 1];
+    if records.is_empty() {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+            "reject-empty-packed-reference-record",
+        ));
+    }
+    for (index, line) in records.split(|byte| *byte == b'\n').enumerate() {
         if line.is_empty() {
-            continue;
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reject-empty-packed-reference-record",
+            ));
         }
         if line.contains(&b'\r') || line.contains(&0) {
             return Err(incomplete(
@@ -1237,10 +1266,40 @@ fn parse_packed_refs_v1(
                 "parse-packed-reference-line",
             ));
         }
-        if line.starts_with(b"#") {
+        if let Some(traits) = line.strip_prefix(b"# pack-refs with: ") {
+            let Some(traits) = traits.strip_suffix(b" ") else {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "validate-packed-reference-header-termination",
+                ));
+            };
+            if index != 0 || traits.is_empty() {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "validate-packed-reference-header-position",
+                ));
+            }
+            let mut seen_traits = BTreeSet::new();
+            for feature in traits.split(|byte| *byte == b' ') {
+                if feature.is_empty()
+                    || !matches!(feature, b"peeled" | b"fully-peeled" | b"sorted")
+                    || !seen_traits.insert(feature)
+                {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "validate-packed-reference-header-features",
+                    ));
+                }
+            }
             previous_was_ref = false;
             previous_was_peeled = false;
             continue;
+        }
+        if line.starts_with(b"#") {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reject-packed-reference-comment",
+            ));
         }
         if let Some(peeled) = line.strip_prefix(b"^") {
             if !previous_was_ref
@@ -1324,7 +1383,7 @@ enum EffectiveRawRefValueV1 {
 }
 
 fn effective_raw_refs_v1(
-    metadata: &GitMetadataInventoryV1,
+    metadata: &GitMetadataShadowV1,
     format: StrictGitObjectFormatV1,
     limits: GitObservationLimitsV1,
 ) -> Result<BTreeMap<String, EffectiveRawRefValueV1>, StrictGitRawTopologyIncompleteV1> {
@@ -1358,6 +1417,18 @@ fn effective_raw_refs_v1(
             }
         };
         refs.insert(name.clone(), value);
+    }
+    let mut effective_payload_bytes = 0_u64;
+    for (name, value) in &refs {
+        checked_retain_v1(&mut effective_payload_bytes, name.len(), limits)?;
+        match value {
+            EffectiveRawRefValueV1::DirectObjectId(object_id) => {
+                checked_retain_v1(&mut effective_payload_bytes, object_id.len(), limits)?;
+            }
+            EffectiveRawRefValueV1::SymbolicTarget(target) => {
+                checked_retain_v1(&mut effective_payload_bytes, target.len(), limits)?;
+            }
+        }
     }
     let mut folded = BTreeSet::new();
     for (name, value) in &refs {
@@ -1490,22 +1561,16 @@ fn resolve_symbolic_ref_terminals_v1(
     Ok(terminals)
 }
 
-fn reconcile_raw_and_observed_refs_v1(
+fn pin_immutable_raw_refs_v1(
     raw: BTreeMap<String, EffectiveRawRefValueV1>,
     terminals: Vec<usize>,
-    observed: Vec<ObservedGitRefV1>,
+    limits: GitObservationLimitsV1,
 ) -> Result<Vec<StrictGitRefPinV1>, StrictGitRawTopologyIncompleteV1> {
-    if raw.len() != observed.len() {
-        return Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-            "reconcile-raw-and-git-reference-counts",
-        ));
-    }
     let mut raw_names = Vec::new();
     raw_names.try_reserve_exact(raw.len()).map_err(|_| {
         incomplete(
             StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
-            "allocate-reconciled-reference-name-index",
+            "allocate-shadow-reference-name-index",
         )
     })?;
     raw_names.extend(raw.keys().map(String::as_str));
@@ -1513,87 +1578,47 @@ fn reconcile_raw_and_observed_refs_v1(
     pins.try_reserve_exact(raw.len()).map_err(|_| {
         incomplete(
             StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
-            "allocate-reconciled-git-reference-pins",
+            "allocate-shadow-git-reference-pins",
         )
     })?;
-    for (index, ((raw_name, raw_value), observed)) in raw.iter().zip(observed).enumerate() {
-        if raw_name != &observed.ref_name {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "reconcile-raw-and-git-reference-names",
-            ));
-        }
-        let symref_target = match raw_value {
-            EffectiveRawRefValueV1::DirectObjectId(raw_object_id) => {
-                if raw_object_id != &observed.object_id || observed.reported_symref_target.is_some()
-                {
-                    return Err(incomplete(
-                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                        "reconcile-direct-reference-value",
-                    ));
-                }
-                None
-            }
-            EffectiveRawRefValueV1::SymbolicTarget(target) => {
-                let terminal_name = raw_names[terminals[index]];
-                let terminal_object_id = match raw.get(terminal_name) {
-                    Some(EffectiveRawRefValueV1::DirectObjectId(object_id)) => object_id,
-                    _ => {
-                        return Err(incomplete(
-                            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                            "resolve-symbolic-reference-terminal-object",
-                        ));
-                    }
-                };
-                if observed.reported_symref_target.as_deref() != Some(terminal_name)
-                    || &observed.object_id != terminal_object_id
-                {
-                    return Err(incomplete(
-                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                        "reconcile-symbolic-reference-value",
-                    ));
-                }
-                Some(target.clone())
+    let mut retained_payload_bytes = 0_u64;
+    for (index, (raw_name, raw_value)) in raw.iter().enumerate() {
+        let terminal_name = raw_names[terminals[index]];
+        let object_id = match raw.get(terminal_name) {
+            Some(EffectiveRawRefValueV1::DirectObjectId(object_id)) => object_id,
+            _ => {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "resolve-shadow-reference-terminal-object",
+                ));
             }
         };
+        let symref_target = match raw_value {
+            EffectiveRawRefValueV1::DirectObjectId(_) => None,
+            EffectiveRawRefValueV1::SymbolicTarget(target) => Some(target),
+        };
+        checked_retain_v1(&mut retained_payload_bytes, raw_name.len(), limits)?;
+        checked_retain_v1(&mut retained_payload_bytes, object_id.len(), limits)?;
+        if let Some(target) = &symref_target {
+            checked_retain_v1(&mut retained_payload_bytes, target.len(), limits)?;
+        }
         pins.push(StrictGitRefPinV1 {
-            ref_name: observed.ref_name,
-            object_id: observed.object_id,
-            object_kind: observed.object_kind,
-            symref_target,
+            ref_name: raw_name.clone(),
+            object_id: object_id.clone(),
+            symref_target: symref_target.cloned(),
         });
     }
     Ok(pins)
 }
 
 fn read_refs_v1(
-    anchor: &GitRepoAnchor,
-    metadata: &GitMetadataInventoryV1,
+    metadata: &GitMetadataShadowV1,
     format: StrictGitObjectFormatV1,
     limits: GitObservationLimitsV1,
 ) -> Result<Vec<StrictGitRefPinV1>, StrictGitRawTopologyIncompleteV1> {
     let raw = effective_raw_refs_v1(metadata, format, limits)?;
     let terminals = resolve_symbolic_ref_terminals_v1(&raw)?;
-    let count = limits.max_refs.checked_add(1).ok_or_else(|| {
-        incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
-            "bound-git-reference-command-count",
-        )
-    })?;
-    let output = run_held_git_query_v1(
-        anchor,
-        HeldGitReadQueryV1::ForEachRef { count },
-        limits.max_command_stdout_bytes,
-        "read-bounded-git-references",
-    )?;
-    if !output.status.success() {
-        return Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
-            "read-bounded-git-references",
-        ));
-    }
-    let observed = parse_ref_output_v1(&output.stdout, format, limits)?;
-    reconcile_raw_and_observed_refs_v1(raw, terminals, observed)
+    pin_immutable_raw_refs_v1(raw, terminals, limits)
 }
 
 enum ParsedRawHeadV1 {
@@ -1645,132 +1670,54 @@ fn parse_raw_head_v1(
 }
 
 fn read_head_v1(
-    anchor: &GitRepoAnchor,
-    metadata: &GitMetadataInventoryV1,
+    metadata: &GitMetadataShadowV1,
     format: StrictGitObjectFormatV1,
     refs: &[StrictGitRefPinV1],
     limits: GitObservationLimitsV1,
 ) -> Result<StrictGitHeadPinV1, StrictGitRawTopologyIncompleteV1> {
     let raw_head = parse_raw_head_v1(&metadata.raw_head, format, limits)?;
-    let symbolic = run_held_git_query_v1(
-        anchor,
-        HeldGitReadQueryV1::SymbolicHeadNoRecurse,
-        limits.max_ref_or_symref_bytes.saturating_add(2),
-        "read-git-symbolic-head",
-    )?;
-    let resolved = run_held_git_query_v1(
-        anchor,
-        HeldGitReadQueryV1::ResolvedHeadCommit,
-        u64::from(limits.sha256_oid_hex_bytes).saturating_add(2),
-        "read-git-resolved-head",
-    )?;
-    let resolved_object_id = if resolved.status.success() {
-        let line = exact_single_line_v1(&resolved.stdout).ok_or_else(|| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-resolved-head",
-            )
-        })?;
-        Some(parse_object_id_v1(line, format, limits).ok_or_else(|| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "parse-git-resolved-head",
-            )
-        })?)
-    } else if resolved.status.code() == Some(1) && resolved.stdout.is_empty() {
-        None
-    } else {
-        return Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
-            "read-git-resolved-head",
-        ));
-    };
-
-    if symbolic.status.success() {
-        let target = exact_single_line_v1(&symbolic.stdout)
-            .and_then(|bytes| std::str::from_utf8(bytes).ok())
-            .map(str::to_owned)
-            .ok_or_else(|| {
+    match raw_head {
+        ParsedRawHeadV1::Symbolic(target) => {
+            let folded_target = validate_ref_name_v1(&target, limits).ok_or_else(|| {
                 incomplete(
                     StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                    "parse-git-symbolic-head",
+                    "validate-shadow-symbolic-head",
                 )
             })?;
-        let folded_target = validate_ref_name_v1(&target, limits).ok_or_else(|| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "validate-git-symbolic-head",
-            )
-        })?;
-        if !target.starts_with("refs/heads/") {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "require-symbolic-head-branch-target",
-            ));
-        }
-        if !matches!(&raw_head, ParsedRawHeadV1::Symbolic(raw_target) if raw_target == &target) {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "reconcile-raw-and-git-symbolic-head",
-            ));
-        }
-        if let Some(oid) = &resolved_object_id {
-            if !refs
+            let raw_target_object_id = refs
                 .iter()
-                .any(|pin| pin.ref_name == target && pin.object_id == *oid)
-            {
-                return Err(incomplete(
-                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                    "bind-symbolic-head-to-reference",
-                ));
-            }
-        } else {
-            for pin in refs {
-                let folded_pin = validate_ref_name_v1(&pin.ref_name, limits).ok_or_else(|| {
-                    incomplete(
-                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                        "revalidate-git-reference-for-unborn-head",
-                    )
-                })?;
-                if folded_pin == folded_target
-                    || folded_pin
-                        .strip_prefix(&folded_target)
-                        .is_some_and(|suffix| suffix.starts_with('/'))
-                    || folded_target
-                        .strip_prefix(&folded_pin)
-                        .is_some_and(|suffix| suffix.starts_with('/'))
-                {
-                    return Err(incomplete(
-                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                        "reject-unborn-head-portable-alias",
-                    ));
+                .find(|pin| pin.ref_name == target)
+                .map(|pin| pin.object_id.clone());
+            if raw_target_object_id.is_none() {
+                for pin in refs {
+                    let folded_pin =
+                        validate_ref_name_v1(&pin.ref_name, limits).ok_or_else(|| {
+                            incomplete(
+                                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                                "revalidate-shadow-reference-for-unborn-head",
+                            )
+                        })?;
+                    if folded_pin == folded_target
+                        || folded_pin
+                            .strip_prefix(&folded_target)
+                            .is_some_and(|suffix| suffix.starts_with('/'))
+                        || folded_target
+                            .strip_prefix(&folded_pin)
+                            .is_some_and(|suffix| suffix.starts_with('/'))
+                    {
+                        return Err(incomplete(
+                            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                            "reject-unborn-head-portable-alias",
+                        ));
+                    }
                 }
             }
+            Ok(StrictGitHeadPinV1::Symbolic {
+                target,
+                raw_target_object_id,
+            })
         }
-        Ok(StrictGitHeadPinV1::Symbolic {
-            target,
-            resolved_object_id,
-        })
-    } else if symbolic.status.code() == Some(1) && symbolic.stdout.is_empty() {
-        let object_id = resolved_object_id.ok_or_else(|| {
-            incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "require-detached-head-object",
-            )
-        })?;
-        if !matches!(&raw_head, ParsedRawHeadV1::Detached(raw_object_id) if raw_object_id == &object_id)
-        {
-            return Err(incomplete(
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
-                "reconcile-raw-and-git-detached-head",
-            ));
-        }
-        Ok(StrictGitHeadPinV1::Detached { object_id })
-    } else {
-        Err(incomplete(
-            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
-            "read-git-symbolic-head",
-        ))
+        ParsedRawHeadV1::Detached(object_id) => Ok(StrictGitHeadPinV1::Detached { object_id }),
     }
 }
 
@@ -1794,6 +1741,11 @@ mod tests {
     );
     static_assertions::assert_not_impl_any!(
         StrictGitRefPinV1: Clone,
+        serde::Serialize
+    );
+    static_assertions::assert_not_impl_any!(
+        StrictLocalGitShadowWitnessV1: Clone,
+        Copy,
         serde::Serialize
     );
 
@@ -1873,7 +1825,7 @@ mod tests {
         }
     }
 
-    fn begin_topology(pending: &PendingStrictLocalSnapshotV1) -> PendingStrictGitRawTopologyV1 {
+    fn begin_topology(pending: &mut PendingStrictLocalSnapshotV1) -> PendingStrictGitRawTopologyV1 {
         match begin_strict_git_raw_topology_v1(pending) {
             StrictGitRawTopologyBeginV1::Pending(topology) => *topology,
             StrictGitRawTopologyBeginV1::Incomplete(incomplete) => {
@@ -1882,19 +1834,32 @@ mod tests {
         }
     }
 
-    fn finish_topology(pending: PendingStrictGitRawTopologyV1) -> HeldStrictGitRawTopologyV1 {
-        match pending.revalidate_after_external_reads() {
-            StrictGitRawTopologyFinishV1::Held(topology) => topology,
+    fn finish_topology(
+        local: PendingStrictLocalSnapshotV1,
+        pending: PendingStrictGitRawTopologyV1,
+    ) -> (HeldStrictGitRawTopologyV1, RevalidatedStrictLocalSnapshotV1) {
+        let local = finish_local(local);
+        match pending.revalidate_after_external_reads(local) {
+            StrictGitRawTopologyFinishV1::Held { topology, local } => (topology, local),
             StrictGitRawTopologyFinishV1::Incomplete(incomplete) => {
                 panic!("expected held GitRaw topology: {incomplete:?}")
             }
         }
     }
 
+    fn finish_local(local: PendingStrictLocalSnapshotV1) -> RevalidatedStrictLocalSnapshotV1 {
+        match local.revalidate_inventory_c().unwrap() {
+            StrictLocalSnapshotFinishV1::Complete(local) => local,
+            StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
+                panic!("local inventory C must remain stable: {incomplete:?}")
+            }
+        }
+    }
+
     fn begin_incomplete(
-        pending: &PendingStrictLocalSnapshotV1,
+        mut pending: PendingStrictLocalSnapshotV1,
     ) -> StrictGitRawTopologyIncompleteV1 {
-        match begin_strict_git_raw_topology_v1(pending) {
+        match begin_strict_git_raw_topology_v1(&mut pending) {
             StrictGitRawTopologyBeginV1::Incomplete(incomplete) => incomplete,
             StrictGitRawTopologyBeginV1::Pending(_) => {
                 panic!("expected GitRaw topology to fail closed")
@@ -1908,12 +1873,13 @@ mod tests {
         run_git(&root, &["branch", "z-last"]);
         run_git(&root, &["branch", "a-first"]);
         std::fs::write(root.join(".git/tcfs.lock"), b"").unwrap();
-        let pending = pending_local(&root);
-        let topology = finish_topology(begin_topology(&pending));
+        let mut pending = pending_local(&root);
+        let pending_topology = begin_topology(&mut pending);
+        let (topology, _local) = finish_topology(pending, pending_topology);
 
         assert_eq!(topology.object_format(), StrictGitObjectFormatV1::Sha1);
         assert_eq!(topology.head().symbolic_target(), Some("refs/heads/main"));
-        assert!(topology.head().resolved_object_id().is_some());
+        assert!(topology.head().raw_target_object_id().is_some());
         let refs = topology
             .refs()
             .map(|pin| pin.ref_name().to_owned())
@@ -1924,17 +1890,11 @@ mod tests {
         );
         assert_eq!(topology.contract().pass_count(), 2);
 
-        match pending.revalidate_inventory_c().unwrap() {
-            StrictLocalSnapshotFinishV1::Complete(_) => {}
-            StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
-                panic!("local inventory C must remain stable: {incomplete:?}")
-            }
-        }
         topology.revalidate_capabilities().unwrap();
     }
 
     #[test]
-    fn sha1_and_sha256_packed_tags_and_symbolic_chains_are_exact() {
+    fn sha1_and_sha256_packed_refs_and_symbolic_chains_are_exact() {
         for (format, expected_format, object_id_len) in [
             ("sha1", StrictGitObjectFormatV1::Sha1, 40),
             ("sha256", StrictGitObjectFormatV1::Sha256, 64),
@@ -1966,24 +1926,21 @@ mod tests {
                 &["symbolic-ref", "refs/heads/alias", "refs/heads/middle"],
             );
 
-            let pending = pending_local(&root);
-            let topology = finish_topology(begin_topology(&pending));
+            let mut pending = pending_local(&root);
+            let pending_topology = begin_topology(&mut pending);
+            let (topology, _local) = finish_topology(pending, pending_topology);
             assert_eq!(topology.object_format(), expected_format);
             assert!(root.join(".git/packed-refs").is_file());
             assert!(topology
                 .refs()
                 .all(|pin| pin.object_id().len() == object_id_len));
 
-            let annotated = topology
+            assert!(topology
                 .refs()
-                .find(|pin| pin.ref_name() == "refs/tags/annotated")
-                .unwrap();
-            assert_eq!(annotated.object_kind, StrictGitObjectKindV1::Tag);
-            let lightweight = topology
+                .any(|pin| pin.ref_name() == "refs/tags/annotated"));
+            assert!(topology
                 .refs()
-                .find(|pin| pin.ref_name() == "refs/tags/lightweight")
-                .unwrap();
-            assert_eq!(lightweight.object_kind, StrictGitObjectKindV1::Commit);
+                .any(|pin| pin.ref_name() == "refs/tags/lightweight"));
             let main = topology
                 .refs()
                 .find(|pin| pin.ref_name() == "refs/heads/main")
@@ -2000,18 +1957,20 @@ mod tests {
     #[test]
     fn unborn_and_detached_head_states_are_explicit() {
         let (_unborn_temporary, unborn) = canonical_unborn_repo();
-        let pending = pending_local(&unborn);
-        let topology = finish_topology(begin_topology(&pending));
+        let mut pending = pending_local(&unborn);
+        let pending_topology = begin_topology(&mut pending);
+        let (topology, _local) = finish_topology(pending, pending_topology);
         assert_eq!(topology.head().symbolic_target(), Some("refs/heads/main"));
-        assert_eq!(topology.head().resolved_object_id(), None);
+        assert_eq!(topology.head().raw_target_object_id(), None);
         assert_eq!(topology.refs().len(), 0);
 
         let (_detached_temporary, detached) = canonical_committed_repo();
         run_git(&detached, &["checkout", "--quiet", "--detach"]);
-        let pending = pending_local(&detached);
-        let topology = finish_topology(begin_topology(&pending));
+        let mut pending = pending_local(&detached);
+        let pending_topology = begin_topology(&mut pending);
+        let (topology, _local) = finish_topology(pending, pending_topology);
         assert_eq!(topology.head().symbolic_target(), None);
-        assert!(topology.head().resolved_object_id().is_some());
+        assert!(topology.head().raw_target_object_id().is_some());
     }
 
     #[test]
@@ -2023,7 +1982,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            begin_incomplete(&pending_local(&dangling)).kind(),
+            begin_incomplete(pending_local(&dangling)).kind(),
             StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
         );
 
@@ -2039,7 +1998,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            begin_incomplete(&pending_local(&cycle)).kind(),
+            begin_incomplete(pending_local(&cycle)).kind(),
             StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
         );
 
@@ -2047,7 +2006,7 @@ mod tests {
         run_git(&alias, &["branch", "foo"]);
         std::fs::write(alias.join(".git/HEAD"), b"ref: refs/heads/Foo\n").unwrap();
         assert_eq!(
-            begin_incomplete(&pending_local(&alias)).kind(),
+            begin_incomplete(pending_local(&alias)).kind(),
             StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
         );
 
@@ -2059,13 +2018,13 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            begin_incomplete(&pending_local(&df_conflict)).kind(),
+            begin_incomplete(pending_local(&df_conflict)).kind(),
             StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
         );
     }
 
     #[test]
-    fn detached_head_must_name_a_commit_object_directly() {
+    fn detached_head_retains_an_opaque_raw_object_id_without_kind_claims() {
         let (_temporary, root) = canonical_committed_repo();
         run_git(
             &root,
@@ -2084,53 +2043,89 @@ mod tests {
         );
         let tag_object = git_stdout(&root, &["rev-parse", "refs/tags/annotated"]);
         std::fs::write(root.join(".git/HEAD"), format!("{tag_object}\n")).unwrap();
+        let mut pending = pending_local(&root);
+        let pending_topology = begin_topology(&mut pending);
+        let (topology, _local) = finish_topology(pending, pending_topology);
         assert_eq!(
-            begin_incomplete(&pending_local(&root)).kind(),
-            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
+            topology.head().raw_target_object_id(),
+            Some(tag_object.as_str())
         );
     }
 
     #[test]
-    fn reference_mutation_between_passes_is_typed_incomplete() {
+    fn immutable_shadow_never_reinterprets_live_config_head_or_refs() {
         let (_temporary, root) = canonical_committed_repo();
-        let pending = pending_local(&root);
-        let topology = begin_topology(&pending);
-        run_git(&root, &["branch", "appeared-between-passes"]);
+        let original_oid = git_stdout(&root, &["rev-parse", "refs/heads/main"]);
+        let mut pending = pending_local(&root);
+        let topology = begin_topology(&mut pending);
+        std::fs::write(
+            root.join(".git/config"),
+            b"[core]\n\trepositoryformatversion = 0\n\tbare = true\n",
+        )
+        .unwrap();
+        std::fs::write(root.join(".git/HEAD"), format!("{}\n", "b".repeat(40))).unwrap();
+        std::fs::write(
+            root.join(".git/refs/heads/main"),
+            format!("{}\n", "c".repeat(40)),
+        )
+        .unwrap();
+
+        let repeated = read_topology_snapshot_v1(&topology.shadow, topology.contract).unwrap();
+        assert!(repeated == topology.first);
+        assert_eq!(repeated.head.symbolic_target(), Some("refs/heads/main"));
+        assert_eq!(
+            repeated.head.raw_target_object_id(),
+            Some(original_oid.as_str())
+        );
         assert!(matches!(
-            topology.revalidate_after_external_reads(),
-            StrictGitRawTopologyFinishV1::Incomplete(incomplete)
-                if incomplete.kind()
-                    == StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged
+            pending.revalidate_inventory_c().unwrap(),
+            StrictLocalSnapshotFinishV1::Incomplete(_)
         ));
     }
 
     #[test]
-    fn root_and_git_directory_replacement_between_passes_are_typed_changed() {
+    fn git_shadow_witness_is_one_shot_and_bound_to_one_local_acquisition() {
+        let (_temporary, root) = canonical_committed_repo();
+        let mut pending_a = pending_local(&root);
+        let topology_a = begin_topology(&mut pending_a);
+        assert!(matches!(
+            begin_strict_git_raw_topology_v1(&mut pending_a),
+            StrictGitRawTopologyBeginV1::Incomplete(ref incomplete)
+                if incomplete.kind()
+                    == StrictGitRawTopologyIncompleteKindV1::CapabilityOpenFailed
+                    && incomplete.operation() == "issue-one-shot-local-git-shadow-witness"
+        ));
+
+        let mut pending_b = pending_local(&root);
+        let topology_b = begin_topology(&mut pending_b);
+        drop(topology_b);
+        let local_b = finish_local(pending_b);
+        assert!(matches!(
+            topology_a.revalidate_after_external_reads(local_b),
+            StrictGitRawTopologyFinishV1::Incomplete(ref incomplete)
+                if incomplete.kind()
+                    == StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged
+                    && incomplete.operation() == "bind-shadow-to-inventory-c-acquisition"
+        ));
+    }
+
+    #[test]
+    fn root_and_git_directory_replacement_are_rejected_by_the_held_anchor() {
         let (_root_temporary, root) = canonical_committed_repo();
-        let pending = pending_local(&root);
-        let topology = begin_topology(&pending);
+        let mut pending = pending_local(&root);
+        let topology = begin_topology(&mut pending);
         let original_root = root.with_extension("original");
         std::fs::rename(&root, &original_root).unwrap();
         std::fs::create_dir(&root).unwrap();
-        assert!(matches!(
-            topology.revalidate_after_external_reads(),
-            StrictGitRawTopologyFinishV1::Incomplete(incomplete)
-                if incomplete.kind()
-                    == StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged
-        ));
+        assert!(topology.anchor.revalidate().is_err());
 
         let (_git_temporary, git_root) = canonical_committed_repo();
-        let pending = pending_local(&git_root);
-        let topology = begin_topology(&pending);
+        let mut pending = pending_local(&git_root);
+        let topology = begin_topology(&mut pending);
         let original_git = git_root.join(".git-original");
         std::fs::rename(git_root.join(".git"), &original_git).unwrap();
         std::fs::create_dir(git_root.join(".git")).unwrap();
-        assert!(matches!(
-            topology.revalidate_after_external_reads(),
-            StrictGitRawTopologyFinishV1::Incomplete(incomplete)
-                if incomplete.kind()
-                    == StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged
-        ));
+        assert!(topology.anchor.revalidate().is_err());
     }
 
     #[test]
@@ -2212,7 +2207,7 @@ mod tests {
                 std::fs::write(&path, bytes).unwrap();
             }
             assert_eq!(
-                begin_incomplete(&pending_local(&root)).kind(),
+                begin_incomplete(pending_local(&root)).kind(),
                 expected,
                 "{relative}"
             );
@@ -2234,7 +2229,7 @@ mod tests {
             let (_temporary, root) = canonical_committed_repo();
             run_git(&root, &["config", key, value]);
             assert_eq!(
-                begin_incomplete(&pending_local(&root)).kind(),
+                begin_incomplete(pending_local(&root)).kind(),
                 StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
                 "{key}"
             );
@@ -2243,16 +2238,36 @@ mod tests {
         let (_config_temporary, config_root) = canonical_committed_repo();
         std::fs::write(config_root.join(".git/config"), vec![b'x'; 1024 * 1024 + 1]).unwrap();
         assert_eq!(
-            begin_incomplete(&pending_local(&config_root)).kind(),
+            begin_incomplete(pending_local(&config_root)).kind(),
             StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
         );
 
         let (_head_temporary, head_root) = canonical_committed_repo();
         std::fs::write(head_root.join(".git/HEAD"), vec![b'x'; 1030]).unwrap();
         assert_eq!(
-            begin_incomplete(&pending_local(&head_root)).kind(),
+            begin_incomplete(pending_local(&head_root)).kind(),
             StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
         );
+
+        let (_malformed_temporary, malformed_root) = canonical_committed_repo();
+        std::fs::write(
+            malformed_root.join(".git/config"),
+            b"[core\n\tbare = false\n",
+        )
+        .unwrap();
+        assert_eq!(
+            begin_incomplete(pending_local(&malformed_root)).kind(),
+            StrictGitRawTopologyIncompleteKindV1::TopologyRejected
+        );
+
+        for false_value in ["false", "no", "off", "0", "+0", "-0", "00", "0x0"] {
+            let (_temporary, root) = canonical_committed_repo();
+            run_git(&root, &["config", "core.bare", false_value]);
+            run_git(&root, &["config", "core.sharedRepository", false_value]);
+            let mut pending = pending_local(&root);
+            let topology = begin_topology(&mut pending);
+            let (_topology, _local) = finish_topology(pending, topology);
+        }
     }
 
     fn fixture_limits(max_refs: u64, max_name: u64, max_retained: u64) -> GitObservationLimitsV1 {
@@ -2268,104 +2283,18 @@ mod tests {
         }
     }
 
-    fn record(name: &str, oid: &str, kind: &str, symref: &str) -> Vec<u8> {
-        format!("{name}\0{oid}\0{kind}\0{symref}\n").into_bytes()
-    }
-
     #[test]
-    fn parser_enforces_exact_count_name_and_retained_byte_limits() {
+    fn packed_ref_parser_rejects_malformed_records() {
         let oid = "a".repeat(40);
-        let one = record("refs/heads/a", &oid, "commit", "");
-        let two = record("refs/heads/b", &oid, "commit", "");
-        let exact = [one.clone(), two.clone()].concat();
-        assert_eq!(
-            parse_ref_output_v1(
-                &exact,
-                StrictGitObjectFormatV1::Sha1,
-                fixture_limits(2, 64, 1024)
-            )
-            .unwrap()
-            .len(),
-            2
-        );
-        let error = parse_ref_output_v1(
-            &exact,
-            StrictGitObjectFormatV1::Sha1,
-            fixture_limits(1, 64, 1024),
-        )
-        .unwrap_err();
-        assert_eq!(
-            error.kind(),
-            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
-        );
-        let error = parse_ref_output_v1(
-            &one,
-            StrictGitObjectFormatV1::Sha1,
-            fixture_limits(1, 11, 1024),
-        )
-        .unwrap_err();
-        assert_eq!(
-            error.kind(),
-            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
-        );
-        let error = parse_ref_output_v1(
-            &one,
-            StrictGitObjectFormatV1::Sha1,
-            fixture_limits(1, 64, 1),
-        )
-        .unwrap_err();
-        assert_eq!(
-            error.kind(),
-            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
-        );
-    }
-
-    #[test]
-    fn parser_rejects_unsorted_duplicate_alias_and_malformed_records() {
-        let oid = "a".repeat(40);
-        let unsorted = [
-            record("refs/heads/b", &oid, "commit", ""),
-            record("refs/heads/a", &oid, "commit", ""),
-        ]
-        .concat();
-        let alias = [
-            record("refs/heads/Foo", &oid, "commit", ""),
-            record("refs/heads/foo", &oid, "commit", ""),
-        ]
-        .concat();
-        for bytes in [
-            unsorted,
-            alias,
-            record("refs/heads/a", &"A".repeat(40), "commit", ""),
-            record("refs/heads/a", &oid, "blob", ""),
-            record("refs/heads/a\tb", &oid, "commit", ""),
-            record("refs/heads/a\u{7f}b", &oid, "commit", ""),
-            b"refs/heads/a\0missing-fields\n".to_vec(),
-            format!("refs/heads/a\0{oid}\0commit\0\0extra\n").into_bytes(),
-            [
-                b"refs/heads/".as_slice(),
-                &[0xff],
-                format!("\0{oid}\0commit\0\n").as_bytes(),
-            ]
-            .concat(),
-        ] {
-            assert_eq!(
-                parse_ref_output_v1(
-                    &bytes,
-                    StrictGitObjectFormatV1::Sha1,
-                    fixture_limits(8, 128, 4096),
-                )
-                .unwrap_err()
-                .kind(),
-                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
-            );
-        }
-
         for bytes in [
             format!("{oid} refs/heads/a extra\n").into_bytes(),
             format!("^{oid}\n").into_bytes(),
             format!("# pack-refs\n{oid} refs/tags/a\n^{oid}\n^{oid}\n").into_bytes(),
             format!("{oid} refs/heads/a\0bad\n").into_bytes(),
+            format!("{oid} refs/heads/a\n\n").into_bytes(),
+            format!("{oid} refs/heads/a\n# pack-refs with: sorted\n").into_bytes(),
+            format!("# arbitrary comment\n{oid} refs/heads/a\n").into_bytes(),
+            format!("{oid} refs/tags/a\n\n^{oid}\n").into_bytes(),
         ] {
             assert_eq!(
                 parse_packed_refs_v1(
@@ -2378,5 +2307,119 @@ mod tests {
                 StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
             );
         }
+    }
+
+    #[test]
+    fn captured_config_query_enforces_exact_output_limit_and_reaps_failures() {
+        let raw_config = b"[core]\n\trepositoryformatversion = 0\n\tbare = false\n";
+        let observed =
+            run_captured_config_query_v1(raw_config, 1024, CapturedConfigQueryV1::List).unwrap();
+        assert!(observed.status.success());
+        let exact = u64::try_from(observed.stdout.len()).unwrap();
+        assert!(
+            run_captured_config_query_v1(raw_config, exact, CapturedConfigQueryV1::List,).is_ok()
+        );
+        let limited = match run_captured_config_query_v1(
+            raw_config,
+            exact.saturating_sub(1),
+            CapturedConfigQueryV1::List,
+        ) {
+            Err(incomplete) => incomplete,
+            Ok(_) => panic!("one byte below the captured config output must fail"),
+        };
+        assert_eq!(
+            limited.kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        );
+        let malformed =
+            match run_captured_config_query_v1(b"[core\n", 1024, CapturedConfigQueryV1::List) {
+                Err(incomplete) => incomplete,
+                Ok(_) => panic!("malformed captured config must fail"),
+            };
+        assert_eq!(
+            malformed.kind(),
+            StrictGitRawTopologyIncompleteKindV1::TopologyRejected
+        );
+    }
+
+    #[test]
+    fn effective_and_canonical_ref_payloads_have_aggregate_exact_limits() {
+        let oid_a = "a".repeat(40);
+        let oid_b = vec![b'b'; 40];
+        let packed_name = "refs/heads/a";
+        let loose_name = "refs/heads/b";
+        let mut loose_refs = BTreeMap::new();
+        loose_refs.insert(
+            loose_name.to_owned(),
+            RawLooseRefValueV1::DirectObjectId(oid_b),
+        );
+        let shadow = GitMetadataShadowV1 {
+            raw_config: Vec::new(),
+            loose_refs,
+            packed_refs: Some(format!("{oid_a} {packed_name}\n").into_bytes()),
+            raw_head: Vec::new(),
+        };
+        let exact_effective = u64::try_from(packed_name.len() + loose_name.len() + 80).unwrap();
+        assert!(effective_raw_refs_v1(
+            &shadow,
+            StrictGitObjectFormatV1::Sha1,
+            fixture_limits(8, 128, exact_effective),
+        )
+        .is_ok());
+        let limited = match effective_raw_refs_v1(
+            &shadow,
+            StrictGitObjectFormatV1::Sha1,
+            fixture_limits(8, 128, exact_effective - 1),
+        ) {
+            Err(incomplete) => incomplete,
+            Ok(_) => panic!("one byte below the effective ref payload must fail"),
+        };
+        assert_eq!(
+            limited.kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        );
+
+        let direct_name = "refs/heads/main";
+        let alias_name = "refs/heads/alias";
+        let mut symbolic = BTreeMap::new();
+        symbolic.insert(
+            direct_name.to_owned(),
+            EffectiveRawRefValueV1::DirectObjectId(oid_a),
+        );
+        symbolic.insert(
+            alias_name.to_owned(),
+            EffectiveRawRefValueV1::SymbolicTarget(direct_name.to_owned()),
+        );
+        let terminals = resolve_symbolic_ref_terminals_v1(&symbolic).unwrap();
+        let exact_canonical =
+            u64::try_from(direct_name.len() + 40 + alias_name.len() + 40 + direct_name.len())
+                .unwrap();
+        assert!(pin_immutable_raw_refs_v1(
+            symbolic,
+            terminals,
+            fixture_limits(8, 128, exact_canonical),
+        )
+        .is_ok());
+
+        let mut symbolic = BTreeMap::new();
+        symbolic.insert(
+            direct_name.to_owned(),
+            EffectiveRawRefValueV1::DirectObjectId("a".repeat(40)),
+        );
+        symbolic.insert(
+            alias_name.to_owned(),
+            EffectiveRawRefValueV1::SymbolicTarget(direct_name.to_owned()),
+        );
+        let terminals = resolve_symbolic_ref_terminals_v1(&symbolic).unwrap();
+        assert_eq!(
+            pin_immutable_raw_refs_v1(
+                symbolic,
+                terminals,
+                fixture_limits(8, 128, exact_canonical - 1),
+            )
+            .unwrap_err()
+            .kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        );
     }
 }

--- a/crates/tcfs-sync/src/registered_git_topology.rs
+++ b/crates/tcfs-sync/src/registered_git_topology.rs
@@ -1,0 +1,2382 @@
+//! Held, bounded Git topology evidence for one `git-raw-v1` root.
+//!
+//! This module proves only that one already-authorized local root exposed the
+//! same ordinary standalone Git topology and canonical ref set in two bounded
+//! observations around the external state/remote read window. It does not
+//! prove remote Git object semantics, fast-forward ancestry, catalog
+//! completeness/currentness, bootstrap safety, continuous stability, or
+//! writer fencing against same-principal swap/restore. The opaque artifact
+//! therefore has no digest, serialization, clone, plan, or action conversion.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::process::ExitStatus;
+
+use tcfs_core::config::{RootGitObservationContractV1, RootGitPolicyV1};
+
+use crate::conflict_git::{GitRepoAnchor, HeldGitReadErrorV1, HeldGitReadQueryV1};
+use crate::index_entry::portable_casefold_path;
+use crate::registered_local_snapshot::{
+    PendingStrictLocalSnapshotV1, StrictInitialLocalEntryKindV1,
+    StrictLocalSnapshotIncompleteKindV1, StrictLocalSnapshotIncompleteV1,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StrictGitRawTopologyIncompleteKindV1 {
+    UnsupportedProfile,
+    CapabilityOpenFailed,
+    TopologyRejected,
+    ActivityDetected,
+    ReferenceReadFailed,
+    ReferenceMalformed,
+    ReferenceResourceLimit,
+    ReferenceSetChanged,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct StrictGitRawTopologyIncompleteV1 {
+    kind: StrictGitRawTopologyIncompleteKindV1,
+    operation: &'static str,
+}
+
+impl StrictGitRawTopologyIncompleteV1 {
+    pub(crate) const fn kind(&self) -> StrictGitRawTopologyIncompleteKindV1 {
+        self.kind
+    }
+
+    pub(crate) const fn operation(&self) -> &'static str {
+        self.operation
+    }
+}
+
+impl fmt::Debug for StrictGitRawTopologyIncompleteV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StrictGitRawTopologyIncompleteV1")
+            .field("kind", &self.kind)
+            .field("operation", &self.operation)
+            .finish()
+    }
+}
+
+fn incomplete(
+    kind: StrictGitRawTopologyIncompleteKindV1,
+    operation: &'static str,
+) -> StrictGitRawTopologyIncompleteV1 {
+    StrictGitRawTopologyIncompleteV1 { kind, operation }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StrictGitObjectFormatV1 {
+    Sha1,
+    Sha256,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StrictGitObjectKindV1 {
+    Commit,
+    Tree,
+    Blob,
+    Tag,
+}
+
+#[derive(PartialEq, Eq)]
+pub(crate) struct StrictGitRefPinV1 {
+    ref_name: String,
+    object_id: String,
+    object_kind: StrictGitObjectKindV1,
+    symref_target: Option<String>,
+}
+
+impl StrictGitRefPinV1 {
+    pub(crate) fn ref_name(&self) -> &str {
+        &self.ref_name
+    }
+
+    pub(crate) fn object_id(&self) -> &str {
+        &self.object_id
+    }
+
+    pub(crate) fn symref_target(&self) -> Option<&str> {
+        self.symref_target.as_deref()
+    }
+}
+
+impl fmt::Debug for StrictGitRefPinV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StrictGitRefPinV1")
+            .field("ref_name", &self.ref_name)
+            .field("object_id", &self.object_id)
+            .field("object_kind", &self.object_kind)
+            .field("symref_target", &self.symref_target)
+            .finish()
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub(crate) enum StrictGitHeadPinV1 {
+    Symbolic {
+        target: String,
+        resolved_object_id: Option<String>,
+    },
+    Detached {
+        object_id: String,
+    },
+}
+
+impl StrictGitHeadPinV1 {
+    pub(crate) fn symbolic_target(&self) -> Option<&str> {
+        match self {
+            Self::Symbolic { target, .. } => Some(target),
+            Self::Detached { .. } => None,
+        }
+    }
+
+    pub(crate) fn resolved_object_id(&self) -> Option<&str> {
+        match self {
+            Self::Symbolic {
+                resolved_object_id, ..
+            } => resolved_object_id.as_deref(),
+            Self::Detached { object_id } => Some(object_id),
+        }
+    }
+}
+
+impl fmt::Debug for StrictGitHeadPinV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Symbolic {
+                target,
+                resolved_object_id,
+            } => formatter
+                .debug_struct("Symbolic")
+                .field("target", target)
+                .field("resolved_object_id", resolved_object_id)
+                .finish(),
+            Self::Detached { object_id } => formatter
+                .debug_struct("Detached")
+                .field("object_id", object_id)
+                .finish(),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+struct StrictGitRawTopologySnapshotV1 {
+    object_format: StrictGitObjectFormatV1,
+    head: StrictGitHeadPinV1,
+    refs: Vec<StrictGitRefPinV1>,
+}
+
+/// First local Git observation plus the descriptor capabilities that performed
+/// it. Only an exact second pass can promote this to held local evidence.
+pub(crate) struct PendingStrictGitRawTopologyV1 {
+    anchor: GitRepoAnchor,
+    contract: RootGitObservationContractV1,
+    metadata: GitMetadataInventoryV1,
+    first: StrictGitRawTopologySnapshotV1,
+}
+
+/// Exact two-pass local Git topology evidence retained under the same root and
+/// `.git` descriptors.
+///
+/// "Complete" is intentionally not in this type name: this is one local input
+/// prerequisite, not complete registered-root truth.
+pub(crate) struct HeldStrictGitRawTopologyV1 {
+    anchor: GitRepoAnchor,
+    contract: RootGitObservationContractV1,
+    snapshot: StrictGitRawTopologySnapshotV1,
+}
+
+impl HeldStrictGitRawTopologyV1 {
+    pub(crate) const fn object_format(&self) -> StrictGitObjectFormatV1 {
+        self.snapshot.object_format
+    }
+
+    pub(crate) fn head(&self) -> &StrictGitHeadPinV1 {
+        &self.snapshot.head
+    }
+
+    pub(crate) fn refs(&self) -> impl ExactSizeIterator<Item = &StrictGitRefPinV1> {
+        self.snapshot.refs.iter()
+    }
+
+    pub(crate) const fn contract(&self) -> RootGitObservationContractV1 {
+        self.contract
+    }
+
+    /// Recheck only the held root and `.git` identities after inventory C.
+    ///
+    /// Ref equality is intentionally a two-pass contract. The local inventory
+    /// C bracket separately checks the raw `.git` identities/content
+    /// acquisition; this final check ensures the retained descriptors were not
+    /// replaced while it ran.
+    pub(crate) fn revalidate_capabilities(&self) -> Result<(), StrictGitRawTopologyIncompleteV1> {
+        self.anchor.revalidate().map_err(|_| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+                "revalidate-git-capabilities-after-local-inventory",
+            )
+        })
+    }
+}
+
+impl fmt::Debug for HeldStrictGitRawTopologyV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HeldStrictGitRawTopologyV1")
+            .field("canonical_root", &self.anchor.canonical_root())
+            .field("contract", &self.contract)
+            .field("object_format", &self.snapshot.object_format)
+            .field("head", &self.snapshot.head)
+            .field("ref_count", &self.snapshot.refs.len())
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) enum StrictGitRawTopologyBeginV1 {
+    Pending(Box<PendingStrictGitRawTopologyV1>),
+    Incomplete(StrictGitRawTopologyIncompleteV1),
+}
+
+pub(crate) enum StrictGitRawTopologyFinishV1 {
+    Held(HeldStrictGitRawTopologyV1),
+    Incomplete(StrictGitRawTopologyIncompleteV1),
+}
+
+pub(crate) fn begin_strict_git_raw_topology_v1(
+    local: &PendingStrictLocalSnapshotV1,
+) -> StrictGitRawTopologyBeginV1 {
+    let profile = local.profile();
+    let policy = profile.policy().settings().git_policy();
+    let contract = policy.observation_contract();
+    if policy != RootGitPolicyV1::StandaloneRawWithFastForwardProofV1
+        || !contract.is_applicable()
+        || contract.pass_count() != 2
+        || contract.retry_count() != 0
+    {
+        return StrictGitRawTopologyBeginV1::Incomplete(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::UnsupportedProfile,
+            "select-git-observation-contract",
+        ));
+    }
+
+    let directory = match local.try_clone_root_descriptor() {
+        Ok(directory) => directory,
+        Err(_) => {
+            return StrictGitRawTopologyBeginV1::Incomplete(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::CapabilityOpenFailed,
+                "clone-held-root-descriptor",
+            ));
+        }
+    };
+    let anchor = match GitRepoAnchor::capture_from_authorized_root(
+        local.canonical_local_root(),
+        directory,
+    ) {
+        Ok(anchor) => anchor,
+        Err(_) => {
+            return StrictGitRawTopologyBeginV1::Incomplete(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::CapabilityOpenFailed,
+                "capture-held-git-descriptors",
+            ));
+        }
+    };
+    let limits = GitObservationLimitsV1::from(contract);
+    let metadata = match capture_initial_git_metadata_v1(local, &anchor, limits) {
+        Ok(metadata) => metadata,
+        Err(incomplete) => {
+            return StrictGitRawTopologyBeginV1::Incomplete(incomplete);
+        }
+    };
+    let first = match read_topology_snapshot_v1(&anchor, &metadata, contract) {
+        Ok(snapshot) => snapshot,
+        Err(incomplete) => {
+            return StrictGitRawTopologyBeginV1::Incomplete(incomplete);
+        }
+    };
+    StrictGitRawTopologyBeginV1::Pending(Box::new(PendingStrictGitRawTopologyV1 {
+        anchor,
+        contract,
+        metadata,
+        first,
+    }))
+}
+
+impl PendingStrictGitRawTopologyV1 {
+    pub(crate) fn revalidate_after_external_reads(self) -> StrictGitRawTopologyFinishV1 {
+        let second = match read_topology_snapshot_v1(&self.anchor, &self.metadata, self.contract) {
+            Ok(snapshot) => snapshot,
+            Err(_) => {
+                return StrictGitRawTopologyFinishV1::Incomplete(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+                    "repeat-git-topology-observation",
+                ));
+            }
+        };
+        if self.first != second {
+            return StrictGitRawTopologyFinishV1::Incomplete(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+                "compare-git-topology-passes",
+            ));
+        }
+        StrictGitRawTopologyFinishV1::Held(HeldStrictGitRawTopologyV1 {
+            anchor: self.anchor,
+            contract: self.contract,
+            snapshot: second,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct GitObservationLimitsV1 {
+    max_refs: u64,
+    max_ref_or_symref_bytes: u64,
+    max_retained_bytes: u64,
+    max_command_stdout_bytes: u64,
+    max_config_file_bytes: u64,
+    max_head_file_bytes: u64,
+    sha1_oid_hex_bytes: u8,
+    sha256_oid_hex_bytes: u8,
+}
+
+impl From<RootGitObservationContractV1> for GitObservationLimitsV1 {
+    fn from(contract: RootGitObservationContractV1) -> Self {
+        Self {
+            max_refs: contract.max_refs(),
+            max_ref_or_symref_bytes: contract.max_ref_or_symref_bytes(),
+            max_retained_bytes: contract.max_retained_bytes(),
+            max_command_stdout_bytes: contract.max_command_stdout_bytes(),
+            max_config_file_bytes: contract.max_config_file_bytes(),
+            max_head_file_bytes: contract.max_head_file_bytes(),
+            sha1_oid_hex_bytes: contract.sha1_oid_hex_bytes(),
+            sha256_oid_hex_bytes: contract.sha256_oid_hex_bytes(),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum RawLooseRefValueV1 {
+    DirectObjectId(Vec<u8>),
+    SymbolicTarget(String),
+}
+
+struct GitMetadataInventoryV1 {
+    loose_refs: BTreeMap<String, RawLooseRefValueV1>,
+    packed_refs: Option<Vec<u8>>,
+    raw_head: Vec<u8>,
+}
+
+fn path_is_or_descends_v1(path: &str, root: &str) -> bool {
+    path == root
+        || path
+            .strip_prefix(root)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn map_held_local_read_failure_v1(
+    failure: StrictLocalSnapshotIncompleteV1,
+    operation: &'static str,
+) -> StrictGitRawTopologyIncompleteV1 {
+    let kind = match failure.kind() {
+        StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded => {
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        }
+        StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed => {
+            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed
+        }
+        StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead => {
+            StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged
+        }
+        _ => StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+    };
+    incomplete(kind, operation)
+}
+
+#[cfg(unix)]
+fn effective_principal_uid_v1() -> Option<u32> {
+    // SAFETY: `geteuid` has no preconditions and only reads process identity.
+    Some(unsafe { libc::geteuid() })
+}
+
+#[cfg(not(unix))]
+fn effective_principal_uid_v1() -> Option<u32> {
+    None
+}
+
+fn capture_initial_git_metadata_v1(
+    local: &PendingStrictLocalSnapshotV1,
+    anchor: &GitRepoAnchor,
+    limits: GitObservationLimitsV1,
+) -> Result<GitMetadataInventoryV1, StrictGitRawTopologyIncompleteV1> {
+    anchor.revalidate().map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+            "revalidate-before-raw-git-inventory",
+        )
+    })?;
+
+    let effective_uid = effective_principal_uid_v1().ok_or_else(|| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::CapabilityOpenFailed,
+            "unsupported-git-metadata-principal-platform",
+        )
+    })?;
+    let mut saw_git_directory = false;
+    let mut saw_refs_directory = false;
+    let mut saw_objects_directory = false;
+    let mut loose_refs = BTreeMap::new();
+    let mut folded_refs = BTreeSet::new();
+    let mut retained_bytes = 0_u64;
+    let mut packed_refs = None;
+    let mut raw_head = None;
+    let mut saw_config = false;
+
+    for entry in local.initial_inventory_entries() {
+        let raw_path = entry.rel_path();
+        if raw_path != b".git" && !raw_path.starts_with(b".git/") {
+            continue;
+        }
+        let path = std::str::from_utf8(raw_path).map_err(|_| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "decode-raw-git-metadata-path",
+            )
+        })?;
+        let trusted_metadata = path == ".git"
+            || path_is_or_descends_v1(path, ".git/refs")
+            || path_is_or_descends_v1(path, ".git/objects")
+            || path_is_or_descends_v1(path, ".git/logs")
+            || matches!(
+                path,
+                ".git/HEAD" | ".git/config" | ".git/index" | ".git/packed-refs"
+            );
+        if trusted_metadata
+            && (matches!(
+                entry.kind(),
+                StrictInitialLocalEntryKindV1::Symlink | StrictInitialLocalEntryKindV1::Special
+            ) || entry.uid() != effective_uid
+                || entry.mode() & 0o022 != 0
+                || crate::path_acl::reject_write_grant_acl(&anchor.canonical_root().join(path))
+                    .is_err())
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "validate-bounded-git-metadata-trust",
+            ));
+        }
+
+        match path {
+            ".git" => {
+                saw_git_directory = entry.kind() == StrictInitialLocalEntryKindV1::Directory;
+            }
+            ".git/refs" => {
+                saw_refs_directory = entry.kind() == StrictInitialLocalEntryKindV1::Directory;
+            }
+            ".git/objects" => {
+                saw_objects_directory = entry.kind() == StrictInitialLocalEntryKindV1::Directory;
+            }
+            ".git/config" => {
+                if entry.kind() != StrictInitialLocalEntryKindV1::Regular || entry.size() < 0 {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                        "require-regular-git-config",
+                    ));
+                }
+                let size = u64::try_from(entry.size()).map_err(|_| {
+                    incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "validate-git-config-size",
+                    )
+                })?;
+                if size > limits.max_config_file_bytes {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                        "maximum-git-config-file-bytes",
+                    ));
+                }
+                saw_config = true;
+            }
+            ".git/HEAD" => {
+                if entry.kind() != StrictInitialLocalEntryKindV1::Regular
+                    || entry.size() < 0
+                    || raw_head.is_some()
+                {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                        "require-regular-git-head",
+                    ));
+                }
+                let size = u64::try_from(entry.size()).map_err(|_| {
+                    incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "validate-git-head-size",
+                    )
+                })?;
+                if size > limits.max_head_file_bytes {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                        "maximum-git-head-file-bytes",
+                    ));
+                }
+                raw_head = Some(
+                    local
+                        .read_initial_regular_file_bounded(raw_path, limits.max_head_file_bytes)
+                        .map_err(|failure| {
+                            map_held_local_read_failure_v1(failure, "read-held-git-head")
+                        })?,
+                );
+            }
+            _ => {}
+        }
+
+        if matches!(
+            path,
+            ".git/commondir"
+                | ".git/config.worktree"
+                | ".git/shallow"
+                | ".git/objects/info/alternates"
+                | ".git/objects/info/http-alternates"
+        ) || path_is_or_descends_v1(path, ".git/worktrees")
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "reject-git-topology-extension",
+            ));
+        }
+        if matches!(
+            path,
+            ".git/gc.pid"
+                | ".git/shallow.lock"
+                | ".git/MERGE_HEAD"
+                | ".git/CHERRY_PICK_HEAD"
+                | ".git/BISECT_LOG"
+                | ".git/REVERT_HEAD"
+        ) || path_is_or_descends_v1(path, ".git/rebase-merge")
+            || path_is_or_descends_v1(path, ".git/rebase-apply")
+            || path_is_or_descends_v1(path, ".git/sequencer")
+            || (path != ".git/tcfs.lock"
+                && path.starts_with(".git/")
+                && path
+                    .rsplit('/')
+                    .next()
+                    .is_some_and(|name| name.ends_with(".lock")))
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ActivityDetected,
+                "reject-native-git-activity",
+            ));
+        }
+
+        if path == ".git/packed-refs" {
+            if entry.kind() != StrictInitialLocalEntryKindV1::Regular || packed_refs.is_some() {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                    "require-regular-packed-refs",
+                ));
+            }
+            let size = u64::try_from(entry.size()).map_err(|_| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "validate-packed-refs-size",
+                )
+            })?;
+            if size > limits.max_command_stdout_bytes {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                    "maximum-packed-refs-bytes",
+                ));
+            }
+            packed_refs = Some(
+                local
+                    .read_initial_regular_file_bounded(raw_path, limits.max_command_stdout_bytes)
+                    .map_err(|failure| {
+                        map_held_local_read_failure_v1(failure, "read-held-packed-refs")
+                    })?,
+            );
+        }
+
+        let Some(ref_name_bytes) = raw_path.strip_prefix(b".git/refs/") else {
+            continue;
+        };
+        if entry.kind() == StrictInitialLocalEntryKindV1::Directory {
+            continue;
+        }
+        if entry.kind() != StrictInitialLocalEntryKindV1::Regular {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "require-regular-loose-reference",
+            ));
+        }
+        if u64::try_from(loose_refs.len()).unwrap_or(u64::MAX) >= limits.max_refs {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-loose-reference-count",
+            ));
+        }
+        let full_ref_name_len = b"refs/"
+            .len()
+            .checked_add(ref_name_bytes.len())
+            .ok_or_else(|| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                    "count-loose-reference-name-bytes",
+                )
+            })?;
+        if full_ref_name_len > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX)
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-loose-reference-name-bytes",
+            ));
+        }
+        let ref_name = std::str::from_utf8(ref_name_bytes).map_err(|_| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "decode-loose-reference-name",
+            )
+        })?;
+        let mut full_ref_name = String::new();
+        full_ref_name
+            .try_reserve_exact(full_ref_name_len)
+            .map_err(|_| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                    "allocate-loose-reference-name",
+                )
+            })?;
+        full_ref_name.push_str("refs/");
+        full_ref_name.push_str(ref_name);
+        let folded_ref = validate_ref_name_v1(&full_ref_name, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "validate-loose-reference-name",
+            )
+        })?;
+        if !folded_refs.insert(folded_ref.clone()) {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reject-loose-reference-portable-alias",
+            ));
+        }
+        let raw_value_limit = limits
+            .max_ref_or_symref_bytes
+            .max(u64::from(limits.sha256_oid_hex_bytes))
+            .saturating_add(6);
+        let size = u64::try_from(entry.size()).map_err(|_| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "validate-loose-reference-size",
+            )
+        })?;
+        if size > raw_value_limit {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-loose-reference-value-bytes",
+            ));
+        }
+        let bytes = local
+            .read_initial_regular_file_bounded(raw_path, raw_value_limit)
+            .map_err(|failure| {
+                map_held_local_read_failure_v1(failure, "read-held-loose-reference")
+            })?;
+        let line = exact_single_line_v1(&bytes).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-loose-reference-line",
+            )
+        })?;
+        let value = if let Some(target_bytes) = line.strip_prefix(b"ref: ") {
+            if target_bytes.len()
+                > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX)
+            {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                    "maximum-loose-symref-target-bytes",
+                ));
+            }
+            let target = std::str::from_utf8(target_bytes)
+                .ok()
+                .and_then(|target| validate_ref_name_v1(target, limits).map(|_| target.to_owned()))
+                .ok_or_else(|| {
+                    incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "validate-loose-symref-target",
+                    )
+                })?;
+            RawLooseRefValueV1::SymbolicTarget(target)
+        } else {
+            if line.len() > usize::from(limits.sha256_oid_hex_bytes) {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                    "maximum-loose-object-id-bytes",
+                ));
+            }
+            RawLooseRefValueV1::DirectObjectId(line.to_vec())
+        };
+        checked_retain_v1(&mut retained_bytes, full_ref_name.len(), limits)?;
+        checked_retain_v1(&mut retained_bytes, folded_ref.len(), limits)?;
+        match &value {
+            RawLooseRefValueV1::DirectObjectId(object_id) => {
+                checked_retain_v1(&mut retained_bytes, object_id.len(), limits)?;
+            }
+            RawLooseRefValueV1::SymbolicTarget(target) => {
+                checked_retain_v1(&mut retained_bytes, target.len(), limits)?;
+            }
+        }
+        if loose_refs.insert(full_ref_name, value).is_some() {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reject-duplicate-loose-reference",
+            ));
+        }
+    }
+
+    if !saw_git_directory
+        || !saw_refs_directory
+        || !saw_objects_directory
+        || !saw_config
+        || raw_head.is_none()
+    {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            "require-standalone-git-layout",
+        ));
+    }
+    anchor.revalidate().map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+            "revalidate-after-raw-git-inventory",
+        )
+    })?;
+    Ok(GitMetadataInventoryV1 {
+        loose_refs,
+        packed_refs,
+        raw_head: raw_head.expect("validated raw HEAD presence"),
+    })
+}
+
+struct BoundedCommandOutputV1 {
+    status: ExitStatus,
+    stdout: Vec<u8>,
+}
+
+fn run_held_git_query_v1(
+    anchor: &GitRepoAnchor,
+    query: HeldGitReadQueryV1,
+    stdout_limit: u64,
+    operation: &'static str,
+) -> Result<BoundedCommandOutputV1, StrictGitRawTopologyIncompleteV1> {
+    match anchor.run_held_read_query(query, stdout_limit) {
+        Ok(output) => {
+            let (status, stdout) = output.into_parts();
+            Ok(BoundedCommandOutputV1 { status, stdout })
+        }
+        Err(HeldGitReadErrorV1::OutputLimit) => Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            operation,
+        )),
+        Err(HeldGitReadErrorV1::Failed) => Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged,
+            operation,
+        )),
+    }
+}
+
+fn require_only_false_config_values_v1(
+    output: &BoundedCommandOutputV1,
+    operation: &'static str,
+) -> Result<(), StrictGitRawTopologyIncompleteV1> {
+    match output.status.code() {
+        Some(0) => {
+            let values = output.stdout.strip_suffix(&[0]).ok_or_else(|| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    operation,
+                )
+            })?;
+            if values.is_empty()
+                || values
+                    .split(|byte| *byte == 0)
+                    .any(|value| value != b"false")
+            {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                    operation,
+                ));
+            }
+            Ok(())
+        }
+        Some(1) if output.stdout.is_empty() => Ok(()),
+        _ => Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            operation,
+        )),
+    }
+}
+
+fn validate_bounded_git_routing_v1(
+    anchor: &GitRepoAnchor,
+    limits: GitObservationLimitsV1,
+) -> Result<(), StrictGitRawTopologyIncompleteV1> {
+    let config = run_held_git_query_v1(
+        anchor,
+        HeldGitReadQueryV1::EffectiveConfigNames,
+        limits.max_command_stdout_bytes,
+        "read-bounded-effective-git-config",
+    )
+    .map_err(|failure| {
+        if failure.kind() == StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit {
+            failure
+        } else {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "read-bounded-effective-git-config",
+            )
+        }
+    })?;
+    if !config.status.success() || (!config.stdout.is_empty() && !config.stdout.ends_with(&[0])) {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            "read-bounded-effective-git-config",
+        ));
+    }
+    for raw_key in config
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|key| !key.is_empty())
+    {
+        if raw_key.len() > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX) {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-effective-git-config-key-bytes",
+            ));
+        }
+        let key = std::str::from_utf8(raw_key)
+            .map_err(|_| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "decode-effective-git-config-key",
+                )
+            })?
+            .to_ascii_lowercase();
+        let remote_promisor = key.starts_with("remote.")
+            && (key.ends_with(".promisor") || key.ends_with(".partialclonefilter"));
+        if key == "extensions.partialclone"
+            || key == "extensions.refstorage"
+            || key == "extensions.worktreeconfig"
+            || remote_promisor
+            || key == "protocol.ext.allow"
+            || key == "core.alternaterefscommand"
+            || key == "core.worktree"
+            || key == "include.path"
+            || (key.starts_with("includeif.") && key.ends_with(".path"))
+            || key.starts_with("fsck.")
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "reject-effective-git-config-key",
+            ));
+        }
+    }
+
+    let shared = run_held_git_query_v1(
+        anchor,
+        HeldGitReadQueryV1::SharedRepositoryValues,
+        1024,
+        "read-bounded-shared-repository-config",
+    )
+    .map_err(|failure| {
+        if failure.kind() == StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit {
+            failure
+        } else {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "read-bounded-shared-repository-config",
+            )
+        }
+    })?;
+    require_only_false_config_values_v1(&shared, "reject-shared-repository-config")?;
+
+    let bare = run_held_git_query_v1(
+        anchor,
+        HeldGitReadQueryV1::BareRepositoryValues,
+        1024,
+        "read-bounded-bare-repository-config",
+    )
+    .map_err(|failure| {
+        if failure.kind() == StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit {
+            failure
+        } else {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "read-bounded-bare-repository-config",
+            )
+        }
+    })?;
+    require_only_false_config_values_v1(&bare, "reject-bare-repository-config")?;
+
+    Ok(())
+}
+
+fn read_topology_snapshot_v1(
+    anchor: &GitRepoAnchor,
+    metadata: &GitMetadataInventoryV1,
+    contract: RootGitObservationContractV1,
+) -> Result<StrictGitRawTopologySnapshotV1, StrictGitRawTopologyIncompleteV1> {
+    let limits = GitObservationLimitsV1::from(contract);
+    validate_bounded_git_routing_v1(anchor, limits)?;
+    let object_format = read_object_format_v1(anchor, limits)?;
+    let refs = read_refs_v1(anchor, metadata, object_format, limits)?;
+    let head = read_head_v1(anchor, metadata, object_format, &refs, limits)?;
+    Ok(StrictGitRawTopologySnapshotV1 {
+        object_format,
+        head,
+        refs,
+    })
+}
+
+fn exact_single_line_v1(bytes: &[u8]) -> Option<&[u8]> {
+    let line = bytes.strip_suffix(b"\n").unwrap_or(bytes);
+    if line.is_empty() || line.contains(&b'\n') || line.contains(&b'\r') || line.contains(&0) {
+        None
+    } else {
+        Some(line)
+    }
+}
+
+fn read_object_format_v1(
+    anchor: &GitRepoAnchor,
+    limits: GitObservationLimitsV1,
+) -> Result<StrictGitObjectFormatV1, StrictGitRawTopologyIncompleteV1> {
+    let output = run_held_git_query_v1(
+        anchor,
+        HeldGitReadQueryV1::ObjectFormat,
+        limits.max_command_stdout_bytes.min(32),
+        "read-git-object-format",
+    )?;
+    if !output.status.success() {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+            "read-git-object-format",
+        ));
+    }
+    match exact_single_line_v1(&output.stdout) {
+        Some(b"sha1") => Ok(StrictGitObjectFormatV1::Sha1),
+        Some(b"sha256") => Ok(StrictGitObjectFormatV1::Sha256),
+        _ => Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+            "parse-git-object-format",
+        )),
+    }
+}
+
+fn expected_oid_len_v1(format: StrictGitObjectFormatV1, limits: GitObservationLimitsV1) -> usize {
+    match format {
+        StrictGitObjectFormatV1::Sha1 => usize::from(limits.sha1_oid_hex_bytes),
+        StrictGitObjectFormatV1::Sha256 => usize::from(limits.sha256_oid_hex_bytes),
+    }
+}
+
+fn parse_object_id_v1(
+    bytes: &[u8],
+    format: StrictGitObjectFormatV1,
+    limits: GitObservationLimitsV1,
+) -> Option<String> {
+    (bytes.len() == expected_oid_len_v1(format, limits)
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')))
+    .then(|| String::from_utf8(bytes.to_vec()).expect("validated ASCII object ID"))
+}
+
+fn parse_object_kind_v1(bytes: &[u8]) -> Option<StrictGitObjectKindV1> {
+    match bytes {
+        b"commit" => Some(StrictGitObjectKindV1::Commit),
+        b"tree" => Some(StrictGitObjectKindV1::Tree),
+        b"blob" => Some(StrictGitObjectKindV1::Blob),
+        b"tag" => Some(StrictGitObjectKindV1::Tag),
+        _ => None,
+    }
+}
+
+fn validate_ref_name_v1(value: &str, limits: GitObservationLimitsV1) -> Option<String> {
+    if !value.starts_with("refs/")
+        || value.len() > usize::try_from(limits.max_ref_or_symref_bytes).ok()?
+        || value == "refs/"
+        || value.ends_with('/')
+        || value.ends_with('.')
+        || value.contains("..")
+        || value.contains("@{")
+        || value.chars().any(|character| {
+            character.is_ascii_control()
+                || matches!(character, ' ' | '~' | '^' | ':' | '?' | '*' | '[' | '\\')
+        })
+        || value.split('/').any(|component| {
+            component.is_empty()
+                || component == "."
+                || component == ".."
+                || component.starts_with('.')
+                || component.ends_with(".lock")
+        })
+    {
+        return None;
+    }
+    portable_casefold_path(&format!(".git/{value}")).ok()
+}
+
+fn checked_retain_v1(
+    retained: &mut u64,
+    additional: usize,
+    limits: GitObservationLimitsV1,
+) -> Result<(), StrictGitRawTopologyIncompleteV1> {
+    *retained = retained
+        .checked_add(u64::try_from(additional).map_err(|_| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "count-retained-git-reference-bytes",
+            )
+        })?)
+        .ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "count-retained-git-reference-bytes",
+            )
+        })?;
+    if *retained > limits.max_retained_bytes {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "maximum-retained-git-reference-bytes",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ObservedGitRefV1 {
+    ref_name: String,
+    object_id: String,
+    object_kind: StrictGitObjectKindV1,
+    reported_symref_target: Option<String>,
+}
+
+fn parse_ref_output_v1(
+    bytes: &[u8],
+    format: StrictGitObjectFormatV1,
+    limits: GitObservationLimitsV1,
+) -> Result<Vec<ObservedGitRefV1>, StrictGitRawTopologyIncompleteV1> {
+    let mut refs = Vec::new();
+    let mut previous_ref: Option<String> = None;
+    let mut folded_refs = BTreeSet::new();
+    let mut retained_bytes = 0_u64;
+    let mut lines = bytes.split(|byte| *byte == b'\n').peekable();
+    while let Some(line) = lines.next() {
+        if line.is_empty() && lines.peek().is_none() {
+            break;
+        }
+        if line.is_empty() || line.contains(&b'\r') {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-reference-record",
+            ));
+        }
+        let mut fields = line.splitn(5, |byte| *byte == 0);
+        let Some(ref_name_bytes) = fields.next() else {
+            unreachable!("splitn always yields one field");
+        };
+        let Some(object_id_bytes) = fields.next() else {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-reference-fields",
+            ));
+        };
+        let Some(object_kind_bytes) = fields.next() else {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-reference-fields",
+            ));
+        };
+        let Some(symref_target_bytes) = fields.next() else {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-reference-fields",
+            ));
+        };
+        if fields.next().is_some() {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-reference-fields",
+            ));
+        }
+        if u64::try_from(refs.len()).unwrap_or(u64::MAX) >= limits.max_refs {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-git-reference-count",
+            ));
+        }
+        if ref_name_bytes.len()
+            > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX)
+            || symref_target_bytes.len()
+                > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX)
+            || object_id_bytes.len() > usize::from(limits.sha256_oid_hex_bytes)
+            || object_kind_bytes.len() > 6
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-git-reference-field-bytes",
+            ));
+        }
+        let ref_name_borrowed = std::str::from_utf8(ref_name_bytes).map_err(|_| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "decode-git-reference-name",
+            )
+        })?;
+        let folded_ref = validate_ref_name_v1(ref_name_borrowed, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "validate-git-reference-name",
+            )
+        })?;
+        let ref_name = ref_name_borrowed.to_owned();
+        if previous_ref
+            .as_ref()
+            .is_some_and(|previous| previous >= &ref_name)
+            || !folded_refs.insert(folded_ref.clone())
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "require-sorted-unique-git-references",
+            ));
+        }
+        let object_id = parse_object_id_v1(object_id_bytes, format, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-reference-object-id",
+            )
+        })?;
+        let object_kind = parse_object_kind_v1(object_kind_bytes).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-reference-object-kind",
+            )
+        })?;
+        if ref_name.starts_with("refs/heads/") && object_kind != StrictGitObjectKindV1::Commit {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "require-branch-reference-commit",
+            ));
+        }
+        let reported_symref_target = if symref_target_bytes.is_empty() {
+            None
+        } else {
+            let target = std::str::from_utf8(symref_target_bytes).map_err(|_| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "decode-git-symref-target",
+                )
+            })?;
+            validate_ref_name_v1(target, limits).ok_or_else(|| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "validate-git-symref-target",
+                )
+            })?;
+            Some(target.to_owned())
+        };
+        checked_retain_v1(&mut retained_bytes, ref_name.len(), limits)?;
+        checked_retain_v1(&mut retained_bytes, folded_ref.len(), limits)?;
+        checked_retain_v1(&mut retained_bytes, object_id.len(), limits)?;
+        checked_retain_v1(&mut retained_bytes, object_kind_bytes.len(), limits)?;
+        if let Some(target) = &reported_symref_target {
+            checked_retain_v1(&mut retained_bytes, target.len(), limits)?;
+        }
+        previous_ref = Some(ref_name.clone());
+        refs.try_reserve(1).map_err(|_| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "allocate-git-reference-record",
+            )
+        })?;
+        refs.push(ObservedGitRefV1 {
+            ref_name,
+            object_id,
+            object_kind,
+            reported_symref_target,
+        });
+    }
+    Ok(refs)
+}
+
+fn parse_packed_refs_v1(
+    bytes: &[u8],
+    format: StrictGitObjectFormatV1,
+    limits: GitObservationLimitsV1,
+) -> Result<BTreeMap<String, String>, StrictGitRawTopologyIncompleteV1> {
+    if bytes.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    if !bytes.ends_with(b"\n") {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+            "require-packed-refs-terminal-newline",
+        ));
+    }
+    let mut refs = BTreeMap::new();
+    let mut retained_bytes = 0_u64;
+    let mut previous_was_ref = false;
+    let mut previous_was_peeled = false;
+    for line in bytes.split(|byte| *byte == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+        if line.contains(&b'\r') || line.contains(&0) {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-packed-reference-line",
+            ));
+        }
+        if line.starts_with(b"#") {
+            previous_was_ref = false;
+            previous_was_peeled = false;
+            continue;
+        }
+        if let Some(peeled) = line.strip_prefix(b"^") {
+            if !previous_was_ref
+                || previous_was_peeled
+                || parse_object_id_v1(peeled, format, limits).is_none()
+            {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "parse-packed-peeled-object-id",
+                ));
+            }
+            previous_was_peeled = true;
+            continue;
+        }
+        previous_was_peeled = false;
+        if u64::try_from(refs.len()).unwrap_or(u64::MAX) >= limits.max_refs {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-packed-reference-count",
+            ));
+        }
+        let Some(separator) = line.iter().position(|byte| *byte == b' ') else {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-packed-reference-fields",
+            ));
+        };
+        let object_id_bytes = &line[..separator];
+        let ref_name_bytes = &line[separator + 1..];
+        if ref_name_bytes.len()
+            > usize::try_from(limits.max_ref_or_symref_bytes).unwrap_or(usize::MAX)
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-packed-reference-field-bytes",
+            ));
+        }
+        if ref_name_bytes.contains(&b' ') {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-packed-reference-name",
+            ));
+        }
+        let object_id = parse_object_id_v1(object_id_bytes, format, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-packed-reference-object-id",
+            )
+        })?;
+        let ref_name = std::str::from_utf8(ref_name_bytes)
+            .map_err(|_| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "decode-packed-reference-name",
+                )
+            })?
+            .to_owned();
+        let folded = validate_ref_name_v1(&ref_name, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "validate-packed-reference-name",
+            )
+        })?;
+        checked_retain_v1(&mut retained_bytes, ref_name.len(), limits)?;
+        checked_retain_v1(&mut retained_bytes, folded.len(), limits)?;
+        checked_retain_v1(&mut retained_bytes, object_id.len(), limits)?;
+        if refs.insert(ref_name, object_id).is_some() {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reject-duplicate-packed-reference",
+            ));
+        }
+        previous_was_ref = true;
+    }
+    Ok(refs)
+}
+
+enum EffectiveRawRefValueV1 {
+    DirectObjectId(String),
+    SymbolicTarget(String),
+}
+
+fn effective_raw_refs_v1(
+    metadata: &GitMetadataInventoryV1,
+    format: StrictGitObjectFormatV1,
+    limits: GitObservationLimitsV1,
+) -> Result<BTreeMap<String, EffectiveRawRefValueV1>, StrictGitRawTopologyIncompleteV1> {
+    let mut refs = match &metadata.packed_refs {
+        Some(bytes) => parse_packed_refs_v1(bytes, format, limits)?
+            .into_iter()
+            .map(|(name, oid)| (name, EffectiveRawRefValueV1::DirectObjectId(oid)))
+            .collect::<BTreeMap<_, _>>(),
+        None => BTreeMap::new(),
+    };
+    for (name, value) in &metadata.loose_refs {
+        if !refs.contains_key(name)
+            && u64::try_from(refs.len()).unwrap_or(u64::MAX) >= limits.max_refs
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "maximum-effective-raw-reference-count",
+            ));
+        }
+        let value = match value {
+            RawLooseRefValueV1::DirectObjectId(raw) => EffectiveRawRefValueV1::DirectObjectId(
+                parse_object_id_v1(raw, format, limits).ok_or_else(|| {
+                    incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "parse-loose-reference-object-id",
+                    )
+                })?,
+            ),
+            RawLooseRefValueV1::SymbolicTarget(target) => {
+                EffectiveRawRefValueV1::SymbolicTarget(target.clone())
+            }
+        };
+        refs.insert(name.clone(), value);
+    }
+    let mut folded = BTreeSet::new();
+    for (name, value) in &refs {
+        let folded_name = validate_ref_name_v1(name, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "validate-effective-raw-reference-name",
+            )
+        })?;
+        if !folded.insert(folded_name) {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reject-effective-raw-reference-portable-alias",
+            ));
+        }
+        if let EffectiveRawRefValueV1::SymbolicTarget(target) = value {
+            if !refs.contains_key(target) {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "reject-dangling-symbolic-reference",
+                ));
+            }
+        }
+    }
+    for folded_name in &folded {
+        for (separator, _) in folded_name.match_indices('/') {
+            if folded.contains(&folded_name[..separator]) {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "reject-reference-file-directory-conflict",
+                ));
+            }
+        }
+    }
+    Ok(refs)
+}
+
+fn resolve_symbolic_ref_terminals_v1(
+    raw: &BTreeMap<String, EffectiveRawRefValueV1>,
+) -> Result<Vec<usize>, StrictGitRawTopologyIncompleteV1> {
+    let mut names = Vec::new();
+    names.try_reserve_exact(raw.len()).map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "allocate-symbolic-reference-name-index",
+        )
+    })?;
+    names.extend(raw.keys().map(String::as_str));
+
+    let mut terminals = Vec::new();
+    terminals.try_reserve_exact(raw.len()).map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "allocate-symbolic-reference-terminal-index",
+        )
+    })?;
+    terminals.resize(raw.len(), usize::MAX);
+    for (index, value) in raw.values().enumerate() {
+        if matches!(value, EffectiveRawRefValueV1::DirectObjectId(_)) {
+            terminals[index] = index;
+        }
+    }
+
+    let mut visit_generation = Vec::new();
+    visit_generation.try_reserve_exact(raw.len()).map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "allocate-symbolic-reference-cycle-index",
+        )
+    })?;
+    visit_generation.resize(raw.len(), 0_usize);
+
+    let mut path = Vec::new();
+    path.try_reserve_exact(raw.len()).map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "allocate-symbolic-reference-resolution-path",
+        )
+    })?;
+
+    for start in 0..raw.len() {
+        if terminals[start] != usize::MAX {
+            continue;
+        }
+        path.clear();
+        let generation = start.checked_add(1).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+                "count-symbolic-reference-resolution-generation",
+            )
+        })?;
+        let mut current = start;
+        let terminal = loop {
+            if terminals[current] != usize::MAX {
+                break terminals[current];
+            }
+            if visit_generation[current] == generation {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "reject-symbolic-reference-cycle",
+                ));
+            }
+            visit_generation[current] = generation;
+            path.push(current);
+            let target = match raw.get(names[current]) {
+                Some(EffectiveRawRefValueV1::SymbolicTarget(target)) => target,
+                Some(EffectiveRawRefValueV1::DirectObjectId(_)) => {
+                    terminals[current] = current;
+                    break current;
+                }
+                None => {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "resolve-symbolic-reference-source",
+                    ));
+                }
+            };
+            current = names.binary_search(&target.as_str()).map_err(|_| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "reject-dangling-symbolic-reference",
+                )
+            })?;
+        };
+        for index in path.iter().copied() {
+            terminals[index] = terminal;
+        }
+    }
+
+    Ok(terminals)
+}
+
+fn reconcile_raw_and_observed_refs_v1(
+    raw: BTreeMap<String, EffectiveRawRefValueV1>,
+    terminals: Vec<usize>,
+    observed: Vec<ObservedGitRefV1>,
+) -> Result<Vec<StrictGitRefPinV1>, StrictGitRawTopologyIncompleteV1> {
+    if raw.len() != observed.len() {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+            "reconcile-raw-and-git-reference-counts",
+        ));
+    }
+    let mut raw_names = Vec::new();
+    raw_names.try_reserve_exact(raw.len()).map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "allocate-reconciled-reference-name-index",
+        )
+    })?;
+    raw_names.extend(raw.keys().map(String::as_str));
+    let mut pins = Vec::new();
+    pins.try_reserve_exact(raw.len()).map_err(|_| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "allocate-reconciled-git-reference-pins",
+        )
+    })?;
+    for (index, ((raw_name, raw_value), observed)) in raw.iter().zip(observed).enumerate() {
+        if raw_name != &observed.ref_name {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reconcile-raw-and-git-reference-names",
+            ));
+        }
+        let symref_target = match raw_value {
+            EffectiveRawRefValueV1::DirectObjectId(raw_object_id) => {
+                if raw_object_id != &observed.object_id || observed.reported_symref_target.is_some()
+                {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "reconcile-direct-reference-value",
+                    ));
+                }
+                None
+            }
+            EffectiveRawRefValueV1::SymbolicTarget(target) => {
+                let terminal_name = raw_names[terminals[index]];
+                let terminal_object_id = match raw.get(terminal_name) {
+                    Some(EffectiveRawRefValueV1::DirectObjectId(object_id)) => object_id,
+                    _ => {
+                        return Err(incomplete(
+                            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                            "resolve-symbolic-reference-terminal-object",
+                        ));
+                    }
+                };
+                if observed.reported_symref_target.as_deref() != Some(terminal_name)
+                    || &observed.object_id != terminal_object_id
+                {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "reconcile-symbolic-reference-value",
+                    ));
+                }
+                Some(target.clone())
+            }
+        };
+        pins.push(StrictGitRefPinV1 {
+            ref_name: observed.ref_name,
+            object_id: observed.object_id,
+            object_kind: observed.object_kind,
+            symref_target,
+        });
+    }
+    Ok(pins)
+}
+
+fn read_refs_v1(
+    anchor: &GitRepoAnchor,
+    metadata: &GitMetadataInventoryV1,
+    format: StrictGitObjectFormatV1,
+    limits: GitObservationLimitsV1,
+) -> Result<Vec<StrictGitRefPinV1>, StrictGitRawTopologyIncompleteV1> {
+    let raw = effective_raw_refs_v1(metadata, format, limits)?;
+    let terminals = resolve_symbolic_ref_terminals_v1(&raw)?;
+    let count = limits.max_refs.checked_add(1).ok_or_else(|| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit,
+            "bound-git-reference-command-count",
+        )
+    })?;
+    let output = run_held_git_query_v1(
+        anchor,
+        HeldGitReadQueryV1::ForEachRef { count },
+        limits.max_command_stdout_bytes,
+        "read-bounded-git-references",
+    )?;
+    if !output.status.success() {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+            "read-bounded-git-references",
+        ));
+    }
+    let observed = parse_ref_output_v1(&output.stdout, format, limits)?;
+    reconcile_raw_and_observed_refs_v1(raw, terminals, observed)
+}
+
+enum ParsedRawHeadV1 {
+    Symbolic(String),
+    Detached(String),
+}
+
+fn parse_raw_head_v1(
+    bytes: &[u8],
+    format: StrictGitObjectFormatV1,
+    limits: GitObservationLimitsV1,
+) -> Result<ParsedRawHeadV1, StrictGitRawTopologyIncompleteV1> {
+    let line = exact_single_line_v1(bytes).ok_or_else(|| {
+        incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+            "parse-raw-git-head-line",
+        )
+    })?;
+    if let Some(target_bytes) = line.strip_prefix(b"ref: ") {
+        let target = std::str::from_utf8(target_bytes).map_err(|_| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "decode-raw-git-symbolic-head",
+            )
+        })?;
+        validate_ref_name_v1(target, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "validate-raw-git-symbolic-head",
+            )
+        })?;
+        if !target.starts_with("refs/heads/") {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "require-raw-symbolic-head-branch-target",
+            ));
+        }
+        Ok(ParsedRawHeadV1::Symbolic(target.to_owned()))
+    } else {
+        parse_object_id_v1(line, format, limits)
+            .map(ParsedRawHeadV1::Detached)
+            .ok_or_else(|| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "parse-raw-git-detached-head",
+                )
+            })
+    }
+}
+
+fn read_head_v1(
+    anchor: &GitRepoAnchor,
+    metadata: &GitMetadataInventoryV1,
+    format: StrictGitObjectFormatV1,
+    refs: &[StrictGitRefPinV1],
+    limits: GitObservationLimitsV1,
+) -> Result<StrictGitHeadPinV1, StrictGitRawTopologyIncompleteV1> {
+    let raw_head = parse_raw_head_v1(&metadata.raw_head, format, limits)?;
+    let symbolic = run_held_git_query_v1(
+        anchor,
+        HeldGitReadQueryV1::SymbolicHeadNoRecurse,
+        limits.max_ref_or_symref_bytes.saturating_add(2),
+        "read-git-symbolic-head",
+    )?;
+    let resolved = run_held_git_query_v1(
+        anchor,
+        HeldGitReadQueryV1::ResolvedHeadCommit,
+        u64::from(limits.sha256_oid_hex_bytes).saturating_add(2),
+        "read-git-resolved-head",
+    )?;
+    let resolved_object_id = if resolved.status.success() {
+        let line = exact_single_line_v1(&resolved.stdout).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-resolved-head",
+            )
+        })?;
+        Some(parse_object_id_v1(line, format, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "parse-git-resolved-head",
+            )
+        })?)
+    } else if resolved.status.code() == Some(1) && resolved.stdout.is_empty() {
+        None
+    } else {
+        return Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+            "read-git-resolved-head",
+        ));
+    };
+
+    if symbolic.status.success() {
+        let target = exact_single_line_v1(&symbolic.stdout)
+            .and_then(|bytes| std::str::from_utf8(bytes).ok())
+            .map(str::to_owned)
+            .ok_or_else(|| {
+                incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "parse-git-symbolic-head",
+                )
+            })?;
+        let folded_target = validate_ref_name_v1(&target, limits).ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "validate-git-symbolic-head",
+            )
+        })?;
+        if !target.starts_with("refs/heads/") {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "require-symbolic-head-branch-target",
+            ));
+        }
+        if !matches!(&raw_head, ParsedRawHeadV1::Symbolic(raw_target) if raw_target == &target) {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reconcile-raw-and-git-symbolic-head",
+            ));
+        }
+        if let Some(oid) = &resolved_object_id {
+            if !refs
+                .iter()
+                .any(|pin| pin.ref_name == target && pin.object_id == *oid)
+            {
+                return Err(incomplete(
+                    StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                    "bind-symbolic-head-to-reference",
+                ));
+            }
+        } else {
+            for pin in refs {
+                let folded_pin = validate_ref_name_v1(&pin.ref_name, limits).ok_or_else(|| {
+                    incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "revalidate-git-reference-for-unborn-head",
+                    )
+                })?;
+                if folded_pin == folded_target
+                    || folded_pin
+                        .strip_prefix(&folded_target)
+                        .is_some_and(|suffix| suffix.starts_with('/'))
+                    || folded_target
+                        .strip_prefix(&folded_pin)
+                        .is_some_and(|suffix| suffix.starts_with('/'))
+                {
+                    return Err(incomplete(
+                        StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                        "reject-unborn-head-portable-alias",
+                    ));
+                }
+            }
+        }
+        Ok(StrictGitHeadPinV1::Symbolic {
+            target,
+            resolved_object_id,
+        })
+    } else if symbolic.status.code() == Some(1) && symbolic.stdout.is_empty() {
+        let object_id = resolved_object_id.ok_or_else(|| {
+            incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "require-detached-head-object",
+            )
+        })?;
+        if !matches!(&raw_head, ParsedRawHeadV1::Detached(raw_object_id) if raw_object_id == &object_id)
+        {
+            return Err(incomplete(
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed,
+                "reconcile-raw-and-git-detached-head",
+            ));
+        }
+        Ok(StrictGitHeadPinV1::Detached { object_id })
+    } else {
+        Err(incomplete(
+            StrictGitRawTopologyIncompleteKindV1::ReferenceReadFailed,
+            "read-git-symbolic-head",
+        ))
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use crate::registered_local_snapshot::{
+        begin_strict_local_snapshot_v1, StrictLocalSnapshotFinishV1, StrictLocalSnapshotHoldReadV1,
+    };
+    use std::path::Path;
+    use std::process::Command;
+    use tcfs_core::config::RootProfileV1;
+
+    static_assertions::assert_not_impl_any!(
+        HeldStrictGitRawTopologyV1: Clone,
+        serde::Serialize,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>,
+        Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
+        Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        StrictGitRefPinV1: Clone,
+        serde::Serialize
+    );
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(["-C", repo.to_str().unwrap()])
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?}");
+    }
+
+    fn git_stdout(repo: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(["-C", repo.to_str().unwrap()])
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "git {args:?}");
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    }
+
+    fn canonical_unborn_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+        canonical_unborn_repo_with_format("sha1")
+    }
+
+    fn canonical_unborn_repo_with_format(format: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("repo");
+        std::fs::create_dir(&root).unwrap();
+        run_git(
+            &root,
+            &[
+                "init",
+                "--quiet",
+                "--initial-branch=main",
+                &format!("--object-format={format}"),
+            ],
+        );
+        (temporary, root.canonicalize().unwrap())
+    }
+
+    fn canonical_committed_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+        canonical_committed_repo_with_format("sha1")
+    }
+
+    fn canonical_committed_repo_with_format(
+        format: &str,
+    ) -> (tempfile::TempDir, std::path::PathBuf) {
+        let (temporary, root) = canonical_unborn_repo_with_format(format);
+        std::fs::write(root.join("tracked"), b"payload").unwrap();
+        run_git(&root, &["add", "tracked"]);
+        run_git(
+            &root,
+            &[
+                "-c",
+                "user.name=TCFS Test",
+                "-c",
+                "user.email=tcfs@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "base",
+            ],
+        );
+        (temporary, root)
+    }
+
+    fn pending_local(root: &Path) -> PendingStrictLocalSnapshotV1 {
+        match begin_strict_local_snapshot_v1(root, RootProfileV1::GitRawV1).unwrap() {
+            StrictLocalSnapshotHoldReadV1::Pending(pending) => pending,
+            StrictLocalSnapshotHoldReadV1::Incomplete(incomplete) => {
+                panic!("expected pending GitRaw local snapshot: {incomplete:?}")
+            }
+        }
+    }
+
+    fn begin_topology(pending: &PendingStrictLocalSnapshotV1) -> PendingStrictGitRawTopologyV1 {
+        match begin_strict_git_raw_topology_v1(pending) {
+            StrictGitRawTopologyBeginV1::Pending(topology) => *topology,
+            StrictGitRawTopologyBeginV1::Incomplete(incomplete) => {
+                panic!("expected pending GitRaw topology: {incomplete:?}")
+            }
+        }
+    }
+
+    fn finish_topology(pending: PendingStrictGitRawTopologyV1) -> HeldStrictGitRawTopologyV1 {
+        match pending.revalidate_after_external_reads() {
+            StrictGitRawTopologyFinishV1::Held(topology) => topology,
+            StrictGitRawTopologyFinishV1::Incomplete(incomplete) => {
+                panic!("expected held GitRaw topology: {incomplete:?}")
+            }
+        }
+    }
+
+    fn begin_incomplete(
+        pending: &PendingStrictLocalSnapshotV1,
+    ) -> StrictGitRawTopologyIncompleteV1 {
+        match begin_strict_git_raw_topology_v1(pending) {
+            StrictGitRawTopologyBeginV1::Incomplete(incomplete) => incomplete,
+            StrictGitRawTopologyBeginV1::Pending(_) => {
+                panic!("expected GitRaw topology to fail closed")
+            }
+        }
+    }
+
+    #[test]
+    fn ordinary_standalone_repo_yields_sorted_opaque_ref_pins() {
+        let (_temporary, root) = canonical_committed_repo();
+        run_git(&root, &["branch", "z-last"]);
+        run_git(&root, &["branch", "a-first"]);
+        std::fs::write(root.join(".git/tcfs.lock"), b"").unwrap();
+        let pending = pending_local(&root);
+        let topology = finish_topology(begin_topology(&pending));
+
+        assert_eq!(topology.object_format(), StrictGitObjectFormatV1::Sha1);
+        assert_eq!(topology.head().symbolic_target(), Some("refs/heads/main"));
+        assert!(topology.head().resolved_object_id().is_some());
+        let refs = topology
+            .refs()
+            .map(|pin| pin.ref_name().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            refs,
+            vec!["refs/heads/a-first", "refs/heads/main", "refs/heads/z-last"]
+        );
+        assert_eq!(topology.contract().pass_count(), 2);
+
+        match pending.revalidate_inventory_c().unwrap() {
+            StrictLocalSnapshotFinishV1::Complete(_) => {}
+            StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
+                panic!("local inventory C must remain stable: {incomplete:?}")
+            }
+        }
+        topology.revalidate_capabilities().unwrap();
+    }
+
+    #[test]
+    fn sha1_and_sha256_packed_tags_and_symbolic_chains_are_exact() {
+        for (format, expected_format, object_id_len) in [
+            ("sha1", StrictGitObjectFormatV1::Sha1, 40),
+            ("sha256", StrictGitObjectFormatV1::Sha256, 64),
+        ] {
+            let (_temporary, root) = canonical_committed_repo_with_format(format);
+            run_git(&root, &["update-ref", "refs/tags/lightweight", "HEAD"]);
+            run_git(
+                &root,
+                &[
+                    "-c",
+                    "user.name=TCFS Test",
+                    "-c",
+                    "user.email=tcfs@example.invalid",
+                    "-c",
+                    "tag.gpgsign=false",
+                    "tag",
+                    "--annotate",
+                    "annotated",
+                    "--message=tag",
+                ],
+            );
+            run_git(&root, &["pack-refs", "--all", "--prune"]);
+            run_git(
+                &root,
+                &["symbolic-ref", "refs/heads/middle", "refs/heads/main"],
+            );
+            run_git(
+                &root,
+                &["symbolic-ref", "refs/heads/alias", "refs/heads/middle"],
+            );
+
+            let pending = pending_local(&root);
+            let topology = finish_topology(begin_topology(&pending));
+            assert_eq!(topology.object_format(), expected_format);
+            assert!(root.join(".git/packed-refs").is_file());
+            assert!(topology
+                .refs()
+                .all(|pin| pin.object_id().len() == object_id_len));
+
+            let annotated = topology
+                .refs()
+                .find(|pin| pin.ref_name() == "refs/tags/annotated")
+                .unwrap();
+            assert_eq!(annotated.object_kind, StrictGitObjectKindV1::Tag);
+            let lightweight = topology
+                .refs()
+                .find(|pin| pin.ref_name() == "refs/tags/lightweight")
+                .unwrap();
+            assert_eq!(lightweight.object_kind, StrictGitObjectKindV1::Commit);
+            let main = topology
+                .refs()
+                .find(|pin| pin.ref_name() == "refs/heads/main")
+                .unwrap();
+            let alias = topology
+                .refs()
+                .find(|pin| pin.ref_name() == "refs/heads/alias")
+                .unwrap();
+            assert_eq!(alias.symref_target(), Some("refs/heads/middle"));
+            assert_eq!(alias.object_id(), main.object_id());
+        }
+    }
+
+    #[test]
+    fn unborn_and_detached_head_states_are_explicit() {
+        let (_unborn_temporary, unborn) = canonical_unborn_repo();
+        let pending = pending_local(&unborn);
+        let topology = finish_topology(begin_topology(&pending));
+        assert_eq!(topology.head().symbolic_target(), Some("refs/heads/main"));
+        assert_eq!(topology.head().resolved_object_id(), None);
+        assert_eq!(topology.refs().len(), 0);
+
+        let (_detached_temporary, detached) = canonical_committed_repo();
+        run_git(&detached, &["checkout", "--quiet", "--detach"]);
+        let pending = pending_local(&detached);
+        let topology = finish_topology(begin_topology(&pending));
+        assert_eq!(topology.head().symbolic_target(), None);
+        assert!(topology.head().resolved_object_id().is_some());
+    }
+
+    #[test]
+    fn dangling_cyclic_and_nonportable_unborn_symrefs_are_rejected() {
+        let (_dangling_temporary, dangling) = canonical_committed_repo();
+        std::fs::write(
+            dangling.join(".git/refs/heads/dangling"),
+            b"ref: refs/heads/missing\n",
+        )
+        .unwrap();
+        assert_eq!(
+            begin_incomplete(&pending_local(&dangling)).kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
+        );
+
+        let (_cycle_temporary, cycle) = canonical_committed_repo();
+        std::fs::write(
+            cycle.join(".git/refs/heads/cycle-a"),
+            b"ref: refs/heads/cycle-b\n",
+        )
+        .unwrap();
+        std::fs::write(
+            cycle.join(".git/refs/heads/cycle-b"),
+            b"ref: refs/heads/cycle-a\n",
+        )
+        .unwrap();
+        assert_eq!(
+            begin_incomplete(&pending_local(&cycle)).kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
+        );
+
+        let (_alias_temporary, alias) = canonical_committed_repo();
+        run_git(&alias, &["branch", "foo"]);
+        std::fs::write(alias.join(".git/HEAD"), b"ref: refs/heads/Foo\n").unwrap();
+        assert_eq!(
+            begin_incomplete(&pending_local(&alias)).kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
+        );
+
+        let (_df_temporary, df_conflict) = canonical_committed_repo();
+        run_git(&df_conflict, &["branch", "topic"]);
+        std::fs::write(
+            df_conflict.join(".git/HEAD"),
+            b"ref: refs/heads/topic/child\n",
+        )
+        .unwrap();
+        assert_eq!(
+            begin_incomplete(&pending_local(&df_conflict)).kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
+        );
+    }
+
+    #[test]
+    fn detached_head_must_name_a_commit_object_directly() {
+        let (_temporary, root) = canonical_committed_repo();
+        run_git(
+            &root,
+            &[
+                "-c",
+                "user.name=TCFS Test",
+                "-c",
+                "user.email=tcfs@example.invalid",
+                "-c",
+                "tag.gpgsign=false",
+                "tag",
+                "--annotate",
+                "annotated",
+                "--message=tag",
+            ],
+        );
+        let tag_object = git_stdout(&root, &["rev-parse", "refs/tags/annotated"]);
+        std::fs::write(root.join(".git/HEAD"), format!("{tag_object}\n")).unwrap();
+        assert_eq!(
+            begin_incomplete(&pending_local(&root)).kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
+        );
+    }
+
+    #[test]
+    fn reference_mutation_between_passes_is_typed_incomplete() {
+        let (_temporary, root) = canonical_committed_repo();
+        let pending = pending_local(&root);
+        let topology = begin_topology(&pending);
+        run_git(&root, &["branch", "appeared-between-passes"]);
+        assert!(matches!(
+            topology.revalidate_after_external_reads(),
+            StrictGitRawTopologyFinishV1::Incomplete(incomplete)
+                if incomplete.kind()
+                    == StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged
+        ));
+    }
+
+    #[test]
+    fn root_and_git_directory_replacement_between_passes_are_typed_changed() {
+        let (_root_temporary, root) = canonical_committed_repo();
+        let pending = pending_local(&root);
+        let topology = begin_topology(&pending);
+        let original_root = root.with_extension("original");
+        std::fs::rename(&root, &original_root).unwrap();
+        std::fs::create_dir(&root).unwrap();
+        assert!(matches!(
+            topology.revalidate_after_external_reads(),
+            StrictGitRawTopologyFinishV1::Incomplete(incomplete)
+                if incomplete.kind()
+                    == StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged
+        ));
+
+        let (_git_temporary, git_root) = canonical_committed_repo();
+        let pending = pending_local(&git_root);
+        let topology = begin_topology(&pending);
+        let original_git = git_root.join(".git-original");
+        std::fs::rename(git_root.join(".git"), &original_git).unwrap();
+        std::fs::create_dir(git_root.join(".git")).unwrap();
+        assert!(matches!(
+            topology.revalidate_after_external_reads(),
+            StrictGitRawTopologyFinishV1::Incomplete(incomplete)
+                if incomplete.kind()
+                    == StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged
+        ));
+    }
+
+    #[test]
+    fn topology_extensions_and_native_activity_are_rejected() {
+        for (relative, directory, bytes, expected) in [
+            (
+                "commondir",
+                false,
+                b"../shared\n".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            ),
+            (
+                "config.worktree",
+                false,
+                b"".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            ),
+            (
+                "worktrees",
+                true,
+                b"".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            ),
+            (
+                "shallow",
+                false,
+                b"0000000000000000000000000000000000000000\n".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            ),
+            (
+                "objects/info/alternates",
+                false,
+                b"../external\n".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            ),
+            (
+                "objects/info/http-alternates",
+                false,
+                b"https://example.invalid/\n".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+            ),
+            (
+                "index.lock",
+                false,
+                b"".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::ActivityDetected,
+            ),
+            (
+                "config.lock",
+                false,
+                b"".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::ActivityDetected,
+            ),
+            (
+                "objects/pack/write.lock",
+                false,
+                b"".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::ActivityDetected,
+            ),
+            (
+                "MERGE_HEAD",
+                false,
+                b"".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::ActivityDetected,
+            ),
+            (
+                "sequencer",
+                true,
+                b"".as_slice(),
+                StrictGitRawTopologyIncompleteKindV1::ActivityDetected,
+            ),
+        ] {
+            let (_temporary, root) = canonical_committed_repo();
+            let path = root.join(".git").join(relative);
+            if directory {
+                std::fs::create_dir_all(&path).unwrap();
+            } else {
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                std::fs::write(&path, bytes).unwrap();
+            }
+            assert_eq!(
+                begin_incomplete(&pending_local(&root)).kind(),
+                expected,
+                "{relative}"
+            );
+        }
+    }
+
+    #[test]
+    fn repository_config_routing_and_oversized_inputs_are_rejected() {
+        for (key, value) in [
+            ("include.path", "/does/not-exist"),
+            ("includeIf.onbranch:main.path", "/does/not-exist"),
+            ("core.worktree", "/tmp/external-worktree"),
+            ("core.bare", "true"),
+            ("core.sharedRepository", "group"),
+            ("extensions.worktreeConfig", "true"),
+            ("extensions.refStorage", "reftable"),
+            ("remote.origin.promisor", "true"),
+        ] {
+            let (_temporary, root) = canonical_committed_repo();
+            run_git(&root, &["config", key, value]);
+            assert_eq!(
+                begin_incomplete(&pending_local(&root)).kind(),
+                StrictGitRawTopologyIncompleteKindV1::TopologyRejected,
+                "{key}"
+            );
+        }
+
+        let (_config_temporary, config_root) = canonical_committed_repo();
+        std::fs::write(config_root.join(".git/config"), vec![b'x'; 1024 * 1024 + 1]).unwrap();
+        assert_eq!(
+            begin_incomplete(&pending_local(&config_root)).kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        );
+
+        let (_head_temporary, head_root) = canonical_committed_repo();
+        std::fs::write(head_root.join(".git/HEAD"), vec![b'x'; 1030]).unwrap();
+        assert_eq!(
+            begin_incomplete(&pending_local(&head_root)).kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        );
+    }
+
+    fn fixture_limits(max_refs: u64, max_name: u64, max_retained: u64) -> GitObservationLimitsV1 {
+        GitObservationLimitsV1 {
+            max_refs,
+            max_ref_or_symref_bytes: max_name,
+            max_retained_bytes: max_retained,
+            max_command_stdout_bytes: 1024,
+            max_config_file_bytes: 1024,
+            max_head_file_bytes: 1029,
+            sha1_oid_hex_bytes: 40,
+            sha256_oid_hex_bytes: 64,
+        }
+    }
+
+    fn record(name: &str, oid: &str, kind: &str, symref: &str) -> Vec<u8> {
+        format!("{name}\0{oid}\0{kind}\0{symref}\n").into_bytes()
+    }
+
+    #[test]
+    fn parser_enforces_exact_count_name_and_retained_byte_limits() {
+        let oid = "a".repeat(40);
+        let one = record("refs/heads/a", &oid, "commit", "");
+        let two = record("refs/heads/b", &oid, "commit", "");
+        let exact = [one.clone(), two.clone()].concat();
+        assert_eq!(
+            parse_ref_output_v1(
+                &exact,
+                StrictGitObjectFormatV1::Sha1,
+                fixture_limits(2, 64, 1024)
+            )
+            .unwrap()
+            .len(),
+            2
+        );
+        let error = parse_ref_output_v1(
+            &exact,
+            StrictGitObjectFormatV1::Sha1,
+            fixture_limits(1, 64, 1024),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        );
+        let error = parse_ref_output_v1(
+            &one,
+            StrictGitObjectFormatV1::Sha1,
+            fixture_limits(1, 11, 1024),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        );
+        let error = parse_ref_output_v1(
+            &one,
+            StrictGitObjectFormatV1::Sha1,
+            fixture_limits(1, 64, 1),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.kind(),
+            StrictGitRawTopologyIncompleteKindV1::ReferenceResourceLimit
+        );
+    }
+
+    #[test]
+    fn parser_rejects_unsorted_duplicate_alias_and_malformed_records() {
+        let oid = "a".repeat(40);
+        let unsorted = [
+            record("refs/heads/b", &oid, "commit", ""),
+            record("refs/heads/a", &oid, "commit", ""),
+        ]
+        .concat();
+        let alias = [
+            record("refs/heads/Foo", &oid, "commit", ""),
+            record("refs/heads/foo", &oid, "commit", ""),
+        ]
+        .concat();
+        for bytes in [
+            unsorted,
+            alias,
+            record("refs/heads/a", &"A".repeat(40), "commit", ""),
+            record("refs/heads/a", &oid, "blob", ""),
+            record("refs/heads/a\tb", &oid, "commit", ""),
+            record("refs/heads/a\u{7f}b", &oid, "commit", ""),
+            b"refs/heads/a\0missing-fields\n".to_vec(),
+            format!("refs/heads/a\0{oid}\0commit\0\0extra\n").into_bytes(),
+            [
+                b"refs/heads/".as_slice(),
+                &[0xff],
+                format!("\0{oid}\0commit\0\n").as_bytes(),
+            ]
+            .concat(),
+        ] {
+            assert_eq!(
+                parse_ref_output_v1(
+                    &bytes,
+                    StrictGitObjectFormatV1::Sha1,
+                    fixture_limits(8, 128, 4096),
+                )
+                .unwrap_err()
+                .kind(),
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
+            );
+        }
+
+        for bytes in [
+            format!("{oid} refs/heads/a extra\n").into_bytes(),
+            format!("^{oid}\n").into_bytes(),
+            format!("# pack-refs\n{oid} refs/tags/a\n^{oid}\n^{oid}\n").into_bytes(),
+            format!("{oid} refs/heads/a\0bad\n").into_bytes(),
+        ] {
+            assert_eq!(
+                parse_packed_refs_v1(
+                    &bytes,
+                    StrictGitObjectFormatV1::Sha1,
+                    fixture_limits(8, 128, 4096),
+                )
+                .unwrap_err()
+                .kind(),
+                StrictGitRawTopologyIncompleteKindV1::ReferenceMalformed
+            );
+        }
+    }
+}

--- a/crates/tcfs-sync/src/registered_local_snapshot.rs
+++ b/crates/tcfs-sync/src/registered_local_snapshot.rs
@@ -486,6 +486,16 @@ pub(crate) struct RevalidatedStrictLocalSnapshotV1 {
 }
 
 impl RevalidatedStrictLocalSnapshotV1 {
+    pub(crate) fn canonical_local_root(&self) -> &Path {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.canonical_local_root()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
     pub(crate) fn snapshot(&self) -> &CompleteStrictLocalSnapshotV1 {
         #[cfg(target_os = "linux")]
         {
@@ -915,11 +925,16 @@ mod supported {
     }
 
     pub(super) struct RevalidatedSupportedSnapshotV1 {
+        canonical_local_root: PathBuf,
         _root: File,
         snapshot: CompleteStrictLocalSnapshotV1,
     }
 
     impl RevalidatedSupportedSnapshotV1 {
+        pub(super) fn canonical_local_root(&self) -> &Path {
+            &self.canonical_local_root
+        }
+
         pub(super) fn snapshot(&self) -> &CompleteStrictLocalSnapshotV1 {
             &self.snapshot
         }
@@ -1018,6 +1033,7 @@ mod supported {
             &held.entries,
         );
         Ok(RevalidatedSupportedSnapshotV1 {
+            canonical_local_root: held.canonical_local_root,
             _root: held.root,
             snapshot: CompleteStrictLocalSnapshotV1 {
                 profile: held.profile,

--- a/crates/tcfs-sync/src/registered_local_snapshot.rs
+++ b/crates/tcfs-sync/src/registered_local_snapshot.rs
@@ -444,12 +444,120 @@ pub(crate) struct PendingStrictLocalSnapshotV1 {
     unsupported: std::convert::Infallible,
 }
 
+/// Descriptor-bracketed identity metadata from the provisional inventory.
+///
+/// This intentionally carries neither file contents nor a snapshot digest. It
+/// lets another held-input prerequisite validate a narrow metadata namespace
+/// without performing a second unbounded pathname walk.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StrictInitialLocalEntryKindV1 {
+    Directory,
+    Regular,
+    Symlink,
+    Special,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct StrictInitialLocalInventoryEntryV1<'a> {
+    rel_path: &'a [u8],
+    kind: StrictInitialLocalEntryKindV1,
+    mode: u32,
+    uid: u32,
+    size: i64,
+}
+
+impl<'a> StrictInitialLocalInventoryEntryV1<'a> {
+    pub(crate) const fn rel_path(self) -> &'a [u8] {
+        self.rel_path
+    }
+
+    pub(crate) const fn kind(self) -> StrictInitialLocalEntryKindV1 {
+        self.kind
+    }
+
+    pub(crate) const fn mode(self) -> u32 {
+        self.mode
+    }
+
+    pub(crate) const fn uid(self) -> u32 {
+        self.uid
+    }
+
+    pub(crate) const fn size(self) -> i64 {
+        self.size
+    }
+}
+
 impl PendingStrictLocalSnapshotV1 {
+    pub(crate) fn profile(&self) -> RootProfileV1 {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.profile()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
     /// Exact canonical spelling whose descriptor is held by this acquisition.
     pub(crate) fn canonical_local_root(&self) -> &Path {
         #[cfg(target_os = "linux")]
         {
             self.inner.canonical_local_root()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
+    /// Clone the already-authorized configured-root descriptor.
+    ///
+    /// This does not reopen the configured pathname. The clone is intended for
+    /// read-only, descriptor-relative observations that must occur while this
+    /// pending snapshot keeps the original capability alive.
+    pub(crate) fn try_clone_root_descriptor(&self) -> std::io::Result<std::fs::File> {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.try_clone_root_descriptor()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
+    /// Iterate the already-bounded provisional identity inventory.
+    ///
+    /// Inventory C still has to match this inventory before any composed
+    /// evidence can survive. Exposing identities here does not expose a digest
+    /// or make the provisional snapshot complete.
+    pub(crate) fn initial_inventory_entries(
+        &self,
+    ) -> impl ExactSizeIterator<Item = StrictInitialLocalInventoryEntryV1<'_>> {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.initial_inventory_entries()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
+    /// Re-read one inventory-A regular file through the held root descriptor.
+    ///
+    /// The implementation rechecks the exact inventory identity before and
+    /// after the read. The typed incomplete result preserves whether the held
+    /// read exceeded its resource bound, failed at the filesystem, or raced
+    /// the provisional inventory.
+    pub(crate) fn read_initial_regular_file_bounded(
+        &self,
+        rel_path: &[u8],
+        max_bytes: u64,
+    ) -> std::result::Result<Vec<u8>, StrictLocalSnapshotIncompleteV1> {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner
+                .read_initial_regular_file_bounded(rel_path, max_bytes)
+                .map_err(CaptureFailure::into_public)
         }
 
         #[cfg(not(target_os = "linux"))]
@@ -919,8 +1027,141 @@ mod supported {
     }
 
     impl PendingSupportedSnapshotV1 {
+        pub(super) const fn profile(&self) -> RootProfileV1 {
+            self.profile
+        }
+
         pub(super) fn canonical_local_root(&self) -> &Path {
             &self.canonical_local_root
+        }
+
+        pub(super) fn try_clone_root_descriptor(&self) -> std::io::Result<File> {
+            self.root.try_clone()
+        }
+
+        pub(super) fn initial_inventory_entries(
+            &self,
+        ) -> impl ExactSizeIterator<Item = StrictInitialLocalInventoryEntryV1<'_>> {
+            self.inventory_a.entries.iter().map(|(rel_path, record)| {
+                let kind = match record.identity.object_kind() {
+                    ObjectKind::Directory => StrictInitialLocalEntryKindV1::Directory,
+                    ObjectKind::Regular => StrictInitialLocalEntryKindV1::Regular,
+                    ObjectKind::Symlink => StrictInitialLocalEntryKindV1::Symlink,
+                    ObjectKind::Special => StrictInitialLocalEntryKindV1::Special,
+                };
+                StrictInitialLocalInventoryEntryV1 {
+                    rel_path,
+                    kind,
+                    mode: record.identity.mode,
+                    uid: record.identity.uid,
+                    size: record.identity.size,
+                }
+            })
+        }
+
+        pub(super) fn read_initial_regular_file_bounded(
+            &self,
+            rel_path: &[u8],
+            max_bytes: u64,
+        ) -> std::result::Result<Vec<u8>, CaptureFailure> {
+            let record = self
+                .inventory_a
+                .entries
+                .get(rel_path)
+                .ok_or_else(|| changed(rel_path, "lookup-held-regular-file-in-inventory"))?;
+            let expected = record.identity;
+            if expected.object_kind() != ObjectKind::Regular || expected.size < 0 {
+                return Err(changed(rel_path, "require-held-regular-file"));
+            }
+            let expected_size = u64::try_from(expected.size)
+                .map_err(|_| changed(rel_path, "convert-held-regular-file-size"))?;
+            if expected_size > max_bytes {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_bytes(rel_path),
+                    "held-regular-file-caller-limit",
+                ));
+            }
+
+            let (parent, leaf_name, expected_parent) =
+                open_inventory_parent(&self.root, &self.inventory_a, rel_path)?;
+            let before_parent =
+                fstat_identity(parent.as_raw_fd(), Some(rel_path), "stat-held-file-parent")?;
+            if before_parent != expected_parent {
+                return Err(changed(rel_path, "compare-held-file-parent-before"));
+            }
+            let c_name = c_string_name(&leaf_name, rel_path)?;
+            let mut file = openat_descendant_file(
+                parent.as_raw_fd(),
+                &c_name,
+                false,
+                Some(rel_path),
+                "open-held-regular-file",
+            )?;
+            let before = fstat_identity(
+                file.as_raw_fd(),
+                Some(rel_path),
+                "stat-held-regular-file-before",
+            )?;
+            if before != expected || before.object_kind() != ObjectKind::Regular {
+                return Err(changed(rel_path, "compare-held-regular-file-before"));
+            }
+
+            let capacity = usize::try_from(expected_size).map_err(|_| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_bytes(rel_path),
+                    "held-regular-file-size-does-not-fit-memory",
+                )
+            })?;
+            let sentinel_capacity = expected_size
+                .checked_add(1)
+                .and_then(|size| usize::try_from(size).ok())
+                .ok_or_else(|| {
+                    CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                        display_rel_bytes(rel_path),
+                        "held-regular-file-sentinel-size-does-not-fit-memory",
+                    )
+                })?;
+            let mut bytes = Vec::new();
+            bytes.try_reserve_exact(sentinel_capacity).map_err(|_| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_bytes(rel_path),
+                    "allocate-held-regular-file",
+                )
+            })?;
+            (&mut file)
+                .take(expected_size.saturating_add(1))
+                .read_to_end(&mut bytes)
+                .map_err(|_| {
+                    CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+                        display_rel_bytes(rel_path),
+                        "read-held-regular-file",
+                    )
+                })?;
+            if bytes.len() != capacity {
+                return Err(changed(rel_path, "compare-held-regular-file-size"));
+            }
+            let after = fstat_identity(
+                file.as_raw_fd(),
+                Some(rel_path),
+                "stat-held-regular-file-after",
+            )?;
+            if after != expected {
+                return Err(changed(rel_path, "compare-held-regular-file-after"));
+            }
+            let after_parent = fstat_identity(
+                parent.as_raw_fd(),
+                Some(rel_path),
+                "restat-held-file-parent",
+            )?;
+            if after_parent != expected_parent {
+                return Err(changed(rel_path, "compare-held-file-parent-after"));
+            }
+            Ok(bytes)
         }
     }
 
@@ -2581,7 +2822,7 @@ mod tests {
         ));
         assert_eq!(
             snapshot.digest().to_string(),
-            "b3v1:59aa9308444225642cb34a9cfff19ac45e4bc53f17b95fb522e39e3a83d61511"
+            "b3v1:3132baf74f192cb3221791c7f16192ff770ba508326ed9372a027bcc4a26b470"
         );
     }
 
@@ -2857,6 +3098,61 @@ mod tests {
         fs::write(&payload, b"after!").unwrap();
         assert_eq!(
             finish_incomplete(pending).kind(),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+    }
+
+    #[test]
+    fn pending_snapshot_clones_the_held_root_descriptor_without_reopening() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join("payload"), b"stable").unwrap();
+        let pending = pending(&root, RootProfileV1::AgentStaticV1);
+
+        let cloned_root = pending
+            .try_clone_root_descriptor()
+            .expect("clone held configured-root descriptor");
+        let cloned_metadata = cloned_root.metadata().unwrap();
+        let configured_metadata = fs::metadata(&root).unwrap();
+        assert_eq!(cloned_metadata.dev(), configured_metadata.dev());
+        assert_eq!(cloned_metadata.ino(), configured_metadata.ino());
+
+        match pending.revalidate_inventory_c().unwrap() {
+            StrictLocalSnapshotFinishV1::Complete(_) => {}
+            StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
+                panic!("descriptor cloning must not disturb the snapshot: {incomplete:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn held_regular_file_read_enforces_bound_and_inventory_identity() {
+        let (_temporary, root) = canonical_root();
+        let payload = root.join("payload");
+        fs::write(&payload, b"stable").unwrap();
+        let pending = pending(&root, RootProfileV1::AgentStaticV1);
+
+        assert_eq!(
+            pending
+                .read_initial_regular_file_bounded(b"payload", 6)
+                .unwrap(),
+            b"stable"
+        );
+        assert_eq!(
+            pending
+                .read_initial_regular_file_bounded(b"payload", 5)
+                .unwrap_err()
+                .kind(),
+            StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded
+        );
+
+        let replacement = root.join("replacement");
+        fs::write(&replacement, b"change").unwrap();
+        fs::rename(&replacement, &payload).unwrap();
+        assert_eq!(
+            pending
+                .read_initial_regular_file_bounded(b"payload", 6)
+                .unwrap_err()
+                .kind(),
             StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
         );
     }

--- a/crates/tcfs-sync/src/registered_local_snapshot.rs
+++ b/crates/tcfs-sync/src/registered_local_snapshot.rs
@@ -10,8 +10,11 @@
 //! 2. records a descriptor-relative identity inventory;
 //! 3. captures every included leaf while checking its descriptor and parent
 //!    identities before and after the read;
-//! 4. records a second identity inventory and requires exact equality; and
-//! 5. reopens the configured root and requires the original root identity.
+//! 4. records a second identity inventory and requires exact equality;
+//! 5. keeps the configured-root descriptor alive while state and remote inputs
+//!    are acquired;
+//! 6. records inventory C through that same descriptor; and
+//! 7. reopens the configured route and requires the original root identity.
 //!
 //! Acquisition identities make races fail closed but are intentionally absent
 //! from the portable semantic digest. Descriptor, size, mtime, and ctime
@@ -427,6 +430,124 @@ impl StrictLocalSnapshotReadV1 {
     }
 }
 
+/// One provisional local observation whose configured-root descriptor remains
+/// live.
+///
+/// The provisional snapshot deliberately exposes no digest. Only
+/// [`PendingStrictLocalSnapshotV1::revalidate_inventory_c`] can turn it into a
+/// complete snapshot, after inventory C and the configured-route identity
+/// check succeed.
+pub(crate) struct PendingStrictLocalSnapshotV1 {
+    #[cfg(target_os = "linux")]
+    inner: Box<supported::PendingSupportedSnapshotV1>,
+    #[cfg(not(target_os = "linux"))]
+    unsupported: std::convert::Infallible,
+}
+
+impl PendingStrictLocalSnapshotV1 {
+    /// Exact canonical spelling whose descriptor is held by this acquisition.
+    pub(crate) fn canonical_local_root(&self) -> &Path {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.canonical_local_root()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
+    /// Revalidate the local acquisition only after all external reads finish.
+    pub(crate) fn revalidate_inventory_c(self) -> Result<StrictLocalSnapshotFinishV1> {
+        #[cfg(target_os = "linux")]
+        {
+            Ok(match supported::finish_supported(*self.inner) {
+                Ok(snapshot) => {
+                    StrictLocalSnapshotFinishV1::Complete(RevalidatedStrictLocalSnapshotV1 {
+                        inner: Box::new(snapshot),
+                    })
+                }
+                Err(failure) => StrictLocalSnapshotFinishV1::Incomplete(failure.into_public()),
+            })
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+}
+
+/// Inventory-C-validated local input that still owns the original root
+/// descriptor. Cross-input composition may inspect the complete snapshot while
+/// retaining the capability; compatibility callers explicitly consume it.
+pub(crate) struct RevalidatedStrictLocalSnapshotV1 {
+    #[cfg(target_os = "linux")]
+    inner: Box<supported::RevalidatedSupportedSnapshotV1>,
+    #[cfg(not(target_os = "linux"))]
+    unsupported: std::convert::Infallible,
+}
+
+impl RevalidatedStrictLocalSnapshotV1 {
+    pub(crate) fn snapshot(&self) -> &CompleteStrictLocalSnapshotV1 {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.snapshot()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
+    fn into_snapshot(self) -> CompleteStrictLocalSnapshotV1 {
+        #[cfg(target_os = "linux")]
+        {
+            (*self.inner).into_snapshot()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+}
+
+/// Starting a strict acquisition either yields a held root capability or a
+/// typed, digest-less failure.
+pub(crate) enum StrictLocalSnapshotHoldReadV1 {
+    Pending(PendingStrictLocalSnapshotV1),
+    Incomplete(StrictLocalSnapshotIncompleteV1),
+}
+
+pub(crate) enum StrictLocalSnapshotFinishV1 {
+    Complete(RevalidatedStrictLocalSnapshotV1),
+    Incomplete(StrictLocalSnapshotIncompleteV1),
+}
+
+pub(crate) fn begin_strict_local_snapshot_v1(
+    canonical_local_root: &Path,
+    profile: RootProfileV1,
+) -> Result<StrictLocalSnapshotHoldReadV1> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (canonical_local_root, profile);
+        return Ok(StrictLocalSnapshotHoldReadV1::Incomplete(
+            CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
+                "platform-check",
+            )
+            .into_public(),
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        Ok(
+            match supported::begin_supported(canonical_local_root, profile) {
+                Ok(held) => StrictLocalSnapshotHoldReadV1::Pending(PendingStrictLocalSnapshotV1 {
+                    inner: Box::new(held),
+                }),
+                Err(failure) => StrictLocalSnapshotHoldReadV1::Incomplete(failure.into_public()),
+            },
+        )
+    }
+}
+
 #[derive(Debug)]
 struct CaptureFailure {
     kind: StrictLocalSnapshotIncompleteKindV1,
@@ -474,23 +595,19 @@ pub fn capture_strict_local_snapshot_v1(
     canonical_local_root: &Path,
     profile: RootProfileV1,
 ) -> Result<StrictLocalSnapshotReadV1> {
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (canonical_local_root, profile);
-        return Ok(StrictLocalSnapshotReadV1::Incomplete(
-            CaptureFailure::root(
-                StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
-                "platform-check",
-            )
-            .into_public(),
-        ));
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        match capture_supported(canonical_local_root, profile) {
-            Ok(snapshot) => Ok(StrictLocalSnapshotReadV1::Complete(snapshot)),
-            Err(failure) => Ok(StrictLocalSnapshotReadV1::Incomplete(failure.into_public())),
+    match begin_strict_local_snapshot_v1(canonical_local_root, profile)? {
+        StrictLocalSnapshotHoldReadV1::Pending(pending) => {
+            match pending.revalidate_inventory_c()? {
+                StrictLocalSnapshotFinishV1::Complete(revalidated) => Ok(
+                    StrictLocalSnapshotReadV1::Complete(revalidated.into_snapshot()),
+                ),
+                StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
+                    Ok(StrictLocalSnapshotReadV1::Incomplete(incomplete))
+                }
+            }
+        }
+        StrictLocalSnapshotHoldReadV1::Incomplete(incomplete) => {
+            Ok(StrictLocalSnapshotReadV1::Incomplete(incomplete))
         }
     }
 }
@@ -542,7 +659,7 @@ fn local_snapshot_acquisition_fingerprint_v1() -> StrictLocalSnapshotAcquisition
     );
     encoder.field(
         "stability",
-        b"inventory-a-leaf-bracket-inventory-b-reopen-v1",
+        b"inventory-a-leaf-bracket-inventory-b-initial-reopen-held-read-inventory-c-final-reopen-v1",
     );
     encoder.field("namespace", b"portable-nfc-casefold-file-directory-role-v1");
     encoder.field("regular", b"raw-blake3-exact-size-eof-mode-mtime-v1");
@@ -780,10 +897,42 @@ mod supported {
         }
     }
 
-    pub(super) fn capture_supported(
+    pub(super) struct PendingSupportedSnapshotV1 {
+        canonical_local_root: PathBuf,
+        profile: RootProfileV1,
+        root: File,
+        root_identity: StableIdentity,
+        root_mount_id: u64,
+        inventory_a: IdentityInventory,
+        namespace_claims: BTreeMap<String, StrictLocalNamespaceClaimV1>,
+        entries: BTreeMap<String, StrictLocalEntryV1>,
+    }
+
+    impl PendingSupportedSnapshotV1 {
+        pub(super) fn canonical_local_root(&self) -> &Path {
+            &self.canonical_local_root
+        }
+    }
+
+    pub(super) struct RevalidatedSupportedSnapshotV1 {
+        _root: File,
+        snapshot: CompleteStrictLocalSnapshotV1,
+    }
+
+    impl RevalidatedSupportedSnapshotV1 {
+        pub(super) fn snapshot(&self) -> &CompleteStrictLocalSnapshotV1 {
+            &self.snapshot
+        }
+
+        pub(super) fn into_snapshot(self) -> CompleteStrictLocalSnapshotV1 {
+            self.snapshot
+        }
+    }
+
+    pub(super) fn begin_supported(
         canonical_local_root: &Path,
         profile: RootProfileV1,
-    ) -> std::result::Result<CompleteStrictLocalSnapshotV1, CaptureFailure> {
+    ) -> std::result::Result<PendingSupportedSnapshotV1, CaptureFailure> {
         validate_configured_root(canonical_local_root)?;
         crate::conflict_git::validate_trusted_configured_path(canonical_local_root).map_err(
             |_| {
@@ -812,48 +961,107 @@ mod supported {
         verify_inventory_tree(&root, root_identity, root_mount_id, profile, &inventory_a)?;
 
         run_test_hook(TestHookPoint::RootPathBeforeReopen);
-        validate_configured_root(canonical_local_root)?;
-        crate::conflict_git::validate_trusted_configured_path(canonical_local_root).map_err(
-            |_| {
-                CaptureFailure::root(
-                    StrictLocalSnapshotIncompleteKindV1::ConfiguredRootTrustRejected,
-                    "revalidate-configured-root-trust",
-                )
-            },
+        verify_configured_root_route(
+            canonical_local_root,
+            root_identity,
+            root_mount_id,
+            "revalidate-initial-configured-root-trust",
+            "initial-reopen-configured-root",
+            "initial-restat-configured-root",
+            "initial-restatx-configured-root",
+            "compare-initial-reopened-root-identity",
         )?;
-        let reopened = open_absolute_directory(canonical_local_root, "reopen-configured-root")?;
-        let reopened_identity =
-            fstat_identity(reopened.as_raw_fd(), None, "restat-configured-root")?;
-        let reopened_mount_id =
-            statx_mount_id(reopened.as_raw_fd(), None, "restatx-configured-root")?;
-        if reopened_identity != root_identity || reopened_mount_id != root_mount_id {
-            return Err(CaptureFailure::root(
-                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
-                "compare-reopened-root-identity",
-            ));
-        }
 
-        let policy = profile.policy();
+        Ok(PendingSupportedSnapshotV1 {
+            canonical_local_root: canonical_local_root.to_owned(),
+            profile,
+            root,
+            root_identity,
+            root_mount_id,
+            inventory_a,
+            namespace_claims,
+            entries,
+        })
+    }
+
+    pub(super) fn finish_supported(
+        held: PendingSupportedSnapshotV1,
+    ) -> std::result::Result<RevalidatedSupportedSnapshotV1, CaptureFailure> {
+        verify_inventory_tree(
+            &held.root,
+            held.root_identity,
+            held.root_mount_id,
+            held.profile,
+            &held.inventory_a,
+        )?;
+
+        verify_configured_root_route(
+            &held.canonical_local_root,
+            held.root_identity,
+            held.root_mount_id,
+            "revalidate-final-configured-root-trust",
+            "final-reopen-configured-root",
+            "final-restat-configured-root",
+            "final-restatx-configured-root",
+            "compare-final-reopened-root-identity",
+        )?;
+
+        let policy = held.profile.policy();
         let profile_settings_fingerprint = policy.settings_fingerprint();
         let plan_contract_fingerprint = RegisteredRootPlanContractV1::strict_v1().fingerprint();
         let acquisition_fingerprint = local_snapshot_acquisition_fingerprint_v1();
         let semantic_encoding_fingerprint = local_snapshot_semantic_encoding_fingerprint_v1();
         let digest = semantic_snapshot_digest_v1(
-            profile,
+            held.profile,
             profile_settings_fingerprint,
             semantic_encoding_fingerprint,
-            &entries,
+            &held.entries,
         );
-        Ok(CompleteStrictLocalSnapshotV1 {
-            profile,
-            profile_settings_fingerprint,
-            plan_contract_fingerprint,
-            acquisition_fingerprint,
-            semantic_encoding_fingerprint,
-            namespace_claims,
-            entries,
-            digest,
+        Ok(RevalidatedSupportedSnapshotV1 {
+            _root: held.root,
+            snapshot: CompleteStrictLocalSnapshotV1 {
+                profile: held.profile,
+                profile_settings_fingerprint,
+                plan_contract_fingerprint,
+                acquisition_fingerprint,
+                semantic_encoding_fingerprint,
+                namespace_claims: held.namespace_claims,
+                entries: held.entries,
+                digest,
+            },
         })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn verify_configured_root_route(
+        canonical_local_root: &Path,
+        expected_identity: StableIdentity,
+        expected_mount_id: u64,
+        trust_operation: &'static str,
+        open_operation: &'static str,
+        stat_operation: &'static str,
+        statx_operation: &'static str,
+        compare_operation: &'static str,
+    ) -> std::result::Result<(), CaptureFailure> {
+        validate_configured_root(canonical_local_root)?;
+        crate::conflict_git::validate_trusted_configured_path(canonical_local_root).map_err(
+            |_| {
+                CaptureFailure::root(
+                    StrictLocalSnapshotIncompleteKindV1::ConfiguredRootTrustRejected,
+                    trust_operation,
+                )
+            },
+        )?;
+        let reopened = open_absolute_directory(canonical_local_root, open_operation)?;
+        let reopened_identity = fstat_identity(reopened.as_raw_fd(), None, stat_operation)?;
+        let reopened_mount_id = statx_mount_id(reopened.as_raw_fd(), None, statx_operation)?;
+        if reopened_identity != expected_identity || reopened_mount_id != expected_mount_id {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                compare_operation,
+            ));
+        }
+        Ok(())
     }
 
     fn validate_configured_root(path: &Path) -> std::result::Result<(), CaptureFailure> {
@@ -2255,9 +2463,6 @@ mod supported {
     fn run_test_hook(_point: TestHookPoint) {}
 }
 
-#[cfg(target_os = "linux")]
-use supported::capture_supported;
-
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::supported::{install_test_hook, openat_descendant_identity, TestHookPoint};
@@ -2285,6 +2490,27 @@ mod tests {
             StrictLocalSnapshotReadV1::Incomplete(incomplete) => {
                 panic!("expected complete snapshot, got {incomplete:?}")
             }
+        }
+    }
+
+    fn pending(root: &Path, profile: RootProfileV1) -> PendingStrictLocalSnapshotV1 {
+        match begin_strict_local_snapshot_v1(root, profile).unwrap() {
+            StrictLocalSnapshotHoldReadV1::Pending(pending) => pending,
+            StrictLocalSnapshotHoldReadV1::Incomplete(incomplete) => {
+                panic!("expected pending snapshot, got {incomplete:?}")
+            }
+        }
+    }
+
+    fn finish_incomplete(pending: PendingStrictLocalSnapshotV1) -> StrictLocalSnapshotIncompleteV1 {
+        match pending.revalidate_inventory_c().unwrap() {
+            StrictLocalSnapshotFinishV1::Complete(complete) => {
+                panic!(
+                    "expected incomplete snapshot, got {:?}",
+                    complete.snapshot()
+                )
+            }
+            StrictLocalSnapshotFinishV1::Incomplete(incomplete) => incomplete,
         }
     }
 
@@ -2602,6 +2828,53 @@ mod tests {
             incomplete_kind(&root, RootProfileV1::AgentStaticV1),
             StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
         );
+    }
+
+    #[test]
+    fn mutation_during_held_external_read_window_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        let payload = root.join("payload");
+        fs::write(&payload, b"before").unwrap();
+        let pending = pending(&root, RootProfileV1::AgentStaticV1);
+        assert_eq!(pending.canonical_local_root(), root);
+
+        fs::write(&payload, b"after!").unwrap();
+        assert_eq!(
+            finish_incomplete(pending).kind(),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+    }
+
+    #[test]
+    fn configured_route_replacement_during_held_window_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join("payload"), b"stable").unwrap();
+        let pending = pending(&root, RootProfileV1::AgentStaticV1);
+
+        let original = root.with_extension("original");
+        fs::rename(&root, &original).unwrap();
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join("payload"), b"stable").unwrap();
+
+        let incomplete = finish_incomplete(pending);
+        assert_eq!(
+            incomplete.kind(),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+        assert_eq!(
+            incomplete.operation(),
+            // Renaming the original directory changes the identity observed
+            // through the still-held descriptor, so inventory C rejects before
+            // the final route reopen is even needed.
+            "compare-verify-root-before-walk"
+        );
+    }
+
+    #[test]
+    fn pending_and_revalidated_capabilities_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PendingStrictLocalSnapshotV1>();
+        assert_send_sync::<RevalidatedStrictLocalSnapshotV1>();
     }
 
     #[test]

--- a/crates/tcfs-sync/src/registered_local_snapshot.rs
+++ b/crates/tcfs-sync/src/registered_local_snapshot.rs
@@ -444,6 +444,17 @@ pub(crate) struct PendingStrictLocalSnapshotV1 {
     unsupported: std::convert::Infallible,
 }
 
+struct StrictLocalGitShadowExpectedV1(std::sync::Arc<()>);
+
+/// One-shot, opaque proof that a Git metadata shadow came from the exact local
+/// acquisition later promoted by inventory C.
+///
+/// The witness is intentionally neither clonable nor inspectable. The local
+/// acquisition retains the matching half and consumes it during binding, so a
+/// shadow cannot be paired with a separately acquired snapshot of the same
+/// pathname or inode.
+pub(crate) struct StrictLocalGitShadowWitnessV1(std::sync::Arc<()>);
+
 /// Descriptor-bracketed identity metadata from the provisional inventory.
 ///
 /// This intentionally carries neither file contents nor a snapshot digest. It
@@ -519,6 +530,17 @@ impl PendingStrictLocalSnapshotV1 {
         #[cfg(target_os = "linux")]
         {
             self.inner.try_clone_root_descriptor()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
+    /// Issue the only Git-shadow witness for this provisional acquisition.
+    pub(crate) fn issue_git_shadow_witness(&mut self) -> Option<StrictLocalGitShadowWitnessV1> {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner.issue_git_shadow_witness()
         }
 
         #[cfg(not(target_os = "linux"))]
@@ -608,6 +630,24 @@ impl RevalidatedStrictLocalSnapshotV1 {
         #[cfg(target_os = "linux")]
         {
             self.inner.snapshot()
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        match self.unsupported {}
+    }
+
+    /// Consume and bind the one-shot witness issued by this acquisition.
+    pub(crate) fn bind_git_shadow_witness(
+        self,
+        witness: StrictLocalGitShadowWitnessV1,
+    ) -> Option<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            self.inner
+                .bind_git_shadow_witness(witness)
+                .map(|inner| Self {
+                    inner: Box::new(inner),
+                })
         }
 
         #[cfg(not(target_os = "linux"))]
@@ -1024,6 +1064,7 @@ mod supported {
         inventory_a: IdentityInventory,
         namespace_claims: BTreeMap<String, StrictLocalNamespaceClaimV1>,
         entries: BTreeMap<String, StrictLocalEntryV1>,
+        git_shadow_expected: Option<StrictLocalGitShadowExpectedV1>,
     }
 
     impl PendingSupportedSnapshotV1 {
@@ -1037,6 +1078,15 @@ mod supported {
 
         pub(super) fn try_clone_root_descriptor(&self) -> std::io::Result<File> {
             self.root.try_clone()
+        }
+
+        pub(super) fn issue_git_shadow_witness(&mut self) -> Option<StrictLocalGitShadowWitnessV1> {
+            if self.git_shadow_expected.is_some() {
+                return None;
+            }
+            let acquisition = std::sync::Arc::new(());
+            self.git_shadow_expected = Some(StrictLocalGitShadowExpectedV1(acquisition.clone()));
+            Some(StrictLocalGitShadowWitnessV1(acquisition))
         }
 
         pub(super) fn initial_inventory_entries(
@@ -1169,6 +1219,7 @@ mod supported {
         canonical_local_root: PathBuf,
         _root: File,
         snapshot: CompleteStrictLocalSnapshotV1,
+        git_shadow_expected: Option<StrictLocalGitShadowExpectedV1>,
     }
 
     impl RevalidatedSupportedSnapshotV1 {
@@ -1178,6 +1229,14 @@ mod supported {
 
         pub(super) fn snapshot(&self) -> &CompleteStrictLocalSnapshotV1 {
             &self.snapshot
+        }
+
+        pub(super) fn bind_git_shadow_witness(
+            mut self,
+            witness: StrictLocalGitShadowWitnessV1,
+        ) -> Option<Self> {
+            let expected = self.git_shadow_expected.take()?;
+            std::sync::Arc::ptr_eq(&expected.0, &witness.0).then_some(self)
         }
 
         pub(super) fn into_snapshot(self) -> CompleteStrictLocalSnapshotV1 {
@@ -1237,6 +1296,7 @@ mod supported {
             inventory_a,
             namespace_claims,
             entries,
+            git_shadow_expected: None,
         })
     }
 
@@ -1276,6 +1336,7 @@ mod supported {
         Ok(RevalidatedSupportedSnapshotV1 {
             canonical_local_root: held.canonical_local_root,
             _root: held.root,
+            git_shadow_expected: held.git_shadow_expected,
             snapshot: CompleteStrictLocalSnapshotV1 {
                 profile: held.profile,
                 profile_settings_fingerprint,

--- a/crates/tcfs-sync/src/registered_local_snapshot.rs
+++ b/crates/tcfs-sync/src/registered_local_snapshot.rs
@@ -1,0 +1,2859 @@
+//! Strict, read-only local snapshots for registered-root planning.
+//!
+//! This module deliberately does not reuse the primary sync collector. A
+//! registered-root plan needs one bounded, verified observation, not a best-effort
+//! traversal that can follow renamed path components or update primary state.
+//! The supported Linux implementation therefore:
+//!
+//! 1. opens the canonical configured root one component at a time without
+//!    following symlinks;
+//! 2. records a descriptor-relative identity inventory;
+//! 3. captures every included leaf while checking its descriptor and parent
+//!    identities before and after the read;
+//! 4. records a second identity inventory and requires exact equality; and
+//! 5. reopens the configured root and requires the original root identity.
+//!
+//! Acquisition identities make races fail closed but are intentionally absent
+//! from the portable semantic digest. Descriptor, size, mtime, and ctime
+//! brackets detect ordinary concurrent writers on the supported filesystem;
+//! they are not a hostile-writer lease or a kernel filesystem snapshot. A
+//! future executor must replan under its execution lock rather than treating
+//! this read-only artifact as enduring authority.
+
+use crate::blacklist::Blacklist;
+use crate::index_entry::{portable_casefold_path, validate_namespace_logical_path};
+use anyhow::Result;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::Path;
+use tcfs_core::config::{
+    RegisteredRootPlanContractFingerprintV1, RegisteredRootPlanContractV1,
+    RootLocalSnapshotContractV1, RootProfileSettingsFingerprintV1, RootProfileV1,
+};
+
+const LOCAL_SNAPSHOT_DIGEST_DOMAIN_V1: &str = "tinyland.tcfs.registered-root-local-snapshot.b3v1";
+const LOCAL_SNAPSHOT_ACQUISITION_FINGERPRINT_DOMAIN_V1: &str =
+    "tinyland.tcfs.registered-root-local-snapshot-acquisition.b3v1";
+const LOCAL_SNAPSHOT_SEMANTIC_ENCODING_FINGERPRINT_DOMAIN_V1: &str =
+    "tinyland.tcfs.registered-root-local-snapshot-semantic-encoding.b3v1";
+const LOCAL_SNAPSHOT_SEMANTIC_ENCODING_NAME_V1: &str =
+    "portable-derived-directory-regular-symlink-v1";
+const LOCAL_SNAPSHOT_CONTRACT_V1: RootLocalSnapshotContractV1 =
+    RegisteredRootPlanContractV1::strict_v1().local_snapshot_contract();
+const MAX_DEPTH_V1: usize = LOCAL_SNAPSHOT_CONTRACT_V1.max_depth() as usize;
+const MAX_ENTRIES_V1: usize = LOCAL_SNAPSHOT_CONTRACT_V1.max_entries() as usize;
+const MAX_RETAINED_PATH_BYTES_V1: usize =
+    LOCAL_SNAPSHOT_CONTRACT_V1.max_retained_path_bytes() as usize;
+const MAX_SYMLINK_TARGET_BYTES_V1: usize =
+    LOCAL_SNAPSHOT_CONTRACT_V1.max_symlink_target_bytes() as usize;
+const MAX_REGULAR_FILE_BYTES_V1: u64 = LOCAL_SNAPSHOT_CONTRACT_V1.max_regular_file_bytes();
+const MAX_TOTAL_HASHED_BYTES_V1: u64 = LOCAL_SNAPSHOT_CONTRACT_V1.max_total_hashed_bytes();
+const HASH_BUFFER_BYTES_V1: usize = LOCAL_SNAPSHOT_CONTRACT_V1.hash_buffer_bytes() as usize;
+
+/// Portable BLAKE3 identity of one complete local semantic snapshot.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StrictLocalSnapshotDigestV1([u8; 32]);
+
+impl StrictLocalSnapshotDigestV1 {
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for StrictLocalSnapshotDigestV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("b3v1:")?;
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for StrictLocalSnapshotDigestV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "StrictLocalSnapshotDigestV1({self})")
+    }
+}
+
+/// Opaque identity of the acquisition proof and its resource bounds.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StrictLocalSnapshotAcquisitionFingerprintV1([u8; 32]);
+
+impl StrictLocalSnapshotAcquisitionFingerprintV1 {
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for StrictLocalSnapshotAcquisitionFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("b3v1:")?;
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for StrictLocalSnapshotAcquisitionFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "StrictLocalSnapshotAcquisitionFingerprintV1({self})"
+        )
+    }
+}
+
+/// Portable identity of the semantic entry encoding, independent of the
+/// platform-specific acquisition proof and resource limits.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StrictLocalSnapshotSemanticEncodingFingerprintV1([u8; 32]);
+
+impl StrictLocalSnapshotSemanticEncodingFingerprintV1 {
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for StrictLocalSnapshotSemanticEncodingFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("b3v1:")?;
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for StrictLocalSnapshotSemanticEncodingFingerprintV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "StrictLocalSnapshotSemanticEncodingFingerprintV1({self})"
+        )
+    }
+}
+
+/// Immutable metadata and raw-byte identity of an included regular file.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StrictLocalRegularFileV1 {
+    raw_blake3: [u8; 32],
+    size: u64,
+    portable_mode: u32,
+    mtime_seconds: i64,
+    mtime_nanoseconds: u32,
+}
+
+impl StrictLocalRegularFileV1 {
+    pub const fn raw_blake3(&self) -> &[u8; 32] {
+        &self.raw_blake3
+    }
+
+    pub const fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub const fn portable_mode(&self) -> u32 {
+        self.portable_mode
+    }
+
+    pub const fn mtime_seconds(&self) -> i64 {
+        self.mtime_seconds
+    }
+
+    pub const fn mtime_nanoseconds(&self) -> u32 {
+        self.mtime_nanoseconds
+    }
+}
+
+impl fmt::Debug for StrictLocalRegularFileV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StrictLocalRegularFileV1")
+            .field("raw_blake3", &blake3::Hash::from_bytes(self.raw_blake3))
+            .field("size", &self.size)
+            .field(
+                "portable_mode",
+                &format_args!("{:#05o}", self.portable_mode),
+            )
+            .field("mtime_seconds", &self.mtime_seconds)
+            .field("mtime_nanoseconds", &self.mtime_nanoseconds)
+            .finish()
+    }
+}
+
+/// Exact, validated target of an included symbolic link.
+///
+/// `Debug` deliberately exposes only length and digest. The exact target is
+/// available through the explicit accessor for planning, never accidentally
+/// through diagnostics.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StrictLocalSymlinkV1 {
+    target: String,
+    target_blake3: [u8; 32],
+}
+
+impl StrictLocalSymlinkV1 {
+    pub fn target(&self) -> &str {
+        &self.target
+    }
+
+    pub const fn target_blake3(&self) -> &[u8; 32] {
+        &self.target_blake3
+    }
+}
+
+impl fmt::Debug for StrictLocalSymlinkV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StrictLocalSymlinkV1")
+            .field("target_len", &self.target.len())
+            .field(
+                "target_blake3",
+                &blake3::Hash::from_bytes(self.target_blake3),
+            )
+            .finish()
+    }
+}
+
+/// One portable namespace role in a complete local snapshot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StrictLocalEntryV1 {
+    Directory,
+    Regular(StrictLocalRegularFileV1),
+    Symlink(StrictLocalSymlinkV1),
+}
+
+impl StrictLocalEntryV1 {
+    pub const fn canonical_kind_name(&self) -> &'static str {
+        match self {
+            Self::Directory => "directory",
+            Self::Regular(_) => "regular",
+            Self::Symlink(_) => "symlink",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StrictLocalNamespaceRoleV1 {
+    File,
+    Directory,
+}
+
+/// Acquisition-only namespace evidence retained for the future cross-input
+/// composer. Ignored empty directories live here, not in the semantic digest.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StrictLocalNamespaceClaimV1 {
+    exact_path: String,
+    role: StrictLocalNamespaceRoleV1,
+}
+
+impl StrictLocalNamespaceClaimV1 {
+    pub(crate) fn exact_path(&self) -> &str {
+        &self.exact_path
+    }
+
+    pub(crate) const fn role(&self) -> StrictLocalNamespaceRoleV1 {
+        self.role
+    }
+}
+
+/// A complete, race-checked local semantic snapshot.
+///
+/// "Complete" is scoped to this one local acquisition. It is not a complete
+/// registered-root plan and carries no state/remote composition proof.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CompleteStrictLocalSnapshotV1 {
+    profile: RootProfileV1,
+    profile_settings_fingerprint: RootProfileSettingsFingerprintV1,
+    plan_contract_fingerprint: RegisteredRootPlanContractFingerprintV1,
+    acquisition_fingerprint: StrictLocalSnapshotAcquisitionFingerprintV1,
+    semantic_encoding_fingerprint: StrictLocalSnapshotSemanticEncodingFingerprintV1,
+    namespace_claims: BTreeMap<String, StrictLocalNamespaceClaimV1>,
+    entries: BTreeMap<String, StrictLocalEntryV1>,
+    digest: StrictLocalSnapshotDigestV1,
+}
+
+impl CompleteStrictLocalSnapshotV1 {
+    pub const fn profile(&self) -> RootProfileV1 {
+        self.profile
+    }
+
+    pub const fn profile_settings_fingerprint(&self) -> RootProfileSettingsFingerprintV1 {
+        self.profile_settings_fingerprint
+    }
+
+    pub const fn acquisition_contract_name(&self) -> &'static str {
+        LOCAL_SNAPSHOT_CONTRACT_V1.canonical_name()
+    }
+
+    pub const fn plan_contract_fingerprint(&self) -> RegisteredRootPlanContractFingerprintV1 {
+        self.plan_contract_fingerprint
+    }
+
+    pub const fn acquisition_fingerprint(&self) -> StrictLocalSnapshotAcquisitionFingerprintV1 {
+        self.acquisition_fingerprint
+    }
+
+    pub const fn semantic_encoding_name(&self) -> &'static str {
+        LOCAL_SNAPSHOT_SEMANTIC_ENCODING_NAME_V1
+    }
+
+    pub const fn semantic_encoding_fingerprint(
+        &self,
+    ) -> StrictLocalSnapshotSemanticEncodingFingerprintV1 {
+        self.semantic_encoding_fingerprint
+    }
+
+    pub fn entries(&self) -> impl ExactSizeIterator<Item = (&str, &StrictLocalEntryV1)> {
+        self.entries
+            .iter()
+            .map(|(path, entry)| (path.as_str(), entry))
+    }
+
+    pub fn entry(&self, rel_path: &str) -> Option<&StrictLocalEntryV1> {
+        self.entries.get(rel_path)
+    }
+
+    pub(crate) fn namespace_claims(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (&str, &StrictLocalNamespaceClaimV1)> {
+        self.namespace_claims
+            .iter()
+            .map(|(folded_path, claim)| (folded_path.as_str(), claim))
+    }
+
+    pub const fn digest(&self) -> StrictLocalSnapshotDigestV1 {
+        self.digest
+    }
+}
+
+impl fmt::Debug for CompleteStrictLocalSnapshotV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CompleteStrictLocalSnapshotV1")
+            .field("profile", &self.profile)
+            .field(
+                "profile_settings_fingerprint",
+                &self.profile_settings_fingerprint,
+            )
+            .field("plan_contract_fingerprint", &self.plan_contract_fingerprint)
+            .field("acquisition_fingerprint", &self.acquisition_fingerprint)
+            .field(
+                "semantic_encoding_fingerprint",
+                &self.semantic_encoding_fingerprint,
+            )
+            .field("namespace_claim_count", &self.namespace_claims.len())
+            .field("entries", &self.entries)
+            .field("digest", &self.digest)
+            .finish()
+    }
+}
+
+/// Stable class of a fail-closed, digest-less acquisition result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StrictLocalSnapshotIncompleteKindV1 {
+    UnsupportedPlatform,
+    InvalidConfiguredRoot,
+    ConfiguredRootTrustRejected,
+    FilesystemReadFailed,
+    AcquisitionLimitExceeded,
+    NamespaceRejected,
+    GitLayoutRejected,
+    HardlinkRejected,
+    DuplicateIdentityRejected,
+    UnsupportedObjectRejected,
+    UnsafeModeRejected,
+    SymlinkTargetRejected,
+    MountBoundaryRejected,
+    ChangedDuringRead,
+}
+
+/// Typed, non-sensitive explanation for an incomplete local snapshot.
+#[derive(Clone, PartialEq, Eq)]
+pub struct StrictLocalSnapshotIncompleteV1 {
+    kind: StrictLocalSnapshotIncompleteKindV1,
+    rel_path: Option<String>,
+    operation: &'static str,
+}
+
+impl StrictLocalSnapshotIncompleteV1 {
+    pub const fn kind(&self) -> StrictLocalSnapshotIncompleteKindV1 {
+        self.kind
+    }
+
+    pub fn rel_path(&self) -> Option<&str> {
+        self.rel_path.as_deref()
+    }
+
+    pub const fn operation(&self) -> &'static str {
+        self.operation
+    }
+}
+
+impl fmt::Debug for StrictLocalSnapshotIncompleteV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StrictLocalSnapshotIncompleteV1")
+            .field("kind", &self.kind)
+            .field("rel_path", &self.rel_path)
+            .field("operation", &self.operation)
+            .finish()
+    }
+}
+
+/// A strict snapshot is either complete with a digest or incomplete without
+/// one. Callers cannot manufacture a digest for an incomplete acquisition.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StrictLocalSnapshotReadV1 {
+    Complete(CompleteStrictLocalSnapshotV1),
+    Incomplete(StrictLocalSnapshotIncompleteV1),
+}
+
+impl StrictLocalSnapshotReadV1 {
+    pub fn complete(&self) -> Option<&CompleteStrictLocalSnapshotV1> {
+        match self {
+            Self::Complete(snapshot) => Some(snapshot),
+            Self::Incomplete(_) => None,
+        }
+    }
+
+    pub fn incomplete(&self) -> Option<&StrictLocalSnapshotIncompleteV1> {
+        match self {
+            Self::Complete(_) => None,
+            Self::Incomplete(incomplete) => Some(incomplete),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CaptureFailure {
+    kind: StrictLocalSnapshotIncompleteKindV1,
+    rel_path: Option<String>,
+    operation: &'static str,
+}
+
+impl CaptureFailure {
+    fn root(kind: StrictLocalSnapshotIncompleteKindV1, operation: &'static str) -> Self {
+        Self {
+            kind,
+            rel_path: None,
+            operation,
+        }
+    }
+
+    fn path(
+        kind: StrictLocalSnapshotIncompleteKindV1,
+        rel_path: impl Into<String>,
+        operation: &'static str,
+    ) -> Self {
+        Self {
+            kind,
+            rel_path: Some(rel_path.into()),
+            operation,
+        }
+    }
+
+    fn into_public(self) -> StrictLocalSnapshotIncompleteV1 {
+        StrictLocalSnapshotIncompleteV1 {
+            kind: self.kind,
+            rel_path: self.rel_path,
+            operation: self.operation,
+        }
+    }
+}
+
+/// Capture one strict, read-only local snapshot.
+///
+/// Expected policy, platform, I/O, and race failures are returned as a typed
+/// `Incomplete` value with no digest. The outer `Result` is retained for
+/// composition with the registered-root planner and for future internal
+/// invariant errors.
+pub fn capture_strict_local_snapshot_v1(
+    canonical_local_root: &Path,
+    profile: RootProfileV1,
+) -> Result<StrictLocalSnapshotReadV1> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (canonical_local_root, profile);
+        return Ok(StrictLocalSnapshotReadV1::Incomplete(
+            CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
+                "platform-check",
+            )
+            .into_public(),
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        match capture_supported(canonical_local_root, profile) {
+            Ok(snapshot) => Ok(StrictLocalSnapshotReadV1::Complete(snapshot)),
+            Err(failure) => Ok(StrictLocalSnapshotReadV1::Incomplete(failure.into_public())),
+        }
+    }
+}
+
+struct LengthFramedHasherV1 {
+    hasher: blake3::Hasher,
+}
+
+impl LengthFramedHasherV1 {
+    fn new(domain: &'static str) -> Self {
+        Self {
+            hasher: blake3::Hasher::new_derive_key(domain),
+        }
+    }
+
+    fn field(&mut self, tag: &'static str, value: &[u8]) {
+        self.hasher.update(&(tag.len() as u32).to_be_bytes());
+        self.hasher.update(tag.as_bytes());
+        self.hasher.update(&(value.len() as u64).to_be_bytes());
+        self.hasher.update(value);
+    }
+
+    fn finish(self) -> [u8; 32] {
+        *self.hasher.finalize().as_bytes()
+    }
+}
+
+fn local_snapshot_acquisition_fingerprint_v1() -> StrictLocalSnapshotAcquisitionFingerprintV1 {
+    let mut encoder = LengthFramedHasherV1::new(LOCAL_SNAPSHOT_ACQUISITION_FINGERPRINT_DOMAIN_V1);
+    let plan_contract = RegisteredRootPlanContractV1::strict_v1();
+    encoder.field(
+        "contract_name",
+        LOCAL_SNAPSHOT_CONTRACT_V1.canonical_name().as_bytes(),
+    );
+    encoder.field(
+        "plan_contract_fingerprint",
+        plan_contract.fingerprint().as_bytes(),
+    );
+    encoder.field(
+        "mount_boundary_policy",
+        LOCAL_SNAPSHOT_CONTRACT_V1
+            .mount_boundary_policy()
+            .canonical_name()
+            .as_bytes(),
+    );
+    encoder.field(
+        "identity_acquisition",
+        b"descriptor-relative-no-follow-stable-identity-content-identity-v1",
+    );
+    encoder.field(
+        "stability",
+        b"inventory-a-leaf-bracket-inventory-b-reopen-v1",
+    );
+    encoder.field("namespace", b"portable-nfc-casefold-file-directory-role-v1");
+    encoder.field("regular", b"raw-blake3-exact-size-eof-mode-mtime-v1");
+    encoder.field("symlink", b"exact-utf8-safe-relative-target-v1");
+    encoder.field(
+        "excluded_inventory",
+        b"excluded-root-identity-pruned-subtree-v1",
+    );
+    encoder.field("max_depth", &(MAX_DEPTH_V1 as u64).to_be_bytes());
+    encoder.field("max_entries", &(MAX_ENTRIES_V1 as u64).to_be_bytes());
+    encoder.field(
+        "max_retained_path_bytes",
+        &(MAX_RETAINED_PATH_BYTES_V1 as u64).to_be_bytes(),
+    );
+    encoder.field(
+        "max_symlink_target_bytes",
+        &(MAX_SYMLINK_TARGET_BYTES_V1 as u64).to_be_bytes(),
+    );
+    encoder.field(
+        "max_regular_file_bytes",
+        &MAX_REGULAR_FILE_BYTES_V1.to_be_bytes(),
+    );
+    encoder.field(
+        "max_total_hashed_bytes",
+        &MAX_TOTAL_HASHED_BYTES_V1.to_be_bytes(),
+    );
+    encoder.field(
+        "hash_buffer_bytes",
+        &(HASH_BUFFER_BYTES_V1 as u64).to_be_bytes(),
+    );
+    StrictLocalSnapshotAcquisitionFingerprintV1(encoder.finish())
+}
+
+fn local_snapshot_semantic_encoding_fingerprint_v1(
+) -> StrictLocalSnapshotSemanticEncodingFingerprintV1 {
+    let mut encoder =
+        LengthFramedHasherV1::new(LOCAL_SNAPSHOT_SEMANTIC_ENCODING_FINGERPRINT_DOMAIN_V1);
+    encoder.field(
+        "encoding_name",
+        LOCAL_SNAPSHOT_SEMANTIC_ENCODING_NAME_V1.as_bytes(),
+    );
+    encoder.field(
+        "path_encoding",
+        b"utf8-nfc-portable-casefold-canonical-byte-order-v1",
+    );
+    encoder.field(
+        "directory_encoding",
+        b"derived-ancestors-of-included-leaves-v1",
+    );
+    encoder.field(
+        "regular_encoding",
+        b"raw-blake3-size-portable-mode-mtime-seconds-nanoseconds-v1",
+    );
+    encoder.field(
+        "symlink_encoding",
+        b"exact-utf8-target-and-raw-target-blake3-v1",
+    );
+    encoder.field("field_framing", b"u32-tag-length-u64-value-length-v1");
+    StrictLocalSnapshotSemanticEncodingFingerprintV1(encoder.finish())
+}
+
+fn semantic_snapshot_digest_v1(
+    profile: RootProfileV1,
+    profile_settings_fingerprint: RootProfileSettingsFingerprintV1,
+    semantic_encoding_fingerprint: StrictLocalSnapshotSemanticEncodingFingerprintV1,
+    entries: &BTreeMap<String, StrictLocalEntryV1>,
+) -> StrictLocalSnapshotDigestV1 {
+    let mut encoder = LengthFramedHasherV1::new(LOCAL_SNAPSHOT_DIGEST_DOMAIN_V1);
+    encoder.field(
+        "semantic_encoding_name",
+        LOCAL_SNAPSHOT_SEMANTIC_ENCODING_NAME_V1.as_bytes(),
+    );
+    encoder.field(
+        "semantic_encoding_fingerprint",
+        semantic_encoding_fingerprint.as_bytes(),
+    );
+    encoder.field("profile", profile.canonical_name().as_bytes());
+    encoder.field(
+        "profile_settings_fingerprint",
+        profile_settings_fingerprint.as_bytes(),
+    );
+    encoder.field("entry_count", &(entries.len() as u64).to_be_bytes());
+    for (path, entry) in entries {
+        encoder.field("path", path.as_bytes());
+        encoder.field("kind", entry.canonical_kind_name().as_bytes());
+        match entry {
+            StrictLocalEntryV1::Directory => {}
+            StrictLocalEntryV1::Regular(regular) => {
+                encoder.field("raw_blake3", regular.raw_blake3());
+                encoder.field("size", &regular.size().to_be_bytes());
+                encoder.field("portable_mode", &regular.portable_mode().to_be_bytes());
+                encoder.field("mtime_seconds", &regular.mtime_seconds().to_be_bytes());
+                encoder.field(
+                    "mtime_nanoseconds",
+                    &regular.mtime_nanoseconds().to_be_bytes(),
+                );
+            }
+            StrictLocalEntryV1::Symlink(symlink) => {
+                encoder.field("target", symlink.target().as_bytes());
+                encoder.field("target_blake3", symlink.target_blake3());
+            }
+        }
+    }
+    StrictLocalSnapshotDigestV1(encoder.finish())
+}
+
+#[cfg(target_os = "linux")]
+mod supported {
+    use super::*;
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::ffi::{CStr, CString, OsString};
+    use std::fs::File;
+    use std::io::Read;
+    use std::mem::MaybeUninit;
+    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::path::{Component, Path, PathBuf};
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct StableIdentity {
+        dev: u64,
+        ino: u64,
+        mode: u32,
+        nlink: u64,
+        uid: u32,
+        gid: u32,
+        rdev: u64,
+        size: i64,
+        mtime_seconds: i64,
+        mtime_nanoseconds: i64,
+        ctime_seconds: i64,
+        ctime_nanoseconds: i64,
+    }
+
+    impl StableIdentity {
+        fn object_kind(self) -> ObjectKind {
+            match self.mode & libc::S_IFMT {
+                libc::S_IFDIR => ObjectKind::Directory,
+                libc::S_IFREG => ObjectKind::Regular,
+                libc::S_IFLNK => ObjectKind::Symlink,
+                _ => ObjectKind::Special,
+            }
+        }
+
+        fn dev_ino(self) -> (u64, u64) {
+            (self.dev, self.ino)
+        }
+
+        fn has_special_permissions(self) -> bool {
+            self.mode & 0o7000 != 0
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum ObjectKind {
+        Directory,
+        Regular,
+        Symlink,
+        Special,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Disposition {
+        Included,
+        Excluded,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct InventoryRecord {
+        identity: StableIdentity,
+        disposition: Disposition,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct IdentityInventory {
+        root: StableIdentity,
+        root_mount_id: u64,
+        entries: BTreeMap<Vec<u8>, InventoryRecord>,
+    }
+
+    struct InventoryContext<'a> {
+        profile: RootProfileV1,
+        entries: BTreeMap<Vec<u8>, InventoryRecord>,
+        expected: Option<&'a IdentityInventory>,
+        observed_count: usize,
+        retained_path_bytes: usize,
+        directory_identities: BTreeSet<(u64, u64)>,
+        included_leaf_identities: BTreeSet<(u64, u64)>,
+        total_hashed_bytes: u64,
+        saw_root_git_directory: bool,
+    }
+
+    struct InventoryDirectoryFrame {
+        directory: File,
+        stream: DirectoryStream,
+        components: Vec<Vec<u8>>,
+        parent_excluded: bool,
+        depth: usize,
+        expected_identity_after_walk: Option<StableIdentity>,
+    }
+
+    impl<'a> InventoryContext<'a> {
+        fn collecting(profile: RootProfileV1, root: StableIdentity) -> Self {
+            let mut directory_identities = BTreeSet::new();
+            directory_identities.insert(root.dev_ino());
+            Self {
+                profile,
+                entries: BTreeMap::new(),
+                expected: None,
+                observed_count: 0,
+                retained_path_bytes: 0,
+                directory_identities,
+                included_leaf_identities: BTreeSet::new(),
+                total_hashed_bytes: 0,
+                saw_root_git_directory: false,
+            }
+        }
+
+        fn verifying(
+            profile: RootProfileV1,
+            root: StableIdentity,
+            expected: &'a IdentityInventory,
+        ) -> Self {
+            let mut context = Self::collecting(profile, root);
+            context.expected = Some(expected);
+            context
+        }
+
+        fn retained_entry_count(&self) -> usize {
+            if self.expected.is_some() {
+                self.observed_count
+            } else {
+                self.entries.len()
+            }
+        }
+    }
+
+    pub(super) fn capture_supported(
+        canonical_local_root: &Path,
+        profile: RootProfileV1,
+    ) -> std::result::Result<CompleteStrictLocalSnapshotV1, CaptureFailure> {
+        validate_configured_root(canonical_local_root)?;
+        crate::conflict_git::validate_trusted_configured_path(canonical_local_root).map_err(
+            |_| {
+                CaptureFailure::root(
+                    StrictLocalSnapshotIncompleteKindV1::ConfiguredRootTrustRejected,
+                    "validate-configured-root-trust",
+                )
+            },
+        )?;
+
+        let root = open_absolute_directory(canonical_local_root, "open-configured-root")?;
+        let root_identity = fstat_identity(root.as_raw_fd(), None, "stat-configured-root")?;
+        let root_mount_id = statx_mount_id(root.as_raw_fd(), None, "statx-configured-root")?;
+        if root_identity.object_kind() != ObjectKind::Directory {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::InvalidConfiguredRoot,
+                "configured-root-not-directory",
+            ));
+        }
+
+        let inventory_a = inventory_tree(&root, root_identity, root_mount_id, profile)?;
+        let namespace_claims = portable_namespace_claims(&inventory_a.entries)?;
+        run_test_hook(TestHookPoint::InventoryAToLeaf);
+        let entries = capture_semantic_entries(&root, &inventory_a)?;
+        run_test_hook(TestHookPoint::LeafToInventoryB);
+        verify_inventory_tree(&root, root_identity, root_mount_id, profile, &inventory_a)?;
+
+        run_test_hook(TestHookPoint::RootPathBeforeReopen);
+        validate_configured_root(canonical_local_root)?;
+        crate::conflict_git::validate_trusted_configured_path(canonical_local_root).map_err(
+            |_| {
+                CaptureFailure::root(
+                    StrictLocalSnapshotIncompleteKindV1::ConfiguredRootTrustRejected,
+                    "revalidate-configured-root-trust",
+                )
+            },
+        )?;
+        let reopened = open_absolute_directory(canonical_local_root, "reopen-configured-root")?;
+        let reopened_identity =
+            fstat_identity(reopened.as_raw_fd(), None, "restat-configured-root")?;
+        let reopened_mount_id =
+            statx_mount_id(reopened.as_raw_fd(), None, "restatx-configured-root")?;
+        if reopened_identity != root_identity || reopened_mount_id != root_mount_id {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                "compare-reopened-root-identity",
+            ));
+        }
+
+        let policy = profile.policy();
+        let profile_settings_fingerprint = policy.settings_fingerprint();
+        let plan_contract_fingerprint = RegisteredRootPlanContractV1::strict_v1().fingerprint();
+        let acquisition_fingerprint = local_snapshot_acquisition_fingerprint_v1();
+        let semantic_encoding_fingerprint = local_snapshot_semantic_encoding_fingerprint_v1();
+        let digest = semantic_snapshot_digest_v1(
+            profile,
+            profile_settings_fingerprint,
+            semantic_encoding_fingerprint,
+            &entries,
+        );
+        Ok(CompleteStrictLocalSnapshotV1 {
+            profile,
+            profile_settings_fingerprint,
+            plan_contract_fingerprint,
+            acquisition_fingerprint,
+            semantic_encoding_fingerprint,
+            namespace_claims,
+            entries,
+            digest,
+        })
+    }
+
+    fn validate_configured_root(path: &Path) -> std::result::Result<(), CaptureFailure> {
+        if !path.is_absolute()
+            || path.components().any(|component| {
+                matches!(
+                    component,
+                    Component::CurDir | Component::ParentDir | Component::Prefix(_)
+                )
+            })
+        {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::InvalidConfiguredRoot,
+                "require-absolute-normal-components",
+            ));
+        }
+        let canonical = path.canonicalize().map_err(|_| {
+            CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::InvalidConfiguredRoot,
+                "canonicalize-configured-root",
+            )
+        })?;
+        if canonical.as_os_str().as_bytes() != path.as_os_str().as_bytes() {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::InvalidConfiguredRoot,
+                "require-exact-canonical-root-spelling",
+            ));
+        }
+        Ok(())
+    }
+
+    fn inventory_tree(
+        root: &File,
+        expected_root: StableIdentity,
+        expected_root_mount_id: u64,
+        profile: RootProfileV1,
+    ) -> std::result::Result<IdentityInventory, CaptureFailure> {
+        let observed_root = fstat_identity(root.as_raw_fd(), None, "stat-inventory-root")?;
+        if observed_root != expected_root {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                "compare-inventory-root",
+            ));
+        }
+        let observed_mount_id = statx_mount_id(root.as_raw_fd(), None, "statx-inventory-root")?;
+        if observed_mount_id != expected_root_mount_id {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                "compare-inventory-root-mount-identity",
+            ));
+        }
+        let mut context = InventoryContext::collecting(profile, observed_root);
+        inventory_directory(root, &[], false, 0, &mut context)?;
+        let after_root = fstat_identity(root.as_raw_fd(), None, "restat-inventory-root")?;
+        let after_mount_id = statx_mount_id(root.as_raw_fd(), None, "restatx-inventory-root")?;
+        if after_root != observed_root || after_mount_id != observed_mount_id {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                "compare-inventory-root-after-walk",
+            ));
+        }
+        if profile == RootProfileV1::GitRawV1 && !context.saw_root_git_directory {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::GitLayoutRejected,
+                "require-root-dot-git-directory",
+            ));
+        }
+        Ok(IdentityInventory {
+            root: observed_root,
+            root_mount_id: observed_mount_id,
+            entries: context.entries,
+        })
+    }
+
+    fn verify_inventory_tree(
+        root: &File,
+        expected_root: StableIdentity,
+        expected_root_mount_id: u64,
+        profile: RootProfileV1,
+        expected: &IdentityInventory,
+    ) -> std::result::Result<(), CaptureFailure> {
+        let observed_root = fstat_identity(root.as_raw_fd(), None, "stat-verify-root")?;
+        let observed_mount_id = statx_mount_id(root.as_raw_fd(), None, "statx-verify-root")?;
+        if observed_root != expected_root
+            || observed_mount_id != expected_root_mount_id
+            || observed_root != expected.root
+            || observed_mount_id != expected.root_mount_id
+        {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                "compare-verify-root-before-walk",
+            ));
+        }
+        let mut context = InventoryContext::verifying(profile, observed_root, expected);
+        inventory_directory(root, &[], false, 0, &mut context)?;
+        let after_root = fstat_identity(root.as_raw_fd(), None, "restat-verify-root")?;
+        let after_mount_id = statx_mount_id(root.as_raw_fd(), None, "restatx-verify-root")?;
+        if after_root != observed_root || after_mount_id != observed_mount_id {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                "compare-verify-root-after-walk",
+            ));
+        }
+        if profile == RootProfileV1::GitRawV1 && !context.saw_root_git_directory {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::GitLayoutRejected,
+                "reverify-root-dot-git-directory",
+            ));
+        }
+        if context.observed_count != expected.entries.len() {
+            return Err(CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                "compare-verify-entry-count",
+            ));
+        }
+        Ok(())
+    }
+
+    fn inventory_directory(
+        directory: &File,
+        parent_components: &[Vec<u8>],
+        parent_excluded: bool,
+        depth: usize,
+        context: &mut InventoryContext<'_>,
+    ) -> std::result::Result<(), CaptureFailure> {
+        if depth > MAX_DEPTH_V1 {
+            return Err(CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                display_rel_components(parent_components),
+                "maximum-directory-depth",
+            ));
+        }
+        let root_directory = directory.try_clone().map_err(|_| {
+            CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+                display_rel_components(parent_components),
+                "clone-inventory-root-descriptor",
+            )
+        })?;
+        let root_stream = open_directory_stream(root_directory.as_raw_fd(), parent_components)?;
+        let mut stack = vec![InventoryDirectoryFrame {
+            directory: root_directory,
+            stream: root_stream,
+            components: parent_components.to_vec(),
+            parent_excluded,
+            depth,
+            expected_identity_after_walk: None,
+        }];
+
+        while !stack.is_empty() {
+            let name = {
+                let frame = stack
+                    .last_mut()
+                    .expect("nonempty inventory directory frame stack");
+                read_next_raw_name(
+                    &mut frame.stream,
+                    &frame.components,
+                    MAX_ENTRIES_V1.saturating_sub(context.retained_entry_count()),
+                    MAX_RETAINED_PATH_BYTES_V1.saturating_sub(context.retained_path_bytes),
+                )?
+            };
+            let Some(name) = name else {
+                let mut completed = stack
+                    .pop()
+                    .expect("nonempty inventory directory frame stack");
+                completed.stream.close().map_err(|_| {
+                    CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+                        display_rel_components(&completed.components),
+                        "closedir",
+                    )
+                })?;
+                if let Some(expected) = completed.expected_identity_after_walk {
+                    let rel_bytes = join_rel_components(&completed.components);
+                    let after = fstat_identity(
+                        completed.directory.as_raw_fd(),
+                        Some(&rel_bytes),
+                        "restat-directory",
+                    )?;
+                    if after != expected {
+                        return Err(CaptureFailure::path(
+                            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                            display_rel_bytes(&rel_bytes),
+                            "compare-directory-after-inventory",
+                        ));
+                    }
+                }
+                continue;
+            };
+
+            let (directory_fd, parent_components, parent_excluded, depth) = {
+                let frame = stack
+                    .last()
+                    .expect("nonempty inventory directory frame stack");
+                (
+                    frame.directory.as_raw_fd(),
+                    frame.components.clone(),
+                    frame.parent_excluded,
+                    frame.depth,
+                )
+            };
+            let parent_is_root = parent_components.is_empty();
+            let mut components = parent_components;
+            components.push(name.clone());
+            if components.len() > MAX_DEPTH_V1 {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_components(&components),
+                    "maximum-path-component-depth",
+                ));
+            }
+            let rel_bytes = join_rel_components(&components);
+            let rel_display = display_rel_bytes(&rel_bytes);
+            context.retained_path_bytes = context
+                .retained_path_bytes
+                .checked_add(rel_bytes.len())
+                .ok_or_else(|| {
+                    CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                        rel_display.clone(),
+                        "retained-path-byte-overflow",
+                    )
+                })?;
+            if context.retained_path_bytes > MAX_RETAINED_PATH_BYTES_V1 {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    rel_display,
+                    "maximum-retained-path-bytes",
+                ));
+            }
+            if context.retained_entry_count() >= MAX_ENTRIES_V1 {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_bytes(&rel_bytes),
+                    "maximum-entry-count",
+                ));
+            }
+
+            let c_name = c_string_name(&name, &rel_bytes)?;
+            // The constrained O_PATH open must be the first metadata operation
+            // on a descendant name. An unconstrained stat lookup could enter a
+            // mount inserted at that name (and trigger an automount) before
+            // NO_XDEV had a chance to reject the boundary.
+            let identity_handle = openat_descendant_identity(
+                directory_fd,
+                &c_name,
+                Some(&rel_bytes),
+                "open-inventory-entry",
+            )?;
+            let identity = fstat_identity(
+                identity_handle.as_raw_fd(),
+                Some(&rel_bytes),
+                "stat-inventory-entry",
+            )?;
+            let exact_dot_git = name.as_slice() == b".git";
+            let ascii_dot_git = name.eq_ignore_ascii_case(b".git");
+            if ascii_dot_git && !exact_dot_git && !parent_excluded {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                    display_rel_bytes(&rel_bytes),
+                    "noncanonical-dot-git-alias",
+                ));
+            }
+
+            let is_root_dot_git = parent_is_root && exact_dot_git;
+            let nested_dot_git = !parent_is_root && exact_dot_git;
+            if context.profile == RootProfileV1::GitRawV1 && is_root_dot_git {
+                if identity.object_kind() != ObjectKind::Directory {
+                    return Err(CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::GitLayoutRejected,
+                        display_rel_bytes(&rel_bytes),
+                        "root-dot-git-must-be-real-directory",
+                    ));
+                }
+                context.saw_root_git_directory = true;
+            }
+            if context.profile == RootProfileV1::GitRawV1 && nested_dot_git {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::GitLayoutRejected,
+                    display_rel_bytes(&rel_bytes),
+                    "nested-dot-git-rejected",
+                ));
+            }
+
+            let rel_os_path = raw_rel_path(&components);
+            let profile_excluded = context.profile == RootProfileV1::AgentStaticV1 && exact_dot_git;
+            let fixed_excluded = Blacklist::default()
+                .check_fixed_ingress_path_components(&rel_os_path)
+                .is_some();
+            let excluded = parent_excluded || profile_excluded || fixed_excluded;
+            let disposition = if excluded {
+                Disposition::Excluded
+            } else {
+                Disposition::Included
+            };
+
+            if !excluded
+                && identity.object_kind() == ObjectKind::Regular
+                && identity.has_special_permissions()
+            {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::UnsafeModeRejected,
+                    display_rel_bytes(&rel_bytes),
+                    "setuid-setgid-sticky-mode",
+                ));
+            }
+            match identity.object_kind() {
+                ObjectKind::Directory => {
+                    if !context.directory_identities.insert(identity.dev_ino()) {
+                        return Err(CaptureFailure::path(
+                            StrictLocalSnapshotIncompleteKindV1::DuplicateIdentityRejected,
+                            display_rel_bytes(&rel_bytes),
+                            "repeated-directory-identity",
+                        ));
+                    }
+                }
+                ObjectKind::Regular | ObjectKind::Symlink if !excluded => {
+                    if identity.nlink != 1 {
+                        return Err(CaptureFailure::path(
+                            StrictLocalSnapshotIncompleteKindV1::HardlinkRejected,
+                            display_rel_bytes(&rel_bytes),
+                            "included-leaf-link-count",
+                        ));
+                    }
+                    if identity.object_kind() == ObjectKind::Regular {
+                        let size = u64::try_from(identity.size).map_err(|_| {
+                            CaptureFailure::path(
+                                StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                                display_rel_bytes(&rel_bytes),
+                                "negative-regular-file-size-before-hash",
+                            )
+                        })?;
+                        if size > MAX_REGULAR_FILE_BYTES_V1 {
+                            return Err(CaptureFailure::path(
+                                StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                                display_rel_bytes(&rel_bytes),
+                                "maximum-regular-file-bytes",
+                            ));
+                        }
+                        context.total_hashed_bytes = context
+                            .total_hashed_bytes
+                            .checked_add(size)
+                            .ok_or_else(|| {
+                            CaptureFailure::path(
+                                StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                                display_rel_bytes(&rel_bytes),
+                                "total-hashed-byte-overflow",
+                            )
+                        })?;
+                        if context.total_hashed_bytes > MAX_TOTAL_HASHED_BYTES_V1 {
+                            return Err(CaptureFailure::path(
+                                StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                                display_rel_bytes(&rel_bytes),
+                                "maximum-total-hashed-bytes",
+                            ));
+                        }
+                    }
+                    if !context.included_leaf_identities.insert(identity.dev_ino()) {
+                        return Err(CaptureFailure::path(
+                            StrictLocalSnapshotIncompleteKindV1::DuplicateIdentityRejected,
+                            display_rel_bytes(&rel_bytes),
+                            "duplicate-included-leaf-identity",
+                        ));
+                    }
+                }
+                ObjectKind::Special if !excluded => {
+                    return Err(CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::UnsupportedObjectRejected,
+                        display_rel_bytes(&rel_bytes),
+                        "included-special-object",
+                    ));
+                }
+                ObjectKind::Regular | ObjectKind::Symlink | ObjectKind::Special => {}
+            }
+
+            let record = InventoryRecord {
+                identity,
+                disposition,
+            };
+            if let Some(expected) = context.expected {
+                if expected.entries.get(&rel_bytes) != Some(&record) {
+                    return Err(CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                        display_rel_bytes(&rel_bytes),
+                        "compare-verify-inventory-entry",
+                    ));
+                }
+                context.observed_count =
+                    context.observed_count.checked_add(1).ok_or_else(|| {
+                        CaptureFailure::path(
+                            StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                            display_rel_bytes(&rel_bytes),
+                            "verify-entry-count-overflow",
+                        )
+                    })?;
+            } else if context.entries.insert(rel_bytes.clone(), record).is_some() {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::DuplicateIdentityRejected,
+                    display_rel_bytes(&rel_bytes),
+                    "duplicate-inventory-path",
+                ));
+            }
+
+            if identity.object_kind() == ObjectKind::Directory && !excluded {
+                let child = openat_descendant_file(
+                    directory_fd,
+                    &c_name,
+                    true,
+                    Some(&rel_bytes),
+                    "open-inventory-directory",
+                )?;
+                let opened_identity =
+                    fstat_identity(child.as_raw_fd(), Some(&rel_bytes), "stat-opened-directory")?;
+                if opened_identity != identity {
+                    return Err(CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                        display_rel_bytes(&rel_bytes),
+                        "compare-opened-directory-identity",
+                    ));
+                }
+                let child_depth = depth.checked_add(1).ok_or_else(|| {
+                    CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                        display_rel_bytes(&rel_bytes),
+                        "directory-depth-overflow",
+                    )
+                })?;
+                if child_depth > MAX_DEPTH_V1 {
+                    return Err(CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                        display_rel_bytes(&rel_bytes),
+                        "maximum-directory-depth",
+                    ));
+                }
+                let child_stream = open_directory_stream(child.as_raw_fd(), &components)?;
+                stack.push(InventoryDirectoryFrame {
+                    directory: child,
+                    stream: child_stream,
+                    components,
+                    parent_excluded: excluded,
+                    depth: child_depth,
+                    expected_identity_after_walk: Some(identity),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn portable_namespace_claims(
+        entries: &BTreeMap<Vec<u8>, InventoryRecord>,
+    ) -> std::result::Result<BTreeMap<String, StrictLocalNamespaceClaimV1>, CaptureFailure> {
+        let mut claims: BTreeMap<String, StrictLocalNamespaceClaimV1> = BTreeMap::new();
+        for (raw_path, record) in entries {
+            if record.disposition == Disposition::Excluded {
+                continue;
+            }
+            let rel_path = std::str::from_utf8(raw_path).map_err(|_| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                    display_rel_bytes(raw_path),
+                    "non-utf8-path",
+                )
+            })?;
+            validate_namespace_logical_path(rel_path).map_err(|_| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                    rel_path,
+                    "noncanonical-logical-path",
+                )
+            })?;
+            let leaf_role = match record.identity.object_kind() {
+                ObjectKind::Directory => StrictLocalNamespaceRoleV1::Directory,
+                ObjectKind::Regular | ObjectKind::Symlink => StrictLocalNamespaceRoleV1::File,
+                ObjectKind::Special => continue,
+            };
+            let components: Vec<&str> = rel_path.split('/').collect();
+            for end in 1..=components.len() {
+                let exact = components[..end].join("/");
+                let role = if end == components.len() {
+                    leaf_role
+                } else {
+                    StrictLocalNamespaceRoleV1::Directory
+                };
+                let folded = portable_casefold_path(&exact).map_err(|_| {
+                    CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                        rel_path,
+                        "portable-casefold-path",
+                    )
+                })?;
+                if let Some(prior) = claims.get(&folded) {
+                    if prior.exact_path != exact || prior.role != role {
+                        return Err(CaptureFailure::path(
+                            StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                            rel_path,
+                            "portable-casefold-or-role-collision",
+                        ));
+                    }
+                } else {
+                    claims.insert(
+                        folded,
+                        StrictLocalNamespaceClaimV1 {
+                            exact_path: exact,
+                            role,
+                        },
+                    );
+                }
+            }
+        }
+        Ok(claims)
+    }
+
+    fn capture_semantic_entries(
+        root: &File,
+        inventory: &IdentityInventory,
+    ) -> std::result::Result<BTreeMap<String, StrictLocalEntryV1>, CaptureFailure> {
+        let mut entries = BTreeMap::new();
+        let mut required_directories = BTreeSet::new();
+        for (raw_path, record) in &inventory.entries {
+            if record.disposition == Disposition::Excluded {
+                continue;
+            }
+            let rel_path = std::str::from_utf8(raw_path).map_err(|_| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                    display_rel_bytes(raw_path),
+                    "non-utf8-semantic-path",
+                )
+            })?;
+            let entry = match record.identity.object_kind() {
+                ObjectKind::Directory => continue,
+                ObjectKind::Regular => StrictLocalEntryV1::Regular(capture_regular_file(
+                    root,
+                    inventory,
+                    raw_path,
+                    record.identity,
+                )?),
+                ObjectKind::Symlink => StrictLocalEntryV1::Symlink(capture_symlink(
+                    root,
+                    inventory,
+                    raw_path,
+                    record.identity,
+                )?),
+                ObjectKind::Special => {
+                    return Err(CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::UnsupportedObjectRejected,
+                        rel_path,
+                        "special-object-reached-semantic-capture",
+                    ));
+                }
+            };
+            for (separator, _) in rel_path.match_indices('/') {
+                required_directories.insert(rel_path[..separator].to_owned());
+            }
+            entries.insert(rel_path.to_owned(), entry);
+        }
+        for directory in required_directories {
+            let has_included_directory =
+                inventory
+                    .entries
+                    .get(directory.as_bytes())
+                    .is_some_and(|record| {
+                        record.disposition == Disposition::Included
+                            && record.identity.object_kind() == ObjectKind::Directory
+                    });
+            if !has_included_directory {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                    directory,
+                    "missing-included-semantic-ancestor",
+                ));
+            }
+            entries.insert(directory, StrictLocalEntryV1::Directory);
+        }
+        Ok(entries)
+    }
+
+    fn capture_regular_file(
+        root: &File,
+        inventory: &IdentityInventory,
+        rel_path: &[u8],
+        expected: StableIdentity,
+    ) -> std::result::Result<StrictLocalRegularFileV1, CaptureFailure> {
+        if expected.size < 0 {
+            return Err(CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                display_rel_bytes(rel_path),
+                "negative-regular-file-size",
+            ));
+        }
+        let (parent, leaf_name, expected_parent) =
+            open_inventory_parent(root, inventory, rel_path)?;
+        let before_parent =
+            fstat_identity(parent.as_raw_fd(), Some(rel_path), "stat-regular-parent")?;
+        if before_parent != expected_parent {
+            return Err(changed(rel_path, "compare-regular-parent-before"));
+        }
+        let c_name = c_string_name(&leaf_name, rel_path)?;
+        // Preserve the inventory's no-crossing proof for both the initial
+        // binding and the post-read pathname revalidation. Never lstat a
+        // descendant name outside an openat2(NO_XDEV) descriptor.
+        let probe = openat_descendant_identity(
+            parent.as_raw_fd(),
+            &c_name,
+            Some(rel_path),
+            "open-regular-identity-probe",
+        )?;
+        let before_probe = fstat_identity(
+            probe.as_raw_fd(),
+            Some(rel_path),
+            "stat-regular-identity-probe",
+        )?;
+        if before_probe != expected {
+            return Err(changed(rel_path, "compare-regular-identity-probe"));
+        }
+        run_test_hook(TestHookPoint::RegularAfterInitialProbe);
+        let mut file = openat_descendant_file(
+            parent.as_raw_fd(),
+            &c_name,
+            false,
+            Some(rel_path),
+            "open-regular-file",
+        )?;
+        let before_fd = fstat_identity(file.as_raw_fd(), Some(rel_path), "stat-regular-fd")?;
+        if before_fd != expected || before_fd.object_kind() != ObjectKind::Regular {
+            return Err(changed(rel_path, "compare-opened-regular-identity"));
+        }
+
+        let expected_size = expected.size as u64;
+        let mut remaining = expected_size;
+        let mut buffer = vec![0u8; HASH_BUFFER_BYTES_V1];
+        let mut hasher = blake3::Hasher::new();
+        let mut ran_hash_hook = false;
+        while remaining > 0 {
+            let requested = usize::try_from(remaining.min(buffer.len() as u64))
+                .expect("bounded hash read length fits usize");
+            let count = file.read(&mut buffer[..requested]).map_err(|_| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+                    display_rel_bytes(rel_path),
+                    "read-regular-file",
+                )
+            })?;
+            if count == 0 {
+                return Err(changed(rel_path, "regular-file-short-read"));
+            }
+            hasher.update(&buffer[..count]);
+            remaining -= count as u64;
+            if !ran_hash_hook {
+                run_test_hook(TestHookPoint::RegularAfterFirstHashChunk);
+                ran_hash_hook = true;
+            }
+        }
+        let mut sentinel = [0u8; 1];
+        let sentinel_count = file.read(&mut sentinel).map_err(|_| {
+            CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+                display_rel_bytes(rel_path),
+                "read-regular-eof-sentinel",
+            )
+        })?;
+        if sentinel_count != 0 {
+            return Err(changed(rel_path, "regular-file-grew-during-read"));
+        }
+
+        let after_fd = fstat_identity(file.as_raw_fd(), Some(rel_path), "restat-regular-fd")?;
+        let after_probe = fstat_identity(
+            probe.as_raw_fd(),
+            Some(rel_path),
+            "restat-regular-identity-probe",
+        )?;
+        let rebound_probe = openat_descendant_identity(
+            parent.as_raw_fd(),
+            &c_name,
+            Some(rel_path),
+            "reopen-regular-path-binding",
+        )?;
+        let rebound_identity = fstat_identity(
+            rebound_probe.as_raw_fd(),
+            Some(rel_path),
+            "restat-reopened-regular-path-binding",
+        )?;
+        let after_parent =
+            fstat_identity(parent.as_raw_fd(), Some(rel_path), "restat-regular-parent")?;
+        if after_fd != expected
+            || after_probe != expected
+            || rebound_identity != expected
+            || after_parent != expected_parent
+        {
+            return Err(changed(rel_path, "compare-regular-after-read"));
+        }
+        let mtime_nanoseconds = u32::try_from(expected.mtime_nanoseconds).map_err(|_| {
+            CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                display_rel_bytes(rel_path),
+                "regular-mtime-nanoseconds-out-of-range",
+            )
+        })?;
+        if mtime_nanoseconds >= 1_000_000_000 {
+            return Err(CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+                display_rel_bytes(rel_path),
+                "regular-mtime-nanoseconds-not-normalized",
+            ));
+        }
+        Ok(StrictLocalRegularFileV1 {
+            raw_blake3: *hasher.finalize().as_bytes(),
+            size: expected_size,
+            portable_mode: expected.mode & 0o777,
+            mtime_seconds: expected.mtime_seconds,
+            mtime_nanoseconds,
+        })
+    }
+
+    fn capture_symlink(
+        root: &File,
+        inventory: &IdentityInventory,
+        rel_path: &[u8],
+        expected: StableIdentity,
+    ) -> std::result::Result<StrictLocalSymlinkV1, CaptureFailure> {
+        if expected.size < 0 || expected.size as usize > MAX_SYMLINK_TARGET_BYTES_V1 {
+            return Err(CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::SymlinkTargetRejected,
+                display_rel_bytes(rel_path),
+                "symlink-target-size",
+            ));
+        }
+        let (parent, leaf_name, expected_parent) =
+            open_inventory_parent(root, inventory, rel_path)?;
+        let before_parent =
+            fstat_identity(parent.as_raw_fd(), Some(rel_path), "stat-symlink-parent")?;
+        if before_parent != expected_parent {
+            return Err(changed(rel_path, "compare-symlink-parent-before"));
+        }
+        let c_name = c_string_name(&leaf_name, rel_path)?;
+        // O_PATH|O_NOFOLLOW pins the link object itself while NO_XDEV rejects
+        // a newly inserted mount before any descendant metadata lookup.
+        let probe = openat_descendant_identity(
+            parent.as_raw_fd(),
+            &c_name,
+            Some(rel_path),
+            "open-symlink-identity-probe",
+        )?;
+        let before_probe = fstat_identity(
+            probe.as_raw_fd(),
+            Some(rel_path),
+            "stat-symlink-identity-probe",
+        )?;
+        if before_probe != expected || before_probe.object_kind() != ObjectKind::Symlink {
+            return Err(changed(rel_path, "compare-symlink-identity-probe"));
+        }
+
+        let mut target_buffer = [0u8; MAX_SYMLINK_TARGET_BYTES_V1 + 1];
+        let empty = CString::new("").expect("empty string contains no NUL");
+        // SAFETY: the O_PATH descriptor pins the symlink itself; Linux
+        // readlinkat with an empty path reads that pinned link and writes at
+        // most the supplied initialized buffer length.
+        let target_len = unsafe {
+            libc::readlinkat(
+                probe.as_raw_fd(),
+                empty.as_ptr(),
+                target_buffer.as_mut_ptr().cast(),
+                target_buffer.len(),
+            )
+        };
+        if target_len < 0 {
+            return Err(CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+                display_rel_bytes(rel_path),
+                "readlinkat",
+            ));
+        }
+        let target_len = target_len as usize;
+        if target_len > MAX_SYMLINK_TARGET_BYTES_V1 || target_len != expected.size as usize {
+            return Err(changed(rel_path, "compare-symlink-target-length"));
+        }
+        let rebound_probe = openat_descendant_identity(
+            parent.as_raw_fd(),
+            &c_name,
+            Some(rel_path),
+            "reopen-symlink-path-binding",
+        )?;
+        let rebound_identity = fstat_identity(
+            rebound_probe.as_raw_fd(),
+            Some(rel_path),
+            "restat-reopened-symlink-path-binding",
+        )?;
+        let after_parent =
+            fstat_identity(parent.as_raw_fd(), Some(rel_path), "restat-symlink-parent")?;
+        let after_probe = fstat_identity(
+            probe.as_raw_fd(),
+            Some(rel_path),
+            "restat-symlink-identity-probe",
+        )?;
+        if rebound_identity != expected
+            || after_probe != expected
+            || after_parent != expected_parent
+        {
+            return Err(changed(rel_path, "compare-symlink-after-read"));
+        }
+
+        let target_bytes = &target_buffer[..target_len];
+        let target = std::str::from_utf8(target_bytes).map_err(|_| {
+            CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::SymlinkTargetRejected,
+                display_rel_bytes(rel_path),
+                "symlink-target-non-utf8",
+            )
+        })?;
+        let rel_text = std::str::from_utf8(rel_path).map_err(|_| {
+            CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                display_rel_bytes(rel_path),
+                "symlink-path-non-utf8",
+            )
+        })?;
+        crate::engine::validate_indexed_symlink_target(Path::new(rel_text), target).map_err(
+            |_| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::SymlinkTargetRejected,
+                    rel_text,
+                    "validate-symlink-target",
+                )
+            },
+        )?;
+        Ok(StrictLocalSymlinkV1 {
+            target: target.to_owned(),
+            target_blake3: *blake3::hash(target_bytes).as_bytes(),
+        })
+    }
+
+    fn open_inventory_parent(
+        root: &File,
+        inventory: &IdentityInventory,
+        rel_path: &[u8],
+    ) -> std::result::Result<(File, Vec<u8>, StableIdentity), CaptureFailure> {
+        let components: Vec<&[u8]> = rel_path.split(|byte| *byte == b'/').collect();
+        let (leaf, parent_components) = components.split_last().ok_or_else(|| {
+            CaptureFailure::root(
+                StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                "empty-inventory-path",
+            )
+        })?;
+        let dot = CString::new(".").expect("dot contains no NUL");
+        let mut current = openat_descendant_file(
+            root.as_raw_fd(),
+            &dot,
+            true,
+            None,
+            "open-root-for-leaf-walk",
+        )?;
+        let mut walked = Vec::<Vec<u8>>::new();
+        let mut expected_current = inventory.root;
+        for component in parent_components {
+            let observed =
+                fstat_identity(current.as_raw_fd(), Some(rel_path), "stat-leaf-walk-parent")?;
+            if observed != expected_current {
+                return Err(changed(rel_path, "compare-leaf-walk-parent"));
+            }
+            let c_name = c_string_name(component, rel_path)?;
+            current = openat_descendant_file(
+                current.as_raw_fd(),
+                &c_name,
+                true,
+                Some(rel_path),
+                "open-leaf-walk-component",
+            )?;
+            run_test_hook(TestHookPoint::ParentWalkAfterComponentOpen);
+            walked.push(component.to_vec());
+            let walked_key = join_rel_components(&walked);
+            expected_current = inventory
+                .entries
+                .get(&walked_key)
+                .filter(|record| record.identity.object_kind() == ObjectKind::Directory)
+                .map(|record| record.identity)
+                .ok_or_else(|| changed(rel_path, "missing-inventory-parent"))?;
+            let opened = fstat_identity(
+                current.as_raw_fd(),
+                Some(rel_path),
+                "stat-opened-leaf-parent",
+            )?;
+            if opened != expected_current {
+                return Err(changed(rel_path, "compare-opened-leaf-parent"));
+            }
+        }
+        Ok((current, leaf.to_vec(), expected_current))
+    }
+
+    fn changed(rel_path: &[u8], operation: &'static str) -> CaptureFailure {
+        CaptureFailure::path(
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead,
+            display_rel_bytes(rel_path),
+            operation,
+        )
+    }
+
+    fn open_absolute_directory(
+        path: &Path,
+        operation: &'static str,
+    ) -> std::result::Result<File, CaptureFailure> {
+        let slash = CString::new("/").expect("slash contains no NUL");
+        let mut current =
+            openat_root_file(libc::AT_FDCWD, &slash, true, None, "open-filesystem-root")?;
+        for component in path.components() {
+            match component {
+                Component::RootDir => {}
+                Component::Normal(name) => {
+                    let name_bytes = name.as_bytes();
+                    let c_name = CString::new(name_bytes).map_err(|_| {
+                        CaptureFailure::root(
+                            StrictLocalSnapshotIncompleteKindV1::InvalidConfiguredRoot,
+                            "configured-root-component-nul",
+                        )
+                    })?;
+                    current =
+                        openat_root_file(current.as_raw_fd(), &c_name, true, None, operation)?;
+                }
+                Component::CurDir | Component::ParentDir | Component::Prefix(_) => {
+                    return Err(CaptureFailure::root(
+                        StrictLocalSnapshotIncompleteKindV1::InvalidConfiguredRoot,
+                        "configured-root-component-shape",
+                    ));
+                }
+            }
+        }
+        Ok(current)
+    }
+
+    fn openat_root_file(
+        parent_fd: RawFd,
+        name: &CStr,
+        directory: bool,
+        rel_path: Option<&[u8]>,
+        operation: &'static str,
+    ) -> std::result::Result<File, CaptureFailure> {
+        let mut flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
+        if directory {
+            flags |= libc::O_DIRECTORY;
+        }
+        // SAFETY: `parent_fd` is an open directory descriptor (or AT_FDCWD for
+        // the absolute slash open), and `name` is NUL terminated. On success
+        // the returned descriptor has exactly one `File` owner.
+        let fd = unsafe { libc::openat(parent_fd, name.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(io_failure(rel_path, operation));
+        }
+        // SAFETY: `fd` is freshly returned by openat and uniquely owned.
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+
+    fn openat_descendant_file(
+        parent_fd: RawFd,
+        name: &CStr,
+        directory: bool,
+        rel_path: Option<&[u8]>,
+        operation: &'static str,
+    ) -> std::result::Result<File, CaptureFailure> {
+        let mut flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
+        if directory {
+            flags |= libc::O_DIRECTORY;
+        }
+        openat2_resolved_file(parent_fd, name, flags, rel_path, operation)
+    }
+
+    pub(super) fn openat_descendant_identity(
+        parent_fd: RawFd,
+        name: &CStr,
+        rel_path: Option<&[u8]>,
+        operation: &'static str,
+    ) -> std::result::Result<File, CaptureFailure> {
+        openat2_resolved_file(
+            parent_fd,
+            name,
+            libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            rel_path,
+            operation,
+        )
+    }
+
+    fn openat2_resolved_file(
+        parent_fd: RawFd,
+        name: &CStr,
+        flags: libc::c_int,
+        rel_path: Option<&[u8]>,
+        operation: &'static str,
+    ) -> std::result::Result<File, CaptureFailure> {
+        // `libc::open_how` is non-exhaustive. Zero-initialize the kernel ABI
+        // structure so future tail fields remain disabled, then set only the
+        // fields defined by this contract.
+        // SAFETY: all-zero is the kernel-defined disabled state for every
+        // open_how field; the three public fields are populated immediately.
+        let mut how = unsafe { MaybeUninit::<libc::open_how>::zeroed().assume_init() };
+        how.flags = flags as u64;
+        how.mode = 0;
+        how.resolve = libc::RESOLVE_NO_XDEV
+            | libc::RESOLVE_NO_MAGICLINKS
+            | libc::RESOLVE_NO_SYMLINKS
+            | libc::RESOLVE_BENEATH;
+        // SAFETY: openat2 receives a valid parent descriptor, NUL-terminated
+        // single-component path, and correctly sized open_how-compatible
+        // structure. Every successful descriptor gets exactly one File owner.
+        let fd = unsafe {
+            libc::syscall(
+                libc::SYS_openat2,
+                parent_fd,
+                name.as_ptr(),
+                &how as *const libc::open_how,
+                std::mem::size_of::<libc::open_how>(),
+            )
+        };
+        if fd < 0 {
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            if matches!(
+                errno,
+                Some(code) if matches!(code, libc::ENOSYS | libc::EINVAL | libc::E2BIG)
+            ) {
+                return Err(match rel_path {
+                    Some(path) => CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
+                        display_rel_bytes(path),
+                        operation,
+                    ),
+                    None => CaptureFailure::root(
+                        StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
+                        operation,
+                    ),
+                });
+            }
+            return Err(io_failure(rel_path, operation));
+        }
+        let fd = RawFd::try_from(fd).map_err(|_| io_failure(rel_path, operation))?;
+        // SAFETY: `fd` is freshly returned by openat2 and uniquely owned.
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+
+    fn statx_mount_id(
+        fd: RawFd,
+        rel_path: Option<&[u8]>,
+        operation: &'static str,
+    ) -> std::result::Result<u64, CaptureFailure> {
+        let empty = CString::new("").expect("empty string contains no NUL");
+        let mut statx = MaybeUninit::<libc::statx>::zeroed();
+        // SAFETY: fd is valid and AT_EMPTY_PATH requests metadata for that
+        // descriptor. `statx` points to writable storage.
+        let result = unsafe {
+            libc::statx(
+                fd,
+                empty.as_ptr(),
+                libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW,
+                libc::STATX_MNT_ID,
+                statx.as_mut_ptr(),
+            )
+        };
+        if result != 0 {
+            let errno = std::io::Error::last_os_error().raw_os_error();
+            if matches!(
+                errno,
+                Some(code) if matches!(code, libc::ENOSYS | libc::EINVAL)
+            ) {
+                return Err(match rel_path {
+                    Some(path) => CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
+                        display_rel_bytes(path),
+                        operation,
+                    ),
+                    None => CaptureFailure::root(
+                        StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
+                        operation,
+                    ),
+                });
+            }
+            return Err(io_failure(rel_path, operation));
+        }
+        // SAFETY: statx succeeded and initialized the output.
+        let statx = unsafe { statx.assume_init() };
+        if statx.stx_mask & libc::STATX_MNT_ID == 0 {
+            return Err(match rel_path {
+                Some(path) => CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
+                    display_rel_bytes(path),
+                    operation,
+                ),
+                None => CaptureFailure::root(
+                    StrictLocalSnapshotIncompleteKindV1::UnsupportedPlatform,
+                    operation,
+                ),
+            });
+        }
+        Ok(statx.stx_mnt_id)
+    }
+
+    fn fstat_identity(
+        fd: RawFd,
+        rel_path: Option<&[u8]>,
+        operation: &'static str,
+    ) -> std::result::Result<StableIdentity, CaptureFailure> {
+        let mut stat = MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: `stat` points to writable storage and `fd` is open.
+        if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
+            return Err(io_failure(rel_path, operation));
+        }
+        // SAFETY: fstat succeeded and initialized the structure.
+        Ok(stable_identity(unsafe { stat.assume_init() }))
+    }
+
+    fn stable_identity(stat: libc::stat) -> StableIdentity {
+        StableIdentity {
+            dev: stat.st_dev,
+            ino: stat.st_ino,
+            mode: stat.st_mode,
+            nlink: stat.st_nlink,
+            uid: stat.st_uid,
+            gid: stat.st_gid,
+            rdev: stat.st_rdev,
+            size: stat.st_size,
+            mtime_seconds: stat.st_mtime,
+            mtime_nanoseconds: stat.st_mtime_nsec,
+            ctime_seconds: stat.st_ctime,
+            ctime_nanoseconds: stat.st_ctime_nsec,
+        }
+    }
+
+    fn open_directory_stream(
+        directory_fd: RawFd,
+        parent_components: &[Vec<u8>],
+    ) -> std::result::Result<DirectoryStream, CaptureFailure> {
+        let dot = CString::new(".").expect("dot contains no NUL");
+        let stream_file = openat_descendant_file(
+            directory_fd,
+            &dot,
+            true,
+            None,
+            "open-independent-directory-stream",
+        )?;
+        let stream_fd = stream_file.into_raw_fd();
+        // SAFETY: fdopendir takes ownership of this dedicated descriptor.
+        let directory = unsafe { libc::fdopendir(stream_fd) };
+        if directory.is_null() {
+            // SAFETY: fdopendir failed and did not take ownership.
+            unsafe {
+                libc::close(stream_fd);
+            }
+            return Err(CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+                display_rel_components(parent_components),
+                "fdopendir",
+            ));
+        }
+        Ok(DirectoryStream(directory))
+    }
+
+    fn read_next_raw_name(
+        stream: &mut DirectoryStream,
+        parent_components: &[Vec<u8>],
+        remaining_entries: usize,
+        remaining_path_bytes: usize,
+    ) -> std::result::Result<Option<Vec<u8>>, CaptureFailure> {
+        let parent_path_len = parent_components
+            .iter()
+            .try_fold(0usize, |total, component| {
+                total.checked_add(component.len())
+            })
+            .and_then(|component_bytes| {
+                component_bytes.checked_add(parent_components.len().saturating_sub(1))
+            })
+            .ok_or_else(|| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_components(parent_components),
+                    "directory-path-length-overflow",
+                )
+            })?;
+        let child_prefix_len = if parent_components.is_empty() {
+            0
+        } else {
+            parent_path_len.checked_add(1).ok_or_else(|| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_components(parent_components),
+                    "child-path-prefix-overflow",
+                )
+            })?
+        };
+        loop {
+            clear_errno();
+            // SAFETY: `stream.0` is a valid DIR pointer until Drop.
+            let entry = unsafe { libc::readdir(stream.0) };
+            if entry.is_null() {
+                if read_errno() != 0 {
+                    return Err(CaptureFailure::path(
+                        StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+                        display_rel_components(parent_components),
+                        "readdir",
+                    ));
+                }
+                return Ok(None);
+            }
+            // SAFETY: readdir returned a valid dirent with NUL-terminated d_name
+            // until the next call on this stream. Copy bytes immediately.
+            let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
+            if name == b"." || name == b".." {
+                continue;
+            }
+            if remaining_entries == 0 {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_components(parent_components),
+                    "maximum-entry-count-before-name-allocation",
+                ));
+            }
+            let child_path_len = child_prefix_len.checked_add(name.len()).ok_or_else(|| {
+                CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_components(parent_components),
+                    "child-path-length-overflow",
+                )
+            })?;
+            if child_path_len > remaining_path_bytes {
+                return Err(CaptureFailure::path(
+                    StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded,
+                    display_rel_components(parent_components),
+                    "maximum-retained-path-bytes-before-name-allocation",
+                ));
+            }
+            return Ok(Some(name.to_vec()));
+        }
+    }
+
+    struct DirectoryStream(*mut libc::DIR);
+
+    impl DirectoryStream {
+        fn close(&mut self) -> std::io::Result<()> {
+            if self.0.is_null() {
+                return Ok(());
+            }
+            // SAFETY: this object uniquely owns the DIR pointer.
+            let result = unsafe { libc::closedir(self.0) };
+            self.0 = std::ptr::null_mut();
+            if result == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        }
+    }
+
+    impl Drop for DirectoryStream {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: this object uniquely owns the DIR pointer.
+                unsafe {
+                    libc::closedir(self.0);
+                }
+                self.0 = std::ptr::null_mut();
+            }
+        }
+    }
+
+    fn errno_pointer() -> *mut libc::c_int {
+        // SAFETY: libc returns the current thread's errno location.
+        unsafe { libc::__errno_location() }
+    }
+
+    fn clear_errno() {
+        // SAFETY: errno_pointer returns writable thread-local errno storage.
+        unsafe {
+            *errno_pointer() = 0;
+        }
+    }
+
+    fn read_errno() -> libc::c_int {
+        // SAFETY: errno_pointer returns readable thread-local errno storage.
+        unsafe { *errno_pointer() }
+    }
+
+    fn io_failure(rel_path: Option<&[u8]>, operation: &'static str) -> CaptureFailure {
+        let errno = std::io::Error::last_os_error().raw_os_error();
+        let kind = match errno {
+            Some(libc::EXDEV) => StrictLocalSnapshotIncompleteKindV1::MountBoundaryRejected,
+            Some(libc::ENOENT | libc::ESTALE | libc::ELOOP | libc::EAGAIN) => {
+                StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+            }
+            _ => StrictLocalSnapshotIncompleteKindV1::FilesystemReadFailed,
+        };
+        match rel_path {
+            Some(path) => CaptureFailure::path(kind, display_rel_bytes(path), operation),
+            None => CaptureFailure::root(kind, operation),
+        }
+    }
+
+    fn c_string_name(name: &[u8], rel_path: &[u8]) -> std::result::Result<CString, CaptureFailure> {
+        CString::new(name).map_err(|_| {
+            CaptureFailure::path(
+                StrictLocalSnapshotIncompleteKindV1::NamespaceRejected,
+                display_rel_bytes(rel_path),
+                "path-component-nul",
+            )
+        })
+    }
+
+    fn join_rel_components(components: &[Vec<u8>]) -> Vec<u8> {
+        let capacity = components
+            .iter()
+            .map(Vec::len)
+            .sum::<usize>()
+            .saturating_add(components.len().saturating_sub(1));
+        let mut result = Vec::with_capacity(capacity);
+        for (index, component) in components.iter().enumerate() {
+            if index != 0 {
+                result.push(b'/');
+            }
+            result.extend_from_slice(component);
+        }
+        result
+    }
+
+    fn raw_rel_path(components: &[Vec<u8>]) -> PathBuf {
+        let mut path = PathBuf::new();
+        for component in components {
+            path.push(OsString::from_vec(component.clone()));
+        }
+        path
+    }
+
+    fn display_rel_components(components: &[Vec<u8>]) -> String {
+        display_rel_bytes(&join_rel_components(components))
+    }
+
+    fn display_rel_bytes(path: &[u8]) -> String {
+        if path.is_empty() {
+            ".".to_owned()
+        } else {
+            String::from_utf8_lossy(path).into_owned()
+        }
+    }
+
+    #[cfg(test)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(super) enum TestHookPoint {
+        InventoryAToLeaf,
+        LeafToInventoryB,
+        RootPathBeforeReopen,
+        RegularAfterInitialProbe,
+        RegularAfterFirstHashChunk,
+        ParentWalkAfterComponentOpen,
+    }
+
+    #[cfg(test)]
+    type TestHook = Box<dyn FnMut(TestHookPoint)>;
+
+    #[cfg(test)]
+    thread_local! {
+        static TEST_HOOK: std::cell::RefCell<Option<TestHook>> =
+            std::cell::RefCell::new(None);
+    }
+
+    #[cfg(test)]
+    pub(super) struct TestHookGuard;
+
+    #[cfg(test)]
+    impl Drop for TestHookGuard {
+        fn drop(&mut self) {
+            TEST_HOOK.with(|slot| {
+                slot.borrow_mut().take();
+            });
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn install_test_hook(hook: impl FnMut(TestHookPoint) + 'static) -> TestHookGuard {
+        TEST_HOOK.with(|slot| {
+            assert!(slot.borrow().is_none(), "test hook already installed");
+            *slot.borrow_mut() = Some(Box::new(hook));
+        });
+        TestHookGuard
+    }
+
+    #[cfg(test)]
+    fn run_test_hook(point: TestHookPoint) {
+        TEST_HOOK.with(|slot| {
+            if let Some(hook) = slot.borrow_mut().as_mut() {
+                hook(point);
+            }
+        });
+    }
+
+    #[cfg(not(test))]
+    #[derive(Clone, Copy)]
+    enum TestHookPoint {
+        InventoryAToLeaf,
+        LeafToInventoryB,
+        RootPathBeforeReopen,
+        RegularAfterInitialProbe,
+        RegularAfterFirstHashChunk,
+        ParentWalkAfterComponentOpen,
+    }
+
+    #[cfg(not(test))]
+    fn run_test_hook(_point: TestHookPoint) {}
+}
+
+#[cfg(target_os = "linux")]
+use supported::capture_supported;
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::supported::{install_test_hook, openat_descendant_identity, TestHookPoint};
+    use super::*;
+    use std::cell::Cell;
+    use std::collections::BTreeMap;
+    use std::ffi::CString;
+    use std::fs;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
+    use std::path::{Path, PathBuf};
+    use std::rc::Rc;
+
+    fn canonical_root() -> (tempfile::TempDir, PathBuf) {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        (temporary, root.canonicalize().unwrap())
+    }
+
+    fn complete(root: &Path, profile: RootProfileV1) -> CompleteStrictLocalSnapshotV1 {
+        match capture_strict_local_snapshot_v1(root, profile).unwrap() {
+            StrictLocalSnapshotReadV1::Complete(snapshot) => snapshot,
+            StrictLocalSnapshotReadV1::Incomplete(incomplete) => {
+                panic!("expected complete snapshot, got {incomplete:?}")
+            }
+        }
+    }
+
+    fn incomplete_kind(root: &Path, profile: RootProfileV1) -> StrictLocalSnapshotIncompleteKindV1 {
+        match capture_strict_local_snapshot_v1(root, profile).unwrap() {
+            StrictLocalSnapshotReadV1::Complete(snapshot) => {
+                panic!("expected incomplete snapshot, got {snapshot:?}")
+            }
+            StrictLocalSnapshotReadV1::Incomplete(incomplete) => incomplete.kind(),
+        }
+    }
+
+    #[test]
+    fn stable_hidden_regular_directory_and_safe_links_have_golden_digest() {
+        let (_temporary, root) = canonical_root();
+        fs::create_dir(root.join(".hidden")).unwrap();
+        fs::write(root.join(".hidden/payload"), b"portable bytes\n").unwrap();
+        fs::set_permissions(
+            root.join(".hidden/payload"),
+            fs::Permissions::from_mode(0o640),
+        )
+        .unwrap();
+        let stable_timestamp = std::time::SystemTime::UNIX_EPOCH
+            + std::time::Duration::new(1_700_000_000, 123_456_789);
+        fs::File::open(root.join(".hidden/payload"))
+            .unwrap()
+            .set_times(
+                fs::FileTimes::new()
+                    .set_accessed(stable_timestamp)
+                    .set_modified(stable_timestamp),
+            )
+            .unwrap();
+        symlink(".hidden/payload", root.join("safe-link")).unwrap();
+        symlink("missing-target", root.join("broken-link")).unwrap();
+
+        let snapshot = complete(&root, RootProfileV1::AgentStaticV1);
+        assert!(matches!(
+            snapshot.entry(".hidden"),
+            Some(StrictLocalEntryV1::Directory)
+        ));
+        assert!(matches!(
+            snapshot.entry(".hidden/payload"),
+            Some(StrictLocalEntryV1::Regular(_))
+        ));
+        assert!(matches!(
+            snapshot.entry("safe-link"),
+            Some(StrictLocalEntryV1::Symlink(link)) if link.target() == ".hidden/payload"
+        ));
+        assert!(matches!(
+            snapshot.entry("broken-link"),
+            Some(StrictLocalEntryV1::Symlink(link)) if link.target() == "missing-target"
+        ));
+        assert_eq!(
+            snapshot.digest().to_string(),
+            "b3v1:59aa9308444225642cb34a9cfff19ac45e4bc53f17b95fb522e39e3a83d61511"
+        );
+    }
+
+    #[test]
+    fn configured_root_requires_exact_canonical_raw_spelling() {
+        let (_temporary, root) = canonical_root();
+        assert!(matches!(
+            capture_strict_local_snapshot_v1(&root, RootProfileV1::AgentStaticV1).unwrap(),
+            StrictLocalSnapshotReadV1::Complete(_)
+        ));
+
+        let parent = root.parent().unwrap();
+        let name = root.file_name().unwrap().to_str().unwrap();
+        let spellings = [
+            PathBuf::from(format!("{}//{name}", parent.display())),
+            PathBuf::from(format!("{}/./{name}", parent.display())),
+            PathBuf::from(format!("{}/", root.display())),
+        ];
+        for spelling in spellings {
+            assert_eq!(
+                incomplete_kind(&spelling, RootProfileV1::AgentStaticV1),
+                StrictLocalSnapshotIncompleteKindV1::InvalidConfiguredRoot,
+                "spelling must fail: {}",
+                spelling.display()
+            );
+        }
+
+        let alias = parent.join("root-alias");
+        symlink(&root, &alias).unwrap();
+        assert_eq!(
+            incomplete_kind(&alias, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::InvalidConfiguredRoot
+        );
+    }
+
+    #[test]
+    fn profiles_apply_distinct_dot_git_contracts() {
+        let (_temporary, root) = canonical_root();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join(".git/HEAD"), b"ref: refs/heads/main\n").unwrap();
+        fs::write(root.join("visible"), b"x").unwrap();
+
+        let agent = complete(&root, RootProfileV1::AgentStaticV1);
+        assert!(agent.entry(".git").is_none());
+        assert!(agent.entry(".git/HEAD").is_none());
+        assert!(agent.entry("visible").is_some());
+
+        let git = complete(&root, RootProfileV1::GitRawV1);
+        assert!(matches!(
+            git.entry(".git"),
+            Some(StrictLocalEntryV1::Directory)
+        ));
+        assert!(matches!(
+            git.entry(".git/HEAD"),
+            Some(StrictLocalEntryV1::Regular(_))
+        ));
+        assert_ne!(agent.digest(), git.digest());
+    }
+
+    #[test]
+    fn git_raw_rejects_gitfile_and_nested_dot_git() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join(".git"), b"gitdir: /elsewhere\n").unwrap();
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::GitRawV1),
+            StrictLocalSnapshotIncompleteKindV1::GitLayoutRejected
+        );
+
+        fs::remove_file(root.join(".git")).unwrap();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::create_dir(root.join("nested")).unwrap();
+        fs::create_dir(root.join("nested/.git")).unwrap();
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::GitRawV1),
+            StrictLocalSnapshotIncompleteKindV1::GitLayoutRejected
+        );
+    }
+
+    #[test]
+    fn included_hardlinks_are_rejected() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join("first"), b"same inode").unwrap();
+        fs::hard_link(root.join("first"), root.join("second")).unwrap();
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::HardlinkRejected
+        );
+    }
+
+    #[test]
+    fn special_permission_policy_applies_only_to_regular_files() {
+        let (_temporary, root) = canonical_root();
+        let executable = root.join("executable");
+        fs::write(&executable, b"payload").unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o4755)).unwrap();
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::UnsafeModeRejected
+        );
+
+        fs::remove_file(&executable).unwrap();
+        let sticky = root.join("sticky");
+        fs::create_dir(&sticky).unwrap();
+        fs::set_permissions(&sticky, fs::Permissions::from_mode(0o1777)).unwrap();
+        fs::write(sticky.join("payload"), b"ordinary").unwrap();
+        let sticky_digest = complete(&root, RootProfileV1::AgentStaticV1).digest();
+        fs::set_permissions(&sticky, fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(
+            sticky_digest,
+            complete(&root, RootProfileV1::AgentStaticV1).digest()
+        );
+    }
+
+    #[test]
+    fn openat2_mount_proof_rejects_a_descendant_mount() {
+        if !Path::new("/proc").is_dir() {
+            return;
+        }
+        let root = fs::File::open("/").unwrap();
+        let proc_name = CString::new("proc").unwrap();
+        let error = openat_descendant_identity(
+            root.as_raw_fd(),
+            &proc_name,
+            Some(b"proc"),
+            "test-proc-mount-boundary",
+        )
+        .expect_err("procfs must be a descendant mount boundary");
+        assert_eq!(
+            error.kind,
+            StrictLocalSnapshotIncompleteKindV1::MountBoundaryRejected
+        );
+    }
+
+    #[test]
+    fn regular_hash_work_limits_fail_before_content_reads() {
+        let (_temporary, root) = canonical_root();
+        fs::File::create(root.join("oversized"))
+            .unwrap()
+            .set_len(MAX_REGULAR_FILE_BYTES_V1 + 1)
+            .unwrap();
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded
+        );
+
+        fs::remove_file(root.join("oversized")).unwrap();
+        for index in 0..=(MAX_TOTAL_HASHED_BYTES_V1 / MAX_REGULAR_FILE_BYTES_V1) {
+            fs::File::create(root.join(format!("sparse-{index}")))
+                .unwrap()
+                .set_len(MAX_REGULAR_FILE_BYTES_V1)
+                .unwrap();
+        }
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded
+        );
+    }
+
+    #[test]
+    fn fifo_and_socket_are_rejected_without_blocking() {
+        let (_temporary, root) = canonical_root();
+        let fifo = root.join("fifo");
+        let fifo_name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        // SAFETY: the path is NUL terminated and points into the test root.
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::UnsupportedObjectRejected
+        );
+
+        fs::remove_file(&fifo).unwrap();
+        let _listener = std::os::unix::net::UnixListener::bind(root.join("socket")).unwrap();
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::UnsupportedObjectRejected
+        );
+    }
+
+    #[test]
+    fn escaping_symlink_is_rejected() {
+        let (_temporary, root) = canonical_root();
+        fs::create_dir(root.join("nested")).unwrap();
+        symlink("../../outside", root.join("nested/escape")).unwrap();
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::SymlinkTargetRejected
+        );
+    }
+
+    #[test]
+    fn portable_case_alias_is_rejected_when_filesystem_can_represent_it() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join("Case"), b"one").unwrap();
+        if fs::write(root.join("case"), b"two").is_err() {
+            return;
+        }
+        let first = fs::metadata(root.join("Case")).unwrap();
+        let second = fs::metadata(root.join("case")).unwrap();
+        if first.dev() == second.dev() && first.ino() == second.ino() {
+            return;
+        }
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::NamespaceRejected
+        );
+    }
+
+    #[test]
+    fn component_depth_256_is_allowed_but_257_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        let mut deepest = root.clone();
+        let mut depth_255 = None;
+        for component_index in 0..MAX_DEPTH_V1 {
+            deepest.push("d");
+            fs::create_dir(&deepest).unwrap();
+            if component_index + 1 == MAX_DEPTH_V1 - 1 {
+                depth_255 = Some(deepest.clone());
+            }
+        }
+        fs::write(depth_255.unwrap().join("boundary-file"), b"x").unwrap();
+        let snapshot = complete(&root, RootProfileV1::AgentStaticV1);
+        assert_eq!(snapshot.entries().len(), MAX_DEPTH_V1);
+
+        fs::write(deepest.join("too-deep"), b"x").unwrap();
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::AcquisitionLimitExceeded
+        );
+    }
+
+    #[test]
+    fn mutation_between_inventory_a_and_leaf_capture_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        let payload = root.join("payload");
+        fs::write(&payload, b"before").unwrap();
+        let hook_payload = payload.clone();
+        let _hook = install_test_hook(move |point| {
+            if point == TestHookPoint::InventoryAToLeaf {
+                fs::write(&hook_payload, b"after!").unwrap();
+            }
+        });
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+    }
+
+    #[test]
+    fn mutation_between_leaf_capture_and_inventory_b_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        let payload = root.join("payload");
+        fs::write(&payload, b"before").unwrap();
+        let hook_payload = payload.clone();
+        let _hook = install_test_hook(move |point| {
+            if point == TestHookPoint::LeafToInventoryB {
+                fs::write(&hook_payload, b"after!").unwrap();
+            }
+        });
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+    }
+
+    #[test]
+    fn same_size_in_place_rewrite_during_hash_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        let payload = root.join("payload");
+        let byte_count = HASH_BUFFER_BYTES_V1 * 2;
+        fs::write(&payload, vec![b'a'; byte_count]).unwrap();
+        let fired = Rc::new(Cell::new(false));
+        let hook_fired = Rc::clone(&fired);
+        let hook_payload = payload.clone();
+        let _hook = install_test_hook(move |point| {
+            if point == TestHookPoint::RegularAfterFirstHashChunk && !hook_fired.replace(true) {
+                fs::write(&hook_payload, vec![b'b'; byte_count]).unwrap();
+            }
+        });
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+        assert!(fired.get());
+    }
+
+    #[test]
+    fn leaf_replacement_after_initial_probe_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        let payload = root.join("payload");
+        let parked = root.join("parked");
+        fs::write(&payload, b"same-size").unwrap();
+        let fired = Rc::new(Cell::new(false));
+        let hook_fired = Rc::clone(&fired);
+        let hook_payload = payload.clone();
+        let hook_parked = parked.clone();
+        let _hook = install_test_hook(move |point| {
+            if point == TestHookPoint::RegularAfterInitialProbe && !hook_fired.replace(true) {
+                fs::rename(&hook_payload, &hook_parked).unwrap();
+                fs::write(&hook_payload, b"same-size").unwrap();
+            }
+        });
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+        assert!(fired.get());
+    }
+
+    #[test]
+    fn parent_rename_during_descriptor_walk_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        let parent = root.join("parent");
+        let moved = root.join("moved-parent");
+        fs::create_dir(&parent).unwrap();
+        fs::write(parent.join("payload"), b"payload").unwrap();
+        let fired = Rc::new(Cell::new(false));
+        let hook_fired = Rc::clone(&fired);
+        let hook_parent = parent.clone();
+        let hook_moved = moved.clone();
+        let _hook = install_test_hook(move |point| {
+            if point == TestHookPoint::ParentWalkAfterComponentOpen && !hook_fired.replace(true) {
+                fs::rename(&hook_parent, &hook_moved).unwrap();
+                fs::create_dir(&hook_parent).unwrap();
+            }
+        });
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+        assert!(fired.get());
+    }
+
+    #[test]
+    fn configured_root_path_replacement_before_reopen_is_incomplete() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join("payload"), b"before").unwrap();
+        let original = root.with_extension("original");
+        let hook_root = root.clone();
+        let hook_original = original.clone();
+        let _hook = install_test_hook(move |point| {
+            if point == TestHookPoint::RootPathBeforeReopen {
+                fs::rename(&hook_root, &hook_original).unwrap();
+                fs::create_dir(&hook_root).unwrap();
+                fs::write(hook_root.join("payload"), b"before").unwrap();
+            }
+        });
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct NoWriteRecord {
+        kind: u32,
+        mode: u32,
+        size: u64,
+        modified: Option<std::time::SystemTime>,
+        bytes_or_target: Vec<u8>,
+    }
+
+    fn no_write_inventory(root: &Path) -> BTreeMap<PathBuf, NoWriteRecord> {
+        fn walk(root: &Path, rel: &Path, output: &mut BTreeMap<PathBuf, NoWriteRecord>) {
+            let directory = root.join(rel);
+            let mut names: Vec<_> = fs::read_dir(&directory)
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name())
+                .collect();
+            names.sort();
+            for name in names {
+                let child_rel = rel.join(name);
+                let path = root.join(&child_rel);
+                let metadata = fs::symlink_metadata(&path).unwrap();
+                let file_type = metadata.file_type();
+                let bytes_or_target = if file_type.is_file() {
+                    fs::read(&path).unwrap()
+                } else if file_type.is_symlink() {
+                    fs::read_link(&path)
+                        .unwrap()
+                        .as_os_str()
+                        .as_bytes()
+                        .to_vec()
+                } else {
+                    Vec::new()
+                };
+                output.insert(
+                    child_rel.clone(),
+                    NoWriteRecord {
+                        kind: metadata.mode() & libc::S_IFMT,
+                        mode: metadata.mode(),
+                        size: metadata.size(),
+                        modified: metadata.modified().ok(),
+                        bytes_or_target,
+                    },
+                );
+                if file_type.is_dir() {
+                    walk(root, &child_rel, output);
+                }
+            }
+        }
+        let mut result = BTreeMap::new();
+        walk(root, Path::new(""), &mut result);
+        result
+    }
+
+    #[test]
+    fn capture_does_not_modify_tree_contents_or_metadata_contract() {
+        let (_temporary, root) = canonical_root();
+        fs::create_dir(root.join("dir")).unwrap();
+        fs::write(root.join("dir/file"), b"payload").unwrap();
+        symlink("dir/file", root.join("link")).unwrap();
+        let before = no_write_inventory(&root);
+        let _ = complete(&root, RootProfileV1::AgentStaticV1);
+        let after = no_write_inventory(&root);
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn symlink_debug_redacts_exact_target() {
+        let target = "sensitive-but-valid-relative-target";
+        let link = StrictLocalSymlinkV1 {
+            target: target.to_owned(),
+            target_blake3: *blake3::hash(target.as_bytes()).as_bytes(),
+        };
+        let debug = format!("{link:?}");
+        assert!(!debug.contains(target));
+        assert!(debug.contains("target_len"));
+        assert!(debug.contains("target_blake3"));
+    }
+
+    #[test]
+    fn semantic_digest_does_not_bind_acquisition_proof_bytes() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join("visible"), b"read").unwrap();
+        let snapshot = complete(&root, RootProfileV1::AgentStaticV1);
+        let digest = snapshot.digest();
+        let mut alternate_proof = snapshot.clone();
+        alternate_proof.acquisition_fingerprint =
+            StrictLocalSnapshotAcquisitionFingerprintV1([0x5a; 32]);
+        assert_ne!(
+            snapshot.acquisition_fingerprint(),
+            alternate_proof.acquisition_fingerprint()
+        );
+        assert_eq!(digest, alternate_proof.digest());
+    }
+
+    #[test]
+    fn fixed_deny_entries_are_inventory_only_and_semantically_omitted() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join(".env"), b"not read").unwrap();
+        fs::write(root.join("visible"), b"read").unwrap();
+        let snapshot = complete(&root, RootProfileV1::AgentStaticV1);
+        assert!(snapshot.entry(".env").is_none());
+        assert!(snapshot.entry("visible").is_some());
+    }
+
+    #[test]
+    fn adding_an_empty_directory_does_not_change_semantic_digest() {
+        let (_temporary, root) = canonical_root();
+        fs::write(root.join("visible"), b"read").unwrap();
+        let before = complete(&root, RootProfileV1::AgentStaticV1).digest();
+        fs::create_dir(root.join("empty")).unwrap();
+        let with_empty = complete(&root, RootProfileV1::AgentStaticV1);
+        assert!(with_empty.entry("empty").is_none());
+        let (folded_path, empty_claim) = with_empty
+            .namespace_claims()
+            .find(|(_, claim)| claim.exact_path() == "empty")
+            .expect("ignored empty directory must retain a namespace claim");
+        assert_eq!(folded_path, "empty");
+        assert_eq!(empty_claim.role(), StrictLocalNamespaceRoleV1::Directory);
+        assert_eq!(before, with_empty.digest());
+        fs::remove_dir(root.join("empty")).unwrap();
+        assert_eq!(
+            before,
+            complete(&root, RootProfileV1::AgentStaticV1).digest()
+        );
+    }
+
+    #[test]
+    fn excluded_directory_payload_churn_is_ignored() {
+        let (_temporary, root) = canonical_root();
+        let denied = root.join(".ssh");
+        fs::create_dir(&denied).unwrap();
+        let payload = denied.join("id");
+        fs::write(&payload, b"before").unwrap();
+        fs::write(root.join("visible"), b"read").unwrap();
+        let mutation = payload.clone();
+        let _hook = install_test_hook(move |point| {
+            if point == TestHookPoint::LeafToInventoryB {
+                fs::write(&mutation, b"after!").unwrap();
+            }
+        });
+        let snapshot = complete(&root, RootProfileV1::AgentStaticV1);
+        assert!(snapshot.entry(".ssh").is_none());
+        assert!(snapshot.entry(".ssh/id").is_none());
+    }
+
+    #[test]
+    fn excluded_directory_replacement_is_detected() {
+        let (_temporary, root) = canonical_root();
+        let denied = root.join(".ssh");
+        fs::create_dir(&denied).unwrap();
+        fs::write(denied.join("id"), b"before").unwrap();
+        let moved = root.with_extension("excluded-old");
+        let hook_denied = denied.clone();
+        let _hook = install_test_hook(move |point| {
+            if point == TestHookPoint::LeafToInventoryB {
+                fs::rename(&hook_denied, &moved).unwrap();
+                fs::create_dir(&hook_denied).unwrap();
+            }
+        });
+        assert_eq!(
+            incomplete_kind(&root, RootProfileV1::AgentStaticV1),
+            StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead
+        );
+    }
+}

--- a/crates/tcfs-sync/src/registered_local_snapshot.rs
+++ b/crates/tcfs-sync/src/registered_local_snapshot.rs
@@ -561,7 +561,7 @@ impl PendingStrictLocalSnapshotV1 {
         }
 
         #[cfg(not(target_os = "linux"))]
-        match self.unsupported {}
+        std::iter::empty::<StrictInitialLocalInventoryEntryV1<'_>>()
     }
 
     /// Re-read one inventory-A regular file through the held root descriptor.

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -1069,7 +1069,7 @@ impl BoundRemoteObjectSnapshotV1 {
     }
 }
 
-fn bind_remote_object_v1(snapshot: RawObjectSnapshotV1) -> BoundRemoteObjectSnapshotV1 {
+pub(crate) fn bind_remote_object_v1(snapshot: RawObjectSnapshotV1) -> BoundRemoteObjectSnapshotV1 {
     let binding = if let Some(version) = snapshot.binding().version() {
         RegisteredRootRemoteObjectBindingV1::Version {
             version: version.to_owned(),

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -1,0 +1,2354 @@
+//! Strict, read-only inputs for registered-root reconciliation planning.
+//!
+//! This module is intentionally separate from the compatibility readers and
+//! mutable reconciliation engine. V1 planning never recovers remote
+//! `preparing` records, reads a state backup, creates a state lock, or performs
+//! a storage write.
+
+use anyhow::{Context, Result};
+use opendal::Operator;
+use serde::de::{Error as _, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::marker::PhantomData;
+use std::path::Path;
+use unicode_normalization::UnicodeNormalization;
+
+use crate::blacklist::Blacklist;
+use crate::conflict::{ConflictInfo, VectorClock};
+use crate::index_entry::portable_casefold_path;
+use crate::index_entry::{
+    manifest_object_id, read_raw_object_snapshot_v1, validate_canonical_namespace_remote_prefix,
+    validate_namespace_logical_path, validate_relative_storage_key, validate_storage_key_component,
+    DeletionEvidence, IndexEntryState, PortableNamespaceRole, RawObjectReadV1, RawObjectSnapshotV1,
+    RemoteEntryKind,
+};
+use crate::state::{
+    read_primary_state_bytes_read_only_v1, FileSyncStatus, ReadOnlyPrimaryStateBytesV1,
+};
+
+const REGISTERED_ROOT_INDEX_MAX_BYTES_V1: u64 = 1024 * 1024;
+const REGISTERED_ROOT_MANIFEST_MAX_BYTES_V1: u64 = 16 * 1024 * 1024;
+const REGISTERED_ROOT_IDENTITY_MAX_BYTES_V1: usize = 512;
+const REGISTERED_ROOT_RECIPIENT_MAX_BYTES_V1: usize = 1024;
+const REGISTERED_ROOT_ALGORITHM_MAX_BYTES_V1: usize = 128;
+const REGISTERED_ROOT_WRAPPED_KEY_MAX_BYTES_V1: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UniqueBTreeMap<K, V>(BTreeMap<K, V>);
+
+impl<K, V> UniqueBTreeMap<K, V> {
+    fn into_inner(self) -> BTreeMap<K, V> {
+        self.0
+    }
+}
+
+impl<'de, K, V> Deserialize<'de> for UniqueBTreeMap<K, V>
+where
+    K: Deserialize<'de> + Ord + fmt::Debug,
+    V: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct UniqueMapVisitor<K, V>(PhantomData<(K, V)>);
+
+        impl<'de, K, V> Visitor<'de> for UniqueMapVisitor<K, V>
+        where
+            K: Deserialize<'de> + Ord + fmt::Debug,
+            V: Deserialize<'de>,
+        {
+            type Value = UniqueBTreeMap<K, V>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a map with unique keys")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut values = BTreeMap::new();
+                while let Some((key, value)) = map.next_entry()? {
+                    if values.insert(key, value).is_some() {
+                        return Err(A::Error::custom("duplicate key in registered-root V1 map"));
+                    }
+                }
+                Ok(UniqueBTreeMap(values))
+            }
+        }
+
+        deserializer.deserialize_map(UniqueMapVisitor(PhantomData))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RequiredNullable<T>(Option<T>);
+
+impl<'de, T> Deserialize<'de> for RequiredNullable<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<T>::deserialize(deserializer).map(Self)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictVectorClockWireV1 {
+    clocks: UniqueBTreeMap<String, u64>,
+}
+
+impl StrictVectorClockWireV1 {
+    fn try_into_vector_clock(self) -> Result<VectorClock> {
+        let clocks = self.clocks.into_inner();
+        for (device_id, counter) in &clocks {
+            validate_strict_identity_v1(device_id, "strict vector-clock device id")?;
+            anyhow::ensure!(*counter > 0, "strict vector-clock counters must be nonzero");
+        }
+        Ok(VectorClock { clocks })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictConflictWireV1 {
+    rel_path: String,
+    local_vclock: StrictVectorClockWireV1,
+    remote_vclock: StrictVectorClockWireV1,
+    local_blake3: String,
+    remote_blake3: String,
+    local_device: String,
+    remote_device: String,
+    detected_at: u64,
+    times_recorded: u64,
+    remote_manifest_key: RequiredNullable<String>,
+}
+
+impl StrictConflictWireV1 {
+    fn try_into_conflict(self) -> Result<ConflictInfo> {
+        validate_strict_identity_v1(&self.local_device, "strict conflict local device id")?;
+        validate_strict_identity_v1(&self.remote_device, "strict conflict remote device id")?;
+        Ok(ConflictInfo {
+            rel_path: self.rel_path,
+            local_vclock: self.local_vclock.try_into_vector_clock()?,
+            remote_vclock: self.remote_vclock.try_into_vector_clock()?,
+            local_blake3: self.local_blake3,
+            remote_blake3: self.remote_blake3,
+            local_device: self.local_device,
+            remote_device: self.remote_device,
+            detected_at: self.detected_at,
+            times_recorded: self.times_recorded,
+            remote_manifest_key: self.remote_manifest_key.0,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictSyncStateWireV1 {
+    blake3: String,
+    size: u64,
+    mtime: u64,
+    chunk_count: u64,
+    remote_path: String,
+    last_synced: u64,
+    vclock: StrictVectorClockWireV1,
+    device_id: String,
+    #[serde(default)]
+    conflict: Option<StrictConflictWireV1>,
+    status: FileSyncStatus,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictStateCacheWireV1 {
+    last_nats_seq: u64,
+    device_id: String,
+    entries: UniqueBTreeMap<String, StrictSyncStateWireV1>,
+}
+
+/// Strict semantic state for one cache key.
+#[derive(Debug, Clone)]
+pub struct StrictSyncStateV1 {
+    blake3: String,
+    size: u64,
+    mtime: u64,
+    chunk_count: u64,
+    remote_path: String,
+    last_synced: u64,
+    vclock: VectorClock,
+    device_id: String,
+    conflict: Option<ConflictInfo>,
+    status: FileSyncStatus,
+}
+
+/// One state entry bound to the selected root and remote namespace.
+#[derive(Debug, Clone)]
+pub struct BoundStrictSyncStateV1 {
+    rel_path: String,
+    index_key: String,
+    baseline_manifest_key: String,
+    state: StrictSyncStateV1,
+}
+
+impl BoundStrictSyncStateV1 {
+    pub fn rel_path(&self) -> &str {
+        &self.rel_path
+    }
+
+    pub fn index_key(&self) -> &str {
+        &self.index_key
+    }
+
+    pub fn baseline_manifest_key(&self) -> &str {
+        &self.baseline_manifest_key
+    }
+
+    pub const fn state(&self) -> &StrictSyncStateV1 {
+        &self.state
+    }
+}
+
+impl StrictSyncStateV1 {
+    pub fn blake3(&self) -> &str {
+        &self.blake3
+    }
+
+    pub const fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub const fn mtime(&self) -> u64 {
+        self.mtime
+    }
+
+    pub const fn chunk_count(&self) -> u64 {
+        self.chunk_count
+    }
+
+    pub fn remote_path(&self) -> &str {
+        &self.remote_path
+    }
+
+    pub const fn last_synced(&self) -> u64 {
+        self.last_synced
+    }
+
+    pub const fn vclock(&self) -> &VectorClock {
+        &self.vclock
+    }
+
+    pub fn device_id(&self) -> &str {
+        &self.device_id
+    }
+
+    pub const fn conflict(&self) -> Option<&ConflictInfo> {
+        self.conflict.as_ref()
+    }
+
+    pub const fn status(&self) -> FileSyncStatus {
+        self.status
+    }
+}
+
+impl StrictSyncStateWireV1 {
+    fn into_state(self) -> Result<StrictSyncStateV1> {
+        validate_lower_hex_64(&self.blake3, "strict state content digest")?;
+        validate_relative_storage_key(&self.remote_path, "strict state remote path")?;
+        validate_strict_identity_v1(&self.device_id, "strict state device id")?;
+        let vclock = self.vclock.try_into_vector_clock()?;
+        anyhow::ensure!(
+            (self.status == FileSyncStatus::Conflict) == self.conflict.is_some(),
+            "strict state conflict status and payload must be present together"
+        );
+        if let Some(conflict) = self.conflict.as_ref() {
+            validate_namespace_logical_path(&conflict.rel_path)?;
+            validate_lower_hex_64(&conflict.local_blake3, "strict conflict local digest")?;
+            validate_lower_hex_64(&conflict.remote_blake3, "strict conflict remote digest")?;
+            validate_strict_identity_v1(&conflict.local_device, "strict conflict local device id")?;
+            validate_strict_identity_v1(
+                &conflict.remote_device,
+                "strict conflict remote device id",
+            )?;
+            if let Some(key) = conflict.remote_manifest_key.0.as_deref() {
+                validate_relative_storage_key(key, "strict conflict remote manifest key")?;
+            }
+        }
+        Ok(StrictSyncStateV1 {
+            blake3: self.blake3,
+            size: self.size,
+            mtime: self.mtime,
+            chunk_count: self.chunk_count,
+            remote_path: self.remote_path,
+            last_synced: self.last_synced,
+            vclock,
+            device_id: self.device_id,
+            conflict: self
+                .conflict
+                .map(StrictConflictWireV1::try_into_conflict)
+                .transpose()?,
+            status: self.status,
+        })
+    }
+}
+
+/// Exact representation digest for one accepted state primary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StrictPrimaryStateBytesDigestV1([u8; 32]);
+
+impl StrictPrimaryStateBytesDigestV1 {
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Strict, quiet, primary-only registered-root state.
+#[derive(Clone)]
+pub struct StrictPrimaryStateSnapshotV1 {
+    raw_bytes_digest: StrictPrimaryStateBytesDigestV1,
+    entries: BTreeMap<String, BoundStrictSyncStateV1>,
+    last_nats_seq: u64,
+    device_id: String,
+}
+
+impl fmt::Debug for StrictPrimaryStateSnapshotV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StrictPrimaryStateSnapshotV1")
+            .field("raw_bytes_digest", &self.raw_bytes_digest)
+            .field("entry_count", &self.entries.len())
+            .field("last_nats_seq", &self.last_nats_seq)
+            .field("device_id", &self.device_id)
+            .finish()
+    }
+}
+
+impl StrictPrimaryStateSnapshotV1 {
+    pub const fn raw_bytes_digest(&self) -> StrictPrimaryStateBytesDigestV1 {
+        self.raw_bytes_digest
+    }
+
+    pub const fn entries(&self) -> &BTreeMap<String, BoundStrictSyncStateV1> {
+        &self.entries
+    }
+
+    pub const fn last_nats_seq(&self) -> u64 {
+        self.last_nats_seq
+    }
+
+    pub fn device_id(&self) -> &str {
+        &self.device_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StrictPrimaryStateIncompleteV1 {
+    PrimaryMissing,
+    WriterActive,
+    PrimaryChangedDuringRead,
+    InvalidPrimary,
+    PersistedEntriesBusy {
+        active_keys: Vec<String>,
+        locked_keys: Vec<String>,
+    },
+    InvalidRootBinding,
+}
+
+#[derive(Debug, Clone)]
+pub enum StrictPrimaryStateReadV1 {
+    Complete(StrictPrimaryStateSnapshotV1),
+    Incomplete(StrictPrimaryStateIncompleteV1),
+}
+
+/// Read, strictly parse, and route-bind one selected V1 state primary.
+///
+/// `Complete` means every persisted entry has an exact canonical path under
+/// `canonical_local_root` and an immutable manifest key under
+/// `canonical_remote_prefix`; compatibility suffix matching is never used.
+pub fn read_and_bind_strict_primary_state_v1(
+    state_path: &Path,
+    canonical_local_root: &Path,
+    canonical_remote_prefix: &str,
+) -> Result<StrictPrimaryStateReadV1> {
+    let raw_snapshot = match read_primary_state_bytes_read_only_v1(state_path)? {
+        ReadOnlyPrimaryStateBytesV1::Missing => {
+            return Ok(StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::PrimaryMissing,
+            ));
+        }
+        ReadOnlyPrimaryStateBytesV1::WriterActive => {
+            return Ok(StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::WriterActive,
+            ));
+        }
+        ReadOnlyPrimaryStateBytesV1::Unstable => {
+            return Ok(StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::PrimaryChangedDuringRead,
+            ));
+        }
+        ReadOnlyPrimaryStateBytesV1::Snapshot(snapshot) => snapshot,
+    };
+
+    let wire: StrictStateCacheWireV1 = match serde_json::from_slice(raw_snapshot.raw_bytes()) {
+        Ok(wire) => wire,
+        Err(_) => {
+            return Ok(StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::InvalidPrimary,
+            ));
+        }
+    };
+    if validate_strict_identity_v1(&wire.device_id, "strict state-cache device id").is_err() {
+        return Ok(StrictPrimaryStateReadV1::Incomplete(
+            StrictPrimaryStateIncompleteV1::InvalidPrimary,
+        ));
+    }
+
+    let mut active_keys = Vec::new();
+    let mut locked_keys = Vec::new();
+    let mut raw_entries = BTreeMap::new();
+    for (cache_key, state) in wire.entries.into_inner() {
+        let state = match state.into_state() {
+            Ok(state) => state,
+            Err(_) => {
+                return Ok(StrictPrimaryStateReadV1::Incomplete(
+                    StrictPrimaryStateIncompleteV1::InvalidPrimary,
+                ));
+            }
+        };
+        match state.status() {
+            FileSyncStatus::Active => active_keys.push(cache_key.clone()),
+            FileSyncStatus::Locked => locked_keys.push(cache_key.clone()),
+            FileSyncStatus::NotSynced | FileSyncStatus::Synced | FileSyncStatus::Conflict => {}
+        }
+        raw_entries.insert(cache_key, state);
+    }
+    if !active_keys.is_empty() || !locked_keys.is_empty() {
+        return Ok(StrictPrimaryStateReadV1::Incomplete(
+            StrictPrimaryStateIncompleteV1::PersistedEntriesBusy {
+                active_keys,
+                locked_keys,
+            },
+        ));
+    }
+    let entries = match bind_strict_state_entries_v1(
+        raw_entries,
+        canonical_local_root,
+        canonical_remote_prefix,
+    ) {
+        Ok(entries) => entries,
+        Err(_) => {
+            return Ok(StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::InvalidRootBinding,
+            ));
+        }
+    };
+
+    let raw_digest = StrictPrimaryStateBytesDigestV1(*raw_snapshot.raw_bytes_digest().as_bytes());
+    let (_raw_bytes, _) = raw_snapshot.into_parts();
+    Ok(StrictPrimaryStateReadV1::Complete(
+        StrictPrimaryStateSnapshotV1 {
+            raw_bytes_digest: raw_digest,
+            entries,
+            last_nats_seq: wire.last_nats_seq,
+            device_id: wire.device_id,
+        },
+    ))
+}
+
+fn bind_strict_state_entries_v1(
+    raw_entries: BTreeMap<String, StrictSyncStateV1>,
+    canonical_local_root: &Path,
+    canonical_remote_prefix: &str,
+) -> Result<BTreeMap<String, BoundStrictSyncStateV1>> {
+    anyhow::ensure!(
+        canonical_local_root.is_absolute(),
+        "strict state root binding requires an absolute local root"
+    );
+    let observed_root = std::fs::canonicalize(canonical_local_root)
+        .context("canonicalizing strict state local root")?;
+    anyhow::ensure!(
+        observed_root == canonical_local_root,
+        "strict state local root input is not its canonical spelling"
+    );
+    anyhow::ensure!(
+        std::fs::symlink_metadata(canonical_local_root)
+            .context("inspecting strict state local root")?
+            .is_dir(),
+        "strict state local root is not a directory"
+    );
+    canonical_local_root
+        .to_str()
+        .context("strict state local root is not valid UTF-8")?;
+
+    let prefix = validate_canonical_namespace_remote_prefix(canonical_remote_prefix)?;
+    anyhow::ensure!(
+        !prefix.is_empty(),
+        "strict state root binding requires a non-empty remote prefix"
+    );
+
+    let mut namespace_claims: BTreeMap<String, (String, PortableNamespaceRole)> = BTreeMap::new();
+    let mut entries = BTreeMap::new();
+    for (cache_key, state) in raw_entries {
+        let rel_path = bind_strict_cache_key_v1(&cache_key, canonical_local_root)?;
+        if Blacklist::default()
+            .check_fixed_ingress_path_components(Path::new(&rel_path))
+            .is_some()
+        {
+            anyhow::bail!("strict state cache path is excluded by the fixed profile");
+        }
+        let baseline_manifest_key =
+            validate_exact_manifest_key_v1(prefix, state.remote_path())?.to_owned();
+        if let Some(conflict) = state.conflict() {
+            anyhow::ensure!(
+                conflict.rel_path == rel_path,
+                "strict conflict path does not match its bound state path"
+            );
+            let conflict_manifest_key = conflict
+                .remote_manifest_key
+                .as_deref()
+                .context("strict conflict requires an exact remote manifest pin")?;
+            validate_exact_manifest_key_v1(prefix, conflict_manifest_key)?;
+        }
+
+        reserve_state_namespace_claims_v1(&rel_path, &mut namespace_claims)?;
+        let index_key = format!("{prefix}/index/{rel_path}");
+        let entry = BoundStrictSyncStateV1 {
+            rel_path: rel_path.clone(),
+            index_key,
+            baseline_manifest_key,
+            state,
+        };
+        anyhow::ensure!(
+            entries.insert(rel_path, entry).is_none(),
+            "strict state cache contains duplicate bound paths"
+        );
+    }
+    Ok(entries)
+}
+
+fn bind_strict_cache_key_v1(cache_key: &str, canonical_local_root: &Path) -> Result<String> {
+    anyhow::ensure!(
+        !cache_key.is_empty()
+            && !cache_key.ends_with('/')
+            && !cache_key.contains("//")
+            && !cache_key.contains('\\')
+            && !cache_key.contains('\u{fffd}')
+            && !cache_key.chars().any(char::is_control),
+        "strict state cache key has a noncanonical spelling"
+    );
+    let cache_path = Path::new(cache_key);
+    anyhow::ensure!(
+        cache_path.is_absolute() && cache_path != canonical_local_root,
+        "strict state cache key is not a file path below its selected root"
+    );
+    let rel_path = cache_path
+        .strip_prefix(canonical_local_root)
+        .context("strict state cache key is outside its selected root")?
+        .to_str()
+        .context("strict state relative path is not valid UTF-8")?
+        .to_owned();
+    validate_namespace_logical_path(&rel_path)?;
+    anyhow::ensure!(
+        canonical_local_root.join(&rel_path) == cache_path,
+        "strict state cache key does not round-trip through its selected root"
+    );
+    let parent = cache_path
+        .parent()
+        .context("strict state cache key has no parent")?;
+    anyhow::ensure!(
+        std::fs::canonicalize(parent).context("canonicalizing strict state cache-key parent")?
+            == parent,
+        "strict state cache-key parent is missing or uses an alternate path"
+    );
+    Ok(rel_path)
+}
+
+fn validate_exact_manifest_key_v1<'a>(remote_prefix: &str, key: &'a str) -> Result<&'a str> {
+    let manifest_prefix = format!("{remote_prefix}/manifests/");
+    let object_id = key
+        .strip_prefix(&manifest_prefix)
+        .context("strict state remote path is outside its manifest namespace")?;
+    validate_lower_hex_64(object_id, "strict state manifest object id")?;
+    anyhow::ensure!(
+        key == format!("{manifest_prefix}{object_id}"),
+        "strict state manifest key is not canonical"
+    );
+    Ok(key)
+}
+
+fn reserve_state_namespace_claims_v1(
+    rel_path: &str,
+    claims: &mut BTreeMap<String, (String, PortableNamespaceRole)>,
+) -> Result<()> {
+    let components: Vec<&str> = rel_path.split('/').collect();
+    for end in 1..=components.len() {
+        let exact_path = components[..end].join("/");
+        let role = if end == components.len() {
+            PortableNamespaceRole::File
+        } else {
+            PortableNamespaceRole::Directory
+        };
+        let folded_path = portable_casefold_path(&exact_path)?;
+        if let Some((existing_path, existing_role)) = claims.get(&folded_path) {
+            anyhow::ensure!(
+                existing_path == &exact_path && *existing_role == role,
+                "strict state namespace has a portable spelling or role collision"
+            );
+        } else {
+            claims.insert(folded_path, (exact_path, role));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictRemoteIndexEntryWireV1 {
+    manifest_hash: String,
+    size: u64,
+    chunks: u64,
+    #[serde(default)]
+    kind: Option<RemoteEntryKind>,
+    #[serde(default)]
+    symlink_target: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictPendingIndexEntryWireV1 {
+    manifest_hash: String,
+    size: u64,
+    chunks: u64,
+    #[serde(default)]
+    kind: Option<RemoteEntryKind>,
+    #[serde(default)]
+    symlink_target: Option<String>,
+    staged_manifest_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictDeletionEvidenceWireV1 {
+    safety_copy_key: String,
+    safety_copy_blake3: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictVersionedIndexEntryWireV1 {
+    version: u8,
+    state: IndexEntryState,
+    current: RequiredNullable<StrictRemoteIndexEntryWireV1>,
+    pending: RequiredNullable<StrictPendingIndexEntryWireV1>,
+    #[serde(default)]
+    deletion_evidence: Option<StrictDeletionEvidenceWireV1>,
+}
+
+/// Strict committed manifest pointer from a V1 index record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrictRemoteIndexEntryV1 {
+    manifest_hash: String,
+    size: u64,
+    chunks: u64,
+    kind: RemoteEntryKind,
+    symlink_target: Option<String>,
+}
+
+impl StrictRemoteIndexEntryV1 {
+    pub fn manifest_hash(&self) -> &str {
+        &self.manifest_hash
+    }
+
+    pub const fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub const fn chunks(&self) -> u64 {
+        self.chunks
+    }
+
+    pub const fn kind(&self) -> RemoteEntryKind {
+        self.kind
+    }
+
+    pub fn symlink_target(&self) -> Option<&str> {
+        self.symlink_target.as_deref()
+    }
+}
+
+impl StrictRemoteIndexEntryWireV1 {
+    fn into_entry(self) -> Result<StrictRemoteIndexEntryV1> {
+        strict_remote_entry_v1(
+            self.manifest_hash,
+            self.size,
+            self.chunks,
+            self.kind,
+            self.symlink_target,
+        )
+    }
+}
+
+/// Strict pending publication pointer retained only for diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrictPendingIndexEntryV1 {
+    entry: StrictRemoteIndexEntryV1,
+    staged_manifest_key: String,
+}
+
+impl StrictPendingIndexEntryV1 {
+    pub const fn entry(&self) -> &StrictRemoteIndexEntryV1 {
+        &self.entry
+    }
+
+    pub fn staged_manifest_key(&self) -> &str {
+        &self.staged_manifest_key
+    }
+}
+
+impl StrictPendingIndexEntryWireV1 {
+    fn into_entry(self) -> Result<StrictPendingIndexEntryV1> {
+        validate_relative_storage_key(
+            &self.staged_manifest_key,
+            "strict pending staged manifest key",
+        )?;
+        Ok(StrictPendingIndexEntryV1 {
+            entry: strict_remote_entry_v1(
+                self.manifest_hash,
+                self.size,
+                self.chunks,
+                self.kind,
+                self.symlink_target,
+            )?,
+            staged_manifest_key: self.staged_manifest_key,
+        })
+    }
+}
+
+fn strict_remote_entry_v1(
+    manifest_hash: String,
+    size: u64,
+    chunks: u64,
+    kind: Option<RemoteEntryKind>,
+    symlink_target: Option<String>,
+) -> Result<StrictRemoteIndexEntryV1> {
+    validate_lower_hex_64(&manifest_hash, "strict index manifest object id")?;
+    let kind = kind.unwrap_or(RemoteEntryKind::RegularFile);
+    match kind {
+        RemoteEntryKind::RegularFile => {
+            anyhow::ensure!(
+                symlink_target.is_none(),
+                "strict regular index entry forbids symlink target"
+            );
+        }
+        RemoteEntryKind::Symlink => {
+            let target = symlink_target
+                .as_deref()
+                .context("strict symlink index entry requires target")?;
+            anyhow::ensure!(
+                !target.is_empty() && !target.chars().any(char::is_control),
+                "strict symlink index target must be non-empty and control-free"
+            );
+            anyhow::ensure!(
+                chunks == 0
+                    && size
+                        == u64::try_from(target.len())
+                            .context("strict symlink target length does not fit u64")?,
+                "strict symlink index metadata does not match target"
+            );
+        }
+    }
+    Ok(StrictRemoteIndexEntryV1 {
+        manifest_hash,
+        size,
+        chunks,
+        kind,
+        symlink_target,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegisteredRootRemoteObjectBindingV1 {
+    Version {
+        version: String,
+        etag: Option<String>,
+    },
+    Etag {
+        etag: String,
+    },
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct BoundRemoteObjectSnapshotV1 {
+    raw_bytes_len: u64,
+    raw_blake3: [u8; 32],
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+impl fmt::Debug for BoundRemoteObjectSnapshotV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BoundRemoteObjectSnapshotV1")
+            .field("raw_bytes_len", &self.raw_bytes_len)
+            .field("raw_blake3", &blake3::Hash::from_bytes(self.raw_blake3))
+            .field("binding", &self.binding)
+            .finish()
+    }
+}
+
+impl BoundRemoteObjectSnapshotV1 {
+    pub const fn raw_bytes_len(&self) -> u64 {
+        self.raw_bytes_len
+    }
+
+    pub const fn raw_blake3(&self) -> &[u8; 32] {
+        &self.raw_blake3
+    }
+
+    pub const fn binding(&self) -> &RegisteredRootRemoteObjectBindingV1 {
+        &self.binding
+    }
+}
+
+fn bind_remote_object_v1(snapshot: RawObjectSnapshotV1) -> BoundRemoteObjectSnapshotV1 {
+    let binding = if let Some(version) = snapshot.binding().version() {
+        RegisteredRootRemoteObjectBindingV1::Version {
+            version: version.to_owned(),
+            etag: snapshot.binding().etag().map(str::to_owned),
+        }
+    } else {
+        RegisteredRootRemoteObjectBindingV1::Etag {
+            etag: snapshot
+                .binding()
+                .etag()
+                .expect("bound non-versioned object must carry an ETag")
+                .to_owned(),
+        }
+    };
+    let (raw_bytes, raw_blake3, _) = snapshot.into_parts();
+    BoundRemoteObjectSnapshotV1 {
+        raw_bytes_len: u64::try_from(raw_bytes.len())
+            .expect("bounded remote object length must fit u64"),
+        raw_blake3: *raw_blake3.as_bytes(),
+        binding,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrictIndexRecordFormatV1 {
+    Version2,
+    Version3,
+    Version4Deleted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisteredRootRemoteIndexRouteV1 {
+    remote_prefix: String,
+    rel_path: String,
+    index_key: String,
+}
+
+impl RegisteredRootRemoteIndexRouteV1 {
+    pub fn remote_prefix(&self) -> &str {
+        &self.remote_prefix
+    }
+
+    pub fn rel_path(&self) -> &str {
+        &self.rel_path
+    }
+
+    pub fn index_key(&self) -> &str {
+        &self.index_key
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawCommittedIndexEntryV1 {
+    object: BoundRemoteObjectSnapshotV1,
+    current: StrictRemoteIndexEntryV1,
+    format: StrictIndexRecordFormatV1,
+    route: RegisteredRootRemoteIndexRouteV1,
+}
+
+impl RawCommittedIndexEntryV1 {
+    pub const fn object(&self) -> &BoundRemoteObjectSnapshotV1 {
+        &self.object
+    }
+
+    pub const fn current(&self) -> &StrictRemoteIndexEntryV1 {
+        &self.current
+    }
+
+    pub const fn format(&self) -> StrictIndexRecordFormatV1 {
+        self.format
+    }
+
+    pub const fn route(&self) -> &RegisteredRootRemoteIndexRouteV1 {
+        &self.route
+    }
+
+    pub fn remote_prefix(&self) -> &str {
+        self.route.remote_prefix()
+    }
+
+    pub fn rel_path(&self) -> &str {
+        self.route.rel_path()
+    }
+
+    pub fn index_key(&self) -> &str {
+        self.route.index_key()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawDeletedIndexEntryV1 {
+    object: BoundRemoteObjectSnapshotV1,
+    deletion_evidence: Option<DeletionEvidence>,
+    route: RegisteredRootRemoteIndexRouteV1,
+}
+
+impl RawDeletedIndexEntryV1 {
+    pub const fn object(&self) -> &BoundRemoteObjectSnapshotV1 {
+        &self.object
+    }
+
+    pub const fn deletion_evidence(&self) -> Option<&DeletionEvidence> {
+        self.deletion_evidence.as_ref()
+    }
+
+    pub const fn route(&self) -> &RegisteredRootRemoteIndexRouteV1 {
+        &self.route
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrictRemoteIndexIncompleteV1 {
+    UnboundObject,
+    InvalidIndexRecord,
+    PreparingObserved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExactRawIndexEntryReadV1 {
+    Missing,
+    Incomplete(StrictRemoteIndexIncompleteV1),
+    Deleted(RawDeletedIndexEntryV1),
+    Committed(RawCommittedIndexEntryV1),
+}
+
+enum ParsedStrictIndexRecordV1 {
+    Deleted {
+        deletion_evidence: Option<DeletionEvidence>,
+    },
+    Preparing {
+        current: Option<StrictRemoteIndexEntryV1>,
+        pending: StrictPendingIndexEntryV1,
+    },
+    Committed {
+        current: StrictRemoteIndexEntryV1,
+        format: StrictIndexRecordFormatV1,
+    },
+}
+
+fn parse_strict_index_record_v1(bytes: &[u8]) -> Result<ParsedStrictIndexRecordV1> {
+    let wire: StrictVersionedIndexEntryWireV1 =
+        serde_json::from_slice(bytes).context("parsing strict V1 index record")?;
+    let current = wire
+        .current
+        .0
+        .map(StrictRemoteIndexEntryWireV1::into_entry)
+        .transpose()?;
+    let pending = wire
+        .pending
+        .0
+        .map(StrictPendingIndexEntryWireV1::into_entry)
+        .transpose()?;
+    let deletion_evidence = wire
+        .deletion_evidence
+        .map(|evidence| -> Result<DeletionEvidence> {
+            validate_relative_storage_key(
+                &evidence.safety_copy_key,
+                "strict deletion safety-copy key",
+            )?;
+            validate_lower_hex_64(
+                &evidence.safety_copy_blake3,
+                "strict deletion safety-copy digest",
+            )?;
+            Ok(DeletionEvidence {
+                safety_copy_key: evidence.safety_copy_key,
+                safety_copy_blake3: evidence.safety_copy_blake3,
+            })
+        })
+        .transpose()?;
+
+    match (wire.version, wire.state) {
+        (4, IndexEntryState::Deleted) => {
+            anyhow::ensure!(
+                current.is_none() && pending.is_none(),
+                "strict deleted index record forbids current and pending entries"
+            );
+            Ok(ParsedStrictIndexRecordV1::Deleted { deletion_evidence })
+        }
+        (2 | 3, IndexEntryState::Committed) => {
+            anyhow::ensure!(
+                pending.is_none() && deletion_evidence.is_none(),
+                "strict committed index record forbids pending/deletion evidence"
+            );
+            let current =
+                current.context("strict committed index record requires current entry")?;
+            validate_index_format_matches_entries_v1(wire.version, Some(&current), None)?;
+            Ok(ParsedStrictIndexRecordV1::Committed {
+                current,
+                format: if wire.version == 2 {
+                    StrictIndexRecordFormatV1::Version2
+                } else {
+                    StrictIndexRecordFormatV1::Version3
+                },
+            })
+        }
+        (2 | 3, IndexEntryState::Preparing) => {
+            anyhow::ensure!(
+                deletion_evidence.is_none(),
+                "strict preparing index record forbids deletion evidence"
+            );
+            let pending =
+                pending.context("strict preparing index record requires pending entry")?;
+            validate_index_format_matches_entries_v1(
+                wire.version,
+                current.as_ref(),
+                Some(pending.entry()),
+            )?;
+            Ok(ParsedStrictIndexRecordV1::Preparing { current, pending })
+        }
+        _ => anyhow::bail!("unsupported strict V1 index version/state combination"),
+    }
+}
+
+fn validate_index_format_matches_entries_v1(
+    version: u8,
+    current: Option<&StrictRemoteIndexEntryV1>,
+    pending: Option<&StrictRemoteIndexEntryV1>,
+) -> Result<()> {
+    let has_symlink = current
+        .into_iter()
+        .chain(pending)
+        .any(|entry| entry.kind() == RemoteEntryKind::Symlink);
+    anyhow::ensure!(
+        (version == 3) == has_symlink,
+        "strict index version does not match entry kinds"
+    );
+    Ok(())
+}
+
+fn validate_strict_index_path_semantics_v1(
+    parsed: &ParsedStrictIndexRecordV1,
+    rel_path: &str,
+) -> Result<()> {
+    let validate_entry = |entry: &StrictRemoteIndexEntryV1| -> Result<()> {
+        if let Some(target) = entry.symlink_target() {
+            crate::engine::validate_indexed_symlink_target(Path::new(rel_path), target)?;
+        }
+        Ok(())
+    };
+    match parsed {
+        ParsedStrictIndexRecordV1::Deleted { .. } => {}
+        ParsedStrictIndexRecordV1::Preparing {
+            current, pending, ..
+        } => {
+            if let Some(current) = current {
+                validate_entry(current)?;
+            }
+            validate_entry(pending.entry())?;
+        }
+        ParsedStrictIndexRecordV1::Committed { current, .. } => validate_entry(current)?,
+    }
+    Ok(())
+}
+
+/// Read and classify one exact canonical path-index object without recovery.
+pub async fn read_exact_raw_index_entry_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    rel_path: &str,
+) -> Result<ExactRawIndexEntryReadV1> {
+    let prefix = validate_canonical_namespace_remote_prefix(remote_prefix)?;
+    validate_namespace_logical_path(rel_path)?;
+    let index_key = if prefix.is_empty() {
+        format!("index/{rel_path}")
+    } else {
+        format!("{prefix}/index/{rel_path}")
+    };
+    let Some(raw_read) =
+        read_raw_object_snapshot_v1(op, &index_key, REGISTERED_ROOT_INDEX_MAX_BYTES_V1).await?
+    else {
+        return Ok(ExactRawIndexEntryReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactRawIndexEntryReadV1::Incomplete(
+                StrictRemoteIndexIncompleteV1::UnboundObject,
+            ));
+        }
+    };
+    let parsed = match parse_strict_index_record_v1(raw_snapshot.raw_bytes()) {
+        Ok(parsed) if validate_strict_index_path_semantics_v1(&parsed, rel_path).is_ok() => parsed,
+        Err(_) => {
+            return Ok(ExactRawIndexEntryReadV1::Incomplete(
+                StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
+            ));
+        }
+        Ok(_) => {
+            return Ok(ExactRawIndexEntryReadV1::Incomplete(
+                StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
+            ));
+        }
+    };
+    if matches!(&parsed, ParsedStrictIndexRecordV1::Preparing { .. }) {
+        return Ok(ExactRawIndexEntryReadV1::Incomplete(
+            StrictRemoteIndexIncompleteV1::PreparingObserved,
+        ));
+    }
+    let object = bind_remote_object_v1(raw_snapshot);
+    let route = RegisteredRootRemoteIndexRouteV1 {
+        remote_prefix: prefix.to_owned(),
+        rel_path: rel_path.to_owned(),
+        index_key,
+    };
+
+    Ok(match parsed {
+        ParsedStrictIndexRecordV1::Deleted { deletion_evidence } => {
+            ExactRawIndexEntryReadV1::Deleted(RawDeletedIndexEntryV1 {
+                object,
+                deletion_evidence,
+                route,
+            })
+        }
+        ParsedStrictIndexRecordV1::Preparing { .. } => {
+            unreachable!("preparing records return incomplete before binding object evidence")
+        }
+        ParsedStrictIndexRecordV1::Committed { current, format } => {
+            ExactRawIndexEntryReadV1::Committed(RawCommittedIndexEntryV1 {
+                object,
+                current,
+                format,
+                route,
+            })
+        }
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictWrappedFileKeyWireV1 {
+    recipient_device_id: String,
+    recipient: String,
+    algorithm: String,
+    wrapped_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictRegularManifestWireV1 {
+    version: u32,
+    file_hash: String,
+    file_size: u64,
+    chunks: Vec<String>,
+    vclock: StrictVectorClockWireV1,
+    written_by: String,
+    written_at: u64,
+    rel_path: String,
+    mode: u32,
+    mtime: (i64, u32),
+    #[serde(default)]
+    encrypted_file_key: Option<String>,
+    #[serde(default)]
+    wrapped_file_keys: Vec<StrictWrappedFileKeyWireV1>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StrictSymlinkManifestWireV1 {
+    version: u32,
+    kind: RemoteEntryKind,
+    symlink_target: String,
+    vclock: StrictVectorClockWireV1,
+    written_by: String,
+    written_at: u64,
+    rel_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrictRegularManifestV1 {
+    file_hash: String,
+    file_size: u64,
+    chunks: Vec<String>,
+    vclock: VectorClock,
+    written_by: String,
+    written_at: u64,
+    rel_path: String,
+    mode: u32,
+    mtime: (i64, u32),
+}
+
+impl StrictRegularManifestV1 {
+    pub fn file_hash(&self) -> &str {
+        &self.file_hash
+    }
+
+    pub const fn file_size(&self) -> u64 {
+        self.file_size
+    }
+
+    pub fn chunks(&self) -> &[String] {
+        &self.chunks
+    }
+
+    pub const fn vclock(&self) -> &VectorClock {
+        &self.vclock
+    }
+
+    pub fn written_by(&self) -> &str {
+        &self.written_by
+    }
+
+    pub const fn written_at(&self) -> u64 {
+        self.written_at
+    }
+
+    pub fn rel_path(&self) -> &str {
+        &self.rel_path
+    }
+
+    pub const fn mode(&self) -> u32 {
+        self.mode
+    }
+
+    pub const fn mtime(&self) -> (i64, u32) {
+        self.mtime
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrictSymlinkManifestV1 {
+    symlink_target: String,
+    vclock: VectorClock,
+    written_by: String,
+    written_at: u64,
+    rel_path: String,
+}
+
+impl StrictSymlinkManifestV1 {
+    pub fn symlink_target(&self) -> &str {
+        &self.symlink_target
+    }
+
+    pub const fn vclock(&self) -> &VectorClock {
+        &self.vclock
+    }
+
+    pub fn written_by(&self) -> &str {
+        &self.written_by
+    }
+
+    pub const fn written_at(&self) -> u64 {
+        self.written_at
+    }
+
+    pub fn rel_path(&self) -> &str {
+        &self.rel_path
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StrictRemoteManifestV1 {
+    Regular {
+        object: BoundRemoteObjectSnapshotV1,
+        manifest: StrictRegularManifestV1,
+    },
+    Symlink {
+        object: BoundRemoteObjectSnapshotV1,
+        manifest: StrictSymlinkManifestV1,
+    },
+}
+
+impl StrictRemoteManifestV1 {
+    pub const fn object(&self) -> &BoundRemoteObjectSnapshotV1 {
+        match self {
+            Self::Regular { object, .. } | Self::Symlink { object, .. } => object,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrictRemoteManifestIncompleteV1 {
+    MissingObject,
+    UnboundObject,
+    AddressMismatch,
+    InvalidManifest,
+    ExcludedPath,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StrictRemoteManifestReadV1 {
+    Complete(Box<StrictRemoteManifestV1>),
+    Incomplete(StrictRemoteManifestIncompleteV1),
+}
+
+/// Read the exact manifest object named by one strict committed index entry.
+///
+/// The object key must equal the domain-addressed manifest bytes literally;
+/// legacy embedded file-hash and symlink-target identities are not accepted.
+pub async fn read_strict_remote_manifest_v1(
+    op: &Operator,
+    committed_index: &RawCommittedIndexEntryV1,
+) -> Result<StrictRemoteManifestReadV1> {
+    let index_entry = committed_index.current();
+    let prefix = committed_index.remote_prefix();
+    let rel_path = committed_index.rel_path();
+    if Blacklist::default()
+        .check_fixed_ingress_path_components(Path::new(rel_path))
+        .is_some()
+    {
+        return Ok(StrictRemoteManifestReadV1::Incomplete(
+            StrictRemoteManifestIncompleteV1::ExcludedPath,
+        ));
+    }
+    let manifest_key = if prefix.is_empty() {
+        format!("manifests/{}", index_entry.manifest_hash())
+    } else {
+        format!("{prefix}/manifests/{}", index_entry.manifest_hash())
+    };
+    let Some(raw_read) =
+        read_raw_object_snapshot_v1(op, &manifest_key, REGISTERED_ROOT_MANIFEST_MAX_BYTES_V1)
+            .await?
+    else {
+        return Ok(StrictRemoteManifestReadV1::Incomplete(
+            StrictRemoteManifestIncompleteV1::MissingObject,
+        ));
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(StrictRemoteManifestReadV1::Incomplete(
+                StrictRemoteManifestIncompleteV1::UnboundObject,
+            ));
+        }
+    };
+    if manifest_object_id(raw_snapshot.raw_bytes()) != index_entry.manifest_hash() {
+        return Ok(StrictRemoteManifestReadV1::Incomplete(
+            StrictRemoteManifestIncompleteV1::AddressMismatch,
+        ));
+    }
+
+    let parsed = match index_entry.kind() {
+        RemoteEntryKind::RegularFile => {
+            let wire: StrictRegularManifestWireV1 =
+                match serde_json::from_slice(raw_snapshot.raw_bytes()) {
+                    Ok(wire) => wire,
+                    Err(_) => {
+                        return Ok(StrictRemoteManifestReadV1::Incomplete(
+                            StrictRemoteManifestIncompleteV1::InvalidManifest,
+                        ));
+                    }
+                };
+            match strict_regular_manifest_v1(wire, rel_path, index_entry) {
+                Ok(manifest) => ParsedStrictManifestV1::Regular(manifest),
+                Err(_) => {
+                    return Ok(StrictRemoteManifestReadV1::Incomplete(
+                        StrictRemoteManifestIncompleteV1::InvalidManifest,
+                    ));
+                }
+            }
+        }
+        RemoteEntryKind::Symlink => {
+            let wire: StrictSymlinkManifestWireV1 =
+                match serde_json::from_slice(raw_snapshot.raw_bytes()) {
+                    Ok(wire) => wire,
+                    Err(_) => {
+                        return Ok(StrictRemoteManifestReadV1::Incomplete(
+                            StrictRemoteManifestIncompleteV1::InvalidManifest,
+                        ));
+                    }
+                };
+            match strict_symlink_manifest_v1(wire, rel_path, index_entry) {
+                Ok(manifest) => ParsedStrictManifestV1::Symlink(manifest),
+                Err(_) => {
+                    return Ok(StrictRemoteManifestReadV1::Incomplete(
+                        StrictRemoteManifestIncompleteV1::InvalidManifest,
+                    ));
+                }
+            }
+        }
+    };
+    let object = bind_remote_object_v1(raw_snapshot);
+    Ok(StrictRemoteManifestReadV1::Complete(Box::new(
+        match parsed {
+            ParsedStrictManifestV1::Regular(manifest) => {
+                StrictRemoteManifestV1::Regular { object, manifest }
+            }
+            ParsedStrictManifestV1::Symlink(manifest) => {
+                StrictRemoteManifestV1::Symlink { object, manifest }
+            }
+        },
+    )))
+}
+
+enum ParsedStrictManifestV1 {
+    Regular(StrictRegularManifestV1),
+    Symlink(StrictSymlinkManifestV1),
+}
+
+fn strict_regular_manifest_v1(
+    wire: StrictRegularManifestWireV1,
+    rel_path: &str,
+    index_entry: &StrictRemoteIndexEntryV1,
+) -> Result<StrictRegularManifestV1> {
+    const POSIX_FILE_TYPE_MASK: u32 = 0o170000;
+    const POSIX_REGULAR_FILE: u32 = 0o100000;
+    const PORTABLE_PERMISSION_MASK: u32 = 0o777;
+
+    anyhow::ensure!(
+        matches!(wire.version, 2 | 3),
+        "strict regular manifest requires version 2 or 3"
+    );
+    validate_lower_hex_64(&wire.file_hash, "strict regular manifest file digest")?;
+    for chunk in &wire.chunks {
+        validate_lower_hex_64(chunk, "strict regular manifest chunk digest")?;
+    }
+    validate_namespace_logical_path(&wire.rel_path)?;
+    anyhow::ensure!(
+        wire.rel_path == rel_path,
+        "strict regular manifest path does not match index path"
+    );
+    anyhow::ensure!(
+        wire.file_size == index_entry.size()
+            && u64::try_from(wire.chunks.len())
+                .context("strict regular manifest chunk count does not fit u64")?
+                == index_entry.chunks(),
+        "strict regular manifest metadata does not match index entry"
+    );
+    // The current Unix writer serializes `PermissionsExt::mode()`, which
+    // includes S_IFREG, while historical/non-Unix fixtures carry permission
+    // bits alone. Accept those two exact shapes, reject every other file type
+    // and special bit, and expose only the portable permission bits.
+    let mode_file_type = wire.mode & POSIX_FILE_TYPE_MASK;
+    let allowed_mode_bits = PORTABLE_PERMISSION_MASK
+        | if mode_file_type == POSIX_REGULAR_FILE {
+            POSIX_FILE_TYPE_MASK
+        } else {
+            0
+        };
+    anyhow::ensure!(
+        matches!(mode_file_type, 0 | POSIX_REGULAR_FILE) && wire.mode & !allowed_mode_bits == 0,
+        "strict regular manifest mode is not a supported regular-file permission encoding"
+    );
+    let portable_mode = wire.mode & PORTABLE_PERMISSION_MASK;
+    anyhow::ensure!(
+        wire.mtime.1 < 1_000_000_000,
+        "strict regular manifest mtime nanos are out of range"
+    );
+    validate_strict_identity_v1(&wire.written_by, "strict regular manifest writer")?;
+    if let Some(encrypted_file_key) = wire.encrypted_file_key.as_deref() {
+        validate_bounded_control_free_v1(
+            encrypted_file_key,
+            REGISTERED_ROOT_WRAPPED_KEY_MAX_BYTES_V1,
+            "strict regular manifest encrypted key",
+        )?;
+    }
+    let mut recipient_device_ids = BTreeSet::new();
+    for wrapped in &wire.wrapped_file_keys {
+        validate_strict_identity_v1(
+            &wrapped.recipient_device_id,
+            "strict wrapped-key recipient device id",
+        )?;
+        validate_bounded_control_free_v1(
+            &wrapped.recipient,
+            REGISTERED_ROOT_RECIPIENT_MAX_BYTES_V1,
+            "strict wrapped-key recipient",
+        )?;
+        validate_bounded_control_free_v1(
+            &wrapped.algorithm,
+            REGISTERED_ROOT_ALGORITHM_MAX_BYTES_V1,
+            "strict wrapped-key algorithm",
+        )?;
+        validate_bounded_control_free_v1(
+            &wrapped.wrapped_key,
+            REGISTERED_ROOT_WRAPPED_KEY_MAX_BYTES_V1,
+            "strict wrapped-key payload",
+        )?;
+        anyhow::ensure!(
+            recipient_device_ids.insert(wrapped.recipient_device_id.as_str()),
+            "strict regular manifest has duplicate wrapped-key recipient device ids"
+        );
+    }
+    match wire.version {
+        2 => {
+            anyhow::ensure!(
+                wire.wrapped_file_keys.is_empty() || wire.encrypted_file_key.is_some(),
+                "strict v2 dual manifest requires its rollback master-wrapped key"
+            );
+        }
+        3 => {
+            anyhow::ensure!(
+                !wire.wrapped_file_keys.is_empty() && wire.encrypted_file_key.is_none(),
+                "strict v3 per-device manifest requires wraps and forbids a master-wrapped key"
+            );
+        }
+        _ => unreachable!("manifest version was checked above"),
+    }
+    let vclock = wire.vclock.try_into_vector_clock()?;
+    Ok(StrictRegularManifestV1 {
+        file_hash: wire.file_hash,
+        file_size: wire.file_size,
+        chunks: wire.chunks,
+        vclock,
+        written_by: wire.written_by,
+        written_at: wire.written_at,
+        rel_path: wire.rel_path,
+        mode: portable_mode,
+        mtime: wire.mtime,
+    })
+}
+
+fn strict_symlink_manifest_v1(
+    wire: StrictSymlinkManifestWireV1,
+    rel_path: &str,
+    index_entry: &StrictRemoteIndexEntryV1,
+) -> Result<StrictSymlinkManifestV1> {
+    anyhow::ensure!(
+        wire.version == 3 && wire.kind == RemoteEntryKind::Symlink,
+        "strict symlink manifest requires version 3 symlink kind"
+    );
+    anyhow::ensure!(
+        !wire.symlink_target.is_empty()
+            && !wire.symlink_target.chars().any(char::is_control)
+            && index_entry.symlink_target() == Some(wire.symlink_target.as_str()),
+        "strict symlink manifest target does not match index entry"
+    );
+    crate::engine::validate_indexed_symlink_target(Path::new(rel_path), &wire.symlink_target)?;
+    validate_namespace_logical_path(&wire.rel_path)?;
+    anyhow::ensure!(
+        wire.rel_path == rel_path,
+        "strict symlink manifest path does not match index path"
+    );
+    validate_strict_identity_v1(&wire.written_by, "strict symlink manifest writer")?;
+    let vclock = wire.vclock.try_into_vector_clock()?;
+    Ok(StrictSymlinkManifestV1 {
+        symlink_target: wire.symlink_target,
+        vclock,
+        written_by: wire.written_by,
+        written_at: wire.written_at,
+        rel_path: wire.rel_path,
+    })
+}
+
+fn validate_lower_hex_64(value: &str, description: &str) -> Result<()> {
+    validate_storage_key_component(value, description)?;
+    anyhow::ensure!(
+        value.len() == 64
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "{description} must be 64 lowercase hexadecimal characters"
+    );
+    Ok(())
+}
+
+fn validate_bounded_control_free_v1(
+    value: &str,
+    max_bytes: usize,
+    description: &str,
+) -> Result<()> {
+    anyhow::ensure!(
+        !value.is_empty() && value.len() <= max_bytes && !value.chars().any(char::is_control),
+        "{description} must be non-empty, control-free, and at most {max_bytes} bytes"
+    );
+    Ok(())
+}
+
+fn validate_strict_identity_v1(value: &str, description: &str) -> Result<()> {
+    validate_bounded_control_free_v1(value, REGISTERED_ROOT_IDENTITY_MAX_BYTES_V1, description)?;
+    anyhow::ensure!(
+        value.nfc().collect::<String>() == value,
+        "{description} must use Unicode NFC spelling"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal::raw::{Access, AccessorInfo, OpRead, OpStat, RpRead, RpStat};
+    use opendal::services::Memory;
+    use opendal::{Buffer, Capability, EntryMode, ErrorKind, Metadata, OperatorBuilder};
+    use std::sync::Arc;
+
+    fn directory_inventory(
+        path: &Path,
+    ) -> Vec<(String, bool, u64, std::time::SystemTime, Vec<u8>)> {
+        let mut inventory = std::fs::read_dir(path)
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                let metadata = std::fs::symlink_metadata(entry.path()).unwrap();
+                let bytes = if metadata.is_file() {
+                    std::fs::read(entry.path()).unwrap()
+                } else {
+                    Vec::new()
+                };
+                (
+                    entry.file_name().to_string_lossy().into_owned(),
+                    metadata.is_dir(),
+                    metadata.len(),
+                    metadata.modified().unwrap(),
+                    bytes,
+                )
+            })
+            .collect::<Vec<_>>();
+        inventory.sort_by(|left, right| left.0.cmp(&right.0));
+        inventory
+    }
+
+    async fn object_inventory(op: &Operator) -> BTreeMap<String, Vec<u8>> {
+        let mut inventory = BTreeMap::new();
+        for entry in op.list_with("").recursive(true).await.unwrap() {
+            if entry.path().ends_with('/') {
+                continue;
+            }
+            inventory.insert(
+                entry.path().to_owned(),
+                op.read(entry.path()).await.unwrap().to_vec(),
+            );
+        }
+        inventory
+    }
+
+    fn write_private(path: &Path, bytes: &[u8]) {
+        std::fs::write(path, bytes).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct BoundObjectTestBackend {
+        objects: Arc<BTreeMap<String, Vec<u8>>>,
+        info: Arc<AccessorInfo>,
+    }
+
+    impl Access for BoundObjectTestBackend {
+        type Reader = Buffer;
+        type Writer = ();
+        type Lister = ();
+        type Deleter = ();
+
+        fn info(&self) -> Arc<AccessorInfo> {
+            self.info.clone()
+        }
+
+        async fn stat(&self, path: &str, _: OpStat) -> opendal::Result<RpStat> {
+            let bytes = self.objects.get(path).ok_or_else(|| {
+                opendal::Error::new(ErrorKind::NotFound, "bound test object is missing")
+            })?;
+            Ok(RpStat::new(
+                Metadata::new(EntryMode::FILE)
+                    .with_content_length(bytes.len() as u64)
+                    .with_etag(blake3::hash(bytes).to_hex().to_string()),
+            ))
+        }
+
+        async fn read(&self, path: &str, args: OpRead) -> opendal::Result<(RpRead, Buffer)> {
+            let bytes = self.objects.get(path).ok_or_else(|| {
+                opendal::Error::new(ErrorKind::NotFound, "bound test object is missing")
+            })?;
+            let etag = blake3::hash(bytes).to_hex().to_string();
+            if args.if_match().is_some_and(|expected| expected != etag) {
+                return Err(opendal::Error::new(
+                    ErrorKind::ConditionNotMatch,
+                    "bound test object ETag changed",
+                ));
+            }
+            let range = args.range();
+            let start = usize::try_from(range.offset()).unwrap_or(usize::MAX);
+            let end = range
+                .size()
+                .and_then(|size| usize::try_from(size).ok())
+                .map(|size| start.saturating_add(size))
+                .unwrap_or(bytes.len())
+                .min(bytes.len());
+            let selected = if start <= end {
+                bytes[start..end].to_vec()
+            } else {
+                Vec::new()
+            };
+            Ok((
+                RpRead::new().with_size(Some(selected.len() as u64)),
+                Buffer::from(selected),
+            ))
+        }
+    }
+
+    fn bound_object_test_operator(objects: BTreeMap<String, Vec<u8>>) -> Operator {
+        let info = AccessorInfo::default();
+        info.set_scheme("registered-root-bound-test")
+            .set_root("/")
+            .set_name("registered-root-bound-test")
+            .set_native_capability(Capability {
+                stat: true,
+                read: true,
+                read_with_if_match: true,
+                ..Default::default()
+            });
+        OperatorBuilder::new(BoundObjectTestBackend {
+            objects: Arc::new(objects),
+            info: Arc::new(info),
+        })
+        .finish()
+    }
+
+    fn valid_state_json(local_root: &Path, status: &str) -> Vec<u8> {
+        let cache_key = local_root.join("file").to_string_lossy().into_owned();
+        format!(
+            r#"{{
+  "last_nats_seq": 7,
+  "device_id": "sting",
+  "entries": {{
+    "{cache_key}": {{
+      "blake3": "{digest}",
+      "size": 4,
+      "mtime": 5,
+      "chunk_count": 1,
+      "remote_path": "roots/manifests/{manifest_id}",
+      "last_synced": 6,
+      "vclock": {{ "clocks": {{ "sting": 1 }} }},
+      "device_id": "sting",
+      "status": "{status}"
+    }}
+  }}
+}}"#,
+            digest = "a".repeat(64),
+            manifest_id = "b".repeat(64),
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn strict_primary_accepts_current_shape_and_rejects_legacy_unknown_and_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let local_root = dir.path().join("root");
+        std::fs::create_dir(&local_root).unwrap();
+        let local_root = std::fs::canonicalize(local_root).unwrap();
+        write_private(&path, &valid_state_json(&local_root, "synced"));
+        let before_inventory = directory_inventory(dir.path());
+        let snapshot =
+            match read_and_bind_strict_primary_state_v1(&path, &local_root, "roots").unwrap() {
+                StrictPrimaryStateReadV1::Complete(snapshot) => snapshot,
+                other => panic!("expected strict state snapshot, got {other:?}"),
+            };
+        assert_eq!(snapshot.last_nats_seq(), 7);
+        assert_eq!(snapshot.device_id(), "sting");
+        assert_eq!(snapshot.entries().len(), 1);
+        let entry = &snapshot.entries()["file"];
+        assert_eq!(entry.rel_path(), "file");
+        assert_eq!(entry.index_key(), "roots/index/file");
+        assert_eq!(
+            entry.baseline_manifest_key(),
+            format!("roots/manifests/{}", "b".repeat(64))
+        );
+        assert_ne!(
+            entry.baseline_manifest_key().rsplit('/').next().unwrap(),
+            entry.state().blake3()
+        );
+        assert_eq!(directory_inventory(dir.path()), before_inventory);
+
+        write_private(&path, br#"{"/tmp/file":{"blake3":"legacy"}}"#);
+        assert!(matches!(
+            read_and_bind_strict_primary_state_v1(&path, &local_root, "roots").unwrap(),
+            StrictPrimaryStateReadV1::Incomplete(StrictPrimaryStateIncompleteV1::InvalidPrimary)
+        ));
+
+        let mut unknown = String::from_utf8(valid_state_json(&local_root, "synced")).unwrap();
+        unknown = unknown.replacen(
+            "\"last_nats_seq\": 7,",
+            "\"last_nats_seq\": 7, \"unexpected\": true,",
+            1,
+        );
+        write_private(&path, unknown.as_bytes());
+        assert!(matches!(
+            read_and_bind_strict_primary_state_v1(&path, &local_root, "roots").unwrap(),
+            StrictPrimaryStateReadV1::Incomplete(StrictPrimaryStateIncompleteV1::InvalidPrimary)
+        ));
+
+        write_private(&path, &valid_state_json(&local_root, "active"));
+        let active_key = local_root.join("file").to_string_lossy().into_owned();
+        assert!(matches!(
+            read_and_bind_strict_primary_state_v1(&path, &local_root, "roots").unwrap(),
+            StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::PersistedEntriesBusy {
+                    active_keys,
+                    locked_keys
+                }
+            ) if active_keys == vec![active_key] && locked_keys.is_empty()
+        ));
+    }
+
+    #[test]
+    fn strict_primary_rejects_duplicate_entry_and_clock_keys() {
+        let entry = format!(
+            r#"{{
+  "blake3": "{digest}",
+  "size": 1,
+  "mtime": 2,
+  "chunk_count": 1,
+  "remote_path": "roots/file",
+  "last_synced": 3,
+  "vclock": {{ "clocks": {{ "sting": 1 }} }},
+  "device_id": "sting",
+  "status": "synced"
+}}"#,
+            digest = "d".repeat(64)
+        );
+        let duplicate_entries = format!(
+            r#"{{
+  "last_nats_seq": 0,
+  "device_id": "sting",
+  "entries": {{ "same": {entry}, "same": {entry} }}
+}}"#
+        );
+        assert!(serde_json::from_str::<StrictStateCacheWireV1>(&duplicate_entries).is_err());
+
+        let duplicate_clock = String::from_utf8(valid_state_json(Path::new("/tmp"), "synced"))
+            .unwrap()
+            .replacen("\"sting\": 1", "\"sting\": 1, \"sting\": 2", 1);
+        assert!(serde_json::from_str::<StrictStateCacheWireV1>(&duplicate_clock).is_err());
+    }
+
+    #[test]
+    fn strict_primary_rejects_semantic_clock_status_and_route_contradictions() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let local_root = dir.path().join("root");
+        std::fs::create_dir(&local_root).unwrap();
+        let local_root = std::fs::canonicalize(local_root).unwrap();
+
+        let zero_clock = String::from_utf8(valid_state_json(&local_root, "synced"))
+            .unwrap()
+            .replacen("\"sting\": 1", "\"sting\": 0", 1);
+        write_private(&state_path, zero_clock.as_bytes());
+        assert!(matches!(
+            read_and_bind_strict_primary_state_v1(&state_path, &local_root, "roots").unwrap(),
+            StrictPrimaryStateReadV1::Incomplete(StrictPrimaryStateIncompleteV1::InvalidPrimary)
+        ));
+
+        write_private(&state_path, &valid_state_json(&local_root, "conflict"));
+        assert!(matches!(
+            read_and_bind_strict_primary_state_v1(&state_path, &local_root, "roots").unwrap(),
+            StrictPrimaryStateReadV1::Incomplete(StrictPrimaryStateIncompleteV1::InvalidPrimary)
+        ));
+
+        let wrong_route = String::from_utf8(valid_state_json(&local_root, "synced"))
+            .unwrap()
+            .replacen(
+                &format!("roots/manifests/{}", "b".repeat(64)),
+                "roots/index/file",
+                1,
+            );
+        write_private(&state_path, wrong_route.as_bytes());
+        assert!(matches!(
+            read_and_bind_strict_primary_state_v1(&state_path, &local_root, "roots").unwrap(),
+            StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::InvalidRootBinding
+            )
+        ));
+    }
+
+    #[test]
+    fn strict_primary_binds_conflict_pin_and_rejects_portable_aliases() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let local_root = dir.path().join("root");
+        std::fs::create_dir(&local_root).unwrap();
+        let local_root = std::fs::canonicalize(local_root).unwrap();
+
+        let mut conflict: serde_json::Value =
+            serde_json::from_slice(&valid_state_json(&local_root, "synced")).unwrap();
+        let cache_key = local_root.join("file").to_string_lossy().into_owned();
+        let state = &mut conflict["entries"][&cache_key];
+        state["status"] = serde_json::json!("conflict");
+        state["conflict"] = serde_json::json!({
+            "rel_path": "file",
+            "local_vclock": { "clocks": { "sting": 2 } },
+            "remote_vclock": { "clocks": { "neo": 3 } },
+            "local_blake3": "c".repeat(64),
+            "remote_blake3": "d".repeat(64),
+            "local_device": "sting",
+            "remote_device": "neo",
+            "detected_at": 10,
+            "times_recorded": 2,
+            "remote_manifest_key": format!("roots/manifests/{}", "e".repeat(64))
+        });
+        write_private(&state_path, &serde_json::to_vec(&conflict).unwrap());
+        let snapshot =
+            match read_and_bind_strict_primary_state_v1(&state_path, &local_root, "roots").unwrap()
+            {
+                StrictPrimaryStateReadV1::Complete(snapshot) => snapshot,
+                other => panic!("expected bound conflict state, got {other:?}"),
+            };
+        assert_ne!(
+            snapshot.entries()["file"].baseline_manifest_key(),
+            snapshot.entries()["file"]
+                .state()
+                .conflict()
+                .unwrap()
+                .remote_manifest_key
+                .as_deref()
+                .unwrap()
+        );
+
+        let mut aliases: serde_json::Value =
+            serde_json::from_slice(&valid_state_json(&local_root, "synced")).unwrap();
+        let original = aliases["entries"]
+            .as_object_mut()
+            .unwrap()
+            .remove(&cache_key)
+            .unwrap();
+        aliases["entries"][local_root.join("Foo").to_string_lossy().as_ref()] = original.clone();
+        aliases["entries"][local_root.join("foo").to_string_lossy().as_ref()] = original;
+        write_private(&state_path, &serde_json::to_vec(&aliases).unwrap());
+        assert!(matches!(
+            read_and_bind_strict_primary_state_v1(&state_path, &local_root, "roots").unwrap(),
+            StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::InvalidRootBinding
+            )
+        ));
+    }
+
+    #[test]
+    fn strict_index_parser_classifies_versioned_records_and_rejects_unknowns() {
+        let manifest_hash = "b".repeat(64);
+        let committed = format!(
+            r#"{{
+  "version": 2,
+  "state": "committed",
+  "current": {{
+    "manifest_hash": "{manifest_hash}",
+    "size": 4,
+    "chunks": 1
+  }},
+  "pending": null
+}}"#
+        );
+        assert!(matches!(
+            parse_strict_index_record_v1(committed.as_bytes()).unwrap(),
+            ParsedStrictIndexRecordV1::Committed {
+                format: StrictIndexRecordFormatV1::Version2,
+                ..
+            }
+        ));
+
+        let preparing = committed.replace("\"committed\"", "\"preparing\"").replace(
+            "\"pending\": null",
+            &format!(
+                r#""pending": {{
+    "manifest_hash": "{manifest_hash}",
+    "size": 4,
+    "chunks": 1,
+    "staged_manifest_key": "roots/staging/object"
+  }}"#
+            ),
+        );
+        assert!(matches!(
+            parse_strict_index_record_v1(preparing.as_bytes()).unwrap(),
+            ParsedStrictIndexRecordV1::Preparing { .. }
+        ));
+
+        let unknown = committed.replacen("\"version\": 2,", "\"version\": 2, \"extra\": 1,", 1);
+        assert!(parse_strict_index_record_v1(unknown.as_bytes()).is_err());
+        assert!(parse_strict_index_record_v1(b"manifest_hash=legacy\n").is_err());
+    }
+
+    fn regular_manifest_json(rel_path: &str) -> Vec<u8> {
+        format!(
+            r#"{{
+  "version": 2,
+  "file_hash": "{file_hash}",
+  "file_size": 4,
+  "chunks": ["{chunk_hash}"],
+  "vclock": {{ "clocks": {{ "sting": 1 }} }},
+  "written_by": "sting",
+  "written_at": 7,
+  "rel_path": "{rel_path}",
+  "mode": 420,
+  "mtime": [8, 9]
+}}"#,
+            file_hash = "d".repeat(64),
+            chunk_hash = "e".repeat(64),
+        )
+        .into_bytes()
+    }
+
+    fn committed_index_for_test(index: StrictRemoteIndexEntryV1) -> RawCommittedIndexEntryV1 {
+        RawCommittedIndexEntryV1 {
+            object: BoundRemoteObjectSnapshotV1 {
+                raw_bytes_len: 0,
+                raw_blake3: *blake3::hash(b"test-index-proof").as_bytes(),
+                binding: RegisteredRootRemoteObjectBindingV1::Version {
+                    version: "test-version".to_owned(),
+                    etag: Some("test-etag".to_owned()),
+                },
+            },
+            current: index,
+            format: StrictIndexRecordFormatV1::Version2,
+            route: RegisteredRootRemoteIndexRouteV1 {
+                remote_prefix: "roots".to_owned(),
+                rel_path: "file".to_owned(),
+                index_key: "roots/index/file".to_owned(),
+            },
+        }
+    }
+
+    #[test]
+    fn strict_manifest_requires_exact_current_metadata_shape() {
+        let manifest_hash = "f".repeat(64);
+        let index = StrictRemoteIndexEntryV1 {
+            manifest_hash,
+            size: 4,
+            chunks: 1,
+            kind: RemoteEntryKind::RegularFile,
+            symlink_target: None,
+        };
+        let bytes = regular_manifest_json("file");
+        let wire: StrictRegularManifestWireV1 = serde_json::from_slice(&bytes).unwrap();
+        let manifest = strict_regular_manifest_v1(wire, "file", &index).unwrap();
+        assert_eq!(manifest.file_size(), 4);
+        assert_eq!(manifest.mode(), 0o644);
+        assert_eq!(manifest.mtime(), (8, 9));
+
+        let unknown = String::from_utf8(bytes.clone()).unwrap().replacen(
+            "\"version\": 2,",
+            "\"version\": 2, \"extra\": true,",
+            1,
+        );
+        assert!(serde_json::from_str::<StrictRegularManifestWireV1>(&unknown).is_err());
+        let missing_mode = String::from_utf8(bytes)
+            .unwrap()
+            .replace("  \"mode\": 420,\n", "");
+        assert!(serde_json::from_str::<StrictRegularManifestWireV1>(&missing_mode).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strict_regular_manifest_accepts_and_normalizes_actual_unix_writer_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("writer-mode");
+        std::fs::write(&file, b"test").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o640)).unwrap();
+        let writer_mode = std::fs::metadata(&file).unwrap().permissions().mode();
+        assert_eq!(writer_mode & 0o170000, 0o100000);
+
+        let index = StrictRemoteIndexEntryV1 {
+            manifest_hash: "f".repeat(64),
+            size: 4,
+            chunks: 1,
+            kind: RemoteEntryKind::RegularFile,
+            symlink_target: None,
+        };
+        let mut writer_manifest: serde_json::Value =
+            serde_json::from_slice(&regular_manifest_json("file")).unwrap();
+        writer_manifest["mode"] = serde_json::json!(writer_mode);
+        let manifest = strict_regular_manifest_v1(
+            serde_json::from_value(writer_manifest).unwrap(),
+            "file",
+            &index,
+        )
+        .unwrap();
+        assert_eq!(manifest.mode(), 0o640);
+
+        for rejected in [0o040640_u32, 0o120640, 0o100640 | 0o4000] {
+            let mut invalid: serde_json::Value =
+                serde_json::from_slice(&regular_manifest_json("file")).unwrap();
+            invalid["mode"] = serde_json::json!(rejected);
+            assert!(
+                strict_regular_manifest_v1(
+                    serde_json::from_value(invalid).unwrap(),
+                    "file",
+                    &index,
+                )
+                .is_err(),
+                "mode {rejected:o} must fail closed"
+            );
+        }
+    }
+
+    #[test]
+    fn strict_regular_manifest_accepts_master_dual_and_per_device_shapes_only() {
+        let index = StrictRemoteIndexEntryV1 {
+            manifest_hash: "f".repeat(64),
+            size: 4,
+            chunks: 1,
+            kind: RemoteEntryKind::RegularFile,
+            symlink_target: None,
+        };
+        let base: serde_json::Value =
+            serde_json::from_slice(&regular_manifest_json("file")).unwrap();
+        let wrapped = serde_json::json!([{
+            "recipient_device_id": "sting",
+            "recipient": "age1recipient",
+            "algorithm": "age-x25519-v1",
+            "wrapped_key": "wrapped"
+        }]);
+
+        let mut master = base.clone();
+        master["encrypted_file_key"] = serde_json::json!("master");
+        assert!(strict_regular_manifest_v1(
+            serde_json::from_value(master).unwrap(),
+            "file",
+            &index
+        )
+        .is_ok());
+
+        let mut dual = base.clone();
+        dual["encrypted_file_key"] = serde_json::json!("master");
+        dual["wrapped_file_keys"] = wrapped.clone();
+        assert!(
+            strict_regular_manifest_v1(serde_json::from_value(dual).unwrap(), "file", &index)
+                .is_ok()
+        );
+
+        let mut invalid_dual = base.clone();
+        invalid_dual["wrapped_file_keys"] = wrapped.clone();
+        assert!(strict_regular_manifest_v1(
+            serde_json::from_value(invalid_dual).unwrap(),
+            "file",
+            &index
+        )
+        .is_err());
+
+        let mut per_device = base.clone();
+        per_device["version"] = serde_json::json!(3);
+        per_device["wrapped_file_keys"] = wrapped.clone();
+        assert!(strict_regular_manifest_v1(
+            serde_json::from_value(per_device.clone()).unwrap(),
+            "file",
+            &index
+        )
+        .is_ok());
+
+        per_device["encrypted_file_key"] = serde_json::json!("master");
+        assert!(strict_regular_manifest_v1(
+            serde_json::from_value(per_device).unwrap(),
+            "file",
+            &index
+        )
+        .is_err());
+
+        let mut duplicate = base;
+        duplicate["encrypted_file_key"] = serde_json::json!("master");
+        duplicate["wrapped_file_keys"] = serde_json::json!([
+            {
+                "recipient_device_id": "sting",
+                "recipient": "age1a",
+                "algorithm": "age-x25519-v1",
+                "wrapped_key": "a"
+            },
+            {
+                "recipient_device_id": "sting",
+                "recipient": "age1b",
+                "algorithm": "age-x25519-v1",
+                "wrapped_key": "b"
+            }
+        ]);
+        assert!(strict_regular_manifest_v1(
+            serde_json::from_value(duplicate).unwrap(),
+            "file",
+            &index
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn strict_symlink_manifest_preserves_safe_target_and_rejects_escape() {
+        let index = StrictRemoteIndexEntryV1 {
+            manifest_hash: "f".repeat(64),
+            size: 6,
+            chunks: 0,
+            kind: RemoteEntryKind::Symlink,
+            symlink_target: Some("target".to_owned()),
+        };
+        let wire: StrictSymlinkManifestWireV1 = serde_json::from_value(serde_json::json!({
+            "version": 3,
+            "kind": "symlink",
+            "symlink_target": "target",
+            "vclock": { "clocks": { "sting": 1 } },
+            "written_by": "sting",
+            "written_at": 7,
+            "rel_path": "dir/link"
+        }))
+        .unwrap();
+        assert!(strict_symlink_manifest_v1(wire, "dir/link", &index).is_ok());
+
+        let escaping_index = StrictRemoteIndexEntryV1 {
+            symlink_target: Some("../../escape".to_owned()),
+            size: 12,
+            ..index
+        };
+        let escaping: StrictSymlinkManifestWireV1 = serde_json::from_value(serde_json::json!({
+            "version": 3,
+            "kind": "symlink",
+            "symlink_target": "../../escape",
+            "vclock": { "clocks": { "sting": 1 } },
+            "written_by": "sting",
+            "written_at": 7,
+            "rel_path": "dir/link"
+        }))
+        .unwrap();
+        assert!(strict_symlink_manifest_v1(escaping, "dir/link", &escaping_index).is_err());
+    }
+
+    #[tokio::test]
+    async fn strict_index_read_marks_unbound_memory_incomplete_without_writes() {
+        let op = Operator::new(Memory::default()).unwrap().finish();
+        let manifest_hash = "c".repeat(64);
+        let record = format!(
+            r#"{{"version":2,"state":"committed","current":{{"manifest_hash":"{manifest_hash}","size":0,"chunks":0}},"pending":null}}"#
+        );
+        op.write("roots/index/file", record.clone()).await.unwrap();
+        let before = object_inventory(&op).await;
+
+        assert!(matches!(
+            read_exact_raw_index_entry_v1(&op, "roots", "file")
+                .await
+                .unwrap(),
+            ExactRawIndexEntryReadV1::Incomplete(StrictRemoteIndexIncompleteV1::UnboundObject)
+        ));
+        assert_eq!(object_inventory(&op).await, before);
+    }
+
+    #[tokio::test]
+    async fn strict_bound_index_read_reports_preparing_without_object_evidence() {
+        let manifest_hash = "c".repeat(64);
+        let record = format!(
+            r#"{{
+  "version": 2,
+  "state": "preparing",
+  "current": null,
+  "pending": {{
+    "manifest_hash": "{manifest_hash}",
+    "size": 4,
+    "chunks": 1,
+    "staged_manifest_key": "roots/staging/object"
+  }}
+}}"#
+        )
+        .into_bytes();
+        let op =
+            bound_object_test_operator(BTreeMap::from([("roots/index/file".to_owned(), record)]));
+
+        assert_eq!(
+            read_exact_raw_index_entry_v1(&op, "roots", "file")
+                .await
+                .unwrap(),
+            ExactRawIndexEntryReadV1::Incomplete(StrictRemoteIndexIncompleteV1::PreparingObserved)
+        );
+    }
+
+    #[tokio::test]
+    async fn strict_manifest_read_derives_the_committed_index_route() {
+        let manifest_bytes = regular_manifest_json("dir/file");
+        let manifest_hash = manifest_object_id(&manifest_bytes);
+        let index_record = format!(
+            r#"{{
+  "version": 2,
+  "state": "committed",
+  "current": {{
+    "manifest_hash": "{manifest_hash}",
+    "size": 4,
+    "chunks": 1
+  }},
+  "pending": null
+}}"#
+        )
+        .into_bytes();
+        let op = bound_object_test_operator(BTreeMap::from([
+            ("roots/index/dir/file".to_owned(), index_record),
+            (format!("roots/manifests/{manifest_hash}"), manifest_bytes),
+        ]));
+
+        let committed = match read_exact_raw_index_entry_v1(&op, "roots", "dir/file")
+            .await
+            .unwrap()
+        {
+            ExactRawIndexEntryReadV1::Committed(committed) => committed,
+            other => panic!("expected route-bound committed index, got {other:?}"),
+        };
+        assert_eq!(committed.route().remote_prefix(), "roots");
+        assert_eq!(committed.route().rel_path(), "dir/file");
+        assert_eq!(committed.route().index_key(), "roots/index/dir/file");
+
+        let manifest = read_strict_remote_manifest_v1(&op, &committed)
+            .await
+            .unwrap();
+        assert!(matches!(
+            manifest,
+            StrictRemoteManifestReadV1::Complete(manifest)
+                if matches!(
+                    manifest.as_ref(),
+                    StrictRemoteManifestV1::Regular { manifest, .. }
+                        if manifest.rel_path() == "dir/file"
+                )
+        ));
+    }
+
+    #[tokio::test]
+    async fn strict_manifest_refuses_unbound_completion_without_reading_bytes() {
+        let op = Operator::new(Memory::default()).unwrap().finish();
+        let bytes = regular_manifest_json("file");
+        let object_id = manifest_object_id(&bytes);
+        let object_key = format!("roots/manifests/{object_id}");
+        op.write(&object_key, bytes.clone()).await.unwrap();
+        let before_unbound = object_inventory(&op).await;
+        let index = committed_index_for_test(StrictRemoteIndexEntryV1 {
+            manifest_hash: object_id.clone(),
+            size: 4,
+            chunks: 1,
+            kind: RemoteEntryKind::RegularFile,
+            symlink_target: None,
+        });
+        assert!(matches!(
+            read_strict_remote_manifest_v1(&op, &index).await.unwrap(),
+            StrictRemoteManifestReadV1::Incomplete(StrictRemoteManifestIncompleteV1::UnboundObject)
+        ));
+        assert_eq!(object_inventory(&op).await, before_unbound);
+
+        let legacy_file_hash = "d".repeat(64);
+        let legacy_key = format!("roots/manifests/{legacy_file_hash}");
+        op.write(&legacy_key, bytes.clone()).await.unwrap();
+        let before_legacy = object_inventory(&op).await;
+        let legacy_index = committed_index_for_test(StrictRemoteIndexEntryV1 {
+            manifest_hash: legacy_file_hash.clone(),
+            size: 4,
+            chunks: 1,
+            kind: RemoteEntryKind::RegularFile,
+            symlink_target: None,
+        });
+        assert!(matches!(
+            read_strict_remote_manifest_v1(&op, &legacy_index)
+                .await
+                .unwrap(),
+            StrictRemoteManifestReadV1::Incomplete(StrictRemoteManifestIncompleteV1::UnboundObject)
+        ));
+        assert_eq!(object_inventory(&op).await, before_legacy);
+    }
+}

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -1310,7 +1310,7 @@ impl StrictRegularManifestV1 {
     }
 }
 
-fn validate_registered_remote_logical_path_bounds_v1(rel_path: &str) -> Result<()> {
+pub(crate) fn validate_registered_remote_logical_path_bounds_v1(rel_path: &str) -> Result<()> {
     validate_namespace_logical_path(rel_path)?;
     let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
     anyhow::ensure!(

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::marker::PhantomData;
 use std::path::Path;
+use tcfs_core::config::RegisteredRootPlanContractV1;
 use unicode_normalization::UnicodeNormalization;
 
 use crate::blacklist::Blacklist;
@@ -29,8 +30,6 @@ use crate::state::{
     read_primary_state_bytes_read_only_v1, FileSyncStatus, ReadOnlyPrimaryStateBytesV1,
 };
 
-const REGISTERED_ROOT_INDEX_MAX_BYTES_V1: u64 = 1024 * 1024;
-const REGISTERED_ROOT_MANIFEST_MAX_BYTES_V1: u64 = 16 * 1024 * 1024;
 const REGISTERED_ROOT_IDENTITY_MAX_BYTES_V1: usize = 512;
 const REGISTERED_ROOT_RECIPIENT_MAX_BYTES_V1: usize = 1024;
 const REGISTERED_ROOT_ALGORITHM_MAX_BYTES_V1: usize = 128;
@@ -108,7 +107,17 @@ struct StrictVectorClockWireV1 {
 
 impl StrictVectorClockWireV1 {
     fn try_into_vector_clock(self) -> Result<VectorClock> {
+        self.try_into_vector_clock_bounded(u64::MAX)
+    }
+
+    fn try_into_vector_clock_bounded(self, max_entries: u64) -> Result<VectorClock> {
         let clocks = self.clocks.into_inner();
+        anyhow::ensure!(
+            u64::try_from(clocks.len())
+                .context("strict vector-clock entry count does not fit u64")?
+                <= max_entries,
+            "strict vector clock exceeds its entry bound"
+        );
         for (device_id, counter) in &clocks {
             validate_strict_identity_v1(device_id, "strict vector-clock device id")?;
             anyhow::ensure!(*counter > 0, "strict vector-clock counters must be nonzero");
@@ -262,7 +271,10 @@ impl StrictSyncStateV1 {
 impl StrictSyncStateWireV1 {
     fn into_state(self) -> Result<StrictSyncStateV1> {
         validate_lower_hex_64(&self.blake3, "strict state content digest")?;
-        validate_relative_storage_key(&self.remote_path, "strict state remote path")?;
+        validate_registered_remote_storage_key_bounds_v1(
+            &self.remote_path,
+            "strict state remote path",
+        )?;
         validate_strict_identity_v1(&self.device_id, "strict state device id")?;
         let vclock = self.vclock.try_into_vector_clock()?;
         anyhow::ensure!(
@@ -270,7 +282,7 @@ impl StrictSyncStateWireV1 {
             "strict state conflict status and payload must be present together"
         );
         if let Some(conflict) = self.conflict.as_ref() {
-            validate_namespace_logical_path(&conflict.rel_path)?;
+            validate_registered_remote_logical_path_bounds_v1(&conflict.rel_path)?;
             validate_lower_hex_64(&conflict.local_blake3, "strict conflict local digest")?;
             validate_lower_hex_64(&conflict.remote_blake3, "strict conflict remote digest")?;
             validate_strict_identity_v1(&conflict.local_device, "strict conflict local device id")?;
@@ -279,7 +291,10 @@ impl StrictSyncStateWireV1 {
                 "strict conflict remote device id",
             )?;
             if let Some(key) = conflict.remote_manifest_key.0.as_deref() {
-                validate_relative_storage_key(key, "strict conflict remote manifest key")?;
+                validate_registered_remote_storage_key_bounds_v1(
+                    key,
+                    "strict conflict remote manifest key",
+                )?;
             }
         }
         Ok(StrictSyncStateV1 {
@@ -540,6 +555,7 @@ fn bind_strict_state_entries_v1(
         !prefix.is_empty(),
         "strict state root binding requires a non-empty remote prefix"
     );
+    validate_registered_remote_storage_key_bounds_v1(prefix, "strict state remote prefix")?;
 
     let mut namespace_claims: BTreeMap<String, (String, PortableNamespaceRole)> = BTreeMap::new();
     let mut entries = BTreeMap::new();
@@ -567,6 +583,7 @@ fn bind_strict_state_entries_v1(
 
         reserve_state_namespace_claims_v1(&rel_path, &mut namespace_claims)?;
         let index_key = format!("{prefix}/index/{rel_path}");
+        validate_registered_remote_storage_key_bounds_v1(&index_key, "strict state index key")?;
         let entry = BoundStrictSyncStateV1 {
             rel_path: rel_path.clone(),
             index_key,
@@ -606,7 +623,7 @@ fn bind_strict_cache_key_v1(
         .to_str()
         .context("strict state relative path is not valid UTF-8")?
         .to_owned();
-    validate_namespace_logical_path(&rel_path)?;
+    validate_registered_remote_logical_path_bounds_v1(&rel_path)?;
     anyhow::ensure!(
         canonical_local_root.join(&rel_path) == cache_path,
         "strict state cache key does not round-trip through its selected root"
@@ -626,6 +643,7 @@ fn bind_strict_cache_key_v1(
 }
 
 fn validate_exact_manifest_key_v1<'a>(remote_prefix: &str, key: &'a str) -> Result<&'a str> {
+    validate_registered_remote_storage_key_bounds_v1(key, "strict state manifest key")?;
     let manifest_prefix = format!("{remote_prefix}/manifests/");
     let object_id = key
         .strip_prefix(&manifest_prefix)
@@ -769,7 +787,7 @@ impl StrictPendingIndexEntryV1 {
 
 impl StrictPendingIndexEntryWireV1 {
     fn into_entry(self) -> Result<StrictPendingIndexEntryV1> {
-        validate_relative_storage_key(
+        validate_registered_remote_storage_key_bounds_v1(
             &self.staged_manifest_key,
             "strict pending staged manifest key",
         )?;
@@ -806,6 +824,7 @@ fn strict_remote_entry_v1(
             let target = symlink_target
                 .as_deref()
                 .context("strict symlink index entry requires target")?;
+            validate_registered_symlink_target_bound_v1(target)?;
             anyhow::ensure!(
                 !target.is_empty() && !target.chars().any(char::is_control),
                 "strict symlink index target must be non-empty and control-free"
@@ -1027,7 +1046,7 @@ fn parse_strict_index_record_v1(bytes: &[u8]) -> Result<ParsedStrictIndexRecordV
     let deletion_evidence = wire
         .deletion_evidence
         .map(|evidence| -> Result<DeletionEvidence> {
-            validate_relative_storage_key(
+            validate_registered_remote_storage_key_bounds_v1(
                 &evidence.safety_copy_key,
                 "strict deletion safety-copy key",
             )?;
@@ -1133,15 +1152,16 @@ pub async fn read_exact_raw_index_entry_v1(
     rel_path: &str,
 ) -> Result<ExactRawIndexEntryReadV1> {
     let prefix = validate_canonical_namespace_remote_prefix(remote_prefix)?;
-    validate_namespace_logical_path(rel_path)?;
+    validate_registered_remote_logical_path_bounds_v1(rel_path)?;
     let index_key = if prefix.is_empty() {
         format!("index/{rel_path}")
     } else {
         format!("{prefix}/index/{rel_path}")
     };
-    let Some(raw_read) =
-        read_raw_object_snapshot_v1(op, &index_key, REGISTERED_ROOT_INDEX_MAX_BYTES_V1).await?
-    else {
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_index_object_bytes();
+    let Some(raw_read) = read_raw_object_snapshot_v1(op, &index_key, max_bytes).await? else {
         return Ok(ExactRawIndexEntryReadV1::Missing);
     };
     let raw_snapshot = match raw_read {
@@ -1290,6 +1310,54 @@ impl StrictRegularManifestV1 {
     }
 }
 
+fn validate_registered_remote_logical_path_bounds_v1(rel_path: &str) -> Result<()> {
+    validate_namespace_logical_path(rel_path)?;
+    let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    anyhow::ensure!(
+        u64::try_from(rel_path.len())
+            .context("strict remote logical-path length does not fit u64")?
+            <= remote_contract.max_logical_path_bytes(),
+        "strict remote logical path exceeds the registered-root byte bound: {rel_path:?}"
+    );
+    anyhow::ensure!(
+        u32::try_from(rel_path.split('/').count())
+            .context("strict remote logical-path depth does not fit u32")?
+            <= remote_contract.max_logical_path_depth(),
+        "strict remote logical path exceeds the registered-root depth bound: {rel_path:?}"
+    );
+    anyhow::ensure!(
+        rel_path.split('/').all(|component| {
+            u64::try_from(component.len())
+                .is_ok_and(|length| length <= remote_contract.max_logical_component_bytes())
+        }),
+        "strict remote logical path exceeds the portable component-byte bound: {rel_path:?}"
+    );
+    Ok(())
+}
+
+fn validate_registered_remote_storage_key_bounds_v1(key: &str, description: &str) -> Result<()> {
+    validate_relative_storage_key(key, description)?;
+    anyhow::ensure!(
+        u64::try_from(key.len()).context("strict remote storage-key length does not fit u64")?
+            <= RegisteredRootPlanContractV1::strict_v1()
+                .remote_contract()
+                .max_storage_key_bytes(),
+        "{description} exceeds the registered-root storage-key byte bound"
+    );
+    Ok(())
+}
+
+fn validate_registered_symlink_target_bound_v1(target: &str) -> Result<()> {
+    anyhow::ensure!(
+        u64::try_from(target.len()).context("strict symlink target length does not fit u64")?
+            <= RegisteredRootPlanContractV1::strict_v1()
+                .local_snapshot_contract()
+                .max_symlink_target_bytes(),
+        "strict remote symlink target exceeds the local snapshot byte bound"
+    );
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StrictSymlinkManifestV1 {
     symlink_target: String,
@@ -1380,10 +1448,10 @@ pub async fn read_strict_remote_manifest_v1(
     } else {
         format!("{prefix}/manifests/{}", index_entry.manifest_hash())
     };
-    let Some(raw_read) =
-        read_raw_object_snapshot_v1(op, &manifest_key, REGISTERED_ROOT_MANIFEST_MAX_BYTES_V1)
-            .await?
-    else {
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_manifest_object_bytes();
+    let Some(raw_read) = read_raw_object_snapshot_v1(op, &manifest_key, max_bytes).await? else {
         return Ok(StrictRemoteManifestReadV1::Incomplete(
             StrictRemoteManifestIncompleteV1::MissingObject,
         ));
@@ -1468,16 +1536,29 @@ fn strict_regular_manifest_v1(
     const POSIX_FILE_TYPE_MASK: u32 = 0o170000;
     const POSIX_REGULAR_FILE: u32 = 0o100000;
     const PORTABLE_PERMISSION_MASK: u32 = 0o777;
+    let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
 
     anyhow::ensure!(
         matches!(wire.version, 2 | 3),
         "strict regular manifest requires version 2 or 3"
     );
+    anyhow::ensure!(
+        u64::try_from(wire.chunks.len())
+            .context("strict regular manifest chunk count does not fit u64")?
+            <= remote_contract.max_manifest_chunk_entries(),
+        "strict regular manifest exceeds the chunk-entry bound"
+    );
+    anyhow::ensure!(
+        u64::try_from(wire.wrapped_file_keys.len())
+            .context("strict regular manifest wrapped-key count does not fit u64")?
+            <= remote_contract.max_manifest_wrapped_key_entries(),
+        "strict regular manifest exceeds the wrapped-key entry bound"
+    );
     validate_lower_hex_64(&wire.file_hash, "strict regular manifest file digest")?;
     for chunk in &wire.chunks {
         validate_lower_hex_64(chunk, "strict regular manifest chunk digest")?;
     }
-    validate_namespace_logical_path(&wire.rel_path)?;
+    validate_registered_remote_logical_path_bounds_v1(&wire.rel_path)?;
     anyhow::ensure!(
         wire.rel_path == rel_path,
         "strict regular manifest path does not match index path"
@@ -1558,7 +1639,9 @@ fn strict_regular_manifest_v1(
         }
         _ => unreachable!("manifest version was checked above"),
     }
-    let vclock = wire.vclock.try_into_vector_clock()?;
+    let vclock = wire
+        .vclock
+        .try_into_vector_clock_bounded(remote_contract.max_remote_vector_clock_entries())?;
     Ok(StrictRegularManifestV1 {
         file_hash: wire.file_hash,
         file_size: wire.file_size,
@@ -1577,6 +1660,7 @@ fn strict_symlink_manifest_v1(
     rel_path: &str,
     index_entry: &StrictRemoteIndexEntryV1,
 ) -> Result<StrictSymlinkManifestV1> {
+    let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
     anyhow::ensure!(
         wire.version == 3 && wire.kind == RemoteEntryKind::Symlink,
         "strict symlink manifest requires version 3 symlink kind"
@@ -1587,14 +1671,17 @@ fn strict_symlink_manifest_v1(
             && index_entry.symlink_target() == Some(wire.symlink_target.as_str()),
         "strict symlink manifest target does not match index entry"
     );
+    validate_registered_symlink_target_bound_v1(&wire.symlink_target)?;
     crate::engine::validate_indexed_symlink_target(Path::new(rel_path), &wire.symlink_target)?;
-    validate_namespace_logical_path(&wire.rel_path)?;
+    validate_registered_remote_logical_path_bounds_v1(&wire.rel_path)?;
     anyhow::ensure!(
         wire.rel_path == rel_path,
         "strict symlink manifest path does not match index path"
     );
     validate_strict_identity_v1(&wire.written_by, "strict symlink manifest writer")?;
-    let vclock = wire.vclock.try_into_vector_clock()?;
+    let vclock = wire
+        .vclock
+        .try_into_vector_clock_bounded(remote_contract.max_remote_vector_clock_entries())?;
     Ok(StrictSymlinkManifestV1 {
         symlink_target: wire.symlink_target,
         vclock,
@@ -2085,6 +2172,34 @@ mod tests {
             parse_strict_index_record_v1(preparing.as_bytes()).unwrap(),
             ParsedStrictIndexRecordV1::Preparing { .. }
         ));
+        let overlong_key = "k".repeat(
+            usize::try_from(
+                RegisteredRootPlanContractV1::strict_v1()
+                    .remote_contract()
+                    .max_storage_key_bytes()
+                    + 1,
+            )
+            .unwrap(),
+        );
+        assert!(parse_strict_index_record_v1(
+            preparing
+                .replace("roots/staging/object", &overlong_key)
+                .as_bytes()
+        )
+        .is_err());
+        let deleted_with_overlong_evidence = format!(
+            r#"{{
+  "version": 4,
+  "state": "deleted",
+  "current": null,
+  "pending": null,
+  "deletion_evidence": {{
+    "safety_copy_key": "{overlong_key}",
+    "safety_copy_blake3": "{manifest_hash}"
+  }}
+}}"#
+        );
+        assert!(parse_strict_index_record_v1(deleted_with_overlong_evidence.as_bytes()).is_err());
 
         let unknown = committed.replacen("\"version\": 2,", "\"version\": 2, \"extra\": 1,", 1);
         assert!(parse_strict_index_record_v1(unknown.as_bytes()).is_err());
@@ -2329,6 +2444,122 @@ mod tests {
         }))
         .unwrap();
         assert!(strict_symlink_manifest_v1(escaping, "dir/link", &escaping_index).is_err());
+    }
+
+    #[test]
+    fn strict_remote_routes_enforce_path_depth_and_storage_key_bounds() {
+        let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let exact_path = [
+            "a".repeat(255),
+            "b".repeat(255),
+            "c".repeat(255),
+            "d".repeat(254),
+            "e".to_owned(),
+        ]
+        .join("/");
+        assert_eq!(
+            u64::try_from(exact_path.len()).unwrap(),
+            remote_contract.max_logical_path_bytes()
+        );
+        assert!(validate_registered_remote_logical_path_bounds_v1(&exact_path).is_ok());
+        assert!(
+            validate_registered_remote_logical_path_bounds_v1(&format!("{exact_path}a")).is_err()
+        );
+        let overlong_component =
+            "a".repeat(usize::try_from(remote_contract.max_logical_component_bytes() + 1).unwrap());
+        assert!(validate_registered_remote_logical_path_bounds_v1(&overlong_component).is_err());
+
+        let over_depth = std::iter::repeat_n(
+            "a",
+            usize::try_from(remote_contract.max_logical_path_depth() + 1).unwrap(),
+        )
+        .collect::<Vec<_>>()
+        .join("/");
+        assert!(validate_registered_remote_logical_path_bounds_v1(&over_depth).is_err());
+
+        let exact_key =
+            "k".repeat(usize::try_from(remote_contract.max_storage_key_bytes()).unwrap());
+        assert!(
+            validate_registered_remote_storage_key_bounds_v1(&exact_key, "test storage key")
+                .is_ok()
+        );
+        assert!(validate_registered_remote_storage_key_bounds_v1(
+            &format!("{exact_key}k"),
+            "test storage key"
+        )
+        .is_err());
+
+        let overlong_target = "t".repeat(
+            usize::try_from(
+                RegisteredRootPlanContractV1::strict_v1()
+                    .local_snapshot_contract()
+                    .max_symlink_target_bytes()
+                    + 1,
+            )
+            .unwrap(),
+        );
+        assert!(strict_remote_entry_v1(
+            "f".repeat(64),
+            u64::try_from(overlong_target.len()).unwrap(),
+            0,
+            Some(RemoteEntryKind::Symlink),
+            Some(overlong_target),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn strict_remote_manifest_enforces_decoded_collection_bounds() {
+        let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let wrapped_file_keys = (0..=remote_contract.max_manifest_wrapped_key_entries())
+            .map(|index| StrictWrappedFileKeyWireV1 {
+                recipient_device_id: format!("device-{index}"),
+                recipient: "age1test".to_owned(),
+                algorithm: "age-x25519-v1".to_owned(),
+                wrapped_key: "wrapped".to_owned(),
+            })
+            .collect();
+        let wire = StrictRegularManifestWireV1 {
+            version: 2,
+            file_hash: "f".repeat(64),
+            file_size: 0,
+            chunks: Vec::new(),
+            vclock: StrictVectorClockWireV1 {
+                clocks: UniqueBTreeMap(BTreeMap::from([("sting".to_owned(), 1)])),
+            },
+            written_by: "sting".to_owned(),
+            written_at: 1,
+            rel_path: "file".to_owned(),
+            mode: 0o644,
+            mtime: (1, 0),
+            encrypted_file_key: Some("master".to_owned()),
+            wrapped_file_keys,
+        };
+        let index = StrictRemoteIndexEntryV1 {
+            manifest_hash: "m".repeat(64),
+            size: 0,
+            chunks: 0,
+            kind: RemoteEntryKind::RegularFile,
+            symlink_target: None,
+        };
+        let error = strict_regular_manifest_v1(wire, "file", &index).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("wrapped-key entry bound"),
+            "{error:#}"
+        );
+
+        let clocks = (0..=remote_contract.max_remote_vector_clock_entries())
+            .map(|index| (format!("device-{index}"), 1))
+            .collect();
+        let error = StrictVectorClockWireV1 {
+            clocks: UniqueBTreeMap(clocks),
+        }
+        .try_into_vector_clock_bounded(remote_contract.max_remote_vector_clock_entries())
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("vector clock exceeds"),
+            "{error:#}"
+        );
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -925,18 +925,22 @@ pub enum StrictIndexRecordFormatV1 {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegisteredRootRemoteIndexRouteV1 {
-    remote_prefix: String,
-    rel_path: String,
     index_key: String,
+    remote_prefix_len: usize,
+    index_rel_offset: usize,
 }
 
 impl RegisteredRootRemoteIndexRouteV1 {
     pub fn remote_prefix(&self) -> &str {
-        &self.remote_prefix
+        self.index_key
+            .get(..self.remote_prefix_len)
+            .expect("bound index prefix offset is an internal invariant")
     }
 
     pub fn rel_path(&self) -> &str {
-        &self.rel_path
+        self.index_key
+            .get(self.index_rel_offset..)
+            .expect("bound index relative-path offset is an internal invariant")
     }
 
     pub fn index_key(&self) -> &str {
@@ -1014,6 +1018,17 @@ pub enum StrictRemoteIndexIncompleteV1 {
 pub enum ExactRawIndexEntryReadV1 {
     Missing,
     Incomplete(StrictRemoteIndexIncompleteV1),
+    Deleted(RawDeletedIndexEntryV1),
+    Committed(RawCommittedIndexEntryV1),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExactObservedRawIndexEntryReadV1 {
+    Missing,
+    Incomplete {
+        reason: StrictRemoteIndexIncompleteV1,
+        observed_object: Option<BoundRemoteObjectSnapshotV1>,
+    },
     Deleted(RawDeletedIndexEntryV1),
     Committed(RawCommittedIndexEntryV1),
 }
@@ -1162,6 +1177,27 @@ pub async fn read_exact_raw_index_entry_v1(
     remote_prefix: &str,
     rel_path: &str,
 ) -> Result<ExactRawIndexEntryReadV1> {
+    Ok(
+        match read_exact_observed_raw_index_entry_v1(op, remote_prefix, rel_path).await? {
+            ExactObservedRawIndexEntryReadV1::Missing => ExactRawIndexEntryReadV1::Missing,
+            ExactObservedRawIndexEntryReadV1::Incomplete { reason, .. } => {
+                ExactRawIndexEntryReadV1::Incomplete(reason)
+            }
+            ExactObservedRawIndexEntryReadV1::Deleted(index) => {
+                ExactRawIndexEntryReadV1::Deleted(index)
+            }
+            ExactObservedRawIndexEntryReadV1::Committed(index) => {
+                ExactRawIndexEntryReadV1::Committed(index)
+            }
+        },
+    )
+}
+
+pub(crate) async fn read_exact_observed_raw_index_entry_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    rel_path: &str,
+) -> Result<ExactObservedRawIndexEntryReadV1> {
     let suffix_bytes = "index/"
         .len()
         .checked_add(rel_path.len())
@@ -1182,14 +1218,15 @@ pub async fn read_exact_raw_index_entry_v1(
         .remote_contract()
         .max_index_object_bytes();
     let Some(raw_read) = read_raw_object_snapshot_v1(op, &index_key, max_bytes).await? else {
-        return Ok(ExactRawIndexEntryReadV1::Missing);
+        return Ok(ExactObservedRawIndexEntryReadV1::Missing);
     };
     let raw_snapshot = match raw_read {
         RawObjectReadV1::Bound(snapshot) => snapshot,
         RawObjectReadV1::Unbound => {
-            return Ok(ExactRawIndexEntryReadV1::Incomplete(
-                StrictRemoteIndexIncompleteV1::UnboundObject,
-            ));
+            return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
+                reason: StrictRemoteIndexIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
         }
     };
     let parsed = match parse_strict_index_record_v1(raw_snapshot.raw_bytes()) {
@@ -1199,31 +1236,38 @@ pub async fn read_exact_raw_index_entry_v1(
             parsed
         }
         Err(_) => {
-            return Ok(ExactRawIndexEntryReadV1::Incomplete(
-                StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
-            ));
+            return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
+                reason: StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
+                observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+            });
         }
         Ok(_) => {
-            return Ok(ExactRawIndexEntryReadV1::Incomplete(
-                StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
-            ));
+            return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
+                reason: StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
+                observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+            });
         }
     };
     if matches!(&parsed, ParsedStrictIndexRecordV1::Preparing { .. }) {
-        return Ok(ExactRawIndexEntryReadV1::Incomplete(
-            StrictRemoteIndexIncompleteV1::PreparingObserved,
-        ));
+        return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
+            reason: StrictRemoteIndexIncompleteV1::PreparingObserved,
+            observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+        });
     }
     let object = bind_remote_object_v1(raw_snapshot);
+    let index_rel_offset = index_key
+        .len()
+        .checked_sub(rel_path.len())
+        .expect("validated index key must end with its relative path");
     let route = RegisteredRootRemoteIndexRouteV1 {
-        remote_prefix: prefix.to_owned(),
-        rel_path: rel_path.to_owned(),
         index_key,
+        remote_prefix_len: prefix.len(),
+        index_rel_offset,
     };
 
     Ok(match parsed {
         ParsedStrictIndexRecordV1::Deleted { deletion_evidence } => {
-            ExactRawIndexEntryReadV1::Deleted(RawDeletedIndexEntryV1 {
+            ExactObservedRawIndexEntryReadV1::Deleted(RawDeletedIndexEntryV1 {
                 object,
                 deletion_evidence,
                 route,
@@ -1233,7 +1277,7 @@ pub async fn read_exact_raw_index_entry_v1(
             unreachable!("preparing records return incomplete before binding object evidence")
         }
         ParsedStrictIndexRecordV1::Committed { current, format } => {
-            ExactRawIndexEntryReadV1::Committed(RawCommittedIndexEntryV1 {
+            ExactObservedRawIndexEntryReadV1::Committed(RawCommittedIndexEntryV1 {
                 object,
                 current,
                 format,
@@ -1338,6 +1382,17 @@ pub(crate) enum ExactRawDirectoryMarkerReadV1 {
     Deleted(RawDeletedDirectoryMarkerV1),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExactObservedRawDirectoryMarkerReadV1 {
+    Missing,
+    Incomplete {
+        reason: StrictRemoteDirectoryMarkerIncompleteV1,
+        observed_object: Option<BoundRemoteObjectSnapshotV1>,
+    },
+    Live(RawLiveDirectoryMarkerV1),
+    Deleted(RawDeletedDirectoryMarkerV1),
+}
+
 /// Read one listed directory-marker candidate by storage identity.
 ///
 /// The only accepted live body is [`DIRECTORY_MARKER_BYTES`]. The only
@@ -1349,6 +1404,29 @@ pub(crate) async fn read_exact_raw_directory_marker_v1(
     remote_prefix: &str,
     logical_dir: &str,
 ) -> Result<ExactRawDirectoryMarkerReadV1> {
+    Ok(
+        match read_exact_observed_raw_directory_marker_v1(op, remote_prefix, logical_dir).await? {
+            ExactObservedRawDirectoryMarkerReadV1::Missing => {
+                ExactRawDirectoryMarkerReadV1::Missing
+            }
+            ExactObservedRawDirectoryMarkerReadV1::Incomplete { reason, .. } => {
+                ExactRawDirectoryMarkerReadV1::Incomplete(reason)
+            }
+            ExactObservedRawDirectoryMarkerReadV1::Live(marker) => {
+                ExactRawDirectoryMarkerReadV1::Live(marker)
+            }
+            ExactObservedRawDirectoryMarkerReadV1::Deleted(marker) => {
+                ExactRawDirectoryMarkerReadV1::Deleted(marker)
+            }
+        },
+    )
+}
+
+pub(crate) async fn read_exact_observed_raw_directory_marker_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    logical_dir: &str,
+) -> Result<ExactObservedRawDirectoryMarkerReadV1> {
     let marker_rel_path_bytes = logical_dir
         .len()
         .checked_add("/.tcfs_dir".len())
@@ -1375,14 +1453,15 @@ pub(crate) async fn read_exact_raw_directory_marker_v1(
         .remote_contract()
         .max_index_object_bytes();
     let Some(raw_read) = read_raw_object_snapshot_v1(op, &index_key, max_bytes).await? else {
-        return Ok(ExactRawDirectoryMarkerReadV1::Missing);
+        return Ok(ExactObservedRawDirectoryMarkerReadV1::Missing);
     };
     let raw_snapshot = match raw_read {
         RawObjectReadV1::Bound(snapshot) => snapshot,
         RawObjectReadV1::Unbound => {
-            return Ok(ExactRawDirectoryMarkerReadV1::Incomplete(
-                StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
-            ));
+            return Ok(ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                reason: StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
         }
     };
     let marker_rel_offset = index_key
@@ -1396,7 +1475,7 @@ pub(crate) async fn read_exact_raw_directory_marker_v1(
         logical_rel_len: logical_dir.len(),
     };
     if raw_snapshot.raw_bytes() == DIRECTORY_MARKER_BYTES {
-        return Ok(ExactRawDirectoryMarkerReadV1::Live(
+        return Ok(ExactObservedRawDirectoryMarkerReadV1::Live(
             RawLiveDirectoryMarkerV1 {
                 object: bind_remote_object_v1(raw_snapshot),
                 route,
@@ -1418,12 +1497,13 @@ pub(crate) async fn read_exact_raw_directory_marker_v1(
             }
         }
         _ => {
-            return Ok(ExactRawDirectoryMarkerReadV1::Incomplete(
-                StrictRemoteDirectoryMarkerIncompleteV1::InvalidMarkerRecord,
-            ));
+            return Ok(ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                reason: StrictRemoteDirectoryMarkerIncompleteV1::InvalidMarkerRecord,
+                observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+            });
         }
     };
-    Ok(ExactRawDirectoryMarkerReadV1::Deleted(
+    Ok(ExactObservedRawDirectoryMarkerReadV1::Deleted(
         RawDeletedDirectoryMarkerV1 {
             object: bind_remote_object_v1(raw_snapshot),
             deletion_evidence,
@@ -1486,6 +1566,16 @@ pub(crate) enum ExactNamespaceReservationReadV1 {
     Bound(BoundNamespaceReservationV1),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExactObservedNamespaceReservationReadV1 {
+    Missing,
+    Incomplete {
+        reason: StrictNamespaceReservationIncompleteV1,
+        observed_object: Option<BoundRemoteObjectSnapshotV1>,
+    },
+    Bound(BoundNamespaceReservationV1),
+}
+
 /// Read one listed portable-namespace reservation by storage identity.
 ///
 /// V1 planning accepts only the canonical serialized reservation body whose
@@ -1496,6 +1586,26 @@ pub(crate) async fn read_exact_namespace_reservation_v1(
     remote_prefix: &str,
     object_id: &str,
 ) -> Result<ExactNamespaceReservationReadV1> {
+    Ok(
+        match read_exact_observed_namespace_reservation_v1(op, remote_prefix, object_id).await? {
+            ExactObservedNamespaceReservationReadV1::Missing => {
+                ExactNamespaceReservationReadV1::Missing
+            }
+            ExactObservedNamespaceReservationReadV1::Incomplete { reason, .. } => {
+                ExactNamespaceReservationReadV1::Incomplete(reason)
+            }
+            ExactObservedNamespaceReservationReadV1::Bound(reservation) => {
+                ExactNamespaceReservationReadV1::Bound(reservation)
+            }
+        },
+    )
+}
+
+pub(crate) async fn read_exact_observed_namespace_reservation_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    object_id: &str,
+) -> Result<ExactObservedNamespaceReservationReadV1> {
     let suffix_bytes = ".tcfs-namespace/v1/"
         .len()
         .checked_add(object_id.len())
@@ -1517,14 +1627,15 @@ pub(crate) async fn read_exact_namespace_reservation_v1(
         .remote_contract()
         .max_reservation_object_bytes();
     let Some(raw_read) = read_raw_object_snapshot_v1(op, &object_key, max_bytes).await? else {
-        return Ok(ExactNamespaceReservationReadV1::Missing);
+        return Ok(ExactObservedNamespaceReservationReadV1::Missing);
     };
     let raw_snapshot = match raw_read {
         RawObjectReadV1::Bound(snapshot) => snapshot,
         RawObjectReadV1::Unbound => {
-            return Ok(ExactNamespaceReservationReadV1::Incomplete(
-                StrictNamespaceReservationIncompleteV1::UnboundObject,
-            ));
+            return Ok(ExactObservedNamespaceReservationReadV1::Incomplete {
+                reason: StrictNamespaceReservationIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
         }
     };
     let reservation =
@@ -1539,18 +1650,20 @@ pub(crate) async fn read_exact_namespace_reservation_v1(
                 reservation
             }
             _ => {
-                return Ok(ExactNamespaceReservationReadV1::Incomplete(
-                    StrictNamespaceReservationIncompleteV1::InvalidReservation,
-                ));
+                return Ok(ExactObservedNamespaceReservationReadV1::Incomplete {
+                    reason: StrictNamespaceReservationIncompleteV1::InvalidReservation,
+                    observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+                });
             }
         };
     if namespace_reservation_object_id(reservation.folded_path()) != object_id {
-        return Ok(ExactNamespaceReservationReadV1::Incomplete(
-            StrictNamespaceReservationIncompleteV1::AddressMismatch,
-        ));
+        return Ok(ExactObservedNamespaceReservationReadV1::Incomplete {
+            reason: StrictNamespaceReservationIncompleteV1::AddressMismatch,
+            observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+        });
     }
     let object_id_offset = reservation_prefix.len();
-    Ok(ExactNamespaceReservationReadV1::Bound(
+    Ok(ExactObservedNamespaceReservationReadV1::Bound(
         BoundNamespaceReservationV1 {
             object: bind_remote_object_v1(raw_snapshot),
             object_key,
@@ -1786,6 +1899,15 @@ pub enum StrictRemoteManifestReadV1 {
     Incomplete(StrictRemoteManifestIncompleteV1),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum StrictObservedRemoteManifestReadV1 {
+    Complete(Box<StrictRemoteManifestV1>),
+    Incomplete {
+        reason: StrictRemoteManifestIncompleteV1,
+        observed_object: Option<BoundRemoteObjectSnapshotV1>,
+    },
+}
+
 /// Read the exact manifest object named by one strict committed index entry.
 ///
 /// The object key must equal the domain-addressed manifest bytes literally;
@@ -1794,17 +1916,56 @@ pub async fn read_strict_remote_manifest_v1(
     op: &Operator,
     committed_index: &RawCommittedIndexEntryV1,
 ) -> Result<StrictRemoteManifestReadV1> {
+    Ok(
+        match read_observed_strict_remote_manifest_for_references_v1(op, &[committed_index]).await?
+        {
+            StrictObservedRemoteManifestReadV1::Complete(manifest) => {
+                StrictRemoteManifestReadV1::Complete(manifest)
+            }
+            StrictObservedRemoteManifestReadV1::Incomplete { reason, .. } => {
+                StrictRemoteManifestReadV1::Incomplete(reason)
+            }
+        },
+    )
+}
+
+/// Bind one unique manifest object once and validate it against every index
+/// route that named its content address.
+///
+/// Strict manifests embed their logical route, so a shared object ID across
+/// distinct routes is expected to fail validation. The body is nevertheless
+/// fetched only once and no reference is silently skipped.
+pub(crate) async fn read_observed_strict_remote_manifest_for_references_v1(
+    op: &Operator,
+    committed_indexes: &[&RawCommittedIndexEntryV1],
+) -> Result<StrictObservedRemoteManifestReadV1> {
+    let Some(committed_index) = committed_indexes.first().copied() else {
+        anyhow::bail!("strict remote manifest reference group must be non-empty");
+    };
     let index_entry = committed_index.current();
     let prefix = committed_index.remote_prefix();
     let rel_path = committed_index.rel_path();
-    if Blacklist::default()
-        .check_fixed_ingress_path_components(Path::new(rel_path))
-        .is_some()
-    {
-        return Ok(StrictRemoteManifestReadV1::Incomplete(
-            StrictRemoteManifestIncompleteV1::ExcludedPath,
-        ));
+    for reference in committed_indexes {
+        if reference.remote_prefix() != prefix
+            || reference.current().manifest_hash() != index_entry.manifest_hash()
+        {
+            anyhow::bail!("strict remote manifest reference group mixed roots or object addresses");
+        }
+        if Blacklist::default()
+            .check_fixed_ingress_path_components(Path::new(reference.rel_path()))
+            .is_some()
+        {
+            return Ok(StrictObservedRemoteManifestReadV1::Incomplete {
+                reason: StrictRemoteManifestIncompleteV1::ExcludedPath,
+                observed_object: None,
+            });
+        }
     }
+    let suffix_bytes = "manifests/"
+        .len()
+        .checked_add(index_entry.manifest_hash().len())
+        .context("strict manifest key length overflow")?;
+    validate_registered_remote_derived_key_length_v1(prefix, suffix_bytes, "strict manifest key")?;
     let manifest_key = if prefix.is_empty() {
         format!("manifests/{}", index_entry.manifest_hash())
     } else {
@@ -1814,21 +1975,33 @@ pub async fn read_strict_remote_manifest_v1(
         .remote_contract()
         .max_manifest_object_bytes();
     let Some(raw_read) = read_raw_object_snapshot_v1(op, &manifest_key, max_bytes).await? else {
-        return Ok(StrictRemoteManifestReadV1::Incomplete(
-            StrictRemoteManifestIncompleteV1::MissingObject,
-        ));
+        return Ok(StrictObservedRemoteManifestReadV1::Incomplete {
+            reason: StrictRemoteManifestIncompleteV1::MissingObject,
+            observed_object: None,
+        });
     };
     let raw_snapshot = match raw_read {
         RawObjectReadV1::Bound(snapshot) => snapshot,
         RawObjectReadV1::Unbound => {
-            return Ok(StrictRemoteManifestReadV1::Incomplete(
-                StrictRemoteManifestIncompleteV1::UnboundObject,
-            ));
+            return Ok(StrictObservedRemoteManifestReadV1::Incomplete {
+                reason: StrictRemoteManifestIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
         }
     };
     if manifest_object_id(raw_snapshot.raw_bytes()) != index_entry.manifest_hash() {
-        return Ok(StrictRemoteManifestReadV1::Incomplete(
+        return Ok(observed_manifest_incomplete_after_bound_v1(
             StrictRemoteManifestIncompleteV1::AddressMismatch,
+            raw_snapshot,
+        ));
+    }
+    if committed_indexes
+        .iter()
+        .any(|reference| reference.current().kind() != index_entry.kind())
+    {
+        return Ok(observed_manifest_incomplete_after_bound_v1(
+            StrictRemoteManifestIncompleteV1::InvalidManifest,
+            raw_snapshot,
         ));
     }
 
@@ -1838,16 +2011,18 @@ pub async fn read_strict_remote_manifest_v1(
                 match serde_json::from_slice(raw_snapshot.raw_bytes()) {
                     Ok(wire) => wire,
                     Err(_) => {
-                        return Ok(StrictRemoteManifestReadV1::Incomplete(
+                        return Ok(observed_manifest_incomplete_after_bound_v1(
                             StrictRemoteManifestIncompleteV1::InvalidManifest,
+                            raw_snapshot,
                         ));
                     }
                 };
             match strict_regular_manifest_v1(wire, rel_path, index_entry) {
                 Ok(manifest) => ParsedStrictManifestV1::Regular(manifest),
                 Err(_) => {
-                    return Ok(StrictRemoteManifestReadV1::Incomplete(
+                    return Ok(observed_manifest_incomplete_after_bound_v1(
                         StrictRemoteManifestIncompleteV1::InvalidManifest,
+                        raw_snapshot,
                     ));
                 }
             }
@@ -1857,23 +2032,34 @@ pub async fn read_strict_remote_manifest_v1(
                 match serde_json::from_slice(raw_snapshot.raw_bytes()) {
                     Ok(wire) => wire,
                     Err(_) => {
-                        return Ok(StrictRemoteManifestReadV1::Incomplete(
+                        return Ok(observed_manifest_incomplete_after_bound_v1(
                             StrictRemoteManifestIncompleteV1::InvalidManifest,
+                            raw_snapshot,
                         ));
                     }
                 };
             match strict_symlink_manifest_v1(wire, rel_path, index_entry) {
                 Ok(manifest) => ParsedStrictManifestV1::Symlink(manifest),
                 Err(_) => {
-                    return Ok(StrictRemoteManifestReadV1::Incomplete(
+                    return Ok(observed_manifest_incomplete_after_bound_v1(
                         StrictRemoteManifestIncompleteV1::InvalidManifest,
+                        raw_snapshot,
                     ));
                 }
             }
         }
     };
+    if committed_indexes
+        .iter()
+        .any(|reference| validate_parsed_strict_manifest_reference_v1(&parsed, reference).is_err())
+    {
+        return Ok(observed_manifest_incomplete_after_bound_v1(
+            StrictRemoteManifestIncompleteV1::InvalidManifest,
+            raw_snapshot,
+        ));
+    }
     let object = bind_remote_object_v1(raw_snapshot);
-    Ok(StrictRemoteManifestReadV1::Complete(Box::new(
+    Ok(StrictObservedRemoteManifestReadV1::Complete(Box::new(
         match parsed {
             ParsedStrictManifestV1::Regular(manifest) => {
                 StrictRemoteManifestV1::Regular { object, manifest }
@@ -1885,9 +2071,52 @@ pub async fn read_strict_remote_manifest_v1(
     )))
 }
 
+fn observed_manifest_incomplete_after_bound_v1(
+    reason: StrictRemoteManifestIncompleteV1,
+    raw_snapshot: RawObjectSnapshotV1,
+) -> StrictObservedRemoteManifestReadV1 {
+    StrictObservedRemoteManifestReadV1::Incomplete {
+        reason,
+        observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+    }
+}
+
 enum ParsedStrictManifestV1 {
     Regular(StrictRegularManifestV1),
     Symlink(StrictSymlinkManifestV1),
+}
+
+fn validate_parsed_strict_manifest_reference_v1(
+    parsed: &ParsedStrictManifestV1,
+    committed_index: &RawCommittedIndexEntryV1,
+) -> Result<()> {
+    let index_entry = committed_index.current();
+    let rel_path = committed_index.rel_path();
+    match (parsed, index_entry.kind()) {
+        (ParsedStrictManifestV1::Regular(manifest), RemoteEntryKind::RegularFile) => {
+            anyhow::ensure!(
+                manifest.rel_path() == rel_path
+                    && manifest.file_size() == index_entry.size()
+                    && u64::try_from(manifest.chunks().len())
+                        .context("strict regular manifest chunk count does not fit u64")?
+                        == index_entry.chunks(),
+                "strict regular manifest does not satisfy every index reference"
+            );
+        }
+        (ParsedStrictManifestV1::Symlink(manifest), RemoteEntryKind::Symlink) => {
+            anyhow::ensure!(
+                manifest.rel_path() == rel_path
+                    && index_entry.symlink_target() == Some(manifest.symlink_target()),
+                "strict symlink manifest does not satisfy every index reference"
+            );
+            crate::engine::validate_indexed_symlink_target(
+                Path::new(rel_path),
+                manifest.symlink_target(),
+            )?;
+        }
+        _ => anyhow::bail!("strict manifest kind does not match an index reference"),
+    }
+    Ok(())
 }
 
 fn strict_regular_manifest_v1(
@@ -2626,9 +2855,9 @@ mod tests {
             current: index,
             format: StrictIndexRecordFormatV1::Version2,
             route: RegisteredRootRemoteIndexRouteV1 {
-                remote_prefix: "roots".to_owned(),
-                rel_path: "file".to_owned(),
                 index_key: "roots/index/file".to_owned(),
+                remote_prefix_len: "roots".len(),
+                index_rel_offset: "roots/index/".len(),
             },
         }
     }

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -21,11 +21,12 @@ use crate::conflict::{ConflictInfo, VectorClock};
 use crate::index_entry::portable_casefold_path;
 use crate::index_entry::{
     manifest_object_id, namespace_reservation_object_id, namespace_reservation_prefix,
-    read_raw_object_snapshot_v1, validate_canonical_namespace_remote_prefix,
-    validate_namespace_logical_path, validate_relative_storage_key, validate_storage_key_component,
-    validate_trash_safety_copy_route, DeletionEvidence, IndexEntryState,
-    PortableNamespaceReservationV1, PortableNamespaceRole, RawObjectReadV1, RawObjectSnapshotV1,
-    RemoteEntryKind, DIRECTORY_MARKER_BYTES,
+    read_expected_raw_object_snapshot_v1, read_raw_object_snapshot_v1,
+    validate_canonical_namespace_remote_prefix, validate_namespace_logical_path,
+    validate_relative_storage_key, validate_storage_key_component,
+    validate_trash_safety_copy_route, DeletionEvidence, ExpectedRawObjectBindingV1,
+    IndexEntryState, PortableNamespaceReservationV1, PortableNamespaceRole, RawObjectReadV1,
+    RawObjectSnapshotV1, RemoteEntryKind, DIRECTORY_MARKER_BYTES,
 };
 use crate::registered_local_snapshot::PendingStrictLocalSnapshotV1;
 use crate::state::{
@@ -1037,6 +1038,22 @@ pub enum RegisteredRootRemoteObjectBindingV1 {
     },
 }
 
+pub(crate) fn expected_raw_object_binding_v1(
+    binding: &RegisteredRootRemoteObjectBindingV1,
+) -> ExpectedRawObjectBindingV1<'_> {
+    match binding {
+        RegisteredRootRemoteObjectBindingV1::Version { version, etag } => {
+            ExpectedRawObjectBindingV1::Version {
+                version,
+                etag: etag.as_deref(),
+            }
+        }
+        RegisteredRootRemoteObjectBindingV1::Etag { etag } => {
+            ExpectedRawObjectBindingV1::Etag { etag }
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct BoundRemoteObjectSnapshotV1 {
     raw_bytes_len: u64,
@@ -1375,6 +1392,59 @@ pub(crate) async fn read_exact_observed_raw_index_entry_v1(
     remote_prefix: &str,
     rel_path: &str,
 ) -> Result<ExactObservedRawIndexEntryReadV1> {
+    let route = strict_remote_index_route_v1(remote_prefix, rel_path)?;
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_index_object_bytes();
+    let Some(raw_read) = read_raw_object_snapshot_v1(op, route.index_key(), max_bytes).await?
+    else {
+        return Ok(ExactObservedRawIndexEntryReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
+                reason: StrictRemoteIndexIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
+        }
+    };
+    Ok(classify_observed_raw_index_entry_v1(raw_snapshot, route))
+}
+
+#[allow(dead_code)] // Composed by the catalog-authoritative remote-universe pass.
+pub(crate) async fn read_expected_observed_raw_index_entry_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    rel_path: &str,
+    expected_binding: &RegisteredRootRemoteObjectBindingV1,
+) -> Result<ExactObservedRawIndexEntryReadV1> {
+    let route = strict_remote_index_route_v1(remote_prefix, rel_path)?;
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_index_object_bytes();
+    let expected = expected_raw_object_binding_v1(expected_binding);
+    let Some(raw_read) =
+        read_expected_raw_object_snapshot_v1(op, route.index_key(), max_bytes, expected).await?
+    else {
+        return Ok(ExactObservedRawIndexEntryReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
+                reason: StrictRemoteIndexIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
+        }
+    };
+    Ok(classify_observed_raw_index_entry_v1(raw_snapshot, route))
+}
+
+fn strict_remote_index_route_v1(
+    remote_prefix: &str,
+    rel_path: &str,
+) -> Result<RegisteredRootRemoteIndexRouteV1> {
     let suffix_bytes = "index/"
         .len()
         .checked_add(rel_path.len())
@@ -1391,58 +1461,48 @@ pub(crate) async fn read_exact_observed_raw_index_entry_v1(
     } else {
         format!("{prefix}/index/{rel_path}")
     };
-    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
-        .remote_contract()
-        .max_index_object_bytes();
-    let Some(raw_read) = read_raw_object_snapshot_v1(op, &index_key, max_bytes).await? else {
-        return Ok(ExactObservedRawIndexEntryReadV1::Missing);
-    };
-    let raw_snapshot = match raw_read {
-        RawObjectReadV1::Bound(snapshot) => snapshot,
-        RawObjectReadV1::Unbound => {
-            return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
-                reason: StrictRemoteIndexIncompleteV1::UnboundObject,
-                observed_object: None,
-            });
-        }
-    };
-    let parsed = match parse_strict_index_record_v1(raw_snapshot.raw_bytes()) {
-        Ok(parsed)
-            if validate_strict_index_route_semantics_v1(&parsed, prefix, rel_path).is_ok() =>
-        {
-            parsed
-        }
-        Err(_) => {
-            return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
-                reason: StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
-                observed_object: Some(bind_remote_object_v1(raw_snapshot)),
-            });
-        }
-        Ok(_) => {
-            return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
-                reason: StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
-                observed_object: Some(bind_remote_object_v1(raw_snapshot)),
-            });
-        }
-    };
-    if matches!(&parsed, ParsedStrictIndexRecordV1::Preparing { .. }) {
-        return Ok(ExactObservedRawIndexEntryReadV1::Incomplete {
-            reason: StrictRemoteIndexIncompleteV1::PreparingObserved,
-            observed_object: Some(bind_remote_object_v1(raw_snapshot)),
-        });
-    }
-    let object = bind_remote_object_v1(raw_snapshot);
     let index_rel_offset = index_key
         .len()
         .checked_sub(rel_path.len())
         .expect("validated index key must end with its relative path");
-    let route = RegisteredRootRemoteIndexRouteV1 {
+    Ok(RegisteredRootRemoteIndexRouteV1 {
         index_key,
         remote_prefix_len: prefix.len(),
         index_rel_offset,
-    };
+    })
+}
 
-    Ok(match parsed {
+fn classify_observed_raw_index_entry_v1(
+    raw_snapshot: RawObjectSnapshotV1,
+    route: RegisteredRootRemoteIndexRouteV1,
+) -> ExactObservedRawIndexEntryReadV1 {
+    let parsed = match parse_strict_index_record_v1(raw_snapshot.raw_bytes()) {
+        Ok(parsed)
+            if validate_strict_index_route_semantics_v1(
+                &parsed,
+                route.remote_prefix(),
+                route.rel_path(),
+            )
+            .is_ok() =>
+        {
+            parsed
+        }
+        _ => {
+            return ExactObservedRawIndexEntryReadV1::Incomplete {
+                reason: StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
+                observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+            };
+        }
+    };
+    if matches!(&parsed, ParsedStrictIndexRecordV1::Preparing { .. }) {
+        return ExactObservedRawIndexEntryReadV1::Incomplete {
+            reason: StrictRemoteIndexIncompleteV1::PreparingObserved,
+            observed_object: Some(bind_remote_object_v1(raw_snapshot)),
+        };
+    }
+    let object = bind_remote_object_v1(raw_snapshot);
+
+    match parsed {
         ParsedStrictIndexRecordV1::Deleted { deletion_evidence } => {
             ExactObservedRawIndexEntryReadV1::Deleted(RawDeletedIndexEntryV1 {
                 object,
@@ -1461,7 +1521,7 @@ pub(crate) async fn read_exact_observed_raw_index_entry_v1(
                 route,
             })
         }
-    })
+    }
 }
 
 #[allow(dead_code)] // Composed by the next full list-and-bind pass.
@@ -1604,6 +1664,65 @@ pub(crate) async fn read_exact_observed_raw_directory_marker_v1(
     remote_prefix: &str,
     logical_dir: &str,
 ) -> Result<ExactObservedRawDirectoryMarkerReadV1> {
+    let route = strict_remote_directory_marker_route_v1(remote_prefix, logical_dir)?;
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_index_object_bytes();
+    let Some(raw_read) = read_raw_object_snapshot_v1(op, route.marker_key(), max_bytes).await?
+    else {
+        return Ok(ExactObservedRawDirectoryMarkerReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                reason: StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
+        }
+    };
+    Ok(classify_observed_raw_directory_marker_v1(
+        raw_snapshot,
+        route,
+    ))
+}
+
+#[allow(dead_code)] // Composed by the catalog-authoritative remote-universe pass.
+pub(crate) async fn read_expected_observed_raw_directory_marker_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    logical_dir: &str,
+    expected_binding: &RegisteredRootRemoteObjectBindingV1,
+) -> Result<ExactObservedRawDirectoryMarkerReadV1> {
+    let route = strict_remote_directory_marker_route_v1(remote_prefix, logical_dir)?;
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_index_object_bytes();
+    let expected = expected_raw_object_binding_v1(expected_binding);
+    let Some(raw_read) =
+        read_expected_raw_object_snapshot_v1(op, route.marker_key(), max_bytes, expected).await?
+    else {
+        return Ok(ExactObservedRawDirectoryMarkerReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                reason: StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
+        }
+    };
+    Ok(classify_observed_raw_directory_marker_v1(
+        raw_snapshot,
+        route,
+    ))
+}
+
+fn strict_remote_directory_marker_route_v1(
+    remote_prefix: &str,
+    logical_dir: &str,
+) -> Result<RegisteredRootRemoteDirectoryMarkerRouteV1> {
     let marker_rel_path_bytes = logical_dir
         .len()
         .checked_add("/.tcfs_dir".len())
@@ -1626,38 +1745,27 @@ pub(crate) async fn read_exact_observed_raw_directory_marker_v1(
         format!("{prefix}/index/{marker_rel_path}")
     };
     validate_registered_remote_storage_key_bounds_v1(&index_key, "strict directory-marker key")?;
-    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
-        .remote_contract()
-        .max_index_object_bytes();
-    let Some(raw_read) = read_raw_object_snapshot_v1(op, &index_key, max_bytes).await? else {
-        return Ok(ExactObservedRawDirectoryMarkerReadV1::Missing);
-    };
-    let raw_snapshot = match raw_read {
-        RawObjectReadV1::Bound(snapshot) => snapshot,
-        RawObjectReadV1::Unbound => {
-            return Ok(ExactObservedRawDirectoryMarkerReadV1::Incomplete {
-                reason: StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
-                observed_object: None,
-            });
-        }
-    };
     let marker_rel_offset = index_key
         .len()
         .checked_sub(marker_rel_path.len())
         .expect("validated marker key must end with its relative path");
-    let route = RegisteredRootRemoteDirectoryMarkerRouteV1 {
+    Ok(RegisteredRootRemoteDirectoryMarkerRouteV1 {
         marker_key: index_key,
         remote_prefix_len: prefix.len(),
         marker_rel_offset,
         logical_rel_len: logical_dir.len(),
-    };
+    })
+}
+
+fn classify_observed_raw_directory_marker_v1(
+    raw_snapshot: RawObjectSnapshotV1,
+    route: RegisteredRootRemoteDirectoryMarkerRouteV1,
+) -> ExactObservedRawDirectoryMarkerReadV1 {
     if raw_snapshot.raw_bytes() == DIRECTORY_MARKER_BYTES {
-        return Ok(ExactObservedRawDirectoryMarkerReadV1::Live(
-            RawLiveDirectoryMarkerV1 {
-                object: bind_remote_object_v1(raw_snapshot),
-                route,
-            },
-        ));
+        return ExactObservedRawDirectoryMarkerReadV1::Live(RawLiveDirectoryMarkerV1 {
+            object: bind_remote_object_v1(raw_snapshot),
+            route,
+        });
     }
     let deletion_evidence = match parse_strict_index_record_v1(raw_snapshot.raw_bytes()) {
         Ok(parsed @ ParsedStrictIndexRecordV1::Deleted { .. })
@@ -1674,19 +1782,17 @@ pub(crate) async fn read_exact_observed_raw_directory_marker_v1(
             }
         }
         _ => {
-            return Ok(ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+            return ExactObservedRawDirectoryMarkerReadV1::Incomplete {
                 reason: StrictRemoteDirectoryMarkerIncompleteV1::InvalidMarkerRecord,
                 observed_object: Some(bind_remote_object_v1(raw_snapshot)),
-            });
+            };
         }
     };
-    Ok(ExactObservedRawDirectoryMarkerReadV1::Deleted(
-        RawDeletedDirectoryMarkerV1 {
-            object: bind_remote_object_v1(raw_snapshot),
-            deletion_evidence,
-            route,
-        },
-    ))
+    ExactObservedRawDirectoryMarkerReadV1::Deleted(RawDeletedDirectoryMarkerV1 {
+        object: bind_remote_object_v1(raw_snapshot),
+        deletion_evidence,
+        route,
+    })
 }
 
 #[allow(dead_code)] // Composed by the next full list-and-bind pass.
@@ -1753,6 +1859,23 @@ pub(crate) enum ExactObservedNamespaceReservationReadV1 {
     Bound(BoundNamespaceReservationV1),
 }
 
+struct StrictNamespaceReservationRouteV1 {
+    object_key: String,
+    object_id_offset: usize,
+}
+
+impl StrictNamespaceReservationRouteV1 {
+    fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    fn object_id(&self) -> &str {
+        self.object_key
+            .get(self.object_id_offset..)
+            .expect("strict reservation-key offset is an internal invariant")
+    }
+}
+
 /// Read one listed portable-namespace reservation by storage identity.
 ///
 /// V1 planning accepts only the canonical serialized reservation body whose
@@ -1783,6 +1906,65 @@ pub(crate) async fn read_exact_observed_namespace_reservation_v1(
     remote_prefix: &str,
     object_id: &str,
 ) -> Result<ExactObservedNamespaceReservationReadV1> {
+    let route = strict_namespace_reservation_route_v1(remote_prefix, object_id)?;
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_reservation_object_bytes();
+    let Some(raw_read) = read_raw_object_snapshot_v1(op, route.object_key(), max_bytes).await?
+    else {
+        return Ok(ExactObservedNamespaceReservationReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactObservedNamespaceReservationReadV1::Incomplete {
+                reason: StrictNamespaceReservationIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
+        }
+    };
+    Ok(classify_observed_namespace_reservation_v1(
+        raw_snapshot,
+        route,
+    ))
+}
+
+#[allow(dead_code)] // Composed by the catalog-authoritative remote-universe pass.
+pub(crate) async fn read_expected_observed_namespace_reservation_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    object_id: &str,
+    expected_binding: &RegisteredRootRemoteObjectBindingV1,
+) -> Result<ExactObservedNamespaceReservationReadV1> {
+    let route = strict_namespace_reservation_route_v1(remote_prefix, object_id)?;
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_reservation_object_bytes();
+    let expected = expected_raw_object_binding_v1(expected_binding);
+    let Some(raw_read) =
+        read_expected_raw_object_snapshot_v1(op, route.object_key(), max_bytes, expected).await?
+    else {
+        return Ok(ExactObservedNamespaceReservationReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactObservedNamespaceReservationReadV1::Incomplete {
+                reason: StrictNamespaceReservationIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
+        }
+    };
+    Ok(classify_observed_namespace_reservation_v1(
+        raw_snapshot,
+        route,
+    ))
+}
+
+fn strict_namespace_reservation_route_v1(
+    remote_prefix: &str,
+    object_id: &str,
+) -> Result<StrictNamespaceReservationRouteV1> {
     let suffix_bytes = ".tcfs-namespace/v1/"
         .len()
         .checked_add(object_id.len())
@@ -1800,21 +1982,16 @@ pub(crate) async fn read_exact_observed_namespace_reservation_v1(
         &object_key,
         "strict namespace-reservation key",
     )?;
-    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
-        .remote_contract()
-        .max_reservation_object_bytes();
-    let Some(raw_read) = read_raw_object_snapshot_v1(op, &object_key, max_bytes).await? else {
-        return Ok(ExactObservedNamespaceReservationReadV1::Missing);
-    };
-    let raw_snapshot = match raw_read {
-        RawObjectReadV1::Bound(snapshot) => snapshot,
-        RawObjectReadV1::Unbound => {
-            return Ok(ExactObservedNamespaceReservationReadV1::Incomplete {
-                reason: StrictNamespaceReservationIncompleteV1::UnboundObject,
-                observed_object: None,
-            });
-        }
-    };
+    Ok(StrictNamespaceReservationRouteV1 {
+        object_key,
+        object_id_offset: reservation_prefix.len(),
+    })
+}
+
+fn classify_observed_namespace_reservation_v1(
+    raw_snapshot: RawObjectSnapshotV1,
+    route: StrictNamespaceReservationRouteV1,
+) -> ExactObservedNamespaceReservationReadV1 {
     let reservation =
         match PortableNamespaceReservationV1::from_json_bytes(raw_snapshot.raw_bytes()) {
             Ok(reservation)
@@ -1827,27 +2004,24 @@ pub(crate) async fn read_exact_observed_namespace_reservation_v1(
                 reservation
             }
             _ => {
-                return Ok(ExactObservedNamespaceReservationReadV1::Incomplete {
+                return ExactObservedNamespaceReservationReadV1::Incomplete {
                     reason: StrictNamespaceReservationIncompleteV1::InvalidReservation,
                     observed_object: Some(bind_remote_object_v1(raw_snapshot)),
-                });
+                };
             }
         };
-    if namespace_reservation_object_id(reservation.folded_path()) != object_id {
-        return Ok(ExactObservedNamespaceReservationReadV1::Incomplete {
+    if namespace_reservation_object_id(reservation.folded_path()) != route.object_id() {
+        return ExactObservedNamespaceReservationReadV1::Incomplete {
             reason: StrictNamespaceReservationIncompleteV1::AddressMismatch,
             observed_object: Some(bind_remote_object_v1(raw_snapshot)),
-        });
+        };
     }
-    let object_id_offset = reservation_prefix.len();
-    Ok(ExactObservedNamespaceReservationReadV1::Bound(
-        BoundNamespaceReservationV1 {
-            object: bind_remote_object_v1(raw_snapshot),
-            object_key,
-            object_id_offset,
-            reservation,
-        },
-    ))
+    ExactObservedNamespaceReservationReadV1::Bound(BoundNamespaceReservationV1 {
+        object: bind_remote_object_v1(raw_snapshot),
+        object_key: route.object_key,
+        object_id_offset: route.object_id_offset,
+        reservation,
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -1966,7 +2140,10 @@ pub(crate) fn validate_registered_remote_logical_path_bounds_v1(rel_path: &str) 
     Ok(())
 }
 
-fn validate_registered_remote_storage_key_bounds_v1(key: &str, description: &str) -> Result<()> {
+pub(crate) fn validate_registered_remote_storage_key_bounds_v1(
+    key: &str,
+    description: &str,
+) -> Result<()> {
     validate_relative_storage_key(key, description)?;
     anyhow::ensure!(
         u64::try_from(key.len()).context("strict remote storage-key length does not fit u64")?
@@ -2116,37 +2293,12 @@ pub(crate) async fn read_observed_strict_remote_manifest_for_references_v1(
     op: &Operator,
     committed_indexes: &[&RawCommittedIndexEntryV1],
 ) -> Result<StrictObservedRemoteManifestReadV1> {
-    let Some(committed_index) = committed_indexes.first().copied() else {
-        anyhow::bail!("strict remote manifest reference group must be non-empty");
-    };
-    let index_entry = committed_index.current();
-    let prefix = committed_index.remote_prefix();
-    let rel_path = committed_index.rel_path();
-    for reference in committed_indexes {
-        if reference.remote_prefix() != prefix
-            || reference.current().manifest_hash() != index_entry.manifest_hash()
-        {
-            anyhow::bail!("strict remote manifest reference group mixed roots or object addresses");
-        }
-        if Blacklist::default()
-            .check_fixed_ingress_path_components(Path::new(reference.rel_path()))
-            .is_some()
-        {
-            return Ok(StrictObservedRemoteManifestReadV1::Incomplete {
-                reason: StrictRemoteManifestIncompleteV1::ExcludedPath,
-                observed_object: None,
-            });
-        }
-    }
-    let suffix_bytes = "manifests/"
-        .len()
-        .checked_add(index_entry.manifest_hash().len())
-        .context("strict manifest key length overflow")?;
-    validate_registered_remote_derived_key_length_v1(prefix, suffix_bytes, "strict manifest key")?;
-    let manifest_key = if prefix.is_empty() {
-        format!("manifests/{}", index_entry.manifest_hash())
-    } else {
-        format!("{prefix}/manifests/{}", index_entry.manifest_hash())
+    let Some(manifest_key) = strict_remote_manifest_key_for_references_v1(committed_indexes)?
+    else {
+        return Ok(StrictObservedRemoteManifestReadV1::Incomplete {
+            reason: StrictRemoteManifestIncompleteV1::ExcludedPath,
+            observed_object: None,
+        });
     };
     let max_bytes = RegisteredRootPlanContractV1::strict_v1()
         .remote_contract()
@@ -2166,20 +2318,110 @@ pub(crate) async fn read_observed_strict_remote_manifest_for_references_v1(
             });
         }
     };
+    Ok(classify_observed_strict_remote_manifest_for_references_v1(
+        raw_snapshot,
+        committed_indexes,
+    ))
+}
+
+#[allow(dead_code)] // Composed by the catalog-authoritative remote-universe pass.
+pub(crate) async fn read_expected_observed_strict_remote_manifest_for_references_v1(
+    op: &Operator,
+    committed_indexes: &[&RawCommittedIndexEntryV1],
+    expected_binding: &RegisteredRootRemoteObjectBindingV1,
+) -> Result<StrictObservedRemoteManifestReadV1> {
+    let Some(manifest_key) = strict_remote_manifest_key_for_references_v1(committed_indexes)?
+    else {
+        return Ok(StrictObservedRemoteManifestReadV1::Incomplete {
+            reason: StrictRemoteManifestIncompleteV1::ExcludedPath,
+            observed_object: None,
+        });
+    };
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_manifest_object_bytes();
+    let expected = expected_raw_object_binding_v1(expected_binding);
+    let Some(raw_read) =
+        read_expected_raw_object_snapshot_v1(op, &manifest_key, max_bytes, expected).await?
+    else {
+        return Ok(StrictObservedRemoteManifestReadV1::Incomplete {
+            reason: StrictRemoteManifestIncompleteV1::MissingObject,
+            observed_object: None,
+        });
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(StrictObservedRemoteManifestReadV1::Incomplete {
+                reason: StrictRemoteManifestIncompleteV1::UnboundObject,
+                observed_object: None,
+            });
+        }
+    };
+    Ok(classify_observed_strict_remote_manifest_for_references_v1(
+        raw_snapshot,
+        committed_indexes,
+    ))
+}
+
+fn strict_remote_manifest_key_for_references_v1(
+    committed_indexes: &[&RawCommittedIndexEntryV1],
+) -> Result<Option<String>> {
+    let Some(committed_index) = committed_indexes.first().copied() else {
+        anyhow::bail!("strict remote manifest reference group must be non-empty");
+    };
+    let index_entry = committed_index.current();
+    let prefix = committed_index.remote_prefix();
+    for reference in committed_indexes {
+        if reference.remote_prefix() != prefix
+            || reference.current().manifest_hash() != index_entry.manifest_hash()
+        {
+            anyhow::bail!("strict remote manifest reference group mixed roots or object addresses");
+        }
+        if Blacklist::default()
+            .check_fixed_ingress_path_components(Path::new(reference.rel_path()))
+            .is_some()
+        {
+            return Ok(None);
+        }
+    }
+    let suffix_bytes = "manifests/"
+        .len()
+        .checked_add(index_entry.manifest_hash().len())
+        .context("strict manifest key length overflow")?;
+    validate_registered_remote_derived_key_length_v1(prefix, suffix_bytes, "strict manifest key")?;
+    let manifest_key = if prefix.is_empty() {
+        format!("manifests/{}", index_entry.manifest_hash())
+    } else {
+        format!("{prefix}/manifests/{}", index_entry.manifest_hash())
+    };
+    Ok(Some(manifest_key))
+}
+
+fn classify_observed_strict_remote_manifest_for_references_v1(
+    raw_snapshot: RawObjectSnapshotV1,
+    committed_indexes: &[&RawCommittedIndexEntryV1],
+) -> StrictObservedRemoteManifestReadV1 {
+    let committed_index = committed_indexes
+        .first()
+        .copied()
+        .expect("validated strict remote manifest reference group must be non-empty");
+    let index_entry = committed_index.current();
+    let rel_path = committed_index.rel_path();
     if manifest_object_id(raw_snapshot.raw_bytes()) != index_entry.manifest_hash() {
-        return Ok(observed_manifest_incomplete_after_bound_v1(
+        return observed_manifest_incomplete_after_bound_v1(
             StrictRemoteManifestIncompleteV1::AddressMismatch,
             raw_snapshot,
-        ));
+        );
     }
     if committed_indexes
         .iter()
         .any(|reference| reference.current().kind() != index_entry.kind())
     {
-        return Ok(observed_manifest_incomplete_after_bound_v1(
+        return observed_manifest_incomplete_after_bound_v1(
             StrictRemoteManifestIncompleteV1::InvalidManifest,
             raw_snapshot,
-        ));
+        );
     }
 
     let parsed = match index_entry.kind() {
@@ -2188,19 +2430,19 @@ pub(crate) async fn read_observed_strict_remote_manifest_for_references_v1(
                 match serde_json::from_slice(raw_snapshot.raw_bytes()) {
                     Ok(wire) => wire,
                     Err(_) => {
-                        return Ok(observed_manifest_incomplete_after_bound_v1(
+                        return observed_manifest_incomplete_after_bound_v1(
                             StrictRemoteManifestIncompleteV1::InvalidManifest,
                             raw_snapshot,
-                        ));
+                        );
                     }
                 };
             match strict_regular_manifest_v1(wire, rel_path, index_entry) {
                 Ok(manifest) => ParsedStrictManifestV1::Regular(manifest),
                 Err(_) => {
-                    return Ok(observed_manifest_incomplete_after_bound_v1(
+                    return observed_manifest_incomplete_after_bound_v1(
                         StrictRemoteManifestIncompleteV1::InvalidManifest,
                         raw_snapshot,
-                    ));
+                    );
                 }
             }
         }
@@ -2209,19 +2451,19 @@ pub(crate) async fn read_observed_strict_remote_manifest_for_references_v1(
                 match serde_json::from_slice(raw_snapshot.raw_bytes()) {
                     Ok(wire) => wire,
                     Err(_) => {
-                        return Ok(observed_manifest_incomplete_after_bound_v1(
+                        return observed_manifest_incomplete_after_bound_v1(
                             StrictRemoteManifestIncompleteV1::InvalidManifest,
                             raw_snapshot,
-                        ));
+                        );
                     }
                 };
             match strict_symlink_manifest_v1(wire, rel_path, index_entry) {
                 Ok(manifest) => ParsedStrictManifestV1::Symlink(manifest),
                 Err(_) => {
-                    return Ok(observed_manifest_incomplete_after_bound_v1(
+                    return observed_manifest_incomplete_after_bound_v1(
                         StrictRemoteManifestIncompleteV1::InvalidManifest,
                         raw_snapshot,
-                    ));
+                    );
                 }
             }
         }
@@ -2230,22 +2472,20 @@ pub(crate) async fn read_observed_strict_remote_manifest_for_references_v1(
         .iter()
         .any(|reference| validate_parsed_strict_manifest_reference_v1(&parsed, reference).is_err())
     {
-        return Ok(observed_manifest_incomplete_after_bound_v1(
+        return observed_manifest_incomplete_after_bound_v1(
             StrictRemoteManifestIncompleteV1::InvalidManifest,
             raw_snapshot,
-        ));
+        );
     }
     let object = bind_remote_object_v1(raw_snapshot);
-    Ok(StrictObservedRemoteManifestReadV1::Complete(Box::new(
-        match parsed {
-            ParsedStrictManifestV1::Regular(manifest) => {
-                StrictRemoteManifestV1::Regular { object, manifest }
-            }
-            ParsedStrictManifestV1::Symlink(manifest) => {
-                StrictRemoteManifestV1::Symlink { object, manifest }
-            }
-        },
-    )))
+    StrictObservedRemoteManifestReadV1::Complete(Box::new(match parsed {
+        ParsedStrictManifestV1::Regular(manifest) => {
+            StrictRemoteManifestV1::Regular { object, manifest }
+        }
+        ParsedStrictManifestV1::Symlink(manifest) => {
+            StrictRemoteManifestV1::Symlink { object, manifest }
+        }
+    }))
 }
 
 fn observed_manifest_incomplete_after_bound_v1(

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -24,6 +24,7 @@ use crate::index_entry::{
     DeletionEvidence, IndexEntryState, PortableNamespaceRole, RawObjectReadV1, RawObjectSnapshotV1,
     RemoteEntryKind,
 };
+use crate::registered_local_snapshot::PendingStrictLocalSnapshotV1;
 use crate::state::{
     read_primary_state_bytes_read_only_v1, FileSyncStatus, ReadOnlyPrimaryStateBytesV1,
 };
@@ -377,6 +378,49 @@ pub fn read_and_bind_strict_primary_state_v1(
     canonical_local_root: &Path,
     canonical_remote_prefix: &str,
 ) -> Result<StrictPrimaryStateReadV1> {
+    read_and_bind_strict_primary_state_inner_v1(
+        state_path,
+        canonical_local_root,
+        canonical_remote_prefix,
+        StrictStateRootBindingModeV1::PathnameProbed,
+    )
+}
+
+/// Bind state lexically to the exact spelling owned by a still-live root
+/// capability.
+///
+/// The pending capability authenticates and retains the selected root
+/// spelling. Descendant topology and file/directory role proof remain a
+/// mandatory cross-input composition step. Probing cache-key parents by
+/// pathname here would reintroduce a second, racy authority path and would
+/// reject valid remote-only paths whose parents do not exist locally yet.
+#[allow(dead_code)] // Becomes live when the strict remote-universe constructor lands.
+pub(crate) fn read_and_bind_strict_primary_state_for_pending_root_v1(
+    state_path: &Path,
+    pending_local: &PendingStrictLocalSnapshotV1,
+    canonical_remote_prefix: &str,
+) -> Result<StrictPrimaryStateReadV1> {
+    read_and_bind_strict_primary_state_inner_v1(
+        state_path,
+        pending_local.canonical_local_root(),
+        canonical_remote_prefix,
+        StrictStateRootBindingModeV1::HeldDescriptor,
+    )
+}
+
+#[allow(dead_code)] // HeldDescriptor is exercised now and composed in the next source-only slice.
+#[derive(Clone, Copy)]
+enum StrictStateRootBindingModeV1 {
+    PathnameProbed,
+    HeldDescriptor,
+}
+
+fn read_and_bind_strict_primary_state_inner_v1(
+    state_path: &Path,
+    canonical_local_root: &Path,
+    canonical_remote_prefix: &str,
+    binding_mode: StrictStateRootBindingModeV1,
+) -> Result<StrictPrimaryStateReadV1> {
     let raw_snapshot = match read_primary_state_bytes_read_only_v1(state_path)? {
         ReadOnlyPrimaryStateBytesV1::Missing => {
             return Ok(StrictPrimaryStateReadV1::Incomplete(
@@ -441,6 +485,7 @@ pub fn read_and_bind_strict_primary_state_v1(
         raw_entries,
         canonical_local_root,
         canonical_remote_prefix,
+        binding_mode,
     ) {
         Ok(entries) => entries,
         Err(_) => {
@@ -466,23 +511,26 @@ fn bind_strict_state_entries_v1(
     raw_entries: BTreeMap<String, StrictSyncStateV1>,
     canonical_local_root: &Path,
     canonical_remote_prefix: &str,
+    binding_mode: StrictStateRootBindingModeV1,
 ) -> Result<BTreeMap<String, BoundStrictSyncStateV1>> {
     anyhow::ensure!(
         canonical_local_root.is_absolute(),
         "strict state root binding requires an absolute local root"
     );
-    let observed_root = std::fs::canonicalize(canonical_local_root)
-        .context("canonicalizing strict state local root")?;
-    anyhow::ensure!(
-        observed_root == canonical_local_root,
-        "strict state local root input is not its canonical spelling"
-    );
-    anyhow::ensure!(
-        std::fs::symlink_metadata(canonical_local_root)
-            .context("inspecting strict state local root")?
-            .is_dir(),
-        "strict state local root is not a directory"
-    );
+    if matches!(binding_mode, StrictStateRootBindingModeV1::PathnameProbed) {
+        let observed_root = std::fs::canonicalize(canonical_local_root)
+            .context("canonicalizing strict state local root")?;
+        anyhow::ensure!(
+            observed_root == canonical_local_root,
+            "strict state local root input is not its canonical spelling"
+        );
+        anyhow::ensure!(
+            std::fs::symlink_metadata(canonical_local_root)
+                .context("inspecting strict state local root")?
+                .is_dir(),
+            "strict state local root is not a directory"
+        );
+    }
     canonical_local_root
         .to_str()
         .context("strict state local root is not valid UTF-8")?;
@@ -496,7 +544,7 @@ fn bind_strict_state_entries_v1(
     let mut namespace_claims: BTreeMap<String, (String, PortableNamespaceRole)> = BTreeMap::new();
     let mut entries = BTreeMap::new();
     for (cache_key, state) in raw_entries {
-        let rel_path = bind_strict_cache_key_v1(&cache_key, canonical_local_root)?;
+        let rel_path = bind_strict_cache_key_v1(&cache_key, canonical_local_root, binding_mode)?;
         if Blacklist::default()
             .check_fixed_ingress_path_components(Path::new(&rel_path))
             .is_some()
@@ -533,7 +581,11 @@ fn bind_strict_state_entries_v1(
     Ok(entries)
 }
 
-fn bind_strict_cache_key_v1(cache_key: &str, canonical_local_root: &Path) -> Result<String> {
+fn bind_strict_cache_key_v1(
+    cache_key: &str,
+    canonical_local_root: &Path,
+    binding_mode: StrictStateRootBindingModeV1,
+) -> Result<String> {
     anyhow::ensure!(
         !cache_key.is_empty()
             && !cache_key.ends_with('/')
@@ -559,14 +611,17 @@ fn bind_strict_cache_key_v1(cache_key: &str, canonical_local_root: &Path) -> Res
         canonical_local_root.join(&rel_path) == cache_path,
         "strict state cache key does not round-trip through its selected root"
     );
-    let parent = cache_path
-        .parent()
-        .context("strict state cache key has no parent")?;
-    anyhow::ensure!(
-        std::fs::canonicalize(parent).context("canonicalizing strict state cache-key parent")?
-            == parent,
-        "strict state cache-key parent is missing or uses an alternate path"
-    );
+    if matches!(binding_mode, StrictStateRootBindingModeV1::PathnameProbed) {
+        let parent = cache_path
+            .parent()
+            .context("strict state cache key has no parent")?;
+        anyhow::ensure!(
+            std::fs::canonicalize(parent)
+                .context("canonicalizing strict state cache-key parent")?
+                == parent,
+            "strict state cache-key parent is missing or uses an alternate path"
+        );
+    }
     Ok(rel_path)
 }
 
@@ -1799,6 +1854,65 @@ mod tests {
                     locked_keys
                 }
             ) if active_keys == vec![active_key] && locked_keys.is_empty()
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn pending_root_binds_missing_local_parent_without_pathname_reprobe() {
+        use crate::registered_local_snapshot::{
+            begin_strict_local_snapshot_v1, StrictLocalSnapshotFinishV1,
+            StrictLocalSnapshotHoldReadV1,
+        };
+        use tcfs_core::config::RootProfileV1;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let local_root = dir.path().join("root");
+        std::fs::create_dir(&local_root).unwrap();
+        let local_root = std::fs::canonicalize(local_root).unwrap();
+        let old_key = local_root.join("file").to_string_lossy().into_owned();
+        let new_key = local_root
+            .join("remote-only/child")
+            .to_string_lossy()
+            .into_owned();
+        let state = String::from_utf8(valid_state_json(&local_root, "synced"))
+            .unwrap()
+            .replacen(&old_key, &new_key, 1);
+        write_private(&state_path, state.as_bytes());
+
+        assert!(matches!(
+            read_and_bind_strict_primary_state_v1(&state_path, &local_root, "roots").unwrap(),
+            StrictPrimaryStateReadV1::Incomplete(
+                StrictPrimaryStateIncompleteV1::InvalidRootBinding
+            )
+        ));
+
+        let pending = match begin_strict_local_snapshot_v1(
+            &local_root,
+            RootProfileV1::AgentStaticV1,
+        )
+        .unwrap()
+        {
+            StrictLocalSnapshotHoldReadV1::Pending(pending) => pending,
+            StrictLocalSnapshotHoldReadV1::Incomplete(incomplete) => {
+                panic!("expected pending local snapshot, got {incomplete:?}")
+            }
+        };
+        let snapshot = match read_and_bind_strict_primary_state_for_pending_root_v1(
+            &state_path,
+            &pending,
+            "roots",
+        )
+        .unwrap()
+        {
+            StrictPrimaryStateReadV1::Complete(snapshot) => snapshot,
+            other => panic!("expected held-root state snapshot, got {other:?}"),
+        };
+        assert!(snapshot.entries().contains_key("remote-only/child"));
+        assert!(matches!(
+            pending.revalidate_inventory_c().unwrap(),
+            StrictLocalSnapshotFinishV1::Complete(_)
         ));
     }
 

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -20,10 +20,12 @@ use crate::blacklist::Blacklist;
 use crate::conflict::{ConflictInfo, VectorClock};
 use crate::index_entry::portable_casefold_path;
 use crate::index_entry::{
-    manifest_object_id, read_raw_object_snapshot_v1, validate_canonical_namespace_remote_prefix,
+    manifest_object_id, namespace_reservation_object_id, namespace_reservation_prefix,
+    read_raw_object_snapshot_v1, validate_canonical_namespace_remote_prefix,
     validate_namespace_logical_path, validate_relative_storage_key, validate_storage_key_component,
-    DeletionEvidence, IndexEntryState, PortableNamespaceRole, RawObjectReadV1, RawObjectSnapshotV1,
-    RemoteEntryKind,
+    validate_trash_safety_copy_route, DeletionEvidence, IndexEntryState,
+    PortableNamespaceReservationV1, PortableNamespaceRole, RawObjectReadV1, RawObjectSnapshotV1,
+    RemoteEntryKind, DIRECTORY_MARKER_BYTES,
 };
 use crate::registered_local_snapshot::PendingStrictLocalSnapshotV1;
 use crate::state::{
@@ -1120,8 +1122,9 @@ fn validate_index_format_matches_entries_v1(
     Ok(())
 }
 
-fn validate_strict_index_path_semantics_v1(
+fn validate_strict_index_route_semantics_v1(
     parsed: &ParsedStrictIndexRecordV1,
+    remote_prefix: &str,
     rel_path: &str,
 ) -> Result<()> {
     let validate_entry = |entry: &StrictRemoteIndexEntryV1| -> Result<()> {
@@ -1131,7 +1134,15 @@ fn validate_strict_index_path_semantics_v1(
         Ok(())
     };
     match parsed {
-        ParsedStrictIndexRecordV1::Deleted { .. } => {}
+        ParsedStrictIndexRecordV1::Deleted { deletion_evidence } => {
+            if let Some(evidence) = deletion_evidence {
+                validate_trash_safety_copy_route(
+                    remote_prefix,
+                    rel_path,
+                    &evidence.safety_copy_key,
+                )?;
+            }
+        }
         ParsedStrictIndexRecordV1::Preparing {
             current, pending, ..
         } => {
@@ -1151,6 +1162,15 @@ pub async fn read_exact_raw_index_entry_v1(
     remote_prefix: &str,
     rel_path: &str,
 ) -> Result<ExactRawIndexEntryReadV1> {
+    let suffix_bytes = "index/"
+        .len()
+        .checked_add(rel_path.len())
+        .context("strict index key length overflow")?;
+    validate_registered_remote_derived_key_length_v1(
+        remote_prefix,
+        suffix_bytes,
+        "strict index key",
+    )?;
     let prefix = validate_canonical_namespace_remote_prefix(remote_prefix)?;
     validate_registered_remote_logical_path_bounds_v1(rel_path)?;
     let index_key = if prefix.is_empty() {
@@ -1173,7 +1193,11 @@ pub async fn read_exact_raw_index_entry_v1(
         }
     };
     let parsed = match parse_strict_index_record_v1(raw_snapshot.raw_bytes()) {
-        Ok(parsed) if validate_strict_index_path_semantics_v1(&parsed, rel_path).is_ok() => parsed,
+        Ok(parsed)
+            if validate_strict_index_route_semantics_v1(&parsed, prefix, rel_path).is_ok() =>
+        {
+            parsed
+        }
         Err(_) => {
             return Ok(ExactRawIndexEntryReadV1::Incomplete(
                 StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
@@ -1217,6 +1241,323 @@ pub async fn read_exact_raw_index_entry_v1(
             })
         }
     })
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RegisteredRootRemoteDirectoryMarkerRouteV1 {
+    marker_key: String,
+    remote_prefix_len: usize,
+    marker_rel_offset: usize,
+    logical_rel_len: usize,
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+impl RegisteredRootRemoteDirectoryMarkerRouteV1 {
+    pub(crate) fn remote_prefix(&self) -> &str {
+        self.marker_key
+            .get(..self.remote_prefix_len)
+            .expect("bound marker prefix offset is an internal invariant")
+    }
+
+    pub(crate) fn logical_dir(&self) -> &str {
+        let end = self
+            .marker_rel_offset
+            .checked_add(self.logical_rel_len)
+            .expect("bound marker logical-path length is an internal invariant");
+        self.marker_key
+            .get(self.marker_rel_offset..end)
+            .expect("bound marker logical-path offsets are an internal invariant")
+    }
+
+    pub(crate) fn marker_rel_path(&self) -> &str {
+        self.marker_key
+            .get(self.marker_rel_offset..)
+            .expect("bound marker relative-path offset is an internal invariant")
+    }
+
+    pub(crate) fn marker_key(&self) -> &str {
+        &self.marker_key
+    }
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RawLiveDirectoryMarkerV1 {
+    object: BoundRemoteObjectSnapshotV1,
+    route: RegisteredRootRemoteDirectoryMarkerRouteV1,
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+impl RawLiveDirectoryMarkerV1 {
+    pub(crate) const fn object(&self) -> &BoundRemoteObjectSnapshotV1 {
+        &self.object
+    }
+
+    pub(crate) const fn route(&self) -> &RegisteredRootRemoteDirectoryMarkerRouteV1 {
+        &self.route
+    }
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RawDeletedDirectoryMarkerV1 {
+    object: BoundRemoteObjectSnapshotV1,
+    deletion_evidence: Option<DeletionEvidence>,
+    route: RegisteredRootRemoteDirectoryMarkerRouteV1,
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+impl RawDeletedDirectoryMarkerV1 {
+    pub(crate) const fn object(&self) -> &BoundRemoteObjectSnapshotV1 {
+        &self.object
+    }
+
+    pub(crate) const fn deletion_evidence(&self) -> Option<&DeletionEvidence> {
+        self.deletion_evidence.as_ref()
+    }
+
+    pub(crate) const fn route(&self) -> &RegisteredRootRemoteDirectoryMarkerRouteV1 {
+        &self.route
+    }
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StrictRemoteDirectoryMarkerIncompleteV1 {
+    UnboundObject,
+    InvalidMarkerRecord,
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExactRawDirectoryMarkerReadV1 {
+    Missing,
+    Incomplete(StrictRemoteDirectoryMarkerIncompleteV1),
+    Live(RawLiveDirectoryMarkerV1),
+    Deleted(RawDeletedDirectoryMarkerV1),
+}
+
+/// Read one listed directory-marker candidate by storage identity.
+///
+/// The only accepted live body is [`DIRECTORY_MARKER_BYTES`]. The only
+/// accepted structured body is a strict v4 Deleted index record. Compatibility
+/// marker readers are intentionally excluded from registered-root planning.
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+pub(crate) async fn read_exact_raw_directory_marker_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    logical_dir: &str,
+) -> Result<ExactRawDirectoryMarkerReadV1> {
+    let marker_rel_path_bytes = logical_dir
+        .len()
+        .checked_add("/.tcfs_dir".len())
+        .context("strict directory-marker relative-path length overflow")?;
+    let suffix_bytes = "index/"
+        .len()
+        .checked_add(marker_rel_path_bytes)
+        .context("strict directory-marker key length overflow")?;
+    validate_registered_remote_derived_key_length_v1(
+        remote_prefix,
+        suffix_bytes,
+        "strict directory-marker key",
+    )?;
+    let prefix = validate_canonical_namespace_remote_prefix(remote_prefix)?;
+    validate_registered_remote_logical_path_bounds_v1(logical_dir)?;
+    let marker_rel_path = format!("{logical_dir}/.tcfs_dir");
+    let index_key = if prefix.is_empty() {
+        format!("index/{marker_rel_path}")
+    } else {
+        format!("{prefix}/index/{marker_rel_path}")
+    };
+    validate_registered_remote_storage_key_bounds_v1(&index_key, "strict directory-marker key")?;
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_index_object_bytes();
+    let Some(raw_read) = read_raw_object_snapshot_v1(op, &index_key, max_bytes).await? else {
+        return Ok(ExactRawDirectoryMarkerReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactRawDirectoryMarkerReadV1::Incomplete(
+                StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
+            ));
+        }
+    };
+    let marker_rel_offset = index_key
+        .len()
+        .checked_sub(marker_rel_path.len())
+        .expect("validated marker key must end with its relative path");
+    let route = RegisteredRootRemoteDirectoryMarkerRouteV1 {
+        marker_key: index_key,
+        remote_prefix_len: prefix.len(),
+        marker_rel_offset,
+        logical_rel_len: logical_dir.len(),
+    };
+    if raw_snapshot.raw_bytes() == DIRECTORY_MARKER_BYTES {
+        return Ok(ExactRawDirectoryMarkerReadV1::Live(
+            RawLiveDirectoryMarkerV1 {
+                object: bind_remote_object_v1(raw_snapshot),
+                route,
+            },
+        ));
+    }
+    let deletion_evidence = match parse_strict_index_record_v1(raw_snapshot.raw_bytes()) {
+        Ok(parsed @ ParsedStrictIndexRecordV1::Deleted { .. })
+            if validate_strict_index_route_semantics_v1(
+                &parsed,
+                route.remote_prefix(),
+                route.marker_rel_path(),
+            )
+            .is_ok() =>
+        {
+            match parsed {
+                ParsedStrictIndexRecordV1::Deleted { deletion_evidence } => deletion_evidence,
+                _ => unreachable!("guard only accepts a strict deleted marker"),
+            }
+        }
+        _ => {
+            return Ok(ExactRawDirectoryMarkerReadV1::Incomplete(
+                StrictRemoteDirectoryMarkerIncompleteV1::InvalidMarkerRecord,
+            ));
+        }
+    };
+    Ok(ExactRawDirectoryMarkerReadV1::Deleted(
+        RawDeletedDirectoryMarkerV1 {
+            object: bind_remote_object_v1(raw_snapshot),
+            deletion_evidence,
+            route,
+        },
+    ))
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct BoundNamespaceReservationV1 {
+    object: BoundRemoteObjectSnapshotV1,
+    object_key: String,
+    object_id_offset: usize,
+    reservation: PortableNamespaceReservationV1,
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+impl BoundNamespaceReservationV1 {
+    pub(crate) const fn object(&self) -> &BoundRemoteObjectSnapshotV1 {
+        &self.object
+    }
+
+    pub(crate) fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub(crate) fn object_id(&self) -> &str {
+        self.object_key
+            .get(self.object_id_offset..)
+            .expect("bound reservation-key offset is an internal invariant")
+    }
+
+    pub(crate) fn exact_path(&self) -> &str {
+        self.reservation.exact_path()
+    }
+
+    pub(crate) fn folded_path(&self) -> &str {
+        self.reservation.folded_path()
+    }
+
+    pub(crate) const fn role(&self) -> PortableNamespaceRole {
+        self.reservation.role()
+    }
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StrictNamespaceReservationIncompleteV1 {
+    UnboundObject,
+    InvalidReservation,
+    AddressMismatch,
+}
+
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExactNamespaceReservationReadV1 {
+    Missing,
+    Incomplete(StrictNamespaceReservationIncompleteV1),
+    Bound(BoundNamespaceReservationV1),
+}
+
+/// Read one listed portable-namespace reservation by storage identity.
+///
+/// V1 planning accepts only the canonical serialized reservation body whose
+/// folded path hashes to the listed 64-hex object ID.
+#[allow(dead_code)] // Composed by the next full list-and-bind pass.
+pub(crate) async fn read_exact_namespace_reservation_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    object_id: &str,
+) -> Result<ExactNamespaceReservationReadV1> {
+    let suffix_bytes = ".tcfs-namespace/v1/"
+        .len()
+        .checked_add(object_id.len())
+        .context("strict namespace-reservation key length overflow")?;
+    validate_registered_remote_derived_key_length_v1(
+        remote_prefix,
+        suffix_bytes,
+        "strict namespace-reservation key",
+    )?;
+    let prefix = validate_canonical_namespace_remote_prefix(remote_prefix)?;
+    validate_lower_hex_64(object_id, "strict namespace-reservation object id")?;
+    let reservation_prefix = namespace_reservation_prefix(prefix);
+    let object_key = format!("{reservation_prefix}{object_id}");
+    validate_registered_remote_storage_key_bounds_v1(
+        &object_key,
+        "strict namespace-reservation key",
+    )?;
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_reservation_object_bytes();
+    let Some(raw_read) = read_raw_object_snapshot_v1(op, &object_key, max_bytes).await? else {
+        return Ok(ExactNamespaceReservationReadV1::Missing);
+    };
+    let raw_snapshot = match raw_read {
+        RawObjectReadV1::Bound(snapshot) => snapshot,
+        RawObjectReadV1::Unbound => {
+            return Ok(ExactNamespaceReservationReadV1::Incomplete(
+                StrictNamespaceReservationIncompleteV1::UnboundObject,
+            ));
+        }
+    };
+    let reservation =
+        match PortableNamespaceReservationV1::from_json_bytes(raw_snapshot.raw_bytes()) {
+            Ok(reservation)
+                if validate_registered_remote_logical_path_bounds_v1(reservation.exact_path())
+                    .is_ok()
+                    && reservation
+                        .to_json_bytes()
+                        .is_ok_and(|canonical| canonical == raw_snapshot.raw_bytes()) =>
+            {
+                reservation
+            }
+            _ => {
+                return Ok(ExactNamespaceReservationReadV1::Incomplete(
+                    StrictNamespaceReservationIncompleteV1::InvalidReservation,
+                ));
+            }
+        };
+    if namespace_reservation_object_id(reservation.folded_path()) != object_id {
+        return Ok(ExactNamespaceReservationReadV1::Incomplete(
+            StrictNamespaceReservationIncompleteV1::AddressMismatch,
+        ));
+    }
+    let object_id_offset = reservation_prefix.len();
+    Ok(ExactNamespaceReservationReadV1::Bound(
+        BoundNamespaceReservationV1 {
+            object: bind_remote_object_v1(raw_snapshot),
+            object_key,
+            object_id_offset,
+            reservation,
+        },
+    ))
 }
 
 #[derive(Debug, Deserialize)]
@@ -1339,6 +1680,27 @@ fn validate_registered_remote_storage_key_bounds_v1(key: &str, description: &str
     validate_relative_storage_key(key, description)?;
     anyhow::ensure!(
         u64::try_from(key.len()).context("strict remote storage-key length does not fit u64")?
+            <= RegisteredRootPlanContractV1::strict_v1()
+                .remote_contract()
+                .max_storage_key_bytes(),
+        "{description} exceeds the registered-root storage-key byte bound"
+    );
+    Ok(())
+}
+
+fn validate_registered_remote_derived_key_length_v1(
+    remote_prefix: &str,
+    suffix_bytes: usize,
+    description: &str,
+) -> Result<()> {
+    let length = remote_prefix
+        .len()
+        .checked_add(usize::from(!remote_prefix.is_empty()))
+        .and_then(|length| length.checked_add(suffix_bytes))
+        .context("strict remote derived storage-key length overflow")?;
+    anyhow::ensure!(
+        u64::try_from(length)
+            .context("strict remote derived storage-key length does not fit u64")?
             <= RegisteredRootPlanContractV1::strict_v1()
                 .remote_contract()
                 .max_storage_key_bytes(),
@@ -1730,6 +2092,7 @@ mod tests {
     use opendal::raw::{Access, AccessorInfo, OpRead, OpStat, RpRead, RpStat};
     use opendal::services::Memory;
     use opendal::{Buffer, Capability, EntryMode, ErrorKind, Metadata, OperatorBuilder};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
     fn directory_inventory(
@@ -1785,6 +2148,7 @@ mod tests {
     struct BoundObjectTestBackend {
         objects: Arc<BTreeMap<String, Vec<u8>>>,
         info: Arc<AccessorInfo>,
+        stat_calls: Arc<AtomicUsize>,
     }
 
     impl Access for BoundObjectTestBackend {
@@ -1798,6 +2162,7 @@ mod tests {
         }
 
         async fn stat(&self, path: &str, _: OpStat) -> opendal::Result<RpStat> {
+            self.stat_calls.fetch_add(1, Ordering::SeqCst);
             let bytes = self.objects.get(path).ok_or_else(|| {
                 opendal::Error::new(ErrorKind::NotFound, "bound test object is missing")
             })?;
@@ -1840,6 +2205,12 @@ mod tests {
     }
 
     fn bound_object_test_operator(objects: BTreeMap<String, Vec<u8>>) -> Operator {
+        bound_object_test_operator_with_stat_counter(objects).0
+    }
+
+    fn bound_object_test_operator_with_stat_counter(
+        objects: BTreeMap<String, Vec<u8>>,
+    ) -> (Operator, Arc<AtomicUsize>) {
         let info = AccessorInfo::default();
         info.set_scheme("registered-root-bound-test")
             .set_root("/")
@@ -1850,11 +2221,14 @@ mod tests {
                 read_with_if_match: true,
                 ..Default::default()
             });
-        OperatorBuilder::new(BoundObjectTestBackend {
+        let stat_calls = Arc::new(AtomicUsize::new(0));
+        let op = OperatorBuilder::new(BoundObjectTestBackend {
             objects: Arc::new(objects),
             info: Arc::new(info),
+            stat_calls: stat_calls.clone(),
         })
-        .finish()
+        .finish();
+        (op, stat_calls)
     }
 
     fn valid_state_json(local_root: &Path, status: &str) -> Vec<u8> {
@@ -2224,6 +2598,19 @@ mod tests {
             chunk_hash = "e".repeat(64),
         )
         .into_bytes()
+    }
+
+    fn strict_deleted_index_json(safety_copy_key: Option<&str>) -> Vec<u8> {
+        match safety_copy_key {
+            Some(safety_copy_key) => format!(
+                r#"{{"version":4,"state":"deleted","current":null,"pending":null,"deletion_evidence":{{"safety_copy_key":"{safety_copy_key}","safety_copy_blake3":"{digest}"}}}}"#,
+                digest = "a".repeat(64),
+            )
+            .into_bytes(),
+            None => {
+                br#"{"version":4,"state":"deleted","current":null,"pending":null}"#.to_vec()
+            }
+        }
     }
 
     fn committed_index_for_test(index: StrictRemoteIndexEntryV1) -> RawCommittedIndexEntryV1 {
@@ -2607,6 +2994,385 @@ mod tests {
                 .unwrap(),
             ExactRawIndexEntryReadV1::Incomplete(StrictRemoteIndexIncompleteV1::PreparingObserved)
         );
+    }
+
+    #[tokio::test]
+    async fn strict_bound_index_read_requires_route_canonical_deletion_evidence() {
+        let generation = "123-00000000-0000-4000-8000-000000000000";
+        let valid =
+            strict_deleted_index_json(Some(&format!("roots/.tcfs-trash/{generation}/dir/file")));
+        let op = bound_object_test_operator(BTreeMap::from([(
+            "roots/index/dir/file".to_owned(),
+            valid,
+        )]));
+        let deleted = match read_exact_raw_index_entry_v1(&op, "roots", "dir/file")
+            .await
+            .unwrap()
+        {
+            ExactRawIndexEntryReadV1::Deleted(deleted) => deleted,
+            other => panic!("expected route-bound deleted index, got {other:?}"),
+        };
+        assert_eq!(
+            deleted.deletion_evidence().unwrap().safety_copy_key,
+            format!("roots/.tcfs-trash/{generation}/dir/file")
+        );
+        let evidence_free_op = bound_object_test_operator(BTreeMap::from([(
+            "roots/index/dir/file".to_owned(),
+            strict_deleted_index_json(None),
+        )]));
+        assert!(matches!(
+            read_exact_raw_index_entry_v1(&evidence_free_op, "roots", "dir/file")
+                .await
+                .unwrap(),
+            ExactRawIndexEntryReadV1::Deleted(ref deleted)
+                if deleted.deletion_evidence().is_none()
+        ));
+
+        for safety_copy_key in [
+            "other/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/dir/file",
+            "roots/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/other",
+            "roots/.tcfs-trash//dir/file",
+            "roots/.tcfs-trash/123/dir/file",
+            "roots/.tcfs-trash/0123-00000000-0000-4000-8000-000000000000/dir/file",
+            "roots/.tcfs-trash/18446744073709551616-00000000-0000-4000-8000-000000000000/dir/file",
+            "roots/.tcfs-trash/123-00000000-0000-3000-8000-000000000000/dir/file",
+            "roots/.tcfs-trash/123-00000000-0000-4000-7000-000000000000/dir/file",
+            "roots/.tcfs-trash/123-00000000-0000-4000-8000-00000000000A/dir/file",
+        ] {
+            let op = bound_object_test_operator(BTreeMap::from([(
+                "roots/index/dir/file".to_owned(),
+                strict_deleted_index_json(Some(safety_copy_key)),
+            )]));
+            assert_eq!(
+                read_exact_raw_index_entry_v1(&op, "roots", "dir/file")
+                    .await
+                    .unwrap(),
+                ExactRawIndexEntryReadV1::Incomplete(
+                    StrictRemoteIndexIncompleteV1::InvalidIndexRecord
+                ),
+                "accepted noncanonical deletion evidence {safety_copy_key:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn strict_directory_marker_read_binds_live_and_deleted_bodies() {
+        let marker_key = "roots/index/dir/.tcfs_dir";
+        let live_op = bound_object_test_operator(BTreeMap::from([(
+            marker_key.to_owned(),
+            DIRECTORY_MARKER_BYTES.to_vec(),
+        )]));
+        let live = match read_exact_raw_directory_marker_v1(&live_op, "roots", "dir")
+            .await
+            .unwrap()
+        {
+            ExactRawDirectoryMarkerReadV1::Live(live) => live,
+            other => panic!("expected bound live marker, got {other:?}"),
+        };
+        assert_eq!(live.route().remote_prefix(), "roots");
+        assert_eq!(live.route().logical_dir(), "dir");
+        assert_eq!(live.route().marker_rel_path(), "dir/.tcfs_dir");
+        assert_eq!(live.route().marker_key(), marker_key);
+        assert_eq!(
+            live.object().raw_bytes_len(),
+            u64::try_from(DIRECTORY_MARKER_BYTES.len()).unwrap()
+        );
+        assert_eq!(
+            live.object().raw_blake3(),
+            blake3::hash(DIRECTORY_MARKER_BYTES).as_bytes()
+        );
+
+        let deleted_op = bound_object_test_operator(BTreeMap::from([(
+            marker_key.to_owned(),
+            strict_deleted_index_json(Some(
+                "roots/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/dir/.tcfs_dir",
+            )),
+        )]));
+        let deleted = match read_exact_raw_directory_marker_v1(&deleted_op, "roots", "dir")
+            .await
+            .unwrap()
+        {
+            ExactRawDirectoryMarkerReadV1::Deleted(deleted) => deleted,
+            other => panic!("expected bound deleted marker, got {other:?}"),
+        };
+        assert_eq!(deleted.route().logical_dir(), "dir");
+        assert_eq!(deleted.route().marker_rel_path(), "dir/.tcfs_dir");
+        assert_eq!(deleted.route().marker_key(), marker_key);
+        assert_eq!(
+            deleted.object().raw_bytes_len(),
+            u64::try_from(
+                strict_deleted_index_json(Some(
+                    "roots/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/dir/.tcfs_dir"
+                ))
+                .len()
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            deleted.deletion_evidence().unwrap().safety_copy_key,
+            "roots/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/dir/.tcfs_dir"
+        );
+        let evidence_free_op = bound_object_test_operator(BTreeMap::from([(
+            marker_key.to_owned(),
+            strict_deleted_index_json(None),
+        )]));
+        assert!(matches!(
+            read_exact_raw_directory_marker_v1(&evidence_free_op, "roots", "dir")
+                .await
+                .unwrap(),
+            ExactRawDirectoryMarkerReadV1::Deleted(ref deleted)
+                if deleted.deletion_evidence().is_none()
+        ));
+    }
+
+    #[tokio::test]
+    async fn strict_directory_marker_read_rejects_compatibility_and_wrong_route_bodies() {
+        let marker_key = "roots/index/dir/.tcfs_dir";
+        let committed = format!(
+            r#"{{"version":2,"state":"committed","current":{{"manifest_hash":"{}","size":0,"chunks":0}},"pending":null}}"#,
+            "b".repeat(64)
+        )
+        .into_bytes();
+        let preparing = format!(
+            r#"{{"version":2,"state":"preparing","current":null,"pending":{{"manifest_hash":"{}","size":0,"chunks":0,"staged_manifest_key":"roots/staging/object"}}}}"#,
+            "b".repeat(64)
+        )
+        .into_bytes();
+        for body in [
+            b"type=directory\r\n".to_vec(),
+            b"type=directory\n\n".to_vec(),
+            committed,
+            preparing,
+            strict_deleted_index_json(Some(
+                "roots/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/other/.tcfs_dir",
+            )),
+        ] {
+            let op = bound_object_test_operator(BTreeMap::from([(marker_key.to_owned(), body)]));
+            assert_eq!(
+                read_exact_raw_directory_marker_v1(&op, "roots", "dir")
+                    .await
+                    .unwrap(),
+                ExactRawDirectoryMarkerReadV1::Incomplete(
+                    StrictRemoteDirectoryMarkerIncompleteV1::InvalidMarkerRecord
+                )
+            );
+        }
+
+        let missing = bound_object_test_operator(BTreeMap::new());
+        assert_eq!(
+            read_exact_raw_directory_marker_v1(&missing, "roots", "dir")
+                .await
+                .unwrap(),
+            ExactRawDirectoryMarkerReadV1::Missing
+        );
+    }
+
+    #[tokio::test]
+    async fn strict_namespace_reservation_read_requires_canonical_bound_body_and_address() {
+        let canonical =
+            br#"{"version":1,"exact_path":"doc.txt","folded_path":"doc.txt","role":"file"}"#
+                .to_vec();
+        let object_id = namespace_reservation_object_id("doc.txt");
+        let object_key = format!("roots/.tcfs-namespace/v1/{object_id}");
+        let op =
+            bound_object_test_operator(BTreeMap::from([(object_key.clone(), canonical.clone())]));
+        let bound = match read_exact_namespace_reservation_v1(&op, "roots", &object_id)
+            .await
+            .unwrap()
+        {
+            ExactNamespaceReservationReadV1::Bound(bound) => bound,
+            other => panic!("expected bound namespace reservation, got {other:?}"),
+        };
+        assert_eq!(bound.object_key(), object_key);
+        assert_eq!(bound.object_id(), object_id);
+        assert_eq!(bound.exact_path(), "doc.txt");
+        assert_eq!(bound.folded_path(), "doc.txt");
+        assert_eq!(bound.role(), PortableNamespaceRole::File);
+        assert_eq!(
+            bound.object().raw_bytes_len(),
+            u64::try_from(canonical.len()).unwrap()
+        );
+
+        let noncanonical = br#"{
+  "version": 1,
+  "exact_path": "doc.txt",
+  "folded_path": "doc.txt",
+  "role": "file"
+}"#
+        .to_vec();
+        let op = bound_object_test_operator(BTreeMap::from([(object_key.clone(), noncanonical)]));
+        assert_eq!(
+            read_exact_namespace_reservation_v1(&op, "roots", &object_id)
+                .await
+                .unwrap(),
+            ExactNamespaceReservationReadV1::Incomplete(
+                StrictNamespaceReservationIncompleteV1::InvalidReservation
+            )
+        );
+
+        let wrong_id = namespace_reservation_object_id("other.txt");
+        assert_ne!(wrong_id, object_id);
+        let wrong_key = format!("roots/.tcfs-namespace/v1/{wrong_id}");
+        let op = bound_object_test_operator(BTreeMap::from([(wrong_key, canonical)]));
+        assert_eq!(
+            read_exact_namespace_reservation_v1(&op, "roots", &wrong_id)
+                .await
+                .unwrap(),
+            ExactNamespaceReservationReadV1::Incomplete(
+                StrictNamespaceReservationIncompleteV1::AddressMismatch
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn strict_namespace_reservation_read_rejects_invalid_semantics_and_bounds() {
+        let object_id = namespace_reservation_object_id("doc.txt");
+        let object_key = format!("roots/.tcfs-namespace/v1/{object_id}");
+        let overlong = "a".repeat(
+            usize::try_from(
+                RegisteredRootPlanContractV1::strict_v1()
+                    .remote_contract()
+                    .max_logical_component_bytes()
+                    + 1,
+            )
+            .unwrap(),
+        );
+        for body in [
+            br#"{"version":1,"exact_path":"doc.txt","folded_path":"DOC.TXT","role":"file"}"#
+                .to_vec(),
+            br#"{"version":2,"exact_path":"doc.txt","folded_path":"doc.txt","role":"file"}"#
+                .to_vec(),
+            br#"{"version":1,"exact_path":"doc.txt","folded_path":"doc.txt","role":"file","extra":true}"#
+                .to_vec(),
+            format!(
+                r#"{{"version":1,"exact_path":"{overlong}","folded_path":"{overlong}","role":"file"}}"#
+            )
+            .into_bytes(),
+        ] {
+            let op = bound_object_test_operator(BTreeMap::from([(
+                object_key.clone(),
+                body,
+            )]));
+            assert_eq!(
+                read_exact_namespace_reservation_v1(&op, "roots", &object_id)
+                    .await
+                    .unwrap(),
+                ExactNamespaceReservationReadV1::Incomplete(
+                    StrictNamespaceReservationIncompleteV1::InvalidReservation
+                )
+            );
+        }
+
+        let missing = bound_object_test_operator(BTreeMap::new());
+        assert_eq!(
+            read_exact_namespace_reservation_v1(&missing, "roots", &object_id)
+                .await
+                .unwrap(),
+            ExactNamespaceReservationReadV1::Missing
+        );
+    }
+
+    #[tokio::test]
+    async fn strict_marker_and_reservation_reads_refuse_unbound_objects() {
+        let op = Operator::new(Memory::default()).unwrap().finish();
+        op.write("roots/index/dir/.tcfs_dir", DIRECTORY_MARKER_BYTES.to_vec())
+            .await
+            .unwrap();
+        let reservation =
+            br#"{"version":1,"exact_path":"doc.txt","folded_path":"doc.txt","role":"file"}"#;
+        let object_id = namespace_reservation_object_id("doc.txt");
+        op.write(
+            &format!("roots/.tcfs-namespace/v1/{object_id}"),
+            reservation.to_vec(),
+        )
+        .await
+        .unwrap();
+        let before = object_inventory(&op).await;
+
+        assert_eq!(
+            read_exact_raw_directory_marker_v1(&op, "roots", "dir")
+                .await
+                .unwrap(),
+            ExactRawDirectoryMarkerReadV1::Incomplete(
+                StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject
+            )
+        );
+        assert_eq!(
+            read_exact_namespace_reservation_v1(&op, "roots", &object_id)
+                .await
+                .unwrap(),
+            ExactNamespaceReservationReadV1::Incomplete(
+                StrictNamespaceReservationIncompleteV1::UnboundObject
+            )
+        );
+        assert_eq!(object_inventory(&op).await, before);
+    }
+
+    #[tokio::test]
+    async fn strict_remote_body_readers_reject_oversized_prefix_before_backend_io() {
+        let (op, stat_calls) = bound_object_test_operator_with_stat_counter(BTreeMap::new());
+        let oversized_prefix = "p".repeat(
+            usize::try_from(
+                RegisteredRootPlanContractV1::strict_v1()
+                    .remote_contract()
+                    .max_storage_key_bytes()
+                    + 1,
+            )
+            .unwrap(),
+        );
+        let object_id = namespace_reservation_object_id("doc.txt");
+
+        assert!(
+            read_exact_raw_index_entry_v1(&op, &oversized_prefix, "doc.txt")
+                .await
+                .is_err()
+        );
+        assert!(
+            read_exact_raw_directory_marker_v1(&op, &oversized_prefix, "dir")
+                .await
+                .is_err()
+        );
+        assert!(
+            read_exact_namespace_reservation_v1(&op, &oversized_prefix, &object_id)
+                .await
+                .is_err()
+        );
+        assert_eq!(stat_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn strict_namespace_reservation_read_accepts_the_exact_path_ceiling() {
+        let exact_path = format!(
+            "{}/{}/{}/{}/e",
+            "a".repeat(255),
+            "b".repeat(255),
+            "c".repeat(255),
+            "d".repeat(254),
+        );
+        assert_eq!(
+            u64::try_from(exact_path.len()).unwrap(),
+            RegisteredRootPlanContractV1::strict_v1()
+                .remote_contract()
+                .max_logical_path_bytes()
+        );
+        let body = format!(
+            r#"{{"version":1,"exact_path":"{exact_path}","folded_path":"{exact_path}","role":"directory"}}"#
+        )
+        .into_bytes();
+        let object_id = namespace_reservation_object_id(&exact_path);
+        let object_key = format!("roots/.tcfs-namespace/v1/{object_id}");
+        let op = bound_object_test_operator(BTreeMap::from([(object_key, body)]));
+
+        let bound = match read_exact_namespace_reservation_v1(&op, "roots", &object_id)
+            .await
+            .unwrap()
+        {
+            ExactNamespaceReservationReadV1::Bound(bound) => bound,
+            other => panic!("expected ceiling-sized reservation, got {other:?}"),
+        };
+        assert_eq!(bound.exact_path(), exact_path);
+        assert_eq!(bound.folded_path(), exact_path);
+        assert_eq!(bound.role(), PortableNamespaceRole::Directory);
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -20,7 +20,8 @@ use crate::blacklist::Blacklist;
 use crate::conflict::{ConflictInfo, VectorClock};
 use crate::index_entry::portable_casefold_path;
 use crate::index_entry::{
-    manifest_object_id, namespace_reservation_object_id, namespace_reservation_prefix,
+    manifest_object_id, namespace_index_prefix, namespace_logical_entry_from_index_path,
+    namespace_reservation_object_id, namespace_reservation_prefix,
     read_expected_raw_object_snapshot_v1, read_raw_object_snapshot_v1,
     validate_canonical_namespace_remote_prefix, validate_namespace_logical_path,
     validate_relative_storage_key, validate_storage_key_component,
@@ -1241,6 +1242,68 @@ enum ParsedStrictIndexRecordV1 {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CatalogValidatedIndexStateV1 {
+    Current,
+    Historical,
+}
+
+/// Strict semantic projection of one catalog-visible index or directory-marker
+/// payload. Construction is intentionally limited to the same parsers and
+/// route validators used by the registered-root semantic reader.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CatalogValidatedIndexPayloadV1 {
+    logical_path: String,
+    role: PortableNamespaceRole,
+    state: CatalogValidatedIndexStateV1,
+    committed: Option<StrictRemoteIndexEntryV1>,
+}
+
+impl CatalogValidatedIndexPayloadV1 {
+    pub(crate) fn logical_path(&self) -> &str {
+        &self.logical_path
+    }
+
+    pub(crate) const fn role(&self) -> PortableNamespaceRole {
+        self.role
+    }
+
+    pub(crate) const fn state(&self) -> CatalogValidatedIndexStateV1 {
+        self.state
+    }
+
+    pub(crate) const fn committed(&self) -> Option<&StrictRemoteIndexEntryV1> {
+        self.committed.as_ref()
+    }
+}
+
+/// One strict committed-index reference used to validate a manifest against
+/// the complete successor catalog rather than a caller-selected subset.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CatalogManifestReferenceV1 {
+    remote_prefix: String,
+    rel_path: String,
+    entry: StrictRemoteIndexEntryV1,
+}
+
+impl CatalogManifestReferenceV1 {
+    pub(crate) fn new(
+        remote_prefix: &str,
+        rel_path: &str,
+        entry: &StrictRemoteIndexEntryV1,
+    ) -> Self {
+        Self {
+            remote_prefix: remote_prefix.to_owned(),
+            rel_path: rel_path.to_owned(),
+            entry: entry.clone(),
+        }
+    }
+
+    pub(crate) fn manifest_hash(&self) -> &str {
+        self.entry.manifest_hash()
+    }
+}
+
 fn parse_strict_index_record_v1(bytes: &[u8]) -> Result<ParsedStrictIndexRecordV1> {
     let wire: StrictVersionedIndexEntryWireV1 =
         serde_json::from_slice(bytes).context("parsing strict V1 index record")?;
@@ -1312,6 +1375,87 @@ fn parse_strict_index_record_v1(bytes: &[u8]) -> Result<ParsedStrictIndexRecordV
             Ok(ParsedStrictIndexRecordV1::Preparing { current, pending })
         }
         _ => anyhow::bail!("unsupported strict V1 index version/state combination"),
+    }
+}
+
+/// Parse one proposed catalog index/marker payload through the production
+/// strict validators without manufacturing a bound storage object.
+pub(crate) fn validate_catalog_index_payload_v1(
+    remote_prefix: &str,
+    object_key: &str,
+    raw_bytes: &[u8],
+) -> Result<CatalogValidatedIndexPayloadV1> {
+    let index_prefix = namespace_index_prefix(remote_prefix);
+    let index_rel_path = object_key
+        .strip_prefix(&index_prefix)
+        .context("catalog successor index is outside the selected namespace")?;
+    let (logical_path, role) = namespace_logical_entry_from_index_path(index_rel_path)
+        .context("catalog successor index route is not canonical")?;
+
+    match role {
+        PortableNamespaceRole::File => {
+            let route = strict_remote_index_route_v1(remote_prefix, &logical_path)?;
+            anyhow::ensure!(
+                route.index_key() == object_key,
+                "catalog successor index route does not round-trip"
+            );
+            let parsed = parse_strict_index_record_v1(raw_bytes)?;
+            validate_strict_index_route_semantics_v1(
+                &parsed,
+                route.remote_prefix(),
+                route.rel_path(),
+            )?;
+            match parsed {
+                ParsedStrictIndexRecordV1::Deleted { .. } => Ok(CatalogValidatedIndexPayloadV1 {
+                    logical_path,
+                    role,
+                    state: CatalogValidatedIndexStateV1::Historical,
+                    committed: None,
+                }),
+                ParsedStrictIndexRecordV1::Committed { current, .. } => {
+                    Ok(CatalogValidatedIndexPayloadV1 {
+                        logical_path,
+                        role,
+                        state: CatalogValidatedIndexStateV1::Current,
+                        committed: Some(current),
+                    })
+                }
+                ParsedStrictIndexRecordV1::Preparing { .. } => {
+                    anyhow::bail!("catalog successor index cannot remain preparing")
+                }
+            }
+        }
+        PortableNamespaceRole::Directory => {
+            let route = strict_remote_directory_marker_route_v1(remote_prefix, &logical_path)?;
+            anyhow::ensure!(
+                route.marker_key() == object_key,
+                "catalog successor marker route does not round-trip"
+            );
+            if raw_bytes == DIRECTORY_MARKER_BYTES {
+                return Ok(CatalogValidatedIndexPayloadV1 {
+                    logical_path,
+                    role,
+                    state: CatalogValidatedIndexStateV1::Current,
+                    committed: None,
+                });
+            }
+            let parsed = parse_strict_index_record_v1(raw_bytes)?;
+            validate_strict_index_route_semantics_v1(
+                &parsed,
+                route.remote_prefix(),
+                route.marker_rel_path(),
+            )?;
+            anyhow::ensure!(
+                matches!(parsed, ParsedStrictIndexRecordV1::Deleted { .. }),
+                "catalog successor marker must be live marker bytes or a strict deletion"
+            );
+            Ok(CatalogValidatedIndexPayloadV1 {
+                logical_path,
+                role,
+                state: CatalogValidatedIndexStateV1::Historical,
+                committed: None,
+            })
+        }
     }
 }
 
@@ -2024,6 +2168,61 @@ fn classify_observed_namespace_reservation_v1(
     })
 }
 
+/// Strict semantic projection of one proposed namespace-reservation payload.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CatalogValidatedReservationPayloadV1 {
+    exact_path: String,
+    folded_path: String,
+    role: PortableNamespaceRole,
+}
+
+impl CatalogValidatedReservationPayloadV1 {
+    pub(crate) fn exact_path(&self) -> &str {
+        &self.exact_path
+    }
+
+    pub(crate) fn folded_path(&self) -> &str {
+        &self.folded_path
+    }
+
+    pub(crate) const fn role(&self) -> PortableNamespaceRole {
+        self.role
+    }
+}
+
+/// Parse one proposed reservation through the production canonical serializer,
+/// path bounds, and content-addressed route check.
+pub(crate) fn validate_catalog_reservation_payload_v1(
+    remote_prefix: &str,
+    object_key: &str,
+    raw_bytes: &[u8],
+) -> Result<CatalogValidatedReservationPayloadV1> {
+    let reservation_prefix = namespace_reservation_prefix(remote_prefix);
+    let object_id = object_key
+        .strip_prefix(&reservation_prefix)
+        .context("catalog successor reservation is outside the selected namespace")?;
+    let route = strict_namespace_reservation_route_v1(remote_prefix, object_id)?;
+    anyhow::ensure!(
+        route.object_key() == object_key,
+        "catalog successor reservation route does not round-trip"
+    );
+    let reservation = PortableNamespaceReservationV1::from_json_bytes(raw_bytes)?;
+    validate_registered_remote_logical_path_bounds_v1(reservation.exact_path())?;
+    anyhow::ensure!(
+        reservation.to_json_bytes()? == raw_bytes,
+        "catalog successor reservation is not canonically encoded"
+    );
+    anyhow::ensure!(
+        namespace_reservation_object_id(reservation.folded_path()) == route.object_id(),
+        "catalog successor reservation address does not match its folded path"
+    );
+    Ok(CatalogValidatedReservationPayloadV1 {
+        exact_path: reservation.exact_path().to_owned(),
+        folded_path: reservation.folded_path().to_owned(),
+        role: reservation.role(),
+    })
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct StrictWrappedFileKeyWireV1 {
@@ -2534,6 +2733,136 @@ fn validate_parsed_strict_manifest_reference_v1(
         _ => anyhow::bail!("strict manifest kind does not match an index reference"),
     }
     Ok(())
+}
+
+fn validate_catalog_manifest_reference_group_v1<'a>(
+    object_key: &str,
+    references: &'a [CatalogManifestReferenceV1],
+) -> Result<&'a CatalogManifestReferenceV1> {
+    let first = references
+        .first()
+        .context("catalog successor manifest reference group is empty")?;
+    validate_canonical_namespace_remote_prefix(&first.remote_prefix)?;
+    validate_registered_remote_logical_path_bounds_v1(&first.rel_path)?;
+    validate_lower_hex_64(
+        first.entry.manifest_hash(),
+        "catalog successor manifest object id",
+    )?;
+    let expected_key = format!(
+        "{}/manifests/{}",
+        first.remote_prefix,
+        first.entry.manifest_hash()
+    );
+    anyhow::ensure!(
+        object_key == expected_key,
+        "catalog successor manifest route does not match its references"
+    );
+    for reference in references {
+        anyhow::ensure!(
+            reference.remote_prefix == first.remote_prefix
+                && reference.entry.manifest_hash() == first.entry.manifest_hash()
+                && reference.entry.kind() == first.entry.kind(),
+            "catalog successor manifest reference group mixes roots, addresses, or kinds"
+        );
+        validate_registered_remote_logical_path_bounds_v1(&reference.rel_path)?;
+        anyhow::ensure!(
+            Blacklist::default()
+                .check_fixed_ingress_path_components(Path::new(&reference.rel_path))
+                .is_none(),
+            "catalog successor manifest reference is excluded by the fixed profile"
+        );
+    }
+    Ok(first)
+}
+
+fn validate_catalog_parsed_manifest_references_v1(
+    parsed: &ParsedStrictManifestV1,
+    references: &[CatalogManifestReferenceV1],
+) -> Result<()> {
+    for reference in references {
+        match (parsed, reference.entry.kind()) {
+            (ParsedStrictManifestV1::Regular(manifest), RemoteEntryKind::RegularFile) => {
+                anyhow::ensure!(
+                    manifest.rel_path() == reference.rel_path
+                        && manifest.file_size() == reference.entry.size()
+                        && u64::try_from(manifest.chunks().len())
+                            .context("catalog successor manifest chunk count does not fit u64")?
+                            == reference.entry.chunks(),
+                    "catalog successor regular manifest does not satisfy every reference"
+                );
+            }
+            (ParsedStrictManifestV1::Symlink(manifest), RemoteEntryKind::Symlink) => {
+                anyhow::ensure!(
+                    manifest.rel_path() == reference.rel_path
+                        && reference.entry.symlink_target() == Some(manifest.symlink_target()),
+                    "catalog successor symlink manifest does not satisfy every reference"
+                );
+                crate::engine::validate_indexed_symlink_target(
+                    Path::new(&reference.rel_path),
+                    manifest.symlink_target(),
+                )?;
+            }
+            _ => anyhow::bail!(
+                "catalog successor manifest kind does not match every index reference"
+            ),
+        }
+    }
+    Ok(())
+}
+
+/// Parse and validate one proposed manifest payload against the complete
+/// successor reference group using the production strict manifest rules.
+pub(crate) fn validate_catalog_manifest_payload_v1(
+    object_key: &str,
+    raw_bytes: &[u8],
+    references: &[CatalogManifestReferenceV1],
+) -> Result<()> {
+    let first = validate_catalog_manifest_reference_group_v1(object_key, references)?;
+    anyhow::ensure!(
+        manifest_object_id(raw_bytes) == first.entry.manifest_hash(),
+        "catalog successor manifest bytes do not match their content address"
+    );
+    let parsed = match first.entry.kind() {
+        RemoteEntryKind::RegularFile => {
+            let wire: StrictRegularManifestWireV1 =
+                serde_json::from_slice(raw_bytes).context("parsing strict regular manifest")?;
+            ParsedStrictManifestV1::Regular(strict_regular_manifest_v1(
+                wire,
+                &first.rel_path,
+                &first.entry,
+            )?)
+        }
+        RemoteEntryKind::Symlink => {
+            let wire: StrictSymlinkManifestWireV1 =
+                serde_json::from_slice(raw_bytes).context("parsing strict symlink manifest")?;
+            ParsedStrictManifestV1::Symlink(strict_symlink_manifest_v1(
+                wire,
+                &first.rel_path,
+                &first.entry,
+            )?)
+        }
+    };
+    validate_catalog_parsed_manifest_references_v1(&parsed, references)
+}
+
+/// Recheck one already-bound predecessor manifest against the complete
+/// successor reference group. This prevents a changed index set from reusing
+/// a manifest whose old semantic proof covered a different set of claims.
+pub(crate) fn validate_bound_catalog_manifest_references_v1(
+    object_key: &str,
+    manifest: &StrictRemoteManifestV1,
+    references: &[CatalogManifestReferenceV1],
+) -> Result<()> {
+    validate_catalog_manifest_reference_group_v1(object_key, references)?;
+    let parsed = match manifest {
+        StrictRemoteManifestV1::Regular { manifest, .. } => {
+            ParsedStrictManifestV1::Regular(manifest.clone())
+        }
+        StrictRemoteManifestV1::Symlink { manifest, .. } => {
+            ParsedStrictManifestV1::Symlink(manifest.clone())
+        }
+    };
+    validate_catalog_parsed_manifest_references_v1(&parsed, references)
 }
 
 fn strict_regular_manifest_v1(

--- a/crates/tcfs-sync/src/registered_reconcile.rs
+++ b/crates/tcfs-sync/src/registered_reconcile.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Deserializer};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::marker::PhantomData;
-use std::path::Path;
-use tcfs_core::config::RegisteredRootPlanContractV1;
+use std::path::{Path, PathBuf};
+use tcfs_core::config::{RegisteredRootPlanContractV1, RootStateContractV1};
 use unicode_normalization::UnicodeNormalization;
 
 use crate::blacklist::Blacklist;
@@ -328,12 +328,31 @@ impl StrictPrimaryStateBytesDigestV1 {
 }
 
 /// Strict, quiet, primary-only registered-root state.
-#[derive(Clone)]
 pub struct StrictPrimaryStateSnapshotV1 {
     raw_bytes_digest: StrictPrimaryStateBytesDigestV1,
+    selected_state_path: PathBuf,
+    canonical_local_root: PathBuf,
+    remote_prefix: String,
+    namespace_claims: BTreeMap<String, StrictStateNamespaceClaimV1>,
     entries: BTreeMap<String, BoundStrictSyncStateV1>,
     last_nats_seq: u64,
     device_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StrictStateNamespaceClaimV1 {
+    exact_path: String,
+    role: PortableNamespaceRole,
+}
+
+impl StrictStateNamespaceClaimV1 {
+    pub(crate) fn exact_path(&self) -> &str {
+        &self.exact_path
+    }
+
+    pub(crate) const fn role(&self) -> PortableNamespaceRole {
+        self.role
+    }
 }
 
 impl fmt::Debug for StrictPrimaryStateSnapshotV1 {
@@ -341,6 +360,10 @@ impl fmt::Debug for StrictPrimaryStateSnapshotV1 {
         formatter
             .debug_struct("StrictPrimaryStateSnapshotV1")
             .field("raw_bytes_digest", &self.raw_bytes_digest)
+            .field("selected_state_path", &self.selected_state_path)
+            .field("canonical_local_root", &self.canonical_local_root)
+            .field("remote_prefix", &self.remote_prefix)
+            .field("namespace_claim_count", &self.namespace_claims.len())
             .field("entry_count", &self.entries.len())
             .field("last_nats_seq", &self.last_nats_seq)
             .field("device_id", &self.device_id)
@@ -351,6 +374,26 @@ impl fmt::Debug for StrictPrimaryStateSnapshotV1 {
 impl StrictPrimaryStateSnapshotV1 {
     pub const fn raw_bytes_digest(&self) -> StrictPrimaryStateBytesDigestV1 {
         self.raw_bytes_digest
+    }
+
+    pub(crate) fn selected_state_path(&self) -> &Path {
+        &self.selected_state_path
+    }
+
+    pub(crate) fn canonical_local_root(&self) -> &Path {
+        &self.canonical_local_root
+    }
+
+    pub(crate) fn remote_prefix(&self) -> &str {
+        &self.remote_prefix
+    }
+
+    pub(crate) fn namespace_claims(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (&str, &StrictStateNamespaceClaimV1)> {
+        self.namespace_claims
+            .iter()
+            .map(|(folded_path, claim)| (folded_path.as_str(), claim))
     }
 
     pub const fn entries(&self) -> &BTreeMap<String, BoundStrictSyncStateV1> {
@@ -377,9 +420,41 @@ pub enum StrictPrimaryStateIncompleteV1 {
         locked_keys: Vec<String>,
     },
     InvalidRootBinding,
+    NamespaceResourceLimit {
+        resource: StrictStateNamespaceResourceV1,
+    },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrictStateNamespaceResourceV1 {
+    GeneratedClaims,
+    GeneratedClaimBytes,
+    RetainedClaims,
+    RetainedClaimBytes,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("strict state namespace claim resource limit exceeded: {0:?}")]
+struct StrictStateNamespaceResourceLimitErrorV1(StrictStateNamespaceResourceV1);
+
+impl StrictStateNamespaceResourceLimitErrorV1 {
+    const fn resource(&self) -> StrictStateNamespaceResourceV1 {
+        self.0
+    }
+}
+
+fn strict_state_binding_incomplete_v1(error: &anyhow::Error) -> StrictPrimaryStateIncompleteV1 {
+    error
+        .downcast_ref::<StrictStateNamespaceResourceLimitErrorV1>()
+        .map_or(
+            StrictPrimaryStateIncompleteV1::InvalidRootBinding,
+            |limit| StrictPrimaryStateIncompleteV1::NamespaceResourceLimit {
+                resource: limit.resource(),
+            },
+        )
+}
+
+#[derive(Debug)]
 pub enum StrictPrimaryStateReadV1 {
     Complete(StrictPrimaryStateSnapshotV1),
     Incomplete(StrictPrimaryStateIncompleteV1),
@@ -498,16 +573,16 @@ fn read_and_bind_strict_primary_state_inner_v1(
             },
         ));
     }
-    let entries = match bind_strict_state_entries_v1(
+    let bound = match bind_strict_state_entries_v1(
         raw_entries,
         canonical_local_root,
         canonical_remote_prefix,
         binding_mode,
     ) {
         Ok(entries) => entries,
-        Err(_) => {
+        Err(error) => {
             return Ok(StrictPrimaryStateReadV1::Incomplete(
-                StrictPrimaryStateIncompleteV1::InvalidRootBinding,
+                strict_state_binding_incomplete_v1(&error),
             ));
         }
     };
@@ -517,11 +592,21 @@ fn read_and_bind_strict_primary_state_inner_v1(
     Ok(StrictPrimaryStateReadV1::Complete(
         StrictPrimaryStateSnapshotV1 {
             raw_bytes_digest: raw_digest,
-            entries,
+            selected_state_path: state_path.to_owned(),
+            canonical_local_root: canonical_local_root.to_owned(),
+            remote_prefix: bound.remote_prefix,
+            namespace_claims: bound.namespace_claims,
+            entries: bound.entries,
             last_nats_seq: wire.last_nats_seq,
             device_id: wire.device_id,
         },
     ))
+}
+
+struct BoundStrictStateEntriesV1 {
+    remote_prefix: String,
+    namespace_claims: BTreeMap<String, StrictStateNamespaceClaimV1>,
+    entries: BTreeMap<String, BoundStrictSyncStateV1>,
 }
 
 fn bind_strict_state_entries_v1(
@@ -529,7 +614,7 @@ fn bind_strict_state_entries_v1(
     canonical_local_root: &Path,
     canonical_remote_prefix: &str,
     binding_mode: StrictStateRootBindingModeV1,
-) -> Result<BTreeMap<String, BoundStrictSyncStateV1>> {
+) -> Result<BoundStrictStateEntriesV1> {
     anyhow::ensure!(
         canonical_local_root.is_absolute(),
         "strict state root binding requires an absolute local root"
@@ -559,7 +644,12 @@ fn bind_strict_state_entries_v1(
     );
     validate_registered_remote_storage_key_bounds_v1(prefix, "strict state remote prefix")?;
 
-    let mut namespace_claims: BTreeMap<String, (String, PortableNamespaceRole)> = BTreeMap::new();
+    let mut namespace_claims = BTreeMap::new();
+    let mut namespace_budget = StrictStateNamespaceBudgetV1::default();
+    // The retained state-side map is required for ordered cross-source
+    // composition. Its state-owned, fingerprinted ceilings prevent one valid
+    // primary from amplifying into an unbounded claim set.
+    let namespace_contract = RegisteredRootPlanContractV1::strict_v1().state_contract();
     let mut entries = BTreeMap::new();
     for (cache_key, state) in raw_entries {
         let rel_path = bind_strict_cache_key_v1(&cache_key, canonical_local_root, binding_mode)?;
@@ -583,7 +673,12 @@ fn bind_strict_state_entries_v1(
             validate_exact_manifest_key_v1(prefix, conflict_manifest_key)?;
         }
 
-        reserve_state_namespace_claims_v1(&rel_path, &mut namespace_claims)?;
+        reserve_state_namespace_claims_v1(
+            &rel_path,
+            &mut namespace_claims,
+            &mut namespace_budget,
+            namespace_contract,
+        )?;
         let index_key = format!("{prefix}/index/{rel_path}");
         validate_registered_remote_storage_key_bounds_v1(&index_key, "strict state index key")?;
         let entry = BoundStrictSyncStateV1 {
@@ -597,7 +692,11 @@ fn bind_strict_state_entries_v1(
             "strict state cache contains duplicate bound paths"
         );
     }
-    Ok(entries)
+    Ok(BoundStrictStateEntriesV1 {
+        remote_prefix: prefix.to_owned(),
+        namespace_claims,
+        entries,
+    })
 }
 
 fn bind_strict_cache_key_v1(
@@ -658,9 +757,72 @@ fn validate_exact_manifest_key_v1<'a>(remote_prefix: &str, key: &'a str) -> Resu
     Ok(key)
 }
 
+#[derive(Default)]
+struct StrictStateNamespaceBudgetV1 {
+    generated_claims: u64,
+    generated_claim_bytes: u64,
+    retained_claims: u64,
+    retained_claim_bytes: u64,
+}
+
+fn checked_state_namespace_increment_v1(
+    value: &mut u64,
+    increment: u64,
+    maximum: u64,
+    resource: StrictStateNamespaceResourceV1,
+) -> Result<()> {
+    *value = value
+        .checked_add(increment)
+        .filter(|next| *next <= maximum)
+        .ok_or(StrictStateNamespaceResourceLimitErrorV1(resource))?;
+    Ok(())
+}
+
+impl StrictStateNamespaceBudgetV1 {
+    fn observe_generated_claim(
+        &mut self,
+        claim_bytes: u64,
+        contract: RootStateContractV1,
+    ) -> Result<()> {
+        checked_state_namespace_increment_v1(
+            &mut self.generated_claims,
+            1,
+            contract.max_generated_claim_observations(),
+            StrictStateNamespaceResourceV1::GeneratedClaims,
+        )?;
+        checked_state_namespace_increment_v1(
+            &mut self.generated_claim_bytes,
+            claim_bytes,
+            contract.max_generated_claim_bytes(),
+            StrictStateNamespaceResourceV1::GeneratedClaimBytes,
+        )
+    }
+
+    fn observe_retained_claim(
+        &mut self,
+        claim_bytes: u64,
+        contract: RootStateContractV1,
+    ) -> Result<()> {
+        checked_state_namespace_increment_v1(
+            &mut self.retained_claims,
+            1,
+            contract.max_retained_unique_claims(),
+            StrictStateNamespaceResourceV1::RetainedClaims,
+        )?;
+        checked_state_namespace_increment_v1(
+            &mut self.retained_claim_bytes,
+            claim_bytes,
+            contract.max_retained_unique_claim_bytes(),
+            StrictStateNamespaceResourceV1::RetainedClaimBytes,
+        )
+    }
+}
+
 fn reserve_state_namespace_claims_v1(
     rel_path: &str,
-    claims: &mut BTreeMap<String, (String, PortableNamespaceRole)>,
+    claims: &mut BTreeMap<String, StrictStateNamespaceClaimV1>,
+    budget: &mut StrictStateNamespaceBudgetV1,
+    contract: RootStateContractV1,
 ) -> Result<()> {
     let components: Vec<&str> = rel_path.split('/').collect();
     for end in 1..=components.len() {
@@ -671,13 +833,28 @@ fn reserve_state_namespace_claims_v1(
             PortableNamespaceRole::Directory
         };
         let folded_path = portable_casefold_path(&exact_path)?;
-        if let Some((existing_path, existing_role)) = claims.get(&folded_path) {
+        let claim_bytes = u64::try_from(exact_path.len())
+            .ok()
+            .and_then(|exact_bytes| {
+                u64::try_from(folded_path.len())
+                    .ok()
+                    .and_then(|folded_bytes| exact_bytes.checked_add(folded_bytes))
+            })
+            .ok_or(StrictStateNamespaceResourceLimitErrorV1(
+                StrictStateNamespaceResourceV1::GeneratedClaimBytes,
+            ))?;
+        budget.observe_generated_claim(claim_bytes, contract)?;
+        if let Some(existing) = claims.get(&folded_path) {
             anyhow::ensure!(
-                existing_path == &exact_path && *existing_role == role,
+                existing.exact_path == exact_path && existing.role == role,
                 "strict state namespace has a portable spelling or role collision"
             );
         } else {
-            claims.insert(folded_path, (exact_path, role));
+            budget.observe_retained_claim(claim_bytes, contract)?;
+            claims.insert(
+                folded_path,
+                StrictStateNamespaceClaimV1 { exact_path, role },
+            );
         }
     }
     Ok(())
@@ -2545,6 +2722,122 @@ mod tests {
                 }
             ) if active_keys == vec![active_key] && locked_keys.is_empty()
         ));
+    }
+
+    #[test]
+    fn empty_strict_primary_retains_exact_route_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let local_root = dir.path().join("root");
+        std::fs::create_dir(&local_root).unwrap();
+        let local_root = std::fs::canonicalize(local_root).unwrap();
+        write_private(
+            &state_path,
+            br#"{"last_nats_seq":0,"device_id":"sting","entries":{}}"#,
+        );
+        let state_path = std::fs::canonicalize(state_path).unwrap();
+
+        for prefix in ["roots-a", "roots-b"] {
+            let snapshot =
+                match read_and_bind_strict_primary_state_v1(&state_path, &local_root, prefix)
+                    .unwrap()
+                {
+                    StrictPrimaryStateReadV1::Complete(snapshot) => snapshot,
+                    other => panic!("expected empty strict state snapshot, got {other:?}"),
+                };
+            assert_eq!(snapshot.selected_state_path(), state_path);
+            assert_eq!(snapshot.canonical_local_root(), local_root);
+            assert_eq!(snapshot.remote_prefix(), prefix);
+            assert_eq!(snapshot.entries().len(), 0);
+            assert_eq!(snapshot.namespace_claims().len(), 0);
+        }
+    }
+
+    #[test]
+    fn strict_state_namespace_claim_budget_is_fingerprinted_and_charged_before_dedupe() {
+        type ObserveClaimV1 =
+            fn(&mut StrictStateNamespaceBudgetV1, u64, RootStateContractV1) -> Result<()>;
+
+        fn assert_typed_limit_v1(error: &anyhow::Error, expected: StrictStateNamespaceResourceV1) {
+            assert_eq!(
+                error
+                    .downcast_ref::<StrictStateNamespaceResourceLimitErrorV1>()
+                    .unwrap()
+                    .resource(),
+                expected
+            );
+            assert_eq!(
+                strict_state_binding_incomplete_v1(error),
+                StrictPrimaryStateIncompleteV1::NamespaceResourceLimit { resource: expected }
+            );
+        }
+
+        let contract = RegisteredRootPlanContractV1::strict_v1().state_contract();
+        let mut claims = BTreeMap::new();
+        let mut budget = StrictStateNamespaceBudgetV1::default();
+        reserve_state_namespace_claims_v1("parent/first", &mut claims, &mut budget, contract)
+            .unwrap();
+        reserve_state_namespace_claims_v1("parent/second", &mut claims, &mut budget, contract)
+            .unwrap();
+        assert_eq!(budget.generated_claims, 4);
+        assert_eq!(budget.retained_claims, 3);
+        assert_eq!(claims.len(), 3);
+
+        let rows: [(
+            StrictStateNamespaceResourceV1,
+            StrictStateNamespaceBudgetV1,
+            ObserveClaimV1,
+            u64,
+        ); 4] = [
+            (
+                StrictStateNamespaceResourceV1::GeneratedClaims,
+                StrictStateNamespaceBudgetV1 {
+                    generated_claims: contract.max_generated_claim_observations() - 1,
+                    ..StrictStateNamespaceBudgetV1::default()
+                },
+                StrictStateNamespaceBudgetV1::observe_generated_claim,
+                0,
+            ),
+            (
+                StrictStateNamespaceResourceV1::GeneratedClaimBytes,
+                StrictStateNamespaceBudgetV1 {
+                    generated_claim_bytes: contract.max_generated_claim_bytes() - 1,
+                    ..StrictStateNamespaceBudgetV1::default()
+                },
+                StrictStateNamespaceBudgetV1::observe_generated_claim,
+                1,
+            ),
+            (
+                StrictStateNamespaceResourceV1::RetainedClaims,
+                StrictStateNamespaceBudgetV1 {
+                    retained_claims: contract.max_retained_unique_claims() - 1,
+                    ..StrictStateNamespaceBudgetV1::default()
+                },
+                StrictStateNamespaceBudgetV1::observe_retained_claim,
+                0,
+            ),
+            (
+                StrictStateNamespaceResourceV1::RetainedClaimBytes,
+                StrictStateNamespaceBudgetV1 {
+                    retained_claim_bytes: contract.max_retained_unique_claim_bytes() - 1,
+                    ..StrictStateNamespaceBudgetV1::default()
+                },
+                StrictStateNamespaceBudgetV1::observe_retained_claim,
+                1,
+            ),
+        ];
+        for (resource, mut exact, observe, increment) in rows {
+            observe(&mut exact, increment, contract)
+                .expect("the exact state claim resource ceiling is accepted");
+            let error = observe(&mut exact, increment, contract)
+                .expect_err("one claim beyond the state resource ceiling is rejected");
+            assert_typed_limit_v1(&error, resource);
+        }
+
+        assert_eq!(
+            strict_state_binding_incomplete_v1(&anyhow::anyhow!("invalid binding")),
+            StrictPrimaryStateIncompleteV1::InvalidRootBinding
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/tcfs-sync/src/registered_remote_catalog.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog.rs
@@ -125,6 +125,11 @@ pub(crate) enum StrictRemoteCatalogIncompleteV1 {
     HeadMissing,
     HeadUnboundCurrentEtag,
     HeadChanged,
+    /// A canonical publishing marker for the exact selected context is visible.
+    /// Readers cannot independently authenticate the external writer lease and
+    /// must not fall back to an older committed revision while mutation may be
+    /// in flight.
+    PublicationInProgress,
     ClosureObjectMissing {
         kind: RemoteCatalogClosureObjectKindV1,
     },
@@ -339,6 +344,11 @@ pub(crate) struct VerifiedRemoteCatalogClosureV1 {
     publication_nonce: [u8; 32],
     parent_head_revision: Option<[u8; 32]>,
     head_revision: [u8; 32],
+    // Retained so a future publication transaction can archive the complete
+    // predecessor HEAD before replacing the mutable key with a visible fence.
+    // A revision hash alone is not recoverable without forbidden LIST-based
+    // discovery.
+    head_raw_bytes: Vec<u8>,
     head_object: BoundRemoteObjectSnapshotV1,
     root_object: BoundRemoteObjectSnapshotV1,
     page_objects: Vec<BoundRemoteObjectSnapshotV1>,
@@ -701,7 +711,13 @@ fn validate_catalog_lineage_v1(
         return None;
     }
     let parent = match parent_head_revision {
-        Some(parent) => Some(parse_lower_hex_32(parent)?),
+        Some(parent) => {
+            let parent = parse_lower_hex_32(parent)?;
+            if parent == [0_u8; 32] {
+                return None;
+            }
+            Some(parent)
+        }
         None => None,
     };
     if (sequence.get() == 1) != parent.is_none() {
@@ -1150,8 +1166,21 @@ fn validate_head_v1(
     selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
 ) -> std::result::Result<ValidatedRemoteCatalogHeadV1, StrictRemoteCatalogIncompleteV1> {
     let kind = RemoteCatalogClosureObjectKindV1::Head;
-    let head = canonical_wire_v1::<RemoteCatalogHeadWireV1>(raw.raw_bytes())
-        .ok_or_else(|| invalid(kind, InvalidRemoteCatalogReasonV1::CanonicalEncoding))?;
+    let head = match canonical_wire_v1::<RemoteCatalogHeadWireV1>(raw.raw_bytes()) {
+        Some(head) => head,
+        None => match publication::classify_publishing_head_v1(raw.raw_bytes(), selected) {
+            Some(Ok(())) => {
+                return Err(StrictRemoteCatalogIncompleteV1::PublicationInProgress);
+            }
+            Some(Err(reason)) => return Err(invalid(kind, reason)),
+            None => {
+                return Err(invalid(
+                    kind,
+                    InvalidRemoteCatalogReasonV1::CanonicalEncoding,
+                ));
+            }
+        },
+    };
     if head.version != CATALOG_SCHEMA_VERSION_V1 {
         return Err(invalid(
             kind,
@@ -1506,6 +1535,7 @@ pub(crate) async fn read_verified_remote_catalog_closure_v1(
     }
 
     let head_revision = catalog_head_revision_v1(head_a_raw.raw_bytes());
+    let head_raw_bytes = head_a_raw.raw_bytes().to_vec();
     let head_object = bind_remote_object_v1(head_a_raw);
     let root_object = bind_remote_object_v1(root_raw);
     Ok(StrictRemoteCatalogClosureReadV1::Verified(Box::new(
@@ -1521,6 +1551,7 @@ pub(crate) async fn read_verified_remote_catalog_closure_v1(
             publication_nonce,
             parent_head_revision,
             head_revision,
+            head_raw_bytes,
             head_object,
             root_object,
             page_objects,
@@ -2110,6 +2141,12 @@ pub(crate) async fn read_semantically_bound_remote_catalog_corpus_v1(
         }),
     ))
 }
+
+// Source-only catalog publication protocol. Production constructors for the
+// external bootstrap/high-water/writer-fence receipts deliberately do not
+// exist yet, so this module cannot authorize a live writer or a plan digest.
+#[allow(dead_code)]
+pub(crate) mod publication;
 
 #[cfg(test)]
 pub(crate) mod tests {
@@ -3992,6 +4029,108 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn visible_publishing_head_blocks_catalog_readers() {
+        let publishing = fixture("roots", Vec::new());
+        let committed =
+            serde_json::from_slice::<RemoteCatalogHeadWireV1>(&publishing.head_bytes).unwrap();
+        let publishing_bytes =
+            publication::canonical_publishing_head_bytes_for_test_v1(committed.context);
+        publishing.backend.insert(
+            publishing.head_key.clone(),
+            scripted_object(publishing_bytes, "publishing-head-etag"),
+        );
+        let receipt = publishing.receipt("roots").await;
+        assert_eq!(
+            incomplete(publishing.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::PublicationInProgress
+        );
+        assert!(publishing.backend.reads.lock().unwrap().iter().all(|read| {
+            read.path == publishing.head_key
+                || read
+                    .path
+                    .contains(".tcfs-capability-probes/conditional-write-")
+        }));
+    }
+
+    #[tokio::test]
+    async fn publishing_head_context_drift_is_not_another_roots_fence() {
+        for case in 0_u8..6 {
+            let publishing = fixture("roots", Vec::new());
+            let committed =
+                serde_json::from_slice::<RemoteCatalogHeadWireV1>(&publishing.head_bytes).unwrap();
+            let mut context = committed.context;
+            match case {
+                0 => {
+                    context.root_id = "other-root".to_owned();
+                    let spec = RootSpecV1Config {
+                        version: RootSpecV1Config::VERSION,
+                        remote_prefix: "roots".to_owned(),
+                        profile: context.profile,
+                        generation: NonZeroU64::new(context.root_generation).unwrap(),
+                    };
+                    context.root_identity_fingerprint = spec.identity_fingerprint(&context.root_id);
+                }
+                1 => {
+                    context.root_identity_fingerprint = format!("b3v1:{}", "0".repeat(64));
+                }
+                2 => {
+                    context.root_generation += 1;
+                    let spec = RootSpecV1Config {
+                        version: RootSpecV1Config::VERSION,
+                        remote_prefix: "roots".to_owned(),
+                        profile: context.profile,
+                        generation: NonZeroU64::new(context.root_generation).unwrap(),
+                    };
+                    context.root_identity_fingerprint = spec.identity_fingerprint(&context.root_id);
+                }
+                3 => {
+                    context.profile = RootProfileV1::GitRawV1;
+                    context.profile_settings_fingerprint =
+                        context.profile.policy().settings_fingerprint().to_string();
+                    let spec = RootSpecV1Config {
+                        version: RootSpecV1Config::VERSION,
+                        remote_prefix: "roots".to_owned(),
+                        profile: context.profile,
+                        generation: NonZeroU64::new(context.root_generation).unwrap(),
+                    };
+                    context.root_identity_fingerprint = spec.identity_fingerprint(&context.root_id);
+                }
+                4 => {
+                    context.profile_settings_fingerprint = RootProfileV1::GitRawV1
+                        .policy()
+                        .settings_fingerprint()
+                        .to_string();
+                }
+                5 => {
+                    context.plan_contract_fingerprint = format!("b3v1:{}", "0".repeat(64));
+                }
+                _ => unreachable!(),
+            }
+            let publishing_bytes =
+                publication::canonical_publishing_head_bytes_for_test_v1(context);
+            publishing.backend.insert(
+                publishing.head_key.clone(),
+                scripted_object(publishing_bytes, "publishing-head-etag"),
+            );
+            let receipt = publishing.receipt("roots").await;
+            assert_eq!(
+                incomplete(publishing.read(&receipt).await.unwrap()),
+                StrictRemoteCatalogIncompleteV1::Invalid {
+                    kind: RemoteCatalogClosureObjectKindV1::Head,
+                    reason: InvalidRemoteCatalogReasonV1::Context,
+                },
+                "publishing context drift case {case}"
+            );
+            assert!(publishing.backend.reads.lock().unwrap().iter().all(|read| {
+                read.path == publishing.head_key
+                    || read
+                        .path
+                        .contains(".tcfs-capability-probes/conditional-write-")
+            }));
+        }
+    }
+
+    #[tokio::test]
     async fn unbound_or_changed_closure_objects_are_typed_without_retry() {
         let head = fixture("roots", Vec::new());
         head.backend.insert(
@@ -4253,6 +4392,36 @@ pub(crate) mod tests {
                 reason: InvalidRemoteCatalogReasonV1::Lineage
             }
         );
+
+        let zero_parent = fixture("roots", Vec::new());
+        let mut head =
+            serde_json::from_slice::<RemoteCatalogHeadWireV1>(&zero_parent.head_bytes).unwrap();
+        head.catalog_sequence = 2;
+        head.parent_head_revision = Some("00".repeat(32));
+        zero_parent.backend.insert(
+            zero_parent.head_key.clone(),
+            scripted_object(serde_json::to_vec(&head).unwrap(), "head-etag-a"),
+        );
+        let receipt = zero_parent.receipt("roots").await;
+        assert_eq!(
+            incomplete(zero_parent.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Head,
+                reason: InvalidRemoteCatalogReasonV1::Lineage
+            }
+        );
+        assert!(zero_parent
+            .backend
+            .reads
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|read| {
+                read.path == zero_parent.head_key
+                    || read
+                        .path
+                        .contains(".tcfs-capability-probes/conditional-write-")
+            }));
 
         let zero_nonce = fixture("roots", Vec::new());
         let mut head =

--- a/crates/tcfs-sync/src/registered_remote_catalog.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog.rs
@@ -793,30 +793,35 @@ fn observed_binding_matches_v1(
     }
 }
 
-fn validate_catalog_entry_route_v1(remote_prefix: &str, entry: &RemoteCatalogEntryWireV1) -> bool {
-    if !validate_storage_key_bound_v1(&entry.object_key) {
+fn validate_catalog_object_route_v1(
+    remote_prefix: &str,
+    kind: RemoteCatalogObjectKindV1,
+    object_key: &str,
+) -> bool {
+    if !validate_storage_key_bound_v1(object_key) {
         return false;
     }
-    match entry.kind {
-        RemoteCatalogObjectKindV1::Index => entry
-            .object_key
+    match kind {
+        RemoteCatalogObjectKindV1::Index => object_key
             .strip_prefix(&namespace_index_prefix(remote_prefix))
             .filter(|relative| !relative.is_empty())
             .and_then(|relative| namespace_logical_entry_from_index_path(relative).ok())
             .is_some_and(|(logical_path, _)| {
                 validate_registered_remote_logical_path_bounds_v1(&logical_path).is_ok()
             }),
-        RemoteCatalogObjectKindV1::Reservation => entry
-            .object_key
+        RemoteCatalogObjectKindV1::Reservation => object_key
             .strip_prefix(&namespace_reservation_prefix(remote_prefix))
             .and_then(parse_lower_hex_32)
             .is_some(),
-        RemoteCatalogObjectKindV1::Manifest => entry
-            .object_key
+        RemoteCatalogObjectKindV1::Manifest => object_key
             .strip_prefix(&format!("{remote_prefix}/manifests/"))
             .and_then(parse_lower_hex_32)
             .is_some(),
     }
+}
+
+fn validate_catalog_entry_route_v1(remote_prefix: &str, entry: &RemoteCatalogEntryWireV1) -> bool {
+    validate_catalog_object_route_v1(remote_prefix, entry.kind, &entry.object_key)
 }
 
 fn validate_entry_size_v1(kind: RemoteCatalogObjectKindV1, raw_bytes_len: u64) -> bool {

--- a/crates/tcfs-sync/src/registered_remote_catalog.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog.rs
@@ -4,18 +4,21 @@
 //! an object. The strict registered-root ceremony therefore requires a
 //! conditionally updated current HEAD whose exact bytes select an immutable,
 //! content-addressed catalog root and ordered immutable pages. This module
-//! validates only that catalog closure:
+//! first validates that catalog closure:
 //!
 //! `current HEAD A -> catalog root -> every catalog page -> current HEAD B`
 //!
-//! It deliberately stops before binding every namespace object named by the
-//! pages. It also cannot prove that legacy/direct writers have been fenced or
-//! that the first catalog was bootstrapped from externally complete truth.
+//! A separate opaque semantic reader then exact-fetches the catalog-declared
+//! version of every named object, validates strict namespace semantics and the
+//! exact manifest-reference set, and finally rechecks current HEAD C. That
+//! artifact is still only one internally closed observed revision. It cannot
+//! prove that legacy/direct writers have been fenced or that the first catalog
+//! was bootstrapped from externally complete truth.
 //! The inventory is the registered-root reconcile metadata corpus (indices,
 //! namespace reservations, and manifests), not chunks, staging objects,
-//! probes, or catalog objects. A later semantic gate must still prove that
-//! every index and reservation is present and the manifest entries are exactly
-//! the referenced manifest set.
+//! probes, or catalog objects. The semantic gate below proves that every named
+//! index and reservation is present and that manifest entries are exactly the
+//! referenced manifest set for this revision.
 //! Without linearizable current-HEAD reads or a trusted monotonic high-water
 //! mark, it also proves closure only at the observed revision, not that the
 //! revision is the latest published namespace.
@@ -26,6 +29,7 @@ use anyhow::Result;
 use opendal::Operator;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroU64;
+use std::path::Path;
 #[cfg(test)]
 use tcfs_core::config::RootSpecV1Config;
 use tcfs_core::config::{
@@ -34,14 +38,32 @@ use tcfs_core::config::{
 };
 use tcfs_storage::ConditionalWriteSemanticsReceipt;
 
+use crate::blacklist::Blacklist;
 use crate::index_entry::{
     namespace_index_prefix, namespace_logical_entry_from_index_path, namespace_reservation_prefix,
-    read_current_raw_object_snapshot_v1, read_raw_object_snapshot_v1,
-    validate_canonical_namespace_remote_prefix, RawObjectChangedDuringReadV1,
-    RawObjectReadBindingV1, RawObjectReadV1, RawObjectSnapshotTooLargeV1, RawObjectSnapshotV1,
+    read_current_raw_object_snapshot_v1, read_expected_raw_object_snapshot_v1,
+    validate_canonical_namespace_remote_prefix, PortableNamespaceRole,
+    RawObjectChangedDuringReadV1, RawObjectReadBindingV1, RawObjectReadV1,
+    RawObjectSnapshotInvalidMetadataV1, RawObjectSnapshotTooLargeV1, RawObjectSnapshotV1,
 };
 use crate::registered_reconcile::{
-    bind_remote_object_v1, BoundRemoteObjectSnapshotV1, RegisteredRootRemoteObjectBindingV1,
+    bind_remote_object_v1, expected_raw_object_binding_v1,
+    read_expected_observed_namespace_reservation_v1,
+    read_expected_observed_raw_directory_marker_v1, read_expected_observed_raw_index_entry_v1,
+    read_expected_observed_strict_remote_manifest_for_references_v1,
+    validate_registered_remote_logical_path_bounds_v1,
+    validate_registered_remote_storage_key_bounds_v1, BoundNamespaceReservationV1,
+    BoundRemoteObjectSnapshotV1, ExactObservedNamespaceReservationReadV1,
+    ExactObservedRawDirectoryMarkerReadV1, ExactObservedRawIndexEntryReadV1,
+    RawCommittedIndexEntryV1, RawDeletedDirectoryMarkerV1, RawDeletedIndexEntryV1,
+    RawLiveDirectoryMarkerV1, RegisteredRootRemoteObjectBindingV1,
+    StrictNamespaceReservationIncompleteV1, StrictObservedRemoteManifestReadV1,
+    StrictRemoteDirectoryMarkerIncompleteV1, StrictRemoteIndexIncompleteV1,
+    StrictRemoteManifestIncompleteV1, StrictRemoteManifestV1,
+};
+use crate::registered_remote_observation::{
+    RemoteNamespaceClaimAccumulatorErrorV1, RemoteNamespaceClaimAccumulatorV1,
+    RemoteNamespaceClaimOriginsV1, RetainedRemoteNamespaceClaimV1,
 };
 use crate::registered_source_composition::ValidatedSelectedRegisteredRootRemoteContextV1;
 
@@ -122,6 +144,62 @@ pub(crate) enum StrictRemoteCatalogIncompleteV1 {
 pub(crate) enum StrictRemoteCatalogClosureReadV1 {
     Verified(Box<VerifiedRemoteCatalogClosureV1>),
     Incomplete(StrictRemoteCatalogIncompleteV1),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteCatalogNamedObjectKindV1 {
+    OrdinaryIndex,
+    DirectoryMarker,
+    NamespaceReservation,
+    Manifest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteCatalogManifestSetMismatchV1 {
+    MissingReferencedManifest,
+    UnreferencedManifest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SemanticRemoteCatalogResourceV1 {
+    AdvertisedObjectBytes,
+    BoundObjectBytes,
+    RetainedBindingBytes,
+    IndexObjects,
+    ReservationObjects,
+    ManifestObjects,
+    ManifestReferenceOrdinals,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StrictSemanticallyBoundRemoteCatalogIncompleteV1 {
+    Catalog(StrictRemoteCatalogIncompleteV1),
+    NamedObjectMissing {
+        kind: RemoteCatalogNamedObjectKindV1,
+    },
+    NamedObjectChanged {
+        kind: RemoteCatalogNamedObjectKindV1,
+    },
+    NamedObjectUnbound {
+        kind: RemoteCatalogNamedObjectKindV1,
+    },
+    NamedObjectIdentity {
+        kind: RemoteCatalogNamedObjectKindV1,
+    },
+    Index(StrictRemoteIndexIncompleteV1),
+    Marker(StrictRemoteDirectoryMarkerIncompleteV1),
+    LiveMarkerExcluded,
+    Reservation(StrictNamespaceReservationIncompleteV1),
+    Manifest(StrictRemoteManifestIncompleteV1),
+    ManifestSet(RemoteCatalogManifestSetMismatchV1),
+    NamespaceClaim(RemoteNamespaceClaimAccumulatorErrorV1),
+    ResourceLimit(SemanticRemoteCatalogResourceV1),
+    HeadChanged,
+}
+
+pub(crate) enum StrictSemanticallyBoundRemoteCatalogReadV1 {
+    Verified(Box<SemanticallyBoundRemoteCatalogCorpusV1>),
+    Incomplete(StrictSemanticallyBoundRemoteCatalogIncompleteV1),
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -323,6 +401,131 @@ impl VerifiedRemoteCatalogClosureV1 {
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum SemanticallyBoundCatalogIndexObjectV1 {
+    Committed(Box<RawCommittedIndexEntryV1>),
+    Deleted(Box<RawDeletedIndexEntryV1>),
+    LiveMarker(Box<RawLiveDirectoryMarkerV1>),
+    DeletedMarker(Box<RawDeletedDirectoryMarkerV1>),
+}
+
+impl SemanticallyBoundCatalogIndexObjectV1 {
+    const fn object(&self) -> &BoundRemoteObjectSnapshotV1 {
+        match self {
+            Self::Committed(index) => index.object(),
+            Self::Deleted(index) => index.object(),
+            Self::LiveMarker(marker) => marker.object(),
+            Self::DeletedMarker(marker) => marker.object(),
+        }
+    }
+
+    fn logical_path(&self) -> &str {
+        match self {
+            Self::Committed(index) => index.rel_path(),
+            Self::Deleted(index) => index.route().rel_path(),
+            Self::LiveMarker(marker) => marker.route().logical_dir(),
+            Self::DeletedMarker(marker) => marker.route().logical_dir(),
+        }
+    }
+
+    fn physical_key(&self) -> &str {
+        match self {
+            Self::Committed(index) => index.index_key(),
+            Self::Deleted(index) => index.route().index_key(),
+            Self::LiveMarker(marker) => marker.route().marker_key(),
+            Self::DeletedMarker(marker) => marker.route().marker_key(),
+        }
+    }
+
+    const fn role(&self) -> PortableNamespaceRole {
+        match self {
+            Self::Committed(_) | Self::Deleted(_) => PortableNamespaceRole::File,
+            Self::LiveMarker(_) | Self::DeletedMarker(_) => PortableNamespaceRole::Directory,
+        }
+    }
+
+    const fn claim_origin(&self) -> RemoteNamespaceClaimOriginsV1 {
+        match self {
+            Self::Committed(_) | Self::LiveMarker(_) => RemoteNamespaceClaimOriginsV1::CURRENT,
+            Self::Deleted(_) | Self::DeletedMarker(_) => RemoteNamespaceClaimOriginsV1::HISTORICAL,
+        }
+    }
+
+    const fn committed(&self) -> Option<&RawCommittedIndexEntryV1> {
+        match self {
+            Self::Committed(index) => Some(index),
+            Self::Deleted(_) | Self::LiveMarker(_) | Self::DeletedMarker(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct SemanticallyBoundCatalogManifestV1 {
+    source_index_ordinal: usize,
+    manifest: Box<StrictRemoteManifestV1>,
+}
+
+/// Strict semantic closure of every namespace object named by one unchanged
+/// catalog revision.
+///
+/// This is deliberately opaque, non-cloneable, and non-serializable. It is
+/// not remote-completeness authority: external writer fencing, externally
+/// complete bootstrap, and monotonic replay/high-water proof are still absent.
+pub(crate) struct SemanticallyBoundRemoteCatalogCorpusV1 {
+    // The named entry vector is drained during construction so the retained
+    // semantic corpus does not duplicate every potentially long storage key.
+    closure: VerifiedRemoteCatalogClosureV1,
+    index_objects: Vec<SemanticallyBoundCatalogIndexObjectV1>,
+    reservations: Vec<BoundNamespaceReservationV1>,
+    manifests: Vec<SemanticallyBoundCatalogManifestV1>,
+    claims: Vec<RetainedRemoteNamespaceClaimV1>,
+}
+
+impl std::fmt::Debug for SemanticallyBoundRemoteCatalogCorpusV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SemanticallyBoundRemoteCatalogCorpusV1")
+            .field("remote_prefix", &self.closure.remote_prefix)
+            .field("root_id", &self.closure.root_id)
+            .field("catalog_sequence", &self.closure.catalog_sequence)
+            .field("index_object_count", &self.index_objects.len())
+            .field("reservation_count", &self.reservations.len())
+            .field("manifest_count", &self.manifests.len())
+            .field("claim_count", &self.claims.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl SemanticallyBoundRemoteCatalogCorpusV1 {
+    pub(crate) fn remote_prefix(&self) -> &str {
+        self.closure.remote_prefix()
+    }
+
+    pub(crate) fn root_id(&self) -> &str {
+        self.closure.root_id()
+    }
+
+    pub(crate) const fn catalog_sequence(&self) -> NonZeroU64 {
+        self.closure.catalog_sequence()
+    }
+
+    pub(crate) fn index_object_count(&self) -> usize {
+        self.index_objects.len()
+    }
+
+    pub(crate) fn reservation_count(&self) -> usize {
+        self.reservations.len()
+    }
+
+    pub(crate) fn manifest_count(&self) -> usize {
+        self.manifests.len()
+    }
+
+    pub(crate) fn claim_count(&self) -> usize {
+        self.claims.len()
+    }
+}
+
 fn join_remote_key_v1(remote_prefix: &str, suffix: &str) -> String {
     format!("{remote_prefix}/{suffix}")
 }
@@ -398,20 +601,7 @@ fn invalid(
 }
 
 fn validate_storage_key_bound_v1(key: &str) -> bool {
-    !key.is_empty()
-        && !key.starts_with('/')
-        && !key.ends_with('/')
-        && !key.contains('\\')
-        && !key.chars().any(char::is_control)
-        && !key
-            .split('/')
-            .any(|component| component.is_empty() || component == "." || component == "..")
-        && u64::try_from(key.len()).is_ok_and(|length| {
-            length
-                <= RegisteredRootPlanContractV1::strict_v1()
-                    .remote_contract()
-                    .max_storage_key_bytes()
-        })
+    validate_registered_remote_storage_key_bounds_v1(key, "remote catalog storage key").is_ok()
 }
 
 fn validate_catalog_context_v1(
@@ -548,7 +738,10 @@ fn validate_catalog_entry_route_v1(remote_prefix: &str, entry: &RemoteCatalogEnt
             .object_key
             .strip_prefix(&namespace_index_prefix(remote_prefix))
             .filter(|relative| !relative.is_empty())
-            .is_some_and(|relative| namespace_logical_entry_from_index_path(relative).is_ok()),
+            .and_then(|relative| namespace_logical_entry_from_index_path(relative).ok())
+            .is_some_and(|(logical_path, _)| {
+                validate_registered_remote_logical_path_bounds_v1(&logical_path).is_ok()
+            }),
         RemoteCatalogObjectKindV1::Reservation => entry
             .object_key
             .strip_prefix(&namespace_reservation_prefix(remote_prefix))
@@ -707,6 +900,87 @@ impl RemoteCatalogBudgetV1 {
     }
 }
 
+#[derive(Default)]
+struct SemanticRemoteCatalogBudgetV1 {
+    advertised_object_bytes: u64,
+    bound_object_bytes: u64,
+    retained_binding_bytes: u64,
+}
+
+impl SemanticRemoteCatalogBudgetV1 {
+    fn checked_add(
+        value: &mut u64,
+        increment: u64,
+        maximum: u64,
+        resource: SemanticRemoteCatalogResourceV1,
+    ) -> std::result::Result<(), StrictSemanticallyBoundRemoteCatalogIncompleteV1> {
+        *value = value
+            .checked_add(increment)
+            .ok_or(StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(resource))?;
+        if *value > maximum {
+            return Err(StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(resource));
+        }
+        Ok(())
+    }
+
+    fn observe_advertised(
+        &mut self,
+        entry: &VerifiedRemoteCatalogEntryV1,
+    ) -> std::result::Result<(), StrictSemanticallyBoundRemoteCatalogIncompleteV1> {
+        let maximum = RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_bound_object_bytes_per_pass();
+        Self::checked_add(
+            &mut self.advertised_object_bytes,
+            entry.raw_bytes_len(),
+            maximum,
+            SemanticRemoteCatalogResourceV1::AdvertisedObjectBytes,
+        )
+    }
+
+    fn observe_bound(
+        &mut self,
+        object: &BoundRemoteObjectSnapshotV1,
+    ) -> std::result::Result<(), StrictSemanticallyBoundRemoteCatalogIncompleteV1> {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        Self::checked_add(
+            &mut self.bound_object_bytes,
+            object.raw_bytes_len(),
+            contract.max_bound_object_bytes_per_pass(),
+            SemanticRemoteCatalogResourceV1::BoundObjectBytes,
+        )?;
+        let binding_bytes = match object.binding() {
+            RegisteredRootRemoteObjectBindingV1::Version { version, etag } => version
+                .len()
+                .checked_add(etag.as_ref().map_or(0, String::len)),
+            RegisteredRootRemoteObjectBindingV1::Etag { etag } => Some(etag.len()),
+        }
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .ok_or(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                SemanticRemoteCatalogResourceV1::RetainedBindingBytes,
+            ),
+        )?;
+        Self::checked_add(
+            &mut self.retained_binding_bytes,
+            binding_bytes,
+            contract.max_retained_binding_bytes_per_pass(),
+            SemanticRemoteCatalogResourceV1::RetainedBindingBytes,
+        )
+    }
+}
+
+fn catalog_entry_matches_object_v1(
+    entry: &VerifiedRemoteCatalogEntryV1,
+    physical_key: &str,
+    object: &BoundRemoteObjectSnapshotV1,
+) -> bool {
+    entry.object_key() == physical_key
+        && entry.raw_bytes_len() == object.raw_bytes_len()
+        && entry.raw_blake3() == object.raw_blake3()
+        && entry.binding() == object.binding()
+}
+
 fn read_changed(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<RawObjectChangedDuringReadV1>()
@@ -716,6 +990,12 @@ fn read_changed(error: &anyhow::Error) -> bool {
 fn read_too_large(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<RawObjectSnapshotTooLargeV1>()
+        .is_some()
+}
+
+fn read_invalid_metadata(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<RawObjectSnapshotInvalidMetadataV1>()
         .is_some()
 }
 
@@ -736,6 +1016,12 @@ async fn read_current_head_v1(
                 RemoteCatalogResourceV1::HeadBytes,
             )));
         }
+        Err(error) if read_invalid_metadata(&error) => {
+            return Ok(Err(invalid(
+                RemoteCatalogClosureObjectKindV1::Head,
+                InvalidRemoteCatalogReasonV1::ObjectIdentity,
+            )));
+        }
         Err(error) => return Err(error),
     };
     Ok(match read {
@@ -752,8 +1038,22 @@ async fn read_immutable_closure_object_v1(
     key: &str,
     maximum: u64,
     kind: RemoteCatalogClosureObjectKindV1,
+    expected_binding: &RemoteCatalogObjectBindingWireV1,
 ) -> Result<std::result::Result<RawObjectSnapshotV1, StrictRemoteCatalogIncompleteV1>> {
-    let read = match read_raw_object_snapshot_v1(op, key, maximum).await {
+    let Some(expected_binding) = validate_binding_wire_v1(expected_binding) else {
+        return Ok(Err(invalid(
+            kind,
+            InvalidRemoteCatalogReasonV1::ObjectBinding,
+        )));
+    };
+    let read = match read_expected_raw_object_snapshot_v1(
+        op,
+        key,
+        maximum,
+        expected_raw_object_binding_v1(&expected_binding),
+    )
+    .await
+    {
         Ok(read) => read,
         Err(error) if read_changed(&error) => {
             return Ok(Err(StrictRemoteCatalogIncompleteV1::ClosureObjectChanged {
@@ -768,6 +1068,12 @@ async fn read_immutable_closure_object_v1(
             };
             return Ok(Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
                 resource,
+            )));
+        }
+        Err(error) if read_invalid_metadata(&error) => {
+            return Ok(Err(invalid(
+                kind,
+                InvalidRemoteCatalogReasonV1::ObjectIdentity,
             )));
         }
         Err(error) => return Err(error),
@@ -974,6 +1280,7 @@ pub(crate) async fn read_verified_remote_catalog_closure_v1(
         &root_key,
         remote_contract.max_catalog_root_object_bytes(),
         RemoteCatalogClosureObjectKindV1::Root,
+        &head.catalog_root.binding,
     )
     .await?
     {
@@ -1046,6 +1353,7 @@ pub(crate) async fn read_verified_remote_catalog_closure_v1(
             &page_key,
             remote_contract.max_catalog_page_object_bytes(),
             RemoteCatalogClosureObjectKindV1::Page,
+            &reference.binding,
         )
         .await?
         {
@@ -1173,6 +1481,588 @@ pub(crate) async fn read_verified_remote_catalog_closure_v1(
     )))
 }
 
+fn semantic_named_read_error_v1(
+    error: &anyhow::Error,
+    kind: RemoteCatalogNamedObjectKindV1,
+) -> Option<StrictSemanticallyBoundRemoteCatalogIncompleteV1> {
+    if read_changed(error) {
+        Some(StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectChanged { kind })
+    } else if read_invalid_metadata(error) {
+        Some(StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectIdentity { kind })
+    } else if read_too_large(error) {
+        Some(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                SemanticRemoteCatalogResourceV1::BoundObjectBytes,
+            ),
+        )
+    } else {
+        None
+    }
+}
+
+/// Bind and strictly validate every namespace object named by one unchanged
+/// immutable catalog closure.
+///
+/// This issues no LIST operations and performs no retry, digest, planning, or
+/// action construction. The returned artifact proves only the internal
+/// semantic closure of the observed revision. It remains non-authoritative
+/// until external writer fencing, complete bootstrap, and monotonic
+/// replay/high-water requirements are independently satisfied.
+pub(crate) async fn read_semantically_bound_remote_catalog_corpus_v1(
+    op: &Operator,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+    receipt: &ConditionalWriteSemanticsReceipt,
+) -> Result<StrictSemanticallyBoundRemoteCatalogReadV1> {
+    let closure = match read_verified_remote_catalog_closure_v1(op, selected, receipt).await? {
+        StrictRemoteCatalogClosureReadV1::Verified(closure) => closure,
+        StrictRemoteCatalogClosureReadV1::Incomplete(incomplete) => {
+            return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::Catalog(incomplete),
+            ));
+        }
+    };
+    let mut closure = *closure;
+    let mut budget = SemanticRemoteCatalogBudgetV1::default();
+    for entry in &closure.entries {
+        if let Err(incomplete) = budget.observe_advertised(entry) {
+            return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                incomplete,
+            ));
+        }
+    }
+
+    let index_count = closure
+        .entries
+        .iter()
+        .filter(|entry| entry.kind() == RemoteCatalogObjectKindV1::Index)
+        .count();
+    let reservation_count = closure
+        .entries
+        .iter()
+        .filter(|entry| entry.kind() == RemoteCatalogObjectKindV1::Reservation)
+        .count();
+    let manifest_count = closure
+        .entries
+        .iter()
+        .filter(|entry| entry.kind() == RemoteCatalogObjectKindV1::Manifest)
+        .count();
+    let mut index_objects = Vec::new();
+    if index_objects.try_reserve(index_count).is_err() {
+        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                SemanticRemoteCatalogResourceV1::IndexObjects,
+            ),
+        ));
+    }
+    let mut reservations = Vec::new();
+    if reservations.try_reserve(reservation_count).is_err() {
+        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                SemanticRemoteCatalogResourceV1::ReservationObjects,
+            ),
+        ));
+    }
+    let mut catalog_manifests = Vec::new();
+    if catalog_manifests.try_reserve(manifest_count).is_err() {
+        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                SemanticRemoteCatalogResourceV1::ManifestObjects,
+            ),
+        ));
+    }
+    let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let mut claims = RemoteNamespaceClaimAccumulatorV1::new(contract);
+    let remote_prefix = closure.remote_prefix.clone();
+    let index_prefix = namespace_index_prefix(&remote_prefix);
+    let reservation_prefix = namespace_reservation_prefix(&remote_prefix);
+
+    // Move every catalog entry exactly once. The semantic output retains the
+    // parsed objects and their bound identities rather than a second copy of
+    // every catalog storage key.
+    for entry in std::mem::take(&mut closure.entries) {
+        match entry.kind() {
+            RemoteCatalogObjectKindV1::Index => {
+                let index_rel_path = entry
+                    .object_key()
+                    .strip_prefix(&index_prefix)
+                    .expect("verified catalog index entry must remain under its prefix");
+                let (logical_path, role) = namespace_logical_entry_from_index_path(index_rel_path)
+                    .expect("verified catalog index route must remain canonical");
+                let (kind, observed) = match role {
+                    PortableNamespaceRole::File => {
+                        let read = match read_expected_observed_raw_index_entry_v1(
+                            op,
+                            &remote_prefix,
+                            &logical_path,
+                            entry.binding(),
+                        )
+                        .await
+                        {
+                            Ok(read) => read,
+                            Err(error) => {
+                                if let Some(incomplete) = semantic_named_read_error_v1(
+                                    &error,
+                                    RemoteCatalogNamedObjectKindV1::OrdinaryIndex,
+                                ) {
+                                    return Ok(
+                                        StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                            incomplete,
+                                        ),
+                                    );
+                                }
+                                return Err(error);
+                            }
+                        };
+                        let observed = match read {
+                            ExactObservedRawIndexEntryReadV1::Missing => {
+                                return Ok(
+                                    StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                        StrictSemanticallyBoundRemoteCatalogIncompleteV1::
+                                            NamedObjectMissing {
+                                                kind: RemoteCatalogNamedObjectKindV1::
+                                                    OrdinaryIndex,
+                                            },
+                                    ),
+                                );
+                            }
+                            ExactObservedRawIndexEntryReadV1::Incomplete {
+                                reason: StrictRemoteIndexIncompleteV1::UnboundObject,
+                                ..
+                            } => {
+                                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::
+                                        NamedObjectUnbound {
+                                            kind: RemoteCatalogNamedObjectKindV1::OrdinaryIndex,
+                                        },
+                                ));
+                            }
+                            ExactObservedRawIndexEntryReadV1::Incomplete { reason, .. } => {
+                                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::Index(reason),
+                                ));
+                            }
+                            ExactObservedRawIndexEntryReadV1::Deleted(index) => {
+                                SemanticallyBoundCatalogIndexObjectV1::Deleted(Box::new(index))
+                            }
+                            ExactObservedRawIndexEntryReadV1::Committed(index) => {
+                                SemanticallyBoundCatalogIndexObjectV1::Committed(Box::new(index))
+                            }
+                        };
+                        (RemoteCatalogNamedObjectKindV1::OrdinaryIndex, observed)
+                    }
+                    PortableNamespaceRole::Directory => {
+                        let read = match read_expected_observed_raw_directory_marker_v1(
+                            op,
+                            &remote_prefix,
+                            &logical_path,
+                            entry.binding(),
+                        )
+                        .await
+                        {
+                            Ok(read) => read,
+                            Err(error) => {
+                                if let Some(incomplete) = semantic_named_read_error_v1(
+                                    &error,
+                                    RemoteCatalogNamedObjectKindV1::DirectoryMarker,
+                                ) {
+                                    return Ok(
+                                        StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                            incomplete,
+                                        ),
+                                    );
+                                }
+                                return Err(error);
+                            }
+                        };
+                        let observed = match read {
+                            ExactObservedRawDirectoryMarkerReadV1::Missing => {
+                                return Ok(
+                                    StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                        StrictSemanticallyBoundRemoteCatalogIncompleteV1::
+                                            NamedObjectMissing {
+                                                kind: RemoteCatalogNamedObjectKindV1::
+                                                    DirectoryMarker,
+                                            },
+                                    ),
+                                );
+                            }
+                            ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                                reason: StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
+                                ..
+                            } => {
+                                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::
+                                        NamedObjectUnbound {
+                                            kind: RemoteCatalogNamedObjectKindV1::DirectoryMarker,
+                                        },
+                                ));
+                            }
+                            ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                                reason, ..
+                            } => {
+                                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::Marker(
+                                        reason,
+                                    ),
+                                ));
+                            }
+                            ExactObservedRawDirectoryMarkerReadV1::Live(marker) => {
+                                SemanticallyBoundCatalogIndexObjectV1::LiveMarker(Box::new(marker))
+                            }
+                            ExactObservedRawDirectoryMarkerReadV1::Deleted(marker) => {
+                                SemanticallyBoundCatalogIndexObjectV1::DeletedMarker(Box::new(
+                                    marker,
+                                ))
+                            }
+                        };
+                        (RemoteCatalogNamedObjectKindV1::DirectoryMarker, observed)
+                    }
+                };
+                if !catalog_entry_matches_object_v1(
+                    &entry,
+                    observed.physical_key(),
+                    observed.object(),
+                ) {
+                    return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                        StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectIdentity {
+                            kind,
+                        },
+                    ));
+                }
+                if let Err(incomplete) = budget.observe_bound(observed.object()) {
+                    return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                        incomplete,
+                    ));
+                }
+                if matches!(
+                    &observed,
+                    SemanticallyBoundCatalogIndexObjectV1::LiveMarker(_)
+                ) && Blacklist::default()
+                    .check_fixed_ingress_path_components(Path::new(observed.logical_path()))
+                    .is_some()
+                {
+                    return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                        StrictSemanticallyBoundRemoteCatalogIncompleteV1::LiveMarkerExcluded,
+                    ));
+                }
+                if let Err(incomplete) = claims.observe_path(
+                    observed.logical_path(),
+                    observed.role(),
+                    observed.claim_origin(),
+                ) {
+                    return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                        StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamespaceClaim(
+                            incomplete,
+                        ),
+                    ));
+                }
+                index_objects.push(observed);
+            }
+            RemoteCatalogObjectKindV1::Reservation => {
+                let object_id = entry
+                    .object_key()
+                    .strip_prefix(&reservation_prefix)
+                    .expect("verified catalog reservation must remain under its prefix");
+                let read = match read_expected_observed_namespace_reservation_v1(
+                    op,
+                    &remote_prefix,
+                    object_id,
+                    entry.binding(),
+                )
+                .await
+                {
+                    Ok(read) => read,
+                    Err(error) => {
+                        if let Some(incomplete) = semantic_named_read_error_v1(
+                            &error,
+                            RemoteCatalogNamedObjectKindV1::NamespaceReservation,
+                        ) {
+                            return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                                incomplete,
+                            ));
+                        }
+                        return Err(error);
+                    }
+                };
+                let reservation = match read {
+                    ExactObservedNamespaceReservationReadV1::Missing => {
+                        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectMissing {
+                                kind: RemoteCatalogNamedObjectKindV1::NamespaceReservation,
+                            },
+                        ));
+                    }
+                    ExactObservedNamespaceReservationReadV1::Incomplete {
+                        reason: StrictNamespaceReservationIncompleteV1::UnboundObject,
+                        ..
+                    } => {
+                        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectUnbound {
+                                kind: RemoteCatalogNamedObjectKindV1::NamespaceReservation,
+                            },
+                        ));
+                    }
+                    ExactObservedNamespaceReservationReadV1::Incomplete { reason, .. } => {
+                        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                            StrictSemanticallyBoundRemoteCatalogIncompleteV1::Reservation(reason),
+                        ));
+                    }
+                    ExactObservedNamespaceReservationReadV1::Bound(reservation) => reservation,
+                };
+                if !catalog_entry_matches_object_v1(
+                    &entry,
+                    reservation.object_key(),
+                    reservation.object(),
+                ) {
+                    return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                        StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectIdentity {
+                            kind: RemoteCatalogNamedObjectKindV1::NamespaceReservation,
+                        },
+                    ));
+                }
+                if let Err(incomplete) = budget.observe_bound(reservation.object()) {
+                    return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                        incomplete,
+                    ));
+                }
+                if let Err(incomplete) = claims.observe_path(
+                    reservation.exact_path(),
+                    reservation.role(),
+                    RemoteNamespaceClaimOriginsV1::RESERVATION,
+                ) {
+                    return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                        StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamespaceClaim(
+                            incomplete,
+                        ),
+                    ));
+                }
+                reservations.push(reservation);
+            }
+            RemoteCatalogObjectKindV1::Manifest => catalog_manifests.push(entry),
+        }
+    }
+
+    // Sort only source ordinals; manifest IDs and physical keys remain borrowed
+    // from the now-immobile canonical index vector.
+    let committed_count = index_objects
+        .iter()
+        .filter(|observed| observed.committed().is_some())
+        .count();
+    let mut manifest_reference_ordinals = Vec::new();
+    if manifest_reference_ordinals
+        .try_reserve(committed_count)
+        .is_err()
+    {
+        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                SemanticRemoteCatalogResourceV1::ManifestReferenceOrdinals,
+            ),
+        ));
+    }
+    manifest_reference_ordinals.extend(
+        index_objects
+            .iter()
+            .enumerate()
+            .filter_map(|(ordinal, observed)| observed.committed().map(|_| ordinal)),
+    );
+    manifest_reference_ordinals.sort_unstable_by(|left, right| {
+        let left = index_objects[*left]
+            .committed()
+            .expect("manifest source ordinal must name a committed index");
+        let right = index_objects[*right]
+            .committed()
+            .expect("manifest source ordinal must name a committed index");
+        left.current()
+            .manifest_hash()
+            .cmp(right.current().manifest_hash())
+            .then_with(|| left.index_key().cmp(right.index_key()))
+    });
+
+    let manifest_prefix = format!("{remote_prefix}/manifests/");
+    let mut manifests = Vec::new();
+    if manifests.try_reserve(catalog_manifests.len()).is_err() {
+        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                SemanticRemoteCatalogResourceV1::ManifestObjects,
+            ),
+        ));
+    }
+    let mut reference_cursor = 0;
+    let mut catalog_cursor = 0;
+    while reference_cursor < manifest_reference_ordinals.len() {
+        let source_index_ordinal = manifest_reference_ordinals[reference_cursor];
+        let manifest_id = index_objects[source_index_ordinal]
+            .committed()
+            .expect("manifest source ordinal must name a committed index")
+            .current()
+            .manifest_hash();
+        let Some(catalog_entry) = catalog_manifests.get(catalog_cursor) else {
+            return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::ManifestSet(
+                    RemoteCatalogManifestSetMismatchV1::MissingReferencedManifest,
+                ),
+            ));
+        };
+        let catalog_manifest_id = catalog_entry
+            .object_key()
+            .strip_prefix(&manifest_prefix)
+            .expect("verified catalog manifest must remain under its prefix");
+        match catalog_manifest_id.cmp(manifest_id) {
+            std::cmp::Ordering::Less => {
+                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::ManifestSet(
+                        RemoteCatalogManifestSetMismatchV1::UnreferencedManifest,
+                    ),
+                ));
+            }
+            std::cmp::Ordering::Greater => {
+                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::ManifestSet(
+                        RemoteCatalogManifestSetMismatchV1::MissingReferencedManifest,
+                    ),
+                ));
+            }
+            std::cmp::Ordering::Equal => {}
+        }
+
+        let mut group_end = reference_cursor + 1;
+        while group_end < manifest_reference_ordinals.len()
+            && index_objects[manifest_reference_ordinals[group_end]]
+                .committed()
+                .expect("manifest source ordinal must name a committed index")
+                .current()
+                .manifest_hash()
+                == manifest_id
+        {
+            group_end += 1;
+        }
+        let mut references = Vec::new();
+        if references
+            .try_reserve(group_end - reference_cursor)
+            .is_err()
+        {
+            return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                    SemanticRemoteCatalogResourceV1::ManifestReferenceOrdinals,
+                ),
+            ));
+        }
+        references.extend(
+            manifest_reference_ordinals[reference_cursor..group_end]
+                .iter()
+                .map(|ordinal| {
+                    index_objects[*ordinal]
+                        .committed()
+                        .expect("manifest source ordinal must name a committed index")
+                }),
+        );
+        let read = match read_expected_observed_strict_remote_manifest_for_references_v1(
+            op,
+            &references,
+            catalog_entry.binding(),
+        )
+        .await
+        {
+            Ok(read) => read,
+            Err(error) => {
+                if let Some(incomplete) =
+                    semantic_named_read_error_v1(&error, RemoteCatalogNamedObjectKindV1::Manifest)
+                {
+                    return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                        incomplete,
+                    ));
+                }
+                return Err(error);
+            }
+        };
+        let manifest = match read {
+            StrictObservedRemoteManifestReadV1::Complete(manifest) => manifest,
+            StrictObservedRemoteManifestReadV1::Incomplete {
+                reason: StrictRemoteManifestIncompleteV1::MissingObject,
+                ..
+            } => {
+                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectMissing {
+                        kind: RemoteCatalogNamedObjectKindV1::Manifest,
+                    },
+                ));
+            }
+            StrictObservedRemoteManifestReadV1::Incomplete {
+                reason: StrictRemoteManifestIncompleteV1::UnboundObject,
+                ..
+            } => {
+                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectUnbound {
+                        kind: RemoteCatalogNamedObjectKindV1::Manifest,
+                    },
+                ));
+            }
+            StrictObservedRemoteManifestReadV1::Incomplete { reason, .. } => {
+                return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::Manifest(reason),
+                ));
+            }
+        };
+        if !catalog_entry_matches_object_v1(
+            catalog_entry,
+            catalog_entry.object_key(),
+            manifest.object(),
+        ) {
+            return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectIdentity {
+                    kind: RemoteCatalogNamedObjectKindV1::Manifest,
+                },
+            ));
+        }
+        if let Err(incomplete) = budget.observe_bound(manifest.object()) {
+            return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                incomplete,
+            ));
+        }
+        manifests.push(SemanticallyBoundCatalogManifestV1 {
+            source_index_ordinal,
+            manifest,
+        });
+        reference_cursor = group_end;
+        catalog_cursor += 1;
+    }
+    if catalog_cursor != catalog_manifests.len() {
+        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ManifestSet(
+                RemoteCatalogManifestSetMismatchV1::UnreferencedManifest,
+            ),
+        ));
+    }
+
+    let head_key = catalog_head_key_v1(&remote_prefix);
+    let head_c_raw = match read_current_head_v1(op, &head_key).await? {
+        Ok(raw) => raw,
+        Err(_) => {
+            return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::HeadChanged,
+            ));
+        }
+    };
+    let head_c_revision = catalog_head_revision_v1(head_c_raw.raw_bytes());
+    let head_c_object = bind_remote_object_v1(head_c_raw);
+    if head_c_revision != closure.head_revision || head_c_object != closure.head_object {
+        return Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::HeadChanged,
+        ));
+    }
+
+    let claims = claims.into_retained_claims();
+    Ok(StrictSemanticallyBoundRemoteCatalogReadV1::Verified(
+        Box::new(SemanticallyBoundRemoteCatalogCorpusV1 {
+            closure,
+            index_objects,
+            reservations,
+            manifests,
+            claims,
+        }),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1187,6 +2077,14 @@ mod tests {
 
     static_assertions::assert_not_impl_any!(
         VerifiedRemoteCatalogClosureV1: Clone,
+        serde::Serialize,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>,
+        Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
+        Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        SemanticallyBoundRemoteCatalogCorpusV1: Clone,
         serde::Serialize,
         Into<crate::reconcile::ReconcilePlan>,
         Into<Vec<crate::reconcile::ReconcileAction>>,
@@ -1210,6 +2108,7 @@ mod tests {
         BeforeFirst,
         AfterFirst,
         BeforeSecond,
+        BeforeThird,
     }
 
     #[derive(Clone, Debug)]
@@ -1229,6 +2128,7 @@ mod tests {
     struct ScriptedCatalogBackend {
         info: Arc<AccessorInfo>,
         objects: Arc<Mutex<BTreeMap<String, ScriptedObject>>>,
+        versions: Arc<Mutex<BTreeMap<(String, String), ScriptedObject>>>,
         reads: Arc<Mutex<Vec<ObservedRead>>>,
         stats: Arc<Mutex<Vec<String>>>,
         head_key: String,
@@ -1240,7 +2140,14 @@ mod tests {
 
     impl ScriptedCatalogBackend {
         fn insert(&self, key: impl Into<String>, object: ScriptedObject) {
-            self.objects.lock().unwrap().insert(key.into(), object);
+            let key = key.into();
+            if let Some(version) = object.version.as_ref() {
+                self.versions
+                    .lock()
+                    .unwrap()
+                    .insert((key.clone(), version.clone()), object.clone());
+            }
+            self.objects.lock().unwrap().insert(key, object);
         }
 
         fn remove(&self, key: &str) {
@@ -1264,6 +2171,20 @@ mod tests {
                 .unwrap()
                 .insert(key.into(), replacement);
         }
+
+        fn disable_version_reads(&self) {
+            self.info.set_native_capability(Capability {
+                stat: true,
+                read: true,
+                read_with_if_match: true,
+                write: true,
+                write_can_empty: true,
+                write_with_if_match: true,
+                write_with_if_not_exists: true,
+                delete: true,
+                ..Default::default()
+            });
+        }
     }
 
     impl Access for ScriptedCatalogBackend {
@@ -1276,15 +2197,22 @@ mod tests {
             self.info.clone()
         }
 
-        async fn stat(&self, path: &str, _: OpStat) -> opendal::Result<RpStat> {
+        async fn stat(&self, path: &str, args: OpStat) -> opendal::Result<RpStat> {
             self.stats.lock().unwrap().push(path.to_owned());
-            let object = self
-                .objects
-                .lock()
-                .unwrap()
-                .get(path)
-                .cloned()
-                .ok_or_else(|| Error::new(ErrorKind::NotFound, "scripted object missing"))?;
+            let current = self.objects.lock().unwrap().get(path).cloned();
+            let object = match args.version() {
+                Some(version) => self
+                    .versions
+                    .lock()
+                    .unwrap()
+                    .get(&(path.to_owned(), version.to_owned()))
+                    .cloned()
+                    .or_else(|| {
+                        current.filter(|object| object.version.as_deref() == Some(version))
+                    }),
+                None => current,
+            }
+            .ok_or_else(|| Error::new(ErrorKind::NotFound, "scripted object missing"))?;
             let mut metadata = Metadata::new(EntryMode::FILE)
                 .with_content_length(u64::try_from(object.bytes.len()).unwrap());
             if let Some(etag) = object.etag {
@@ -1309,6 +2237,7 @@ mod tests {
                     (*timing, head_read_index),
                     (HeadMutationTiming::BeforeFirst, Some(0))
                         | (HeadMutationTiming::BeforeSecond, Some(1))
+                        | (HeadMutationTiming::BeforeThird, Some(2))
                 );
                 if applies {
                     self.objects
@@ -1324,13 +2253,20 @@ mod tests {
                     .insert(path.to_owned(), replacement);
             }
 
-            let object = self
-                .objects
-                .lock()
-                .unwrap()
-                .get(path)
-                .cloned()
-                .ok_or_else(|| Error::new(ErrorKind::NotFound, "scripted object missing"))?;
+            let current = self.objects.lock().unwrap().get(path).cloned();
+            let object = match args.version() {
+                Some(version) => self
+                    .versions
+                    .lock()
+                    .unwrap()
+                    .get(&(path.to_owned(), version.to_owned()))
+                    .cloned()
+                    .or_else(|| {
+                        current.filter(|object| object.version.as_deref() == Some(version))
+                    }),
+                None => current,
+            }
+            .ok_or_else(|| Error::new(ErrorKind::NotFound, "scripted object missing"))?;
             self.reads.lock().unwrap().push(ObservedRead {
                 path: path.to_owned(),
                 if_match: args.if_match().map(str::to_owned),
@@ -1468,6 +2404,7 @@ mod tests {
             .set_name("registered-catalog-test")
             .set_native_capability(Capability {
                 stat: true,
+                stat_with_version: true,
                 read: true,
                 read_with_if_match: true,
                 read_with_version: true,
@@ -1481,6 +2418,7 @@ mod tests {
         let backend = ScriptedCatalogBackend {
             info: Arc::new(info),
             objects: Arc::new(Mutex::new(BTreeMap::new())),
+            versions: Arc::new(Mutex::new(BTreeMap::new())),
             reads: Arc::new(Mutex::new(Vec::new())),
             stats: Arc::new(Mutex::new(Vec::new())),
             head_key: catalog_head_key_v1(prefix),
@@ -1551,6 +2489,49 @@ mod tests {
         }
     }
 
+    fn regular_manifest_json(rel_path: &str) -> Vec<u8> {
+        format!(
+            r#"{{
+  "version": 2,
+  "file_hash": "{file_hash}",
+  "file_size": 4,
+  "chunks": ["{chunk_hash}"],
+  "vclock": {{ "clocks": {{ "sting": 1 }} }},
+  "written_by": "sting",
+  "written_at": 7,
+  "rel_path": "{rel_path}",
+  "mode": 420,
+  "mtime": [8, 9]
+}}"#,
+            file_hash = "d".repeat(64),
+            chunk_hash = "e".repeat(64),
+        )
+        .into_bytes()
+    }
+
+    fn committed_index_json(manifest_hash: &str) -> Vec<u8> {
+        format!(
+            r#"{{"version":2,"state":"committed","current":{{"manifest_hash":"{manifest_hash}","size":4,"chunks":1}},"pending":null}}"#
+        )
+        .into_bytes()
+    }
+
+    fn deleted_index_json() -> Vec<u8> {
+        br#"{"version":4,"state":"deleted","current":null,"pending":null}"#.to_vec()
+    }
+
+    fn canonical_reservation_json(exact_path: &str, folded_path: &str, role: &str) -> Vec<u8> {
+        format!(
+            r#"{{"version":1,"exact_path":"{exact_path}","folded_path":"{folded_path}","role":"{role}"}}"#
+        )
+        .into_bytes()
+    }
+
+    fn sorted_entries(mut entries: Vec<RemoteCatalogEntryWireV1>) -> Vec<RemoteCatalogEntryWireV1> {
+        entries.sort_by(|left, right| left.object_key.cmp(&right.object_key));
+        entries
+    }
+
     struct CatalogFixture {
         op: Operator,
         backend: ScriptedCatalogBackend,
@@ -1579,6 +2560,18 @@ mod tests {
             receipt: &ConditionalWriteSemanticsReceipt,
         ) -> Result<StrictRemoteCatalogClosureReadV1> {
             read_verified_remote_catalog_closure_v1(&self.op, &self.selected, receipt).await
+        }
+
+        async fn read_semantic(
+            &self,
+            receipt: &ConditionalWriteSemanticsReceipt,
+        ) -> Result<StrictSemanticallyBoundRemoteCatalogReadV1> {
+            read_semantically_bound_remote_catalog_corpus_v1(&self.op, &self.selected, receipt)
+                .await
+        }
+
+        fn insert_named(&self, key: impl Into<String>, bytes: Vec<u8>, etag: &str) {
+            self.backend.insert(key, scripted_object(bytes, etag));
         }
 
         fn rewrite_root(&mut self, root: &RemoteCatalogRootWireV1) {
@@ -1648,6 +2641,68 @@ mod tests {
                 },
             );
             self.head_bytes = head_bytes;
+        }
+
+        fn make_immutable_objects_version_only_bound(&mut self) {
+            let mut root =
+                serde_json::from_slice::<RemoteCatalogRootWireV1>(&self.root_bytes).unwrap();
+            {
+                let mut objects = self.backend.objects.lock().unwrap();
+                for (ordinal, reference) in root.pages.iter_mut().enumerate() {
+                    let version = format!("page-version-{ordinal}");
+                    reference.binding = RemoteCatalogObjectBindingWireV1 {
+                        version: Some(version.clone()),
+                        etag: None,
+                    };
+                    objects.get_mut(&self.page_keys[ordinal]).unwrap().version = Some(version);
+                }
+            }
+            self.rewrite_root(&root);
+
+            let root_version = "root-version";
+            self.backend
+                .objects
+                .lock()
+                .unwrap()
+                .get_mut(&self.root_key)
+                .unwrap()
+                .version = Some(root_version.to_owned());
+            let mut head =
+                serde_json::from_slice::<RemoteCatalogHeadWireV1>(&self.head_bytes).unwrap();
+            head.catalog_root.binding = RemoteCatalogObjectBindingWireV1 {
+                version: Some(root_version.to_owned()),
+                etag: None,
+            };
+            let head_bytes = serde_json::to_vec(&head).unwrap();
+            self.backend.insert(
+                self.head_key.clone(),
+                ScriptedObject {
+                    bytes: head_bytes.clone(),
+                    etag: Some("head-etag-a".to_owned()),
+                    version: Some("historical-head-version".to_owned()),
+                },
+            );
+            self.head_bytes = head_bytes;
+        }
+
+        fn make_immutable_objects_etag_bound_with_versions(&mut self) {
+            {
+                let mut objects = self.backend.objects.lock().unwrap();
+                for (ordinal, page_key) in self.page_keys.iter().enumerate() {
+                    objects.get_mut(page_key).unwrap().version =
+                        Some(format!("page-current-version-{ordinal}"));
+                }
+            }
+
+            let root = serde_json::from_slice::<RemoteCatalogRootWireV1>(&self.root_bytes).unwrap();
+            self.rewrite_root(&root);
+            self.backend
+                .objects
+                .lock()
+                .unwrap()
+                .get_mut(&self.root_key)
+                .unwrap()
+                .version = Some("root-current-version".to_owned());
         }
     }
 
@@ -1772,6 +2827,17 @@ mod tests {
         }
     }
 
+    fn semantic_incomplete(
+        read: StrictSemanticallyBoundRemoteCatalogReadV1,
+    ) -> StrictSemanticallyBoundRemoteCatalogIncompleteV1 {
+        match read {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => incomplete,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(_) => {
+                panic!("expected incomplete semantic catalog")
+            }
+        }
+    }
+
     #[tokio::test]
     async fn explicit_empty_catalog_is_verified_without_any_listing() {
         let fixture = fixture("roots", Vec::new());
@@ -1816,6 +2882,572 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn semantic_empty_catalog_rechecks_head_c_without_listing_or_retry() {
+        let fixture = fixture("roots", Vec::new());
+        let receipt = fixture.receipt("roots").await;
+        let verified = match fixture.read_semantic(&receipt).await.unwrap() {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(verified) => verified,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => {
+                panic!("expected semantic empty catalog, got {incomplete:?}")
+            }
+        };
+        assert_eq!(verified.remote_prefix(), "roots");
+        assert_eq!(verified.root_id(), "fixture-root");
+        assert_eq!(verified.catalog_sequence().get(), 1);
+        assert_eq!(verified.index_object_count(), 0);
+        assert_eq!(verified.reservation_count(), 0);
+        assert_eq!(verified.manifest_count(), 0);
+        assert_eq!(verified.claim_count(), 0);
+        assert_eq!(fixture.backend.head_reads.load(Ordering::SeqCst), 3);
+        assert_eq!(
+            fixture
+                .backend
+                .reads
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|read| read.path == fixture.head_key)
+                .count(),
+            3
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_catalog_binds_indices_markers_reservation_and_exact_manifest_set() {
+        let manifest_bytes = regular_manifest_json("doc.txt");
+        let manifest_id = crate::index_entry::manifest_object_id(&manifest_bytes);
+        let committed_bytes = committed_index_json(&manifest_id);
+        let deleted_bytes = deleted_index_json();
+        let marker_bytes = crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec();
+        let reservation_exact = "reserved/path";
+        let reservation_folded =
+            crate::index_entry::portable_casefold_path(reservation_exact).unwrap();
+        let reservation_id =
+            crate::index_entry::namespace_reservation_object_id(&reservation_folded);
+        let reservation_bytes =
+            canonical_reservation_json(reservation_exact, &reservation_folded, "file");
+
+        let committed_key = "roots/index/doc.txt";
+        let deleted_key = "roots/index/old.txt";
+        let marker_key = "roots/index/dir/.tcfs_dir";
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let entries = sorted_entries(vec![
+            fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                committed_key,
+                &committed_bytes,
+                "committed-etag",
+            ),
+            fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                deleted_key,
+                &deleted_bytes,
+                "deleted-etag",
+            ),
+            fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                marker_key,
+                &marker_bytes,
+                "marker-etag",
+            ),
+            fixture_entry(
+                RemoteCatalogObjectKindV1::Reservation,
+                &reservation_key,
+                &reservation_bytes,
+                "reservation-etag",
+            ),
+            fixture_entry(
+                RemoteCatalogObjectKindV1::Manifest,
+                &manifest_key,
+                &manifest_bytes,
+                "manifest-etag",
+            ),
+        ]);
+        let fixture = fixture("roots", vec![entries]);
+        fixture.insert_named(committed_key, committed_bytes, "committed-etag");
+        fixture.insert_named(deleted_key, deleted_bytes, "deleted-etag");
+        fixture.insert_named(marker_key, marker_bytes, "marker-etag");
+        fixture.insert_named(
+            reservation_key.clone(),
+            reservation_bytes,
+            "reservation-etag",
+        );
+        fixture.insert_named(manifest_key.clone(), manifest_bytes, "manifest-etag");
+        let receipt = fixture.receipt("roots").await;
+        let verified = match fixture.read_semantic(&receipt).await.unwrap() {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(verified) => verified,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => {
+                panic!("expected semantic catalog, got {incomplete:?}")
+            }
+        };
+        assert_eq!(verified.index_object_count(), 3);
+        assert_eq!(verified.reservation_count(), 1);
+        assert_eq!(verified.manifest_count(), 1);
+        assert_eq!(verified.claim_count(), 5);
+        assert_eq!(
+            fixture
+                .backend
+                .reads
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|read| read.path == manifest_key)
+                .count(),
+            1,
+            "one unique manifest must be fetched exactly once"
+        );
+        assert_eq!(fixture.backend.head_reads.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn semantic_catalog_reads_declared_historical_version_not_newer_current_object() {
+        let key = "roots/index/doc.txt";
+        let historical = deleted_index_json();
+        let mut entry = fixture_entry(
+            RemoteCatalogObjectKindV1::Index,
+            key,
+            &historical,
+            "historical-etag",
+        );
+        entry.binding = version_binding("version-1", "historical-etag");
+        let fixture = fixture("roots", vec![vec![entry]]);
+        fixture.backend.insert(
+            key,
+            ScriptedObject {
+                bytes: historical,
+                etag: Some("historical-etag".to_owned()),
+                version: Some("version-1".to_owned()),
+            },
+        );
+        fixture.backend.insert(
+            key,
+            ScriptedObject {
+                bytes: b"newer-current-body".to_vec(),
+                etag: Some("current-etag".to_owned()),
+                version: Some("version-2".to_owned()),
+            },
+        );
+        let receipt = fixture.receipt("roots").await;
+        let verified = match fixture.read_semantic(&receipt).await.unwrap() {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(verified) => verified,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => {
+                panic!("expected historical version to bind, got {incomplete:?}")
+            }
+        };
+        assert_eq!(verified.index_object_count(), 1);
+        assert!(fixture.backend.reads.lock().unwrap().iter().any(|read| {
+            read.path == key
+                && read.version.as_deref() == Some("version-1")
+                && read.if_match.as_deref() == Some("historical-etag")
+        }));
+    }
+
+    #[tokio::test]
+    async fn semantic_catalog_requires_exact_manifest_set_before_fetching_extras() {
+        let manifest_bytes = regular_manifest_json("doc.txt");
+        let manifest_id = crate::index_entry::manifest_object_id(&manifest_bytes);
+        let committed_bytes = committed_index_json(&manifest_id);
+        let committed_key = "roots/index/doc.txt";
+        let missing = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                committed_key,
+                &committed_bytes,
+                "index-etag",
+            )]],
+        );
+        missing.insert_named(committed_key, committed_bytes, "index-etag");
+        let receipt = missing.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(missing.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ManifestSet(
+                RemoteCatalogManifestSetMismatchV1::MissingReferencedManifest
+            )
+        );
+
+        let extra_id = "a".repeat(64);
+        let extra_key = format!("roots/manifests/{extra_id}");
+        let extra = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Manifest,
+                &extra_key,
+                b"not-read",
+                "extra-etag",
+            )]],
+        );
+        let receipt = extra.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(extra.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::ManifestSet(
+                RemoteCatalogManifestSetMismatchV1::UnreferencedManifest
+            )
+        );
+        assert!(!extra
+            .backend
+            .reads
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|read| read.path == extra_key));
+    }
+
+    #[tokio::test]
+    async fn semantic_catalog_fetches_shared_manifest_once_and_checks_every_reference() {
+        let manifest_bytes = regular_manifest_json("a.txt");
+        let manifest_id = crate::index_entry::manifest_object_id(&manifest_bytes);
+        let index_bytes = committed_index_json(&manifest_id);
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let entries = sorted_entries(vec![
+            fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/a.txt",
+                &index_bytes,
+                "a-etag",
+            ),
+            fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/b.txt",
+                &index_bytes,
+                "b-etag",
+            ),
+            fixture_entry(
+                RemoteCatalogObjectKindV1::Manifest,
+                &manifest_key,
+                &manifest_bytes,
+                "manifest-etag",
+            ),
+        ]);
+        let fixture = fixture("roots", vec![entries]);
+        fixture.insert_named("roots/index/a.txt", index_bytes.clone(), "a-etag");
+        fixture.insert_named("roots/index/b.txt", index_bytes, "b-etag");
+        fixture.insert_named(manifest_key.clone(), manifest_bytes, "manifest-etag");
+        let receipt = fixture.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(fixture.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::Manifest(
+                StrictRemoteManifestIncompleteV1::InvalidManifest
+            )
+        );
+        assert_eq!(
+            fixture
+                .backend
+                .reads
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|read| read.path == manifest_key)
+                .count(),
+            1,
+            "shared manifest must be fetched once before every reference is checked"
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_catalog_preserves_deleted_markers_and_rejects_live_fixed_ingress_markers() {
+        let marker_key = "roots/index/home/.SSH/.tcfs_dir";
+        let deleted_bytes = deleted_index_json();
+        let deleted = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                marker_key,
+                &deleted_bytes,
+                "deleted-marker-etag",
+            )]],
+        );
+        deleted.insert_named(marker_key, deleted_bytes, "deleted-marker-etag");
+        let receipt = deleted.receipt("roots").await;
+        let verified = match deleted.read_semantic(&receipt).await.unwrap() {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(verified) => verified,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => {
+                panic!("expected historical marker evidence, got {incomplete:?}")
+            }
+        };
+        assert_eq!(verified.index_object_count(), 1);
+        assert_eq!(verified.manifest_count(), 0);
+        assert_eq!(verified.claim_count(), 2);
+
+        let live_bytes = crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec();
+        let live = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                marker_key,
+                &live_bytes,
+                "live-marker-etag",
+            )]],
+        );
+        live.insert_named(marker_key, live_bytes, "live-marker-etag");
+        let receipt = live.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(live.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::LiveMarkerExcluded
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_catalog_rejects_invalid_reservations_and_cross_kind_role_conflicts() {
+        let invalid_exact = "invalid";
+        let invalid_id = crate::index_entry::namespace_reservation_object_id(invalid_exact);
+        let invalid_key = format!("roots/.tcfs-namespace/v1/{invalid_id}");
+        let invalid_bytes = br#"{"version":1,"exact_path":"invalid","folded_path":"invalid","role":"file","unexpected":true}"#
+            .to_vec();
+        let invalid = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Reservation,
+                &invalid_key,
+                &invalid_bytes,
+                "invalid-reservation-etag",
+            )]],
+        );
+        invalid.insert_named(invalid_key, invalid_bytes, "invalid-reservation-etag");
+        let receipt = invalid.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(invalid.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::Reservation(
+                StrictNamespaceReservationIncompleteV1::InvalidReservation
+            )
+        );
+
+        let exact_path = "reserved";
+        let folded_path = crate::index_entry::portable_casefold_path(exact_path).unwrap();
+        let reservation_id = crate::index_entry::namespace_reservation_object_id(&folded_path);
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let reservation_bytes = canonical_reservation_json(exact_path, &folded_path, "directory");
+        let index_key = "roots/index/reserved";
+        let index_bytes = deleted_index_json();
+        let conflict = fixture(
+            "roots",
+            vec![sorted_entries(vec![
+                fixture_entry(
+                    RemoteCatalogObjectKindV1::Reservation,
+                    &reservation_key,
+                    &reservation_bytes,
+                    "reservation-etag",
+                ),
+                fixture_entry(
+                    RemoteCatalogObjectKindV1::Index,
+                    index_key,
+                    &index_bytes,
+                    "index-etag",
+                ),
+            ])],
+        );
+        conflict.insert_named(reservation_key, reservation_bytes, "reservation-etag");
+        conflict.insert_named(index_key, index_bytes, "index-etag");
+        let receipt = conflict.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(conflict.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamespaceClaim(
+                RemoteNamespaceClaimAccumulatorErrorV1::Conflict(
+                    crate::registered_remote_observation::RemoteNamespaceClaimConflictV1::
+                        FileDirectoryRole
+                )
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_named_object_failures_are_typed_across_all_kinds() {
+        let missing_bytes = deleted_index_json();
+        let missing_key = "roots/index/missing.txt";
+        let missing = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                missing_key,
+                &missing_bytes,
+                "missing-etag",
+            )]],
+        );
+        let receipt = missing.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(missing.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectMissing {
+                kind: RemoteCatalogNamedObjectKindV1::OrdinaryIndex
+            }
+        );
+
+        let empty_key = "roots/index/empty.txt";
+        let empty_expected = deleted_index_json();
+        let empty = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                empty_key,
+                &empty_expected,
+                "empty-etag",
+            )]],
+        );
+        empty.insert_named(empty_key, Vec::new(), "empty-etag");
+        let receipt = empty.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(empty.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectIdentity {
+                kind: RemoteCatalogNamedObjectKindV1::OrdinaryIndex
+            }
+        );
+
+        let marker_key = "roots/index/changed/.tcfs_dir";
+        let marker_bytes = crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec();
+        let changed = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                marker_key,
+                &marker_bytes,
+                "marker-etag",
+            )]],
+        );
+        changed.insert_named(marker_key, marker_bytes.clone(), "marker-etag");
+        let receipt = changed.receipt("roots").await;
+        changed.backend.replace_object_on_next_read(
+            marker_key,
+            scripted_object(marker_bytes, "marker-etag-changed"),
+        );
+        assert_eq!(
+            semantic_incomplete(changed.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectChanged {
+                kind: RemoteCatalogNamedObjectKindV1::DirectoryMarker
+            }
+        );
+
+        let reservation_exact = "identity";
+        let reservation_folded =
+            crate::index_entry::portable_casefold_path(reservation_exact).unwrap();
+        let reservation_id =
+            crate::index_entry::namespace_reservation_object_id(&reservation_folded);
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let reservation_bytes =
+            canonical_reservation_json(reservation_exact, &reservation_folded, "file");
+        let mut reservation_entry = fixture_entry(
+            RemoteCatalogObjectKindV1::Reservation,
+            &reservation_key,
+            &reservation_bytes,
+            "reservation-etag",
+        );
+        reservation_entry.raw_blake3 = "0".repeat(64);
+        let identity = fixture("roots", vec![vec![reservation_entry]]);
+        identity.insert_named(reservation_key, reservation_bytes, "reservation-etag");
+        let receipt = identity.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(identity.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectIdentity {
+                kind: RemoteCatalogNamedObjectKindV1::NamespaceReservation
+            }
+        );
+
+        let manifest_bytes = regular_manifest_json("unbound.txt");
+        let manifest_id = crate::index_entry::manifest_object_id(&manifest_bytes);
+        let index_bytes = committed_index_json(&manifest_id);
+        let index_key = "roots/index/unbound.txt";
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let mut manifest_entry = fixture_entry(
+            RemoteCatalogObjectKindV1::Manifest,
+            &manifest_key,
+            &manifest_bytes,
+            "manifest-etag",
+        );
+        manifest_entry.binding = version_binding("manifest-version", "manifest-etag");
+        let unbound = fixture(
+            "roots",
+            vec![sorted_entries(vec![
+                fixture_entry(
+                    RemoteCatalogObjectKindV1::Index,
+                    index_key,
+                    &index_bytes,
+                    "index-etag",
+                ),
+                manifest_entry,
+            ])],
+        );
+        unbound.insert_named(index_key, index_bytes, "index-etag");
+        unbound.backend.insert(
+            manifest_key,
+            ScriptedObject {
+                bytes: manifest_bytes,
+                etag: Some("manifest-etag".to_owned()),
+                version: Some("manifest-version".to_owned()),
+            },
+        );
+        let receipt = unbound.receipt("roots").await;
+        unbound.backend.disable_version_reads();
+        assert_eq!(
+            semantic_incomplete(unbound.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectUnbound {
+                kind: RemoteCatalogNamedObjectKindV1::Manifest
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_catalog_rejects_identity_namespace_and_head_c_drift() {
+        let deleted_bytes = deleted_index_json();
+        let mut wrong_identity_entry = fixture_entry(
+            RemoteCatalogObjectKindV1::Index,
+            "roots/index/doc.txt",
+            &deleted_bytes,
+            "index-etag",
+        );
+        wrong_identity_entry.raw_blake3 = "0".repeat(64);
+        let wrong_identity = fixture("roots", vec![vec![wrong_identity_entry]]);
+        wrong_identity.insert_named("roots/index/doc.txt", deleted_bytes.clone(), "index-etag");
+        let receipt = wrong_identity.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(wrong_identity.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamedObjectIdentity {
+                kind: RemoteCatalogNamedObjectKindV1::OrdinaryIndex
+            }
+        );
+
+        let aliases = fixture(
+            "roots",
+            vec![sorted_entries(vec![
+                fixture_entry(
+                    RemoteCatalogObjectKindV1::Index,
+                    "roots/index/Doc.txt",
+                    &deleted_bytes,
+                    "upper-etag",
+                ),
+                fixture_entry(
+                    RemoteCatalogObjectKindV1::Index,
+                    "roots/index/doc.txt",
+                    &deleted_bytes,
+                    "lower-etag",
+                ),
+            ])],
+        );
+        aliases.insert_named("roots/index/Doc.txt", deleted_bytes.clone(), "upper-etag");
+        aliases.insert_named("roots/index/doc.txt", deleted_bytes, "lower-etag");
+        let receipt = aliases.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(aliases.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::NamespaceClaim(
+                RemoteNamespaceClaimAccumulatorErrorV1::Conflict(
+                    crate::registered_remote_observation::RemoteNamespaceClaimConflictV1::
+                        FoldedSpellingAlias
+                )
+            )
+        );
+
+        let head_drift = fixture("roots", Vec::new());
+        head_drift.backend.replace_head_on_first_read(
+            HeadMutationTiming::BeforeThird,
+            scripted_object(head_drift.head_bytes.clone(), "head-etag-c"),
+        );
+        let receipt = head_drift.receipt("roots").await;
+        assert_eq!(
+            semantic_incomplete(head_drift.read_semantic(&receipt).await.unwrap()),
+            StrictSemanticallyBoundRemoteCatalogIncompleteV1::HeadChanged
+        );
+        assert_eq!(head_drift.backend.head_reads.load(Ordering::SeqCst), 3);
     }
 
     #[tokio::test]
@@ -1889,6 +3521,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn immutable_root_and_pages_accept_version_only_catalog_bindings_with_observed_etags() {
+        let entry = fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/a", b"a", "a");
+        let mut fixture = fixture("roots", vec![vec![entry]]);
+        fixture.make_immutable_objects_version_only_bound();
+        let receipt = fixture.receipt("roots").await;
+        assert!(matches!(
+            fixture.read(&receipt).await.unwrap(),
+            StrictRemoteCatalogClosureReadV1::Verified(_)
+        ));
+
+        let reads = fixture.backend.reads.lock().unwrap();
+        assert!(reads.iter().any(|read| {
+            read.path == fixture.root_key
+                && read.version.as_deref() == Some("root-version")
+                && read.if_match.is_none()
+        }));
+        assert!(reads.iter().any(|read| {
+            read.path == fixture.page_keys[0]
+                && read.version.as_deref() == Some("page-version-0")
+                && read.if_match.is_none()
+        }));
+    }
+
+    #[tokio::test]
+    async fn immutable_root_and_pages_honor_etag_only_bindings_on_versioned_objects() {
+        let entry = fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/a", b"a", "a");
+        let mut fixture = fixture("roots", vec![vec![entry]]);
+        fixture.make_immutable_objects_etag_bound_with_versions();
+        let receipt = fixture.receipt("roots").await;
+        assert!(matches!(
+            fixture.read(&receipt).await.unwrap(),
+            StrictRemoteCatalogClosureReadV1::Verified(_)
+        ));
+
+        let reads = fixture.backend.reads.lock().unwrap();
+        assert!(reads.iter().any(|read| {
+            read.path == fixture.root_key
+                && read.version.is_none()
+                && read.if_match.as_deref() == Some("root-etag-rewritten")
+        }));
+        assert!(reads.iter().any(|read| {
+            read.path == fixture.page_keys[0]
+                && read.version.is_none()
+                && read.if_match.as_deref() == Some("page-etag-0")
+        }));
+    }
+
+    #[tokio::test]
     async fn missing_head_or_page_is_typed_and_never_recovered_by_listing() {
         let no_head = fixture("roots", Vec::new());
         no_head.backend.remove(&no_head.head_key);
@@ -1954,7 +3634,7 @@ mod tests {
         let receipt = root.receipt("roots").await;
         assert_eq!(
             incomplete(root.read(&receipt).await.unwrap()),
-            StrictRemoteCatalogIncompleteV1::ClosureObjectUnbound {
+            StrictRemoteCatalogIncompleteV1::ClosureObjectChanged {
                 kind: RemoteCatalogClosureObjectKindV1::Root
             }
         );
@@ -1982,7 +3662,7 @@ mod tests {
         let receipt = page.receipt("roots").await;
         assert_eq!(
             incomplete(page.read(&receipt).await.unwrap()),
-            StrictRemoteCatalogIncompleteV1::ClosureObjectUnbound {
+            StrictRemoteCatalogIncompleteV1::ClosureObjectChanged {
                 kind: RemoteCatalogClosureObjectKindV1::Page
             }
         );
@@ -2088,6 +3768,44 @@ mod tests {
                 reason: InvalidRemoteCatalogReasonV1::EntryRoute
             }
         );
+    }
+
+    #[tokio::test]
+    async fn catalog_route_admission_rejects_logical_shape_aliases() {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let overlong_component =
+            "a".repeat(usize::try_from(remote.max_logical_component_bytes() + 1).unwrap());
+        let over_depth = std::iter::repeat_n(
+            "a",
+            usize::try_from(remote.max_logical_path_depth() + 1).unwrap(),
+        )
+        .collect::<Vec<_>>()
+        .join("/");
+
+        for object_key in [
+            format!("roots/index/{overlong_component}"),
+            format!("roots/index/{over_depth}"),
+            "roots/index/dir/ .tcfs_dir".to_owned(),
+        ] {
+            let fixture = fixture(
+                "roots",
+                vec![vec![fixture_entry(
+                    RemoteCatalogObjectKindV1::Index,
+                    &object_key,
+                    b"index",
+                    "index-etag",
+                )]],
+            );
+            let receipt = fixture.receipt("roots").await;
+            assert_eq!(
+                incomplete(fixture.read(&receipt).await.unwrap()),
+                StrictRemoteCatalogIncompleteV1::Invalid {
+                    kind: RemoteCatalogClosureObjectKindV1::Page,
+                    reason: InvalidRemoteCatalogReasonV1::EntryRoute
+                },
+                "route admission accepted {object_key:?}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -2223,9 +3941,22 @@ mod tests {
         let receipt = page_binding.receipt("roots").await;
         assert_eq!(
             incomplete(page_binding.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ClosureObjectChanged {
+                kind: RemoteCatalogClosureObjectKindV1::Page
+            }
+        );
+
+        let empty_root = fixture("roots", Vec::new());
+        empty_root.backend.insert(
+            empty_root.root_key.clone(),
+            scripted_object(Vec::new(), "root-etag"),
+        );
+        let receipt = empty_root.receipt("roots").await;
+        assert_eq!(
+            incomplete(empty_root.read(&receipt).await.unwrap()),
             StrictRemoteCatalogIncompleteV1::Invalid {
-                kind: RemoteCatalogClosureObjectKindV1::Page,
-                reason: InvalidRemoteCatalogReasonV1::ObjectBinding
+                kind: RemoteCatalogClosureObjectKindV1::Root,
+                reason: InvalidRemoteCatalogReasonV1::ObjectIdentity
             }
         );
 
@@ -2562,6 +4293,130 @@ mod tests {
             Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
                 RemoteCatalogResourceV1::ClosureBytes
             ))
+        );
+    }
+
+    #[test]
+    fn semantic_catalog_resource_accounting_accepts_exact_limits_and_rejects_next_value() {
+        let maximum = RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_bound_object_bytes_per_pass();
+        let entry = VerifiedRemoteCatalogEntryV1 {
+            kind: RemoteCatalogObjectKindV1::Index,
+            object_key: "roots/index/a".to_owned(),
+            raw_bytes_len: 1,
+            raw_blake3: *blake3::hash(b"a").as_bytes(),
+            binding: RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "etag".to_owned(),
+            },
+        };
+        let mut advertised = SemanticRemoteCatalogBudgetV1 {
+            advertised_object_bytes: maximum - 1,
+            ..Default::default()
+        };
+        advertised.observe_advertised(&entry).unwrap();
+        assert_eq!(advertised.advertised_object_bytes, maximum);
+        assert_eq!(
+            advertised.observe_advertised(&entry),
+            Err(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                    SemanticRemoteCatalogResourceV1::AdvertisedObjectBytes
+                )
+            )
+        );
+
+        let mut overflow = u64::MAX;
+        assert_eq!(
+            SemanticRemoteCatalogBudgetV1::checked_add(
+                &mut overflow,
+                1,
+                u64::MAX,
+                SemanticRemoteCatalogResourceV1::BoundObjectBytes,
+            ),
+            Err(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                    SemanticRemoteCatalogResourceV1::BoundObjectBytes
+                )
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_bound_resource_accounting_accepts_exact_limits_and_rejects_next_value() {
+        let index_key = "roots/index/budget.txt";
+        let index_bytes = deleted_index_json();
+        let fixture = fixture(
+            "roots",
+            vec![vec![fixture_entry(
+                RemoteCatalogObjectKindV1::Index,
+                index_key,
+                &index_bytes,
+                "index-etag",
+            )]],
+        );
+        fixture.insert_named(index_key, index_bytes, "index-etag");
+        let receipt = fixture.receipt("roots").await;
+        let verified = match fixture.read_semantic(&receipt).await.unwrap() {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(verified) => verified,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => {
+                panic!("expected semantic catalog, got {incomplete:?}")
+            }
+        };
+        let object = verified.index_objects[0].object();
+        let body_bytes = object.raw_bytes_len();
+        let binding_bytes = match object.binding() {
+            RegisteredRootRemoteObjectBindingV1::Version { version, etag } => {
+                u64::try_from(version.len() + etag.as_ref().map_or(0, String::len)).unwrap()
+            }
+            RegisteredRootRemoteObjectBindingV1::Etag { etag } => {
+                u64::try_from(etag.len()).unwrap()
+            }
+        };
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+
+        let mut exact_body = SemanticRemoteCatalogBudgetV1 {
+            bound_object_bytes: contract.max_bound_object_bytes_per_pass() - body_bytes,
+            ..Default::default()
+        };
+        assert_eq!(exact_body.observe_bound(object), Ok(()));
+        assert_eq!(
+            exact_body.bound_object_bytes,
+            contract.max_bound_object_bytes_per_pass()
+        );
+        let mut over_body = SemanticRemoteCatalogBudgetV1 {
+            bound_object_bytes: contract.max_bound_object_bytes_per_pass() - body_bytes + 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            over_body.observe_bound(object),
+            Err(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                    SemanticRemoteCatalogResourceV1::BoundObjectBytes
+                )
+            )
+        );
+
+        let mut exact_binding = SemanticRemoteCatalogBudgetV1 {
+            retained_binding_bytes: contract.max_retained_binding_bytes_per_pass() - binding_bytes,
+            ..Default::default()
+        };
+        assert_eq!(exact_binding.observe_bound(object), Ok(()));
+        assert_eq!(
+            exact_binding.retained_binding_bytes,
+            contract.max_retained_binding_bytes_per_pass()
+        );
+        let mut over_binding = SemanticRemoteCatalogBudgetV1 {
+            retained_binding_bytes: contract.max_retained_binding_bytes_per_pass() - binding_bytes
+                + 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            over_binding.observe_bound(object),
+            Err(
+                StrictSemanticallyBoundRemoteCatalogIncompleteV1::ResourceLimit(
+                    SemanticRemoteCatalogResourceV1::RetainedBindingBytes
+                )
+            )
         );
     }
 }

--- a/crates/tcfs-sync/src/registered_remote_catalog.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog.rs
@@ -505,6 +505,28 @@ impl SemanticallyBoundRemoteCatalogCorpusV1 {
         self.closure.root_id()
     }
 
+    pub(crate) fn root_identity_fingerprint(&self) -> &str {
+        self.closure.root_identity_fingerprint()
+    }
+
+    pub(crate) const fn root_generation(&self) -> NonZeroU64 {
+        self.closure.root_generation()
+    }
+
+    pub(crate) const fn profile(&self) -> RootProfileV1 {
+        self.closure.profile()
+    }
+
+    pub(crate) const fn profile_settings_fingerprint(&self) -> RootProfileSettingsFingerprintV1 {
+        self.closure.profile_settings_fingerprint()
+    }
+
+    pub(crate) const fn plan_contract_fingerprint(
+        &self,
+    ) -> RegisteredRootPlanContractFingerprintV1 {
+        self.closure.plan_contract_fingerprint()
+    }
+
     pub(crate) const fn catalog_sequence(&self) -> NonZeroU64 {
         self.closure.catalog_sequence()
     }
@@ -523,6 +545,32 @@ impl SemanticallyBoundRemoteCatalogCorpusV1 {
 
     pub(crate) fn claim_count(&self) -> usize {
         self.claims.len()
+    }
+
+    /// Iterate the unique retained claims in ascending folded-path order.
+    ///
+    /// The sibling held-window composer consumes this projection directly for
+    /// its bounded three-way namespace merge. Raw catalog entries, object
+    /// bodies, and bindings remain opaque here: this is namespace-safety
+    /// evidence for one internally closed revision, not action authority.
+    pub(crate) fn namespace_safety_claims(
+        &self,
+    ) -> impl ExactSizeIterator<
+        Item = (
+            &str,
+            &str,
+            PortableNamespaceRole,
+            RemoteNamespaceClaimOriginsV1,
+        ),
+    > {
+        self.claims.iter().map(|claim| {
+            (
+                claim.folded_path(),
+                claim.exact_path(),
+                claim.role(),
+                claim.origins(),
+            )
+        })
     }
 }
 
@@ -2064,7 +2112,7 @@ pub(crate) async fn read_semantically_bound_remote_catalog_corpus_v1(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use opendal::raw::{
         oio, Access, AccessorInfo, OpDelete, OpRead, OpStat, OpWrite, RpDelete, RpRead, RpStat,
@@ -2117,6 +2165,8 @@ mod tests {
         replacement: ScriptedObject,
     }
 
+    type FirstCatalogReadWriteV1 = Option<(std::path::PathBuf, Vec<u8>)>;
+
     #[derive(Clone, Debug, Eq, PartialEq)]
     struct ObservedRead {
         path: String,
@@ -2134,6 +2184,7 @@ mod tests {
         head_key: String,
         head_reads: Arc<AtomicUsize>,
         head_mutation: Arc<Mutex<Option<HeadMutation>>>,
+        first_catalog_read_write: Arc<Mutex<FirstCatalogReadWriteV1>>,
         next_read_replacements: Arc<Mutex<BTreeMap<String, ScriptedObject>>>,
         next_etag: Arc<AtomicU64>,
     }
@@ -2170,6 +2221,14 @@ mod tests {
                 .lock()
                 .unwrap()
                 .insert(key.into(), replacement);
+        }
+
+        fn write_local_file_on_first_catalog_read(
+            &self,
+            target: std::path::PathBuf,
+            bytes: Vec<u8>,
+        ) {
+            *self.first_catalog_read_write.lock().unwrap() = Some((target, bytes));
         }
 
         fn disable_version_reads(&self) {
@@ -2227,6 +2286,18 @@ mod tests {
         async fn read(&self, path: &str, args: OpRead) -> opendal::Result<(RpRead, Buffer)> {
             let head_read_index =
                 (path == self.head_key).then(|| self.head_reads.fetch_add(1, Ordering::SeqCst));
+            if head_read_index == Some(0) {
+                if let Some((target, bytes)) = self.first_catalog_read_write.lock().unwrap().take()
+                {
+                    std::fs::write(&target, bytes).map_err(|error| {
+                        Error::new(
+                            ErrorKind::Unexpected,
+                            "scripted first catalog read could not mutate local fixture",
+                        )
+                        .set_source(error)
+                    })?;
+                }
+            }
             let mutation = head_read_index.and_then(|_| self.head_mutation.lock().unwrap().clone());
             if let Some(HeadMutation {
                 timing,
@@ -2424,6 +2495,7 @@ mod tests {
             head_key: catalog_head_key_v1(prefix),
             head_reads: Arc::new(AtomicUsize::new(0)),
             head_mutation: Arc::new(Mutex::new(None)),
+            first_catalog_read_write: Arc::new(Mutex::new(None)),
             next_read_replacements: Arc::new(Mutex::new(BTreeMap::new())),
             next_etag: Arc::new(AtomicU64::new(1)),
         };
@@ -2452,22 +2524,16 @@ mod tests {
         }
     }
 
-    fn fixture_context(prefix: &str) -> RemoteCatalogContextWireV1 {
-        let root_id = "fixture-root".to_owned();
-        let root_generation = 1;
-        let profile = RootProfileV1::AgentStaticV1;
-        let spec = RootSpecV1Config {
-            version: RootSpecV1Config::VERSION,
-            remote_prefix: prefix.to_owned(),
-            profile,
-            generation: NonZeroU64::new(root_generation).unwrap(),
-        };
+    fn fixture_context_for_selected(
+        root_id: &str,
+        spec: &RootSpecV1Config,
+    ) -> RemoteCatalogContextWireV1 {
         RemoteCatalogContextWireV1 {
-            root_identity_fingerprint: spec.identity_fingerprint(&root_id),
-            root_id,
-            root_generation,
-            profile,
-            profile_settings_fingerprint: profile.policy().settings_fingerprint().to_string(),
+            root_identity_fingerprint: spec.identity_fingerprint(root_id),
+            root_id: root_id.to_owned(),
+            root_generation: spec.generation.get(),
+            profile: spec.profile,
+            profile_settings_fingerprint: spec.profile.policy().settings_fingerprint().to_string(),
             plan_contract_fingerprint: RegisteredRootPlanContractV1::strict_v1()
                 .fingerprint()
                 .to_string(),
@@ -2706,8 +2772,13 @@ mod tests {
         }
     }
 
-    fn fixture(prefix: &str, pages: Vec<Vec<RemoteCatalogEntryWireV1>>) -> CatalogFixture {
-        let context = fixture_context(prefix);
+    fn fixture_for_selected(
+        root_id: &str,
+        spec: &RootSpecV1Config,
+        pages: Vec<Vec<RemoteCatalogEntryWireV1>>,
+    ) -> CatalogFixture {
+        let prefix = &spec.remote_prefix;
+        let context = fixture_context_for_selected(root_id, spec);
         let publication_nonce = "11".repeat(32);
         let mut objects = Vec::new();
         let mut page_references = Vec::new();
@@ -2725,7 +2796,7 @@ mod tests {
             total_key_bytes += entry_key_bytes;
             let page = RemoteCatalogPageWireV1 {
                 version: CATALOG_SCHEMA_VERSION_V1,
-                context: fixture_context(prefix),
+                context: fixture_context_for_selected(root_id, spec),
                 catalog_sequence: 1,
                 publication_nonce: publication_nonce.clone(),
                 ordinal: u64::try_from(ordinal).unwrap(),
@@ -2761,8 +2832,8 @@ mod tests {
             pages: page_references,
         };
         let root_bytes = serde_json::to_vec(&root).unwrap();
-        let root_id = lower_hex(&catalog_root_object_id_v1(&root_bytes));
-        let root_key = catalog_root_key_v1(prefix, &root_id);
+        let catalog_root_id = lower_hex(&catalog_root_object_id_v1(&root_bytes));
+        let root_key = catalog_root_key_v1(prefix, &catalog_root_id);
         let root_etag = "root-etag";
         objects.push((
             root_key.clone(),
@@ -2770,12 +2841,12 @@ mod tests {
         ));
         let head = RemoteCatalogHeadWireV1 {
             version: CATALOG_SCHEMA_VERSION_V1,
-            context: fixture_context(prefix),
+            context: fixture_context_for_selected(root_id, spec),
             catalog_sequence: 1,
             publication_nonce: "11".repeat(32),
             parent_head_revision: None,
             catalog_root: RemoteCatalogRootReferenceWireV1 {
-                object_id: root_id,
+                object_id: catalog_root_id,
                 raw_bytes_len: u64::try_from(root_bytes.len()).unwrap(),
                 binding: etag_binding(root_etag),
                 page_count: root.page_count,
@@ -2796,13 +2867,7 @@ mod tests {
         }
         let selected = crate::registered_source_composition::
             validated_selected_registered_root_remote_context_for_test_v1(
-                "fixture-root",
-                &RootSpecV1Config {
-                    version: RootSpecV1Config::VERSION,
-                    remote_prefix: prefix.to_owned(),
-                    profile: RootProfileV1::AgentStaticV1,
-                    generation: NonZeroU64::new(1).unwrap(),
-                },
+                root_id, spec,
             )
             .unwrap();
         CatalogFixture {
@@ -2815,6 +2880,197 @@ mod tests {
             page_keys,
             head_bytes,
             root_bytes,
+        }
+    }
+
+    fn fixture(prefix: &str, pages: Vec<Vec<RemoteCatalogEntryWireV1>>) -> CatalogFixture {
+        fixture_for_selected(
+            "fixture-root",
+            &RootSpecV1Config {
+                version: RootSpecV1Config::VERSION,
+                remote_prefix: prefix.to_owned(),
+                profile: RootProfileV1::AgentStaticV1,
+                generation: NonZeroU64::new(1).unwrap(),
+            },
+            pages,
+        )
+    }
+
+    #[derive(Clone, Debug)]
+    pub(crate) enum SemanticRemoteCatalogFixtureRowV1 {
+        CurrentFile(String),
+        DeletedFile(String),
+        CurrentDirectory(String),
+        DeletedDirectory(String),
+        Reservation {
+            exact_path: String,
+            role: PortableNamespaceRole,
+        },
+    }
+
+    /// Opaque test-only catalog backend plus the exact conditional-semantics
+    /// receipt acquired before a held local observation begins.
+    ///
+    /// Callers can exercise the production semantic reader, but cannot obtain
+    /// raw catalog wire constructors or manufacture a verified corpus.
+    pub(crate) struct SemanticRemoteCatalogFixtureV1 {
+        operator: Operator,
+        receipt: ConditionalWriteSemanticsReceipt,
+    }
+
+    impl SemanticRemoteCatalogFixtureV1 {
+        pub(crate) const fn operator(&self) -> &Operator {
+            &self.operator
+        }
+
+        pub(crate) const fn receipt(&self) -> &ConditionalWriteSemanticsReceipt {
+            &self.receipt
+        }
+    }
+
+    /// Build an empty or populated semantic catalog for one exact selected
+    /// root identity. Semantic rows are translated into immutable catalog
+    /// entries and exact named objects behind the opaque scripted operator.
+    pub(crate) async fn semantic_remote_catalog_fixture_for_test_v1(
+        root_id: &str,
+        spec: &RootSpecV1Config,
+        rows: &[SemanticRemoteCatalogFixtureRowV1],
+    ) -> SemanticRemoteCatalogFixtureV1 {
+        semantic_remote_catalog_fixture_with_optional_first_read_write_for_test_v1(
+            root_id, spec, rows, None,
+        )
+        .await
+    }
+
+    /// As above, but mutate one local file when the first catalog HEAD read is
+    /// issued. The receipt is acquired before this hook is armed, so a sibling
+    /// held-window test can pin inventory-C drift without conflating it with
+    /// conditional-semantics probing.
+    pub(crate) async fn semantic_remote_catalog_fixture_with_first_read_write_for_test_v1(
+        root_id: &str,
+        spec: &RootSpecV1Config,
+        rows: &[SemanticRemoteCatalogFixtureRowV1],
+        target: std::path::PathBuf,
+        bytes: Vec<u8>,
+    ) -> SemanticRemoteCatalogFixtureV1 {
+        semantic_remote_catalog_fixture_with_optional_first_read_write_for_test_v1(
+            root_id,
+            spec,
+            rows,
+            Some((target, bytes)),
+        )
+        .await
+    }
+
+    async fn semantic_remote_catalog_fixture_with_optional_first_read_write_for_test_v1(
+        root_id: &str,
+        spec: &RootSpecV1Config,
+        rows: &[SemanticRemoteCatalogFixtureRowV1],
+        first_read_write: FirstCatalogReadWriteV1,
+    ) -> SemanticRemoteCatalogFixtureV1 {
+        let prefix = &spec.remote_prefix;
+        let mut entries = Vec::new();
+        let mut named_objects = Vec::new();
+        for (ordinal, row) in rows.iter().enumerate() {
+            let index_etag = format!("fixture-index-{ordinal}");
+            match row {
+                SemanticRemoteCatalogFixtureRowV1::CurrentFile(rel_path) => {
+                    let manifest_bytes = regular_manifest_json(rel_path);
+                    let manifest_id = crate::index_entry::manifest_object_id(&manifest_bytes);
+                    let index_key = format!("{prefix}/index/{rel_path}");
+                    let index_bytes = committed_index_json(&manifest_id);
+                    entries.push(fixture_entry(
+                        RemoteCatalogObjectKindV1::Index,
+                        &index_key,
+                        &index_bytes,
+                        &index_etag,
+                    ));
+                    named_objects.push((index_key, index_bytes, index_etag));
+
+                    let manifest_key = format!("{prefix}/manifests/{manifest_id}");
+                    let manifest_etag = format!("fixture-manifest-{ordinal}");
+                    entries.push(fixture_entry(
+                        RemoteCatalogObjectKindV1::Manifest,
+                        &manifest_key,
+                        &manifest_bytes,
+                        &manifest_etag,
+                    ));
+                    named_objects.push((manifest_key, manifest_bytes, manifest_etag));
+                }
+                SemanticRemoteCatalogFixtureRowV1::DeletedFile(rel_path) => {
+                    let index_key = format!("{prefix}/index/{rel_path}");
+                    let index_bytes = deleted_index_json();
+                    entries.push(fixture_entry(
+                        RemoteCatalogObjectKindV1::Index,
+                        &index_key,
+                        &index_bytes,
+                        &index_etag,
+                    ));
+                    named_objects.push((index_key, index_bytes, index_etag));
+                }
+                SemanticRemoteCatalogFixtureRowV1::CurrentDirectory(rel_path) => {
+                    let index_key = format!("{prefix}/index/{rel_path}/.tcfs_dir");
+                    let marker_bytes = crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec();
+                    entries.push(fixture_entry(
+                        RemoteCatalogObjectKindV1::Index,
+                        &index_key,
+                        &marker_bytes,
+                        &index_etag,
+                    ));
+                    named_objects.push((index_key, marker_bytes, index_etag));
+                }
+                SemanticRemoteCatalogFixtureRowV1::DeletedDirectory(rel_path) => {
+                    let index_key = format!("{prefix}/index/{rel_path}/.tcfs_dir");
+                    let marker_bytes = deleted_index_json();
+                    entries.push(fixture_entry(
+                        RemoteCatalogObjectKindV1::Index,
+                        &index_key,
+                        &marker_bytes,
+                        &index_etag,
+                    ));
+                    named_objects.push((index_key, marker_bytes, index_etag));
+                }
+                SemanticRemoteCatalogFixtureRowV1::Reservation { exact_path, role } => {
+                    let folded_path = crate::index_entry::portable_casefold_path(exact_path)
+                        .expect("semantic catalog fixture path must be canonical");
+                    let reservation_id =
+                        crate::index_entry::namespace_reservation_object_id(&folded_path);
+                    let reservation_key = format!("{prefix}/.tcfs-namespace/v1/{reservation_id}");
+                    let role = match role {
+                        PortableNamespaceRole::File => "file",
+                        PortableNamespaceRole::Directory => "directory",
+                    };
+                    let reservation_bytes =
+                        canonical_reservation_json(exact_path, &folded_path, role);
+                    let reservation_etag = format!("fixture-reservation-{ordinal}");
+                    entries.push(fixture_entry(
+                        RemoteCatalogObjectKindV1::Reservation,
+                        &reservation_key,
+                        &reservation_bytes,
+                        &reservation_etag,
+                    ));
+                    named_objects.push((reservation_key, reservation_bytes, reservation_etag));
+                }
+            }
+        }
+        let pages = if entries.is_empty() {
+            Vec::new()
+        } else {
+            vec![sorted_entries(entries)]
+        };
+        let fixture = fixture_for_selected(root_id, spec, pages);
+        for (key, bytes, etag) in named_objects {
+            fixture.insert_named(key, bytes, &etag);
+        }
+        let receipt = fixture.receipt(prefix).await;
+        if let Some((target, bytes)) = first_read_write {
+            fixture
+                .backend
+                .write_local_file_on_first_catalog_read(target, bytes);
+        }
+        SemanticRemoteCatalogFixtureV1 {
+            operator: fixture.op,
+            receipt,
         }
     }
 
@@ -2896,11 +3152,32 @@ mod tests {
         };
         assert_eq!(verified.remote_prefix(), "roots");
         assert_eq!(verified.root_id(), "fixture-root");
+        assert_eq!(
+            verified.root_identity_fingerprint(),
+            RootSpecV1Config {
+                version: RootSpecV1Config::VERSION,
+                remote_prefix: "roots".to_owned(),
+                profile: RootProfileV1::AgentStaticV1,
+                generation: NonZeroU64::new(1).unwrap(),
+            }
+            .identity_fingerprint("fixture-root")
+        );
+        assert_eq!(verified.root_generation().get(), 1);
+        assert_eq!(verified.profile(), RootProfileV1::AgentStaticV1);
+        assert_eq!(
+            verified.profile_settings_fingerprint(),
+            RootProfileV1::AgentStaticV1.policy().settings_fingerprint()
+        );
+        assert_eq!(
+            verified.plan_contract_fingerprint(),
+            RegisteredRootPlanContractV1::strict_v1().fingerprint()
+        );
         assert_eq!(verified.catalog_sequence().get(), 1);
         assert_eq!(verified.index_object_count(), 0);
         assert_eq!(verified.reservation_count(), 0);
         assert_eq!(verified.manifest_count(), 0);
         assert_eq!(verified.claim_count(), 0);
+        assert_eq!(verified.namespace_safety_claims().len(), 0);
         assert_eq!(fixture.backend.head_reads.load(Ordering::SeqCst), 3);
         assert_eq!(
             fixture
@@ -2912,6 +3189,115 @@ mod tests {
                 .filter(|read| read.path == fixture.head_key)
                 .count(),
             3
+        );
+    }
+
+    #[tokio::test]
+    async fn semantic_fixture_binds_selected_context_orders_claims_and_mutates_on_first_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_file = dir.path().join("local.txt");
+        std::fs::write(&local_file, b"before").unwrap();
+        let spec = RootSpecV1Config {
+            version: RootSpecV1Config::VERSION,
+            remote_prefix: "roots".to_owned(),
+            profile: RootProfileV1::GitRawV1,
+            generation: NonZeroU64::new(7).unwrap(),
+        };
+        let fixture = semantic_remote_catalog_fixture_with_first_read_write_for_test_v1(
+            "work",
+            &spec,
+            &[
+                SemanticRemoteCatalogFixtureRowV1::DeletedFile("z.txt".to_owned()),
+                SemanticRemoteCatalogFixtureRowV1::CurrentFile("a.txt".to_owned()),
+                SemanticRemoteCatalogFixtureRowV1::CurrentDirectory("dir".to_owned()),
+                SemanticRemoteCatalogFixtureRowV1::DeletedDirectory("old-dir".to_owned()),
+                SemanticRemoteCatalogFixtureRowV1::Reservation {
+                    exact_path: "middle".to_owned(),
+                    role: PortableNamespaceRole::Directory,
+                },
+            ],
+            local_file.clone(),
+            b"during-catalog-read".to_vec(),
+        )
+        .await;
+        assert_eq!(std::fs::read(&local_file).unwrap(), b"before");
+        let selected = crate::registered_source_composition::
+            validated_selected_registered_root_remote_context_for_test_v1("work", &spec)
+            .unwrap();
+        let verified = match read_semantically_bound_remote_catalog_corpus_v1(
+            fixture.operator(),
+            &selected,
+            fixture.receipt(),
+        )
+        .await
+        .unwrap()
+        {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(verified) => verified,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => {
+                panic!("expected semantic fixture, got {incomplete:?}")
+            }
+        };
+        assert_eq!(std::fs::read(local_file).unwrap(), b"during-catalog-read");
+        assert_eq!(verified.root_id(), "work");
+        assert_eq!(verified.root_generation().get(), 7);
+        assert_eq!(verified.profile(), RootProfileV1::GitRawV1);
+        let claims = verified
+            .namespace_safety_claims()
+            .map(|(folded, exact, role, origins)| {
+                (
+                    folded.to_owned(),
+                    exact.to_owned(),
+                    role,
+                    origins.current(),
+                    origins.historical(),
+                    origins.reservation(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            claims,
+            vec![
+                (
+                    "a.txt".to_owned(),
+                    "a.txt".to_owned(),
+                    PortableNamespaceRole::File,
+                    true,
+                    false,
+                    false,
+                ),
+                (
+                    "dir".to_owned(),
+                    "dir".to_owned(),
+                    PortableNamespaceRole::Directory,
+                    true,
+                    false,
+                    false,
+                ),
+                (
+                    "middle".to_owned(),
+                    "middle".to_owned(),
+                    PortableNamespaceRole::Directory,
+                    false,
+                    false,
+                    true,
+                ),
+                (
+                    "old-dir".to_owned(),
+                    "old-dir".to_owned(),
+                    PortableNamespaceRole::Directory,
+                    false,
+                    true,
+                    false,
+                ),
+                (
+                    "z.txt".to_owned(),
+                    "z.txt".to_owned(),
+                    PortableNamespaceRole::File,
+                    false,
+                    true,
+                    false,
+                ),
+            ]
         );
     }
 

--- a/crates/tcfs-sync/src/registered_remote_catalog.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog.rs
@@ -1,0 +1,2567 @@
+//! Immutable registered-root remote catalog closure.
+//!
+//! Generic S3-compatible LIST operations cannot prove that they did not omit
+//! an object. The strict registered-root ceremony therefore requires a
+//! conditionally updated current HEAD whose exact bytes select an immutable,
+//! content-addressed catalog root and ordered immutable pages. This module
+//! validates only that catalog closure:
+//!
+//! `current HEAD A -> catalog root -> every catalog page -> current HEAD B`
+//!
+//! It deliberately stops before binding every namespace object named by the
+//! pages. It also cannot prove that legacy/direct writers have been fenced or
+//! that the first catalog was bootstrapped from externally complete truth.
+//! The inventory is the registered-root reconcile metadata corpus (indices,
+//! namespace reservations, and manifests), not chunks, staging objects,
+//! probes, or catalog objects. A later semantic gate must still prove that
+//! every index and reservation is present and the manifest entries are exactly
+//! the referenced manifest set.
+//! Without linearizable current-HEAD reads or a trusted monotonic high-water
+//! mark, it also proves closure only at the observed revision, not that the
+//! revision is the latest published namespace.
+//! Consequently the artifact below is not `CompleteOrNoDigestV1` authority and
+//! has no digest, action, serialization, or planner conversion.
+
+use anyhow::Result;
+use opendal::Operator;
+use serde::{Deserialize, Serialize};
+use std::num::NonZeroU64;
+#[cfg(test)]
+use tcfs_core::config::RootSpecV1Config;
+use tcfs_core::config::{
+    validate_registered_root_id, RegisteredRootPlanContractFingerprintV1,
+    RegisteredRootPlanContractV1, RootProfileSettingsFingerprintV1, RootProfileV1,
+};
+use tcfs_storage::ConditionalWriteSemanticsReceipt;
+
+use crate::index_entry::{
+    namespace_index_prefix, namespace_logical_entry_from_index_path, namespace_reservation_prefix,
+    read_current_raw_object_snapshot_v1, read_raw_object_snapshot_v1,
+    validate_canonical_namespace_remote_prefix, RawObjectChangedDuringReadV1,
+    RawObjectReadBindingV1, RawObjectReadV1, RawObjectSnapshotTooLargeV1, RawObjectSnapshotV1,
+};
+use crate::registered_reconcile::{
+    bind_remote_object_v1, BoundRemoteObjectSnapshotV1, RegisteredRootRemoteObjectBindingV1,
+};
+use crate::registered_source_composition::ValidatedSelectedRegisteredRootRemoteContextV1;
+
+const CATALOG_SCHEMA_VERSION_V1: u32 = 1;
+const CATALOG_HEAD_SUFFIX_V1: &str = ".tcfs-catalog/v1/head";
+const CATALOG_ROOT_SUFFIX_V1: &str = ".tcfs-catalog/v1/roots";
+const CATALOG_PAGE_SUFFIX_V1: &str = ".tcfs-catalog/v1/pages";
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum RemoteCatalogObjectKindV1 {
+    Index,
+    Reservation,
+    Manifest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteCatalogClosureObjectKindV1 {
+    Head,
+    Root,
+    Page,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteCatalogResourceV1 {
+    HeadBytes,
+    RootBytes,
+    PageBytes,
+    ClosureBytes,
+    Pages,
+    EntriesPerPage,
+    Entries,
+    EntryKeyBytes,
+    BindingBytes,
+    IndexEntries,
+    ReservationEntries,
+    ManifestEntries,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InvalidRemoteCatalogReasonV1 {
+    CanonicalEncoding,
+    Context,
+    Lineage,
+    ObjectAddress,
+    ObjectIdentity,
+    ObjectBinding,
+    PageOrder,
+    EntryOrder,
+    EntryRoute,
+    EntryIdentity,
+    Totals,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StrictRemoteCatalogIncompleteV1 {
+    InvalidRemotePrefix,
+    StorageSemanticsUnverified,
+    HeadMissing,
+    HeadUnboundCurrentEtag,
+    HeadChanged,
+    ClosureObjectMissing {
+        kind: RemoteCatalogClosureObjectKindV1,
+    },
+    ClosureObjectUnbound {
+        kind: RemoteCatalogClosureObjectKindV1,
+    },
+    ClosureObjectChanged {
+        kind: RemoteCatalogClosureObjectKindV1,
+    },
+    Invalid {
+        kind: RemoteCatalogClosureObjectKindV1,
+        reason: InvalidRemoteCatalogReasonV1,
+    },
+    ResourceLimit(RemoteCatalogResourceV1),
+}
+
+pub(crate) enum StrictRemoteCatalogClosureReadV1 {
+    Verified(Box<VerifiedRemoteCatalogClosureV1>),
+    Incomplete(StrictRemoteCatalogIncompleteV1),
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogContextWireV1 {
+    root_id: String,
+    root_identity_fingerprint: String,
+    root_generation: u64,
+    profile: RootProfileV1,
+    profile_settings_fingerprint: String,
+    plan_contract_fingerprint: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogObjectBindingWireV1 {
+    version: Option<String>,
+    etag: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogRootReferenceWireV1 {
+    object_id: String,
+    raw_bytes_len: u64,
+    binding: RemoteCatalogObjectBindingWireV1,
+    page_count: u64,
+    entry_count: u64,
+    entry_key_bytes: u64,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogHeadWireV1 {
+    version: u32,
+    context: RemoteCatalogContextWireV1,
+    catalog_sequence: u64,
+    publication_nonce: String,
+    parent_head_revision: Option<String>,
+    catalog_root: RemoteCatalogRootReferenceWireV1,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogPageReferenceWireV1 {
+    ordinal: u64,
+    object_id: String,
+    raw_bytes_len: u64,
+    binding: RemoteCatalogObjectBindingWireV1,
+    entry_count: u64,
+    entry_key_bytes: u64,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogRootWireV1 {
+    version: u32,
+    context: RemoteCatalogContextWireV1,
+    catalog_sequence: u64,
+    publication_nonce: String,
+    parent_head_revision: Option<String>,
+    page_count: u64,
+    entry_count: u64,
+    entry_key_bytes: u64,
+    pages: Vec<RemoteCatalogPageReferenceWireV1>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogEntryWireV1 {
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    raw_bytes_len: u64,
+    raw_blake3: String,
+    binding: RemoteCatalogObjectBindingWireV1,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogPageWireV1 {
+    version: u32,
+    context: RemoteCatalogContextWireV1,
+    catalog_sequence: u64,
+    publication_nonce: String,
+    ordinal: u64,
+    entry_count: u64,
+    entry_key_bytes: u64,
+    entries: Vec<RemoteCatalogEntryWireV1>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct VerifiedRemoteCatalogEntryV1 {
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    raw_bytes_len: u64,
+    raw_blake3: [u8; 32],
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+impl VerifiedRemoteCatalogEntryV1 {
+    pub(crate) const fn kind(&self) -> RemoteCatalogObjectKindV1 {
+        self.kind
+    }
+
+    pub(crate) fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub(crate) const fn raw_bytes_len(&self) -> u64 {
+        self.raw_bytes_len
+    }
+
+    pub(crate) const fn raw_blake3(&self) -> &[u8; 32] {
+        &self.raw_blake3
+    }
+
+    pub(crate) const fn binding(&self) -> &RegisteredRootRemoteObjectBindingV1 {
+        &self.binding
+    }
+}
+
+/// Internally consistent immutable catalog inventory selected by one unchanged
+/// current HEAD.
+///
+/// This remains weaker than complete remote truth until all named namespace
+/// objects are bound and every legacy/direct writer plus bootstrap path is
+/// fenced by the catalog publication protocol.
+pub(crate) struct VerifiedRemoteCatalogClosureV1 {
+    remote_prefix: String,
+    root_id: String,
+    root_identity_fingerprint: String,
+    root_generation: NonZeroU64,
+    profile: RootProfileV1,
+    profile_settings_fingerprint: RootProfileSettingsFingerprintV1,
+    plan_contract_fingerprint: RegisteredRootPlanContractFingerprintV1,
+    catalog_sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: Option<[u8; 32]>,
+    head_revision: [u8; 32],
+    head_object: BoundRemoteObjectSnapshotV1,
+    root_object: BoundRemoteObjectSnapshotV1,
+    page_objects: Vec<BoundRemoteObjectSnapshotV1>,
+    entries: Vec<VerifiedRemoteCatalogEntryV1>,
+}
+
+impl std::fmt::Debug for VerifiedRemoteCatalogClosureV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("VerifiedRemoteCatalogClosureV1")
+            .field("remote_prefix", &self.remote_prefix)
+            .field("root_id", &self.root_id)
+            .field("root_identity_fingerprint", &self.root_identity_fingerprint)
+            .field("root_generation", &self.root_generation)
+            .field("profile", &self.profile)
+            .field("catalog_sequence", &self.catalog_sequence)
+            .field("page_count", &self.page_objects.len())
+            .field("entry_count", &self.entries.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl VerifiedRemoteCatalogClosureV1 {
+    pub(crate) fn remote_prefix(&self) -> &str {
+        &self.remote_prefix
+    }
+
+    pub(crate) fn root_id(&self) -> &str {
+        &self.root_id
+    }
+
+    pub(crate) fn root_identity_fingerprint(&self) -> &str {
+        &self.root_identity_fingerprint
+    }
+
+    pub(crate) const fn root_generation(&self) -> NonZeroU64 {
+        self.root_generation
+    }
+
+    pub(crate) const fn profile(&self) -> RootProfileV1 {
+        self.profile
+    }
+
+    pub(crate) const fn profile_settings_fingerprint(&self) -> RootProfileSettingsFingerprintV1 {
+        self.profile_settings_fingerprint
+    }
+
+    pub(crate) const fn plan_contract_fingerprint(
+        &self,
+    ) -> RegisteredRootPlanContractFingerprintV1 {
+        self.plan_contract_fingerprint
+    }
+
+    pub(crate) const fn catalog_sequence(&self) -> NonZeroU64 {
+        self.catalog_sequence
+    }
+
+    pub(crate) fn entries(&self) -> impl ExactSizeIterator<Item = &VerifiedRemoteCatalogEntryV1> {
+        self.entries.iter()
+    }
+}
+
+fn join_remote_key_v1(remote_prefix: &str, suffix: &str) -> String {
+    format!("{remote_prefix}/{suffix}")
+}
+
+fn catalog_head_key_v1(remote_prefix: &str) -> String {
+    join_remote_key_v1(remote_prefix, CATALOG_HEAD_SUFFIX_V1)
+}
+
+fn catalog_root_key_v1(remote_prefix: &str, object_id: &str) -> String {
+    format!("{}/{}/{}", remote_prefix, CATALOG_ROOT_SUFFIX_V1, object_id)
+}
+
+fn catalog_page_key_v1(remote_prefix: &str, object_id: &str) -> String {
+    format!("{}/{}/{}", remote_prefix, CATALOG_PAGE_SUFFIX_V1, object_id)
+}
+
+fn domain_object_id_v1(domain: &str, raw_bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new_derive_key(domain);
+    hasher.update(raw_bytes);
+    *hasher.finalize().as_bytes()
+}
+
+fn catalog_head_revision_v1(raw_bytes: &[u8]) -> [u8; 32] {
+    domain_object_id_v1("tinyland.tcfs.remote-catalog-head-revision.b3v1", raw_bytes)
+}
+
+fn catalog_root_object_id_v1(raw_bytes: &[u8]) -> [u8; 32] {
+    domain_object_id_v1("tinyland.tcfs.remote-catalog-root-object.b3v1", raw_bytes)
+}
+
+fn catalog_page_object_id_v1(raw_bytes: &[u8]) -> [u8; 32] {
+    domain_object_id_v1("tinyland.tcfs.remote-catalog-page-object.b3v1", raw_bytes)
+}
+
+fn lower_hex(bytes: &[u8; 32]) -> String {
+    let mut text = String::with_capacity(64);
+    for byte in bytes {
+        use std::fmt::Write;
+        write!(&mut text, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    text
+}
+
+fn parse_lower_hex_32(value: &str) -> Option<[u8; 32]> {
+    if value.len() != 64
+        || !value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return None;
+    }
+    let mut result = [0_u8; 32];
+    for (index, output) in result.iter_mut().enumerate() {
+        let start = index.checked_mul(2)?;
+        *output = u8::from_str_radix(value.get(start..start + 2)?, 16).ok()?;
+    }
+    Some(result)
+}
+
+fn valid_b3v1_fingerprint(value: &str) -> bool {
+    value
+        .strip_prefix("b3v1:")
+        .and_then(parse_lower_hex_32)
+        .is_some()
+}
+
+fn invalid(
+    kind: RemoteCatalogClosureObjectKindV1,
+    reason: InvalidRemoteCatalogReasonV1,
+) -> StrictRemoteCatalogIncompleteV1 {
+    StrictRemoteCatalogIncompleteV1::Invalid { kind, reason }
+}
+
+fn validate_storage_key_bound_v1(key: &str) -> bool {
+    !key.is_empty()
+        && !key.starts_with('/')
+        && !key.ends_with('/')
+        && !key.contains('\\')
+        && !key.chars().any(char::is_control)
+        && !key
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
+        && u64::try_from(key.len()).is_ok_and(|length| {
+            length
+                <= RegisteredRootPlanContractV1::strict_v1()
+                    .remote_contract()
+                    .max_storage_key_bytes()
+        })
+}
+
+fn validate_catalog_context_v1(
+    context: &RemoteCatalogContextWireV1,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+) -> Option<(
+    NonZeroU64,
+    RootProfileSettingsFingerprintV1,
+    RegisteredRootPlanContractFingerprintV1,
+)> {
+    validate_registered_root_id(&context.root_id).ok()?;
+    let generation = NonZeroU64::new(context.root_generation)?;
+    let expected_spec = selected.spec();
+    if context.root_id != selected.root_id()
+        || context.root_identity_fingerprint != selected.spec_identity_fingerprint()
+        || generation != expected_spec.generation
+        || context.profile != expected_spec.profile
+        || context.profile_settings_fingerprint
+            != selected.profile_settings_fingerprint().to_string()
+        || context.plan_contract_fingerprint != selected.plan_contract_fingerprint().to_string()
+    {
+        return None;
+    }
+    if !valid_b3v1_fingerprint(&context.root_identity_fingerprint)
+        || expected_spec.identity_fingerprint(selected.root_id())
+            != context.root_identity_fingerprint
+        || expected_spec.profile.policy().settings_fingerprint()
+            != selected.profile_settings_fingerprint()
+        || RegisteredRootPlanContractV1::strict_v1().fingerprint()
+            != selected.plan_contract_fingerprint()
+    {
+        return None;
+    }
+    Some((
+        generation,
+        selected.profile_settings_fingerprint(),
+        selected.plan_contract_fingerprint(),
+    ))
+}
+
+fn validate_catalog_lineage_v1(
+    catalog_sequence: u64,
+    publication_nonce: &str,
+    parent_head_revision: Option<&str>,
+) -> Option<(NonZeroU64, [u8; 32], Option<[u8; 32]>)> {
+    let sequence = NonZeroU64::new(catalog_sequence)?;
+    let nonce = parse_lower_hex_32(publication_nonce)?;
+    if nonce == [0_u8; 32] {
+        return None;
+    }
+    let parent = match parent_head_revision {
+        Some(parent) => Some(parse_lower_hex_32(parent)?),
+        None => None,
+    };
+    if (sequence.get() == 1) != parent.is_none() {
+        return None;
+    }
+    Some((sequence, nonce, parent))
+}
+
+fn canonical_wire_v1<T>(raw_bytes: &[u8]) -> Option<T>
+where
+    T: for<'de> Deserialize<'de> + Serialize,
+{
+    let parsed = serde_json::from_slice::<T>(raw_bytes).ok()?;
+    (serde_json::to_vec(&parsed).ok()?.as_slice() == raw_bytes).then_some(parsed)
+}
+
+fn validate_binding_wire_v1(
+    binding: &RemoteCatalogObjectBindingWireV1,
+) -> Option<RegisteredRootRemoteObjectBindingV1> {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let valid_token = |value: &str| {
+        !value.is_empty()
+            && value != "null"
+            && u64::try_from(value.len())
+                .is_ok_and(|length| length <= remote.max_binding_token_bytes())
+    };
+    match (binding.version.as_deref(), binding.etag.as_deref()) {
+        (Some(version), etag) if valid_token(version) => {
+            if etag.is_some_and(|etag| !valid_token(etag)) {
+                return None;
+            }
+            Some(RegisteredRootRemoteObjectBindingV1::Version {
+                version: version.to_owned(),
+                etag: etag.map(str::to_owned),
+            })
+        }
+        (None, Some(etag)) if valid_token(etag) => {
+            Some(RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: etag.to_owned(),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn binding_wire_bytes_v1(binding: &RemoteCatalogObjectBindingWireV1) -> Option<u64> {
+    binding
+        .version
+        .as_ref()
+        .into_iter()
+        .chain(binding.etag.as_ref())
+        .try_fold(0_u64, |total, token| {
+            total.checked_add(u64::try_from(token.len()).ok()?)
+        })
+}
+
+fn observed_binding_matches_v1(
+    raw: &RawObjectSnapshotV1,
+    expected: &RemoteCatalogObjectBindingWireV1,
+) -> bool {
+    match (
+        raw.binding(),
+        expected.version.as_deref(),
+        expected.etag.as_deref(),
+    ) {
+        (
+            RawObjectReadBindingV1::Version { version, etag },
+            Some(expected_version),
+            expected_etag,
+        ) => version == expected_version && etag.as_deref() == expected_etag,
+        (RawObjectReadBindingV1::Etag { etag }, None, Some(expected_etag)) => etag == expected_etag,
+        _ => false,
+    }
+}
+
+fn validate_catalog_entry_route_v1(remote_prefix: &str, entry: &RemoteCatalogEntryWireV1) -> bool {
+    if !validate_storage_key_bound_v1(&entry.object_key) {
+        return false;
+    }
+    match entry.kind {
+        RemoteCatalogObjectKindV1::Index => entry
+            .object_key
+            .strip_prefix(&namespace_index_prefix(remote_prefix))
+            .filter(|relative| !relative.is_empty())
+            .is_some_and(|relative| namespace_logical_entry_from_index_path(relative).is_ok()),
+        RemoteCatalogObjectKindV1::Reservation => entry
+            .object_key
+            .strip_prefix(&namespace_reservation_prefix(remote_prefix))
+            .and_then(parse_lower_hex_32)
+            .is_some(),
+        RemoteCatalogObjectKindV1::Manifest => entry
+            .object_key
+            .strip_prefix(&format!("{remote_prefix}/manifests/"))
+            .and_then(parse_lower_hex_32)
+            .is_some(),
+    }
+}
+
+fn validate_entry_size_v1(kind: RemoteCatalogObjectKindV1, raw_bytes_len: u64) -> bool {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    raw_bytes_len > 0
+        && raw_bytes_len
+            <= match kind {
+                RemoteCatalogObjectKindV1::Index => remote.max_index_object_bytes(),
+                RemoteCatalogObjectKindV1::Reservation => remote.max_reservation_object_bytes(),
+                RemoteCatalogObjectKindV1::Manifest => remote.max_manifest_object_bytes(),
+            }
+}
+
+#[derive(Default)]
+struct RemoteCatalogBudgetV1 {
+    closure_bytes: u64,
+    pages: u64,
+    entries: u64,
+    entry_key_bytes: u64,
+    binding_bytes: u64,
+    index_entries: u64,
+    reservation_entries: u64,
+    manifest_entries: u64,
+}
+
+impl RemoteCatalogBudgetV1 {
+    fn checked_add(
+        value: &mut u64,
+        increment: u64,
+        maximum: u64,
+        resource: RemoteCatalogResourceV1,
+    ) -> std::result::Result<(), StrictRemoteCatalogIncompleteV1> {
+        *value = value
+            .checked_add(increment)
+            .ok_or(StrictRemoteCatalogIncompleteV1::ResourceLimit(resource))?;
+        if *value > maximum {
+            return Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(resource));
+        }
+        Ok(())
+    }
+
+    fn observe_root(
+        &mut self,
+        raw_bytes_len: u64,
+        binding: &RemoteCatalogObjectBindingWireV1,
+    ) -> std::result::Result<(), StrictRemoteCatalogIncompleteV1> {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        if raw_bytes_len > remote.max_catalog_root_object_bytes() {
+            return Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::RootBytes,
+            ));
+        }
+        Self::checked_add(
+            &mut self.closure_bytes,
+            raw_bytes_len,
+            remote.max_catalog_closure_object_bytes(),
+            RemoteCatalogResourceV1::ClosureBytes,
+        )?;
+        self.observe_binding(binding)
+    }
+
+    fn observe_page(
+        &mut self,
+        raw_bytes_len: u64,
+        binding: &RemoteCatalogObjectBindingWireV1,
+    ) -> std::result::Result<(), StrictRemoteCatalogIncompleteV1> {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        if raw_bytes_len > remote.max_catalog_page_object_bytes() {
+            return Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::PageBytes,
+            ));
+        }
+        Self::checked_add(
+            &mut self.pages,
+            1,
+            remote.max_catalog_pages(),
+            RemoteCatalogResourceV1::Pages,
+        )?;
+        Self::checked_add(
+            &mut self.closure_bytes,
+            raw_bytes_len,
+            remote.max_catalog_closure_object_bytes(),
+            RemoteCatalogResourceV1::ClosureBytes,
+        )?;
+        self.observe_binding(binding)
+    }
+
+    fn observe_binding(
+        &mut self,
+        binding: &RemoteCatalogObjectBindingWireV1,
+    ) -> std::result::Result<(), StrictRemoteCatalogIncompleteV1> {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        Self::checked_add(
+            &mut self.binding_bytes,
+            binding_wire_bytes_v1(binding).ok_or(
+                StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                    RemoteCatalogResourceV1::BindingBytes,
+                ),
+            )?,
+            remote.max_catalog_binding_bytes(),
+            RemoteCatalogResourceV1::BindingBytes,
+        )
+    }
+
+    fn observe_entry(
+        &mut self,
+        entry: &RemoteCatalogEntryWireV1,
+    ) -> std::result::Result<(), StrictRemoteCatalogIncompleteV1> {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        Self::checked_add(
+            &mut self.entries,
+            1,
+            remote.max_catalog_entries(),
+            RemoteCatalogResourceV1::Entries,
+        )?;
+        Self::checked_add(
+            &mut self.entry_key_bytes,
+            u64::try_from(entry.object_key.len()).map_err(|_| {
+                StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                    RemoteCatalogResourceV1::EntryKeyBytes,
+                )
+            })?,
+            remote.max_catalog_entry_key_bytes(),
+            RemoteCatalogResourceV1::EntryKeyBytes,
+        )?;
+        self.observe_binding(&entry.binding)?;
+        let (value, maximum, resource) = match entry.kind {
+            RemoteCatalogObjectKindV1::Index => (
+                &mut self.index_entries,
+                remote.max_index_observations_per_pass(),
+                RemoteCatalogResourceV1::IndexEntries,
+            ),
+            RemoteCatalogObjectKindV1::Reservation => (
+                &mut self.reservation_entries,
+                remote.max_reservation_observations_per_pass(),
+                RemoteCatalogResourceV1::ReservationEntries,
+            ),
+            RemoteCatalogObjectKindV1::Manifest => (
+                &mut self.manifest_entries,
+                remote.max_index_observations_per_pass(),
+                RemoteCatalogResourceV1::ManifestEntries,
+            ),
+        };
+        Self::checked_add(value, 1, maximum, resource)
+    }
+}
+
+fn read_changed(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<RawObjectChangedDuringReadV1>()
+        .is_some()
+}
+
+fn read_too_large(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<RawObjectSnapshotTooLargeV1>()
+        .is_some()
+}
+
+async fn read_current_head_v1(
+    op: &Operator,
+    head_key: &str,
+) -> Result<std::result::Result<RawObjectSnapshotV1, StrictRemoteCatalogIncompleteV1>> {
+    let maximum = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_catalog_head_object_bytes();
+    let read = match read_current_raw_object_snapshot_v1(op, head_key, maximum).await {
+        Ok(read) => read,
+        Err(error) if read_changed(&error) => {
+            return Ok(Err(StrictRemoteCatalogIncompleteV1::HeadChanged));
+        }
+        Err(error) if read_too_large(&error) => {
+            return Ok(Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::HeadBytes,
+            )));
+        }
+        Err(error) => return Err(error),
+    };
+    Ok(match read {
+        None => Err(StrictRemoteCatalogIncompleteV1::HeadMissing),
+        Some(RawObjectReadV1::Unbound) => {
+            Err(StrictRemoteCatalogIncompleteV1::HeadUnboundCurrentEtag)
+        }
+        Some(RawObjectReadV1::Bound(snapshot)) => Ok(snapshot),
+    })
+}
+
+async fn read_immutable_closure_object_v1(
+    op: &Operator,
+    key: &str,
+    maximum: u64,
+    kind: RemoteCatalogClosureObjectKindV1,
+) -> Result<std::result::Result<RawObjectSnapshotV1, StrictRemoteCatalogIncompleteV1>> {
+    let read = match read_raw_object_snapshot_v1(op, key, maximum).await {
+        Ok(read) => read,
+        Err(error) if read_changed(&error) => {
+            return Ok(Err(StrictRemoteCatalogIncompleteV1::ClosureObjectChanged {
+                kind,
+            }));
+        }
+        Err(error) if read_too_large(&error) => {
+            let resource = match kind {
+                RemoteCatalogClosureObjectKindV1::Head => RemoteCatalogResourceV1::HeadBytes,
+                RemoteCatalogClosureObjectKindV1::Root => RemoteCatalogResourceV1::RootBytes,
+                RemoteCatalogClosureObjectKindV1::Page => RemoteCatalogResourceV1::PageBytes,
+            };
+            return Ok(Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                resource,
+            )));
+        }
+        Err(error) => return Err(error),
+    };
+    Ok(match read {
+        None => Err(StrictRemoteCatalogIncompleteV1::ClosureObjectMissing { kind }),
+        Some(RawObjectReadV1::Unbound) => {
+            Err(StrictRemoteCatalogIncompleteV1::ClosureObjectUnbound { kind })
+        }
+        Some(RawObjectReadV1::Bound(snapshot)) => Ok(snapshot),
+    })
+}
+
+struct ValidatedRemoteCatalogHeadV1 {
+    wire: RemoteCatalogHeadWireV1,
+    catalog_sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: Option<[u8; 32]>,
+    root_generation: NonZeroU64,
+    profile_settings_fingerprint: RootProfileSettingsFingerprintV1,
+    plan_contract_fingerprint: RegisteredRootPlanContractFingerprintV1,
+}
+
+fn validate_head_v1(
+    raw: &RawObjectSnapshotV1,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+) -> std::result::Result<ValidatedRemoteCatalogHeadV1, StrictRemoteCatalogIncompleteV1> {
+    let kind = RemoteCatalogClosureObjectKindV1::Head;
+    let head = canonical_wire_v1::<RemoteCatalogHeadWireV1>(raw.raw_bytes())
+        .ok_or_else(|| invalid(kind, InvalidRemoteCatalogReasonV1::CanonicalEncoding))?;
+    if head.version != CATALOG_SCHEMA_VERSION_V1 {
+        return Err(invalid(
+            kind,
+            InvalidRemoteCatalogReasonV1::CanonicalEncoding,
+        ));
+    }
+    let (root_generation, profile_fingerprint, plan_fingerprint) =
+        validate_catalog_context_v1(&head.context, selected)
+            .ok_or_else(|| invalid(kind, InvalidRemoteCatalogReasonV1::Context))?;
+    let (sequence, nonce, parent) = validate_catalog_lineage_v1(
+        head.catalog_sequence,
+        &head.publication_nonce,
+        head.parent_head_revision.as_deref(),
+    )
+    .ok_or_else(|| invalid(kind, InvalidRemoteCatalogReasonV1::Lineage))?;
+    if parse_lower_hex_32(&head.catalog_root.object_id).is_none()
+        || head.catalog_root.raw_bytes_len == 0
+        || validate_binding_wire_v1(&head.catalog_root.binding).is_none()
+    {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::ObjectIdentity));
+    }
+    Ok(ValidatedRemoteCatalogHeadV1 {
+        wire: head,
+        catalog_sequence: sequence,
+        publication_nonce: nonce,
+        parent_head_revision: parent,
+        root_generation,
+        profile_settings_fingerprint: profile_fingerprint,
+        plan_contract_fingerprint: plan_fingerprint,
+    })
+}
+
+fn validate_root_v1(
+    raw: &RawObjectSnapshotV1,
+    head: &RemoteCatalogHeadWireV1,
+) -> std::result::Result<RemoteCatalogRootWireV1, StrictRemoteCatalogIncompleteV1> {
+    let kind = RemoteCatalogClosureObjectKindV1::Root;
+    if lower_hex(&catalog_root_object_id_v1(raw.raw_bytes())) != head.catalog_root.object_id {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::ObjectAddress));
+    }
+    if u64::try_from(raw.raw_bytes().len()).ok() != Some(head.catalog_root.raw_bytes_len)
+        || !observed_binding_matches_v1(raw, &head.catalog_root.binding)
+    {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::ObjectBinding));
+    }
+    let root = canonical_wire_v1::<RemoteCatalogRootWireV1>(raw.raw_bytes())
+        .ok_or_else(|| invalid(kind, InvalidRemoteCatalogReasonV1::CanonicalEncoding))?;
+    if root.version != CATALOG_SCHEMA_VERSION_V1
+        || root.context != head.context
+        || root.catalog_sequence != head.catalog_sequence
+        || root.publication_nonce != head.publication_nonce
+        || root.parent_head_revision != head.parent_head_revision
+    {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::Context));
+    }
+    if root.page_count != head.catalog_root.page_count
+        || root.entry_count != head.catalog_root.entry_count
+        || root.entry_key_bytes != head.catalog_root.entry_key_bytes
+        || u64::try_from(root.pages.len()).ok() != Some(root.page_count)
+    {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::Totals));
+    }
+    Ok(root)
+}
+
+fn validate_page_v1(
+    raw: &RawObjectSnapshotV1,
+    reference: &RemoteCatalogPageReferenceWireV1,
+    root: &RemoteCatalogRootWireV1,
+) -> std::result::Result<RemoteCatalogPageWireV1, StrictRemoteCatalogIncompleteV1> {
+    let kind = RemoteCatalogClosureObjectKindV1::Page;
+    if lower_hex(&catalog_page_object_id_v1(raw.raw_bytes())) != reference.object_id {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::ObjectAddress));
+    }
+    if u64::try_from(raw.raw_bytes().len()).ok() != Some(reference.raw_bytes_len)
+        || !observed_binding_matches_v1(raw, &reference.binding)
+    {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::ObjectBinding));
+    }
+    let page = canonical_wire_v1::<RemoteCatalogPageWireV1>(raw.raw_bytes())
+        .ok_or_else(|| invalid(kind, InvalidRemoteCatalogReasonV1::CanonicalEncoding))?;
+    if page.version != CATALOG_SCHEMA_VERSION_V1
+        || page.context != root.context
+        || page.catalog_sequence != root.catalog_sequence
+        || page.publication_nonce != root.publication_nonce
+        || page.ordinal != reference.ordinal
+    {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::Context));
+    }
+    let entry_key_bytes = page.entries.iter().try_fold(0_u64, |total, entry| {
+        total.checked_add(u64::try_from(entry.object_key.len()).ok()?)
+    });
+    if u64::try_from(page.entries.len()).ok() != Some(page.entry_count)
+        || page.entry_count != reference.entry_count
+        || entry_key_bytes != Some(page.entry_key_bytes)
+        || page.entry_key_bytes != reference.entry_key_bytes
+    {
+        return Err(invalid(kind, InvalidRemoteCatalogReasonV1::Totals));
+    }
+    Ok(page)
+}
+
+/// Validate one exact immutable catalog root and every ordered page selected by
+/// an unchanged, current, ETag-bound HEAD.
+///
+/// No LIST operation is issued. The expected context must come from the
+/// daemon-authenticated selected-root route, never from the remote bytes. The
+/// caller must also acquire a live conditional-semantics receipt for this
+/// exact operator and prefix.
+pub(crate) async fn read_verified_remote_catalog_closure_v1(
+    op: &Operator,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+    receipt: &ConditionalWriteSemanticsReceipt,
+) -> Result<StrictRemoteCatalogClosureReadV1> {
+    let remote_prefix =
+        match validate_canonical_namespace_remote_prefix(&selected.spec().remote_prefix) {
+            Ok(prefix) if !prefix.is_empty() => prefix,
+            _ => {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+                    StrictRemoteCatalogIncompleteV1::InvalidRemotePrefix,
+                ));
+            }
+        };
+    if !receipt.authorizes(op, remote_prefix)? {
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+            StrictRemoteCatalogIncompleteV1::StorageSemanticsUnverified,
+        ));
+    }
+    let head_key = catalog_head_key_v1(remote_prefix);
+    if !validate_storage_key_bound_v1(&head_key) {
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+            StrictRemoteCatalogIncompleteV1::InvalidRemotePrefix,
+        ));
+    }
+    let head_a_raw = match read_current_head_v1(op, &head_key).await? {
+        Ok(raw) => raw,
+        Err(incomplete) => {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+        }
+    };
+    let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    if u64::try_from(head_a_raw.raw_bytes().len()).map_or(true, |length| {
+        length > remote_contract.max_catalog_head_object_bytes()
+    }) {
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+            StrictRemoteCatalogIncompleteV1::ResourceLimit(RemoteCatalogResourceV1::HeadBytes),
+        ));
+    }
+    let ValidatedRemoteCatalogHeadV1 {
+        wire: head,
+        catalog_sequence,
+        publication_nonce,
+        parent_head_revision,
+        root_generation,
+        profile_settings_fingerprint,
+        plan_contract_fingerprint,
+    } = match validate_head_v1(&head_a_raw, selected) {
+        Ok(validated) => validated,
+        Err(incomplete) => {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+        }
+    };
+
+    let mut budget = RemoteCatalogBudgetV1::default();
+    let root_key = catalog_root_key_v1(remote_prefix, &head.catalog_root.object_id);
+    if !validate_storage_key_bound_v1(&root_key) {
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+            RemoteCatalogClosureObjectKindV1::Root,
+            InvalidRemoteCatalogReasonV1::ObjectAddress,
+        )));
+    }
+    let root_raw = match read_immutable_closure_object_v1(
+        op,
+        &root_key,
+        remote_contract.max_catalog_root_object_bytes(),
+        RemoteCatalogClosureObjectKindV1::Root,
+    )
+    .await?
+    {
+        Ok(raw) => raw,
+        Err(incomplete) => {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+        }
+    };
+    if let Err(incomplete) = budget.observe_root(
+        u64::try_from(root_raw.raw_bytes().len()).unwrap_or(u64::MAX),
+        &head.catalog_root.binding,
+    ) {
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+    }
+    let root = match validate_root_v1(&root_raw, &head) {
+        Ok(root) => root,
+        Err(incomplete) => {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+        }
+    };
+    if root.page_count > remote_contract.max_catalog_pages()
+        || root.entry_count > remote_contract.max_catalog_entries()
+        || root.entry_key_bytes > remote_contract.max_catalog_entry_key_bytes()
+    {
+        let resource = if root.page_count > remote_contract.max_catalog_pages() {
+            RemoteCatalogResourceV1::Pages
+        } else if root.entry_count > remote_contract.max_catalog_entries() {
+            RemoteCatalogResourceV1::Entries
+        } else {
+            RemoteCatalogResourceV1::EntryKeyBytes
+        };
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+            StrictRemoteCatalogIncompleteV1::ResourceLimit(resource),
+        ));
+    }
+
+    let mut page_objects = Vec::with_capacity(root.pages.len());
+    // The aggregate root count is untrusted until every page is drained. Grow
+    // only by each already-bounded page so a tiny contradictory root cannot
+    // force the full multi-million-entry allocation before totals fail.
+    let mut entries = Vec::new();
+    let mut previous_key: Option<String> = None;
+    for (expected_ordinal, reference) in root.pages.iter().enumerate() {
+        if reference.ordinal != u64::try_from(expected_ordinal).unwrap_or(u64::MAX)
+            || parse_lower_hex_32(&reference.object_id).is_none()
+            || reference.raw_bytes_len == 0
+            || validate_binding_wire_v1(&reference.binding).is_none()
+        {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+                RemoteCatalogClosureObjectKindV1::Root,
+                InvalidRemoteCatalogReasonV1::PageOrder,
+            )));
+        }
+        if reference.entry_count > remote_contract.max_catalog_entries_per_page() {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+                StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                    RemoteCatalogResourceV1::EntriesPerPage,
+                ),
+            ));
+        }
+        let page_key = catalog_page_key_v1(remote_prefix, &reference.object_id);
+        if !validate_storage_key_bound_v1(&page_key) {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+                RemoteCatalogClosureObjectKindV1::Page,
+                InvalidRemoteCatalogReasonV1::ObjectAddress,
+            )));
+        }
+        let page_raw = match read_immutable_closure_object_v1(
+            op,
+            &page_key,
+            remote_contract.max_catalog_page_object_bytes(),
+            RemoteCatalogClosureObjectKindV1::Page,
+        )
+        .await?
+        {
+            Ok(raw) => raw,
+            Err(incomplete) => {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+            }
+        };
+        if let Err(incomplete) = budget.observe_page(
+            u64::try_from(page_raw.raw_bytes().len()).unwrap_or(u64::MAX),
+            &reference.binding,
+        ) {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+        }
+        let page = match validate_page_v1(&page_raw, reference, &root) {
+            Ok(page) => page,
+            Err(incomplete) => {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+            }
+        };
+        if page.entry_count > remote_contract.max_catalog_entries_per_page() {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+                StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                    RemoteCatalogResourceV1::EntriesPerPage,
+                ),
+            ));
+        }
+        if entries.try_reserve(page.entries.len()).is_err() {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+                StrictRemoteCatalogIncompleteV1::ResourceLimit(RemoteCatalogResourceV1::Entries),
+            ));
+        }
+
+        for entry in page.entries {
+            if let Err(incomplete) = budget.observe_entry(&entry) {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+            }
+            if previous_key
+                .as_deref()
+                .is_some_and(|previous| previous >= entry.object_key.as_str())
+            {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+                    RemoteCatalogClosureObjectKindV1::Page,
+                    InvalidRemoteCatalogReasonV1::EntryOrder,
+                )));
+            }
+            if !validate_catalog_entry_route_v1(remote_prefix, &entry) {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+                    RemoteCatalogClosureObjectKindV1::Page,
+                    InvalidRemoteCatalogReasonV1::EntryRoute,
+                )));
+            }
+            let Some(raw_blake3) = parse_lower_hex_32(&entry.raw_blake3) else {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+                    RemoteCatalogClosureObjectKindV1::Page,
+                    InvalidRemoteCatalogReasonV1::EntryIdentity,
+                )));
+            };
+            if !validate_entry_size_v1(entry.kind, entry.raw_bytes_len) {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+                    RemoteCatalogClosureObjectKindV1::Page,
+                    InvalidRemoteCatalogReasonV1::EntryIdentity,
+                )));
+            }
+            let Some(binding) = validate_binding_wire_v1(&entry.binding) else {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+                    RemoteCatalogClosureObjectKindV1::Page,
+                    InvalidRemoteCatalogReasonV1::EntryIdentity,
+                )));
+            };
+            previous_key = Some(entry.object_key.clone());
+            entries.push(VerifiedRemoteCatalogEntryV1 {
+                kind: entry.kind,
+                object_key: entry.object_key,
+                raw_bytes_len: entry.raw_bytes_len,
+                raw_blake3,
+                binding,
+            });
+        }
+        page_objects.push(bind_remote_object_v1(page_raw));
+    }
+    if budget.pages != root.page_count
+        || budget.entries != root.entry_count
+        || budget.entry_key_bytes != root.entry_key_bytes
+    {
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(invalid(
+            RemoteCatalogClosureObjectKindV1::Root,
+            InvalidRemoteCatalogReasonV1::Totals,
+        )));
+    }
+
+    let head_b_raw = match read_current_head_v1(op, &head_key).await? {
+        Ok(raw) => raw,
+        Err(incomplete) => {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+        }
+    };
+    if head_a_raw != head_b_raw {
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+            StrictRemoteCatalogIncompleteV1::HeadChanged,
+        ));
+    }
+
+    let head_revision = catalog_head_revision_v1(head_a_raw.raw_bytes());
+    let head_object = bind_remote_object_v1(head_a_raw);
+    let root_object = bind_remote_object_v1(root_raw);
+    Ok(StrictRemoteCatalogClosureReadV1::Verified(Box::new(
+        VerifiedRemoteCatalogClosureV1 {
+            remote_prefix: remote_prefix.to_owned(),
+            root_id: head.context.root_id,
+            root_identity_fingerprint: head.context.root_identity_fingerprint,
+            root_generation,
+            profile: head.context.profile,
+            profile_settings_fingerprint,
+            plan_contract_fingerprint,
+            catalog_sequence,
+            publication_nonce,
+            parent_head_revision,
+            head_revision,
+            head_object,
+            root_object,
+            page_objects,
+            entries,
+        },
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal::raw::{
+        oio, Access, AccessorInfo, OpDelete, OpRead, OpStat, OpWrite, RpDelete, RpRead, RpStat,
+        RpWrite,
+    };
+    use opendal::{Buffer, Capability, EntryMode, Error, ErrorKind, Metadata, OperatorBuilder};
+    use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    static_assertions::assert_not_impl_any!(
+        VerifiedRemoteCatalogClosureV1: Clone,
+        serde::Serialize,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>,
+        Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
+        Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        ValidatedSelectedRegisteredRootRemoteContextV1: Clone,
+        serde::Serialize
+    );
+
+    #[derive(Clone, Debug)]
+    struct ScriptedObject {
+        bytes: Vec<u8>,
+        etag: Option<String>,
+        version: Option<String>,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum HeadMutationTiming {
+        BeforeFirst,
+        AfterFirst,
+        BeforeSecond,
+    }
+
+    #[derive(Clone, Debug)]
+    struct HeadMutation {
+        timing: HeadMutationTiming,
+        replacement: ScriptedObject,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct ObservedRead {
+        path: String,
+        if_match: Option<String>,
+        version: Option<String>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct ScriptedCatalogBackend {
+        info: Arc<AccessorInfo>,
+        objects: Arc<Mutex<BTreeMap<String, ScriptedObject>>>,
+        reads: Arc<Mutex<Vec<ObservedRead>>>,
+        stats: Arc<Mutex<Vec<String>>>,
+        head_key: String,
+        head_reads: Arc<AtomicUsize>,
+        head_mutation: Arc<Mutex<Option<HeadMutation>>>,
+        next_read_replacements: Arc<Mutex<BTreeMap<String, ScriptedObject>>>,
+        next_etag: Arc<AtomicU64>,
+    }
+
+    impl ScriptedCatalogBackend {
+        fn insert(&self, key: impl Into<String>, object: ScriptedObject) {
+            self.objects.lock().unwrap().insert(key.into(), object);
+        }
+
+        fn remove(&self, key: &str) {
+            self.objects.lock().unwrap().remove(key);
+        }
+
+        fn replace_head_on_first_read(
+            &self,
+            timing: HeadMutationTiming,
+            replacement: ScriptedObject,
+        ) {
+            *self.head_mutation.lock().unwrap() = Some(HeadMutation {
+                timing,
+                replacement,
+            });
+        }
+
+        fn replace_object_on_next_read(&self, key: impl Into<String>, replacement: ScriptedObject) {
+            self.next_read_replacements
+                .lock()
+                .unwrap()
+                .insert(key.into(), replacement);
+        }
+    }
+
+    impl Access for ScriptedCatalogBackend {
+        type Reader = Buffer;
+        type Writer = oio::OneShotWriter<ScriptedCatalogWriter>;
+        type Lister = ();
+        type Deleter = oio::OneShotDeleter<ScriptedCatalogDeleter>;
+
+        fn info(&self) -> Arc<AccessorInfo> {
+            self.info.clone()
+        }
+
+        async fn stat(&self, path: &str, _: OpStat) -> opendal::Result<RpStat> {
+            self.stats.lock().unwrap().push(path.to_owned());
+            let object = self
+                .objects
+                .lock()
+                .unwrap()
+                .get(path)
+                .cloned()
+                .ok_or_else(|| Error::new(ErrorKind::NotFound, "scripted object missing"))?;
+            let mut metadata = Metadata::new(EntryMode::FILE)
+                .with_content_length(u64::try_from(object.bytes.len()).unwrap());
+            if let Some(etag) = object.etag {
+                metadata = metadata.with_etag(etag);
+            }
+            if let Some(version) = object.version {
+                metadata = metadata.with_version(version);
+            }
+            Ok(RpStat::new(metadata))
+        }
+
+        async fn read(&self, path: &str, args: OpRead) -> opendal::Result<(RpRead, Buffer)> {
+            let head_read_index =
+                (path == self.head_key).then(|| self.head_reads.fetch_add(1, Ordering::SeqCst));
+            let mutation = head_read_index.and_then(|_| self.head_mutation.lock().unwrap().clone());
+            if let Some(HeadMutation {
+                timing,
+                replacement,
+            }) = mutation.as_ref()
+            {
+                let applies = matches!(
+                    (*timing, head_read_index),
+                    (HeadMutationTiming::BeforeFirst, Some(0))
+                        | (HeadMutationTiming::BeforeSecond, Some(1))
+                );
+                if applies {
+                    self.objects
+                        .lock()
+                        .unwrap()
+                        .insert(path.to_owned(), replacement.clone());
+                }
+            }
+            if let Some(replacement) = self.next_read_replacements.lock().unwrap().remove(path) {
+                self.objects
+                    .lock()
+                    .unwrap()
+                    .insert(path.to_owned(), replacement);
+            }
+
+            let object = self
+                .objects
+                .lock()
+                .unwrap()
+                .get(path)
+                .cloned()
+                .ok_or_else(|| Error::new(ErrorKind::NotFound, "scripted object missing"))?;
+            self.reads.lock().unwrap().push(ObservedRead {
+                path: path.to_owned(),
+                if_match: args.if_match().map(str::to_owned),
+                version: args.version().map(str::to_owned),
+            });
+            if args
+                .if_match()
+                .is_some_and(|expected| object.etag.as_deref() != Some(expected))
+                || args
+                    .version()
+                    .is_some_and(|expected| object.version.as_deref() != Some(expected))
+            {
+                return Err(Error::new(
+                    ErrorKind::ConditionNotMatch,
+                    "scripted object identity changed",
+                ));
+            }
+            let range = args.range();
+            let start = usize::try_from(range.offset()).unwrap_or(usize::MAX);
+            let end = range
+                .size()
+                .and_then(|size| usize::try_from(size).ok())
+                .map(|size| start.saturating_add(size))
+                .unwrap_or(object.bytes.len())
+                .min(object.bytes.len());
+            let selected = if start <= end {
+                object.bytes[start..end].to_vec()
+            } else {
+                Vec::new()
+            };
+
+            if let Some(HeadMutation {
+                timing: HeadMutationTiming::AfterFirst,
+                replacement,
+            }) = mutation.filter(|_| head_read_index == Some(0))
+            {
+                self.objects
+                    .lock()
+                    .unwrap()
+                    .insert(path.to_owned(), replacement);
+            }
+            Ok((
+                RpRead::new().with_size(Some(u64::try_from(selected.len()).unwrap())),
+                Buffer::from(selected),
+            ))
+        }
+
+        async fn write(
+            &self,
+            path: &str,
+            args: OpWrite,
+        ) -> opendal::Result<(RpWrite, Self::Writer)> {
+            Ok((
+                RpWrite::new(),
+                oio::OneShotWriter::new(ScriptedCatalogWriter {
+                    path: path.to_owned(),
+                    args,
+                    objects: self.objects.clone(),
+                    next_etag: self.next_etag.clone(),
+                }),
+            ))
+        }
+
+        async fn delete(&self) -> opendal::Result<(RpDelete, Self::Deleter)> {
+            Ok((
+                RpDelete::default(),
+                oio::OneShotDeleter::new(ScriptedCatalogDeleter {
+                    objects: self.objects.clone(),
+                }),
+            ))
+        }
+    }
+
+    struct ScriptedCatalogWriter {
+        path: String,
+        args: OpWrite,
+        objects: Arc<Mutex<BTreeMap<String, ScriptedObject>>>,
+        next_etag: Arc<AtomicU64>,
+    }
+
+    impl oio::OneShotWrite for ScriptedCatalogWriter {
+        async fn write_once(&self, bytes: Buffer) -> opendal::Result<Metadata> {
+            let mut objects = self.objects.lock().unwrap();
+            let current_etag = objects
+                .get(&self.path)
+                .and_then(|object| object.etag.as_deref());
+            if self.args.if_not_exists() && current_etag.is_some() {
+                return Err(Error::new(
+                    ErrorKind::ConditionNotMatch,
+                    "scripted create-if-absent rejected existing object",
+                ));
+            }
+            if self
+                .args
+                .if_match()
+                .is_some_and(|expected| current_etag != Some(expected))
+            {
+                return Err(Error::new(
+                    ErrorKind::ConditionNotMatch,
+                    "scripted conditional write rejected stale ETag",
+                ));
+            }
+            let generation = self.next_etag.fetch_add(1, Ordering::SeqCst);
+            let etag = format!("\"catalog-test-etag-{generation}\"");
+            let bytes = bytes.to_vec();
+            objects.insert(
+                self.path.clone(),
+                ScriptedObject {
+                    bytes: bytes.clone(),
+                    etag: Some(etag.clone()),
+                    version: None,
+                },
+            );
+            Ok(Metadata::new(EntryMode::FILE)
+                .with_content_length(u64::try_from(bytes.len()).unwrap())
+                .with_etag(etag))
+        }
+    }
+
+    struct ScriptedCatalogDeleter {
+        objects: Arc<Mutex<BTreeMap<String, ScriptedObject>>>,
+    }
+
+    impl oio::OneShotDelete for ScriptedCatalogDeleter {
+        async fn delete_once(&self, path: String, _: OpDelete) -> opendal::Result<()> {
+            self.objects.lock().unwrap().remove(&path);
+            Ok(())
+        }
+    }
+
+    fn scripted_operator(prefix: &str) -> (Operator, ScriptedCatalogBackend) {
+        let info = AccessorInfo::default();
+        info.set_scheme("catalog-scripted")
+            .set_root("/")
+            .set_name("registered-catalog-test")
+            .set_native_capability(Capability {
+                stat: true,
+                read: true,
+                read_with_if_match: true,
+                read_with_version: true,
+                write: true,
+                write_can_empty: true,
+                write_with_if_match: true,
+                write_with_if_not_exists: true,
+                delete: true,
+                ..Default::default()
+            });
+        let backend = ScriptedCatalogBackend {
+            info: Arc::new(info),
+            objects: Arc::new(Mutex::new(BTreeMap::new())),
+            reads: Arc::new(Mutex::new(Vec::new())),
+            stats: Arc::new(Mutex::new(Vec::new())),
+            head_key: catalog_head_key_v1(prefix),
+            head_reads: Arc::new(AtomicUsize::new(0)),
+            head_mutation: Arc::new(Mutex::new(None)),
+            next_read_replacements: Arc::new(Mutex::new(BTreeMap::new())),
+            next_etag: Arc::new(AtomicU64::new(1)),
+        };
+        (OperatorBuilder::new(backend.clone()).finish(), backend)
+    }
+
+    fn etag_binding(etag: &str) -> RemoteCatalogObjectBindingWireV1 {
+        RemoteCatalogObjectBindingWireV1 {
+            version: None,
+            etag: Some(etag.to_owned()),
+        }
+    }
+
+    fn version_binding(version: &str, etag: &str) -> RemoteCatalogObjectBindingWireV1 {
+        RemoteCatalogObjectBindingWireV1 {
+            version: Some(version.to_owned()),
+            etag: Some(etag.to_owned()),
+        }
+    }
+
+    fn scripted_object(bytes: Vec<u8>, etag: &str) -> ScriptedObject {
+        ScriptedObject {
+            bytes,
+            etag: Some(etag.to_owned()),
+            version: None,
+        }
+    }
+
+    fn fixture_context(prefix: &str) -> RemoteCatalogContextWireV1 {
+        let root_id = "fixture-root".to_owned();
+        let root_generation = 1;
+        let profile = RootProfileV1::AgentStaticV1;
+        let spec = RootSpecV1Config {
+            version: RootSpecV1Config::VERSION,
+            remote_prefix: prefix.to_owned(),
+            profile,
+            generation: NonZeroU64::new(root_generation).unwrap(),
+        };
+        RemoteCatalogContextWireV1 {
+            root_identity_fingerprint: spec.identity_fingerprint(&root_id),
+            root_id,
+            root_generation,
+            profile,
+            profile_settings_fingerprint: profile.policy().settings_fingerprint().to_string(),
+            plan_contract_fingerprint: RegisteredRootPlanContractV1::strict_v1()
+                .fingerprint()
+                .to_string(),
+        }
+    }
+
+    fn fixture_entry(
+        kind: RemoteCatalogObjectKindV1,
+        object_key: &str,
+        body: &[u8],
+        etag: &str,
+    ) -> RemoteCatalogEntryWireV1 {
+        RemoteCatalogEntryWireV1 {
+            kind,
+            object_key: object_key.to_owned(),
+            raw_bytes_len: u64::try_from(body.len()).unwrap(),
+            raw_blake3: lower_hex(blake3::hash(body).as_bytes()),
+            binding: etag_binding(etag),
+        }
+    }
+
+    struct CatalogFixture {
+        op: Operator,
+        backend: ScriptedCatalogBackend,
+        selected: ValidatedSelectedRegisteredRootRemoteContextV1,
+        remote_prefix: String,
+        head_key: String,
+        root_key: String,
+        page_keys: Vec<String>,
+        head_bytes: Vec<u8>,
+        root_bytes: Vec<u8>,
+    }
+
+    impl CatalogFixture {
+        async fn receipt(&self, prefix: &str) -> ConditionalWriteSemanticsReceipt {
+            let receipt =
+                tcfs_storage::acquire_conditional_write_semantics_receipt(&self.op, prefix)
+                    .await
+                    .unwrap();
+            self.backend.reads.lock().unwrap().clear();
+            self.backend.stats.lock().unwrap().clear();
+            receipt
+        }
+
+        async fn read(
+            &self,
+            receipt: &ConditionalWriteSemanticsReceipt,
+        ) -> Result<StrictRemoteCatalogClosureReadV1> {
+            read_verified_remote_catalog_closure_v1(&self.op, &self.selected, receipt).await
+        }
+
+        fn rewrite_root(&mut self, root: &RemoteCatalogRootWireV1) {
+            let root_bytes = serde_json::to_vec(root).unwrap();
+            let root_id = lower_hex(&catalog_root_object_id_v1(&root_bytes));
+            let root_key = catalog_root_key_v1(&self.remote_prefix, &root_id);
+            let root_etag = "root-etag-rewritten";
+
+            let mut head =
+                serde_json::from_slice::<RemoteCatalogHeadWireV1>(&self.head_bytes).unwrap();
+            head.catalog_root = RemoteCatalogRootReferenceWireV1 {
+                object_id: root_id,
+                raw_bytes_len: u64::try_from(root_bytes.len()).unwrap(),
+                binding: etag_binding(root_etag),
+                page_count: root.page_count,
+                entry_count: root.entry_count,
+                entry_key_bytes: root.entry_key_bytes,
+            };
+            let head_bytes = serde_json::to_vec(&head).unwrap();
+
+            self.backend.insert(
+                root_key.clone(),
+                scripted_object(root_bytes.clone(), root_etag),
+            );
+            self.backend.insert(
+                self.head_key.clone(),
+                scripted_object(head_bytes.clone(), "head-etag-a"),
+            );
+            self.root_key = root_key;
+            self.root_bytes = root_bytes;
+            self.head_bytes = head_bytes;
+        }
+
+        fn make_immutable_objects_versioned(&mut self) {
+            let mut root =
+                serde_json::from_slice::<RemoteCatalogRootWireV1>(&self.root_bytes).unwrap();
+            {
+                let mut objects = self.backend.objects.lock().unwrap();
+                for (ordinal, reference) in root.pages.iter_mut().enumerate() {
+                    let version = format!("page-version-{ordinal}");
+                    let etag = reference.binding.etag.as_deref().unwrap().to_owned();
+                    reference.binding = version_binding(&version, &etag);
+                    objects.get_mut(&self.page_keys[ordinal]).unwrap().version = Some(version);
+                }
+            }
+            self.rewrite_root(&root);
+
+            let root_version = "root-version";
+            let root_etag = "root-etag-rewritten";
+            self.backend
+                .objects
+                .lock()
+                .unwrap()
+                .get_mut(&self.root_key)
+                .unwrap()
+                .version = Some(root_version.to_owned());
+            let mut head =
+                serde_json::from_slice::<RemoteCatalogHeadWireV1>(&self.head_bytes).unwrap();
+            head.catalog_root.binding = version_binding(root_version, root_etag);
+            let head_bytes = serde_json::to_vec(&head).unwrap();
+            self.backend.insert(
+                self.head_key.clone(),
+                ScriptedObject {
+                    bytes: head_bytes.clone(),
+                    etag: Some("head-etag-a".to_owned()),
+                    version: Some("historical-head-version".to_owned()),
+                },
+            );
+            self.head_bytes = head_bytes;
+        }
+    }
+
+    fn fixture(prefix: &str, pages: Vec<Vec<RemoteCatalogEntryWireV1>>) -> CatalogFixture {
+        let context = fixture_context(prefix);
+        let publication_nonce = "11".repeat(32);
+        let mut objects = Vec::new();
+        let mut page_references = Vec::new();
+        let mut page_keys = Vec::new();
+        let mut total_entries = 0_u64;
+        let mut total_key_bytes = 0_u64;
+
+        for (ordinal, entries) in pages.into_iter().enumerate() {
+            let entry_count = u64::try_from(entries.len()).unwrap();
+            let entry_key_bytes = entries
+                .iter()
+                .map(|entry| u64::try_from(entry.object_key.len()).unwrap())
+                .sum();
+            total_entries += entry_count;
+            total_key_bytes += entry_key_bytes;
+            let page = RemoteCatalogPageWireV1 {
+                version: CATALOG_SCHEMA_VERSION_V1,
+                context: fixture_context(prefix),
+                catalog_sequence: 1,
+                publication_nonce: publication_nonce.clone(),
+                ordinal: u64::try_from(ordinal).unwrap(),
+                entry_count,
+                entry_key_bytes,
+                entries,
+            };
+            let page_bytes = serde_json::to_vec(&page).unwrap();
+            let page_id = lower_hex(&catalog_page_object_id_v1(&page_bytes));
+            let page_key = catalog_page_key_v1(prefix, &page_id);
+            let etag = format!("page-etag-{ordinal}");
+            page_references.push(RemoteCatalogPageReferenceWireV1 {
+                ordinal: u64::try_from(ordinal).unwrap(),
+                object_id: page_id,
+                raw_bytes_len: u64::try_from(page_bytes.len()).unwrap(),
+                binding: etag_binding(&etag),
+                entry_count,
+                entry_key_bytes,
+            });
+            page_keys.push(page_key.clone());
+            objects.push((page_key, scripted_object(page_bytes, &etag)));
+        }
+
+        let root = RemoteCatalogRootWireV1 {
+            version: CATALOG_SCHEMA_VERSION_V1,
+            context,
+            catalog_sequence: 1,
+            publication_nonce,
+            parent_head_revision: None,
+            page_count: u64::try_from(page_references.len()).unwrap(),
+            entry_count: total_entries,
+            entry_key_bytes: total_key_bytes,
+            pages: page_references,
+        };
+        let root_bytes = serde_json::to_vec(&root).unwrap();
+        let root_id = lower_hex(&catalog_root_object_id_v1(&root_bytes));
+        let root_key = catalog_root_key_v1(prefix, &root_id);
+        let root_etag = "root-etag";
+        objects.push((
+            root_key.clone(),
+            scripted_object(root_bytes.clone(), root_etag),
+        ));
+        let head = RemoteCatalogHeadWireV1 {
+            version: CATALOG_SCHEMA_VERSION_V1,
+            context: fixture_context(prefix),
+            catalog_sequence: 1,
+            publication_nonce: "11".repeat(32),
+            parent_head_revision: None,
+            catalog_root: RemoteCatalogRootReferenceWireV1 {
+                object_id: root_id,
+                raw_bytes_len: u64::try_from(root_bytes.len()).unwrap(),
+                binding: etag_binding(root_etag),
+                page_count: root.page_count,
+                entry_count: root.entry_count,
+                entry_key_bytes: root.entry_key_bytes,
+            },
+        };
+        let head_bytes = serde_json::to_vec(&head).unwrap();
+        let head_key = catalog_head_key_v1(prefix);
+        objects.push((
+            head_key.clone(),
+            scripted_object(head_bytes.clone(), "head-etag-a"),
+        ));
+
+        let (op, backend) = scripted_operator(prefix);
+        for (key, object) in objects {
+            backend.insert(key, object);
+        }
+        let selected = crate::registered_source_composition::
+            validated_selected_registered_root_remote_context_for_test_v1(
+                "fixture-root",
+                &RootSpecV1Config {
+                    version: RootSpecV1Config::VERSION,
+                    remote_prefix: prefix.to_owned(),
+                    profile: RootProfileV1::AgentStaticV1,
+                    generation: NonZeroU64::new(1).unwrap(),
+                },
+            )
+            .unwrap();
+        CatalogFixture {
+            op,
+            backend,
+            selected,
+            remote_prefix: prefix.to_owned(),
+            head_key,
+            root_key,
+            page_keys,
+            head_bytes,
+            root_bytes,
+        }
+    }
+
+    fn incomplete(read: StrictRemoteCatalogClosureReadV1) -> StrictRemoteCatalogIncompleteV1 {
+        match read {
+            StrictRemoteCatalogClosureReadV1::Incomplete(incomplete) => incomplete,
+            StrictRemoteCatalogClosureReadV1::Verified(_) => {
+                panic!("expected incomplete catalog closure")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_empty_catalog_is_verified_without_any_listing() {
+        let fixture = fixture("roots", Vec::new());
+        let receipt = fixture.receipt("roots").await;
+        let verified = match fixture.read(&receipt).await.unwrap() {
+            StrictRemoteCatalogClosureReadV1::Verified(verified) => verified,
+            StrictRemoteCatalogClosureReadV1::Incomplete(incomplete) => {
+                panic!("expected verified empty catalog, got {incomplete:?}")
+            }
+        };
+        assert_eq!(verified.remote_prefix(), "roots");
+        assert_eq!(verified.root_id(), "fixture-root");
+        assert_eq!(verified.root_generation().get(), 1);
+        assert_eq!(verified.profile(), RootProfileV1::AgentStaticV1);
+        assert_eq!(verified.catalog_sequence().get(), 1);
+        assert_eq!(verified.entries().len(), 0);
+        assert_eq!(
+            fixture.backend.reads.lock().unwrap().as_slice(),
+            &[
+                ObservedRead {
+                    path: fixture.head_key.clone(),
+                    if_match: Some("head-etag-a".to_owned()),
+                    version: None,
+                },
+                ObservedRead {
+                    path: fixture
+                        .backend
+                        .stats
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .find(|key| key.contains("/roots/"))
+                        .unwrap()
+                        .clone(),
+                    if_match: Some("root-etag".to_owned()),
+                    version: None,
+                },
+                ObservedRead {
+                    path: fixture.head_key,
+                    if_match: Some("head-etag-a".to_owned()),
+                    version: None,
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn populated_pages_retain_one_sorted_catalog_inventory() {
+        let index = fixture_entry(
+            RemoteCatalogObjectKindV1::Index,
+            "roots/index/doc.txt",
+            b"index",
+            "index-etag",
+        );
+        let manifest = fixture_entry(
+            RemoteCatalogObjectKindV1::Manifest,
+            &format!("roots/manifests/{}", "a".repeat(64)),
+            b"manifest",
+            "manifest-etag",
+        );
+        let reservation = fixture_entry(
+            RemoteCatalogObjectKindV1::Reservation,
+            &format!("roots/.tcfs-namespace/v1/{}", "b".repeat(64)),
+            b"reservation",
+            "reservation-etag",
+        );
+        let mut entries = vec![reservation, index, manifest];
+        entries.sort_by(|left, right| left.object_key.cmp(&right.object_key));
+        let fixture = fixture("roots", vec![entries]);
+        let receipt = fixture.receipt("roots").await;
+        let verified = match fixture.read(&receipt).await.unwrap() {
+            StrictRemoteCatalogClosureReadV1::Verified(verified) => verified,
+            StrictRemoteCatalogClosureReadV1::Incomplete(incomplete) => {
+                panic!("expected verified catalog, got {incomplete:?}")
+            }
+        };
+        let keys = verified
+            .entries()
+            .map(|entry| entry.object_key())
+            .collect::<Vec<_>>();
+        assert!(keys.windows(2).all(|pair| pair[0] < pair[1]));
+        assert_eq!(keys.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn immutable_root_and_pages_prefer_versions_but_head_uses_current_etag() {
+        let entry = fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/a", b"a", "a");
+        let mut fixture = fixture("roots", vec![vec![entry]]);
+        fixture.make_immutable_objects_versioned();
+        let receipt = fixture.receipt("roots").await;
+        assert!(matches!(
+            fixture.read(&receipt).await.unwrap(),
+            StrictRemoteCatalogClosureReadV1::Verified(_)
+        ));
+
+        let reads = fixture.backend.reads.lock().unwrap();
+        let head_reads = reads
+            .iter()
+            .filter(|read| read.path == fixture.head_key)
+            .collect::<Vec<_>>();
+        assert_eq!(head_reads.len(), 2);
+        assert!(head_reads.iter().all(|read| {
+            read.version.is_none() && read.if_match.as_deref() == Some("head-etag-a")
+        }));
+        assert!(reads.iter().any(|read| {
+            read.path == fixture.root_key
+                && read.version.as_deref() == Some("root-version")
+                && read.if_match.as_deref() == Some("root-etag-rewritten")
+        }));
+        assert!(reads.iter().any(|read| {
+            read.path == fixture.page_keys[0]
+                && read.version.as_deref() == Some("page-version-0")
+                && read.if_match.as_deref() == Some("page-etag-0")
+        }));
+    }
+
+    #[tokio::test]
+    async fn missing_head_or_page_is_typed_and_never_recovered_by_listing() {
+        let no_head = fixture("roots", Vec::new());
+        no_head.backend.remove(&no_head.head_key);
+        let receipt = no_head.receipt("roots").await;
+        assert_eq!(
+            incomplete(no_head.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::HeadMissing
+        );
+
+        let page = fixture_entry(
+            RemoteCatalogObjectKindV1::Index,
+            "roots/index/doc.txt",
+            b"index",
+            "index-etag",
+        );
+        let missing_page = fixture("roots", vec![vec![page]]);
+        missing_page.backend.remove(&missing_page.page_keys[0]);
+        let receipt = missing_page.receipt("roots").await;
+        assert_eq!(
+            incomplete(missing_page.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ClosureObjectMissing {
+                kind: RemoteCatalogClosureObjectKindV1::Page
+            }
+        );
+
+        let missing_root = fixture("roots", Vec::new());
+        missing_root.backend.remove(&missing_root.root_key);
+        let receipt = missing_root.receipt("roots").await;
+        assert_eq!(
+            incomplete(missing_root.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ClosureObjectMissing {
+                kind: RemoteCatalogClosureObjectKindV1::Root
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn unbound_or_changed_closure_objects_are_typed_without_retry() {
+        let head = fixture("roots", Vec::new());
+        head.backend.insert(
+            head.head_key.clone(),
+            ScriptedObject {
+                bytes: head.head_bytes.clone(),
+                etag: None,
+                version: None,
+            },
+        );
+        let receipt = head.receipt("roots").await;
+        assert_eq!(
+            incomplete(head.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::HeadUnboundCurrentEtag
+        );
+
+        let root = fixture("roots", Vec::new());
+        root.backend.insert(
+            root.root_key.clone(),
+            ScriptedObject {
+                bytes: root.root_bytes.clone(),
+                etag: None,
+                version: None,
+            },
+        );
+        let receipt = root.receipt("roots").await;
+        assert_eq!(
+            incomplete(root.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ClosureObjectUnbound {
+                kind: RemoteCatalogClosureObjectKindV1::Root
+            }
+        );
+
+        let page_entry =
+            fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/a", b"a", "a");
+        let page = fixture("roots", vec![vec![page_entry.clone()]]);
+        let page_bytes = page
+            .backend
+            .objects
+            .lock()
+            .unwrap()
+            .get(&page.page_keys[0])
+            .unwrap()
+            .bytes
+            .clone();
+        page.backend.insert(
+            page.page_keys[0].clone(),
+            ScriptedObject {
+                bytes: page_bytes,
+                etag: None,
+                version: None,
+            },
+        );
+        let receipt = page.receipt("roots").await;
+        assert_eq!(
+            incomplete(page.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ClosureObjectUnbound {
+                kind: RemoteCatalogClosureObjectKindV1::Page
+            }
+        );
+
+        let changed_root = fixture("roots", Vec::new());
+        changed_root.backend.replace_object_on_next_read(
+            changed_root.root_key.clone(),
+            scripted_object(changed_root.root_bytes.clone(), "root-etag-changed"),
+        );
+        let receipt = changed_root.receipt("roots").await;
+        assert_eq!(
+            incomplete(changed_root.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ClosureObjectChanged {
+                kind: RemoteCatalogClosureObjectKindV1::Root
+            }
+        );
+
+        let changed_page = fixture("roots", vec![vec![page_entry]]);
+        let page_bytes = changed_page
+            .backend
+            .objects
+            .lock()
+            .unwrap()
+            .get(&changed_page.page_keys[0])
+            .unwrap()
+            .bytes
+            .clone();
+        changed_page.backend.replace_object_on_next_read(
+            changed_page.page_keys[0].clone(),
+            scripted_object(page_bytes, "page-etag-changed"),
+        );
+        let receipt = changed_page.receipt("roots").await;
+        assert_eq!(
+            incomplete(changed_page.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ClosureObjectChanged {
+                kind: RemoteCatalogClosureObjectKindV1::Page
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn every_current_head_change_interleaving_fails_without_retry() {
+        for (timing, expected_head_reads) in [
+            (HeadMutationTiming::BeforeFirst, 1),
+            (HeadMutationTiming::AfterFirst, 2),
+            (HeadMutationTiming::BeforeSecond, 2),
+        ] {
+            let fixture = fixture("roots", Vec::new());
+            fixture.backend.replace_head_on_first_read(
+                timing,
+                scripted_object(fixture.head_bytes.clone(), "head-etag-b"),
+            );
+            let receipt = fixture.receipt("roots").await;
+            assert_eq!(
+                incomplete(fixture.read(&receipt).await.unwrap()),
+                StrictRemoteCatalogIncompleteV1::HeadChanged
+            );
+            assert_eq!(
+                fixture.backend.head_reads.load(Ordering::SeqCst),
+                expected_head_reads,
+                "reader retried instead of failing this head-movement interleaving"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_rejects_noncanonical_head_unsorted_entries_and_cross_prefix_routes() {
+        let noncanonical = fixture("roots", Vec::new());
+        let mut bytes = noncanonical.head_bytes.clone();
+        bytes.push(b'\n');
+        noncanonical.backend.insert(
+            &noncanonical.head_key,
+            scripted_object(bytes, "head-etag-a"),
+        );
+        let receipt = noncanonical.receipt("roots").await;
+        assert_eq!(
+            incomplete(noncanonical.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Head,
+                reason: InvalidRemoteCatalogReasonV1::CanonicalEncoding
+            }
+        );
+
+        let z = fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/z", b"z", "z");
+        let a = fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/a", b"a", "a");
+        let unsorted = fixture("roots", vec![vec![z, a]]);
+        let receipt = unsorted.receipt("roots").await;
+        assert_eq!(
+            incomplete(unsorted.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Page,
+                reason: InvalidRemoteCatalogReasonV1::EntryOrder
+            }
+        );
+
+        let escaped = fixture_entry(RemoteCatalogObjectKindV1::Index, "other/index/a", b"a", "a");
+        let cross_prefix = fixture("roots", vec![vec![escaped]]);
+        let receipt = cross_prefix.receipt("roots").await;
+        assert_eq!(
+            incomplete(cross_prefix.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Page,
+                reason: InvalidRemoteCatalogReasonV1::EntryRoute
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_rejects_wrong_context_lineage_page_identity_and_cross_page_duplicates() {
+        let wrong_context = fixture("roots", Vec::new());
+        let mut head =
+            serde_json::from_slice::<RemoteCatalogHeadWireV1>(&wrong_context.head_bytes).unwrap();
+        head.context.root_id = "other-root".to_owned();
+        head.context.root_identity_fingerprint = RootSpecV1Config {
+            version: RootSpecV1Config::VERSION,
+            remote_prefix: "roots".to_owned(),
+            profile: head.context.profile,
+            generation: NonZeroU64::new(head.context.root_generation).unwrap(),
+        }
+        .identity_fingerprint(&head.context.root_id);
+        wrong_context.backend.insert(
+            wrong_context.head_key.clone(),
+            scripted_object(serde_json::to_vec(&head).unwrap(), "head-etag-a"),
+        );
+        let receipt = wrong_context.receipt("roots").await;
+        assert_eq!(
+            incomplete(wrong_context.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Head,
+                reason: InvalidRemoteCatalogReasonV1::Context
+            }
+        );
+
+        let wrong_plan = fixture("roots", Vec::new());
+        let mut head =
+            serde_json::from_slice::<RemoteCatalogHeadWireV1>(&wrong_plan.head_bytes).unwrap();
+        head.context.plan_contract_fingerprint = format!("b3v1:{}", "0".repeat(64));
+        wrong_plan.backend.insert(
+            wrong_plan.head_key.clone(),
+            scripted_object(serde_json::to_vec(&head).unwrap(), "head-etag-a"),
+        );
+        let receipt = wrong_plan.receipt("roots").await;
+        assert_eq!(
+            incomplete(wrong_plan.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Head,
+                reason: InvalidRemoteCatalogReasonV1::Context
+            }
+        );
+
+        let wrong_lineage = fixture("roots", Vec::new());
+        let mut head =
+            serde_json::from_slice::<RemoteCatalogHeadWireV1>(&wrong_lineage.head_bytes).unwrap();
+        head.catalog_sequence = 2;
+        wrong_lineage.backend.insert(
+            wrong_lineage.head_key.clone(),
+            scripted_object(serde_json::to_vec(&head).unwrap(), "head-etag-a"),
+        );
+        let receipt = wrong_lineage.receipt("roots").await;
+        assert_eq!(
+            incomplete(wrong_lineage.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Head,
+                reason: InvalidRemoteCatalogReasonV1::Lineage
+            }
+        );
+
+        let zero_nonce = fixture("roots", Vec::new());
+        let mut head =
+            serde_json::from_slice::<RemoteCatalogHeadWireV1>(&zero_nonce.head_bytes).unwrap();
+        head.publication_nonce = "00".repeat(32);
+        zero_nonce.backend.insert(
+            zero_nonce.head_key.clone(),
+            scripted_object(serde_json::to_vec(&head).unwrap(), "head-etag-a"),
+        );
+        let receipt = zero_nonce.receipt("roots").await;
+        assert_eq!(
+            incomplete(zero_nonce.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Head,
+                reason: InvalidRemoteCatalogReasonV1::Lineage
+            }
+        );
+
+        let entry = fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/a", b"a", "a");
+        let wrong_page_address = fixture("roots", vec![vec![entry.clone()]]);
+        let mut wrong_page_bytes = wrong_page_address
+            .backend
+            .objects
+            .lock()
+            .unwrap()
+            .get(&wrong_page_address.page_keys[0])
+            .unwrap()
+            .bytes
+            .clone();
+        wrong_page_bytes.push(b'\n');
+        wrong_page_address.backend.insert(
+            wrong_page_address.page_keys[0].clone(),
+            scripted_object(wrong_page_bytes, "page-etag-0"),
+        );
+        let receipt = wrong_page_address.receipt("roots").await;
+        assert_eq!(
+            incomplete(wrong_page_address.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Page,
+                reason: InvalidRemoteCatalogReasonV1::ObjectAddress
+            }
+        );
+
+        let duplicate_across_pages = fixture("roots", vec![vec![entry.clone()], vec![entry]]);
+        let receipt = duplicate_across_pages.receipt("roots").await;
+        assert_eq!(
+            incomplete(duplicate_across_pages.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Page,
+                reason: InvalidRemoteCatalogReasonV1::EntryOrder
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_rejects_binding_and_total_mismatches() {
+        let entry = fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/a", b"a", "a");
+        let page_binding = fixture("roots", vec![vec![entry.clone()]]);
+        let page_bytes = page_binding
+            .backend
+            .objects
+            .lock()
+            .unwrap()
+            .get(&page_binding.page_keys[0])
+            .unwrap()
+            .bytes
+            .clone();
+        page_binding.backend.insert(
+            page_binding.page_keys[0].clone(),
+            scripted_object(page_bytes, "different-page-etag"),
+        );
+        let receipt = page_binding.receipt("roots").await;
+        assert_eq!(
+            incomplete(page_binding.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Page,
+                reason: InvalidRemoteCatalogReasonV1::ObjectBinding
+            }
+        );
+
+        let mut totals = fixture("roots", vec![vec![entry]]);
+        let mut root =
+            serde_json::from_slice::<RemoteCatalogRootWireV1>(&totals.root_bytes).unwrap();
+        root.entry_count = RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_entries();
+        totals.rewrite_root(&root);
+        let receipt = totals.receipt("roots").await;
+        assert_eq!(
+            incomplete(totals.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Root,
+                reason: InvalidRemoteCatalogReasonV1::Totals
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_size_limits_and_semantics_receipts_fail_closed() {
+        let exact_head = fixture("roots", Vec::new());
+        exact_head.backend.insert(
+            exact_head.head_key.clone(),
+            scripted_object(
+                vec![
+                    b'x';
+                    usize::try_from(
+                        RegisteredRootPlanContractV1::strict_v1()
+                            .remote_contract()
+                            .max_catalog_head_object_bytes()
+                    )
+                    .unwrap()
+                ],
+                "head-etag-a",
+            ),
+        );
+        let receipt = exact_head.receipt("roots").await;
+        assert_eq!(
+            incomplete(exact_head.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::Invalid {
+                kind: RemoteCatalogClosureObjectKindV1::Head,
+                reason: InvalidRemoteCatalogReasonV1::CanonicalEncoding
+            }
+        );
+
+        let head = fixture("roots", Vec::new());
+        head.backend.insert(
+            head.head_key.clone(),
+            scripted_object(
+                vec![
+                    b'x';
+                    usize::try_from(
+                        RegisteredRootPlanContractV1::strict_v1()
+                            .remote_contract()
+                            .max_catalog_head_object_bytes()
+                            + 1
+                    )
+                    .unwrap()
+                ],
+                "head-etag-a",
+            ),
+        );
+        let receipt = head.receipt("roots").await;
+        assert_eq!(
+            incomplete(head.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ResourceLimit(RemoteCatalogResourceV1::HeadBytes)
+        );
+
+        let root = fixture("roots", Vec::new());
+        root.backend.insert(
+            root.root_key.clone(),
+            scripted_object(
+                vec![
+                    b'x';
+                    usize::try_from(
+                        RegisteredRootPlanContractV1::strict_v1()
+                            .remote_contract()
+                            .max_catalog_root_object_bytes()
+                            + 1
+                    )
+                    .unwrap()
+                ],
+                "root-etag",
+            ),
+        );
+        let receipt = root.receipt("roots").await;
+        assert_eq!(
+            incomplete(root.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ResourceLimit(RemoteCatalogResourceV1::RootBytes)
+        );
+
+        let page_entry =
+            fixture_entry(RemoteCatalogObjectKindV1::Index, "roots/index/a", b"a", "a");
+        let page = fixture("roots", vec![vec![page_entry.clone()]]);
+        page.backend.insert(
+            page.page_keys[0].clone(),
+            scripted_object(
+                vec![
+                    b'x';
+                    usize::try_from(
+                        RegisteredRootPlanContractV1::strict_v1()
+                            .remote_contract()
+                            .max_catalog_page_object_bytes()
+                            + 1
+                    )
+                    .unwrap()
+                ],
+                "page-etag-0",
+            ),
+        );
+        let receipt = page.receipt("roots").await;
+        assert_eq!(
+            incomplete(page.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ResourceLimit(RemoteCatalogResourceV1::PageBytes)
+        );
+
+        let mut entries_per_page = fixture("roots", vec![vec![page_entry]]);
+        let mut root =
+            serde_json::from_slice::<RemoteCatalogRootWireV1>(&entries_per_page.root_bytes)
+                .unwrap();
+        root.pages[0].entry_count = RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_entries_per_page()
+            + 1;
+        entries_per_page.rewrite_root(&root);
+        let receipt = entries_per_page.receipt("roots").await;
+        assert_eq!(
+            incomplete(entries_per_page.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::ResourceLimit(RemoteCatalogResourceV1::EntriesPerPage)
+        );
+
+        let exact_page_entries = (0..RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_entries_per_page())
+            .map(|ordinal| {
+                fixture_entry(
+                    RemoteCatalogObjectKindV1::Index,
+                    &format!("roots/index/{ordinal:04}"),
+                    b"a",
+                    &format!("entry-etag-{ordinal}"),
+                )
+            })
+            .collect::<Vec<_>>();
+        let exact_entries_per_page = fixture("roots", vec![exact_page_entries]);
+        let receipt = exact_entries_per_page.receipt("roots").await;
+        assert!(matches!(
+            exact_entries_per_page.read(&receipt).await.unwrap(),
+            StrictRemoteCatalogClosureReadV1::Verified(_)
+        ));
+
+        let wrong_scope = fixture("roots", Vec::new());
+        let receipt = wrong_scope.receipt("other").await;
+        assert_eq!(
+            incomplete(wrong_scope.read(&receipt).await.unwrap()),
+            StrictRemoteCatalogIncompleteV1::StorageSemanticsUnverified
+        );
+        assert!(wrong_scope.backend.stats.lock().unwrap().is_empty());
+        assert!(wrong_scope.backend.reads.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn catalog_resource_accounting_accepts_exact_limits_and_rejects_next_value() {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let entry = fixture_entry(
+            RemoteCatalogObjectKindV1::Index,
+            "roots/index/a",
+            b"a",
+            "etag",
+        );
+
+        let mut entries = RemoteCatalogBudgetV1 {
+            entries: remote.max_catalog_entries() - 1,
+            ..Default::default()
+        };
+        entries.observe_entry(&entry).unwrap();
+        assert_eq!(entries.entries, remote.max_catalog_entries());
+        assert_eq!(
+            entries.observe_entry(&entry),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::Entries
+            ))
+        );
+
+        let key_bytes = u64::try_from(entry.object_key.len()).unwrap();
+        let mut keys = RemoteCatalogBudgetV1 {
+            entry_key_bytes: remote.max_catalog_entry_key_bytes() - key_bytes,
+            ..Default::default()
+        };
+        keys.observe_entry(&entry).unwrap();
+        assert_eq!(keys.entry_key_bytes, remote.max_catalog_entry_key_bytes());
+        assert_eq!(
+            keys.observe_entry(&entry),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::EntryKeyBytes
+            ))
+        );
+
+        let mut pages = RemoteCatalogBudgetV1 {
+            pages: remote.max_catalog_pages() - 1,
+            ..Default::default()
+        };
+        pages.observe_page(1, &etag_binding("page")).unwrap();
+        assert_eq!(pages.pages, remote.max_catalog_pages());
+        assert_eq!(
+            pages.observe_page(1, &etag_binding("page")),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::Pages
+            ))
+        );
+
+        let mut closure = RemoteCatalogBudgetV1 {
+            closure_bytes: remote.max_catalog_closure_object_bytes() - 1,
+            ..Default::default()
+        };
+        closure.observe_page(1, &etag_binding("page")).unwrap();
+        assert_eq!(
+            closure.closure_bytes,
+            remote.max_catalog_closure_object_bytes()
+        );
+        assert_eq!(
+            closure.observe_page(1, &etag_binding("page")),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::ClosureBytes
+            ))
+        );
+
+        let binding = etag_binding("etag");
+        let binding_bytes = binding_wire_bytes_v1(&binding).unwrap();
+        let mut bindings = RemoteCatalogBudgetV1 {
+            binding_bytes: remote.max_catalog_binding_bytes() - binding_bytes,
+            ..Default::default()
+        };
+        bindings.observe_binding(&binding).unwrap();
+        assert_eq!(bindings.binding_bytes, remote.max_catalog_binding_bytes());
+        assert_eq!(
+            bindings.observe_binding(&binding),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::BindingBytes
+            ))
+        );
+
+        let mut root_bytes = RemoteCatalogBudgetV1::default();
+        root_bytes
+            .observe_root(
+                remote.max_catalog_root_object_bytes(),
+                &etag_binding("root"),
+            )
+            .unwrap();
+        assert_eq!(
+            RemoteCatalogBudgetV1::default().observe_root(
+                remote.max_catalog_root_object_bytes() + 1,
+                &etag_binding("root")
+            ),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::RootBytes
+            ))
+        );
+
+        let mut page_bytes = RemoteCatalogBudgetV1::default();
+        page_bytes
+            .observe_page(
+                remote.max_catalog_page_object_bytes(),
+                &etag_binding("page"),
+            )
+            .unwrap();
+        assert_eq!(
+            RemoteCatalogBudgetV1::default().observe_page(
+                remote.max_catalog_page_object_bytes() + 1,
+                &etag_binding("page")
+            ),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::PageBytes
+            ))
+        );
+
+        let mut index_entries = RemoteCatalogBudgetV1 {
+            index_entries: remote.max_index_observations_per_pass() - 1,
+            ..Default::default()
+        };
+        index_entries.observe_entry(&entry).unwrap();
+        assert_eq!(
+            index_entries.observe_entry(&entry),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::IndexEntries
+            ))
+        );
+
+        let reservation = fixture_entry(
+            RemoteCatalogObjectKindV1::Reservation,
+            &format!("roots/.tcfs-namespace/v1/{}", "b".repeat(64)),
+            b"reservation",
+            "reservation",
+        );
+        let mut reservation_entries = RemoteCatalogBudgetV1 {
+            reservation_entries: remote.max_reservation_observations_per_pass() - 1,
+            ..Default::default()
+        };
+        reservation_entries.observe_entry(&reservation).unwrap();
+        assert_eq!(
+            reservation_entries.observe_entry(&reservation),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::ReservationEntries
+            ))
+        );
+
+        let manifest = fixture_entry(
+            RemoteCatalogObjectKindV1::Manifest,
+            &format!("roots/manifests/{}", "c".repeat(64)),
+            b"manifest",
+            "manifest",
+        );
+        let mut manifest_entries = RemoteCatalogBudgetV1 {
+            manifest_entries: remote.max_index_observations_per_pass() - 1,
+            ..Default::default()
+        };
+        manifest_entries.observe_entry(&manifest).unwrap();
+        assert_eq!(
+            manifest_entries.observe_entry(&manifest),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::ManifestEntries
+            ))
+        );
+
+        let mut overflow = u64::MAX;
+        assert_eq!(
+            RemoteCatalogBudgetV1::checked_add(
+                &mut overflow,
+                1,
+                u64::MAX,
+                RemoteCatalogResourceV1::ClosureBytes
+            ),
+            Err(StrictRemoteCatalogIncompleteV1::ResourceLimit(
+                RemoteCatalogResourceV1::ClosureBytes
+            ))
+        );
+    }
+}

--- a/crates/tcfs-sync/src/registered_remote_catalog.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog.rs
@@ -207,7 +207,7 @@ pub(crate) enum StrictSemanticallyBoundRemoteCatalogReadV1 {
     Incomplete(StrictSemanticallyBoundRemoteCatalogIncompleteV1),
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 struct RemoteCatalogContextWireV1 {
     root_id: String,
@@ -1288,13 +1288,7 @@ fn validate_page_v1(
     Ok(page)
 }
 
-/// Validate one exact immutable catalog root and every ordered page selected by
-/// an unchanged, current, ETag-bound HEAD.
-///
-/// No LIST operation is issued. The expected context must come from the
-/// daemon-authenticated selected-root route, never from the remote bytes. The
-/// caller must also acquire a live conditional-semantics receipt for this
-/// exact operator and prefix.
+/// Read and validate one unchanged current catalog closure.
 pub(crate) async fn read_verified_remote_catalog_closure_v1(
     op: &Operator,
     selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
@@ -1326,6 +1320,68 @@ pub(crate) async fn read_verified_remote_catalog_closure_v1(
             return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
         }
     };
+    read_verified_remote_catalog_closure_from_head_snapshot_v1(
+        op,
+        selected,
+        receipt,
+        head_a_raw,
+        Some(&head_key),
+    )
+    .await
+}
+
+/// Validate the immutable root/page inventory selected by an exact archived
+/// committed HEAD snapshot.
+///
+/// Unlike the current-HEAD reader this deliberately performs no mutable HEAD
+/// read or stability comparison. The caller must first bind the archive by its
+/// persisted content-address, length, and storage identity, and must recheck
+/// that immutable binding after this function returns.
+pub(crate) async fn read_verified_remote_catalog_closure_from_archived_head_v1(
+    op: &Operator,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+    receipt: &ConditionalWriteSemanticsReceipt,
+    archived_head: RawObjectSnapshotV1,
+) -> Result<StrictRemoteCatalogClosureReadV1> {
+    read_verified_remote_catalog_closure_from_head_snapshot_v1(
+        op,
+        selected,
+        receipt,
+        archived_head,
+        None,
+    )
+    .await
+}
+
+/// Validate one exact immutable catalog root and every ordered page selected by
+/// an already bound committed HEAD snapshot.
+///
+/// No LIST operation is issued. The expected context must come from the
+/// daemon-authenticated selected-root route, never from the remote bytes. The
+/// caller must also acquire a live conditional-semantics receipt for this
+/// exact operator and prefix. `stable_head_key` requests the current-HEAD
+/// second read; archived snapshots deliberately omit it.
+async fn read_verified_remote_catalog_closure_from_head_snapshot_v1(
+    op: &Operator,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+    receipt: &ConditionalWriteSemanticsReceipt,
+    head_a_raw: RawObjectSnapshotV1,
+    stable_head_key: Option<&str>,
+) -> Result<StrictRemoteCatalogClosureReadV1> {
+    let remote_prefix =
+        match validate_canonical_namespace_remote_prefix(&selected.spec().remote_prefix) {
+            Ok(prefix) if !prefix.is_empty() => prefix,
+            _ => {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+                    StrictRemoteCatalogIncompleteV1::InvalidRemotePrefix,
+                ));
+            }
+        };
+    if !receipt.authorizes(op, remote_prefix)? {
+        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+            StrictRemoteCatalogIncompleteV1::StorageSemanticsUnverified,
+        ));
+    }
     let remote_contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
     if u64::try_from(head_a_raw.raw_bytes().len()).map_or(true, |length| {
         length > remote_contract.max_catalog_head_object_bytes()
@@ -1527,16 +1583,18 @@ pub(crate) async fn read_verified_remote_catalog_closure_v1(
         )));
     }
 
-    let head_b_raw = match read_current_head_v1(op, &head_key).await? {
-        Ok(raw) => raw,
-        Err(incomplete) => {
-            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+    if let Some(head_key) = stable_head_key {
+        let head_b_raw = match read_current_head_v1(op, head_key).await? {
+            Ok(raw) => raw,
+            Err(incomplete) => {
+                return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(incomplete));
+            }
+        };
+        if head_a_raw != head_b_raw {
+            return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
+                StrictRemoteCatalogIncompleteV1::HeadChanged,
+            ));
         }
-    };
-    if head_a_raw != head_b_raw {
-        return Ok(StrictRemoteCatalogClosureReadV1::Incomplete(
-            StrictRemoteCatalogIncompleteV1::HeadChanged,
-        ));
     }
 
     let head_revision = catalog_head_revision_v1(head_a_raw.raw_bytes());

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -11,24 +11,22 @@
 //! completeness, exact-current high-water, and the all-writer credential epoch
 //! are opaque external receipts with no production constructors. One external
 //! control acquisition binds those receipts and must move monotonically from
-//! exact-current `Ready` to one exact `PublicationPending` successor before a
-//! future visible `HEAD` CAS. A terminal matcher also specifies the required
-//! `PublicationPending` to exact-current `Ready(n+1)` advance, but cannot mint a
-//! fresh guard. The module can publish the exact immutable predecessor-HEAD
-//! archive. Fact-bound preparation derives predecessors from the semantic
-//! corpus, proves create-key absence through the held accessor, reconstructs
-//! successor semantics, and publishes exact immutable payloads plus an
-//! authoritative journal. A separately namespaced diagnostic draft remains
-//! non-authoritative and cannot convert into that journal. The namespace
-//! mutation gateway accepts only the complete authoritative journal after an
-//! exact visible publishing-HEAD receipt and rechecks a retained backend lease
-//! before and after each conditional write. That receipt and lease still have
-//! no production constructors, so this module cannot mint production
-//! authority, write a live `HEAD`, reach a live namespace mutation, produce a
-//! plan digest, or authorize an action.
+//! exact-current `Ready` to one exact `PublicationPending` successor. The
+//! retained acquisition then derives and installs the visible publishing HEAD,
+//! executes only the complete fact-bound journal, publishes a complete
+//! immutable successor catalog, finalizes committed HEAD, reconstructs exact
+//! recovery states, and advances the external high-water to `Ready(n+1)`.
+//! Every conditional write is bracketed by the retained live backend lease.
+//! A separately namespaced diagnostic draft remains non-authoritative and
+//! cannot convert into the authoritative journal. The lease and authenticated
+//! control receipts still have no production constructors or implementation,
+//! so this source path remains unreachable by deployed writers and cannot mint
+//! production authority, produce a plan digest, or authorize an action.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::num::NonZeroU64;
+use std::pin::Pin;
 
 use anyhow::{Context, Result as AnyhowResult};
 use opendal::Operator;
@@ -41,7 +39,9 @@ use tcfs_core::config::{
 use super::{
     lower_hex, validate_catalog_context_v1, validate_catalog_object_route_v1,
     validate_entry_size_v1, InvalidRemoteCatalogReasonV1, RemoteCatalogContextWireV1,
-    RemoteCatalogObjectBindingWireV1, RemoteCatalogObjectKindV1,
+    RemoteCatalogEntryWireV1, RemoteCatalogHeadWireV1, RemoteCatalogObjectBindingWireV1,
+    RemoteCatalogObjectKindV1, RemoteCatalogPageReferenceWireV1, RemoteCatalogPageWireV1,
+    RemoteCatalogRootReferenceWireV1, RemoteCatalogRootWireV1,
     SemanticallyBoundRemoteCatalogCorpusV1, CATALOG_SCHEMA_VERSION_V1,
 };
 use crate::blacklist::Blacklist;
@@ -299,6 +299,14 @@ struct NonSecretLeasePublicFingerprintV1([u8; 32]);
 /// There is deliberately no production constructor in this checkpoint.
 trait CatalogControlLeaseLivenessV1: Send + Sync {
     fn is_live_v1(&self) -> bool;
+
+    /// Atomically replace the exact pending control revision with the exact
+    /// ready record. Implementations must resolve ambiguous backend outcomes
+    /// by an exact authenticated reread and return the same receipt on replay.
+    fn compare_and_swap_ready_v1<'a>(
+        &'a self,
+        request: CatalogControlReadyAdvanceRequestV1,
+    ) -> CatalogControlReadyAdvanceFutureV1<'a>;
 }
 
 struct RetainedCatalogControlLeaseV1 {
@@ -1623,6 +1631,17 @@ struct BoundCatalogSuccessorPayloadV1 {
     binding: RegisteredRootRemoteObjectBindingV1,
 }
 
+/// Exact predecessor catalog entry retained so committed finalization can
+/// rebuild the complete successor inventory without LIST or caller-supplied
+/// unchanged entries.
+struct RetainedCatalogPredecessorEntryV1 {
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    raw_bytes_len: u64,
+    raw_blake3: [u8; 32],
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
 /// Complete canonical authoritative journal with every successor bound to an
 /// immutable absent-only payload object. Publishing the journal remains a
 /// separate exact-reread step; this type cannot enter a visible fence.
@@ -1636,6 +1655,7 @@ pub(crate) struct PreparedAuthoritativeCatalogMutationJournalV1 {
     raw_bytes: Vec<u8>,
     raw_bytes_len: NonZeroU64,
     successor_payloads: Vec<BoundCatalogSuccessorPayloadV1>,
+    predecessor_entries: Vec<RetainedCatalogPredecessorEntryV1>,
 }
 
 impl std::fmt::Debug for PreparedAuthoritativeCatalogMutationJournalV1 {
@@ -1806,6 +1826,7 @@ pub(crate) struct BoundCatalogMutationJournalV1 {
     raw_bytes_len: NonZeroU64,
     binding: RegisteredRootRemoteObjectBindingV1,
     successor_payloads: Vec<BoundCatalogSuccessorPayloadV1>,
+    predecessor_entries: Vec<RetainedCatalogPredecessorEntryV1>,
 }
 
 fn publication_object_key_v1(
@@ -2077,6 +2098,67 @@ pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 
     validate_complete_successor_semantic_closure_v1(corpus, &mutations)
         .map_err(|error| anyhow::anyhow!("successor semantic closure is invalid: {error:?}"))?;
 
+    let retain_entry =
+        |kind,
+         object_key: String,
+         object: &crate::registered_reconcile::BoundRemoteObjectSnapshotV1| {
+            RetainedCatalogPredecessorEntryV1 {
+                kind,
+                object_key,
+                raw_bytes_len: object.raw_bytes_len(),
+                raw_blake3: *object.raw_blake3(),
+                binding: object.binding().clone(),
+            }
+        };
+    let mut predecessor_entries = Vec::new();
+    predecessor_entries
+        .try_reserve(
+            corpus
+                .index_objects
+                .len()
+                .checked_add(corpus.reservations.len())
+                .and_then(|count| count.checked_add(corpus.manifests.len()))
+                .context("semantic predecessor entry count overflow")?,
+        )
+        .context("reserving semantic predecessor catalog entries")?;
+    predecessor_entries.extend(corpus.index_objects.iter().map(|index| {
+        retain_entry(
+            RemoteCatalogObjectKindV1::Index,
+            index.physical_key().to_owned(),
+            index.object(),
+        )
+    }));
+    predecessor_entries.extend(corpus.reservations.iter().map(|reservation| {
+        retain_entry(
+            RemoteCatalogObjectKindV1::Reservation,
+            reservation.object_key().to_owned(),
+            reservation.object(),
+        )
+    }));
+    for manifest in &corpus.manifests {
+        let source = corpus
+            .index_objects
+            .get(manifest.source_index_ordinal)
+            .and_then(|index| index.committed())
+            .context("semantic predecessor manifest lost its committed source index")?;
+        predecessor_entries.push(retain_entry(
+            RemoteCatalogObjectKindV1::Manifest,
+            format!(
+                "{}/manifests/{}",
+                corpus.remote_prefix(),
+                source.current().manifest_hash()
+            ),
+            manifest.manifest.object(),
+        ));
+    }
+    predecessor_entries.sort_unstable_by(|left, right| left.object_key.cmp(&right.object_key));
+    anyhow::ensure!(
+        predecessor_entries
+            .windows(2)
+            .all(|entries| entries[0].object_key < entries[1].object_key),
+        "semantic predecessor catalog entries are not strictly ordered"
+    );
+
     let mut successor_payloads = Vec::new();
     successor_payloads
         .try_reserve(mutations.len())
@@ -2178,6 +2260,7 @@ pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 
         raw_bytes,
         raw_bytes_len,
         successor_payloads,
+        predecessor_entries,
     })
 }
 
@@ -2260,6 +2343,7 @@ pub(crate) async fn publish_authoritative_catalog_mutation_journal_v1(
         raw_bytes_len,
         binding,
         successor_payloads: prepared.successor_payloads,
+        predecessor_entries: prepared.predecessor_entries,
     })
 }
 
@@ -2478,8 +2562,8 @@ fn validate_catalog_successor_claim_v1<'a>(
     })
 }
 
-/// Prepare one exact successor. The future storage CAS is the cross-process
-/// winner election; callers must never mutate the namespace before it wins.
+/// Prepare one exact successor. The visible storage CAS is the cross-process
+/// winner election; callers cannot mutate the namespace before it wins.
 pub(crate) fn prepare_catalog_publication_fence_v1<'a>(
     prerequisites: MatchedCatalogPublicationPrerequisitesV1<'a>,
     publication_nonce: [u8; 32],
@@ -2523,8 +2607,8 @@ pub(crate) struct TrustedCatalogPublicationPendingReceiptV1 {
     pending_control_record_fingerprint: [u8; 32],
 }
 
-/// The only future input permitted to arm a visible publishing-HEAD CAS. This
-/// checkpoint cannot construct one in production and cannot write `HEAD`.
+/// The only input permitted to arm the visible publishing-HEAD CAS. Production
+/// still cannot construct this value without an authenticated control backend.
 pub(crate) struct BoundPendingCatalogControlV1<'a> {
     transition: PreparedCatalogControlTransitionV1<'a>,
     pending_receipt: TrustedCatalogPublicationPendingReceiptV1,
@@ -2545,16 +2629,6 @@ impl std::fmt::Debug for BoundPendingCatalogControlV1<'_> {
             )
             .finish_non_exhaustive()
     }
-}
-
-/// Opaque backend receipt for the future committed-HEAD -> publishing-HEAD
-/// compare-and-swap. The receipt is not the writer capability: it must be
-/// rebound to the exact visible bytes through the held accessor while the
-/// retained control lease is still live.
-///
-/// There is deliberately no production constructor in this checkpoint.
-pub(crate) struct TrustedCatalogPublishingHeadInstalledReceiptV1 {
-    publishing_head_binding: RegisteredRootRemoteObjectBindingV1,
 }
 
 /// Non-forgeable permission to apply exactly the authoritative journal and no
@@ -2581,24 +2655,25 @@ impl std::fmt::Debug for CatalogNamespaceMutationCapabilityV1<'_> {
     }
 }
 
-/// Failed capability binding that keeps the exact pending transition and its
-/// retained lease owned for recovery instead of dropping authority on error.
-pub(crate) struct CatalogNamespaceMutationCapabilityBindFailureV1<'a> {
+/// Failed visible publishing-HEAD installation that keeps the exact pending
+/// transition and retained lease owned for recovery instead of dropping
+/// authority on an ambiguous or rejected compare-and-swap.
+pub(crate) struct CatalogPublishingHeadInstallFailureV1<'a> {
     pending: BoundPendingCatalogControlV1<'a>,
     error: anyhow::Error,
 }
 
-impl std::fmt::Debug for CatalogNamespaceMutationCapabilityBindFailureV1<'_> {
+impl std::fmt::Debug for CatalogPublishingHeadInstallFailureV1<'_> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
-            .debug_struct("CatalogNamespaceMutationCapabilityBindFailureV1")
+            .debug_struct("CatalogPublishingHeadInstallFailureV1")
             .field("sequence", &self.pending.transition.publication.sequence)
             .field("error", &self.error)
             .finish_non_exhaustive()
     }
 }
 
-impl std::fmt::Display for CatalogNamespaceMutationCapabilityBindFailureV1<'_> {
+impl std::fmt::Display for CatalogPublishingHeadInstallFailureV1<'_> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if formatter.alternate() {
             write!(formatter, "{:#}", self.error)
@@ -2608,7 +2683,7 @@ impl std::fmt::Display for CatalogNamespaceMutationCapabilityBindFailureV1<'_> {
     }
 }
 
-impl std::error::Error for CatalogNamespaceMutationCapabilityBindFailureV1<'_> {
+impl std::error::Error for CatalogPublishingHeadInstallFailureV1<'_> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(self.error.as_ref())
     }
@@ -2728,43 +2803,97 @@ async fn require_namespace_mutation_capability_live_v1(
     Ok(())
 }
 
-/// Rebind the future HEAD-CAS receipt through the same accessor and retain the
-/// live lease. This is the only constructor for the namespace mutation
-/// capability, and this checkpoint cannot produce its trusted receipt in
-/// production.
-pub(crate) async fn bind_catalog_namespace_mutation_capability_v1<'a>(
+/// Atomically replace the exact committed predecessor HEAD with the canonical
+/// publishing fence, then rebind the exact visible bytes through the same
+/// accessor while retaining the live lease.
+///
+/// This is the only constructor for the namespace mutation capability.
+/// Conditional-write failure is treated as an ambiguous outcome until the
+/// bounded reread proves either the exact publishing bytes or a different
+/// state. Callers cannot provide HEAD bytes, keys, or predecessor bindings.
+pub(crate) async fn install_catalog_publishing_head_v1<'a>(
     pending: BoundPendingCatalogControlV1<'a>,
-    receipt: TrustedCatalogPublishingHeadInstalledReceiptV1,
-) -> Result<
-    CatalogNamespaceMutationCapabilityV1<'a>,
-    CatalogNamespaceMutationCapabilityBindFailureV1<'a>,
-> {
-    let capability = CatalogNamespaceMutationCapabilityV1 {
-        pending,
-        publishing_head_binding: receipt.publishing_head_binding,
-    };
-    let result = async {
+) -> Result<CatalogNamespaceMutationCapabilityV1<'a>, CatalogPublishingHeadInstallFailureV1<'a>> {
+    let result: AnyhowResult<RegisteredRootRemoteObjectBindingV1> = async {
+        let transition = &pending.transition;
+        let publication = &transition.publication;
+        require_held_control_lease_live_v1(&publication.control_guard)
+            .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
         anyhow::ensure!(
-            super::validate_binding_wire_v1(&binding_wire_v1(&capability.publishing_head_binding))
-                .is_some()
-                && mutable_head_etag_v1(&capability.publishing_head_binding).is_some(),
-            "publishing HEAD receipt has no usable exact mutable-object binding"
+            publication
+                .storage_authority
+                .conditional_write_receipt
+                .authorizes(
+                    publication.storage_authority.operator,
+                    &publication.context.remote_prefix,
+                )?,
+            "publishing HEAD install lost its exact accessor/prefix conditional-semantics authority"
         );
-        require_namespace_mutation_capability_live_v1(&capability)
+        let expected_bytes =
+            canonical_publishing_head_bytes_v1(publication, transition.pending_revision);
+        let expected_reservation = super::domain_object_id_v1(
+            PUBLISHING_HEAD_RESERVATION_DOMAIN_V1,
+            &expected_bytes,
+        );
+        anyhow::ensure!(
+            transition.canonical_publishing_head_bytes == expected_bytes
+                && transition.publishing_head_reservation_fingerprint == expected_reservation
+                && !publication.expected_parent_head_etag.is_empty(),
+            "publishing HEAD proposal no longer matches its exact pending transition"
+        );
+        let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+        let write_result = publication
+            .storage_authority
+            .operator
+            .write_with(&head_key, expected_bytes.clone())
+            .if_match(&publication.expected_parent_head_etag)
             .await
-            .map_err(|error| {
-                anyhow::anyhow!(
-                    "publishing HEAD receipt does not authorize namespace mutation: {error}"
-                )
-            })
+            .with_context(|| format!("conditionally installing catalog publishing HEAD: {head_key}"));
+        let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_head_object_bytes();
+        let observed = read_raw_object_snapshot_v1(
+            publication.storage_authority.operator,
+            &head_key,
+            max_bytes,
+        )
+        .await
+        .with_context(|| format!("revalidating installed catalog publishing HEAD: {head_key}"))?;
+        let exact_binding = match observed {
+            Some(RawObjectReadV1::Bound(snapshot)) => {
+                let (raw_bytes, _, binding) = snapshot.into_parts();
+                (raw_bytes == expected_bytes).then(|| registered_binding_from_raw_v1(binding))
+            }
+            None | Some(RawObjectReadV1::Unbound) => None,
+        };
+        let Some(binding) = exact_binding else {
+            return match write_result {
+                Ok(_) => anyhow::bail!(
+                    "catalog publishing HEAD changed after its successful compare-and-swap: {head_key}"
+                ),
+                Err(write_error) => Err(write_error).with_context(|| {
+                    format!(
+                        "catalog publishing HEAD compare-and-swap did not install the exact proposal: {head_key}"
+                    )
+                }),
+            };
+        };
+        anyhow::ensure!(
+            super::validate_binding_wire_v1(&binding_wire_v1(&binding)).is_some()
+                && mutable_head_etag_v1(&binding).is_some(),
+            "installed publishing HEAD has no usable exact mutable-object binding"
+        );
+        require_held_control_lease_live_v1(&publication.control_guard)
+            .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+        Ok(binding)
     }
     .await;
     match result {
-        Ok(()) => Ok(capability),
-        Err(error) => {
-            let CatalogNamespaceMutationCapabilityV1 { pending, .. } = capability;
-            Err(CatalogNamespaceMutationCapabilityBindFailureV1 { pending, error })
-        }
+        Ok(publishing_head_binding) => Ok(CatalogNamespaceMutationCapabilityV1 {
+            pending,
+            publishing_head_binding,
+        }),
+        Err(error) => Err(CatalogPublishingHeadInstallFailureV1 { pending, error }),
     }
 }
 
@@ -3010,20 +3139,801 @@ pub(crate) async fn apply_authoritative_catalog_namespace_mutations_v1<'a>(
     })
 }
 
-/// Opaque future proof that the exact reserved successor became the canonical
-/// committed `HEAD`. No production constructor exists until visible fencing,
-/// fact-bound mutation, and committed-HEAD finalization are implemented.
+/// Retry a failed authoritative namespace batch from ordinal zero.
+///
+/// The capability is retained by the failure value, and every successful
+/// predecessor write is exact-reread before being accepted as an idempotent
+/// replay. A missing predecessor, different collision, changed publishing
+/// HEAD, or lost lease remains a terminal fail-closed result.
+pub(crate) async fn recover_failed_catalog_namespace_mutations_v1<'a>(
+    failure: FailedCatalogNamespaceMutationsV1<'a>,
+) -> Result<AppliedCatalogNamespaceMutationsV1<'a>, FailedCatalogNamespaceMutationsV1<'a>> {
+    let FailedCatalogNamespaceMutationsV1 {
+        capability,
+        applied: _,
+        error: _,
+    } = failure;
+    apply_authoritative_catalog_namespace_mutations_v1(capability).await
+}
+
+/// Failed committed-catalog finalization retaining the complete applied
+/// mutation evidence and live capability for exact replay or recovery.
+pub(crate) struct FailedCatalogCommittedFinalizationV1<'a> {
+    applied: AppliedCatalogNamespaceMutationsV1<'a>,
+    error: anyhow::Error,
+}
+
+impl std::fmt::Debug for FailedCatalogCommittedFinalizationV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FailedCatalogCommittedFinalizationV1")
+            .field(
+                "sequence",
+                &self
+                    .applied
+                    .capability
+                    .pending
+                    .transition
+                    .publication
+                    .sequence,
+            )
+            .field("applied_count", &self.applied.applied.len())
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for FailedCatalogCommittedFinalizationV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if formatter.alternate() {
+            write!(formatter, "{:#}", self.error)
+        } else {
+            std::fmt::Display::fmt(&self.error, formatter)
+        }
+    }
+}
+
+impl std::error::Error for FailedCatalogCommittedFinalizationV1<'_> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error.as_ref())
+    }
+}
+
+struct PublishedCatalogSuccessorClosureV1 {
+    committed_head_bytes: Vec<u8>,
+    head_revision: [u8; 32],
+    committed_head_binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+fn complete_successor_catalog_entries_v1(
+    applied: &AppliedCatalogNamespaceMutationsV1<'_>,
+) -> AnyhowResult<Vec<RemoteCatalogEntryWireV1>> {
+    let publication = &applied.capability.pending.transition.publication;
+    let journal = &publication.mutation_journal;
+    let wire = validate_authoritative_catalog_mutation_journal_bytes_v1(
+        &journal.raw_bytes,
+        &publication.context,
+        publication.sequence,
+        publication.publication_nonce,
+        publication.parent_head_revision,
+    )
+    .map_err(|error| anyhow::anyhow!("authoritative mutation journal is invalid: {error:?}"))?;
+    anyhow::ensure!(
+        wire.mutations.len() == journal.successor_payloads.len()
+            && wire.mutations.len() == applied.applied.len(),
+        "applied catalog evidence does not cover the complete authoritative journal"
+    );
+
+    let mut entries = BTreeMap::<String, RemoteCatalogEntryWireV1>::new();
+    for predecessor in &journal.predecessor_entries {
+        anyhow::ensure!(
+            validate_catalog_object_route_v1(
+                &publication.context.remote_prefix,
+                predecessor.kind,
+                &predecessor.object_key,
+            ) && validate_entry_size_v1(predecessor.kind, predecessor.raw_bytes_len)
+                && super::validate_binding_wire_v1(&binding_wire_v1(&predecessor.binding))
+                    .is_some(),
+            "retained predecessor catalog entry is invalid"
+        );
+        let previous = entries.insert(
+            predecessor.object_key.clone(),
+            RemoteCatalogEntryWireV1 {
+                kind: predecessor.kind,
+                object_key: predecessor.object_key.clone(),
+                raw_bytes_len: predecessor.raw_bytes_len,
+                raw_blake3: lower_hex(&predecessor.raw_blake3),
+                binding: binding_wire_v1(&predecessor.binding),
+            },
+        );
+        anyhow::ensure!(
+            previous.is_none(),
+            "retained predecessor catalog entries contain a duplicate key"
+        );
+    }
+
+    for ((mutation, payload), evidence) in wire
+        .mutations
+        .iter()
+        .zip(&journal.successor_payloads)
+        .zip(&applied.applied)
+    {
+        anyhow::ensure!(
+            mutation.kind == payload.kind
+                && mutation.kind == evidence.kind
+                && mutation.object_key == payload.object_key
+                && mutation.object_key == evidence.object_key
+                && payload.raw_bytes_len.get() == mutation.successor_payload.raw_bytes_len
+                && payload.raw_blake3 == evidence.raw_blake3
+                && lower_hex(&payload.raw_blake3) == mutation.successor_payload.raw_blake3
+                && super::validate_binding_wire_v1(&binding_wire_v1(&evidence.binding)).is_some()
+                && (evidence.kind != RemoteCatalogObjectKindV1::Index
+                    || mutable_head_etag_v1(&evidence.binding).is_some()),
+            "applied catalog evidence does not match its authoritative successor"
+        );
+        match (&mutation.operation, &mutation.predecessor) {
+            (
+                RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+                RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+            ) => anyhow::ensure!(
+                !entries.contains_key(&mutation.object_key),
+                "authoritative create is not absent from the retained predecessor catalog"
+            ),
+            (
+                RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+                RemoteCatalogMutationPredecessorDraftWireV1::Present {
+                    raw_bytes_len,
+                    raw_blake3,
+                    binding,
+                },
+            ) => {
+                let predecessor = entries
+                    .get(&mutation.object_key)
+                    .context("authoritative replacement predecessor is missing")?;
+                anyhow::ensure!(
+                    predecessor.kind == mutation.kind
+                        && predecessor.raw_bytes_len == *raw_bytes_len
+                        && predecessor.raw_blake3 == *raw_blake3
+                        && predecessor.binding == *binding,
+                    "authoritative replacement predecessor changed before finalization"
+                );
+            }
+            _ => anyhow::bail!("authoritative catalog mutation operation is invalid"),
+        }
+        entries.insert(
+            mutation.object_key.clone(),
+            RemoteCatalogEntryWireV1 {
+                kind: evidence.kind,
+                object_key: evidence.object_key.clone(),
+                raw_bytes_len: payload.raw_bytes_len.get(),
+                raw_blake3: lower_hex(&payload.raw_blake3),
+                binding: binding_wire_v1(&evidence.binding),
+            },
+        );
+    }
+
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let entry_count =
+        u64::try_from(entries.len()).context("successor catalog entry count does not fit u64")?;
+    anyhow::ensure!(
+        entry_count <= remote.max_catalog_entries(),
+        "successor catalog entry count exceeds the bound"
+    );
+    let entry_key_bytes = entries.keys().try_fold(0_u64, |total, key| {
+        total
+            .checked_add(
+                u64::try_from(key.len())
+                    .context("successor catalog entry key length does not fit u64")?,
+            )
+            .context("successor catalog entry-key total overflow")
+    })?;
+    anyhow::ensure!(
+        entry_key_bytes <= remote.max_catalog_entry_key_bytes(),
+        "successor catalog entry-key total exceeds the bound"
+    );
+    Ok(entries.into_values().collect())
+}
+
+async fn publish_catalog_successor_immutable_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+    object_key: &str,
+    expected_bytes: &[u8],
+    expected_object_id: [u8; 32],
+    object_id: fn(&[u8]) -> [u8; 32],
+    max_bytes: u64,
+) -> AnyhowResult<RegisteredRootRemoteObjectBindingV1> {
+    require_namespace_mutation_capability_live_v1(capability).await?;
+    anyhow::ensure!(
+        !expected_bytes.is_empty()
+            && u64::try_from(expected_bytes.len())
+                .ok()
+                .is_some_and(|len| len <= max_bytes)
+            && object_id(expected_bytes) == expected_object_id,
+        "successor catalog immutable artifact is empty, oversized, or misaddressed"
+    );
+    let operator = capability
+        .pending
+        .transition
+        .publication
+        .storage_authority
+        .operator;
+    let write_result = operator
+        .write_with(object_key, expected_bytes.to_vec())
+        .if_not_exists(true)
+        .await;
+    let observed = read_raw_object_snapshot_v1(operator, object_key, max_bytes)
+        .await
+        .with_context(|| format!("revalidating successor catalog artifact: {object_key}"))?;
+    let exact_binding = match observed {
+        Some(RawObjectReadV1::Bound(snapshot)) => {
+            let (raw_bytes, raw_blake3, binding) = snapshot.into_parts();
+            (raw_bytes == expected_bytes
+                && raw_blake3 == blake3::hash(expected_bytes)
+                && object_id(&raw_bytes) == expected_object_id)
+                .then(|| registered_binding_from_raw_v1(binding))
+        }
+        None | Some(RawObjectReadV1::Unbound) => None,
+    };
+    let Some(binding) = exact_binding else {
+        return match write_result {
+            Ok(_) => anyhow::bail!(
+                "successor catalog artifact changed after absent-only publication: {object_key}"
+            ),
+            Err(write_error) => Err(write_error).with_context(|| {
+                format!(
+                    "successor catalog artifact collision differs from exact bytes: {object_key}"
+                )
+            }),
+        };
+    };
+    anyhow::ensure!(
+        super::validate_binding_wire_v1(&binding_wire_v1(&binding)).is_some(),
+        "successor catalog artifact has no usable exact binding"
+    );
+    require_namespace_mutation_capability_live_v1(capability).await?;
+    Ok(binding)
+}
+
+async fn publish_catalog_successor_closure_v1(
+    applied: &AppliedCatalogNamespaceMutationsV1<'_>,
+) -> AnyhowResult<PublishedCatalogSuccessorClosureV1> {
+    let capability = &applied.capability;
+    require_namespace_mutation_capability_live_v1(capability).await?;
+    let publication = &capability.pending.transition.publication;
+    let entries = complete_successor_catalog_entries_v1(applied)?;
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let max_entries_per_page = usize::try_from(remote.max_catalog_entries_per_page())
+        .context("catalog entries-per-page bound does not fit usize")?;
+    anyhow::ensure!(
+        max_entries_per_page > 0,
+        "catalog entries-per-page bound cannot be zero"
+    );
+    let mut page_references = Vec::new();
+    for (ordinal, page_entries) in entries.chunks(max_entries_per_page).enumerate() {
+        let entry_count = u64::try_from(page_entries.len())
+            .context("catalog page entry count does not fit u64")?;
+        let entry_key_bytes = page_entries.iter().try_fold(0_u64, |total, entry| {
+            total
+                .checked_add(
+                    u64::try_from(entry.object_key.len())
+                        .context("catalog page key length does not fit u64")?,
+                )
+                .context("catalog page key-byte total overflow")
+        })?;
+        let ordinal = u64::try_from(ordinal).context("catalog page ordinal does not fit u64")?;
+        let page = RemoteCatalogPageWireV1 {
+            version: CATALOG_SCHEMA_VERSION_V1,
+            context: publication.context.to_wire(),
+            catalog_sequence: publication.sequence.get(),
+            publication_nonce: lower_hex(&publication.publication_nonce),
+            ordinal,
+            entry_count,
+            entry_key_bytes,
+            entries: page_entries.to_vec(),
+        };
+        let page_bytes = serde_json::to_vec(&page).context("serializing successor catalog page")?;
+        anyhow::ensure!(
+            u64::try_from(page_bytes.len())
+                .ok()
+                .is_some_and(|len| len <= remote.max_catalog_page_object_bytes()),
+            "successor catalog page exceeds the object bound"
+        );
+        let page_object_id = super::catalog_page_object_id_v1(&page_bytes);
+        let page_key = super::catalog_page_key_v1(
+            &publication.context.remote_prefix,
+            &lower_hex(&page_object_id),
+        );
+        let binding = publish_catalog_successor_immutable_v1(
+            capability,
+            &page_key,
+            &page_bytes,
+            page_object_id,
+            super::catalog_page_object_id_v1,
+            remote.max_catalog_page_object_bytes(),
+        )
+        .await?;
+        page_references.push(RemoteCatalogPageReferenceWireV1 {
+            ordinal,
+            object_id: lower_hex(&page_object_id),
+            raw_bytes_len: u64::try_from(page_bytes.len())
+                .context("successor catalog page length does not fit u64")?,
+            binding: binding_wire_v1(&binding),
+            entry_count,
+            entry_key_bytes,
+        });
+    }
+    anyhow::ensure!(
+        u64::try_from(page_references.len()).ok() <= Some(remote.max_catalog_pages()),
+        "successor catalog page count exceeds the bound"
+    );
+    let entry_count =
+        u64::try_from(entries.len()).context("successor catalog entry count does not fit u64")?;
+    let entry_key_bytes = entries.iter().try_fold(0_u64, |total, entry| {
+        total
+            .checked_add(
+                u64::try_from(entry.object_key.len())
+                    .context("successor catalog entry key length does not fit u64")?,
+            )
+            .context("successor catalog entry-key total overflow")
+    })?;
+    let root = RemoteCatalogRootWireV1 {
+        version: CATALOG_SCHEMA_VERSION_V1,
+        context: publication.context.to_wire(),
+        catalog_sequence: publication.sequence.get(),
+        publication_nonce: lower_hex(&publication.publication_nonce),
+        parent_head_revision: Some(lower_hex(&publication.parent_head_revision)),
+        page_count: u64::try_from(page_references.len())
+            .context("successor catalog page count does not fit u64")?,
+        entry_count,
+        entry_key_bytes,
+        pages: page_references,
+    };
+    let root_bytes = serde_json::to_vec(&root).context("serializing successor catalog root")?;
+    anyhow::ensure!(
+        u64::try_from(root_bytes.len())
+            .ok()
+            .is_some_and(|len| len <= remote.max_catalog_root_object_bytes()),
+        "successor catalog root exceeds the object bound"
+    );
+    let root_object_id = super::catalog_root_object_id_v1(&root_bytes);
+    let root_key = super::catalog_root_key_v1(
+        &publication.context.remote_prefix,
+        &lower_hex(&root_object_id),
+    );
+    let root_binding = publish_catalog_successor_immutable_v1(
+        capability,
+        &root_key,
+        &root_bytes,
+        root_object_id,
+        super::catalog_root_object_id_v1,
+        remote.max_catalog_root_object_bytes(),
+    )
+    .await?;
+    require_namespace_mutation_capability_live_v1(capability).await?;
+
+    let committed_head = RemoteCatalogHeadWireV1 {
+        version: CATALOG_SCHEMA_VERSION_V1,
+        context: publication.context.to_wire(),
+        catalog_sequence: publication.sequence.get(),
+        publication_nonce: lower_hex(&publication.publication_nonce),
+        parent_head_revision: Some(lower_hex(&publication.parent_head_revision)),
+        catalog_root: RemoteCatalogRootReferenceWireV1 {
+            object_id: lower_hex(&root_object_id),
+            raw_bytes_len: u64::try_from(root_bytes.len())
+                .context("successor catalog root length does not fit u64")?,
+            binding: binding_wire_v1(&root_binding),
+            page_count: root.page_count,
+            entry_count,
+            entry_key_bytes,
+        },
+    };
+    let committed_head_bytes =
+        serde_json::to_vec(&committed_head).context("serializing committed catalog HEAD")?;
+    anyhow::ensure!(
+        u64::try_from(committed_head_bytes.len())
+            .ok()
+            .is_some_and(|len| len <= remote.max_catalog_head_object_bytes()),
+        "committed catalog HEAD exceeds the object bound"
+    );
+    let publishing_etag = mutable_head_etag_v1(&capability.publishing_head_binding)
+        .context("visible publishing HEAD has no usable ETag")?;
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let write_result = publication
+        .storage_authority
+        .operator
+        .write_with(&head_key, committed_head_bytes.clone())
+        .if_match(&publishing_etag)
+        .await;
+    let observed = read_raw_object_snapshot_v1(
+        publication.storage_authority.operator,
+        &head_key,
+        remote.max_catalog_head_object_bytes(),
+    )
+    .await
+    .with_context(|| format!("revalidating committed catalog HEAD: {head_key}"))?;
+    let exact_binding = match observed {
+        Some(RawObjectReadV1::Bound(snapshot)) => {
+            let (raw_bytes, _, binding) = snapshot.into_parts();
+            (raw_bytes == committed_head_bytes).then(|| registered_binding_from_raw_v1(binding))
+        }
+        None | Some(RawObjectReadV1::Unbound) => None,
+    };
+    let Some(committed_head_binding) = exact_binding else {
+        return match write_result {
+            Ok(_) => anyhow::bail!(
+                "committed catalog HEAD changed after successful finalization: {head_key}"
+            ),
+            Err(write_error) => Err(write_error).with_context(|| {
+                format!(
+                    "committed catalog HEAD compare-and-swap did not install exact bytes: {head_key}"
+                )
+            }),
+        };
+    };
+    anyhow::ensure!(
+        mutable_head_etag_v1(&committed_head_binding).is_some(),
+        "committed catalog HEAD has no usable exact ETag"
+    );
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    let head_revision = super::catalog_head_revision_v1(&committed_head_bytes);
+    Ok(PublishedCatalogSuccessorClosureV1 {
+        committed_head_bytes,
+        head_revision,
+        committed_head_binding,
+    })
+}
+
+/// Publish the complete immutable successor catalog and atomically replace the
+/// exact visible publishing fence with its canonical committed HEAD.
+///
+/// Every unchanged entry comes from the retained semantic predecessor; every
+/// changed entry comes from terminal applied evidence. Immutable page/root
+/// collisions and ambiguous HEAD writes are accepted only after exact bounded
+/// rereads. Failure retains the complete capability and applied prefix.
+pub(crate) async fn finalize_catalog_committed_head_v1<'a>(
+    applied: AppliedCatalogNamespaceMutationsV1<'a>,
+) -> Result<BoundCommittedCatalogSuccessorV1, FailedCatalogCommittedFinalizationV1<'a>> {
+    let published = match publish_catalog_successor_closure_v1(&applied).await {
+        Ok(published) => published,
+        Err(error) => return Err(FailedCatalogCommittedFinalizationV1 { applied, error }),
+    };
+    Ok(bind_committed_catalog_successor_v1(applied, published))
+}
+
+fn bind_committed_catalog_successor_v1(
+    applied: AppliedCatalogNamespaceMutationsV1<'_>,
+    published: PublishedCatalogSuccessorClosureV1,
+) -> BoundCommittedCatalogSuccessorV1 {
+    let AppliedCatalogNamespaceMutationsV1 {
+        capability,
+        applied: _,
+    } = applied;
+    let CatalogNamespaceMutationCapabilityV1 {
+        pending,
+        publishing_head_binding: _,
+    } = capability;
+    let BoundPendingCatalogControlV1 {
+        transition,
+        pending_receipt,
+    } = pending;
+    let PreparedCatalogControlTransitionV1 {
+        publication,
+        pending_revision,
+        publishing_head_reservation_fingerprint,
+        canonical_pending_control_record_bytes,
+        pending_control_record_fingerprint,
+        ..
+    } = transition;
+    debug_assert_eq!(
+        pending_receipt.publishing_head_reservation_fingerprint,
+        publishing_head_reservation_fingerprint
+    );
+    debug_assert_eq!(
+        pending_receipt.pending_control_record_fingerprint,
+        pending_control_record_fingerprint
+    );
+    BoundCommittedCatalogSuccessorV1 {
+        control_guard: publication.control_guard,
+        pending_revision,
+        publishing_head_reservation_fingerprint,
+        pending_control_record_fingerprint,
+        canonical_pending_control_record_bytes,
+        context: publication.context,
+        sequence: publication.sequence,
+        publication_nonce: publication.publication_nonce,
+        parent_head_revision: publication.parent_head_revision,
+        head_revision: published.head_revision,
+        committed_head_bytes: published.committed_head_bytes,
+        committed_head_binding: published.committed_head_binding,
+    }
+}
+
+enum CatalogCommittedRecoveryStateV1 {
+    Publishing,
+    Committed(PublishedCatalogSuccessorClosureV1),
+}
+
+async fn classify_catalog_committed_recovery_state_v1(
+    applied: &AppliedCatalogNamespaceMutationsV1<'_>,
+) -> AnyhowResult<CatalogCommittedRecoveryStateV1> {
+    let capability = &applied.capability;
+    let publication = &capability.pending.transition.publication;
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    anyhow::ensure!(
+        publication
+            .storage_authority
+            .conditional_write_receipt
+            .authorizes(
+                publication.storage_authority.operator,
+                &publication.context.remote_prefix,
+            )?,
+        "catalog committed recovery lost its exact accessor/prefix conditional-semantics authority"
+    );
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let observed = read_raw_object_snapshot_v1(
+        publication.storage_authority.operator,
+        &head_key,
+        remote.max_catalog_head_object_bytes(),
+    )
+    .await
+    .with_context(|| format!("reading catalog HEAD for committed recovery: {head_key}"))?;
+    let Some(RawObjectReadV1::Bound(head_snapshot)) = observed else {
+        anyhow::bail!("catalog HEAD is missing or unbound during committed recovery: {head_key}");
+    };
+    let (head_bytes, _, head_binding) = head_snapshot.into_parts();
+    let head_binding = registered_binding_from_raw_v1(head_binding);
+    if head_bytes
+        == capability
+            .pending
+            .transition
+            .canonical_publishing_head_bytes
+        && head_binding == capability.publishing_head_binding
+    {
+        return Ok(CatalogCommittedRecoveryStateV1::Publishing);
+    }
+
+    let head = serde_json::from_slice::<RemoteCatalogHeadWireV1>(&head_bytes)
+        .context("visible catalog recovery state is neither publishing nor a committed HEAD")?;
+    anyhow::ensure!(
+        serde_json::to_vec(&head).ok().as_deref() == Some(head_bytes.as_slice())
+            && head.version == CATALOG_SCHEMA_VERSION_V1
+            && head.context == publication.context.to_wire()
+            && head.catalog_sequence == publication.sequence.get()
+            && super::parse_lower_hex_32(&head.publication_nonce)
+                == Some(publication.publication_nonce)
+            && head
+                .parent_head_revision
+                .as_deref()
+                .and_then(super::parse_lower_hex_32)
+                == Some(publication.parent_head_revision)
+            && mutable_head_etag_v1(&head_binding).is_some(),
+        "visible committed catalog HEAD does not match the exact pending successor"
+    );
+    let expected_entries = complete_successor_catalog_entries_v1(applied)?;
+    let root_object_id = super::parse_lower_hex_32(&head.catalog_root.object_id)
+        .context("committed catalog root object ID is invalid")?;
+    anyhow::ensure!(
+        head.catalog_root.raw_bytes_len > 0
+            && head.catalog_root.raw_bytes_len <= remote.max_catalog_root_object_bytes()
+            && super::validate_binding_wire_v1(&head.catalog_root.binding).is_some(),
+        "committed catalog root reference is invalid"
+    );
+    let root_key = super::catalog_root_key_v1(
+        &publication.context.remote_prefix,
+        &head.catalog_root.object_id,
+    );
+    let root_snapshot = read_raw_object_snapshot_v1(
+        publication.storage_authority.operator,
+        &root_key,
+        remote.max_catalog_root_object_bytes(),
+    )
+    .await
+    .with_context(|| format!("reading committed catalog root during recovery: {root_key}"))?;
+    let Some(RawObjectReadV1::Bound(root_snapshot)) = root_snapshot else {
+        anyhow::bail!("committed catalog root is missing or unbound: {root_key}");
+    };
+    let (root_bytes, root_blake3, root_binding) = root_snapshot.into_parts();
+    let root_binding = registered_binding_from_raw_v1(root_binding);
+    anyhow::ensure!(
+        u64::try_from(root_bytes.len()).ok() == Some(head.catalog_root.raw_bytes_len)
+            && root_blake3 == blake3::hash(&root_bytes)
+            && super::catalog_root_object_id_v1(&root_bytes) == root_object_id
+            && binding_wire_v1(&root_binding) == head.catalog_root.binding,
+        "committed catalog root does not match its exact HEAD reference"
+    );
+    let root = serde_json::from_slice::<RemoteCatalogRootWireV1>(&root_bytes)
+        .context("committed catalog root is invalid")?;
+    anyhow::ensure!(
+        serde_json::to_vec(&root).ok().as_deref() == Some(root_bytes.as_slice())
+            && root.version == CATALOG_SCHEMA_VERSION_V1
+            && root.context == publication.context.to_wire()
+            && root.catalog_sequence == publication.sequence.get()
+            && super::parse_lower_hex_32(&root.publication_nonce)
+                == Some(publication.publication_nonce)
+            && root
+                .parent_head_revision
+                .as_deref()
+                .and_then(super::parse_lower_hex_32)
+                == Some(publication.parent_head_revision)
+            && root.page_count == u64::try_from(root.pages.len()).unwrap_or(u64::MAX)
+            && root.page_count == head.catalog_root.page_count
+            && root.page_count <= remote.max_catalog_pages()
+            && root.entry_count == head.catalog_root.entry_count
+            && root.entry_key_bytes == head.catalog_root.entry_key_bytes,
+        "committed catalog root lineage or totals are invalid"
+    );
+
+    let mut observed_entries = Vec::new();
+    let expected_capacity =
+        usize::try_from(root.entry_count).context("committed entry count does not fit usize")?;
+    observed_entries
+        .try_reserve(expected_capacity)
+        .context("reserving committed recovery entries")?;
+    let mut total_entry_count = 0_u64;
+    let mut total_entry_key_bytes = 0_u64;
+    for (ordinal, reference) in root.pages.iter().enumerate() {
+        let ordinal = u64::try_from(ordinal).context("catalog page ordinal does not fit u64")?;
+        let page_object_id = super::parse_lower_hex_32(&reference.object_id)
+            .context("committed catalog page object ID is invalid")?;
+        anyhow::ensure!(
+            reference.ordinal == ordinal
+                && reference.raw_bytes_len > 0
+                && reference.raw_bytes_len <= remote.max_catalog_page_object_bytes()
+                && reference.entry_count <= remote.max_catalog_entries_per_page()
+                && super::validate_binding_wire_v1(&reference.binding).is_some(),
+            "committed catalog page reference is invalid"
+        );
+        let page_key =
+            super::catalog_page_key_v1(&publication.context.remote_prefix, &reference.object_id);
+        let page_snapshot = read_raw_object_snapshot_v1(
+            publication.storage_authority.operator,
+            &page_key,
+            remote.max_catalog_page_object_bytes(),
+        )
+        .await
+        .with_context(|| format!("reading committed catalog page during recovery: {page_key}"))?;
+        let Some(RawObjectReadV1::Bound(page_snapshot)) = page_snapshot else {
+            anyhow::bail!("committed catalog page is missing or unbound: {page_key}");
+        };
+        let (page_bytes, page_blake3, page_binding) = page_snapshot.into_parts();
+        let page_binding = registered_binding_from_raw_v1(page_binding);
+        anyhow::ensure!(
+            u64::try_from(page_bytes.len()).ok() == Some(reference.raw_bytes_len)
+                && page_blake3 == blake3::hash(&page_bytes)
+                && super::catalog_page_object_id_v1(&page_bytes) == page_object_id
+                && binding_wire_v1(&page_binding) == reference.binding,
+            "committed catalog page does not match its exact root reference"
+        );
+        let page = serde_json::from_slice::<RemoteCatalogPageWireV1>(&page_bytes)
+            .context("committed catalog page is invalid")?;
+        let page_key_bytes = page.entries.iter().try_fold(0_u64, |total, entry| {
+            total
+                .checked_add(
+                    u64::try_from(entry.object_key.len())
+                        .context("catalog recovery entry key length does not fit u64")?,
+                )
+                .context("catalog recovery page key-byte total overflow")
+        })?;
+        anyhow::ensure!(
+            serde_json::to_vec(&page).ok().as_deref() == Some(page_bytes.as_slice())
+                && page.version == CATALOG_SCHEMA_VERSION_V1
+                && page.context == publication.context.to_wire()
+                && page.catalog_sequence == publication.sequence.get()
+                && super::parse_lower_hex_32(&page.publication_nonce)
+                    == Some(publication.publication_nonce)
+                && page.ordinal == ordinal
+                && page.entry_count == u64::try_from(page.entries.len()).unwrap_or(u64::MAX)
+                && page.entry_count == reference.entry_count
+                && page.entry_key_bytes == page_key_bytes
+                && page.entry_key_bytes == reference.entry_key_bytes
+                && page
+                    .entries
+                    .windows(2)
+                    .all(|entries| { entries[0].object_key < entries[1].object_key })
+                && page.entries.iter().all(|entry| {
+                    validate_catalog_object_route_v1(
+                        &publication.context.remote_prefix,
+                        entry.kind,
+                        &entry.object_key,
+                    ) && validate_entry_size_v1(entry.kind, entry.raw_bytes_len)
+                        && super::parse_lower_hex_32(&entry.raw_blake3).is_some()
+                        && super::validate_binding_wire_v1(&entry.binding).is_some()
+                }),
+            "committed catalog page lineage, order, or totals are invalid"
+        );
+        total_entry_count = total_entry_count
+            .checked_add(page.entry_count)
+            .context("committed catalog entry count overflow")?;
+        total_entry_key_bytes = total_entry_key_bytes
+            .checked_add(page.entry_key_bytes)
+            .context("committed catalog entry-key total overflow")?;
+        observed_entries.extend(page.entries);
+    }
+    anyhow::ensure!(
+        total_entry_count == root.entry_count
+            && total_entry_key_bytes == root.entry_key_bytes
+            && observed_entries == expected_entries,
+        "committed catalog closure does not equal the complete applied successor inventory"
+    );
+
+    for entry in &expected_entries {
+        let snapshot = read_raw_object_snapshot_v1(
+            publication.storage_authority.operator,
+            &entry.object_key,
+            catalog_named_object_max_bytes_v1(entry.kind),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "revalidating committed catalog named object: {}",
+                entry.object_key
+            )
+        })?;
+        let Some(RawObjectReadV1::Bound(snapshot)) = snapshot else {
+            anyhow::bail!(
+                "committed catalog named object is missing or unbound: {}",
+                entry.object_key
+            );
+        };
+        let (raw_bytes, raw_blake3, binding) = snapshot.into_parts();
+        anyhow::ensure!(
+            u64::try_from(raw_bytes.len()).ok() == Some(entry.raw_bytes_len)
+                && lower_hex(raw_blake3.as_bytes()) == entry.raw_blake3
+                && binding_wire_v1(&registered_binding_from_raw_v1(binding)) == entry.binding,
+            "committed catalog named object changed during recovery: {}",
+            entry.object_key
+        );
+    }
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    Ok(CatalogCommittedRecoveryStateV1::Committed(
+        PublishedCatalogSuccessorClosureV1 {
+            head_revision: super::catalog_head_revision_v1(&head_bytes),
+            committed_head_bytes: head_bytes,
+            committed_head_binding: head_binding,
+        },
+    ))
+}
+
+/// Recover a failed finalization without LIST or best-effort guessing.
+///
+/// An exact still-publishing HEAD resumes idempotent page/root publication and
+/// CAS. An exact committed successor is reconstructed through every immutable
+/// root/page reference and every named-object binding before being accepted.
+/// Any third state retains the complete applied evidence and fails closed.
+pub(crate) async fn recover_failed_catalog_committed_finalization_v1<'a>(
+    failure: FailedCatalogCommittedFinalizationV1<'a>,
+) -> Result<BoundCommittedCatalogSuccessorV1, FailedCatalogCommittedFinalizationV1<'a>> {
+    let FailedCatalogCommittedFinalizationV1 { applied, error: _ } = failure;
+    match classify_catalog_committed_recovery_state_v1(&applied).await {
+        Ok(CatalogCommittedRecoveryStateV1::Publishing) => {
+            finalize_catalog_committed_head_v1(applied).await
+        }
+        Ok(CatalogCommittedRecoveryStateV1::Committed(published)) => {
+            Ok(bind_committed_catalog_successor_v1(applied, published))
+        }
+        Err(error) => Err(FailedCatalogCommittedFinalizationV1 { applied, error }),
+    }
+}
+
+/// Opaque proof that the exact reserved successor became the canonical
+/// committed `HEAD` while retaining the live control acquisition.
 pub(crate) struct BoundCommittedCatalogSuccessorV1 {
     control_guard: HeldReadyCatalogControlGuardV1,
     pending_revision: CatalogControlAuthorityRevisionV1,
     publishing_head_reservation_fingerprint: [u8; 32],
     pending_control_record_fingerprint: [u8; 32],
+    canonical_pending_control_record_bytes: Vec<u8>,
     context: CatalogAuthorityContextV1,
     sequence: NonZeroU64,
     publication_nonce: [u8; 32],
     parent_head_revision: [u8; 32],
     head_revision: [u8; 32],
     committed_head_bytes: Vec<u8>,
+    committed_head_binding: RegisteredRootRemoteObjectBindingV1,
 }
 
 /// Opaque receipt for the external `PublicationPending -> Ready(n+1)` CAS.
@@ -3037,6 +3947,56 @@ pub(crate) struct TrustedCatalogHighWaterAdvanceReceiptV1 {
     successor: CatalogHighWaterPointV1,
     ready_revision: CatalogControlAuthorityRevisionV1,
     ready_control_record_fingerprint: [u8; 32],
+}
+
+struct CatalogControlReadyAdvanceRequestV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    publishing_head_reservation_fingerprint: [u8; 32],
+    pending_control_record_fingerprint: [u8; 32],
+    canonical_pending_control_record_bytes: Vec<u8>,
+    successor: CatalogHighWaterPointV1,
+    ready_revision: CatalogControlAuthorityRevisionV1,
+    canonical_ready_control_record_bytes: Vec<u8>,
+    ready_control_record_fingerprint: [u8; 32],
+}
+
+type CatalogControlReadyAdvanceFutureV1<'a> = Pin<
+    Box<dyn Future<Output = AnyhowResult<TrustedCatalogHighWaterAdvanceReceiptV1>> + Send + 'a>,
+>;
+
+/// Failed external high-water advance retaining the exact committed successor
+/// and live lease for an authenticated retry.
+pub(crate) struct FailedCatalogHighWaterAdvanceV1 {
+    committed: BoundCommittedCatalogSuccessorV1,
+    ready_revision_fingerprint: [u8; 32],
+    error: anyhow::Error,
+}
+
+impl std::fmt::Debug for FailedCatalogHighWaterAdvanceV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FailedCatalogHighWaterAdvanceV1")
+            .field("sequence", &self.committed.sequence)
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for FailedCatalogHighWaterAdvanceV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if formatter.alternate() {
+            write!(formatter, "{:#}", self.error)
+        } else {
+            std::fmt::Display::fmt(&self.error, formatter)
+        }
+    }
+}
+
+impl std::error::Error for FailedCatalogHighWaterAdvanceV1 {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error.as_ref())
+    }
 }
 
 /// Terminal proof that one exact successor advanced the monotonic high-water.
@@ -3534,15 +4494,12 @@ pub(crate) fn match_catalog_publication_pending_receipt_v1<'a>(
     })
 }
 
-/// Bind an exact committed successor to the external monotonic
-/// `PublicationPending -> Ready(n+1)` advance. This returns terminal evidence,
-/// never a reusable exact-current guard or action capability.
-pub(crate) fn match_catalog_high_water_advance_v1(
-    committed: BoundCommittedCatalogSuccessorV1,
-    receipt: TrustedCatalogHighWaterAdvanceReceiptV1,
-) -> Result<AdvancedCatalogHighWaterV1, CatalogPublicationContractErrorV1> {
+fn validate_catalog_high_water_advance_receipt_v1(
+    committed: &BoundCommittedCatalogSuccessorV1,
+    receipt: &TrustedCatalogHighWaterAdvanceReceiptV1,
+) -> Result<(), CatalogPublicationContractErrorV1> {
     require_held_control_lease_live_v1(&committed.control_guard)?;
-    let control_binding = committed.control_guard.high_water.binding.clone();
+    let control_binding = &committed.control_guard.high_water.binding;
     let expected_pending_generation = committed
         .control_guard
         .high_water
@@ -3576,7 +4533,7 @@ pub(crate) fn match_catalog_high_water_advance_v1(
         publication_nonce: committed.publication_nonce,
     };
     let committed_revision = super::catalog_head_revision_v1(&committed.committed_head_bytes);
-    let ready_bytes = canonical_ready_control_record_bytes_v1(&committed, receipt.ready_revision);
+    let ready_bytes = canonical_ready_control_record_bytes_v1(committed, receipt.ready_revision);
     let ready_record_fingerprint =
         super::domain_object_id_v1(CATALOG_CONTROL_RECORD_DOMAIN_V1, &ready_bytes);
     if committed.context != control_binding.context
@@ -3585,6 +4542,10 @@ pub(crate) fn match_catalog_high_water_advance_v1(
         || committed.pending_revision.fingerprint == control_binding.ready_revision.fingerprint
         || committed.publishing_head_reservation_fingerprint == [0; 32]
         || committed.pending_control_record_fingerprint == [0; 32]
+        || super::domain_object_id_v1(
+            CATALOG_CONTROL_RECORD_DOMAIN_V1,
+            &committed.canonical_pending_control_record_bytes,
+        ) != committed.pending_control_record_fingerprint
         || committed.sequence != expected_successor_sequence
         || committed.parent_head_revision != control_binding.current.head_revision
         || committed.publication_nonce == [0; 32]
@@ -3592,7 +4553,8 @@ pub(crate) fn match_catalog_high_water_advance_v1(
         || committed.head_revision == [0; 32]
         || committed.head_revision == control_binding.current.head_revision
         || committed_revision != committed.head_revision
-        || receipt.control_binding != control_binding
+        || mutable_head_etag_v1(&committed.committed_head_binding).is_none()
+        || receipt.control_binding != *control_binding
         || receipt.pending_revision != committed.pending_revision
         || receipt.publishing_head_reservation_fingerprint
             != committed.publishing_head_reservation_fingerprint
@@ -3609,7 +4571,23 @@ pub(crate) fn match_catalog_high_water_advance_v1(
     {
         return Err(CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch);
     }
-    Ok(AdvancedCatalogHighWaterV1 {
+    Ok(())
+}
+
+fn finish_catalog_high_water_advance_v1(
+    committed: BoundCommittedCatalogSuccessorV1,
+    receipt: TrustedCatalogHighWaterAdvanceReceiptV1,
+) -> AdvancedCatalogHighWaterV1 {
+    let control_binding = committed.control_guard.high_water.binding.clone();
+    let exact_successor = CatalogHighWaterPointV1 {
+        sequence: committed.sequence,
+        head_revision: committed.head_revision,
+        publication_nonce: committed.publication_nonce,
+    };
+    let ready_bytes = canonical_ready_control_record_bytes_v1(&committed, receipt.ready_revision);
+    let ready_record_fingerprint =
+        super::domain_object_id_v1(CATALOG_CONTROL_RECORD_DOMAIN_V1, &ready_bytes);
+    AdvancedCatalogHighWaterV1 {
         context: control_binding.context,
         bootstrap: control_binding.bootstrap,
         successor: exact_successor,
@@ -3618,7 +4596,118 @@ pub(crate) fn match_catalog_high_water_advance_v1(
         ready_revision: receipt.ready_revision,
         ready_control_record_fingerprint: ready_record_fingerprint,
         retained_control_lease: committed.control_guard.all_writers.retained_control_lease,
-    })
+    }
+}
+
+/// Bind an exact committed successor to an authenticated external monotonic
+/// `PublicationPending -> Ready(n+1)` receipt. This returns terminal evidence,
+/// never a reusable exact-current guard or action capability.
+pub(crate) fn match_catalog_high_water_advance_v1(
+    committed: BoundCommittedCatalogSuccessorV1,
+    receipt: TrustedCatalogHighWaterAdvanceReceiptV1,
+) -> Result<AdvancedCatalogHighWaterV1, CatalogPublicationContractErrorV1> {
+    validate_catalog_high_water_advance_receipt_v1(&committed, &receipt)?;
+    Ok(finish_catalog_high_water_advance_v1(committed, receipt))
+}
+
+/// Ask the retained authenticated control backend to atomically replace the
+/// exact pending record with canonical `Ready(n+1)` bytes.
+///
+/// The request is derived entirely from the committed successor and retained
+/// control acquisition. The backend receipt is revalidated before the
+/// committed capability is consumed. Failure retains that capability for an
+/// authenticated retry; success is terminal and cannot mint a fresh guard.
+pub(crate) async fn advance_catalog_high_water_v1(
+    committed: BoundCommittedCatalogSuccessorV1,
+    ready_revision_fingerprint: [u8; 32],
+) -> Result<AdvancedCatalogHighWaterV1, FailedCatalogHighWaterAdvanceV1> {
+    let result = async {
+        require_held_control_lease_live_v1(&committed.control_guard)
+            .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+        let ready_generation = committed
+            .pending_revision
+            .generation
+            .get()
+            .checked_add(1)
+            .and_then(NonZeroU64::new)
+            .context("catalog control generation overflow")?;
+        let ready_revision = CatalogControlAuthorityRevisionV1 {
+            generation: ready_generation,
+            fingerprint: ready_revision_fingerprint,
+        };
+        let successor = CatalogHighWaterPointV1 {
+            sequence: committed.sequence,
+            head_revision: committed.head_revision,
+            publication_nonce: committed.publication_nonce,
+        };
+        let canonical_ready_control_record_bytes =
+            canonical_ready_control_record_bytes_v1(&committed, ready_revision);
+        let ready_control_record_fingerprint = super::domain_object_id_v1(
+            CATALOG_CONTROL_RECORD_DOMAIN_V1,
+            &canonical_ready_control_record_bytes,
+        );
+        let preview = TrustedCatalogHighWaterAdvanceReceiptV1 {
+            control_binding: committed.control_guard.high_water.binding.clone(),
+            pending_revision: committed.pending_revision,
+            publishing_head_reservation_fingerprint: committed
+                .publishing_head_reservation_fingerprint,
+            pending_control_record_fingerprint: committed.pending_control_record_fingerprint,
+            successor,
+            ready_revision,
+            ready_control_record_fingerprint,
+        };
+        validate_catalog_high_water_advance_receipt_v1(&committed, &preview)
+            .map_err(|error| anyhow::anyhow!("invalid high-water proposal: {error:?}"))?;
+        let request = CatalogControlReadyAdvanceRequestV1 {
+            control_binding: committed.control_guard.high_water.binding.clone(),
+            pending_revision: committed.pending_revision,
+            publishing_head_reservation_fingerprint: committed
+                .publishing_head_reservation_fingerprint,
+            pending_control_record_fingerprint: committed.pending_control_record_fingerprint,
+            canonical_pending_control_record_bytes: committed
+                .canonical_pending_control_record_bytes
+                .clone(),
+            successor,
+            ready_revision,
+            canonical_ready_control_record_bytes,
+            ready_control_record_fingerprint,
+        };
+        let receipt = committed
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .liveness
+            .compare_and_swap_ready_v1(request)
+            .await
+            .context("advancing external catalog high-water to Ready")?;
+        require_held_control_lease_live_v1(&committed.control_guard)
+            .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+        validate_catalog_high_water_advance_receipt_v1(&committed, &receipt)
+            .map_err(|error| anyhow::anyhow!("external high-water receipt mismatch: {error:?}"))?;
+        Ok::<_, anyhow::Error>(receipt)
+    }
+    .await;
+    match result {
+        Ok(receipt) => Ok(finish_catalog_high_water_advance_v1(committed, receipt)),
+        Err(error) => Err(FailedCatalogHighWaterAdvanceV1 {
+            committed,
+            ready_revision_fingerprint,
+            error,
+        }),
+    }
+}
+
+/// Retry an ambiguous or rejected external high-water CAS with the exact same
+/// committed successor and ready revision fingerprint.
+pub(crate) async fn recover_failed_catalog_high_water_advance_v1(
+    failure: FailedCatalogHighWaterAdvanceV1,
+) -> Result<AdvancedCatalogHighWaterV1, FailedCatalogHighWaterAdvanceV1> {
+    let FailedCatalogHighWaterAdvanceV1 {
+        committed,
+        ready_revision_fingerprint,
+        error: _,
+    } = failure;
+    advance_catalog_high_water_v1(committed, ready_revision_fingerprint).await
 }
 
 pub(super) fn classify_publishing_head_v1(
@@ -3826,6 +4915,36 @@ mod tests {
         fn is_live_v1(&self) -> bool {
             self.live.load(std::sync::atomic::Ordering::SeqCst)
         }
+
+        fn compare_and_swap_ready_v1<'a>(
+            &'a self,
+            request: CatalogControlReadyAdvanceRequestV1,
+        ) -> CatalogControlReadyAdvanceFutureV1<'a> {
+            Box::pin(async move {
+                anyhow::ensure!(self.is_live_v1(), "test catalog control lease is not live");
+                anyhow::ensure!(
+                    super::super::domain_object_id_v1(
+                        CATALOG_CONTROL_RECORD_DOMAIN_V1,
+                        &request.canonical_pending_control_record_bytes,
+                    ) == request.pending_control_record_fingerprint
+                        && super::super::domain_object_id_v1(
+                            CATALOG_CONTROL_RECORD_DOMAIN_V1,
+                            &request.canonical_ready_control_record_bytes,
+                        ) == request.ready_control_record_fingerprint,
+                    "test control CAS request contains an invalid canonical record"
+                );
+                Ok(TrustedCatalogHighWaterAdvanceReceiptV1 {
+                    control_binding: request.control_binding,
+                    pending_revision: request.pending_revision,
+                    publishing_head_reservation_fingerprint: request
+                        .publishing_head_reservation_fingerprint,
+                    pending_control_record_fingerprint: request.pending_control_record_fingerprint,
+                    successor: request.successor,
+                    ready_revision: request.ready_revision,
+                    ready_control_record_fingerprint: request.ready_control_record_fingerprint,
+                })
+            })
+        }
     }
 
     fn test_spec() -> RootSpecV1Config {
@@ -3984,11 +5103,6 @@ mod tests {
         Into<Vec<crate::reconcile::ReconcileAction>>
     );
     static_assertions::assert_not_impl_any!(
-        TrustedCatalogPublishingHeadInstalledReceiptV1: Clone,
-        serde::Serialize,
-        Default
-    );
-    static_assertions::assert_not_impl_any!(
         CatalogNamespaceMutationCapabilityV1<'static>: Clone,
         serde::Serialize,
         Default,
@@ -3996,7 +5110,7 @@ mod tests {
         Into<Vec<crate::reconcile::ReconcileAction>>
     );
     static_assertions::assert_not_impl_any!(
-        CatalogNamespaceMutationCapabilityBindFailureV1<'static>: Clone,
+        CatalogPublishingHeadInstallFailureV1<'static>: Clone,
         serde::Serialize,
         Default,
         Into<CatalogNamespaceMutationCapabilityV1<'static>>,
@@ -4021,6 +5135,15 @@ mod tests {
         Into<Vec<crate::reconcile::ReconcileAction>>
     );
     static_assertions::assert_not_impl_any!(
+        FailedCatalogCommittedFinalizationV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<AppliedCatalogNamespaceMutationsV1<'static>>,
+        Into<BoundCommittedCatalogSuccessorV1>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
         BoundCommittedCatalogSuccessorV1: Clone,
         serde::Serialize,
         Default,
@@ -4031,6 +5154,15 @@ mod tests {
         TrustedCatalogHighWaterAdvanceReceiptV1: Clone,
         serde::Serialize,
         Default
+    );
+    static_assertions::assert_not_impl_any!(
+        FailedCatalogHighWaterAdvanceV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundCommittedCatalogSuccessorV1>,
+        Into<AdvancedCatalogHighWaterV1>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
     );
     static_assertions::assert_not_impl_any!(
         AdvancedCatalogHighWaterV1: Clone,
@@ -4241,6 +5373,7 @@ mod tests {
                     etag: "journal-etag".to_owned(),
                 },
                 successor_payloads: Vec::new(),
+                predecessor_entries: Vec::new(),
             },
         )
     }
@@ -4369,39 +5502,6 @@ mod tests {
         match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap()
     }
 
-    async fn install_test_publishing_head_receipt(
-        pending: &BoundPendingCatalogControlV1<'_>,
-    ) -> TrustedCatalogPublishingHeadInstalledReceiptV1 {
-        let publication = &pending.transition.publication;
-        let head_key = super::super::catalog_head_key_v1(&publication.context.remote_prefix);
-        publication
-            .storage_authority
-            .operator
-            .write(
-                &head_key,
-                pending.transition.canonical_publishing_head_bytes.clone(),
-            )
-            .await
-            .unwrap();
-        let observed = read_raw_object_snapshot_v1(
-            publication.storage_authority.operator,
-            &head_key,
-            RegisteredRootPlanContractV1::strict_v1()
-                .remote_contract()
-                .max_catalog_head_object_bytes(),
-        )
-        .await
-        .unwrap()
-        .unwrap();
-        let RawObjectReadV1::Bound(snapshot) = observed else {
-            panic!("test publishing HEAD must carry an exact binding");
-        };
-        let (_, _, binding) = snapshot.into_parts();
-        TrustedCatalogPublishingHeadInstalledReceiptV1 {
-            publishing_head_binding: registered_binding_from_raw_v1(binding),
-        }
-    }
-
     fn committed_successor(
         pending: BoundPendingCatalogControlV1<'_>,
     ) -> BoundCommittedCatalogSuccessorV1 {
@@ -4413,18 +5513,26 @@ mod tests {
             .publishing_head_reservation_fingerprint;
         let pending_control_record_fingerprint =
             pending.pending_receipt.pending_control_record_fingerprint;
+        let canonical_pending_control_record_bytes = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
         let publication = pending.transition.publication;
         BoundCommittedCatalogSuccessorV1 {
             control_guard: publication.control_guard,
             pending_revision,
             publishing_head_reservation_fingerprint,
             pending_control_record_fingerprint,
+            canonical_pending_control_record_bytes,
             context: publication.context,
             sequence: publication.sequence,
             publication_nonce: publication.publication_nonce,
             parent_head_revision: publication.parent_head_revision,
             head_revision,
             committed_head_bytes,
+            committed_head_binding: RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "committed-head-etag".to_owned(),
+            },
         }
     }
 
@@ -4629,10 +5737,7 @@ mod tests {
             .write("roots/index/added.txt", successor_bytes.clone())
             .await
             .unwrap();
-        let receipt = install_test_publishing_head_receipt(&pending).await;
-        let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
-            .await
-            .unwrap();
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
         let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
             .await
             .unwrap();
@@ -4668,6 +5773,89 @@ mod tests {
                 .get(),
             2
         );
+    }
+
+    #[tokio::test]
+    async fn publishing_head_cas_is_exact_replay_safe_and_preserves_competitors() {
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            let expected_bytes = pending.transition.canonical_publishing_head_bytes.clone();
+            let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+
+            assert_eq!(
+                fixture
+                    .operator()
+                    .read("roots/.tcfs-catalog/v1/head")
+                    .await
+                    .unwrap()
+                    .to_vec(),
+                expected_bytes
+            );
+            assert!(mutable_head_etag_v1(&capability.publishing_head_binding).is_some());
+        }
+
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            let expected_bytes = pending.transition.canonical_publishing_head_bytes.clone();
+            let expected_parent_etag = pending
+                .transition
+                .publication
+                .expected_parent_head_etag
+                .clone();
+            fixture
+                .operator()
+                .write_with("roots/.tcfs-catalog/v1/head", expected_bytes)
+                .if_match(&expected_parent_etag)
+                .await
+                .unwrap();
+
+            let capability = install_catalog_publishing_head_v1(pending)
+                .await
+                .expect("an ambiguous exact replay must recover by bounded reread");
+            assert!(mutable_head_etag_v1(&capability.publishing_head_binding).is_some());
+        }
+
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            fixture
+                .operator()
+                .write("roots/.tcfs-catalog/v1/head", b"competing head".to_vec())
+                .await
+                .unwrap();
+
+            let error = install_catalog_publishing_head_v1(pending)
+                .await
+                .expect_err("a stale predecessor must not overwrite a competing HEAD");
+            assert_eq!(
+                error.pending.transition.publication.sequence.get(),
+                2,
+                "failure must retain the exact pending authority"
+            );
+            assert_eq!(
+                fixture
+                    .operator()
+                    .read("roots/.tcfs-catalog/v1/head")
+                    .await
+                    .unwrap()
+                    .to_vec(),
+                b"competing head"
+            );
+        }
     }
 
     #[tokio::test]
@@ -4772,10 +5960,7 @@ mod tests {
         let transition = prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap();
         let receipt = pending_receipt(&transition);
         let pending = match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap();
-        let receipt = install_test_publishing_head_receipt(&pending).await;
-        let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
-            .await
-            .unwrap();
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
         let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
             .await
             .unwrap();
@@ -4815,6 +6000,225 @@ mod tests {
                 .to_vec(),
             manifest_bytes
         );
+        let committed = finalize_catalog_committed_head_v1(applied).await.unwrap();
+        assert_eq!(committed.sequence.get(), 2);
+        let reread = read_semantically_bound_remote_catalog_corpus_v1(
+            fixture.operator(),
+            &test_selected(),
+            fixture.receipt(),
+        )
+        .await
+        .unwrap();
+        let StrictSemanticallyBoundRemoteCatalogReadV1::Verified(reread) = reread else {
+            panic!("all-kind successor catalog must pass the production semantic reader");
+        };
+        assert_eq!(reread.index_object_count(), 1);
+        assert_eq!(reread.reservation_count(), 1);
+        assert_eq!(reread.manifest_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn committed_finalization_publishes_a_complete_readable_successor_catalog() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .unwrap();
+        let committed = finalize_catalog_committed_head_v1(applied).await.unwrap();
+
+        assert_eq!(committed.sequence.get(), 2);
+        assert_eq!(
+            committed.head_revision,
+            super::super::catalog_head_revision_v1(&committed.committed_head_bytes)
+        );
+        assert!(mutable_head_etag_v1(&committed.committed_head_binding).is_some());
+        let head =
+            serde_json::from_slice::<RemoteCatalogHeadWireV1>(&committed.committed_head_bytes)
+                .unwrap();
+        assert_eq!(head.catalog_sequence, 2);
+        assert_eq!(
+            head.parent_head_revision,
+            Some(lower_hex(&observed.head_revision))
+        );
+        assert_eq!(head.catalog_root.entry_count, 2);
+
+        let reread = read_semantically_bound_remote_catalog_corpus_v1(
+            fixture.operator(),
+            &test_selected(),
+            fixture.receipt(),
+        )
+        .await
+        .unwrap();
+        let StrictSemanticallyBoundRemoteCatalogReadV1::Verified(reread) = reread else {
+            panic!("committed successor catalog must pass the production semantic reader");
+        };
+        assert_eq!(reread.catalog_sequence().get(), 2);
+        assert_eq!(reread.index_object_count(), 2);
+        assert_eq!(reread.reservation_count(), 0);
+        assert_eq!(reread.manifest_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn committed_finalization_retains_evidence_on_head_drift_and_lease_loss() {
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+            let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+                .await
+                .unwrap();
+            fixture
+                .operator()
+                .write(
+                    "roots/.tcfs-catalog/v1/head",
+                    b"competing final head".to_vec(),
+                )
+                .await
+                .unwrap();
+
+            let failure = match finalize_catalog_committed_head_v1(applied).await {
+                Err(failure) => failure,
+                Ok(_) => panic!("visible HEAD drift must stop committed finalization"),
+            };
+            assert_eq!(failure.applied.applied.len(), 2);
+            assert!(failure
+                .applied
+                .capability
+                .pending
+                .transition
+                .publication
+                .control_guard
+                .all_writers
+                .retained_control_lease
+                .is_live_v1());
+            assert!(format!("{failure:#}").contains("publishing HEAD changed"));
+        }
+
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+            let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+                .await
+                .unwrap();
+            applied
+                .capability
+                .pending
+                .transition
+                .publication
+                .control_guard
+                .all_writers
+                .retained_control_lease
+                .test_live
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+
+            let failure = match finalize_catalog_committed_head_v1(applied).await {
+                Err(failure) => failure,
+                Ok(_) => panic!("lost backend lease must stop committed finalization"),
+            };
+            assert_eq!(failure.applied.applied.len(), 2);
+            assert!(format!("{failure:#}").contains("control lease is not live"));
+        }
+    }
+
+    #[tokio::test]
+    async fn recovery_replays_partial_namespace_and_reconstructs_committed_closure() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        let (first_kind, first_key, first_bytes, first_blake3) = {
+            let first_payload = &capability
+                .pending
+                .transition
+                .publication
+                .mutation_journal
+                .successor_payloads[0];
+            (
+                first_payload.kind,
+                first_payload.object_key.clone(),
+                first_payload.raw_bytes.clone(),
+                first_payload.raw_blake3,
+            )
+        };
+        fixture
+            .operator()
+            .write(&first_key, first_bytes.clone())
+            .await
+            .unwrap();
+        let first_binding =
+            read_exact_catalog_successor_v1(&capability, first_kind, &first_key, &first_bytes)
+                .await
+                .unwrap();
+        let failure = FailedCatalogNamespaceMutationsV1 {
+            capability,
+            applied: vec![AppliedCatalogNamespaceObjectV1 {
+                kind: first_kind,
+                object_key: first_key,
+                raw_blake3: first_blake3,
+                binding: first_binding,
+            }],
+            error: anyhow::anyhow!("simulated crash after the first canonical mutation"),
+        };
+        let applied = recover_failed_catalog_namespace_mutations_v1(failure)
+            .await
+            .unwrap();
+        assert_eq!(applied.applied.len(), 2);
+
+        let published = publish_catalog_successor_closure_v1(&applied)
+            .await
+            .unwrap();
+        assert_eq!(
+            fixture
+                .operator()
+                .read("roots/.tcfs-catalog/v1/head")
+                .await
+                .unwrap()
+                .to_vec(),
+            published.committed_head_bytes
+        );
+        let failure = FailedCatalogCommittedFinalizationV1 {
+            applied,
+            error: anyhow::anyhow!("simulated crash after committed HEAD CAS"),
+        };
+        let committed = recover_failed_catalog_committed_finalization_v1(failure)
+            .await
+            .unwrap();
+        assert_eq!(committed.sequence.get(), 2);
+        assert_eq!(committed.head_revision, published.head_revision);
+        assert_eq!(
+            committed.committed_head_binding,
+            published.committed_head_binding
+        );
+
+        let reread = read_semantically_bound_remote_catalog_corpus_v1(
+            fixture.operator(),
+            &test_selected(),
+            fixture.receipt(),
+        )
+        .await
+        .unwrap();
+        let StrictSemanticallyBoundRemoteCatalogReadV1::Verified(reread) = reread else {
+            panic!("recovered committed successor must pass the production semantic reader");
+        };
+        assert_eq!(reread.catalog_sequence().get(), 2);
+        assert_eq!(reread.index_object_count(), 2);
     }
 
     #[tokio::test]
@@ -4826,7 +6230,6 @@ mod tests {
                 )])
                 .await;
             let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
-            let receipt = install_test_publishing_head_receipt(&pending).await;
             pending
                 .transition
                 .publication
@@ -4835,10 +6238,19 @@ mod tests {
                 .retained_control_lease
                 .test_live
                 .store(false, std::sync::atomic::Ordering::SeqCst);
-            let error = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
+            let error = install_catalog_publishing_head_v1(pending)
                 .await
-                .expect_err("a lost backend lease must not mint a writer capability");
+                .expect_err("a lost backend lease must not install publishing HEAD");
             assert!(error.to_string().contains("control lease is not live"));
+            assert_eq!(
+                fixture
+                    .operator()
+                    .read("roots/.tcfs-catalog/v1/head")
+                    .await
+                    .unwrap()
+                    .to_vec(),
+                observed.committed_head_bytes
+            );
         }
 
         {
@@ -4848,10 +6260,7 @@ mod tests {
                 )])
                 .await;
             let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
-            let receipt = install_test_publishing_head_receipt(&pending).await;
-            let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
-                .await
-                .unwrap();
+            let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
             capability
                 .pending
                 .transition
@@ -4879,10 +6288,7 @@ mod tests {
                 )])
                 .await;
             let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
-            let receipt = install_test_publishing_head_receipt(&pending).await;
-            let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
-                .await
-                .unwrap();
+            let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
             fixture
                 .operator()
                 .write(
@@ -4915,10 +6321,7 @@ mod tests {
                 .write("roots/index/added.txt", b"wrong collision".to_vec())
                 .await
                 .unwrap();
-            let receipt = install_test_publishing_head_receipt(&pending).await;
-            let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
-                .await
-                .unwrap();
+            let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
             let error = apply_authoritative_catalog_namespace_mutations_v1(capability)
                 .await
                 .expect_err("a different create collision must fail closed");
@@ -6005,6 +7408,48 @@ mod tests {
             match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap_err(),
             CatalogPublicationContractErrorV1::ControlTransitionMismatch
         );
+    }
+
+    #[tokio::test]
+    async fn retained_control_backend_advances_only_the_committed_successor() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .unwrap();
+        let committed = finalize_catalog_committed_head_v1(applied).await.unwrap();
+        let advanced = advance_catalog_high_water_v1(committed, [0xad; 32])
+            .await
+            .unwrap();
+
+        assert_eq!(advanced.successor.sequence.get(), 2);
+        assert_eq!(advanced.ready_revision.generation.get(), 9);
+        assert_eq!(advanced.ready_revision.fingerprint, [0xad; 32]);
+        assert!(advanced.retained_control_lease.is_live_v1());
+
+        let committed = committed_successor(bound_pending(&fixture, &observed));
+        let failure = match advance_catalog_high_water_v1(committed, [0; 32]).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("zero ready revision must not reach the control backend"),
+        };
+        assert_eq!(failure.committed.sequence.get(), 2);
+        assert_eq!(failure.ready_revision_fingerprint, [0; 32]);
+        assert!(failure
+            .committed
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .is_live_v1());
+        let failure = match recover_failed_catalog_high_water_advance_v1(failure).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("invalid high-water proposal must stay fail-closed on recovery"),
+        };
+        assert_eq!(failure.committed.sequence.get(), 2);
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -19,9 +19,13 @@
 //! corpus, proves create-key absence through the held accessor, reconstructs
 //! successor semantics, and publishes exact immutable payloads plus an
 //! authoritative journal. A separately namespaced diagnostic draft remains
-//! non-authoritative and cannot convert into that journal. This module still
-//! cannot mint authority, write a live `HEAD`, mutate the live namespace,
-//! produce a plan digest, or authorize an action.
+//! non-authoritative and cannot convert into that journal. The namespace
+//! mutation gateway accepts only the complete authoritative journal after an
+//! exact visible publishing-HEAD receipt and rechecks a retained backend lease
+//! before and after each conditional write. That receipt and lease still have
+//! no production constructors, so this module cannot mint production
+//! authority, write a live `HEAD`, reach a live namespace mutation, produce a
+//! plan digest, or authorize an action.
 
 use std::collections::BTreeMap;
 use std::num::NonZeroU64;
@@ -198,6 +202,7 @@ pub(crate) enum CatalogPublicationContractErrorV1 {
     MutationPredecessorKindMismatch,
     MutationAbsenceMismatch,
     MutationAbsenceStale,
+    ControlLeaseNotLive,
     InvalidSuccessorPayload,
     InvalidSuccessorClosure,
     InvalidMutationJournal(InvalidCatalogMutationJournalReasonV1),
@@ -287,6 +292,37 @@ struct CatalogControlAuthorityRevisionV1 {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct NonSecretLeasePublicFingerprintV1([u8; 32]);
 
+/// Non-cloneable retained backend lease for one exact control acquisition.
+///
+/// The public fingerprint serialized into catalog/control records is only a
+/// correlation identifier. This value is the separate live backend handle.
+/// There is deliberately no production constructor in this checkpoint.
+trait CatalogControlLeaseLivenessV1: Send + Sync {
+    fn is_live_v1(&self) -> bool;
+}
+
+struct RetainedCatalogControlLeaseV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    writer_fence_authority_revision_fingerprint: [u8; 32],
+    writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
+    liveness: Box<dyn CatalogControlLeaseLivenessV1>,
+    #[cfg(test)]
+    test_live: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl RetainedCatalogControlLeaseV1 {
+    fn matches_writer_fence_v1(&self, writers: &AllNamespaceWritersFencedLeaseV1) -> bool {
+        self.control_binding == writers.control_binding
+            && self.writer_fence_authority_revision_fingerprint
+                == writers.authority_revision_fingerprint
+            && self.writer_fence_lease_public_fingerprint == writers.lease_public_fingerprint
+    }
+
+    fn is_live_v1(&self) -> bool {
+        self.liveness.is_live_v1()
+    }
+}
+
 /// Exact `Ready` state held by one exclusive external control acquisition.
 ///
 /// V1 deliberately freezes the writer epoch to the bootstrap epoch. A future
@@ -325,11 +361,13 @@ pub(crate) struct TrustedCatalogHighWaterGuardV1 {
 /// binaries and direct object-store credentials are part of the epoch. A
 /// future production constructor must keep this lease live through the visible
 /// HEAD CAS, every namespace mutation, committed-HEAD finalization, and
-/// high-water advancement.
+/// high-water advancement. The retained handle is nominally separate from the
+/// serialized public fingerprints and cannot be reconstructed from them.
 pub(crate) struct AllNamespaceWritersFencedLeaseV1 {
     control_binding: CatalogControlAcquisitionBindingV1,
     authority_revision_fingerprint: [u8; 32],
     lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
+    retained_control_lease: RetainedCatalogControlLeaseV1,
 }
 
 /// One held external control acquisition. High-water and all-writer fencing
@@ -340,6 +378,23 @@ pub(crate) struct AllNamespaceWritersFencedLeaseV1 {
 pub(crate) struct HeldReadyCatalogControlGuardV1 {
     high_water: TrustedCatalogHighWaterGuardV1,
     all_writers: AllNamespaceWritersFencedLeaseV1,
+}
+
+fn require_held_control_lease_live_v1(
+    control: &HeldReadyCatalogControlGuardV1,
+) -> Result<(), CatalogPublicationContractErrorV1> {
+    if control.high_water.binding != control.all_writers.control_binding
+        || !control
+            .all_writers
+            .retained_control_lease
+            .matches_writer_fence_v1(&control.all_writers)
+    {
+        return Err(CatalogPublicationContractErrorV1::WriterFenceMismatch);
+    }
+    if !control.all_writers.retained_control_lease.is_live_v1() {
+        return Err(CatalogPublicationContractErrorV1::ControlLeaseNotLive);
+    }
+    Ok(())
 }
 
 /// Exact receipt match for one observed predecessor. This still is not remote
@@ -432,6 +487,7 @@ pub(crate) fn match_catalog_publication_prerequisites_v1<'a>(
     {
         return Err(CatalogPublicationContractErrorV1::BootstrapMismatch);
     }
+    require_held_control_lease_live_v1(&control)?;
     Ok(MatchedCatalogPublicationPrerequisitesV1 {
         storage_authority,
         control_guard: control,
@@ -1041,6 +1097,8 @@ pub(crate) async fn prove_catalog_object_absence_v1<'attempt, 'storage>(
     kind: RemoteCatalogObjectKindV1,
     object_key: String,
 ) -> AnyhowResult<ProvenCatalogObjectAbsenceV1<'attempt, 'storage>> {
+    require_held_control_lease_live_v1(&prerequisites.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
     anyhow::ensure!(
         mutation_inputs_match_corpus_v1(prerequisites, corpus),
         "catalog absence proof does not match the exact semantic predecessor"
@@ -1559,6 +1617,7 @@ struct BoundCatalogSuccessorPayloadV1 {
     kind: RemoteCatalogObjectKindV1,
     object_key: String,
     object_id: [u8; 32],
+    raw_bytes: Vec<u8>,
     raw_bytes_len: NonZeroU64,
     raw_blake3: [u8; 32],
     binding: RegisteredRootRemoteObjectBindingV1,
@@ -1746,6 +1805,7 @@ pub(crate) struct BoundCatalogMutationJournalV1 {
     raw_bytes: Vec<u8>,
     raw_bytes_len: NonZeroU64,
     binding: RegisteredRootRemoteObjectBindingV1,
+    successor_payloads: Vec<BoundCatalogSuccessorPayloadV1>,
 }
 
 fn publication_object_key_v1(
@@ -1836,6 +1896,8 @@ async fn publish_immutable_catalog_artifact_if_absent_exact_v1(
     expected_bytes: &[u8],
     max_bytes: u64,
 ) -> AnyhowResult<([u8; 32], NonZeroU64, RegisteredRootRemoteObjectBindingV1)> {
+    require_held_control_lease_live_v1(&prerequisites.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
     anyhow::ensure!(
         prerequisites
             .storage_authority
@@ -1934,6 +1996,8 @@ pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 
     publication_nonce: [u8; 32],
     mut mutations: Vec<FactBoundCatalogMutationV1<'attempt, 'storage>>,
 ) -> AnyhowResult<PreparedAuthoritativeCatalogMutationJournalV1> {
+    require_held_control_lease_live_v1(&prerequisites.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
     anyhow::ensure!(
         mutation_inputs_match_corpus_v1(prerequisites, corpus),
         "authoritative mutation preparation does not match the semantic predecessor"
@@ -2035,6 +2099,7 @@ pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 
             kind: mutation.successor.kind,
             object_key: mutation.successor.object_key.clone(),
             object_id,
+            raw_bytes: mutation.successor.raw_bytes.clone(),
             raw_bytes_len,
             raw_blake3: mutation.successor.raw_blake3,
             binding,
@@ -2160,6 +2225,9 @@ pub(crate) async fn publish_authoritative_catalog_mutation_journal_v1(
                     mutation.kind == payload.kind
                         && mutation.object_key == payload.object_key
                         && mutation.successor_payload.object_id == lower_hex(&payload.object_id)
+                        && u64::try_from(payload.raw_bytes.len()).ok()
+                            == Some(payload.raw_bytes_len.get())
+                        && *blake3::hash(&payload.raw_bytes).as_bytes() == payload.raw_blake3
                         && mutation.successor_payload.raw_bytes_len == payload.raw_bytes_len.get()
                         && mutation.successor_payload.raw_blake3 == lower_hex(&payload.raw_blake3)
                         && mutation.successor_payload.binding == binding_wire_v1(&payload.binding)
@@ -2191,6 +2259,7 @@ pub(crate) async fn publish_authoritative_catalog_mutation_journal_v1(
         raw_bytes: prepared.raw_bytes,
         raw_bytes_len,
         binding,
+        successor_payloads: prepared.successor_payloads,
     })
 }
 
@@ -2332,6 +2401,7 @@ fn validate_catalog_successor_claim_v1<'a>(
     predecessor_archive: BoundArchivedCatalogHeadV1,
     mutation_journal: BoundCatalogMutationJournalV1,
 ) -> Result<PreparedCatalogPublicationFenceV1<'a>, CatalogPublicationContractErrorV1> {
+    require_held_control_lease_live_v1(&prerequisites.control_guard)?;
     let expected_sequence = prerequisites
         .sequence
         .get()
@@ -2477,11 +2547,474 @@ impl std::fmt::Debug for BoundPendingCatalogControlV1<'_> {
     }
 }
 
+/// Opaque backend receipt for the future committed-HEAD -> publishing-HEAD
+/// compare-and-swap. The receipt is not the writer capability: it must be
+/// rebound to the exact visible bytes through the held accessor while the
+/// retained control lease is still live.
+///
+/// There is deliberately no production constructor in this checkpoint.
+pub(crate) struct TrustedCatalogPublishingHeadInstalledReceiptV1 {
+    publishing_head_binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+/// Non-forgeable permission to apply exactly the authoritative journal and no
+/// caller-selected key or byte string.
+///
+/// The capability retains the pending control transition, exact visible
+/// publishing-HEAD binding, storage authority, and live backend lease. It is
+/// non-cloneable and has no plan/action conversion.
+pub(crate) struct CatalogNamespaceMutationCapabilityV1<'a> {
+    pending: BoundPendingCatalogControlV1<'a>,
+    publishing_head_binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+impl std::fmt::Debug for CatalogNamespaceMutationCapabilityV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CatalogNamespaceMutationCapabilityV1")
+            .field(
+                "remote_prefix",
+                &self.pending.transition.publication.context.remote_prefix,
+            )
+            .field("sequence", &self.pending.transition.publication.sequence)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Failed capability binding that keeps the exact pending transition and its
+/// retained lease owned for recovery instead of dropping authority on error.
+pub(crate) struct CatalogNamespaceMutationCapabilityBindFailureV1<'a> {
+    pending: BoundPendingCatalogControlV1<'a>,
+    error: anyhow::Error,
+}
+
+impl std::fmt::Debug for CatalogNamespaceMutationCapabilityBindFailureV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CatalogNamespaceMutationCapabilityBindFailureV1")
+            .field("sequence", &self.pending.transition.publication.sequence)
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for CatalogNamespaceMutationCapabilityBindFailureV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if formatter.alternate() {
+            write!(formatter, "{:#}", self.error)
+        } else {
+            std::fmt::Display::fmt(&self.error, formatter)
+        }
+    }
+}
+
+impl std::error::Error for CatalogNamespaceMutationCapabilityBindFailureV1<'_> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error.as_ref())
+    }
+}
+
+struct AppliedCatalogNamespaceObjectV1 {
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    raw_blake3: [u8; 32],
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+/// Terminal evidence that every canonical journal entry was observed at its
+/// exact successor bytes in canonical order while the visible publishing HEAD
+/// and retained backend lease remained live.
+///
+/// Future committed-HEAD finalization must consume this value; it cannot be
+/// converted back into a reusable mutation capability.
+pub(crate) struct AppliedCatalogNamespaceMutationsV1<'a> {
+    capability: CatalogNamespaceMutationCapabilityV1<'a>,
+    applied: Vec<AppliedCatalogNamespaceObjectV1>,
+}
+
+impl std::fmt::Debug for AppliedCatalogNamespaceMutationsV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AppliedCatalogNamespaceMutationsV1")
+            .field(
+                "sequence",
+                &self.capability.pending.transition.publication.sequence,
+            )
+            .field("applied_count", &self.applied.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Partial writer failure retaining the live capability and exact applied
+/// prefix. Recovery can inspect/rebind the authoritative journal without
+/// silently releasing the only held control acquisition.
+pub(crate) struct FailedCatalogNamespaceMutationsV1<'a> {
+    capability: CatalogNamespaceMutationCapabilityV1<'a>,
+    applied: Vec<AppliedCatalogNamespaceObjectV1>,
+    error: anyhow::Error,
+}
+
+impl std::fmt::Debug for FailedCatalogNamespaceMutationsV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FailedCatalogNamespaceMutationsV1")
+            .field(
+                "sequence",
+                &self.capability.pending.transition.publication.sequence,
+            )
+            .field("applied_count", &self.applied.len())
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for FailedCatalogNamespaceMutationsV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if formatter.alternate() {
+            write!(formatter, "{:#}", self.error)
+        } else {
+            std::fmt::Display::fmt(&self.error, formatter)
+        }
+    }
+}
+
+impl std::error::Error for FailedCatalogNamespaceMutationsV1<'_> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error.as_ref())
+    }
+}
+
+fn wire_binding_etag_v1(binding: &RemoteCatalogObjectBindingWireV1) -> Option<&str> {
+    binding.etag.as_deref().filter(|etag| !etag.is_empty())
+}
+
+async fn require_namespace_mutation_capability_live_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+) -> AnyhowResult<()> {
+    let publication = &capability.pending.transition.publication;
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    anyhow::ensure!(
+        publication
+            .storage_authority
+            .conditional_write_receipt
+            .authorizes(
+                publication.storage_authority.operator,
+                &publication.context.remote_prefix,
+            )?,
+        "catalog namespace mutation lost its exact accessor/prefix conditional-semantics authority"
+    );
+    let expected_bytes = &capability
+        .pending
+        .transition
+        .canonical_publishing_head_bytes;
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_catalog_head_object_bytes();
+    let observed =
+        read_raw_object_snapshot_v1(publication.storage_authority.operator, &head_key, max_bytes)
+            .await
+            .with_context(|| format!("revalidating visible catalog publishing HEAD: {head_key}"))?;
+    let Some(RawObjectReadV1::Bound(snapshot)) = observed else {
+        anyhow::bail!("visible catalog publishing HEAD is missing or unbound: {head_key}");
+    };
+    let (raw_bytes, _, binding) = snapshot.into_parts();
+    anyhow::ensure!(
+        raw_bytes == *expected_bytes
+            && registered_binding_from_raw_v1(binding) == capability.publishing_head_binding,
+        "visible catalog publishing HEAD changed before namespace mutation: {head_key}"
+    );
+    Ok(())
+}
+
+/// Rebind the future HEAD-CAS receipt through the same accessor and retain the
+/// live lease. This is the only constructor for the namespace mutation
+/// capability, and this checkpoint cannot produce its trusted receipt in
+/// production.
+pub(crate) async fn bind_catalog_namespace_mutation_capability_v1<'a>(
+    pending: BoundPendingCatalogControlV1<'a>,
+    receipt: TrustedCatalogPublishingHeadInstalledReceiptV1,
+) -> Result<
+    CatalogNamespaceMutationCapabilityV1<'a>,
+    CatalogNamespaceMutationCapabilityBindFailureV1<'a>,
+> {
+    let capability = CatalogNamespaceMutationCapabilityV1 {
+        pending,
+        publishing_head_binding: receipt.publishing_head_binding,
+    };
+    let result = async {
+        anyhow::ensure!(
+            super::validate_binding_wire_v1(&binding_wire_v1(&capability.publishing_head_binding))
+                .is_some()
+                && mutable_head_etag_v1(&capability.publishing_head_binding).is_some(),
+            "publishing HEAD receipt has no usable exact mutable-object binding"
+        );
+        require_namespace_mutation_capability_live_v1(&capability)
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "publishing HEAD receipt does not authorize namespace mutation: {error}"
+                )
+            })
+    }
+    .await;
+    match result {
+        Ok(()) => Ok(capability),
+        Err(error) => {
+            let CatalogNamespaceMutationCapabilityV1 { pending, .. } = capability;
+            Err(CatalogNamespaceMutationCapabilityBindFailureV1 { pending, error })
+        }
+    }
+}
+
+async fn read_exact_catalog_successor_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+    kind: RemoteCatalogObjectKindV1,
+    object_key: &str,
+    expected_bytes: &[u8],
+) -> AnyhowResult<RegisteredRootRemoteObjectBindingV1> {
+    let publication = &capability.pending.transition.publication;
+    let observed = read_raw_object_snapshot_v1(
+        publication.storage_authority.operator,
+        object_key,
+        catalog_named_object_max_bytes_v1(kind),
+    )
+    .await
+    .with_context(|| format!("reading exact catalog namespace successor: {object_key}"))?;
+    let Some(RawObjectReadV1::Bound(snapshot)) = observed else {
+        anyhow::bail!("catalog namespace successor is missing or unbound: {object_key}");
+    };
+    let (raw_bytes, raw_blake3, binding) = snapshot.into_parts();
+    anyhow::ensure!(
+        raw_bytes == expected_bytes && raw_blake3 == blake3::hash(expected_bytes),
+        "catalog namespace successor differs from its authoritative journal: {object_key}"
+    );
+    let binding = registered_binding_from_raw_v1(binding);
+    anyhow::ensure!(
+        kind != RemoteCatalogObjectKindV1::Index || mutable_head_etag_v1(&binding).is_some(),
+        "mutable catalog index successor has no usable ETag: {object_key}"
+    );
+    Ok(binding)
+}
+
+async fn apply_one_catalog_namespace_mutation_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+    mutation: &RemoteCatalogFactBoundMutationWireV1,
+    payload: &BoundCatalogSuccessorPayloadV1,
+) -> AnyhowResult<AppliedCatalogNamespaceObjectV1> {
+    anyhow::ensure!(
+        mutation.kind == payload.kind
+            && mutation.object_key == payload.object_key
+            && mutation.successor_payload.object_id == lower_hex(&payload.object_id)
+            && mutation.successor_payload.raw_bytes_len == payload.raw_bytes_len.get()
+            && mutation.successor_payload.raw_blake3 == lower_hex(&payload.raw_blake3)
+            && mutation.successor_payload.binding == binding_wire_v1(&payload.binding)
+            && u64::try_from(payload.raw_bytes.len()).ok() == Some(payload.raw_bytes_len.get())
+            && *blake3::hash(&payload.raw_bytes).as_bytes() == payload.raw_blake3,
+        "catalog namespace mutation lost its exact immutable successor payload"
+    );
+    let payload_key = successor_payload_object_key_v1(
+        &capability.pending.transition.publication.context,
+        &payload.raw_bytes,
+    )
+    .context("catalog successor payload key exceeds the storage-key bound")?;
+    let immutable_payload = read_raw_object_snapshot_v1(
+        capability
+            .pending
+            .transition
+            .publication
+            .storage_authority
+            .operator,
+        &payload_key,
+        catalog_named_object_max_bytes_v1(payload.kind),
+    )
+    .await
+    .with_context(|| format!("revalidating immutable catalog successor payload: {payload_key}"))?;
+    let Some(RawObjectReadV1::Bound(immutable_payload)) = immutable_payload else {
+        anyhow::bail!("immutable catalog successor payload is missing or unbound: {payload_key}");
+    };
+    let (immutable_bytes, immutable_blake3, immutable_binding) = immutable_payload.into_parts();
+    anyhow::ensure!(
+        immutable_bytes == payload.raw_bytes
+            && immutable_blake3 == blake3::hash(&payload.raw_bytes)
+            && registered_binding_from_raw_v1(immutable_binding) == payload.binding,
+        "immutable catalog successor payload changed before namespace mutation: {payload_key}"
+    );
+
+    require_namespace_mutation_capability_live_v1(capability).await?;
+    let operator = capability
+        .pending
+        .transition
+        .publication
+        .storage_authority
+        .operator;
+    let write_result = match (&mutation.operation, &mutation.predecessor) {
+        (
+            RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+            RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+        ) => {
+            operator
+                .write_with(&mutation.object_key, payload.raw_bytes.clone())
+                .if_not_exists(true)
+                .await
+        }
+        (
+            RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+            RemoteCatalogMutationPredecessorDraftWireV1::Present { binding, .. },
+        ) => {
+            let etag = wire_binding_etag_v1(binding)
+                .context("authoritative replacement predecessor has no usable ETag")?;
+            operator
+                .write_with(&mutation.object_key, payload.raw_bytes.clone())
+                .if_match(etag)
+                .await
+        }
+        _ => anyhow::bail!("authoritative catalog journal contains an invalid operation"),
+    };
+
+    let rebound = read_exact_catalog_successor_v1(
+        capability,
+        mutation.kind,
+        &mutation.object_key,
+        &payload.raw_bytes,
+    )
+    .await;
+    let binding = match (write_result, rebound) {
+        (_, Ok(binding)) => binding,
+        (Err(write_error), Err(read_error)) => {
+            return Err(read_error).with_context(|| {
+                format!(
+                    "catalog namespace conditional write also failed ({write_error}): {}",
+                    mutation.object_key
+                )
+            })
+        }
+        (Ok(_), Err(read_error)) => return Err(read_error),
+    };
+    require_namespace_mutation_capability_live_v1(capability).await?;
+    Ok(AppliedCatalogNamespaceObjectV1 {
+        kind: mutation.kind,
+        object_key: mutation.object_key.clone(),
+        raw_blake3: payload.raw_blake3,
+        binding,
+    })
+}
+
+/// Apply the complete authoritative journal in canonical order.
+///
+/// Callers cannot select a key, payload, operation, or predecessor. Creates
+/// remain absent-only; replacements remain exact-ETag conditional. Exact
+/// successor rereads make crash replay idempotent, while any different
+/// collision, stale predecessor, lost publishing HEAD, or lost lease fails
+/// closed. The returned terminal evidence retains the capability for future
+/// committed-HEAD finalization.
+pub(crate) async fn apply_authoritative_catalog_namespace_mutations_v1<'a>(
+    capability: CatalogNamespaceMutationCapabilityV1<'a>,
+) -> Result<AppliedCatalogNamespaceMutationsV1<'a>, FailedCatalogNamespaceMutationsV1<'a>> {
+    let mut applied = Vec::new();
+    if let Err(error) = require_namespace_mutation_capability_live_v1(&capability).await {
+        return Err(FailedCatalogNamespaceMutationsV1 {
+            capability,
+            applied,
+            error,
+        });
+    }
+
+    let wire = {
+        let publication = &capability.pending.transition.publication;
+        let journal = &publication.mutation_journal;
+        validate_authoritative_catalog_mutation_journal_bytes_v1(
+            &journal.raw_bytes,
+            &publication.context,
+            publication.sequence,
+            publication.publication_nonce,
+            publication.parent_head_revision,
+        )
+        .map_err(|error| anyhow::anyhow!("authoritative mutation journal is invalid: {error:?}"))
+        .and_then(|wire| {
+            anyhow::ensure!(
+                wire.mutations.len() == journal.successor_payloads.len(),
+                "authoritative mutation journal lost its complete successor payload set"
+            );
+            Ok(wire)
+        })
+    };
+    let wire = match wire {
+        Ok(wire) => wire,
+        Err(error) => {
+            return Err(FailedCatalogNamespaceMutationsV1 {
+                capability,
+                applied,
+                error,
+            })
+        }
+    };
+    if let Err(error) = applied
+        .try_reserve(wire.mutations.len())
+        .context("reserving applied catalog mutation evidence")
+    {
+        return Err(FailedCatalogNamespaceMutationsV1 {
+            capability,
+            applied,
+            error,
+        });
+    }
+
+    for ordinal in 0..wire.mutations.len() {
+        let result = {
+            let journal = &capability.pending.transition.publication.mutation_journal;
+            apply_one_catalog_namespace_mutation_v1(
+                &capability,
+                &wire.mutations[ordinal],
+                &journal.successor_payloads[ordinal],
+            )
+            .await
+        };
+        match result {
+            Ok(evidence) => applied.push(evidence),
+            Err(error) => {
+                return Err(FailedCatalogNamespaceMutationsV1 {
+                    capability,
+                    applied,
+                    error,
+                })
+            }
+        }
+    }
+    let complete = applied.len() == wire.mutations.len()
+        && applied
+            .iter()
+            .zip(&wire.mutations)
+            .all(|(evidence, mutation)| {
+                evidence.kind == mutation.kind
+                    && evidence.object_key == mutation.object_key
+                    && lower_hex(&evidence.raw_blake3) == mutation.successor_payload.raw_blake3
+                    && super::validate_binding_wire_v1(&binding_wire_v1(&evidence.binding))
+                        .is_some()
+                    && (evidence.kind != RemoteCatalogObjectKindV1::Index
+                        || mutable_head_etag_v1(&evidence.binding).is_some())
+            });
+    if !complete {
+        return Err(FailedCatalogNamespaceMutationsV1 {
+            capability,
+            applied,
+            error: anyhow::anyhow!(
+                "applied catalog namespace evidence is incomplete or out of order"
+            ),
+        });
+    }
+    Ok(AppliedCatalogNamespaceMutationsV1 {
+        capability,
+        applied,
+    })
+}
+
 /// Opaque future proof that the exact reserved successor became the canonical
 /// committed `HEAD`. No production constructor exists until visible fencing,
 /// fact-bound mutation, and committed-HEAD finalization are implemented.
 pub(crate) struct BoundCommittedCatalogSuccessorV1 {
-    control_binding: CatalogControlAcquisitionBindingV1,
+    control_guard: HeldReadyCatalogControlGuardV1,
     pending_revision: CatalogControlAuthorityRevisionV1,
     publishing_head_reservation_fingerprint: [u8; 32],
     pending_control_record_fingerprint: [u8; 32],
@@ -2517,6 +3050,7 @@ pub(crate) struct AdvancedCatalogHighWaterV1 {
     control_authority_fingerprint: [u8; 32],
     ready_revision: CatalogControlAuthorityRevisionV1,
     ready_control_record_fingerprint: [u8; 32],
+    retained_control_lease: RetainedCatalogControlLeaseV1,
 }
 
 impl std::fmt::Debug for AdvancedCatalogHighWaterV1 {
@@ -2526,6 +3060,10 @@ impl std::fmt::Debug for AdvancedCatalogHighWaterV1 {
             .field("remote_prefix", &self.context.remote_prefix)
             .field("sequence", &self.successor.sequence)
             .field("control_generation", &self.ready_revision.generation)
+            .field(
+                "retained_control_lease_live",
+                &self.retained_control_lease.is_live_v1(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -2829,7 +3367,7 @@ fn canonical_ready_control_record_bytes_v1(
     committed: &BoundCommittedCatalogSuccessorV1,
     ready_revision: CatalogControlAuthorityRevisionV1,
 ) -> Vec<u8> {
-    let binding = &committed.control_binding;
+    let binding = &committed.control_guard.high_water.binding;
     serde_json::to_vec(&CatalogControlRecordWireV1 {
         version: CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1,
         remote_prefix: binding.context.remote_prefix.clone(),
@@ -2860,6 +3398,7 @@ pub(crate) fn prepare_catalog_control_transition_v1<'a>(
     publication: PreparedCatalogPublicationFenceV1<'a>,
     pending_revision_fingerprint: [u8; 32],
 ) -> Result<PreparedCatalogControlTransitionV1<'a>, CatalogPublicationContractErrorV1> {
+    require_held_control_lease_live_v1(&publication.control_guard)?;
     let expected_successor_sequence = publication
         .control_guard
         .high_water
@@ -2961,6 +3500,7 @@ pub(crate) fn match_catalog_publication_pending_receipt_v1<'a>(
     transition: PreparedCatalogControlTransitionV1<'a>,
     receipt: TrustedCatalogPublicationPendingReceiptV1,
 ) -> Result<BoundPendingCatalogControlV1<'a>, CatalogPublicationContractErrorV1> {
+    require_held_control_lease_live_v1(&transition.publication.control_guard)?;
     let binding = &transition.publication.control_guard.high_water.binding;
     let expected_publishing_bytes =
         canonical_publishing_head_bytes_v1(&transition.publication, transition.pending_revision);
@@ -3001,8 +3541,12 @@ pub(crate) fn match_catalog_high_water_advance_v1(
     committed: BoundCommittedCatalogSuccessorV1,
     receipt: TrustedCatalogHighWaterAdvanceReceiptV1,
 ) -> Result<AdvancedCatalogHighWaterV1, CatalogPublicationContractErrorV1> {
+    require_held_control_lease_live_v1(&committed.control_guard)?;
+    let control_binding = committed.control_guard.high_water.binding.clone();
     let expected_pending_generation = committed
-        .control_binding
+        .control_guard
+        .high_water
+        .binding
         .ready_revision
         .generation
         .get()
@@ -3010,7 +3554,9 @@ pub(crate) fn match_catalog_high_water_advance_v1(
         .and_then(NonZeroU64::new)
         .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
     let expected_successor_sequence = committed
-        .control_binding
+        .control_guard
+        .high_water
+        .binding
         .current
         .sequence
         .get()
@@ -3033,21 +3579,20 @@ pub(crate) fn match_catalog_high_water_advance_v1(
     let ready_bytes = canonical_ready_control_record_bytes_v1(&committed, receipt.ready_revision);
     let ready_record_fingerprint =
         super::domain_object_id_v1(CATALOG_CONTROL_RECORD_DOMAIN_V1, &ready_bytes);
-    if committed.context != committed.control_binding.context
+    if committed.context != control_binding.context
         || committed.pending_revision.generation != expected_pending_generation
         || committed.pending_revision.fingerprint == [0; 32]
-        || committed.pending_revision.fingerprint
-            == committed.control_binding.ready_revision.fingerprint
+        || committed.pending_revision.fingerprint == control_binding.ready_revision.fingerprint
         || committed.publishing_head_reservation_fingerprint == [0; 32]
         || committed.pending_control_record_fingerprint == [0; 32]
         || committed.sequence != expected_successor_sequence
-        || committed.parent_head_revision != committed.control_binding.current.head_revision
+        || committed.parent_head_revision != control_binding.current.head_revision
         || committed.publication_nonce == [0; 32]
-        || committed.publication_nonce == committed.control_binding.current.publication_nonce
+        || committed.publication_nonce == control_binding.current.publication_nonce
         || committed.head_revision == [0; 32]
-        || committed.head_revision == committed.control_binding.current.head_revision
+        || committed.head_revision == control_binding.current.head_revision
         || committed_revision != committed.head_revision
-        || receipt.control_binding != committed.control_binding
+        || receipt.control_binding != control_binding
         || receipt.pending_revision != committed.pending_revision
         || receipt.publishing_head_reservation_fingerprint
             != committed.publishing_head_reservation_fingerprint
@@ -3057,8 +3602,7 @@ pub(crate) fn match_catalog_high_water_advance_v1(
         || receipt.ready_revision.generation != expected_ready_generation
         || receipt.ready_revision.fingerprint == [0; 32]
         || receipt.ready_revision.fingerprint == committed.pending_revision.fingerprint
-        || receipt.ready_revision.fingerprint
-            == committed.control_binding.ready_revision.fingerprint
+        || receipt.ready_revision.fingerprint == control_binding.ready_revision.fingerprint
         || receipt.ready_control_record_fingerprint == [0; 32]
         || receipt.ready_control_record_fingerprint == committed.pending_control_record_fingerprint
         || receipt.ready_control_record_fingerprint != ready_record_fingerprint
@@ -3066,13 +3610,14 @@ pub(crate) fn match_catalog_high_water_advance_v1(
         return Err(CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch);
     }
     Ok(AdvancedCatalogHighWaterV1 {
-        context: committed.control_binding.context,
-        bootstrap: committed.control_binding.bootstrap,
+        context: control_binding.context,
+        bootstrap: control_binding.bootstrap,
         successor: exact_successor,
-        storage_authority_fingerprint: committed.control_binding.storage_authority_fingerprint,
-        control_authority_fingerprint: committed.control_binding.control_authority_fingerprint,
+        storage_authority_fingerprint: control_binding.storage_authority_fingerprint,
+        control_authority_fingerprint: control_binding.control_authority_fingerprint,
         ready_revision: receipt.ready_revision,
         ready_control_record_fingerprint: ready_record_fingerprint,
+        retained_control_lease: committed.control_guard.all_writers.retained_control_lease,
     })
 }
 
@@ -3273,6 +3818,16 @@ mod tests {
     use crate::registered_source_composition::validated_selected_registered_root_remote_context_for_test_v1;
     use tcfs_core::config::RootSpecV1Config;
 
+    struct TestCatalogControlLeaseLivenessV1 {
+        live: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl CatalogControlLeaseLivenessV1 for TestCatalogControlLeaseLivenessV1 {
+        fn is_live_v1(&self) -> bool {
+            self.live.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
     fn test_spec() -> RootSpecV1Config {
         RootSpecV1Config {
             version: RootSpecV1Config::VERSION,
@@ -3311,6 +3866,11 @@ mod tests {
     );
     static_assertions::assert_not_impl_any!(
         AllNamespaceWritersFencedLeaseV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        RetainedCatalogControlLeaseV1: Clone,
         serde::Serialize,
         Default
     );
@@ -3420,6 +3980,43 @@ mod tests {
         BoundPendingCatalogControlV1<'static>: Clone,
         serde::Serialize,
         Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        TrustedCatalogPublishingHeadInstalledReceiptV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogNamespaceMutationCapabilityV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogNamespaceMutationCapabilityBindFailureV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<CatalogNamespaceMutationCapabilityV1<'static>>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        AppliedCatalogNamespaceMutationsV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<CatalogNamespaceMutationCapabilityV1<'static>>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        FailedCatalogNamespaceMutationsV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<CatalogNamespaceMutationCapabilityV1<'static>>,
+        Into<AppliedCatalogNamespaceMutationsV1<'static>>,
         Into<crate::reconcile::ReconcilePlan>,
         Into<Vec<crate::reconcile::ReconcileAction>>
     );
@@ -3560,6 +4157,20 @@ mod tests {
                 binding: control_binding.clone(),
             },
             AllNamespaceWritersFencedLeaseV1 {
+                retained_control_lease: {
+                    let live = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+                    RetainedCatalogControlLeaseV1 {
+                        control_binding: control_binding.clone(),
+                        writer_fence_authority_revision_fingerprint: [0x89; 32],
+                        writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1(
+                            [0x88; 32],
+                        ),
+                        liveness: Box::new(TestCatalogControlLeaseLivenessV1 {
+                            live: live.clone(),
+                        }),
+                        test_live: live,
+                    }
+                },
                 control_binding,
                 authority_revision_fingerprint: [0x89; 32],
                 lease_public_fingerprint: NonSecretLeasePublicFingerprintV1([0x88; 32]),
@@ -3629,6 +4240,7 @@ mod tests {
                 binding: RegisteredRootRemoteObjectBindingV1::Etag {
                     etag: "journal-etag".to_owned(),
                 },
+                successor_payloads: Vec::new(),
             },
         )
     }
@@ -3689,29 +4301,128 @@ mod tests {
         match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap()
     }
 
+    async fn authoritative_bound_pending<'a>(
+        fixture: &'a SemanticRemoteCatalogFixtureV1,
+        corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> BoundPendingCatalogControlV1<'a> {
+        let publication_nonce = [0x44; 32];
+        let prerequisites = matched(fixture, observed);
+        let successor_bytes = deleted_index_bytes();
+        let replacement = fact_bind_catalog_replacement_v1(
+            &prerequisites,
+            corpus,
+            type_catalog_successor_payload_v1(
+                corpus,
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/retained.txt".to_owned(),
+                successor_bytes.clone(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let create_key = "roots/index/added.txt".to_owned();
+        let absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            corpus,
+            RemoteCatalogObjectKindV1::Index,
+            create_key.clone(),
+        )
+        .await
+        .unwrap();
+        let create = fact_bind_catalog_create_v1(
+            &prerequisites,
+            corpus,
+            absence,
+            type_catalog_successor_payload_v1(
+                corpus,
+                RemoteCatalogObjectKindV1::Index,
+                create_key,
+                successor_bytes,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            corpus,
+            publication_nonce,
+            vec![replacement, create],
+        )
+        .await
+        .unwrap();
+        let journal = publish_authoritative_catalog_mutation_journal_v1(&prerequisites, prepared)
+            .await
+            .unwrap();
+        let archive = publish_predecessor_head_archive_v1(&prerequisites)
+            .await
+            .unwrap();
+        let publication = prepare_catalog_publication_fence_v1(
+            prerequisites,
+            publication_nonce,
+            archive,
+            journal,
+        )
+        .unwrap();
+        let transition = prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap();
+        let receipt = pending_receipt(&transition);
+        match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap()
+    }
+
+    async fn install_test_publishing_head_receipt(
+        pending: &BoundPendingCatalogControlV1<'_>,
+    ) -> TrustedCatalogPublishingHeadInstalledReceiptV1 {
+        let publication = &pending.transition.publication;
+        let head_key = super::super::catalog_head_key_v1(&publication.context.remote_prefix);
+        publication
+            .storage_authority
+            .operator
+            .write(
+                &head_key,
+                pending.transition.canonical_publishing_head_bytes.clone(),
+            )
+            .await
+            .unwrap();
+        let observed = read_raw_object_snapshot_v1(
+            publication.storage_authority.operator,
+            &head_key,
+            RegisteredRootPlanContractV1::strict_v1()
+                .remote_contract()
+                .max_catalog_head_object_bytes(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let RawObjectReadV1::Bound(snapshot) = observed else {
+            panic!("test publishing HEAD must carry an exact binding");
+        };
+        let (_, _, binding) = snapshot.into_parts();
+        TrustedCatalogPublishingHeadInstalledReceiptV1 {
+            publishing_head_binding: registered_binding_from_raw_v1(binding),
+        }
+    }
+
     fn committed_successor(
         pending: BoundPendingCatalogControlV1<'_>,
     ) -> BoundCommittedCatalogSuccessorV1 {
         let committed_head_bytes = br#"{"catalog_sequence":2,"fixture":"committed"}"#.to_vec();
         let head_revision = super::super::catalog_head_revision_v1(&committed_head_bytes);
+        let pending_revision = pending.transition.pending_revision;
+        let publishing_head_reservation_fingerprint = pending
+            .pending_receipt
+            .publishing_head_reservation_fingerprint;
+        let pending_control_record_fingerprint =
+            pending.pending_receipt.pending_control_record_fingerprint;
+        let publication = pending.transition.publication;
         BoundCommittedCatalogSuccessorV1 {
-            control_binding: pending
-                .transition
-                .publication
-                .control_guard
-                .high_water
-                .binding,
-            pending_revision: pending.transition.pending_revision,
-            publishing_head_reservation_fingerprint: pending
-                .pending_receipt
-                .publishing_head_reservation_fingerprint,
-            pending_control_record_fingerprint: pending
-                .pending_receipt
-                .pending_control_record_fingerprint,
-            context: pending.transition.publication.context,
-            sequence: pending.transition.publication.sequence,
-            publication_nonce: pending.transition.publication.publication_nonce,
-            parent_head_revision: pending.transition.publication.parent_head_revision,
+            control_guard: publication.control_guard,
+            pending_revision,
+            publishing_head_reservation_fingerprint,
+            pending_control_record_fingerprint,
+            context: publication.context,
+            sequence: publication.sequence,
+            publication_nonce: publication.publication_nonce,
+            parent_head_revision: publication.parent_head_revision,
             head_revision,
             committed_head_bytes,
         }
@@ -3726,7 +4437,7 @@ mod tests {
         };
         let ready_bytes = canonical_ready_control_record_bytes_v1(committed, ready_revision);
         TrustedCatalogHighWaterAdvanceReceiptV1 {
-            control_binding: committed.control_binding.clone(),
+            control_binding: committed.control_guard.high_water.binding.clone(),
             pending_revision: committed.pending_revision,
             publishing_head_reservation_fingerprint: committed
                 .publishing_head_reservation_fingerprint,
@@ -3901,6 +4612,350 @@ mod tests {
         );
         assert_eq!(bound.catalog_sequence.get(), 2);
         assert_eq!(bound.parent_head_revision, observed.head_revision);
+    }
+
+    #[tokio::test]
+    async fn namespace_writer_applies_only_the_complete_authoritative_journal_with_replay() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+        let successor_bytes = deleted_index_bytes();
+
+        fixture
+            .operator()
+            .write("roots/index/added.txt", successor_bytes.clone())
+            .await
+            .unwrap();
+        let receipt = install_test_publishing_head_receipt(&pending).await;
+        let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
+            .await
+            .unwrap();
+        let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .unwrap();
+
+        assert_eq!(applied.applied.len(), 2);
+        assert_eq!(applied.applied[0].object_key, "roots/index/added.txt");
+        assert_eq!(applied.applied[1].object_key, "roots/index/retained.txt");
+        assert_eq!(
+            fixture
+                .operator()
+                .read("roots/index/added.txt")
+                .await
+                .unwrap()
+                .to_vec(),
+            successor_bytes
+        );
+        assert_eq!(
+            fixture
+                .operator()
+                .read("roots/index/retained.txt")
+                .await
+                .unwrap()
+                .to_vec(),
+            deleted_index_bytes()
+        );
+        assert_eq!(
+            applied
+                .capability
+                .pending
+                .transition
+                .publication
+                .sequence
+                .get(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn namespace_writer_covers_index_reservation_and_manifest_planes() {
+        let (fixture, corpus, observed) = observed_corpus(&[]).await;
+        let prerequisites = matched(&fixture, &observed);
+        let rel_path = "new.txt";
+        let manifest_bytes = regular_manifest_bytes(rel_path);
+        let manifest_id = crate::index_entry::manifest_object_id(&manifest_bytes);
+        let index_key = format!("roots/index/{rel_path}");
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let folded_path = crate::index_entry::portable_casefold_path(rel_path).unwrap();
+        let reservation_key = format!(
+            "roots/.tcfs-namespace/v1/{}",
+            crate::index_entry::namespace_reservation_object_id(&folded_path)
+        );
+        let reservation_bytes = format!(
+            r#"{{"version":1,"exact_path":"{rel_path}","folded_path":"{folded_path}","role":"file"}}"#
+        )
+        .into_bytes();
+
+        let index_absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Index,
+            index_key.clone(),
+        )
+        .await
+        .unwrap();
+        let reservation_absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Reservation,
+            reservation_key.clone(),
+        )
+        .await
+        .unwrap();
+        let manifest_absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Manifest,
+            manifest_key.clone(),
+        )
+        .await
+        .unwrap();
+        let index = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            index_absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Index,
+                index_key.clone(),
+                committed_index_bytes(&manifest_id),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let reservation = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            reservation_absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Reservation,
+                reservation_key.clone(),
+                reservation_bytes.clone(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let manifest = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            manifest_absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Manifest,
+                manifest_key.clone(),
+                manifest_bytes.clone(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            &corpus,
+            [0x44; 32],
+            vec![manifest, reservation, index],
+        )
+        .await
+        .unwrap();
+        let journal = publish_authoritative_catalog_mutation_journal_v1(&prerequisites, prepared)
+            .await
+            .unwrap();
+        let archive = publish_predecessor_head_archive_v1(&prerequisites)
+            .await
+            .unwrap();
+        let publication =
+            prepare_catalog_publication_fence_v1(prerequisites, [0x44; 32], archive, journal)
+                .unwrap();
+        let transition = prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap();
+        let receipt = pending_receipt(&transition);
+        let pending = match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap();
+        let receipt = install_test_publishing_head_receipt(&pending).await;
+        let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
+            .await
+            .unwrap();
+        let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .unwrap();
+
+        assert_eq!(applied.applied.len(), 3);
+        assert!(applied
+            .applied
+            .iter()
+            .any(|object| object.kind == RemoteCatalogObjectKindV1::Index));
+        assert!(applied
+            .applied
+            .iter()
+            .any(|object| object.kind == RemoteCatalogObjectKindV1::Reservation));
+        assert!(applied
+            .applied
+            .iter()
+            .any(|object| object.kind == RemoteCatalogObjectKindV1::Manifest));
+        assert_eq!(
+            fixture.operator().read(&index_key).await.unwrap().to_vec(),
+            committed_index_bytes(&manifest_id)
+        );
+        assert_eq!(
+            fixture
+                .operator()
+                .read(&reservation_key)
+                .await
+                .unwrap()
+                .to_vec(),
+            reservation_bytes
+        );
+        assert_eq!(
+            fixture
+                .operator()
+                .read(&manifest_key)
+                .await
+                .unwrap()
+                .to_vec(),
+            manifest_bytes
+        );
+    }
+
+    #[tokio::test]
+    async fn namespace_writer_rejects_lost_lease_visible_head_drift_and_wrong_collision() {
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            let receipt = install_test_publishing_head_receipt(&pending).await;
+            pending
+                .transition
+                .publication
+                .control_guard
+                .all_writers
+                .retained_control_lease
+                .test_live
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+            let error = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
+                .await
+                .expect_err("a lost backend lease must not mint a writer capability");
+            assert!(error.to_string().contains("control lease is not live"));
+        }
+
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            let receipt = install_test_publishing_head_receipt(&pending).await;
+            let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
+                .await
+                .unwrap();
+            capability
+                .pending
+                .transition
+                .publication
+                .control_guard
+                .all_writers
+                .retained_control_lease
+                .test_live
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+            let error = apply_authoritative_catalog_namespace_mutations_v1(capability)
+                .await
+                .expect_err("a lease lost after capability mint must stop the writer");
+            assert!(error.to_string().contains("control lease is not live"));
+            assert!(!fixture
+                .operator()
+                .exists("roots/index/added.txt")
+                .await
+                .unwrap());
+        }
+
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            let receipt = install_test_publishing_head_receipt(&pending).await;
+            let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
+                .await
+                .unwrap();
+            fixture
+                .operator()
+                .write(
+                    "roots/.tcfs-catalog/v1/head",
+                    observed.committed_head_bytes.clone(),
+                )
+                .await
+                .unwrap();
+            let error = apply_authoritative_catalog_namespace_mutations_v1(capability)
+                .await
+                .expect_err("visible HEAD drift must stop the complete writer");
+            assert!(error.to_string().contains("publishing HEAD changed"));
+            assert_eq!(error.applied.len(), 0);
+            assert!(!fixture
+                .operator()
+                .exists("roots/index/added.txt")
+                .await
+                .unwrap());
+        }
+
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            fixture
+                .operator()
+                .write("roots/index/added.txt", b"wrong collision".to_vec())
+                .await
+                .unwrap();
+            let receipt = install_test_publishing_head_receipt(&pending).await;
+            let capability = bind_catalog_namespace_mutation_capability_v1(pending, receipt)
+                .await
+                .unwrap();
+            let error = apply_authoritative_catalog_namespace_mutations_v1(capability)
+                .await
+                .expect_err("a different create collision must fail closed");
+            assert_eq!(error.applied.len(), 0);
+            assert!(error
+                .capability
+                .pending
+                .transition
+                .publication
+                .control_guard
+                .all_writers
+                .retained_control_lease
+                .is_live_v1());
+            assert!(
+                format!("{error:#}").contains("differs from its authoritative journal"),
+                "unexpected error: {error:#}"
+            );
+            assert_eq!(
+                fixture
+                    .operator()
+                    .read("roots/index/added.txt")
+                    .await
+                    .unwrap()
+                    .to_vec(),
+                b"wrong collision"
+            );
+            assert_eq!(
+                fixture
+                    .operator()
+                    .read("roots/index/retained.txt")
+                    .await
+                    .unwrap()
+                    .to_vec(),
+                deleted_index_bytes(),
+                "canonical key ordering must stop before the later replacement"
+            );
+        }
     }
 
     #[tokio::test]
@@ -4883,6 +5938,13 @@ mod tests {
             .control_binding
             .ready_revision
             .generation = NonZeroU64::new(u64::MAX).unwrap();
+        overflow
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .control_binding
+            .ready_revision
+            .generation = NonZeroU64::new(u64::MAX).unwrap();
         assert_eq!(
             prepare_catalog_control_transition_v1(overflow, [0xac; 32])
                 .err()
@@ -4988,6 +6050,7 @@ mod tests {
         assert_eq!(advanced.storage_authority_fingerprint, [0x99; 32]);
         assert_eq!(advanced.control_authority_fingerprint, [0x9a; 32]);
         assert_eq!(advanced.context, observed.context);
+        assert!(advanced.retained_control_lease.is_live_v1());
 
         {
             let committed = make_committed();
@@ -5018,6 +6081,20 @@ mod tests {
         }
         {
             let committed = make_committed();
+            let receipt = high_water_advance_receipt(&committed);
+            committed
+                .control_guard
+                .all_writers
+                .retained_control_lease
+                .test_live
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::ControlLeaseNotLive
+            );
+        }
+        {
+            let committed = make_committed();
             let mut receipt = high_water_advance_receipt(&committed);
             receipt.ready_revision.fingerprint = committed.pending_revision.fingerprint;
             assert_eq!(
@@ -5028,8 +6105,12 @@ mod tests {
         {
             let committed = make_committed();
             let mut receipt = high_water_advance_receipt(&committed);
-            receipt.ready_revision.fingerprint =
-                committed.control_binding.ready_revision.fingerprint;
+            receipt.ready_revision.fingerprint = committed
+                .control_guard
+                .high_water
+                .binding
+                .ready_revision
+                .fingerprint;
             assert_eq!(
                 match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
                 CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -10,22 +10,30 @@
 //! This checkpoint deliberately stops before production authority. Bootstrap
 //! completeness, exact-current high-water, and the all-writer credential epoch
 //! are opaque external receipts with no production constructors. The module
-//! can validate and compose their exact bindings, but cannot mint them, write a
-//! live `HEAD`, produce a plan digest, or authorize an action.
+//! can validate and compose their exact bindings and publish the exact immutable
+//! predecessor-HEAD archive. A separately namespaced journal draft exercises
+//! bounded artifact mechanics but cannot become authoritative recovery evidence
+//! or enter a publishing fence. This module still cannot mint authority, write
+//! a live `HEAD`, mutate the namespace, produce a plan digest, or authorize an
+//! action.
 
 use std::num::NonZeroU64;
 
+use anyhow::{Context, Result as AnyhowResult};
 use opendal::Operator;
 use serde::{Deserialize, Serialize};
 use tcfs_core::config::{
-    RegisteredRootPlanContractFingerprintV1, RootProfileSettingsFingerprintV1, RootProfileV1,
+    RegisteredRootPlanContractFingerprintV1, RegisteredRootPlanContractV1,
+    RootProfileSettingsFingerprintV1, RootProfileV1,
 };
 
 use super::{
-    lower_hex, validate_catalog_context_v1, InvalidRemoteCatalogReasonV1,
-    RemoteCatalogContextWireV1, RemoteCatalogObjectBindingWireV1,
+    lower_hex, validate_catalog_context_v1, validate_catalog_object_route_v1,
+    validate_entry_size_v1, InvalidRemoteCatalogReasonV1, RemoteCatalogContextWireV1,
+    RemoteCatalogObjectBindingWireV1, RemoteCatalogObjectKindV1,
     SemanticallyBoundRemoteCatalogCorpusV1, CATALOG_SCHEMA_VERSION_V1,
 };
+use crate::index_entry::{read_raw_object_snapshot_v1, RawObjectReadBindingV1, RawObjectReadV1};
 use crate::registered_reconcile::{
     validate_registered_remote_storage_key_bounds_v1, RegisteredRootRemoteObjectBindingV1,
 };
@@ -36,8 +44,24 @@ const ARCHIVED_HEAD_OBJECT_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-archived-head-object.b3v1";
 const MUTATION_JOURNAL_OBJECT_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-mutation-journal-object.b3v1";
+const UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-mutation-journal-draft-object.b3v1";
 const ARCHIVED_HEAD_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/archived-heads";
 const MUTATION_JOURNAL_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/mutation-journals";
+const UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_SUFFIX_V1: &str =
+    ".tcfs-catalog/v1/publications/mutation-journal-drafts";
+const CATALOG_MUTATION_JOURNAL_DRAFT_SCHEMA_VERSION_V1: u32 = 1;
+
+/// One draft is intentionally bounded to one catalog page worth of physical
+/// transitions. Both factors are already committed by the registered-root plan
+/// contract fingerprint, while the draft schema version fixes this derivation.
+fn max_catalog_mutation_draft_key_bytes_v1() -> u64 {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    remote
+        .max_catalog_entries_per_page()
+        .checked_mul(remote.max_storage_key_bytes())
+        .expect("strict catalog mutation draft bounds must multiply without overflow")
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct CatalogAuthorityContextV1 {
@@ -103,6 +127,26 @@ impl std::fmt::Debug for ObservedPublishedCatalogHeadV1 {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InvalidCatalogMutationJournalReasonV1 {
+    CanonicalEncoding,
+    Context,
+    Lineage,
+    Totals,
+    Order,
+    Route,
+    Operation,
+    ObjectIdentity,
+    ObjectBinding,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CatalogMutationJournalResourceV1 {
+    Bytes,
+    Mutations,
+    KeyBytes,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum CatalogPublicationContractErrorV1 {
     CurrentHeadWithoutEtag,
     StorageSemanticsUnverified,
@@ -120,6 +164,8 @@ pub(crate) enum CatalogPublicationContractErrorV1 {
     ControlAuthorityMismatch,
     PredecessorArchiveMismatch,
     MutationJournalMismatch,
+    InvalidMutationJournal(InvalidCatalogMutationJournalReasonV1),
+    MutationJournalResource(CatalogMutationJournalResourceV1),
 }
 
 /// Extract the exact mutable-HEAD ETag needed by a future pre-mutation CAS.
@@ -328,14 +374,508 @@ pub(crate) fn match_catalog_publication_prerequisites_v1<'a>(
     })
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum RemoteCatalogMutationOperationDraftWireV1 {
+    CreateIfAbsent,
+    ReplaceIfMatch,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "state", rename_all = "kebab-case", deny_unknown_fields)]
+enum RemoteCatalogMutationPredecessorDraftWireV1 {
+    Absent,
+    Present {
+        raw_bytes_len: u64,
+        raw_blake3: String,
+        binding: RemoteCatalogObjectBindingWireV1,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogMutationSuccessorDraftWireV1 {
+    raw_bytes_len: u64,
+    raw_blake3: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogMutationDraftWireV1 {
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    operation: RemoteCatalogMutationOperationDraftWireV1,
+    predecessor: RemoteCatalogMutationPredecessorDraftWireV1,
+    successor: RemoteCatalogMutationSuccessorDraftWireV1,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogMutationJournalDraftWireV1 {
+    version: u32,
+    context: RemoteCatalogContextWireV1,
+    catalog_sequence: u64,
+    publication_nonce: String,
+    parent_head_revision: String,
+    mutation_count: u64,
+    mutation_key_bytes: u64,
+    mutations: Vec<RemoteCatalogMutationDraftWireV1>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CatalogMutationDraftObjectIdentityV1 {
+    raw_bytes_len: NonZeroU64,
+    raw_blake3: [u8; 32],
+}
+
+impl CatalogMutationDraftObjectIdentityV1 {
+    fn from_bytes(raw_bytes: &[u8]) -> Option<Self> {
+        let raw_bytes_len = NonZeroU64::new(u64::try_from(raw_bytes.len()).ok()?)?;
+        Some(Self {
+            raw_bytes_len,
+            raw_blake3: *blake3::hash(raw_bytes).as_bytes(),
+        })
+    }
+
+    fn to_wire(&self) -> RemoteCatalogMutationSuccessorDraftWireV1 {
+        RemoteCatalogMutationSuccessorDraftWireV1 {
+            raw_bytes_len: self.raw_bytes_len.get(),
+            raw_blake3: lower_hex(&self.raw_blake3),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CatalogMutationDraftPredecessorV1 {
+    Absent,
+    Present {
+        identity: CatalogMutationDraftObjectIdentityV1,
+        binding: RegisteredRootRemoteObjectBindingV1,
+    },
+}
+
+/// One untrusted draft of a final catalog-visible physical-key transition.
+///
+/// These fields are deliberately caller claims. Shape validation cannot prove
+/// predecessor membership, create-key absence, successor semantics, or
+/// cross-object closure. Consequently this private draft cannot become the
+/// authoritative `BoundCatalogMutationJournalV1` accepted by a publishing
+/// fence. A later planner must derive that value from fact-bound corpus
+/// evidence and immutable successor payloads.
+struct UntrustedCatalogMutationIntentDraftV1 {
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    operation: RemoteCatalogMutationOperationDraftWireV1,
+    predecessor: CatalogMutationDraftPredecessorV1,
+    successor: CatalogMutationDraftObjectIdentityV1,
+}
+
+impl UntrustedCatalogMutationIntentDraftV1 {
+    fn create_if_absent(
+        kind: RemoteCatalogObjectKindV1,
+        object_key: String,
+        successor_bytes: &[u8],
+    ) -> Option<Self> {
+        Some(Self {
+            kind,
+            object_key,
+            operation: RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+            predecessor: CatalogMutationDraftPredecessorV1::Absent,
+            successor: CatalogMutationDraftObjectIdentityV1::from_bytes(successor_bytes)?,
+        })
+    }
+
+    fn replace_if_match(
+        kind: RemoteCatalogObjectKindV1,
+        object_key: String,
+        predecessor_bytes: &[u8],
+        predecessor_binding: RegisteredRootRemoteObjectBindingV1,
+        successor_bytes: &[u8],
+    ) -> Option<Self> {
+        Some(Self {
+            kind,
+            object_key,
+            operation: RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+            predecessor: CatalogMutationDraftPredecessorV1::Present {
+                identity: CatalogMutationDraftObjectIdentityV1::from_bytes(predecessor_bytes)?,
+                binding: predecessor_binding,
+            },
+            successor: CatalogMutationDraftObjectIdentityV1::from_bytes(successor_bytes)?,
+        })
+    }
+
+    fn into_wire(self) -> RemoteCatalogMutationDraftWireV1 {
+        let predecessor = match self.predecessor {
+            CatalogMutationDraftPredecessorV1::Absent => {
+                RemoteCatalogMutationPredecessorDraftWireV1::Absent
+            }
+            CatalogMutationDraftPredecessorV1::Present { identity, binding } => {
+                RemoteCatalogMutationPredecessorDraftWireV1::Present {
+                    raw_bytes_len: identity.raw_bytes_len.get(),
+                    raw_blake3: lower_hex(&identity.raw_blake3),
+                    binding: binding_wire_v1(&binding),
+                }
+            }
+        };
+        RemoteCatalogMutationDraftWireV1 {
+            kind: self.kind,
+            object_key: self.object_key,
+            operation: self.operation,
+            predecessor,
+            successor: self.successor.to_wire(),
+        }
+    }
+}
+
+/// Canonical, bounded, untrusted journal draft prepared without touching
+/// storage.
+///
+/// Successors retain identities, not payload bytes. This is enough for
+/// diagnostic classification, but not for authoritative recovery evidence or
+/// autonomous roll-forward. There is intentionally no conversion from this
+/// type to `BoundCatalogMutationJournalV1` or a prepared publishing fence.
+struct PreparedUntrustedCatalogMutationJournalDraftV1 {
+    context: CatalogAuthorityContextV1,
+    catalog_sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: [u8; 32],
+    object_id: [u8; 32],
+    raw_bytes: Vec<u8>,
+    raw_bytes_len: NonZeroU64,
+}
+
+impl std::fmt::Debug for PreparedUntrustedCatalogMutationJournalDraftV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedUntrustedCatalogMutationJournalDraftV1")
+            .field("remote_prefix", &self.context.remote_prefix)
+            .field("root_id", &self.context.root_id)
+            .field("catalog_sequence", &self.catalog_sequence)
+            .field("mutation_journal_bytes", &self.raw_bytes_len)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Exact immutable publication of an untrusted mutation-journal draft.
+///
+/// The bytes and storage binding are real; the mutation claims are not yet
+/// fact-bound. This type is deliberately distinct from
+/// `BoundCatalogMutationJournalV1`, has no conversion to it, and cannot enter a
+/// prepared publishing fence.
+struct PublishedUntrustedCatalogMutationJournalDraftV1 {
+    context: CatalogAuthorityContextV1,
+    storage_authority_fingerprint: [u8; 32],
+    catalog_sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: [u8; 32],
+    object_id: [u8; 32],
+    raw_bytes: Vec<u8>,
+    raw_bytes_len: NonZeroU64,
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+fn invalid_mutation_journal(
+    reason: InvalidCatalogMutationJournalReasonV1,
+) -> CatalogPublicationContractErrorV1 {
+    CatalogPublicationContractErrorV1::InvalidMutationJournal(reason)
+}
+
+fn mutation_journal_resource(
+    resource: CatalogMutationJournalResourceV1,
+) -> CatalogPublicationContractErrorV1 {
+    CatalogPublicationContractErrorV1::MutationJournalResource(resource)
+}
+
+fn binding_has_usable_etag_v1(binding: &RemoteCatalogObjectBindingWireV1) -> bool {
+    binding
+        .etag
+        .as_deref()
+        .is_some_and(|etag| !etag.is_empty() && etag != "null")
+}
+
+fn validate_catalog_mutation_journal_draft_bytes_v1(
+    raw_bytes: &[u8],
+    expected_context: &CatalogAuthorityContextV1,
+    expected_sequence: NonZeroU64,
+    expected_publication_nonce: [u8; 32],
+    expected_parent_head_revision: [u8; 32],
+) -> Result<RemoteCatalogMutationJournalDraftWireV1, CatalogPublicationContractErrorV1> {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let raw_bytes_len = u64::try_from(raw_bytes.len())
+        .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::Bytes))?;
+    if raw_bytes_len == 0 || raw_bytes_len > remote.max_catalog_page_object_bytes() {
+        return Err(mutation_journal_resource(
+            CatalogMutationJournalResourceV1::Bytes,
+        ));
+    }
+    let wire = serde_json::from_slice::<RemoteCatalogMutationJournalDraftWireV1>(raw_bytes)
+        .map_err(|_| {
+            invalid_mutation_journal(InvalidCatalogMutationJournalReasonV1::CanonicalEncoding)
+        })?;
+    if serde_json::to_vec(&wire).ok().as_deref() != Some(raw_bytes)
+        || wire.version != CATALOG_MUTATION_JOURNAL_DRAFT_SCHEMA_VERSION_V1
+    {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::CanonicalEncoding,
+        ));
+    }
+    if wire.context != expected_context.to_wire() {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Context,
+        ));
+    }
+    if wire.catalog_sequence != expected_sequence.get()
+        || super::parse_lower_hex_32(&wire.publication_nonce) != Some(expected_publication_nonce)
+        || expected_publication_nonce == [0; 32]
+        || super::parse_lower_hex_32(&wire.parent_head_revision)
+            != Some(expected_parent_head_revision)
+        || expected_parent_head_revision == [0; 32]
+    {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Lineage,
+        ));
+    }
+    let mutation_count = u64::try_from(wire.mutations.len())
+        .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::Mutations))?;
+    if mutation_count > remote.max_catalog_entries_per_page() {
+        return Err(mutation_journal_resource(
+            CatalogMutationJournalResourceV1::Mutations,
+        ));
+    }
+    if wire.mutation_count != mutation_count {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Totals,
+        ));
+    }
+
+    let mut mutation_key_bytes = 0_u64;
+    let mut previous_key: Option<&str> = None;
+    for mutation in &wire.mutations {
+        let object_key_bytes = u64::try_from(mutation.object_key.len())
+            .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::KeyBytes))?;
+        mutation_key_bytes = mutation_key_bytes
+            .checked_add(object_key_bytes)
+            .ok_or_else(|| mutation_journal_resource(CatalogMutationJournalResourceV1::KeyBytes))?;
+        if mutation_key_bytes > max_catalog_mutation_draft_key_bytes_v1() {
+            return Err(mutation_journal_resource(
+                CatalogMutationJournalResourceV1::KeyBytes,
+            ));
+        }
+        if previous_key.is_some_and(|previous| previous >= mutation.object_key.as_str()) {
+            return Err(invalid_mutation_journal(
+                InvalidCatalogMutationJournalReasonV1::Order,
+            ));
+        }
+        previous_key = Some(&mutation.object_key);
+        if !validate_catalog_object_route_v1(
+            &expected_context.remote_prefix,
+            mutation.kind,
+            &mutation.object_key,
+        ) {
+            return Err(invalid_mutation_journal(
+                InvalidCatalogMutationJournalReasonV1::Route,
+            ));
+        }
+        let successor_hash = super::parse_lower_hex_32(&mutation.successor.raw_blake3);
+        if successor_hash.is_none()
+            || !validate_entry_size_v1(mutation.kind, mutation.successor.raw_bytes_len)
+        {
+            return Err(invalid_mutation_journal(
+                InvalidCatalogMutationJournalReasonV1::ObjectIdentity,
+            ));
+        }
+        match (&mutation.operation, &mutation.predecessor) {
+            (
+                RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+                RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+            ) => {}
+            (
+                RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+                RemoteCatalogMutationPredecessorDraftWireV1::Present {
+                    raw_bytes_len,
+                    raw_blake3,
+                    binding,
+                },
+            ) if mutation.kind == RemoteCatalogObjectKindV1::Index => {
+                if super::parse_lower_hex_32(raw_blake3).is_none()
+                    || !validate_entry_size_v1(mutation.kind, *raw_bytes_len)
+                {
+                    return Err(invalid_mutation_journal(
+                        InvalidCatalogMutationJournalReasonV1::ObjectIdentity,
+                    ));
+                }
+                if super::validate_binding_wire_v1(binding).is_none()
+                    || !binding_has_usable_etag_v1(binding)
+                {
+                    return Err(invalid_mutation_journal(
+                        InvalidCatalogMutationJournalReasonV1::ObjectBinding,
+                    ));
+                }
+            }
+            _ => {
+                return Err(invalid_mutation_journal(
+                    InvalidCatalogMutationJournalReasonV1::Operation,
+                ))
+            }
+        }
+    }
+    if wire.mutation_key_bytes != mutation_key_bytes {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Totals,
+        ));
+    }
+    Ok(wire)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UntrustedCatalogMutationRecoveryClassificationV1 {
+    NotApplied,
+    Applied,
+    Diverged,
+}
+
+struct ObservedCatalogMutationObjectV1 {
+    raw_bytes_len: NonZeroU64,
+    raw_blake3: [u8; 32],
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+fn mutation_identity_matches_observed_v1(
+    raw_bytes_len: u64,
+    raw_blake3: &str,
+    observed: &ObservedCatalogMutationObjectV1,
+) -> bool {
+    raw_bytes_len == observed.raw_bytes_len.get()
+        && super::parse_lower_hex_32(raw_blake3) == Some(observed.raw_blake3)
+}
+
+/// Classify one untrusted draft transition without writing or retrying.
+///
+/// This diagnostic helper does not authorize recovery. A third state is never
+/// guessed through, and even `Applied`/`NotApplied` cannot promote the draft to
+/// authoritative evidence.
+fn classify_untrusted_catalog_mutation_draft_v1(
+    mutation: &RemoteCatalogMutationDraftWireV1,
+    observed: Option<&ObservedCatalogMutationObjectV1>,
+) -> UntrustedCatalogMutationRecoveryClassificationV1 {
+    if observed.is_some_and(|observed| {
+        mutation_identity_matches_observed_v1(
+            mutation.successor.raw_bytes_len,
+            &mutation.successor.raw_blake3,
+            observed,
+        )
+    }) {
+        return UntrustedCatalogMutationRecoveryClassificationV1::Applied;
+    }
+    match (&mutation.operation, &mutation.predecessor, observed) {
+        (
+            RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+            RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+            None,
+        ) => UntrustedCatalogMutationRecoveryClassificationV1::NotApplied,
+        (
+            RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+            RemoteCatalogMutationPredecessorDraftWireV1::Present {
+                raw_bytes_len,
+                raw_blake3,
+                binding,
+            },
+            Some(observed),
+        ) if mutation_identity_matches_observed_v1(*raw_bytes_len, raw_blake3, observed)
+            && &binding_wire_v1(&observed.binding) == binding =>
+        {
+            UntrustedCatalogMutationRecoveryClassificationV1::NotApplied
+        }
+        _ => UntrustedCatalogMutationRecoveryClassificationV1::Diverged,
+    }
+}
+
+/// Prepare one deterministic transaction journal without writing storage.
+/// Empty journals are structurally valid; later execution policy decides
+/// whether a no-op publication should be attempted.
+fn prepare_untrusted_catalog_mutation_journal_draft_v1(
+    prerequisites: &MatchedCatalogPublicationPrerequisitesV1<'_>,
+    publication_nonce: [u8; 32],
+    mut mutations: Vec<UntrustedCatalogMutationIntentDraftV1>,
+) -> Result<PreparedUntrustedCatalogMutationJournalDraftV1, CatalogPublicationContractErrorV1> {
+    if publication_nonce == [0; 32] {
+        return Err(CatalogPublicationContractErrorV1::ZeroPublicationNonce);
+    }
+    if publication_nonce == prerequisites.publication_nonce {
+        return Err(CatalogPublicationContractErrorV1::ReusedPublicationNonce);
+    }
+    let sequence = prerequisites
+        .sequence
+        .get()
+        .checked_add(1)
+        .and_then(NonZeroU64::new)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let mutation_count = u64::try_from(mutations.len())
+        .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::Mutations))?;
+    if mutation_count > remote.max_catalog_entries_per_page() {
+        return Err(mutation_journal_resource(
+            CatalogMutationJournalResourceV1::Mutations,
+        ));
+    }
+    let mutation_key_bytes = mutations.iter().try_fold(0_u64, |total, mutation| {
+        total.checked_add(u64::try_from(mutation.object_key.len()).ok()?)
+    });
+    let mutation_key_bytes = mutation_key_bytes
+        .filter(|bytes| *bytes <= max_catalog_mutation_draft_key_bytes_v1())
+        .ok_or_else(|| mutation_journal_resource(CatalogMutationJournalResourceV1::KeyBytes))?;
+    mutations.sort_unstable_by(|left, right| left.object_key.cmp(&right.object_key));
+    let mutations = mutations
+        .into_iter()
+        .map(UntrustedCatalogMutationIntentDraftV1::into_wire)
+        .collect::<Vec<_>>();
+    let wire = RemoteCatalogMutationJournalDraftWireV1 {
+        version: CATALOG_MUTATION_JOURNAL_DRAFT_SCHEMA_VERSION_V1,
+        context: prerequisites.context.to_wire(),
+        catalog_sequence: sequence.get(),
+        publication_nonce: lower_hex(&publication_nonce),
+        parent_head_revision: lower_hex(&prerequisites.head_revision),
+        mutation_count,
+        mutation_key_bytes,
+        mutations,
+    };
+    let raw_bytes =
+        serde_json::to_vec(&wire).expect("catalog mutation journal draft is serializable");
+    validate_catalog_mutation_journal_draft_bytes_v1(
+        &raw_bytes,
+        &prerequisites.context,
+        sequence,
+        publication_nonce,
+        prerequisites.head_revision,
+    )?;
+    let raw_bytes_len = NonZeroU64::new(
+        u64::try_from(raw_bytes.len())
+            .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::Bytes))?,
+    )
+    .ok_or_else(|| mutation_journal_resource(CatalogMutationJournalResourceV1::Bytes))?;
+    Ok(PreparedUntrustedCatalogMutationJournalDraftV1 {
+        context: prerequisites.context.clone(),
+        catalog_sequence: sequence,
+        publication_nonce,
+        parent_head_revision: prerequisites.head_revision,
+        object_id: super::domain_object_id_v1(
+            UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_DOMAIN_V1,
+            &raw_bytes,
+        ),
+        raw_bytes,
+        raw_bytes_len,
+    })
+}
+
 /// Exact immutable copy of the complete committed predecessor HEAD.
 ///
 /// The object must be installed absent-only and byte-verified before the
 /// mutable HEAD CAS. `object_id` is the domain-separated digest of the exact
 /// committed HEAD bytes, so its fixed reference lets recovery find and verify
 /// the previous catalog root at a canonical key without LIST. The binding is
-/// tied to the exact storage authority used for HEAD. No production constructor
-/// exists until the immutable publication primitive is implemented.
+/// tied to the exact storage authority used for HEAD. The only source-level
+/// constructor is the absent-only, exact-read-bound publication primitive
+/// below; this value still cannot acquire a live HEAD fence.
 pub(crate) struct BoundArchivedCatalogHeadV1 {
     context: CatalogAuthorityContextV1,
     storage_authority_fingerprint: [u8; 32],
@@ -346,15 +886,15 @@ pub(crate) struct BoundArchivedCatalogHeadV1 {
     binding: RegisteredRootRemoteObjectBindingV1,
 }
 
-/// Exact immutable transaction journal written before the visible fence.
+/// Exact immutable authoritative transaction journal written before the
+/// visible fence.
 ///
-/// The journal must enumerate the complete intended index/reservation/manifest
-/// mutation set plus each predecessor/new byte identity, so crash recovery can
-/// roll forward or remain fenced without reconstructing truth through LIST.
-/// `object_id` is the domain-separated digest of the retained canonical bytes.
-/// Its binding is tied to the exact storage authority and canonical key used
-/// for HEAD. No production constructor or journal-schema validator exists in
-/// this checkpoint.
+/// A future production constructor must prove the complete intended mutation
+/// set against the exact semantic predecessor corpus, prove create-key absence,
+/// validate every typed successor and cross-object closure, and bind immutable
+/// successor payload references. No such constructor or conversion from the
+/// untrusted draft exists in this checkpoint. Without those payload references,
+/// classification can only remain fenced; it cannot roll forward.
 pub(crate) struct BoundCatalogMutationJournalV1 {
     context: CatalogAuthorityContextV1,
     storage_authority_fingerprint: [u8; 32],
@@ -399,6 +939,16 @@ fn mutation_journal_object_key_v1(journal: &BoundCatalogMutationJournalV1) -> Op
     )
 }
 
+fn untrusted_mutation_journal_draft_object_key_v1(
+    journal: &PublishedUntrustedCatalogMutationJournalDraftV1,
+) -> Option<String> {
+    publication_object_key_v1(
+        &journal.context,
+        UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_SUFFIX_V1,
+        &journal.object_id,
+    )
+}
+
 fn binding_wire_v1(
     binding: &RegisteredRootRemoteObjectBindingV1,
 ) -> RemoteCatalogObjectBindingWireV1 {
@@ -414,6 +964,208 @@ fn binding_wire_v1(
             etag: Some(etag.clone()),
         },
     }
+}
+
+fn registered_binding_from_raw_v1(
+    binding: RawObjectReadBindingV1,
+) -> RegisteredRootRemoteObjectBindingV1 {
+    match binding {
+        RawObjectReadBindingV1::Version { version, etag } => {
+            RegisteredRootRemoteObjectBindingV1::Version { version, etag }
+        }
+        RawObjectReadBindingV1::Etag { etag } => RegisteredRootRemoteObjectBindingV1::Etag { etag },
+    }
+}
+
+async fn publish_immutable_catalog_artifact_if_absent_exact_v1(
+    prerequisites: &MatchedCatalogPublicationPrerequisitesV1<'_>,
+    suffix: &str,
+    object_domain: &str,
+    expected_bytes: &[u8],
+    max_bytes: u64,
+) -> AnyhowResult<([u8; 32], NonZeroU64, RegisteredRootRemoteObjectBindingV1)> {
+    anyhow::ensure!(
+        prerequisites
+            .storage_authority
+            .conditional_write_receipt
+            .authorizes(
+                prerequisites.storage_authority.operator,
+                &prerequisites.context.remote_prefix,
+            )?,
+        "catalog artifact publication lost its exact accessor/prefix conditional-semantics authority"
+    );
+    let raw_bytes_len = u64::try_from(expected_bytes.len())
+        .context("catalog publication artifact length does not fit u64")?;
+    let raw_bytes_len =
+        NonZeroU64::new(raw_bytes_len).context("catalog publication artifact must not be empty")?;
+    anyhow::ensure!(
+        raw_bytes_len.get() <= max_bytes,
+        "catalog publication artifact exceeds its bound of {max_bytes} bytes"
+    );
+    let object_id = super::domain_object_id_v1(object_domain, expected_bytes);
+    let object_key = publication_object_key_v1(&prerequisites.context, suffix, &object_id)
+        .context(
+            "catalog publication artifact key exceeds the registered-root storage-key bound",
+        )?;
+    let write_error = prerequisites
+        .storage_authority
+        .operator
+        .write_with(&object_key, expected_bytes.to_vec())
+        .if_not_exists(true)
+        .await
+        .err();
+
+    let observed = match read_raw_object_snapshot_v1(
+        prerequisites.storage_authority.operator,
+        &object_key,
+        max_bytes,
+    )
+    .await
+    {
+        Ok(Some(RawObjectReadV1::Bound(snapshot))) => snapshot,
+        Ok(Some(RawObjectReadV1::Unbound)) => {
+            anyhow::bail!(
+                "catalog publication artifact exists without a usable exact storage binding: {object_key}"
+            )
+        }
+        Ok(None) => {
+            if let Some(error) = write_error {
+                return Err(anyhow::anyhow!(error)).with_context(|| {
+                    format!(
+                        "atomically creating catalog publication artifact and proving its exact bytes: {object_key}"
+                    )
+                });
+            }
+            anyhow::bail!(
+                "catalog publication artifact disappeared after absent-only creation: {object_key}"
+            )
+        }
+        Err(read_error) => {
+            let write_context = write_error
+                .as_ref()
+                .map(|error| format!("; absent-only write also returned: {error}"))
+                .unwrap_or_default();
+            return Err(read_error).with_context(|| {
+                format!(
+                    "proving exact catalog publication artifact after absent-only create{write_context}: {object_key}"
+                )
+            });
+        }
+    };
+    anyhow::ensure!(
+        observed.raw_bytes() == expected_bytes,
+        "catalog publication artifact key contains different bytes: {object_key}"
+    );
+    anyhow::ensure!(
+        observed.raw_bytes().len() == expected_bytes.len(),
+        "catalog publication artifact length changed during exact rebind: {object_key}"
+    );
+    let (observed_bytes, observed_blake3, binding) = observed.into_parts();
+    anyhow::ensure!(
+        observed_blake3 == blake3::hash(expected_bytes)
+            && super::domain_object_id_v1(object_domain, &observed_bytes) == object_id,
+        "catalog publication artifact identity changed during exact rebind: {object_key}"
+    );
+    Ok((
+        object_id,
+        raw_bytes_len,
+        registered_binding_from_raw_v1(binding),
+    ))
+}
+
+/// Publish and bind the complete predecessor HEAD at its deterministic archive
+/// key. A collision is accepted only after an exact bounded identity-bound
+/// reread proves byte equality; this function never overwrites or cleans up.
+pub(crate) async fn publish_predecessor_head_archive_v1(
+    prerequisites: &MatchedCatalogPublicationPrerequisitesV1<'_>,
+) -> AnyhowResult<BoundArchivedCatalogHeadV1> {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let (object_id, raw_bytes_len, binding) =
+        publish_immutable_catalog_artifact_if_absent_exact_v1(
+            prerequisites,
+            ARCHIVED_HEAD_OBJECT_SUFFIX_V1,
+            ARCHIVED_HEAD_OBJECT_DOMAIN_V1,
+            &prerequisites.committed_head_bytes,
+            remote.max_catalog_head_object_bytes(),
+        )
+        .await?;
+    Ok(BoundArchivedCatalogHeadV1 {
+        context: prerequisites.context.clone(),
+        storage_authority_fingerprint: prerequisites.storage_authority.authority_fingerprint,
+        predecessor_head_revision: prerequisites.head_revision,
+        predecessor_head_bytes_blake3: *blake3::hash(&prerequisites.committed_head_bytes)
+            .as_bytes(),
+        object_id,
+        raw_bytes_len,
+        binding,
+    })
+}
+
+/// Publish one canonical bounded untrusted journal draft.
+///
+/// This proves only the artifact's exact bytes and storage binding. The return
+/// type cannot satisfy the authoritative mutation-journal slot in a publishing
+/// fence and does not authorize namespace mutation or recovery.
+async fn publish_untrusted_catalog_mutation_journal_draft_v1(
+    prerequisites: &MatchedCatalogPublicationPrerequisitesV1<'_>,
+    prepared: PreparedUntrustedCatalogMutationJournalDraftV1,
+) -> AnyhowResult<PublishedUntrustedCatalogMutationJournalDraftV1> {
+    anyhow::ensure!(
+        prepared.context == prerequisites.context
+            && prepared.catalog_sequence.get()
+                == prerequisites
+                    .sequence
+                    .get()
+                    .checked_add(1)
+                    .context("catalog sequence overflow")?
+            && prepared.parent_head_revision == prerequisites.head_revision
+            && prepared.publication_nonce != [0; 32]
+            && prepared.publication_nonce != prerequisites.publication_nonce
+            && prepared.object_id
+                == super::domain_object_id_v1(
+                    UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_DOMAIN_V1,
+                    &prepared.raw_bytes,
+                )
+            && prepared.raw_bytes_len.get()
+                == u64::try_from(prepared.raw_bytes.len())
+                    .context("catalog mutation journal draft length does not fit u64")?,
+        "prepared catalog mutation journal draft does not match the exact publication prerequisites"
+    );
+    validate_catalog_mutation_journal_draft_bytes_v1(
+        &prepared.raw_bytes,
+        &prerequisites.context,
+        prepared.catalog_sequence,
+        prepared.publication_nonce,
+        prerequisites.head_revision,
+    )
+    .map_err(|error| {
+        anyhow::anyhow!("prepared catalog mutation journal draft is invalid: {error:?}")
+    })?;
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let (object_id, raw_bytes_len, binding) =
+        publish_immutable_catalog_artifact_if_absent_exact_v1(
+            prerequisites,
+            UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_SUFFIX_V1,
+            UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_DOMAIN_V1,
+            &prepared.raw_bytes,
+            remote.max_catalog_page_object_bytes(),
+        )
+        .await?;
+    anyhow::ensure!(
+        object_id == prepared.object_id && raw_bytes_len == prepared.raw_bytes_len,
+        "published catalog mutation journal draft identity differs from its prepared bytes"
+    );
+    Ok(PublishedUntrustedCatalogMutationJournalDraftV1 {
+        context: prepared.context,
+        storage_authority_fingerprint: prerequisites.storage_authority.authority_fingerprint,
+        catalog_sequence: prepared.catalog_sequence,
+        publication_nonce: prepared.publication_nonce,
+        parent_head_revision: prepared.parent_head_revision,
+        object_id,
+        raw_bytes: prepared.raw_bytes,
+        raw_bytes_len,
+        binding,
+    })
 }
 
 #[derive(Clone)]
@@ -799,6 +1551,22 @@ mod tests {
         Default
     );
     static_assertions::assert_not_impl_any!(
+        PreparedUntrustedCatalogMutationJournalDraftV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundCatalogMutationJournalV1>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        PublishedUntrustedCatalogMutationJournalDraftV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundCatalogMutationJournalV1>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
         MatchedCatalogPublicationPrerequisitesV1<'static>: Clone,
         serde::Serialize,
         Default,
@@ -963,6 +1731,48 @@ mod tests {
         .unwrap()
     }
 
+    fn created_index_mutation(
+        object_key: impl Into<String>,
+    ) -> UntrustedCatalogMutationIntentDraftV1 {
+        UntrustedCatalogMutationIntentDraftV1::create_if_absent(
+            RemoteCatalogObjectKindV1::Index,
+            object_key.into(),
+            br#"{"state":"deleted","version":4}"#,
+        )
+        .unwrap()
+    }
+
+    fn replaced_index_mutation(
+        object_key: impl Into<String>,
+        binding: RegisteredRootRemoteObjectBindingV1,
+    ) -> UntrustedCatalogMutationIntentDraftV1 {
+        UntrustedCatalogMutationIntentDraftV1::replace_if_match(
+            RemoteCatalogObjectKindV1::Index,
+            object_key.into(),
+            br#"{"state":"committed","version":4}"#,
+            binding,
+            br#"{"state":"deleted","version":4}"#,
+        )
+        .unwrap()
+    }
+
+    fn prepared_journal(
+        prerequisites: &MatchedCatalogPublicationPrerequisitesV1<'_>,
+        publication_nonce: [u8; 32],
+    ) -> PreparedUntrustedCatalogMutationJournalDraftV1 {
+        prepare_untrusted_catalog_mutation_journal_draft_v1(
+            prerequisites,
+            publication_nonce,
+            vec![replaced_index_mutation(
+                "roots/index/retained.txt",
+                RegisteredRootRemoteObjectBindingV1::Etag {
+                    etag: "fixture-index-etag".to_owned(),
+                },
+            )],
+        )
+        .unwrap()
+    }
+
     fn successor_claim(
         observed: &ObservedPublishedCatalogHeadV1,
         publication_nonce: [u8; 32],
@@ -1006,6 +1816,436 @@ mod tests {
                 etag: None,
             }),
             None
+        );
+    }
+
+    #[tokio::test]
+    async fn canonical_mutation_journal_sorts_unique_final_transitions_and_accepts_empty() {
+        let (fixture, observed) = observed_head().await;
+        let prerequisites = matched(&fixture, &observed);
+        let prepared = prepare_untrusted_catalog_mutation_journal_draft_v1(
+            &prerequisites,
+            [0x44; 32],
+            vec![
+                created_index_mutation("roots/index/z.txt"),
+                created_index_mutation("roots/index/a.txt"),
+            ],
+        )
+        .unwrap();
+        let wire = validate_catalog_mutation_journal_draft_bytes_v1(
+            &prepared.raw_bytes,
+            &prerequisites.context,
+            NonZeroU64::new(2).unwrap(),
+            [0x44; 32],
+            observed.head_revision,
+        )
+        .unwrap();
+        assert_eq!(wire.mutation_count, 2);
+        assert_eq!(wire.mutations[0].object_key, "roots/index/a.txt");
+        assert_eq!(wire.mutations[1].object_key, "roots/index/z.txt");
+        assert_eq!(
+            wire.mutation_key_bytes,
+            u64::try_from("roots/index/a.txt".len() + "roots/index/z.txt".len()).unwrap()
+        );
+
+        let empty = prepare_untrusted_catalog_mutation_journal_draft_v1(
+            &prerequisites,
+            [0x45; 32],
+            Vec::new(),
+        )
+        .unwrap();
+        let empty_wire = validate_catalog_mutation_journal_draft_bytes_v1(
+            &empty.raw_bytes,
+            &prerequisites.context,
+            NonZeroU64::new(2).unwrap(),
+            [0x45; 32],
+            observed.head_revision,
+        )
+        .unwrap();
+        assert_eq!(empty_wire.mutation_count, 0);
+        assert_eq!(empty_wire.mutation_key_bytes, 0);
+        assert!(empty_wire.mutations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mutation_recovery_classification_is_exact_and_third_states_fail_closed() {
+        let (fixture, observed_head) = observed_head().await;
+        let prerequisites = matched(&fixture, &observed_head);
+
+        let create_successor = br#"{"state":"deleted","version":4}"#;
+        let create = prepare_untrusted_catalog_mutation_journal_draft_v1(
+            &prerequisites,
+            [0x44; 32],
+            vec![UntrustedCatalogMutationIntentDraftV1::create_if_absent(
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/new.txt".to_owned(),
+                create_successor,
+            )
+            .unwrap()],
+        )
+        .unwrap();
+        let create_wire =
+            serde_json::from_slice::<RemoteCatalogMutationJournalDraftWireV1>(&create.raw_bytes)
+                .unwrap();
+        let create_mutation = &create_wire.mutations[0];
+        assert_eq!(
+            classify_untrusted_catalog_mutation_draft_v1(create_mutation, None),
+            UntrustedCatalogMutationRecoveryClassificationV1::NotApplied
+        );
+        let created = ObservedCatalogMutationObjectV1 {
+            raw_bytes_len: NonZeroU64::new(u64::try_from(create_successor.len()).unwrap()).unwrap(),
+            raw_blake3: *blake3::hash(create_successor).as_bytes(),
+            binding: RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "created-etag".to_owned(),
+            },
+        };
+        assert_eq!(
+            classify_untrusted_catalog_mutation_draft_v1(create_mutation, Some(&created)),
+            UntrustedCatalogMutationRecoveryClassificationV1::Applied
+        );
+        let wrong = ObservedCatalogMutationObjectV1 {
+            raw_bytes_len: NonZeroU64::new(5).unwrap(),
+            raw_blake3: *blake3::hash(b"wrong").as_bytes(),
+            binding: RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "wrong-etag".to_owned(),
+            },
+        };
+        assert_eq!(
+            classify_untrusted_catalog_mutation_draft_v1(create_mutation, Some(&wrong)),
+            UntrustedCatalogMutationRecoveryClassificationV1::Diverged
+        );
+
+        let predecessor = br#"{"state":"committed","version":4}"#;
+        let successor = br#"{"state":"deleted","version":4}"#;
+        let predecessor_binding = RegisteredRootRemoteObjectBindingV1::Etag {
+            etag: "predecessor-etag".to_owned(),
+        };
+        let replace = prepare_untrusted_catalog_mutation_journal_draft_v1(
+            &prerequisites,
+            [0x45; 32],
+            vec![UntrustedCatalogMutationIntentDraftV1::replace_if_match(
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/current.txt".to_owned(),
+                predecessor,
+                predecessor_binding.clone(),
+                successor,
+            )
+            .unwrap()],
+        )
+        .unwrap();
+        let replace_wire =
+            serde_json::from_slice::<RemoteCatalogMutationJournalDraftWireV1>(&replace.raw_bytes)
+                .unwrap();
+        let replace_mutation = &replace_wire.mutations[0];
+        let unchanged = ObservedCatalogMutationObjectV1 {
+            raw_bytes_len: NonZeroU64::new(u64::try_from(predecessor.len()).unwrap()).unwrap(),
+            raw_blake3: *blake3::hash(predecessor).as_bytes(),
+            binding: predecessor_binding,
+        };
+        assert_eq!(
+            classify_untrusted_catalog_mutation_draft_v1(replace_mutation, Some(&unchanged)),
+            UntrustedCatalogMutationRecoveryClassificationV1::NotApplied
+        );
+        assert_eq!(
+            classify_untrusted_catalog_mutation_draft_v1(replace_mutation, None),
+            UntrustedCatalogMutationRecoveryClassificationV1::Diverged
+        );
+        let successor_observed = ObservedCatalogMutationObjectV1 {
+            raw_bytes_len: NonZeroU64::new(u64::try_from(successor.len()).unwrap()).unwrap(),
+            raw_blake3: *blake3::hash(successor).as_bytes(),
+            binding: RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "successor-etag".to_owned(),
+            },
+        };
+        assert_eq!(
+            classify_untrusted_catalog_mutation_draft_v1(
+                replace_mutation,
+                Some(&successor_observed)
+            ),
+            UntrustedCatalogMutationRecoveryClassificationV1::Applied
+        );
+        let wrong_predecessor_binding = ObservedCatalogMutationObjectV1 {
+            binding: RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "different-etag".to_owned(),
+            },
+            ..unchanged
+        };
+        assert_eq!(
+            classify_untrusted_catalog_mutation_draft_v1(
+                replace_mutation,
+                Some(&wrong_predecessor_binding)
+            ),
+            UntrustedCatalogMutationRecoveryClassificationV1::Diverged
+        );
+    }
+
+    #[tokio::test]
+    async fn mutation_journal_rejects_duplicate_routes_and_operation_binding_drift() {
+        let (fixture, observed) = observed_head().await;
+        let prerequisites = matched(&fixture, &observed);
+        assert_eq!(
+            prepare_untrusted_catalog_mutation_journal_draft_v1(
+                &prerequisites,
+                [0x44; 32],
+                vec![
+                    created_index_mutation("roots/index/same.txt"),
+                    created_index_mutation("roots/index/same.txt"),
+                ],
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidMutationJournal(
+                InvalidCatalogMutationJournalReasonV1::Order
+            )
+        );
+        assert_eq!(
+            prepare_untrusted_catalog_mutation_journal_draft_v1(
+                &prerequisites,
+                [0x44; 32],
+                vec![created_index_mutation("other/index/file.txt")],
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidMutationJournal(
+                InvalidCatalogMutationJournalReasonV1::Route
+            )
+        );
+        assert_eq!(
+            prepare_untrusted_catalog_mutation_journal_draft_v1(
+                &prerequisites,
+                [0x44; 32],
+                vec![replaced_index_mutation(
+                    "roots/index/file.txt",
+                    RegisteredRootRemoteObjectBindingV1::Version {
+                        version: "version-only".to_owned(),
+                        etag: None,
+                    },
+                )],
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidMutationJournal(
+                InvalidCatalogMutationJournalReasonV1::ObjectBinding
+            )
+        );
+
+        let manifest_key = format!("roots/manifests/{}", "11".repeat(32));
+        let manifest_replace = UntrustedCatalogMutationIntentDraftV1::replace_if_match(
+            RemoteCatalogObjectKindV1::Manifest,
+            manifest_key,
+            b"old",
+            RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "manifest-etag".to_owned(),
+            },
+            b"new",
+        )
+        .unwrap();
+        assert_eq!(
+            prepare_untrusted_catalog_mutation_journal_draft_v1(
+                &prerequisites,
+                [0x44; 32],
+                vec![manifest_replace],
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidMutationJournal(
+                InvalidCatalogMutationJournalReasonV1::Operation
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn mutation_journal_enforces_lineage_canonical_encoding_and_page_bounds() {
+        let (fixture, observed) = observed_head().await;
+        let prerequisites = matched(&fixture, &observed);
+        assert_eq!(
+            prepare_untrusted_catalog_mutation_journal_draft_v1(
+                &prerequisites,
+                [0; 32],
+                Vec::new()
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::ZeroPublicationNonce
+        );
+        assert_eq!(
+            prepare_untrusted_catalog_mutation_journal_draft_v1(
+                &prerequisites,
+                observed.publication_nonce,
+                Vec::new(),
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::ReusedPublicationNonce
+        );
+
+        let prepared = prepare_untrusted_catalog_mutation_journal_draft_v1(
+            &prerequisites,
+            [0x44; 32],
+            vec![created_index_mutation("roots/index/file.txt")],
+        )
+        .unwrap();
+        let mut noncanonical = prepared.raw_bytes.clone();
+        noncanonical.push(b'\n');
+        assert_eq!(
+            validate_catalog_mutation_journal_draft_bytes_v1(
+                &noncanonical,
+                &prerequisites.context,
+                NonZeroU64::new(2).unwrap(),
+                [0x44; 32],
+                observed.head_revision,
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidMutationJournal(
+                InvalidCatalogMutationJournalReasonV1::CanonicalEncoding
+            )
+        );
+
+        let too_many = (0..=4096)
+            .map(|ordinal| created_index_mutation(format!("roots/index/{ordinal:04}.txt")))
+            .collect();
+        assert_eq!(
+            prepare_untrusted_catalog_mutation_journal_draft_v1(
+                &prerequisites,
+                [0x45; 32],
+                too_many
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::MutationJournalResource(
+                CatalogMutationJournalResourceV1::Mutations
+            )
+        );
+
+        let at_mutation_limit = (0..4096)
+            .map(|ordinal| created_index_mutation(format!("roots/index/{ordinal:04}.txt")))
+            .collect();
+        assert!(prepare_untrusted_catalog_mutation_journal_draft_v1(
+            &prerequisites,
+            [0x46; 32],
+            at_mutation_limit,
+        )
+        .is_ok());
+
+        let excessive_aggregate_key_bytes = (0..4096)
+            .map(|_| created_index_mutation("x".repeat(1025)))
+            .collect();
+        assert_eq!(
+            prepare_untrusted_catalog_mutation_journal_draft_v1(
+                &prerequisites,
+                [0x47; 32],
+                excessive_aggregate_key_bytes,
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::MutationJournalResource(
+                CatalogMutationJournalResourceV1::KeyBytes
+            )
+        );
+
+        let oversized = vec![b'x'; 16 * 1024 * 1024 + 1];
+        assert_eq!(
+            validate_catalog_mutation_journal_draft_bytes_v1(
+                &oversized,
+                &prerequisites.context,
+                NonZeroU64::new(2).unwrap(),
+                [0x44; 32],
+                observed.head_revision,
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::MutationJournalResource(
+                CatalogMutationJournalResourceV1::Bytes
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn immutable_archive_and_untrusted_journal_draft_leave_head_unchanged() {
+        let (fixture, observed) = observed_head().await;
+        let head_key = "roots/.tcfs-catalog/v1/head";
+        let head_before = fixture.operator().read(head_key).await.unwrap().to_vec();
+        let prerequisites = matched(&fixture, &observed);
+        let prepared = prepared_journal(&prerequisites, [0x44; 32]);
+        let archive = publish_predecessor_head_archive_v1(&prerequisites)
+            .await
+            .unwrap();
+        let journal = publish_untrusted_catalog_mutation_journal_draft_v1(&prerequisites, prepared)
+            .await
+            .unwrap();
+        let archive_key = archived_head_object_key_v1(&archive).unwrap();
+        let journal_key = untrusted_mutation_journal_draft_object_key_v1(&journal).unwrap();
+        assert_eq!(
+            fixture
+                .operator()
+                .read(&archive_key)
+                .await
+                .unwrap()
+                .to_vec(),
+            observed.committed_head_bytes
+        );
+        assert_eq!(
+            fixture
+                .operator()
+                .read(&journal_key)
+                .await
+                .unwrap()
+                .to_vec(),
+            journal.raw_bytes
+        );
+        assert_eq!(
+            fixture.operator().read(head_key).await.unwrap().to_vec(),
+            head_before,
+            "immutable artifact publication must not mutate HEAD"
+        );
+        assert_eq!(journal.storage_authority_fingerprint, [0x99; 32]);
+        assert_eq!(journal.catalog_sequence.get(), 2);
+        assert_eq!(journal.publication_nonce, [0x44; 32]);
+        assert_eq!(journal.parent_head_revision, observed.head_revision);
+        assert_ne!(journal.raw_bytes_len.get(), 0);
+        assert!(
+            super::super::validate_binding_wire_v1(&binding_wire_v1(&journal.binding)).is_some()
+        );
+        let _archive_remains_authoritative = archive;
+    }
+
+    #[tokio::test]
+    async fn immutable_artifact_publication_is_idempotent_but_rejects_wrong_collision_bytes() {
+        let (fixture, observed) = observed_head().await;
+        let first = matched(&fixture, &observed);
+        let first_archive = publish_predecessor_head_archive_v1(&first).await.unwrap();
+        let first_archive_key = archived_head_object_key_v1(&first_archive).unwrap();
+        let first_binding = binding_wire_v1(&first_archive.binding);
+
+        let second = matched(&fixture, &observed);
+        let second_archive = publish_predecessor_head_archive_v1(&second).await.unwrap();
+        assert_eq!(
+            archived_head_object_key_v1(&second_archive).as_deref(),
+            Some(first_archive_key.as_str())
+        );
+        assert_eq!(binding_wire_v1(&second_archive.binding), first_binding);
+
+        let other_nonce = [0x45; 32];
+        let prepared = prepared_journal(&second, other_nonce);
+        let journal_key = publication_object_key_v1(
+            &second.context,
+            UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_SUFFIX_V1,
+            &prepared.object_id,
+        )
+        .unwrap();
+        fixture
+            .operator()
+            .write(&journal_key, b"wrong collision bytes".to_vec())
+            .await
+            .unwrap();
+        let error = publish_untrusted_catalog_mutation_journal_draft_v1(&second, prepared)
+            .await
+            .err()
+            .expect("wrong collision bytes must be rejected");
+        assert!(
+            error.to_string().contains("contains different bytes"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(
+            fixture
+                .operator()
+                .read(&journal_key)
+                .await
+                .unwrap()
+                .to_vec(),
+            b"wrong collision bytes",
+            "failed absent-only publication must preserve the existing collision bytes"
         );
     }
 

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -1,0 +1,1712 @@
+//! Registered-root catalog publication contract.
+//!
+//! A final `HEAD` compare-and-swap is not a writer fence. Two writers can
+//! mutate different namespace objects from the same predecessor and only one
+//! can win the final CAS, leaving the winning catalog incomplete. The protocol
+//! modeled here therefore makes the mutable catalog `HEAD` visibly
+//! `publishing` *before* the first index, reservation, or manifest mutation.
+//! Readers reject that state instead of falling back to the predecessor.
+//!
+//! This checkpoint deliberately stops before production authority. Bootstrap
+//! completeness, exact-current high-water, and the all-writer credential epoch
+//! are opaque external receipts with no production constructors. The module
+//! can validate and compose their exact bindings, but cannot mint them, write a
+//! live `HEAD`, produce a plan digest, or authorize an action.
+
+use std::num::NonZeroU64;
+
+use opendal::Operator;
+use serde::{Deserialize, Serialize};
+use tcfs_core::config::{
+    RegisteredRootPlanContractFingerprintV1, RootProfileSettingsFingerprintV1, RootProfileV1,
+};
+
+use super::{
+    lower_hex, validate_catalog_context_v1, InvalidRemoteCatalogReasonV1,
+    RemoteCatalogContextWireV1, RemoteCatalogObjectBindingWireV1,
+    SemanticallyBoundRemoteCatalogCorpusV1, CATALOG_SCHEMA_VERSION_V1,
+};
+use crate::registered_reconcile::{
+    validate_registered_remote_storage_key_bounds_v1, RegisteredRootRemoteObjectBindingV1,
+};
+use crate::registered_source_composition::ValidatedSelectedRegisteredRootRemoteContextV1;
+use tcfs_storage::ConditionalWriteSemanticsReceipt;
+
+const ARCHIVED_HEAD_OBJECT_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-archived-head-object.b3v1";
+const MUTATION_JOURNAL_OBJECT_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-mutation-journal-object.b3v1";
+const ARCHIVED_HEAD_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/archived-heads";
+const MUTATION_JOURNAL_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/mutation-journals";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CatalogAuthorityContextV1 {
+    remote_prefix: String,
+    root_id: String,
+    root_identity_fingerprint: String,
+    root_generation: NonZeroU64,
+    profile: RootProfileV1,
+    profile_settings_fingerprint: RootProfileSettingsFingerprintV1,
+    plan_contract_fingerprint: RegisteredRootPlanContractFingerprintV1,
+}
+
+impl CatalogAuthorityContextV1 {
+    fn from_corpus(corpus: &SemanticallyBoundRemoteCatalogCorpusV1) -> Self {
+        Self {
+            remote_prefix: corpus.remote_prefix().to_owned(),
+            root_id: corpus.root_id().to_owned(),
+            root_identity_fingerprint: corpus.root_identity_fingerprint().to_owned(),
+            root_generation: corpus.root_generation(),
+            profile: corpus.profile(),
+            profile_settings_fingerprint: corpus.profile_settings_fingerprint(),
+            plan_contract_fingerprint: corpus.plan_contract_fingerprint(),
+        }
+    }
+
+    fn to_wire(&self) -> RemoteCatalogContextWireV1 {
+        RemoteCatalogContextWireV1 {
+            root_id: self.root_id.clone(),
+            root_identity_fingerprint: self.root_identity_fingerprint.clone(),
+            root_generation: self.root_generation.get(),
+            profile: self.profile,
+            profile_settings_fingerprint: self.profile_settings_fingerprint.to_string(),
+            plan_contract_fingerprint: self.plan_contract_fingerprint.to_string(),
+        }
+    }
+}
+
+/// Exact current `HEAD` selected by one semantically verified catalog corpus.
+///
+/// This is predecessor evidence only. It says nothing about bootstrap,
+/// currentness beyond this observation, or whether every writer participates.
+pub(crate) struct ObservedPublishedCatalogHeadV1 {
+    context: CatalogAuthorityContextV1,
+    sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: Option<[u8; 32]>,
+    head_revision: [u8; 32],
+    committed_head_bytes: Vec<u8>,
+    current_head_etag: String,
+}
+
+impl std::fmt::Debug for ObservedPublishedCatalogHeadV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ObservedPublishedCatalogHeadV1")
+            .field("remote_prefix", &self.context.remote_prefix)
+            .field("root_id", &self.context.root_id)
+            .field("root_generation", &self.context.root_generation)
+            .field("profile", &self.context.profile)
+            .field("sequence", &self.sequence)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CatalogPublicationContractErrorV1 {
+    CurrentHeadWithoutEtag,
+    StorageSemanticsUnverified,
+    SequenceOverflow,
+    SequenceMismatch,
+    ParentRevisionMismatch,
+    ZeroPublicationNonce,
+    ReusedPublicationNonce,
+    ContextMismatch,
+    InvalidBootstrapReceipt,
+    BootstrapMismatch,
+    HighWaterMismatch,
+    WriterFenceMismatch,
+    StorageAuthorityMismatch,
+    ControlAuthorityMismatch,
+    PredecessorArchiveMismatch,
+    MutationJournalMismatch,
+}
+
+/// Extract the exact mutable-HEAD ETag needed by a future pre-mutation CAS.
+fn mutable_head_etag_v1(binding: &RegisteredRootRemoteObjectBindingV1) -> Option<String> {
+    match binding {
+        RegisteredRootRemoteObjectBindingV1::Etag { etag }
+        | RegisteredRootRemoteObjectBindingV1::Version {
+            etag: Some(etag), ..
+        } if !etag.is_empty() => Some(etag.clone()),
+        RegisteredRootRemoteObjectBindingV1::Etag { .. }
+        | RegisteredRootRemoteObjectBindingV1::Version { .. } => None,
+    }
+}
+
+/// Retain the exact mutable-HEAD ETag needed by a future pre-mutation CAS.
+pub(crate) fn observe_published_catalog_head_v1(
+    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+) -> Result<ObservedPublishedCatalogHeadV1, CatalogPublicationContractErrorV1> {
+    let current_head_etag = mutable_head_etag_v1(corpus.closure.head_object.binding())
+        .ok_or(CatalogPublicationContractErrorV1::CurrentHeadWithoutEtag)?;
+    Ok(ObservedPublishedCatalogHeadV1 {
+        context: CatalogAuthorityContextV1::from_corpus(corpus),
+        sequence: corpus.closure.catalog_sequence,
+        publication_nonce: corpus.closure.publication_nonce,
+        parent_head_revision: corpus.closure.parent_head_revision,
+        head_revision: corpus.closure.head_revision,
+        committed_head_bytes: corpus.closure.head_raw_bytes.clone(),
+        current_head_etag,
+    })
+}
+
+/// Opaque binding between an external storage-authority identity and the exact
+/// live accessor/prefix conditional-semantics receipt used for this attempt.
+///
+/// A production constructor must authenticate the endpoint/bucket authority;
+/// deriving this fingerprint from the same replayable catalog prefix is not
+/// sufficient. No such constructor exists in this checkpoint.
+pub(crate) struct TrustedCatalogStorageAuthorityV1<'a> {
+    operator: &'a Operator,
+    conditional_write_receipt: &'a ConditionalWriteSemanticsReceipt,
+    authority_fingerprint: [u8; 32],
+}
+
+/// External attestation that sequence one was built from complete truth while
+/// every legacy/out-of-tree writer was quiesced under its bootstrap credential
+/// epoch. Later publications may use a rotated current epoch.
+///
+/// There is intentionally no production constructor in this checkpoint.
+pub(crate) struct TrustedCatalogBootstrapReceiptV1 {
+    context: CatalogAuthorityContextV1,
+    bootstrap_head_revision: [u8; 32],
+    bootstrap_publication_nonce: [u8; 32],
+    complete_corpus_attestation: [u8; 32],
+    bootstrap_writer_epoch: [u8; 32],
+    storage_authority_fingerprint: [u8; 32],
+    control_authority_fingerprint: [u8; 32],
+}
+
+/// Exclusive external exact-current guard anchored to one trusted bootstrap.
+///
+/// A lower bound is insufficient: without immutable historical HEAD objects,
+/// this source-only client cannot prove an unseen multi-hop lineage. The
+/// receipt must therefore match the exact observed sequence, revision, and
+/// nonce. Same-prefix remote state cannot mint this receipt because it could
+/// be replayed together with `HEAD`. A future production constructor must
+/// acquire the named external authority revision exclusively, keep the lease
+/// live through publication, and advance that revision monotonically before
+/// release; retaining this non-cloneable value alone is not a production
+/// liveness proof.
+pub(crate) struct TrustedCatalogHighWaterGuardV1 {
+    context: CatalogAuthorityContextV1,
+    bootstrap_head_revision: [u8; 32],
+    bootstrap_publication_nonce: [u8; 32],
+    complete_corpus_attestation: [u8; 32],
+    current_writer_epoch: [u8; 32],
+    current_sequence: NonZeroU64,
+    current_head_revision: [u8; 32],
+    current_publication_nonce: [u8; 32],
+    storage_authority_fingerprint: [u8; 32],
+    authority_revision: [u8; 32],
+    lease_nonce: [u8; 32],
+    control_authority_fingerprint: [u8; 32],
+}
+
+/// External proof that every credential and code path able to mutate the
+/// catalog corpus is fenced by the publishing-HEAD protocol.
+///
+/// This is broader than an in-process mutex or storage CAS receipt: old
+/// binaries and direct object-store credentials are part of the epoch. A
+/// future production constructor must keep this lease live through the visible
+/// HEAD CAS, every namespace mutation, committed-HEAD finalization, and
+/// high-water advancement.
+pub(crate) struct AllNamespaceWritersFencedLeaseV1 {
+    context: CatalogAuthorityContextV1,
+    bootstrap_head_revision: [u8; 32],
+    current_writer_epoch: [u8; 32],
+    authority_revision: [u8; 32],
+    lease_nonce: [u8; 32],
+    storage_authority_fingerprint: [u8; 32],
+    control_authority_fingerprint: [u8; 32],
+}
+
+/// Exact receipt match for one observed predecessor. This still is not remote
+/// completeness authority and has no planner/action conversion.
+pub(crate) struct MatchedCatalogPublicationPrerequisitesV1<'a> {
+    storage_authority: TrustedCatalogStorageAuthorityV1<'a>,
+    high_water_guard: TrustedCatalogHighWaterGuardV1,
+    writer_fence_lease: AllNamespaceWritersFencedLeaseV1,
+    context: CatalogAuthorityContextV1,
+    sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    head_revision: [u8; 32],
+    committed_head_bytes: Vec<u8>,
+    current_head_etag: String,
+    bootstrap_head_revision: [u8; 32],
+}
+
+impl std::fmt::Debug for MatchedCatalogPublicationPrerequisitesV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MatchedCatalogPublicationPrerequisitesV1")
+            .field("remote_prefix", &self.context.remote_prefix)
+            .field("root_id", &self.context.root_id)
+            .field("root_generation", &self.context.root_generation)
+            .field("sequence", &self.sequence)
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) fn match_catalog_publication_prerequisites_v1<'a>(
+    storage_authority: TrustedCatalogStorageAuthorityV1<'a>,
+    observed: &ObservedPublishedCatalogHeadV1,
+    bootstrap: &TrustedCatalogBootstrapReceiptV1,
+    high_water: TrustedCatalogHighWaterGuardV1,
+    writers: AllNamespaceWritersFencedLeaseV1,
+) -> Result<MatchedCatalogPublicationPrerequisitesV1<'a>, CatalogPublicationContractErrorV1> {
+    if !storage_authority
+        .conditional_write_receipt
+        .authorizes(storage_authority.operator, &observed.context.remote_prefix)
+        .unwrap_or(false)
+    {
+        return Err(CatalogPublicationContractErrorV1::StorageSemanticsUnverified);
+    }
+    let bootstrap_fields_nonzero = bootstrap.bootstrap_head_revision != [0; 32]
+        && bootstrap.bootstrap_publication_nonce != [0; 32]
+        && bootstrap.complete_corpus_attestation != [0; 32]
+        && bootstrap.bootstrap_writer_epoch != [0; 32]
+        && bootstrap.storage_authority_fingerprint != [0; 32]
+        && bootstrap.control_authority_fingerprint != [0; 32]
+        && storage_authority.authority_fingerprint != [0; 32];
+    if !bootstrap_fields_nonzero {
+        return Err(CatalogPublicationContractErrorV1::InvalidBootstrapReceipt);
+    }
+    if bootstrap.context != observed.context {
+        return Err(CatalogPublicationContractErrorV1::BootstrapMismatch);
+    }
+    if bootstrap.storage_authority_fingerprint != storage_authority.authority_fingerprint
+        || high_water.storage_authority_fingerprint != storage_authority.authority_fingerprint
+        || writers.storage_authority_fingerprint != storage_authority.authority_fingerprint
+    {
+        return Err(CatalogPublicationContractErrorV1::StorageAuthorityMismatch);
+    }
+    if high_water.control_authority_fingerprint != bootstrap.control_authority_fingerprint
+        || writers.control_authority_fingerprint != bootstrap.control_authority_fingerprint
+    {
+        return Err(CatalogPublicationContractErrorV1::ControlAuthorityMismatch);
+    }
+    if high_water.context != observed.context
+        || high_water.bootstrap_head_revision != bootstrap.bootstrap_head_revision
+        || high_water.bootstrap_publication_nonce != bootstrap.bootstrap_publication_nonce
+        || high_water.complete_corpus_attestation != bootstrap.complete_corpus_attestation
+        || high_water.current_writer_epoch == [0; 32]
+        || high_water.current_sequence != observed.sequence
+        || high_water.current_head_revision != observed.head_revision
+        || high_water.current_publication_nonce != observed.publication_nonce
+        || high_water.authority_revision == [0; 32]
+        || high_water.lease_nonce == [0; 32]
+    {
+        return Err(CatalogPublicationContractErrorV1::HighWaterMismatch);
+    }
+    if writers.context != observed.context
+        || writers.bootstrap_head_revision != bootstrap.bootstrap_head_revision
+        || writers.current_writer_epoch != high_water.current_writer_epoch
+        || writers.authority_revision == [0; 32]
+        || writers.lease_nonce == [0; 32]
+    {
+        return Err(CatalogPublicationContractErrorV1::WriterFenceMismatch);
+    }
+    if observed.sequence.get() == 1
+        && (bootstrap.bootstrap_head_revision != observed.head_revision
+            || bootstrap.bootstrap_publication_nonce != observed.publication_nonce)
+    {
+        return Err(CatalogPublicationContractErrorV1::BootstrapMismatch);
+    }
+    Ok(MatchedCatalogPublicationPrerequisitesV1 {
+        storage_authority,
+        high_water_guard: high_water,
+        writer_fence_lease: writers,
+        context: observed.context.clone(),
+        sequence: observed.sequence,
+        publication_nonce: observed.publication_nonce,
+        head_revision: observed.head_revision,
+        committed_head_bytes: observed.committed_head_bytes.clone(),
+        current_head_etag: observed.current_head_etag.clone(),
+        bootstrap_head_revision: bootstrap.bootstrap_head_revision,
+    })
+}
+
+/// Exact immutable copy of the complete committed predecessor HEAD.
+///
+/// The object must be installed absent-only and byte-verified before the
+/// mutable HEAD CAS. `object_id` is the domain-separated digest of the exact
+/// committed HEAD bytes, so its fixed reference lets recovery find and verify
+/// the previous catalog root at a canonical key without LIST. The binding is
+/// tied to the exact storage authority used for HEAD. No production constructor
+/// exists until the immutable publication primitive is implemented.
+pub(crate) struct BoundArchivedCatalogHeadV1 {
+    context: CatalogAuthorityContextV1,
+    storage_authority_fingerprint: [u8; 32],
+    predecessor_head_revision: [u8; 32],
+    predecessor_head_bytes_blake3: [u8; 32],
+    object_id: [u8; 32],
+    raw_bytes_len: NonZeroU64,
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+/// Exact immutable transaction journal written before the visible fence.
+///
+/// The journal must enumerate the complete intended index/reservation/manifest
+/// mutation set plus each predecessor/new byte identity, so crash recovery can
+/// roll forward or remain fenced without reconstructing truth through LIST.
+/// `object_id` is the domain-separated digest of the retained canonical bytes.
+/// Its binding is tied to the exact storage authority and canonical key used
+/// for HEAD. No production constructor or journal-schema validator exists in
+/// this checkpoint.
+pub(crate) struct BoundCatalogMutationJournalV1 {
+    context: CatalogAuthorityContextV1,
+    storage_authority_fingerprint: [u8; 32],
+    catalog_sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: [u8; 32],
+    object_id: [u8; 32],
+    raw_bytes: Vec<u8>,
+    raw_bytes_len: NonZeroU64,
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+fn publication_object_key_v1(
+    context: &CatalogAuthorityContextV1,
+    suffix: &str,
+    object_id: &[u8; 32],
+) -> Option<String> {
+    let key = format!(
+        "{}/{}/{}",
+        context.remote_prefix,
+        suffix,
+        lower_hex(object_id)
+    );
+    validate_registered_remote_storage_key_bounds_v1(&key, "catalog publication object key")
+        .ok()?;
+    Some(key)
+}
+
+fn archived_head_object_key_v1(archive: &BoundArchivedCatalogHeadV1) -> Option<String> {
+    publication_object_key_v1(
+        &archive.context,
+        ARCHIVED_HEAD_OBJECT_SUFFIX_V1,
+        &archive.object_id,
+    )
+}
+
+fn mutation_journal_object_key_v1(journal: &BoundCatalogMutationJournalV1) -> Option<String> {
+    publication_object_key_v1(
+        &journal.context,
+        MUTATION_JOURNAL_OBJECT_SUFFIX_V1,
+        &journal.object_id,
+    )
+}
+
+fn binding_wire_v1(
+    binding: &RegisteredRootRemoteObjectBindingV1,
+) -> RemoteCatalogObjectBindingWireV1 {
+    match binding {
+        RegisteredRootRemoteObjectBindingV1::Version { version, etag } => {
+            RemoteCatalogObjectBindingWireV1 {
+                version: Some(version.clone()),
+                etag: etag.clone(),
+            }
+        }
+        RegisteredRootRemoteObjectBindingV1::Etag { etag } => RemoteCatalogObjectBindingWireV1 {
+            version: None,
+            etag: Some(etag.clone()),
+        },
+    }
+}
+
+#[derive(Clone)]
+struct CatalogSuccessorClaimV1 {
+    context: CatalogAuthorityContextV1,
+    sequence: u64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: [u8; 32],
+}
+
+/// Structurally valid successor plus the exact predecessor CAS baseline.
+///
+/// Future publication starts by conditionally replacing the committed HEAD
+/// with the canonical publishing wire. This type cannot itself mutate storage.
+pub(crate) struct PreparedCatalogPublicationFenceV1<'a> {
+    storage_authority: TrustedCatalogStorageAuthorityV1<'a>,
+    high_water_guard: TrustedCatalogHighWaterGuardV1,
+    writer_fence_lease: AllNamespaceWritersFencedLeaseV1,
+    context: CatalogAuthorityContextV1,
+    sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: [u8; 32],
+    expected_parent_head_etag: String,
+    bootstrap_head_revision: [u8; 32],
+    predecessor_archive: BoundArchivedCatalogHeadV1,
+    mutation_journal: BoundCatalogMutationJournalV1,
+}
+
+impl std::fmt::Debug for PreparedCatalogPublicationFenceV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedCatalogPublicationFenceV1")
+            .field("remote_prefix", &self.context.remote_prefix)
+            .field("root_id", &self.context.root_id)
+            .field("root_generation", &self.context.root_generation)
+            .field("sequence", &self.sequence)
+            .finish_non_exhaustive()
+    }
+}
+
+fn validate_catalog_successor_claim_v1<'a>(
+    prerequisites: MatchedCatalogPublicationPrerequisitesV1<'a>,
+    claim: CatalogSuccessorClaimV1,
+    predecessor_archive: BoundArchivedCatalogHeadV1,
+    mutation_journal: BoundCatalogMutationJournalV1,
+) -> Result<PreparedCatalogPublicationFenceV1<'a>, CatalogPublicationContractErrorV1> {
+    let expected_sequence = prerequisites
+        .sequence
+        .get()
+        .checked_add(1)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    if claim.sequence != expected_sequence {
+        return Err(CatalogPublicationContractErrorV1::SequenceMismatch);
+    }
+    if claim.parent_head_revision != prerequisites.head_revision {
+        return Err(CatalogPublicationContractErrorV1::ParentRevisionMismatch);
+    }
+    if claim.publication_nonce == [0; 32] {
+        return Err(CatalogPublicationContractErrorV1::ZeroPublicationNonce);
+    }
+    if claim.publication_nonce == prerequisites.publication_nonce {
+        return Err(CatalogPublicationContractErrorV1::ReusedPublicationNonce);
+    }
+    if claim.context != prerequisites.context {
+        return Err(CatalogPublicationContractErrorV1::ContextMismatch);
+    }
+    let predecessor_bytes_blake3 = *blake3::hash(&prerequisites.committed_head_bytes).as_bytes();
+    let predecessor_object_id = super::domain_object_id_v1(
+        ARCHIVED_HEAD_OBJECT_DOMAIN_V1,
+        &prerequisites.committed_head_bytes,
+    );
+    let Ok(predecessor_raw_bytes_len) = u64::try_from(prerequisites.committed_head_bytes.len())
+    else {
+        return Err(CatalogPublicationContractErrorV1::PredecessorArchiveMismatch);
+    };
+    if predecessor_archive.context != prerequisites.context
+        || predecessor_archive.storage_authority_fingerprint
+            != prerequisites.storage_authority.authority_fingerprint
+        || predecessor_archive.predecessor_head_revision != prerequisites.head_revision
+        || predecessor_archive.predecessor_head_bytes_blake3 != predecessor_bytes_blake3
+        || predecessor_archive.object_id != predecessor_object_id
+        || predecessor_archive.raw_bytes_len.get() != predecessor_raw_bytes_len
+        || archived_head_object_key_v1(&predecessor_archive).is_none()
+        || super::validate_binding_wire_v1(&binding_wire_v1(&predecessor_archive.binding)).is_none()
+    {
+        return Err(CatalogPublicationContractErrorV1::PredecessorArchiveMismatch);
+    }
+    let journal_object_id = super::domain_object_id_v1(
+        MUTATION_JOURNAL_OBJECT_DOMAIN_V1,
+        &mutation_journal.raw_bytes,
+    );
+    let Ok(journal_raw_bytes_len) = u64::try_from(mutation_journal.raw_bytes.len()) else {
+        return Err(CatalogPublicationContractErrorV1::MutationJournalMismatch);
+    };
+    if mutation_journal.context != prerequisites.context
+        || mutation_journal.storage_authority_fingerprint
+            != prerequisites.storage_authority.authority_fingerprint
+        || mutation_journal.catalog_sequence.get() != expected_sequence
+        || mutation_journal.publication_nonce != claim.publication_nonce
+        || mutation_journal.parent_head_revision != prerequisites.head_revision
+        || mutation_journal.object_id != journal_object_id
+        || mutation_journal.raw_bytes_len.get() != journal_raw_bytes_len
+        || mutation_journal_object_key_v1(&mutation_journal).is_none()
+        || super::validate_binding_wire_v1(&binding_wire_v1(&mutation_journal.binding)).is_none()
+    {
+        return Err(CatalogPublicationContractErrorV1::MutationJournalMismatch);
+    }
+    Ok(PreparedCatalogPublicationFenceV1 {
+        storage_authority: prerequisites.storage_authority,
+        high_water_guard: prerequisites.high_water_guard,
+        writer_fence_lease: prerequisites.writer_fence_lease,
+        context: prerequisites.context,
+        sequence: NonZeroU64::new(expected_sequence)
+            .expect("checked nonzero successor of a nonzero sequence"),
+        publication_nonce: claim.publication_nonce,
+        parent_head_revision: claim.parent_head_revision,
+        expected_parent_head_etag: prerequisites.current_head_etag,
+        bootstrap_head_revision: prerequisites.bootstrap_head_revision,
+        predecessor_archive,
+        mutation_journal,
+    })
+}
+
+/// Prepare one exact successor. The future storage CAS is the cross-process
+/// winner election; callers must never mutate the namespace before it wins.
+pub(crate) fn prepare_catalog_publication_fence_v1<'a>(
+    prerequisites: MatchedCatalogPublicationPrerequisitesV1<'a>,
+    publication_nonce: [u8; 32],
+    predecessor_archive: BoundArchivedCatalogHeadV1,
+    mutation_journal: BoundCatalogMutationJournalV1,
+) -> Result<PreparedCatalogPublicationFenceV1<'a>, CatalogPublicationContractErrorV1> {
+    let sequence = prerequisites
+        .sequence
+        .get()
+        .checked_add(1)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    let claim = CatalogSuccessorClaimV1 {
+        context: prerequisites.context.clone(),
+        sequence,
+        publication_nonce,
+        parent_head_revision: prerequisites.head_revision,
+    };
+    validate_catalog_successor_claim_v1(prerequisites, claim, predecessor_archive, mutation_journal)
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum RemoteCatalogPublishingStateWireV1 {
+    Publishing,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogPublicationObjectReferenceWireV1 {
+    object_id: String,
+    raw_bytes_len: u64,
+    binding: RemoteCatalogObjectBindingWireV1,
+}
+
+/// Visible root-wide fence installed before the first catalog-corpus write.
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogPublishingHeadWireV1 {
+    version: u32,
+    state: RemoteCatalogPublishingStateWireV1,
+    context: RemoteCatalogContextWireV1,
+    catalog_sequence: u64,
+    publication_nonce: String,
+    parent_head_revision: String,
+    bootstrap_head_revision: String,
+    storage_authority_fingerprint: String,
+    control_authority_fingerprint: String,
+    writer_epoch: String,
+    high_water_authority_revision: String,
+    high_water_lease_nonce: String,
+    writer_fence_authority_revision: String,
+    writer_fence_lease_nonce: String,
+    predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1,
+    mutation_journal: RemoteCatalogPublicationObjectReferenceWireV1,
+}
+
+fn canonical_publishing_head_bytes_v1(
+    successor: &PreparedCatalogPublicationFenceV1<'_>,
+) -> Vec<u8> {
+    debug_assert!(
+        successor
+            .storage_authority
+            .conditional_write_receipt
+            .authorizes(
+                successor.storage_authority.operator,
+                &successor.context.remote_prefix,
+            )
+            .unwrap_or(false),
+        "prepared successor must retain its exact accessor/prefix receipt"
+    );
+    serde_json::to_vec(&RemoteCatalogPublishingHeadWireV1 {
+        version: CATALOG_SCHEMA_VERSION_V1,
+        state: RemoteCatalogPublishingStateWireV1::Publishing,
+        context: successor.context.to_wire(),
+        catalog_sequence: successor.sequence.get(),
+        publication_nonce: lower_hex(&successor.publication_nonce),
+        parent_head_revision: lower_hex(&successor.parent_head_revision),
+        bootstrap_head_revision: lower_hex(&successor.bootstrap_head_revision),
+        storage_authority_fingerprint: lower_hex(
+            &successor.storage_authority.authority_fingerprint,
+        ),
+        control_authority_fingerprint: lower_hex(
+            &successor.writer_fence_lease.control_authority_fingerprint,
+        ),
+        writer_epoch: lower_hex(&successor.writer_fence_lease.current_writer_epoch),
+        high_water_authority_revision: lower_hex(&successor.high_water_guard.authority_revision),
+        high_water_lease_nonce: lower_hex(&successor.high_water_guard.lease_nonce),
+        writer_fence_authority_revision: lower_hex(
+            &successor.writer_fence_lease.authority_revision,
+        ),
+        writer_fence_lease_nonce: lower_hex(&successor.writer_fence_lease.lease_nonce),
+        predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1 {
+            object_id: lower_hex(&successor.predecessor_archive.object_id),
+            raw_bytes_len: successor.predecessor_archive.raw_bytes_len.get(),
+            binding: binding_wire_v1(&successor.predecessor_archive.binding),
+        },
+        mutation_journal: RemoteCatalogPublicationObjectReferenceWireV1 {
+            object_id: lower_hex(&successor.mutation_journal.object_id),
+            raw_bytes_len: successor.mutation_journal.raw_bytes_len.get(),
+            binding: binding_wire_v1(&successor.mutation_journal.binding),
+        },
+    })
+    .expect("catalog publishing wire is infallibly serializable")
+}
+
+pub(super) fn classify_publishing_head_v1(
+    raw_bytes: &[u8],
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+) -> Option<Result<(), InvalidRemoteCatalogReasonV1>> {
+    let Ok(wire) = serde_json::from_slice::<RemoteCatalogPublishingHeadWireV1>(raw_bytes) else {
+        return None;
+    };
+    if serde_json::to_vec(&wire).ok().as_deref() != Some(raw_bytes) {
+        return Some(Err(InvalidRemoteCatalogReasonV1::CanonicalEncoding));
+    }
+    if wire.version != CATALOG_SCHEMA_VERSION_V1 {
+        return Some(Err(InvalidRemoteCatalogReasonV1::CanonicalEncoding));
+    }
+    if validate_catalog_context_v1(&wire.context, selected).is_none() {
+        return Some(Err(InvalidRemoteCatalogReasonV1::Context));
+    }
+    let valid_nonzero_hex =
+        |value: &str| super::parse_lower_hex_32(value).is_some_and(|bytes| bytes != [0; 32]);
+    let valid_lineage = wire.catalog_sequence >= 2
+        && valid_nonzero_hex(&wire.publication_nonce)
+        && valid_nonzero_hex(&wire.parent_head_revision)
+        && valid_nonzero_hex(&wire.bootstrap_head_revision)
+        && valid_nonzero_hex(&wire.storage_authority_fingerprint)
+        && valid_nonzero_hex(&wire.control_authority_fingerprint)
+        && valid_nonzero_hex(&wire.writer_epoch)
+        && valid_nonzero_hex(&wire.high_water_authority_revision)
+        && valid_nonzero_hex(&wire.high_water_lease_nonce)
+        && valid_nonzero_hex(&wire.writer_fence_authority_revision)
+        && valid_nonzero_hex(&wire.writer_fence_lease_nonce)
+        && valid_nonzero_hex(&wire.predecessor_head_archive.object_id)
+        && wire.predecessor_head_archive.raw_bytes_len > 0
+        && super::validate_binding_wire_v1(&wire.predecessor_head_archive.binding).is_some()
+        && valid_nonzero_hex(&wire.mutation_journal.object_id)
+        && wire.mutation_journal.raw_bytes_len > 0
+        && super::validate_binding_wire_v1(&wire.mutation_journal.binding).is_some();
+    Some(if valid_lineage {
+        Ok(())
+    } else {
+        Err(InvalidRemoteCatalogReasonV1::Lineage)
+    })
+}
+
+#[cfg(test)]
+fn is_canonical_publishing_head_v1(
+    raw_bytes: &[u8],
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+) -> bool {
+    classify_publishing_head_v1(raw_bytes, selected) == Some(Ok(()))
+}
+
+#[cfg(test)]
+pub(super) fn canonical_publishing_head_bytes_for_test_v1(
+    context: RemoteCatalogContextWireV1,
+) -> Vec<u8> {
+    serde_json::to_vec(&RemoteCatalogPublishingHeadWireV1 {
+        version: CATALOG_SCHEMA_VERSION_V1,
+        state: RemoteCatalogPublishingStateWireV1::Publishing,
+        context,
+        catalog_sequence: 2,
+        publication_nonce: "44".repeat(32),
+        parent_head_revision: "55".repeat(32),
+        bootstrap_head_revision: "66".repeat(32),
+        storage_authority_fingerprint: "99".repeat(32),
+        control_authority_fingerprint: "9a".repeat(32),
+        writer_epoch: "77".repeat(32),
+        high_water_authority_revision: "ab".repeat(32),
+        high_water_lease_nonce: "aa".repeat(32),
+        writer_fence_authority_revision: "89".repeat(32),
+        writer_fence_lease_nonce: "88".repeat(32),
+        predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1 {
+            object_id: "bb".repeat(32),
+            raw_bytes_len: 1,
+            binding: RemoteCatalogObjectBindingWireV1 {
+                version: None,
+                etag: Some("archive-etag".to_owned()),
+            },
+        },
+        mutation_journal: RemoteCatalogPublicationObjectReferenceWireV1 {
+            object_id: "cc".repeat(32),
+            raw_bytes_len: 1,
+            binding: RemoteCatalogObjectBindingWireV1 {
+                version: None,
+                etag: Some("journal-etag".to_owned()),
+            },
+        },
+    })
+    .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registered_remote_catalog::tests::{
+        semantic_remote_catalog_fixture_for_test_v1, SemanticRemoteCatalogFixtureRowV1,
+        SemanticRemoteCatalogFixtureV1,
+    };
+    use crate::registered_remote_catalog::{
+        read_semantically_bound_remote_catalog_corpus_v1,
+        StrictSemanticallyBoundRemoteCatalogReadV1,
+    };
+    use crate::registered_source_composition::validated_selected_registered_root_remote_context_for_test_v1;
+    use tcfs_core::config::RootSpecV1Config;
+
+    fn test_spec() -> RootSpecV1Config {
+        RootSpecV1Config {
+            version: RootSpecV1Config::VERSION,
+            remote_prefix: "roots".to_owned(),
+            profile: RootProfileV1::AgentStaticV1,
+            generation: NonZeroU64::new(1).unwrap(),
+        }
+    }
+
+    fn test_selected() -> ValidatedSelectedRegisteredRootRemoteContextV1 {
+        validated_selected_registered_root_remote_context_for_test_v1("fixture-root", &test_spec())
+            .unwrap()
+    }
+
+    static_assertions::assert_not_impl_any!(
+        ObservedPublishedCatalogHeadV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        TrustedCatalogStorageAuthorityV1<'static>: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        TrustedCatalogBootstrapReceiptV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        TrustedCatalogHighWaterGuardV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        AllNamespaceWritersFencedLeaseV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        BoundArchivedCatalogHeadV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        BoundCatalogMutationJournalV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        MatchedCatalogPublicationPrerequisitesV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        PreparedCatalogPublicationFenceV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+
+    async fn observed_head() -> (
+        SemanticRemoteCatalogFixtureV1,
+        ObservedPublishedCatalogHeadV1,
+    ) {
+        let spec = test_spec();
+        let selected = test_selected();
+        let fixture = semantic_remote_catalog_fixture_for_test_v1(
+            "fixture-root",
+            &spec,
+            &[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )],
+        )
+        .await;
+        let corpus = match read_semantically_bound_remote_catalog_corpus_v1(
+            fixture.operator(),
+            &selected,
+            fixture.receipt(),
+        )
+        .await
+        .unwrap()
+        {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(corpus) => corpus,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => {
+                panic!("expected semantic catalog fixture, got {incomplete:?}")
+            }
+        };
+        let observed = observe_published_catalog_head_v1(&corpus).unwrap();
+        (fixture, observed)
+    }
+
+    fn trusted_receipts(
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> (
+        TrustedCatalogBootstrapReceiptV1,
+        TrustedCatalogHighWaterGuardV1,
+        AllNamespaceWritersFencedLeaseV1,
+    ) {
+        let bootstrap_head_revision = observed.head_revision;
+        let bootstrap_writer_epoch = [0x21; 32];
+        let current_writer_epoch = [0x22; 32];
+        let storage_authority_fingerprint = [0x99; 32];
+        let control_authority_fingerprint = [0x9a; 32];
+        (
+            TrustedCatalogBootstrapReceiptV1 {
+                context: observed.context.clone(),
+                bootstrap_head_revision,
+                bootstrap_publication_nonce: observed.publication_nonce,
+                complete_corpus_attestation: [0x33; 32],
+                bootstrap_writer_epoch,
+                storage_authority_fingerprint,
+                control_authority_fingerprint,
+            },
+            TrustedCatalogHighWaterGuardV1 {
+                context: observed.context.clone(),
+                bootstrap_head_revision,
+                bootstrap_publication_nonce: observed.publication_nonce,
+                complete_corpus_attestation: [0x33; 32],
+                current_writer_epoch,
+                current_sequence: observed.sequence,
+                current_head_revision: observed.head_revision,
+                current_publication_nonce: observed.publication_nonce,
+                storage_authority_fingerprint,
+                authority_revision: [0xab; 32],
+                lease_nonce: [0xaa; 32],
+                control_authority_fingerprint,
+            },
+            AllNamespaceWritersFencedLeaseV1 {
+                context: observed.context.clone(),
+                bootstrap_head_revision,
+                current_writer_epoch,
+                authority_revision: [0x89; 32],
+                lease_nonce: [0x88; 32],
+                storage_authority_fingerprint,
+                control_authority_fingerprint,
+            },
+        )
+    }
+
+    fn trusted_storage(
+        fixture: &SemanticRemoteCatalogFixtureV1,
+    ) -> TrustedCatalogStorageAuthorityV1<'_> {
+        TrustedCatalogStorageAuthorityV1 {
+            operator: fixture.operator(),
+            conditional_write_receipt: fixture.receipt(),
+            authority_fingerprint: [0x99; 32],
+        }
+    }
+
+    fn bound_publication_objects(
+        observed: &ObservedPublishedCatalogHeadV1,
+        publication_nonce: [u8; 32],
+    ) -> (BoundArchivedCatalogHeadV1, BoundCatalogMutationJournalV1) {
+        let archive_object_id = super::super::domain_object_id_v1(
+            ARCHIVED_HEAD_OBJECT_DOMAIN_V1,
+            &observed.committed_head_bytes,
+        );
+        let journal_raw_bytes = br#"{"catalog_sequence":2,"mutations":[],"parent_head_revision":"fixture","publication_nonce":"fixture","version":1}"#.to_vec();
+        let journal_object_id = super::super::domain_object_id_v1(
+            MUTATION_JOURNAL_OBJECT_DOMAIN_V1,
+            &journal_raw_bytes,
+        );
+        (
+            BoundArchivedCatalogHeadV1 {
+                context: observed.context.clone(),
+                storage_authority_fingerprint: [0x99; 32],
+                predecessor_head_revision: observed.head_revision,
+                predecessor_head_bytes_blake3: *blake3::hash(&observed.committed_head_bytes)
+                    .as_bytes(),
+                object_id: archive_object_id,
+                raw_bytes_len: NonZeroU64::new(
+                    u64::try_from(observed.committed_head_bytes.len()).unwrap(),
+                )
+                .unwrap(),
+                binding: RegisteredRootRemoteObjectBindingV1::Etag {
+                    etag: "archive-etag".to_owned(),
+                },
+            },
+            BoundCatalogMutationJournalV1 {
+                context: observed.context.clone(),
+                storage_authority_fingerprint: [0x99; 32],
+                catalog_sequence: NonZeroU64::new(observed.sequence.get() + 1).unwrap(),
+                publication_nonce,
+                parent_head_revision: observed.head_revision,
+                object_id: journal_object_id,
+                raw_bytes_len: NonZeroU64::new(u64::try_from(journal_raw_bytes.len()).unwrap())
+                    .unwrap(),
+                raw_bytes: journal_raw_bytes,
+                binding: RegisteredRootRemoteObjectBindingV1::Etag {
+                    etag: "journal-etag".to_owned(),
+                },
+            },
+        )
+    }
+
+    fn matched<'a>(
+        fixture: &'a SemanticRemoteCatalogFixtureV1,
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> MatchedCatalogPublicationPrerequisitesV1<'a> {
+        let (bootstrap, high_water, writers) = trusted_receipts(observed);
+        match_catalog_publication_prerequisites_v1(
+            trusted_storage(fixture),
+            observed,
+            &bootstrap,
+            high_water,
+            writers,
+        )
+        .unwrap()
+    }
+
+    fn successor_claim(
+        observed: &ObservedPublishedCatalogHeadV1,
+        publication_nonce: [u8; 32],
+    ) -> CatalogSuccessorClaimV1 {
+        CatalogSuccessorClaimV1 {
+            context: observed.context.clone(),
+            sequence: observed.sequence.get() + 1,
+            publication_nonce,
+            parent_head_revision: observed.head_revision,
+        }
+    }
+
+    #[tokio::test]
+    async fn observed_head_retains_exact_current_etag_and_lineage() {
+        let (_fixture, observed) = observed_head().await;
+        assert_eq!(observed.sequence.get(), 1);
+        assert_eq!(observed.parent_head_revision, None);
+        assert_ne!(observed.publication_nonce, [0; 32]);
+        assert_ne!(observed.head_revision, [0; 32]);
+        assert_eq!(observed.current_head_etag, "head-etag-a");
+    }
+
+    #[test]
+    fn mutable_head_cas_accepts_etag_and_version_plus_etag_but_not_version_only() {
+        assert_eq!(
+            mutable_head_etag_v1(&RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "head-etag".to_owned(),
+            }),
+            Some("head-etag".to_owned())
+        );
+        assert_eq!(
+            mutable_head_etag_v1(&RegisteredRootRemoteObjectBindingV1::Version {
+                version: "head-version".to_owned(),
+                etag: Some("head-etag".to_owned()),
+            }),
+            Some("head-etag".to_owned())
+        );
+        assert_eq!(
+            mutable_head_etag_v1(&RegisteredRootRemoteObjectBindingV1::Version {
+                version: "head-version".to_owned(),
+                etag: None,
+            }),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_external_receipts_prepare_one_visible_successor() {
+        let (fixture, observed) = observed_head().await;
+        let publication_nonce = [0x44; 32];
+        let (archive, journal) = bound_publication_objects(&observed, publication_nonce);
+        let fence = prepare_catalog_publication_fence_v1(
+            matched(&fixture, &observed),
+            publication_nonce,
+            archive,
+            journal,
+        )
+        .unwrap();
+        assert_eq!(fence.sequence.get(), 2);
+        assert_eq!(fence.parent_head_revision, observed.head_revision);
+        assert_eq!(fence.expected_parent_head_etag, "head-etag-a");
+        assert_eq!(
+            archived_head_object_key_v1(&fence.predecessor_archive).unwrap(),
+            format!(
+                "roots/{}/{}",
+                ARCHIVED_HEAD_OBJECT_SUFFIX_V1,
+                lower_hex(&fence.predecessor_archive.object_id)
+            )
+        );
+        assert_eq!(
+            mutation_journal_object_key_v1(&fence.mutation_journal).unwrap(),
+            format!(
+                "roots/{}/{}",
+                MUTATION_JOURNAL_OBJECT_SUFFIX_V1,
+                lower_hex(&fence.mutation_journal.object_id)
+            )
+        );
+
+        let bytes = canonical_publishing_head_bytes_v1(&fence);
+        assert!(is_canonical_publishing_head_v1(&bytes, &test_selected()));
+        assert!(
+            super::super::canonical_wire_v1::<super::super::RemoteCatalogHeadWireV1>(&bytes)
+                .is_none()
+        );
+        let wire = serde_json::from_slice::<RemoteCatalogPublishingHeadWireV1>(&bytes).unwrap();
+        assert_eq!(wire.storage_authority_fingerprint, "99".repeat(32));
+        assert_eq!(wire.control_authority_fingerprint, "9a".repeat(32));
+        assert_eq!(wire.writer_epoch, "22".repeat(32));
+        assert_eq!(wire.high_water_authority_revision, "ab".repeat(32));
+        assert_eq!(wire.high_water_lease_nonce, "aa".repeat(32));
+        assert_eq!(wire.writer_fence_authority_revision, "89".repeat(32));
+        assert_eq!(wire.writer_fence_lease_nonce, "88".repeat(32));
+        assert_eq!(
+            wire.predecessor_head_archive.object_id,
+            lower_hex(&super::super::domain_object_id_v1(
+                ARCHIVED_HEAD_OBJECT_DOMAIN_V1,
+                &observed.committed_head_bytes,
+            ))
+        );
+        assert_eq!(
+            wire.mutation_journal.object_id,
+            lower_hex(&fence.mutation_journal.object_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn successor_rejects_sequence_parent_nonce_and_context_drift() {
+        let (fixture, observed) = observed_head().await;
+
+        let mut prerequisites = matched(&fixture, &observed);
+        prerequisites.sequence = NonZeroU64::new(u64::MAX).unwrap();
+        let (archive, journal) = bound_publication_objects(&observed, [0x44; 32]);
+        assert_eq!(
+            prepare_catalog_publication_fence_v1(prerequisites, [0x44; 32], archive, journal,)
+                .unwrap_err(),
+            CatalogPublicationContractErrorV1::SequenceOverflow
+        );
+
+        let cases = [
+            (
+                CatalogSuccessorClaimV1 {
+                    context: observed.context.clone(),
+                    sequence: observed.sequence.get(),
+                    publication_nonce: [0x44; 32],
+                    parent_head_revision: observed.head_revision,
+                },
+                CatalogPublicationContractErrorV1::SequenceMismatch,
+            ),
+            (
+                CatalogSuccessorClaimV1 {
+                    context: observed.context.clone(),
+                    sequence: observed.sequence.get() + 2,
+                    publication_nonce: [0x44; 32],
+                    parent_head_revision: observed.head_revision,
+                },
+                CatalogPublicationContractErrorV1::SequenceMismatch,
+            ),
+            (
+                CatalogSuccessorClaimV1 {
+                    context: observed.context.clone(),
+                    sequence: observed.sequence.get() + 1,
+                    publication_nonce: [0x44; 32],
+                    parent_head_revision: [0x55; 32],
+                },
+                CatalogPublicationContractErrorV1::ParentRevisionMismatch,
+            ),
+            (
+                CatalogSuccessorClaimV1 {
+                    context: observed.context.clone(),
+                    sequence: observed.sequence.get() + 1,
+                    publication_nonce: [0; 32],
+                    parent_head_revision: observed.head_revision,
+                },
+                CatalogPublicationContractErrorV1::ZeroPublicationNonce,
+            ),
+            (
+                CatalogSuccessorClaimV1 {
+                    context: observed.context.clone(),
+                    sequence: observed.sequence.get() + 1,
+                    publication_nonce: observed.publication_nonce,
+                    parent_head_revision: observed.head_revision,
+                },
+                CatalogPublicationContractErrorV1::ReusedPublicationNonce,
+            ),
+        ];
+        for (claim, expected) in cases {
+            let (archive, journal) = bound_publication_objects(&observed, claim.publication_nonce);
+            assert_eq!(
+                validate_catalog_successor_claim_v1(
+                    matched(&fixture, &observed),
+                    claim,
+                    archive,
+                    journal,
+                )
+                .unwrap_err(),
+                expected
+            );
+        }
+
+        let mut wrong_context = observed.context.clone();
+        wrong_context.root_id = "other-root".to_owned();
+        let claim = CatalogSuccessorClaimV1 {
+            context: wrong_context,
+            sequence: observed.sequence.get() + 1,
+            publication_nonce: [0x44; 32],
+            parent_head_revision: observed.head_revision,
+        };
+        let (archive, journal) = bound_publication_objects(&observed, claim.publication_nonce);
+        assert_eq!(
+            validate_catalog_successor_claim_v1(
+                matched(&fixture, &observed),
+                claim,
+                archive,
+                journal,
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::ContextMismatch
+        );
+    }
+
+    #[tokio::test]
+    async fn publication_artifacts_are_exactly_bound_before_the_visible_fence() {
+        let (fixture, observed) = observed_head().await;
+        let publication_nonce = [0x44; 32];
+        let reject = |archive, journal, expected| {
+            assert_eq!(
+                validate_catalog_successor_claim_v1(
+                    matched(&fixture, &observed),
+                    successor_claim(&observed, publication_nonce),
+                    archive,
+                    journal,
+                )
+                .unwrap_err(),
+                expected
+            );
+        };
+
+        let (mut archive, journal) = bound_publication_objects(&observed, publication_nonce);
+        archive.context.root_id = "other-root".to_owned();
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::PredecessorArchiveMismatch,
+        );
+
+        let (mut archive, journal) = bound_publication_objects(&observed, publication_nonce);
+        archive.storage_authority_fingerprint = [0x98; 32];
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::PredecessorArchiveMismatch,
+        );
+
+        let (mut archive, journal) = bound_publication_objects(&observed, publication_nonce);
+        archive.predecessor_head_revision = [0x55; 32];
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::PredecessorArchiveMismatch,
+        );
+
+        let (mut archive, journal) = bound_publication_objects(&observed, publication_nonce);
+        archive.predecessor_head_bytes_blake3 = [0x55; 32];
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::PredecessorArchiveMismatch,
+        );
+
+        let (mut archive, journal) = bound_publication_objects(&observed, publication_nonce);
+        archive.object_id = [0x55; 32];
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::PredecessorArchiveMismatch,
+        );
+
+        let (mut archive, journal) = bound_publication_objects(&observed, publication_nonce);
+        archive.raw_bytes_len = NonZeroU64::new(archive.raw_bytes_len.get() + 1).unwrap();
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::PredecessorArchiveMismatch,
+        );
+
+        let (mut archive, journal) = bound_publication_objects(&observed, publication_nonce);
+        archive.binding = RegisteredRootRemoteObjectBindingV1::Etag {
+            etag: String::new(),
+        };
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::PredecessorArchiveMismatch,
+        );
+
+        let (archive, mut journal) = bound_publication_objects(&observed, publication_nonce);
+        journal.context.root_id = "other-root".to_owned();
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::MutationJournalMismatch,
+        );
+
+        let (archive, mut journal) = bound_publication_objects(&observed, publication_nonce);
+        journal.storage_authority_fingerprint = [0x98; 32];
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::MutationJournalMismatch,
+        );
+
+        let (archive, mut journal) = bound_publication_objects(&observed, publication_nonce);
+        journal.catalog_sequence = NonZeroU64::new(journal.catalog_sequence.get() + 1).unwrap();
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::MutationJournalMismatch,
+        );
+
+        let (archive, mut journal) = bound_publication_objects(&observed, publication_nonce);
+        journal.publication_nonce = [0x45; 32];
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::MutationJournalMismatch,
+        );
+
+        let (archive, mut journal) = bound_publication_objects(&observed, publication_nonce);
+        journal.parent_head_revision = [0x55; 32];
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::MutationJournalMismatch,
+        );
+
+        let (archive, mut journal) = bound_publication_objects(&observed, publication_nonce);
+        journal.raw_bytes.push(b' ');
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::MutationJournalMismatch,
+        );
+
+        let (archive, mut journal) = bound_publication_objects(&observed, publication_nonce);
+        journal.raw_bytes_len = NonZeroU64::new(journal.raw_bytes_len.get() + 1).unwrap();
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::MutationJournalMismatch,
+        );
+
+        let (archive, mut journal) = bound_publication_objects(&observed, publication_nonce);
+        journal.binding = RegisteredRootRemoteObjectBindingV1::Etag {
+            etag: String::new(),
+        };
+        reject(
+            archive,
+            journal,
+            CatalogPublicationContractErrorV1::MutationJournalMismatch,
+        );
+    }
+
+    #[tokio::test]
+    async fn receipt_matching_rejects_bootstrap_high_water_and_writer_epoch_drift() {
+        let (fixture, observed) = observed_head().await;
+        {
+            let (mut bootstrap, high_water, writers) = trusted_receipts(&observed);
+            bootstrap.complete_corpus_attestation = [0; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::InvalidBootstrapReceipt
+            );
+        }
+        {
+            let (mut bootstrap, mut high_water, mut writers) = trusted_receipts(&observed);
+            bootstrap.bootstrap_head_revision = [0x55; 32];
+            high_water.bootstrap_head_revision = [0x55; 32];
+            writers.bootstrap_head_revision = [0x55; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::BootstrapMismatch,
+                "sequence one must be the exact externally attested bootstrap head"
+            );
+        }
+        {
+            let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
+            high_water.current_head_revision = [0x66; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterMismatch
+            );
+        }
+        {
+            let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
+            high_water.current_publication_nonce = [0x66; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterMismatch
+            );
+        }
+        {
+            let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
+            high_water.current_sequence = NonZeroU64::new(observed.sequence.get() + 1).unwrap();
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterMismatch,
+                "a guard ahead of the observed HEAD identifies observed replay or rollback"
+            );
+        }
+        {
+            let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
+            high_water.authority_revision = [0; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterMismatch
+            );
+        }
+        {
+            let (bootstrap, high_water, mut writers) = trusted_receipts(&observed);
+            writers.current_writer_epoch = [0x77; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::WriterFenceMismatch
+            );
+        }
+        {
+            let (bootstrap, high_water, mut writers) = trusted_receipts(&observed);
+            writers.authority_revision = [0; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::WriterFenceMismatch
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_current_guard_rejects_a_stale_guard_behind_the_observed_head() {
+        let (fixture, mut observed) = observed_head().await;
+        observed.sequence = NonZeroU64::new(2).unwrap();
+        observed.parent_head_revision = Some([0x54; 32]);
+        observed.head_revision = [0x55; 32];
+        observed.publication_nonce = [0x56; 32];
+        let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
+        high_water.current_sequence = NonZeroU64::new(1).unwrap();
+        assert_eq!(
+            match_catalog_publication_prerequisites_v1(
+                trusted_storage(&fixture),
+                &observed,
+                &bootstrap,
+                high_water,
+                writers,
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::HighWaterMismatch,
+            "a guard behind the observed HEAD is stale currentness authority"
+        );
+    }
+
+    #[tokio::test]
+    async fn receipt_matching_rejects_storage_and_control_authority_drift() {
+        let (fixture, observed) = observed_head().await;
+
+        {
+            let (mut bootstrap, high_water, writers) = trusted_receipts(&observed);
+            bootstrap.storage_authority_fingerprint = [0x98; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::StorageAuthorityMismatch
+            );
+        }
+        {
+            let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
+            high_water.storage_authority_fingerprint = [0x98; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::StorageAuthorityMismatch
+            );
+        }
+        {
+            let (bootstrap, high_water, mut writers) = trusted_receipts(&observed);
+            writers.storage_authority_fingerprint = [0x98; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::StorageAuthorityMismatch
+            );
+        }
+        {
+            let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
+            high_water.control_authority_fingerprint = [0x9b; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::ControlAuthorityMismatch
+            );
+        }
+        {
+            let (bootstrap, high_water, mut writers) = trusted_receipts(&observed);
+            writers.control_authority_fingerprint = [0x9b; 32];
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    trusted_storage(&fixture),
+                    &observed,
+                    &bootstrap,
+                    high_water,
+                    writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::ControlAuthorityMismatch
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn receipt_matching_rejects_another_accessor_or_prefix() {
+        let (fixture, observed) = observed_head().await;
+        let (other_fixture, _other_observed) = observed_head().await;
+        {
+            let (bootstrap, high_water, writers) = trusted_receipts(&observed);
+            let crossed = TrustedCatalogStorageAuthorityV1 {
+                operator: fixture.operator(),
+                conditional_write_receipt: other_fixture.receipt(),
+                authority_fingerprint: [0x99; 32],
+            };
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    crossed, &observed, &bootstrap, high_water, writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::StorageSemanticsUnverified
+            );
+        }
+        {
+            let (bootstrap, high_water, writers) = trusted_receipts(&observed);
+            let crossed = TrustedCatalogStorageAuthorityV1 {
+                operator: other_fixture.operator(),
+                conditional_write_receipt: fixture.receipt(),
+                authority_fingerprint: [0x99; 32],
+            };
+            assert_eq!(
+                match_catalog_publication_prerequisites_v1(
+                    crossed, &observed, &bootstrap, high_water, writers,
+                )
+                .unwrap_err(),
+                CatalogPublicationContractErrorV1::StorageSemanticsUnverified
+            );
+        }
+    }
+
+    #[test]
+    fn publishing_wire_rejects_noncanonical_zero_and_bootstrap_like_states() {
+        let selected = test_selected();
+        let context = CatalogAuthorityContextV1 {
+            remote_prefix: test_spec().remote_prefix,
+            root_id: selected.root_id().to_owned(),
+            root_identity_fingerprint: selected.spec_identity_fingerprint().to_owned(),
+            root_generation: selected.spec().generation,
+            profile: selected.spec().profile,
+            profile_settings_fingerprint: selected.profile_settings_fingerprint(),
+            plan_contract_fingerprint: selected.plan_contract_fingerprint(),
+        }
+        .to_wire();
+        let wire = RemoteCatalogPublishingHeadWireV1 {
+            version: CATALOG_SCHEMA_VERSION_V1,
+            state: RemoteCatalogPublishingStateWireV1::Publishing,
+            context,
+            catalog_sequence: 2,
+            publication_nonce: "44".repeat(32),
+            parent_head_revision: "55".repeat(32),
+            bootstrap_head_revision: "66".repeat(32),
+            storage_authority_fingerprint: "99".repeat(32),
+            control_authority_fingerprint: "9a".repeat(32),
+            writer_epoch: "77".repeat(32),
+            high_water_authority_revision: "ab".repeat(32),
+            high_water_lease_nonce: "aa".repeat(32),
+            writer_fence_authority_revision: "89".repeat(32),
+            writer_fence_lease_nonce: "88".repeat(32),
+            predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1 {
+                object_id: "bb".repeat(32),
+                raw_bytes_len: 1,
+                binding: RemoteCatalogObjectBindingWireV1 {
+                    version: None,
+                    etag: Some("archive-etag".to_owned()),
+                },
+            },
+            mutation_journal: RemoteCatalogPublicationObjectReferenceWireV1 {
+                object_id: "cc".repeat(32),
+                raw_bytes_len: 1,
+                binding: RemoteCatalogObjectBindingWireV1 {
+                    version: None,
+                    etag: Some("journal-etag".to_owned()),
+                },
+            },
+        };
+        let canonical = serde_json::to_vec(&wire).unwrap();
+        assert!(is_canonical_publishing_head_v1(&canonical, &selected));
+
+        let mut noncanonical = canonical.clone();
+        noncanonical.push(b'\n');
+        assert!(!is_canonical_publishing_head_v1(&noncanonical, &selected));
+
+        let mut zero_nonce = wire;
+        zero_nonce.publication_nonce = "00".repeat(32);
+        assert!(!is_canonical_publishing_head_v1(
+            &serde_json::to_vec(&zero_nonce).unwrap(),
+            &selected
+        ));
+
+        zero_nonce.publication_nonce = "44".repeat(32);
+        zero_nonce.catalog_sequence = 1;
+        assert!(!is_canonical_publishing_head_v1(
+            &serde_json::to_vec(&zero_nonce).unwrap(),
+            &selected
+        ));
+    }
+
+    #[test]
+    fn publishing_wire_rejects_unbound_authority_and_recovery_references() {
+        let fresh_wire = || {
+            let selected = test_selected();
+            let context = CatalogAuthorityContextV1 {
+                remote_prefix: test_spec().remote_prefix,
+                root_id: selected.root_id().to_owned(),
+                root_identity_fingerprint: selected.spec_identity_fingerprint().to_owned(),
+                root_generation: selected.spec().generation,
+                profile: selected.spec().profile,
+                profile_settings_fingerprint: selected.profile_settings_fingerprint(),
+                plan_contract_fingerprint: selected.plan_contract_fingerprint(),
+            }
+            .to_wire();
+            serde_json::from_slice::<RemoteCatalogPublishingHeadWireV1>(
+                &canonical_publishing_head_bytes_for_test_v1(context),
+            )
+            .unwrap()
+        };
+        let selected = test_selected();
+        let reject = |wire: RemoteCatalogPublishingHeadWireV1| {
+            assert!(!is_canonical_publishing_head_v1(
+                &serde_json::to_vec(&wire).unwrap(),
+                &selected,
+            ));
+        };
+
+        let mut wire = fresh_wire();
+        wire.storage_authority_fingerprint = "00".repeat(32);
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.control_authority_fingerprint = "00".repeat(32);
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.high_water_authority_revision = "00".repeat(32);
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.high_water_lease_nonce = "00".repeat(32);
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.writer_fence_authority_revision = "00".repeat(32);
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.writer_fence_lease_nonce = "00".repeat(32);
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.predecessor_head_archive.raw_bytes_len = 0;
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.predecessor_head_archive.binding.etag = Some(String::new());
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.mutation_journal.object_id = "AA".repeat(32);
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.mutation_journal.raw_bytes_len = 0;
+        reject(wire);
+
+        let mut unknown = serde_json::to_value(fresh_wire()).unwrap();
+        unknown
+            .as_object_mut()
+            .unwrap()
+            .insert("future-field".to_owned(), serde_json::json!(true));
+        assert!(!is_canonical_publishing_head_v1(
+            &serde_json::to_vec(&unknown).unwrap(),
+            &selected,
+        ));
+    }
+}

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -15,11 +15,15 @@
 //! future visible `HEAD` CAS. A terminal matcher also specifies the required
 //! `PublicationPending` to exact-current `Ready(n+1)` advance, but cannot mint a
 //! fresh guard. The module can publish the exact immutable predecessor-HEAD
-//! archive. A separately namespaced journal draft exercises bounded artifact
-//! mechanics but cannot become authoritative recovery evidence or enter a
-//! publishing fence. This module still cannot mint authority, write a live
-//! `HEAD`, mutate the namespace, produce a plan digest, or authorize an action.
+//! archive. Fact-bound preparation derives predecessors from the semantic
+//! corpus, proves create-key absence through the held accessor, reconstructs
+//! successor semantics, and publishes exact immutable payloads plus an
+//! authoritative journal. A separately namespaced diagnostic draft remains
+//! non-authoritative and cannot convert into that journal. This module still
+//! cannot mint authority, write a live `HEAD`, mutate the live namespace,
+//! produce a plan digest, or authorize an action.
 
+use std::collections::BTreeMap;
 use std::num::NonZeroU64;
 
 use anyhow::{Context, Result as AnyhowResult};
@@ -36,9 +40,19 @@ use super::{
     RemoteCatalogObjectBindingWireV1, RemoteCatalogObjectKindV1,
     SemanticallyBoundRemoteCatalogCorpusV1, CATALOG_SCHEMA_VERSION_V1,
 };
-use crate::index_entry::{read_raw_object_snapshot_v1, RawObjectReadBindingV1, RawObjectReadV1};
+use crate::blacklist::Blacklist;
+use crate::index_entry::{
+    read_raw_object_snapshot_v1, PortableNamespaceRole, RawObjectReadBindingV1, RawObjectReadV1,
+};
 use crate::registered_reconcile::{
-    validate_registered_remote_storage_key_bounds_v1, RegisteredRootRemoteObjectBindingV1,
+    validate_bound_catalog_manifest_references_v1, validate_catalog_index_payload_v1,
+    validate_catalog_manifest_payload_v1, validate_catalog_reservation_payload_v1,
+    validate_registered_remote_storage_key_bounds_v1, CatalogManifestReferenceV1,
+    CatalogValidatedIndexPayloadV1, CatalogValidatedIndexStateV1,
+    CatalogValidatedReservationPayloadV1, RegisteredRootRemoteObjectBindingV1,
+};
+use crate::registered_remote_observation::{
+    RemoteNamespaceClaimAccumulatorV1, RemoteNamespaceClaimOriginsV1,
 };
 use crate::registered_source_composition::ValidatedSelectedRegisteredRootRemoteContextV1;
 use tcfs_storage::ConditionalWriteSemanticsReceipt;
@@ -49,6 +63,8 @@ const MUTATION_JOURNAL_OBJECT_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-mutation-journal-object.b3v1";
 const UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-mutation-journal-draft-object.b3v1";
+const CATALOG_SUCCESSOR_PAYLOAD_OBJECT_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-successor-payload-object.b3v1";
 const PUBLISHING_HEAD_RESERVATION_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-publishing-head-reservation.b3v1";
 const PREDECESSOR_HEAD_STORAGE_BINDING_DOMAIN_V1: &str =
@@ -57,7 +73,10 @@ const ARCHIVED_HEAD_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/arch
 const MUTATION_JOURNAL_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/mutation-journals";
 const UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_SUFFIX_V1: &str =
     ".tcfs-catalog/v1/publications/mutation-journal-drafts";
+const CATALOG_SUCCESSOR_PAYLOAD_OBJECT_SUFFIX_V1: &str =
+    ".tcfs-catalog/v1/publications/successor-payloads";
 const CATALOG_MUTATION_JOURNAL_DRAFT_SCHEMA_VERSION_V1: u32 = 1;
+const CATALOG_MUTATION_JOURNAL_SCHEMA_VERSION_V1: u32 = 1;
 
 /// One draft is intentionally bounded to one catalog page worth of physical
 /// transitions. Both factors are already committed by the registered-root plan
@@ -174,6 +193,13 @@ pub(crate) enum CatalogPublicationContractErrorV1 {
     HighWaterAdvanceMismatch,
     PredecessorArchiveMismatch,
     MutationJournalMismatch,
+    MutationCorpusMismatch,
+    MutationPredecessorMissing,
+    MutationPredecessorKindMismatch,
+    MutationAbsenceMismatch,
+    MutationAbsenceStale,
+    InvalidSuccessorPayload,
+    InvalidSuccessorClosure,
     InvalidMutationJournal(InvalidCatalogMutationJournalReasonV1),
     MutationJournalResource(CatalogMutationJournalResourceV1),
 }
@@ -912,6 +938,778 @@ fn prepare_untrusted_catalog_mutation_journal_draft_v1(
     })
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CatalogFactObjectIdentityV1 {
+    raw_bytes_len: NonZeroU64,
+    raw_blake3: [u8; 32],
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+impl CatalogFactObjectIdentityV1 {
+    fn from_bound(
+        object: &crate::registered_reconcile::BoundRemoteObjectSnapshotV1,
+    ) -> Option<Self> {
+        Some(Self {
+            raw_bytes_len: NonZeroU64::new(object.raw_bytes_len())?,
+            raw_blake3: *object.raw_blake3(),
+            binding: object.binding().clone(),
+        })
+    }
+}
+
+fn corpus_object_fact_v1(
+    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+    object_key: &str,
+) -> Option<(RemoteCatalogObjectKindV1, CatalogFactObjectIdentityV1)> {
+    if let Some(index) = corpus
+        .index_objects
+        .iter()
+        .find(|index| index.physical_key() == object_key)
+    {
+        return Some((
+            RemoteCatalogObjectKindV1::Index,
+            CatalogFactObjectIdentityV1::from_bound(index.object())?,
+        ));
+    }
+    if let Some(reservation) = corpus
+        .reservations
+        .iter()
+        .find(|reservation| reservation.object_key() == object_key)
+    {
+        return Some((
+            RemoteCatalogObjectKindV1::Reservation,
+            CatalogFactObjectIdentityV1::from_bound(reservation.object())?,
+        ));
+    }
+    for manifest in &corpus.manifests {
+        let source = corpus
+            .index_objects
+            .get(manifest.source_index_ordinal)?
+            .committed()?;
+        let key = format!(
+            "{}/manifests/{}",
+            corpus.remote_prefix(),
+            source.current().manifest_hash()
+        );
+        if key == object_key {
+            return Some((
+                RemoteCatalogObjectKindV1::Manifest,
+                CatalogFactObjectIdentityV1::from_bound(manifest.manifest.object())?,
+            ));
+        }
+    }
+    None
+}
+
+fn catalog_named_object_max_bytes_v1(kind: RemoteCatalogObjectKindV1) -> u64 {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    match kind {
+        RemoteCatalogObjectKindV1::Index => remote.max_index_object_bytes(),
+        RemoteCatalogObjectKindV1::Reservation => remote.max_reservation_object_bytes(),
+        RemoteCatalogObjectKindV1::Manifest => remote.max_manifest_object_bytes(),
+    }
+}
+
+fn mutation_inputs_match_corpus_v1(
+    prerequisites: &MatchedCatalogPublicationPrerequisitesV1<'_>,
+    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+) -> bool {
+    prerequisites.context == CatalogAuthorityContextV1::from_corpus(corpus)
+        && prerequisites.sequence == corpus.closure.catalog_sequence
+        && prerequisites.head_revision == corpus.closure.head_revision
+}
+
+/// Exact missing-object observation tied to the same accessor, storage
+/// authority, semantic predecessor, and held control acquisition as one
+/// publication attempt.
+///
+/// The witness borrows the non-cloneable prerequisite capability. It is
+/// re-read and consumed during authoritative preparation, so an old absence
+/// observation cannot be replayed after the key appears.
+pub(crate) struct ProvenCatalogObjectAbsenceV1<'attempt, 'storage> {
+    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    predecessor_head_revision: [u8; 32],
+}
+
+/// Read one exact proposed create key through the publication's retained
+/// accessor. No LIST result or caller assertion can construct this witness.
+pub(crate) async fn prove_catalog_object_absence_v1<'attempt, 'storage>(
+    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
+    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+) -> AnyhowResult<ProvenCatalogObjectAbsenceV1<'attempt, 'storage>> {
+    anyhow::ensure!(
+        mutation_inputs_match_corpus_v1(prerequisites, corpus),
+        "catalog absence proof does not match the exact semantic predecessor"
+    );
+    anyhow::ensure!(
+        validate_catalog_object_route_v1(&prerequisites.context.remote_prefix, kind, &object_key),
+        "catalog absence proof key has the wrong route for its kind"
+    );
+    anyhow::ensure!(
+        corpus_object_fact_v1(corpus, &object_key).is_none(),
+        "catalog absence proof key is already a predecessor member"
+    );
+    anyhow::ensure!(
+        read_raw_object_snapshot_v1(
+            prerequisites.storage_authority.operator,
+            &object_key,
+            catalog_named_object_max_bytes_v1(kind),
+        )
+        .await?
+        .is_none(),
+        "catalog create key is not absent"
+    );
+    Ok(ProvenCatalogObjectAbsenceV1 {
+        prerequisites,
+        kind,
+        object_key,
+        predecessor_head_revision: prerequisites.head_revision,
+    })
+}
+
+#[derive(Debug)]
+enum TypedCatalogSuccessorSemanticsV1 {
+    Index(CatalogValidatedIndexPayloadV1),
+    Reservation(CatalogValidatedReservationPayloadV1),
+    Manifest,
+}
+
+/// Exact successor bytes parsed into their catalog kind before they can enter
+/// a fact-bound mutation. Fields are private so a raw byte vector cannot
+/// masquerade as a typed successor.
+pub(crate) struct TypedCatalogSuccessorPayloadV1 {
+    context: CatalogAuthorityContextV1,
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    raw_bytes: Vec<u8>,
+    raw_bytes_len: NonZeroU64,
+    raw_blake3: [u8; 32],
+    semantics: TypedCatalogSuccessorSemanticsV1,
+}
+
+impl std::fmt::Debug for TypedCatalogSuccessorPayloadV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TypedCatalogSuccessorPayloadV1")
+            .field("kind", &self.kind)
+            .field("object_key", &self.object_key)
+            .field("raw_bytes_len", &self.raw_bytes_len)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Parse one proposed successor through the strict registered-root validator
+/// for its kind. Manifest reference closure is completed only after every
+/// mutation has been applied to the in-memory successor catalog.
+pub(crate) fn type_catalog_successor_payload_v1(
+    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    raw_bytes: Vec<u8>,
+) -> Result<TypedCatalogSuccessorPayloadV1, CatalogPublicationContractErrorV1> {
+    let context = CatalogAuthorityContextV1::from_corpus(corpus);
+    if !validate_catalog_object_route_v1(&context.remote_prefix, kind, &object_key) {
+        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorPayload);
+    }
+    let raw_bytes_len = NonZeroU64::new(
+        u64::try_from(raw_bytes.len())
+            .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorPayload)?,
+    )
+    .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorPayload)?;
+    if !validate_entry_size_v1(kind, raw_bytes_len.get()) {
+        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorPayload);
+    }
+    let semantics = match kind {
+        RemoteCatalogObjectKindV1::Index => TypedCatalogSuccessorSemanticsV1::Index(
+            validate_catalog_index_payload_v1(&context.remote_prefix, &object_key, &raw_bytes)
+                .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorPayload)?,
+        ),
+        RemoteCatalogObjectKindV1::Reservation => TypedCatalogSuccessorSemanticsV1::Reservation(
+            validate_catalog_reservation_payload_v1(
+                &context.remote_prefix,
+                &object_key,
+                &raw_bytes,
+            )
+            .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorPayload)?,
+        ),
+        RemoteCatalogObjectKindV1::Manifest => {
+            let manifest_prefix = format!("{}/manifests/", context.remote_prefix);
+            let object_id = object_key
+                .strip_prefix(&manifest_prefix)
+                .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorPayload)?;
+            if crate::index_entry::manifest_object_id(&raw_bytes) != object_id {
+                return Err(CatalogPublicationContractErrorV1::InvalidSuccessorPayload);
+            }
+            TypedCatalogSuccessorSemanticsV1::Manifest
+        }
+    };
+    Ok(TypedCatalogSuccessorPayloadV1 {
+        context,
+        kind,
+        object_key,
+        raw_blake3: *blake3::hash(&raw_bytes).as_bytes(),
+        raw_bytes,
+        raw_bytes_len,
+        semantics,
+    })
+}
+
+enum FactBoundCatalogMutationPredecessorV1<'attempt, 'storage> {
+    Absent(ProvenCatalogObjectAbsenceV1<'attempt, 'storage>),
+    Present(CatalogFactObjectIdentityV1),
+}
+
+/// One final-key mutation whose before fact comes only from the exact semantic
+/// corpus or a same-attempt missing-object witness.
+pub(crate) struct FactBoundCatalogMutationV1<'attempt, 'storage> {
+    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
+    predecessor: FactBoundCatalogMutationPredecessorV1<'attempt, 'storage>,
+    successor: TypedCatalogSuccessorPayloadV1,
+}
+
+impl std::fmt::Debug for FactBoundCatalogMutationV1<'_, '_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FactBoundCatalogMutationV1")
+            .field("kind", &self.successor.kind)
+            .field("object_key", &self.successor.object_key)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Derive replacement predecessor identity and binding exclusively from the
+/// semantic corpus. Callers provide only the already-typed successor.
+pub(crate) fn fact_bind_catalog_replacement_v1<'attempt, 'storage>(
+    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
+    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+    successor: TypedCatalogSuccessorPayloadV1,
+) -> Result<FactBoundCatalogMutationV1<'attempt, 'storage>, CatalogPublicationContractErrorV1> {
+    if !mutation_inputs_match_corpus_v1(prerequisites, corpus)
+        || successor.context != prerequisites.context
+    {
+        return Err(CatalogPublicationContractErrorV1::MutationCorpusMismatch);
+    }
+    let Some((kind, predecessor)) = corpus_object_fact_v1(corpus, &successor.object_key) else {
+        return Err(CatalogPublicationContractErrorV1::MutationPredecessorMissing);
+    };
+    if kind != successor.kind {
+        return Err(CatalogPublicationContractErrorV1::MutationPredecessorKindMismatch);
+    }
+    if !binding_has_usable_etag_v1(&binding_wire_v1(&predecessor.binding)) {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::ObjectBinding,
+        ));
+    }
+    Ok(FactBoundCatalogMutationV1 {
+        prerequisites,
+        predecessor: FactBoundCatalogMutationPredecessorV1::Present(predecessor),
+        successor,
+    })
+}
+
+/// Bind a create to one consumed same-attempt absence witness.
+pub(crate) fn fact_bind_catalog_create_v1<'attempt, 'storage>(
+    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
+    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+    absence: ProvenCatalogObjectAbsenceV1<'attempt, 'storage>,
+    successor: TypedCatalogSuccessorPayloadV1,
+) -> Result<FactBoundCatalogMutationV1<'attempt, 'storage>, CatalogPublicationContractErrorV1> {
+    if !mutation_inputs_match_corpus_v1(prerequisites, corpus)
+        || successor.context != prerequisites.context
+        || !std::ptr::eq(absence.prerequisites, prerequisites)
+        || absence.predecessor_head_revision != prerequisites.head_revision
+        || absence.kind != successor.kind
+        || absence.object_key != successor.object_key
+    {
+        return Err(CatalogPublicationContractErrorV1::MutationAbsenceMismatch);
+    }
+    if corpus_object_fact_v1(corpus, &successor.object_key).is_some() {
+        return Err(CatalogPublicationContractErrorV1::MutationAbsenceStale);
+    }
+    Ok(FactBoundCatalogMutationV1 {
+        prerequisites,
+        predecessor: FactBoundCatalogMutationPredecessorV1::Absent(absence),
+        successor,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct CatalogSemanticIndexV1 {
+    logical_path: String,
+    role: PortableNamespaceRole,
+    origins: RemoteNamespaceClaimOriginsV1,
+    committed: Option<CatalogManifestReferenceV1>,
+    raw_bytes_len: u64,
+}
+
+#[derive(Clone, Debug)]
+struct CatalogSemanticReservationV1 {
+    exact_path: String,
+    folded_path: String,
+    role: PortableNamespaceRole,
+    raw_bytes_len: u64,
+}
+
+enum CatalogSemanticObjectV1<'a> {
+    Index(CatalogSemanticIndexV1),
+    Reservation(CatalogSemanticReservationV1),
+    ExistingManifest {
+        manifest: &'a crate::registered_reconcile::StrictRemoteManifestV1,
+        raw_bytes_len: u64,
+    },
+    SuccessorManifest(&'a [u8]),
+}
+
+impl CatalogSemanticObjectV1<'_> {
+    fn raw_bytes_len(&self) -> Option<u64> {
+        match self {
+            Self::Index(index) => Some(index.raw_bytes_len),
+            Self::Reservation(reservation) => Some(reservation.raw_bytes_len),
+            Self::ExistingManifest { raw_bytes_len, .. } => Some(*raw_bytes_len),
+            Self::SuccessorManifest(raw_bytes) => u64::try_from(raw_bytes.len()).ok(),
+        }
+    }
+}
+
+fn semantic_index_from_predecessor_v1(
+    remote_prefix: &str,
+    index: &super::SemanticallyBoundCatalogIndexObjectV1,
+) -> CatalogSemanticIndexV1 {
+    CatalogSemanticIndexV1 {
+        logical_path: index.logical_path().to_owned(),
+        role: index.role(),
+        origins: index.claim_origin(),
+        committed: index.committed().map(|committed| {
+            CatalogManifestReferenceV1::new(
+                remote_prefix,
+                committed.rel_path(),
+                committed.current(),
+            )
+        }),
+        raw_bytes_len: index.object().raw_bytes_len(),
+    }
+}
+
+fn semantic_index_from_successor_v1(
+    remote_prefix: &str,
+    index: &CatalogValidatedIndexPayloadV1,
+    raw_bytes_len: u64,
+) -> CatalogSemanticIndexV1 {
+    CatalogSemanticIndexV1 {
+        logical_path: index.logical_path().to_owned(),
+        role: index.role(),
+        origins: match index.state() {
+            CatalogValidatedIndexStateV1::Current => RemoteNamespaceClaimOriginsV1::CURRENT,
+            CatalogValidatedIndexStateV1::Historical => RemoteNamespaceClaimOriginsV1::HISTORICAL,
+        },
+        committed: index.committed().map(|committed| {
+            CatalogManifestReferenceV1::new(remote_prefix, index.logical_path(), committed)
+        }),
+        raw_bytes_len,
+    }
+}
+
+fn validate_complete_successor_semantic_closure_v1<'a>(
+    corpus: &'a SemanticallyBoundRemoteCatalogCorpusV1,
+    mutations: &'a [FactBoundCatalogMutationV1<'_, '_>],
+) -> Result<(), CatalogPublicationContractErrorV1> {
+    let remote_prefix = corpus.remote_prefix();
+    let mut objects = BTreeMap::<String, CatalogSemanticObjectV1<'a>>::new();
+    for index in &corpus.index_objects {
+        if objects
+            .insert(
+                index.physical_key().to_owned(),
+                CatalogSemanticObjectV1::Index(semantic_index_from_predecessor_v1(
+                    remote_prefix,
+                    index,
+                )),
+            )
+            .is_some()
+        {
+            return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+        }
+    }
+    for reservation in &corpus.reservations {
+        if objects
+            .insert(
+                reservation.object_key().to_owned(),
+                CatalogSemanticObjectV1::Reservation(CatalogSemanticReservationV1 {
+                    exact_path: reservation.exact_path().to_owned(),
+                    folded_path: reservation.folded_path().to_owned(),
+                    role: reservation.role(),
+                    raw_bytes_len: reservation.object().raw_bytes_len(),
+                }),
+            )
+            .is_some()
+        {
+            return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+        }
+    }
+    for manifest in &corpus.manifests {
+        let source = corpus
+            .index_objects
+            .get(manifest.source_index_ordinal)
+            .and_then(super::SemanticallyBoundCatalogIndexObjectV1::committed)
+            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+        let object_key = format!(
+            "{remote_prefix}/manifests/{}",
+            source.current().manifest_hash()
+        );
+        if objects
+            .insert(
+                object_key,
+                CatalogSemanticObjectV1::ExistingManifest {
+                    manifest: &manifest.manifest,
+                    raw_bytes_len: manifest.manifest.object().raw_bytes_len(),
+                },
+            )
+            .is_some()
+        {
+            return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+        }
+    }
+
+    let mut previous_key: Option<&str> = None;
+    for mutation in mutations {
+        if previous_key.is_some_and(|previous| previous >= mutation.successor.object_key.as_str()) {
+            return Err(invalid_mutation_journal(
+                InvalidCatalogMutationJournalReasonV1::Order,
+            ));
+        }
+        previous_key = Some(&mutation.successor.object_key);
+        match &mutation.predecessor {
+            FactBoundCatalogMutationPredecessorV1::Absent(_) => {
+                if objects.contains_key(&mutation.successor.object_key) {
+                    return Err(CatalogPublicationContractErrorV1::MutationAbsenceStale);
+                }
+            }
+            FactBoundCatalogMutationPredecessorV1::Present(_) => {
+                if !objects.contains_key(&mutation.successor.object_key) {
+                    return Err(CatalogPublicationContractErrorV1::MutationPredecessorMissing);
+                }
+            }
+        }
+        let semantic = match &mutation.successor.semantics {
+            TypedCatalogSuccessorSemanticsV1::Index(index) => {
+                CatalogSemanticObjectV1::Index(semantic_index_from_successor_v1(
+                    remote_prefix,
+                    index,
+                    mutation.successor.raw_bytes_len.get(),
+                ))
+            }
+            TypedCatalogSuccessorSemanticsV1::Reservation(reservation) => {
+                CatalogSemanticObjectV1::Reservation(CatalogSemanticReservationV1 {
+                    exact_path: reservation.exact_path().to_owned(),
+                    folded_path: reservation.folded_path().to_owned(),
+                    role: reservation.role(),
+                    raw_bytes_len: mutation.successor.raw_bytes_len.get(),
+                })
+            }
+            TypedCatalogSuccessorSemanticsV1::Manifest => {
+                CatalogSemanticObjectV1::SuccessorManifest(&mutation.successor.raw_bytes)
+            }
+        };
+        objects.insert(mutation.successor.object_key.clone(), semantic);
+    }
+
+    let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let object_count = u64::try_from(objects.len())
+        .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+    if object_count > contract.max_catalog_entries() {
+        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+    }
+    let mut object_key_bytes = 0_u64;
+    let mut object_body_bytes = 0_u64;
+    for (object_key, object) in &objects {
+        object_key_bytes = object_key_bytes
+            .checked_add(
+                u64::try_from(object_key.len())
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?,
+            )
+            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+        object_body_bytes = object_body_bytes
+            .checked_add(
+                object
+                    .raw_bytes_len()
+                    .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?,
+            )
+            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+    }
+    if object_key_bytes > contract.max_catalog_entry_key_bytes()
+        || object_body_bytes > contract.max_bound_object_bytes_per_pass()
+    {
+        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+    }
+    let mut claims = RemoteNamespaceClaimAccumulatorV1::new(contract);
+    let mut references = BTreeMap::<String, Vec<CatalogManifestReferenceV1>>::new();
+    let mut manifest_count = 0_usize;
+    for object in objects.values() {
+        match object {
+            CatalogSemanticObjectV1::Index(index) => {
+                if index.role == PortableNamespaceRole::Directory
+                    && index.origins == RemoteNamespaceClaimOriginsV1::CURRENT
+                    && Blacklist::default()
+                        .check_fixed_ingress_path_components(std::path::Path::new(
+                            &index.logical_path,
+                        ))
+                        .is_some()
+                {
+                    return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+                }
+                claims
+                    .observe_path(&index.logical_path, index.role, index.origins)
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+                if let Some(reference) = &index.committed {
+                    let manifest_key =
+                        format!("{remote_prefix}/manifests/{}", reference.manifest_hash());
+                    references
+                        .entry(manifest_key)
+                        .or_default()
+                        .push(reference.clone());
+                }
+            }
+            CatalogSemanticObjectV1::Reservation(reservation) => {
+                let expected = crate::index_entry::portable_casefold_path(&reservation.exact_path)
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+                if expected != reservation.folded_path {
+                    return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+                }
+                claims
+                    .observe_path(
+                        &reservation.exact_path,
+                        reservation.role,
+                        RemoteNamespaceClaimOriginsV1::RESERVATION,
+                    )
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+            }
+            CatalogSemanticObjectV1::ExistingManifest { .. }
+            | CatalogSemanticObjectV1::SuccessorManifest(_) => {
+                manifest_count = manifest_count
+                    .checked_add(1)
+                    .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+            }
+        }
+    }
+    if references.len() != manifest_count {
+        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+    }
+    for (manifest_key, manifest_references) in &references {
+        let manifest = objects
+            .get(manifest_key)
+            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+        match manifest {
+            CatalogSemanticObjectV1::ExistingManifest { manifest, .. } => {
+                validate_bound_catalog_manifest_references_v1(
+                    manifest_key,
+                    manifest,
+                    manifest_references,
+                )
+                .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+            }
+            CatalogSemanticObjectV1::SuccessorManifest(raw_bytes) => {
+                validate_catalog_manifest_payload_v1(manifest_key, raw_bytes, manifest_references)
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+            }
+            CatalogSemanticObjectV1::Index(_) | CatalogSemanticObjectV1::Reservation(_) => {
+                return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)
+            }
+        }
+    }
+    let _retained_claims = claims.into_retained_claims();
+    Ok(())
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogSuccessorPayloadReferenceWireV1 {
+    object_id: String,
+    raw_bytes_len: u64,
+    raw_blake3: String,
+    binding: RemoteCatalogObjectBindingWireV1,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogFactBoundMutationWireV1 {
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    operation: RemoteCatalogMutationOperationDraftWireV1,
+    predecessor: RemoteCatalogMutationPredecessorDraftWireV1,
+    successor_payload: RemoteCatalogSuccessorPayloadReferenceWireV1,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RemoteCatalogMutationJournalWireV1 {
+    version: u32,
+    context: RemoteCatalogContextWireV1,
+    catalog_sequence: u64,
+    publication_nonce: String,
+    parent_head_revision: String,
+    mutation_count: u64,
+    mutation_key_bytes: u64,
+    mutations: Vec<RemoteCatalogFactBoundMutationWireV1>,
+}
+
+struct BoundCatalogSuccessorPayloadV1 {
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    object_id: [u8; 32],
+    raw_bytes_len: NonZeroU64,
+    raw_blake3: [u8; 32],
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+/// Complete canonical authoritative journal with every successor bound to an
+/// immutable absent-only payload object. Publishing the journal remains a
+/// separate exact-reread step; this type cannot enter a visible fence.
+pub(crate) struct PreparedAuthoritativeCatalogMutationJournalV1 {
+    context: CatalogAuthorityContextV1,
+    storage_authority_fingerprint: [u8; 32],
+    catalog_sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: [u8; 32],
+    object_id: [u8; 32],
+    raw_bytes: Vec<u8>,
+    raw_bytes_len: NonZeroU64,
+    successor_payloads: Vec<BoundCatalogSuccessorPayloadV1>,
+}
+
+impl std::fmt::Debug for PreparedAuthoritativeCatalogMutationJournalV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedAuthoritativeCatalogMutationJournalV1")
+            .field("catalog_sequence", &self.catalog_sequence)
+            .field("raw_bytes_len", &self.raw_bytes_len)
+            .field("successor_payload_count", &self.successor_payloads.len())
+            .finish_non_exhaustive()
+    }
+}
+
+fn validate_authoritative_catalog_mutation_journal_bytes_v1(
+    raw_bytes: &[u8],
+    expected_context: &CatalogAuthorityContextV1,
+    expected_sequence: NonZeroU64,
+    expected_publication_nonce: [u8; 32],
+    expected_parent_head_revision: [u8; 32],
+) -> Result<RemoteCatalogMutationJournalWireV1, CatalogPublicationContractErrorV1> {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let raw_bytes_len = u64::try_from(raw_bytes.len())
+        .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::Bytes))?;
+    if raw_bytes_len == 0 || raw_bytes_len > remote.max_catalog_page_object_bytes() {
+        return Err(mutation_journal_resource(
+            CatalogMutationJournalResourceV1::Bytes,
+        ));
+    }
+    let wire =
+        serde_json::from_slice::<RemoteCatalogMutationJournalWireV1>(raw_bytes).map_err(|_| {
+            invalid_mutation_journal(InvalidCatalogMutationJournalReasonV1::CanonicalEncoding)
+        })?;
+    if serde_json::to_vec(&wire).ok().as_deref() != Some(raw_bytes)
+        || wire.version != CATALOG_MUTATION_JOURNAL_SCHEMA_VERSION_V1
+    {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::CanonicalEncoding,
+        ));
+    }
+    if wire.context != expected_context.to_wire() {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Context,
+        ));
+    }
+    if wire.catalog_sequence != expected_sequence.get()
+        || super::parse_lower_hex_32(&wire.publication_nonce) != Some(expected_publication_nonce)
+        || super::parse_lower_hex_32(&wire.parent_head_revision)
+            != Some(expected_parent_head_revision)
+        || expected_publication_nonce == [0; 32]
+        || expected_parent_head_revision == [0; 32]
+    {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Lineage,
+        ));
+    }
+    let mutation_count = u64::try_from(wire.mutations.len())
+        .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::Mutations))?;
+    if mutation_count > remote.max_catalog_entries_per_page() {
+        return Err(mutation_journal_resource(
+            CatalogMutationJournalResourceV1::Mutations,
+        ));
+    }
+    if wire.mutation_count != mutation_count {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Totals,
+        ));
+    }
+    let mut key_bytes = 0_u64;
+    let mut previous_key: Option<&str> = None;
+    for mutation in &wire.mutations {
+        if previous_key.is_some_and(|previous| previous >= mutation.object_key.as_str()) {
+            return Err(invalid_mutation_journal(
+                InvalidCatalogMutationJournalReasonV1::Order,
+            ));
+        }
+        previous_key = Some(&mutation.object_key);
+        key_bytes = key_bytes
+            .checked_add(u64::try_from(mutation.object_key.len()).map_err(|_| {
+                mutation_journal_resource(CatalogMutationJournalResourceV1::KeyBytes)
+            })?)
+            .ok_or_else(|| mutation_journal_resource(CatalogMutationJournalResourceV1::KeyBytes))?;
+        if key_bytes > max_catalog_mutation_draft_key_bytes_v1() {
+            return Err(mutation_journal_resource(
+                CatalogMutationJournalResourceV1::KeyBytes,
+            ));
+        }
+        let successor_object_id = super::parse_lower_hex_32(&mutation.successor_payload.object_id);
+        let successor_raw_blake3 =
+            super::parse_lower_hex_32(&mutation.successor_payload.raw_blake3);
+        if !validate_catalog_object_route_v1(
+            &expected_context.remote_prefix,
+            mutation.kind,
+            &mutation.object_key,
+        ) || successor_object_id.is_none_or(|object_id| object_id == [0; 32])
+            || successor_raw_blake3.is_none_or(|raw_blake3| raw_blake3 == [0; 32])
+            || !validate_entry_size_v1(mutation.kind, mutation.successor_payload.raw_bytes_len)
+            || super::validate_binding_wire_v1(&mutation.successor_payload.binding).is_none()
+        {
+            return Err(invalid_mutation_journal(
+                InvalidCatalogMutationJournalReasonV1::ObjectIdentity,
+            ));
+        }
+        match (&mutation.operation, &mutation.predecessor) {
+            (
+                RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+                RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+            ) => {}
+            (
+                RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+                RemoteCatalogMutationPredecessorDraftWireV1::Present {
+                    raw_bytes_len,
+                    raw_blake3,
+                    binding,
+                },
+            ) if super::parse_lower_hex_32(raw_blake3).is_some()
+                && validate_entry_size_v1(mutation.kind, *raw_bytes_len)
+                && super::validate_binding_wire_v1(binding).is_some()
+                && binding_has_usable_etag_v1(binding) => {}
+            _ => {
+                return Err(invalid_mutation_journal(
+                    InvalidCatalogMutationJournalReasonV1::Operation,
+                ))
+            }
+        }
+    }
+    if wire.mutation_key_bytes != key_bytes {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Totals,
+        ));
+    }
+    Ok(wire)
+}
+
 /// Exact immutable copy of the complete committed predecessor HEAD.
 ///
 /// The object must be installed absent-only and byte-verified before the
@@ -934,12 +1732,10 @@ pub(crate) struct BoundArchivedCatalogHeadV1 {
 /// Exact immutable authoritative transaction journal written before the
 /// visible fence.
 ///
-/// A future production constructor must prove the complete intended mutation
-/// set against the exact semantic predecessor corpus, prove create-key absence,
-/// validate every typed successor and cross-object closure, and bind immutable
-/// successor payload references. No such constructor or conversion from the
-/// untrusted draft exists in this checkpoint. Without those payload references,
-/// classification can only remain fenced; it cannot roll forward.
+/// Its only constructor consumes the prepared fact-bound journal above. The
+/// diagnostic draft remains nominally separate and cannot convert into this
+/// type. This still authorizes no namespace write, visible HEAD transition, or
+/// recovery action.
 pub(crate) struct BoundCatalogMutationJournalV1 {
     context: CatalogAuthorityContextV1,
     storage_authority_fingerprint: [u8; 32],
@@ -981,6 +1777,17 @@ fn mutation_journal_object_key_v1(journal: &BoundCatalogMutationJournalV1) -> Op
         &journal.context,
         MUTATION_JOURNAL_OBJECT_SUFFIX_V1,
         &journal.object_id,
+    )
+}
+
+fn successor_payload_object_key_v1(
+    context: &CatalogAuthorityContextV1,
+    raw_bytes: &[u8],
+) -> Option<String> {
+    publication_object_key_v1(
+        context,
+        CATALOG_SUCCESSOR_PAYLOAD_OBJECT_SUFFIX_V1,
+        &super::domain_object_id_v1(CATALOG_SUCCESSOR_PAYLOAD_OBJECT_DOMAIN_V1, raw_bytes),
     )
 }
 
@@ -1116,6 +1923,275 @@ async fn publish_immutable_catalog_artifact_if_absent_exact_v1(
         raw_bytes_len,
         registered_binding_from_raw_v1(binding),
     ))
+}
+
+/// Recheck absence freshness, reconstruct the complete successor semantics,
+/// and publish every exact successor body into the immutable payload
+/// namespace. No live namespace key or mutable HEAD is written here.
+pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 'storage>(
+    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
+    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+    publication_nonce: [u8; 32],
+    mut mutations: Vec<FactBoundCatalogMutationV1<'attempt, 'storage>>,
+) -> AnyhowResult<PreparedAuthoritativeCatalogMutationJournalV1> {
+    anyhow::ensure!(
+        mutation_inputs_match_corpus_v1(prerequisites, corpus),
+        "authoritative mutation preparation does not match the semantic predecessor"
+    );
+    anyhow::ensure!(
+        publication_nonce != [0; 32] && publication_nonce != prerequisites.publication_nonce,
+        "authoritative mutation publication nonce is zero or reused"
+    );
+    let catalog_sequence = prerequisites
+        .sequence
+        .get()
+        .checked_add(1)
+        .and_then(NonZeroU64::new)
+        .context("catalog sequence overflow")?;
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    anyhow::ensure!(
+        u64::try_from(mutations.len()).ok() <= Some(remote.max_catalog_entries_per_page()),
+        "authoritative mutation count exceeds the catalog page bound"
+    );
+    mutations
+        .sort_unstable_by(|left, right| left.successor.object_key.cmp(&right.successor.object_key));
+    let mut mutation_key_bytes = 0_u64;
+    let mut previous_key: Option<&str> = None;
+    for mutation in &mutations {
+        anyhow::ensure!(
+            std::ptr::eq(mutation.prerequisites, prerequisites)
+                && mutation.successor.context == prerequisites.context,
+            "fact-bound mutation belongs to a different publication acquisition"
+        );
+        anyhow::ensure!(
+            previous_key.is_none_or(|previous| previous < mutation.successor.object_key.as_str()),
+            "authoritative mutation keys are duplicated"
+        );
+        previous_key = Some(&mutation.successor.object_key);
+        mutation_key_bytes = mutation_key_bytes
+            .checked_add(
+                u64::try_from(mutation.successor.object_key.len())
+                    .context("authoritative mutation key length does not fit u64")?,
+            )
+            .context("authoritative mutation key-byte total overflow")?;
+        anyhow::ensure!(
+            mutation_key_bytes <= max_catalog_mutation_draft_key_bytes_v1(),
+            "authoritative mutation key-byte total exceeds the bound"
+        );
+        match &mutation.predecessor {
+            FactBoundCatalogMutationPredecessorV1::Absent(absence) => {
+                anyhow::ensure!(
+                    std::ptr::eq(absence.prerequisites, prerequisites)
+                        && absence.kind == mutation.successor.kind
+                        && absence.object_key == mutation.successor.object_key
+                        && absence.predecessor_head_revision == prerequisites.head_revision,
+                    "catalog create absence witness does not match the held publication"
+                );
+                anyhow::ensure!(
+                    read_raw_object_snapshot_v1(
+                        prerequisites.storage_authority.operator,
+                        &absence.object_key,
+                        catalog_named_object_max_bytes_v1(absence.kind),
+                    )
+                    .await?
+                    .is_none(),
+                    "catalog create absence witness is stale"
+                );
+            }
+            FactBoundCatalogMutationPredecessorV1::Present(predecessor) => {
+                let (kind, corpus_predecessor) =
+                    corpus_object_fact_v1(corpus, &mutation.successor.object_key)
+                        .context("fact-bound replacement disappeared from the semantic corpus")?;
+                anyhow::ensure!(
+                    kind == mutation.successor.kind && &corpus_predecessor == predecessor,
+                    "fact-bound replacement predecessor does not exactly match corpus membership"
+                );
+            }
+        }
+    }
+
+    validate_complete_successor_semantic_closure_v1(corpus, &mutations)
+        .map_err(|error| anyhow::anyhow!("successor semantic closure is invalid: {error:?}"))?;
+
+    let mut successor_payloads = Vec::new();
+    successor_payloads
+        .try_reserve(mutations.len())
+        .context("reserving authoritative successor payload bindings")?;
+    for mutation in &mutations {
+        let (object_id, raw_bytes_len, binding) =
+            publish_immutable_catalog_artifact_if_absent_exact_v1(
+                prerequisites,
+                CATALOG_SUCCESSOR_PAYLOAD_OBJECT_SUFFIX_V1,
+                CATALOG_SUCCESSOR_PAYLOAD_OBJECT_DOMAIN_V1,
+                &mutation.successor.raw_bytes,
+                catalog_named_object_max_bytes_v1(mutation.successor.kind),
+            )
+            .await?;
+        anyhow::ensure!(
+            raw_bytes_len == mutation.successor.raw_bytes_len,
+            "immutable successor payload length does not match its typed bytes"
+        );
+        successor_payloads.push(BoundCatalogSuccessorPayloadV1 {
+            kind: mutation.successor.kind,
+            object_key: mutation.successor.object_key.clone(),
+            object_id,
+            raw_bytes_len,
+            raw_blake3: mutation.successor.raw_blake3,
+            binding,
+        });
+    }
+
+    let wire_mutations = mutations
+        .iter()
+        .zip(&successor_payloads)
+        .map(|(mutation, payload)| {
+            let (operation, predecessor) = match &mutation.predecessor {
+                FactBoundCatalogMutationPredecessorV1::Absent(_) => (
+                    RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+                    RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+                ),
+                FactBoundCatalogMutationPredecessorV1::Present(predecessor) => (
+                    RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+                    RemoteCatalogMutationPredecessorDraftWireV1::Present {
+                        raw_bytes_len: predecessor.raw_bytes_len.get(),
+                        raw_blake3: lower_hex(&predecessor.raw_blake3),
+                        binding: binding_wire_v1(&predecessor.binding),
+                    },
+                ),
+            };
+            RemoteCatalogFactBoundMutationWireV1 {
+                kind: mutation.successor.kind,
+                object_key: mutation.successor.object_key.clone(),
+                operation,
+                predecessor,
+                successor_payload: RemoteCatalogSuccessorPayloadReferenceWireV1 {
+                    object_id: lower_hex(&payload.object_id),
+                    raw_bytes_len: payload.raw_bytes_len.get(),
+                    raw_blake3: lower_hex(&payload.raw_blake3),
+                    binding: binding_wire_v1(&payload.binding),
+                },
+            }
+        })
+        .collect::<Vec<_>>();
+    let wire = RemoteCatalogMutationJournalWireV1 {
+        version: CATALOG_MUTATION_JOURNAL_SCHEMA_VERSION_V1,
+        context: prerequisites.context.to_wire(),
+        catalog_sequence: catalog_sequence.get(),
+        publication_nonce: lower_hex(&publication_nonce),
+        parent_head_revision: lower_hex(&prerequisites.head_revision),
+        mutation_count: u64::try_from(wire_mutations.len())
+            .context("authoritative mutation count does not fit u64")?,
+        mutation_key_bytes,
+        mutations: wire_mutations,
+    };
+    let raw_bytes =
+        serde_json::to_vec(&wire).context("serializing authoritative catalog mutation journal")?;
+    validate_authoritative_catalog_mutation_journal_bytes_v1(
+        &raw_bytes,
+        &prerequisites.context,
+        catalog_sequence,
+        publication_nonce,
+        prerequisites.head_revision,
+    )
+    .map_err(|error| anyhow::anyhow!("authoritative mutation journal is invalid: {error:?}"))?;
+    let raw_bytes_len = NonZeroU64::new(
+        u64::try_from(raw_bytes.len())
+            .context("authoritative mutation journal length does not fit u64")?,
+    )
+    .context("authoritative mutation journal cannot be empty")?;
+    anyhow::ensure!(
+        raw_bytes_len.get() <= remote.max_catalog_page_object_bytes(),
+        "authoritative mutation journal exceeds the catalog page bound"
+    );
+    Ok(PreparedAuthoritativeCatalogMutationJournalV1 {
+        context: prerequisites.context.clone(),
+        storage_authority_fingerprint: prerequisites.storage_authority.authority_fingerprint,
+        catalog_sequence,
+        publication_nonce,
+        parent_head_revision: prerequisites.head_revision,
+        object_id: super::domain_object_id_v1(MUTATION_JOURNAL_OBJECT_DOMAIN_V1, &raw_bytes),
+        raw_bytes,
+        raw_bytes_len,
+        successor_payloads,
+    })
+}
+
+/// Publish the canonical authoritative journal absent-only and bind its exact
+/// reread. This is the only constructor for `BoundCatalogMutationJournalV1`.
+pub(crate) async fn publish_authoritative_catalog_mutation_journal_v1(
+    prerequisites: &MatchedCatalogPublicationPrerequisitesV1<'_>,
+    prepared: PreparedAuthoritativeCatalogMutationJournalV1,
+) -> AnyhowResult<BoundCatalogMutationJournalV1> {
+    anyhow::ensure!(
+        prepared.context == prerequisites.context
+            && prepared.storage_authority_fingerprint
+                == prerequisites.storage_authority.authority_fingerprint
+            && prepared.catalog_sequence.get()
+                == prerequisites
+                    .sequence
+                    .get()
+                    .checked_add(1)
+                    .context("catalog sequence overflow")?
+            && prepared.parent_head_revision == prerequisites.head_revision
+            && prepared.publication_nonce != [0; 32]
+            && prepared.publication_nonce != prerequisites.publication_nonce
+            && prepared.object_id
+                == super::domain_object_id_v1(
+                    MUTATION_JOURNAL_OBJECT_DOMAIN_V1,
+                    &prepared.raw_bytes,
+                )
+            && prepared.raw_bytes_len.get()
+                == u64::try_from(prepared.raw_bytes.len())
+                    .context("authoritative mutation journal length does not fit u64")?,
+        "prepared authoritative journal does not match publication prerequisites"
+    );
+    let wire = validate_authoritative_catalog_mutation_journal_bytes_v1(
+        &prepared.raw_bytes,
+        &prerequisites.context,
+        prepared.catalog_sequence,
+        prepared.publication_nonce,
+        prerequisites.head_revision,
+    )
+    .map_err(|error| anyhow::anyhow!("prepared authoritative journal is invalid: {error:?}"))?;
+    anyhow::ensure!(
+        wire.mutations.len() == prepared.successor_payloads.len()
+            && wire.mutations.iter().zip(&prepared.successor_payloads).all(
+                |(mutation, payload)| {
+                    mutation.kind == payload.kind
+                        && mutation.object_key == payload.object_key
+                        && mutation.successor_payload.object_id == lower_hex(&payload.object_id)
+                        && mutation.successor_payload.raw_bytes_len == payload.raw_bytes_len.get()
+                        && mutation.successor_payload.raw_blake3 == lower_hex(&payload.raw_blake3)
+                        && mutation.successor_payload.binding == binding_wire_v1(&payload.binding)
+                }
+            ),
+        "prepared authoritative journal lost an immutable successor binding"
+    );
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let (object_id, raw_bytes_len, binding) =
+        publish_immutable_catalog_artifact_if_absent_exact_v1(
+            prerequisites,
+            MUTATION_JOURNAL_OBJECT_SUFFIX_V1,
+            MUTATION_JOURNAL_OBJECT_DOMAIN_V1,
+            &prepared.raw_bytes,
+            remote.max_catalog_page_object_bytes(),
+        )
+        .await?;
+    anyhow::ensure!(
+        object_id == prepared.object_id && raw_bytes_len == prepared.raw_bytes_len,
+        "published authoritative journal identity changed during exact rebind"
+    );
+    Ok(BoundCatalogMutationJournalV1 {
+        context: prepared.context,
+        storage_authority_fingerprint: prepared.storage_authority_fingerprint,
+        catalog_sequence: prepared.catalog_sequence,
+        publication_nonce: prepared.publication_nonce,
+        parent_head_revision: prepared.parent_head_revision,
+        object_id,
+        raw_bytes: prepared.raw_bytes,
+        raw_bytes_len,
+        binding,
+    })
 }
 
 /// Publish and bind the complete predecessor HEAD at its deterministic archive
@@ -2274,6 +3350,31 @@ mod tests {
         Default
     );
     static_assertions::assert_not_impl_any!(
+        ProvenCatalogObjectAbsenceV1<'static, 'static>: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        TypedCatalogSuccessorPayloadV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundCatalogMutationJournalV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        FactBoundCatalogMutationV1<'static, 'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundCatalogMutationJournalV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        PreparedAuthoritativeCatalogMutationJournalV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundCatalogMutationJournalV1>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
         PreparedUntrustedCatalogMutationJournalDraftV1: Clone,
         serde::Serialize,
         Default,
@@ -2344,20 +3445,17 @@ mod tests {
         Into<Vec<crate::reconcile::ReconcileAction>>
     );
 
-    async fn observed_head() -> (
+    async fn observed_corpus(
+        rows: &[SemanticRemoteCatalogFixtureRowV1],
+    ) -> (
         SemanticRemoteCatalogFixtureV1,
+        Box<SemanticallyBoundRemoteCatalogCorpusV1>,
         ObservedPublishedCatalogHeadV1,
     ) {
         let spec = test_spec();
         let selected = test_selected();
-        let fixture = semantic_remote_catalog_fixture_for_test_v1(
-            "fixture-root",
-            &spec,
-            &[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
-                "retained.txt".to_owned(),
-            )],
-        )
-        .await;
+        let fixture =
+            semantic_remote_catalog_fixture_for_test_v1("fixture-root", &spec, rows).await;
         let corpus = match read_semantically_bound_remote_catalog_corpus_v1(
             fixture.operator(),
             &selected,
@@ -2372,7 +3470,50 @@ mod tests {
             }
         };
         let observed = observe_published_catalog_head_v1(&corpus).unwrap();
+        (fixture, corpus, observed)
+    }
+
+    async fn observed_head() -> (
+        SemanticRemoteCatalogFixtureV1,
+        ObservedPublishedCatalogHeadV1,
+    ) {
+        let (fixture, _corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
         (fixture, observed)
+    }
+
+    fn deleted_index_bytes() -> Vec<u8> {
+        br#"{"version":4,"state":"deleted","current":null,"pending":null}"#.to_vec()
+    }
+
+    fn committed_index_bytes(manifest_hash: &str) -> Vec<u8> {
+        format!(
+            r#"{{"version":2,"state":"committed","current":{{"manifest_hash":"{manifest_hash}","size":4,"chunks":1}},"pending":null}}"#
+        )
+        .into_bytes()
+    }
+
+    fn regular_manifest_bytes(rel_path: &str) -> Vec<u8> {
+        format!(
+            r#"{{
+  "version": 2,
+  "file_hash": "{file_hash}",
+  "file_size": 4,
+  "chunks": ["{chunk_hash}"],
+  "vclock": {{ "clocks": {{ "sting": 1 }} }},
+  "written_by": "sting",
+  "written_at": 7,
+  "rel_path": "{rel_path}",
+  "mode": 420,
+  "mtime": [8, 9]
+}}"#,
+            file_hash = "d".repeat(64),
+            chunk_hash = "e".repeat(64),
+        )
+        .into_bytes()
     }
 
     fn trusted_receipts(
@@ -2665,6 +3806,406 @@ mod tests {
         assert_ne!(observed.publication_nonce, [0; 32]);
         assert_ne!(observed.head_revision, [0; 32]);
         assert_eq!(observed.current_head_etag, "head-etag-a");
+    }
+
+    #[tokio::test]
+    async fn fact_bound_journal_derives_predecessors_sorts_and_publishes_exact_payloads() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let prerequisites = matched(&fixture, &observed);
+        let replacement_bytes = deleted_index_bytes();
+        let replacement = fact_bind_catalog_replacement_v1(
+            &prerequisites,
+            &corpus,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/retained.txt".to_owned(),
+                replacement_bytes.clone(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let create_key = "roots/index/added.txt".to_owned();
+        let absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Index,
+            create_key.clone(),
+        )
+        .await
+        .unwrap();
+        let create = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Index,
+                create_key,
+                replacement_bytes.clone(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            &corpus,
+            [0x44; 32],
+            vec![replacement, create],
+        )
+        .await
+        .unwrap();
+        let wire =
+            serde_json::from_slice::<RemoteCatalogMutationJournalWireV1>(&prepared.raw_bytes)
+                .unwrap();
+        assert_eq!(wire.mutation_count, 2);
+        assert_eq!(wire.mutations[0].object_key, "roots/index/added.txt");
+        assert_eq!(wire.mutations[1].object_key, "roots/index/retained.txt");
+        assert!(matches!(
+            wire.mutations[0].predecessor,
+            RemoteCatalogMutationPredecessorDraftWireV1::Absent
+        ));
+        assert!(matches!(
+            wire.mutations[1].predecessor,
+            RemoteCatalogMutationPredecessorDraftWireV1::Present { .. }
+        ));
+        let payload_key =
+            successor_payload_object_key_v1(&prerequisites.context, &replacement_bytes).unwrap();
+        assert_eq!(
+            fixture
+                .operator()
+                .read(&payload_key)
+                .await
+                .unwrap()
+                .to_vec(),
+            replacement_bytes
+        );
+
+        let bound = publish_authoritative_catalog_mutation_journal_v1(&prerequisites, prepared)
+            .await
+            .unwrap();
+        let journal_key = mutation_journal_object_key_v1(&bound).unwrap();
+        assert_eq!(
+            fixture
+                .operator()
+                .read(&journal_key)
+                .await
+                .unwrap()
+                .to_vec(),
+            bound.raw_bytes
+        );
+        assert_eq!(bound.catalog_sequence.get(), 2);
+        assert_eq!(bound.parent_head_revision, observed.head_revision);
+    }
+
+    #[tokio::test]
+    async fn complete_successor_closure_accepts_exact_index_manifest_pair() {
+        let (fixture, corpus, observed) = observed_corpus(&[]).await;
+        let prerequisites = matched(&fixture, &observed);
+        let manifest_bytes = regular_manifest_bytes("new.txt");
+        let manifest_id = crate::index_entry::manifest_object_id(&manifest_bytes);
+        let index_key = "roots/index/new.txt".to_owned();
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+
+        let index_absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Index,
+            index_key.clone(),
+        )
+        .await
+        .unwrap();
+        let manifest_absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Manifest,
+            manifest_key.clone(),
+        )
+        .await
+        .unwrap();
+        let index = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            index_absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Index,
+                index_key,
+                committed_index_bytes(&manifest_id),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let manifest = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            manifest_absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Manifest,
+                manifest_key,
+                manifest_bytes,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            &corpus,
+            [0x44; 32],
+            vec![manifest, index],
+        )
+        .await
+        .unwrap();
+        let wire =
+            serde_json::from_slice::<RemoteCatalogMutationJournalWireV1>(&prepared.raw_bytes)
+                .unwrap();
+        assert_eq!(wire.mutation_count, 2);
+        assert_eq!(wire.mutations[0].object_key, "roots/index/new.txt");
+        assert!(wire.mutations[1].object_key.starts_with("roots/manifests/"));
+    }
+
+    #[tokio::test]
+    async fn replacement_requires_exact_predecessor_membership_and_strict_payload_type() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let prerequisites = matched(&fixture, &observed);
+        let missing = type_catalog_successor_payload_v1(
+            &corpus,
+            RemoteCatalogObjectKindV1::Index,
+            "roots/index/missing.txt".to_owned(),
+            deleted_index_bytes(),
+        )
+        .unwrap();
+        assert_eq!(
+            fact_bind_catalog_replacement_v1(&prerequisites, &corpus, missing).unwrap_err(),
+            CatalogPublicationContractErrorV1::MutationPredecessorMissing
+        );
+        assert_eq!(
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/retained.txt".to_owned(),
+                b"{}".to_vec(),
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidSuccessorPayload
+        );
+        assert_eq!(
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Reservation,
+                "roots/index/retained.txt".to_owned(),
+                deleted_index_bytes(),
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidSuccessorPayload
+        );
+    }
+
+    #[tokio::test]
+    async fn create_absence_is_rechecked_on_the_same_accessor() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let prerequisites = matched(&fixture, &observed);
+        let key = "roots/index/raced.txt".to_owned();
+        let absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Index,
+            key.clone(),
+        )
+        .await
+        .unwrap();
+        let create = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Index,
+                key.clone(),
+                deleted_index_bytes(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        fixture
+            .operator()
+            .write(&key, deleted_index_bytes())
+            .await
+            .unwrap();
+        let error = prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            &corpus,
+            [0x44; 32],
+            vec![create],
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("absence witness is stale"));
+    }
+
+    #[tokio::test]
+    async fn complete_successor_closure_rejects_missing_or_orphaned_manifests_and_claim_collisions()
+    {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::CurrentFile(
+                "file.txt".to_owned(),
+            )])
+            .await;
+        let prerequisites = matched(&fixture, &observed);
+        let missing_manifest_index = fact_bind_catalog_replacement_v1(
+            &prerequisites,
+            &corpus,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/file.txt".to_owned(),
+                committed_index_bytes(&"f".repeat(64)),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            &corpus,
+            [0x44; 32],
+            vec![missing_manifest_index],
+        )
+        .await
+        .is_err());
+
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let prerequisites = matched(&fixture, &observed);
+        let orphan_bytes = regular_manifest_bytes("orphan.txt");
+        let orphan_key = format!(
+            "roots/manifests/{}",
+            crate::index_entry::manifest_object_id(&orphan_bytes)
+        );
+        let orphan_absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Manifest,
+            orphan_key.clone(),
+        )
+        .await
+        .unwrap();
+        let orphan = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            orphan_absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Manifest,
+                orphan_key,
+                orphan_bytes,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            &corpus,
+            [0x45; 32],
+            vec![orphan],
+        )
+        .await
+        .is_err());
+
+        let exact_path = "retained.txt";
+        let folded_path = crate::index_entry::portable_casefold_path(exact_path).unwrap();
+        let reservation_bytes = format!(
+            r#"{{"version":1,"exact_path":"{exact_path}","folded_path":"{folded_path}","role":"directory"}}"#
+        )
+        .into_bytes();
+        let reservation_key = format!(
+            "roots/.tcfs-namespace/v1/{}",
+            crate::index_entry::namespace_reservation_object_id(&folded_path)
+        );
+        let reservation_absence = prove_catalog_object_absence_v1(
+            &prerequisites,
+            &corpus,
+            RemoteCatalogObjectKindV1::Reservation,
+            reservation_key.clone(),
+        )
+        .await
+        .unwrap();
+        let reservation = fact_bind_catalog_create_v1(
+            &prerequisites,
+            &corpus,
+            reservation_absence,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Reservation,
+                reservation_key,
+                reservation_bytes,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            &corpus,
+            [0x46; 32],
+            vec![reservation],
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn immutable_successor_payload_collision_requires_exact_bytes() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let prerequisites = matched(&fixture, &observed);
+        let successor_bytes = deleted_index_bytes();
+        let payload_key =
+            successor_payload_object_key_v1(&prerequisites.context, &successor_bytes).unwrap();
+        fixture
+            .operator()
+            .write(&payload_key, b"wrong".to_vec())
+            .await
+            .unwrap();
+        let replacement = fact_bind_catalog_replacement_v1(
+            &prerequisites,
+            &corpus,
+            type_catalog_successor_payload_v1(
+                &corpus,
+                RemoteCatalogObjectKindV1::Index,
+                "roots/index/retained.txt".to_owned(),
+                successor_bytes,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let error = prepare_authoritative_catalog_mutation_journal_v1(
+            &prerequisites,
+            &corpus,
+            [0x44; 32],
+            vec![replacement],
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("different bytes"));
     }
 
     #[test]

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -9,13 +9,16 @@
 //!
 //! This checkpoint deliberately stops before production authority. Bootstrap
 //! completeness, exact-current high-water, and the all-writer credential epoch
-//! are opaque external receipts with no production constructors. The module
-//! can validate and compose their exact bindings and publish the exact immutable
-//! predecessor-HEAD archive. A separately namespaced journal draft exercises
-//! bounded artifact mechanics but cannot become authoritative recovery evidence
-//! or enter a publishing fence. This module still cannot mint authority, write
-//! a live `HEAD`, mutate the namespace, produce a plan digest, or authorize an
-//! action.
+//! are opaque external receipts with no production constructors. One external
+//! control acquisition binds those receipts and must move monotonically from
+//! exact-current `Ready` to one exact `PublicationPending` successor before a
+//! future visible `HEAD` CAS. A terminal matcher also specifies the required
+//! `PublicationPending` to exact-current `Ready(n+1)` advance, but cannot mint a
+//! fresh guard. The module can publish the exact immutable predecessor-HEAD
+//! archive. A separately namespaced journal draft exercises bounded artifact
+//! mechanics but cannot become authoritative recovery evidence or enter a
+//! publishing fence. This module still cannot mint authority, write a live
+//! `HEAD`, mutate the namespace, produce a plan digest, or authorize an action.
 
 use std::num::NonZeroU64;
 
@@ -46,6 +49,10 @@ const MUTATION_JOURNAL_OBJECT_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-mutation-journal-object.b3v1";
 const UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-mutation-journal-draft-object.b3v1";
+const PUBLISHING_HEAD_RESERVATION_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-publishing-head-reservation.b3v1";
+const PREDECESSOR_HEAD_STORAGE_BINDING_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-predecessor-head-storage-binding.b3v1";
 const ARCHIVED_HEAD_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/archived-heads";
 const MUTATION_JOURNAL_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/mutation-journals";
 const UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_SUFFIX_V1: &str =
@@ -162,6 +169,9 @@ pub(crate) enum CatalogPublicationContractErrorV1 {
     WriterFenceMismatch,
     StorageAuthorityMismatch,
     ControlAuthorityMismatch,
+    ControlTransitionMismatch,
+    PublishingHeadTooLarge,
+    HighWaterAdvanceMismatch,
     PredecessorArchiveMismatch,
     MutationJournalMismatch,
     InvalidMutationJournal(InvalidCatalogMutationJournalReasonV1),
@@ -211,17 +221,60 @@ pub(crate) struct TrustedCatalogStorageAuthorityV1<'a> {
 
 /// External attestation that sequence one was built from complete truth while
 /// every legacy/out-of-tree writer was quiesced under its bootstrap credential
-/// epoch. Later publications may use a rotated current epoch.
+/// epoch. V1 does not model credential-epoch rotation.
 ///
 /// There is intentionally no production constructor in this checkpoint.
 pub(crate) struct TrustedCatalogBootstrapReceiptV1 {
     context: CatalogAuthorityContextV1,
-    bootstrap_head_revision: [u8; 32],
-    bootstrap_publication_nonce: [u8; 32],
-    complete_corpus_attestation: [u8; 32],
-    bootstrap_writer_epoch: [u8; 32],
+    bootstrap: CatalogBootstrapIdentityV1,
     storage_authority_fingerprint: [u8; 32],
     control_authority_fingerprint: [u8; 32],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CatalogBootstrapIdentityV1 {
+    head_revision: [u8; 32],
+    publication_nonce: [u8; 32],
+    complete_corpus_attestation: [u8; 32],
+    writer_epoch: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CatalogHighWaterPointV1 {
+    sequence: NonZeroU64,
+    head_revision: [u8; 32],
+    publication_nonce: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CatalogControlAuthorityRevisionV1 {
+    generation: NonZeroU64,
+    /// Preselected non-secret logical state identifier. This is neither a
+    /// backend-generated ETag nor the content fingerprint of the record that
+    /// embeds it; the latter is computed separately after canonical encoding.
+    fingerprint: [u8; 32],
+}
+
+/// A non-secret identifier suitable for logs and serialized recovery state.
+/// Bearer lease material, renewal credentials, and signing keys must never be
+/// stored in this value or in any catalog object.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct NonSecretLeasePublicFingerprintV1([u8; 32]);
+
+/// Exact `Ready` state held by one exclusive external control acquisition.
+///
+/// V1 deliberately freezes the writer epoch to the bootstrap epoch. A future
+/// credential rotation must be its own monotonic, revocation-backed protocol;
+/// copied current-epoch fields are not continuity evidence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CatalogControlAcquisitionBindingV1 {
+    context: CatalogAuthorityContextV1,
+    bootstrap: CatalogBootstrapIdentityV1,
+    current: CatalogHighWaterPointV1,
+    storage_authority_fingerprint: [u8; 32],
+    control_authority_fingerprint: [u8; 32],
+    ready_revision: CatalogControlAuthorityRevisionV1,
+    lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
 }
 
 /// Exclusive external exact-current guard anchored to one trusted bootstrap.
@@ -236,18 +289,7 @@ pub(crate) struct TrustedCatalogBootstrapReceiptV1 {
 /// release; retaining this non-cloneable value alone is not a production
 /// liveness proof.
 pub(crate) struct TrustedCatalogHighWaterGuardV1 {
-    context: CatalogAuthorityContextV1,
-    bootstrap_head_revision: [u8; 32],
-    bootstrap_publication_nonce: [u8; 32],
-    complete_corpus_attestation: [u8; 32],
-    current_writer_epoch: [u8; 32],
-    current_sequence: NonZeroU64,
-    current_head_revision: [u8; 32],
-    current_publication_nonce: [u8; 32],
-    storage_authority_fingerprint: [u8; 32],
-    authority_revision: [u8; 32],
-    lease_nonce: [u8; 32],
-    control_authority_fingerprint: [u8; 32],
+    binding: CatalogControlAcquisitionBindingV1,
 }
 
 /// External proof that every credential and code path able to mutate the
@@ -259,21 +301,26 @@ pub(crate) struct TrustedCatalogHighWaterGuardV1 {
 /// HEAD CAS, every namespace mutation, committed-HEAD finalization, and
 /// high-water advancement.
 pub(crate) struct AllNamespaceWritersFencedLeaseV1 {
-    context: CatalogAuthorityContextV1,
-    bootstrap_head_revision: [u8; 32],
-    current_writer_epoch: [u8; 32],
-    authority_revision: [u8; 32],
-    lease_nonce: [u8; 32],
-    storage_authority_fingerprint: [u8; 32],
-    control_authority_fingerprint: [u8; 32],
+    control_binding: CatalogControlAcquisitionBindingV1,
+    authority_revision_fingerprint: [u8; 32],
+    lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
+}
+
+/// One held external control acquisition. High-water and all-writer fencing
+/// are inseparable views of this capability; callers cannot submit two
+/// independently acquired field bags to the publication matcher.
+///
+/// There is intentionally no production constructor in this checkpoint.
+pub(crate) struct HeldReadyCatalogControlGuardV1 {
+    high_water: TrustedCatalogHighWaterGuardV1,
+    all_writers: AllNamespaceWritersFencedLeaseV1,
 }
 
 /// Exact receipt match for one observed predecessor. This still is not remote
 /// completeness authority and has no planner/action conversion.
 pub(crate) struct MatchedCatalogPublicationPrerequisitesV1<'a> {
     storage_authority: TrustedCatalogStorageAuthorityV1<'a>,
-    high_water_guard: TrustedCatalogHighWaterGuardV1,
-    writer_fence_lease: AllNamespaceWritersFencedLeaseV1,
+    control_guard: HeldReadyCatalogControlGuardV1,
     context: CatalogAuthorityContextV1,
     sequence: NonZeroU64,
     publication_nonce: [u8; 32],
@@ -299,9 +346,10 @@ pub(crate) fn match_catalog_publication_prerequisites_v1<'a>(
     storage_authority: TrustedCatalogStorageAuthorityV1<'a>,
     observed: &ObservedPublishedCatalogHeadV1,
     bootstrap: &TrustedCatalogBootstrapReceiptV1,
-    high_water: TrustedCatalogHighWaterGuardV1,
-    writers: AllNamespaceWritersFencedLeaseV1,
+    control: HeldReadyCatalogControlGuardV1,
 ) -> Result<MatchedCatalogPublicationPrerequisitesV1<'a>, CatalogPublicationContractErrorV1> {
+    let high_water = &control.high_water;
+    let writers = &control.all_writers;
     if !storage_authority
         .conditional_write_receipt
         .authorizes(storage_authority.operator, &observed.context.remote_prefix)
@@ -309,10 +357,10 @@ pub(crate) fn match_catalog_publication_prerequisites_v1<'a>(
     {
         return Err(CatalogPublicationContractErrorV1::StorageSemanticsUnverified);
     }
-    let bootstrap_fields_nonzero = bootstrap.bootstrap_head_revision != [0; 32]
-        && bootstrap.bootstrap_publication_nonce != [0; 32]
-        && bootstrap.complete_corpus_attestation != [0; 32]
-        && bootstrap.bootstrap_writer_epoch != [0; 32]
+    let bootstrap_fields_nonzero = bootstrap.bootstrap.head_revision != [0; 32]
+        && bootstrap.bootstrap.publication_nonce != [0; 32]
+        && bootstrap.bootstrap.complete_corpus_attestation != [0; 32]
+        && bootstrap.bootstrap.writer_epoch != [0; 32]
         && bootstrap.storage_authority_fingerprint != [0; 32]
         && bootstrap.control_authority_fingerprint != [0; 32]
         && storage_authority.authority_fingerprint != [0; 32];
@@ -323,54 +371,51 @@ pub(crate) fn match_catalog_publication_prerequisites_v1<'a>(
         return Err(CatalogPublicationContractErrorV1::BootstrapMismatch);
     }
     if bootstrap.storage_authority_fingerprint != storage_authority.authority_fingerprint
-        || high_water.storage_authority_fingerprint != storage_authority.authority_fingerprint
-        || writers.storage_authority_fingerprint != storage_authority.authority_fingerprint
+        || high_water.binding.storage_authority_fingerprint
+            != storage_authority.authority_fingerprint
+        || writers.control_binding.storage_authority_fingerprint
+            != storage_authority.authority_fingerprint
     {
         return Err(CatalogPublicationContractErrorV1::StorageAuthorityMismatch);
     }
-    if high_water.control_authority_fingerprint != bootstrap.control_authority_fingerprint
-        || writers.control_authority_fingerprint != bootstrap.control_authority_fingerprint
+    if high_water.binding.control_authority_fingerprint != bootstrap.control_authority_fingerprint
+        || writers.control_binding.control_authority_fingerprint
+            != bootstrap.control_authority_fingerprint
     {
         return Err(CatalogPublicationContractErrorV1::ControlAuthorityMismatch);
     }
-    if high_water.context != observed.context
-        || high_water.bootstrap_head_revision != bootstrap.bootstrap_head_revision
-        || high_water.bootstrap_publication_nonce != bootstrap.bootstrap_publication_nonce
-        || high_water.complete_corpus_attestation != bootstrap.complete_corpus_attestation
-        || high_water.current_writer_epoch == [0; 32]
-        || high_water.current_sequence != observed.sequence
-        || high_water.current_head_revision != observed.head_revision
-        || high_water.current_publication_nonce != observed.publication_nonce
-        || high_water.authority_revision == [0; 32]
-        || high_water.lease_nonce == [0; 32]
+    if high_water.binding.context != observed.context
+        || high_water.binding.bootstrap != bootstrap.bootstrap
+        || high_water.binding.current.sequence != observed.sequence
+        || high_water.binding.current.head_revision != observed.head_revision
+        || high_water.binding.current.publication_nonce != observed.publication_nonce
+        || high_water.binding.ready_revision.fingerprint == [0; 32]
+        || high_water.binding.lease_public_fingerprint.0 == [0; 32]
     {
         return Err(CatalogPublicationContractErrorV1::HighWaterMismatch);
     }
-    if writers.context != observed.context
-        || writers.bootstrap_head_revision != bootstrap.bootstrap_head_revision
-        || writers.current_writer_epoch != high_water.current_writer_epoch
-        || writers.authority_revision == [0; 32]
-        || writers.lease_nonce == [0; 32]
+    if writers.control_binding != high_water.binding
+        || writers.authority_revision_fingerprint == [0; 32]
+        || writers.lease_public_fingerprint.0 == [0; 32]
     {
         return Err(CatalogPublicationContractErrorV1::WriterFenceMismatch);
     }
     if observed.sequence.get() == 1
-        && (bootstrap.bootstrap_head_revision != observed.head_revision
-            || bootstrap.bootstrap_publication_nonce != observed.publication_nonce)
+        && (bootstrap.bootstrap.head_revision != observed.head_revision
+            || bootstrap.bootstrap.publication_nonce != observed.publication_nonce)
     {
         return Err(CatalogPublicationContractErrorV1::BootstrapMismatch);
     }
     Ok(MatchedCatalogPublicationPrerequisitesV1 {
         storage_authority,
-        high_water_guard: high_water,
-        writer_fence_lease: writers,
+        control_guard: control,
         context: observed.context.clone(),
         sequence: observed.sequence,
         publication_nonce: observed.publication_nonce,
         head_revision: observed.head_revision,
         committed_head_bytes: observed.committed_head_bytes.clone(),
         current_head_etag: observed.current_head_etag.clone(),
-        bootstrap_head_revision: bootstrap.bootstrap_head_revision,
+        bootstrap_head_revision: bootstrap.bootstrap.head_revision,
     })
 }
 
@@ -1182,8 +1227,7 @@ struct CatalogSuccessorClaimV1 {
 /// with the canonical publishing wire. This type cannot itself mutate storage.
 pub(crate) struct PreparedCatalogPublicationFenceV1<'a> {
     storage_authority: TrustedCatalogStorageAuthorityV1<'a>,
-    high_water_guard: TrustedCatalogHighWaterGuardV1,
-    writer_fence_lease: AllNamespaceWritersFencedLeaseV1,
+    control_guard: HeldReadyCatalogControlGuardV1,
     context: CatalogAuthorityContextV1,
     sequence: NonZeroU64,
     publication_nonce: [u8; 32],
@@ -1275,8 +1319,7 @@ fn validate_catalog_successor_claim_v1<'a>(
     }
     Ok(PreparedCatalogPublicationFenceV1 {
         storage_authority: prerequisites.storage_authority,
-        high_water_guard: prerequisites.high_water_guard,
-        writer_fence_lease: prerequisites.writer_fence_lease,
+        control_guard: prerequisites.control_guard,
         context: prerequisites.context,
         sequence: NonZeroU64::new(expected_sequence)
             .expect("checked nonzero successor of a nonzero sequence"),
@@ -1311,6 +1354,106 @@ pub(crate) fn prepare_catalog_publication_fence_v1<'a>(
     validate_catalog_successor_claim_v1(prerequisites, claim, predecessor_archive, mutation_journal)
 }
 
+/// Untrusted proposal for the exact `Ready -> PublicationPending` control CAS.
+/// It still carries no authority to write either control state or catalog
+/// `HEAD`.
+pub(crate) struct PreparedCatalogControlTransitionV1<'a> {
+    publication: PreparedCatalogPublicationFenceV1<'a>,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    canonical_publishing_head_bytes: Vec<u8>,
+    publishing_head_reservation_fingerprint: [u8; 32],
+    canonical_pending_control_record_bytes: Vec<u8>,
+    pending_control_record_fingerprint: [u8; 32],
+}
+
+/// Opaque external receipt proving that the exact predecessor `Ready` record
+/// was atomically replaced by the exact `PublicationPending` proposal.
+///
+/// There is intentionally no production constructor in this checkpoint.
+pub(crate) struct TrustedCatalogPublicationPendingReceiptV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    publishing_head_reservation_fingerprint: [u8; 32],
+    pending_control_record_fingerprint: [u8; 32],
+}
+
+/// The only future input permitted to arm a visible publishing-HEAD CAS. This
+/// checkpoint cannot construct one in production and cannot write `HEAD`.
+pub(crate) struct BoundPendingCatalogControlV1<'a> {
+    transition: PreparedCatalogControlTransitionV1<'a>,
+    pending_receipt: TrustedCatalogPublicationPendingReceiptV1,
+}
+
+impl std::fmt::Debug for BoundPendingCatalogControlV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BoundPendingCatalogControlV1")
+            .field(
+                "remote_prefix",
+                &self.transition.publication.context.remote_prefix,
+            )
+            .field("sequence", &self.transition.publication.sequence)
+            .field(
+                "control_generation",
+                &self.transition.pending_revision.generation,
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+/// Opaque future proof that the exact reserved successor became the canonical
+/// committed `HEAD`. No production constructor exists until visible fencing,
+/// fact-bound mutation, and committed-HEAD finalization are implemented.
+pub(crate) struct BoundCommittedCatalogSuccessorV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    publishing_head_reservation_fingerprint: [u8; 32],
+    pending_control_record_fingerprint: [u8; 32],
+    context: CatalogAuthorityContextV1,
+    sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: [u8; 32],
+    head_revision: [u8; 32],
+    committed_head_bytes: Vec<u8>,
+}
+
+/// Opaque receipt for the external `PublicationPending -> Ready(n+1)` CAS.
+/// It binds the exact committed successor and a strictly later control record.
+/// There is intentionally no production constructor in this checkpoint.
+pub(crate) struct TrustedCatalogHighWaterAdvanceReceiptV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    publishing_head_reservation_fingerprint: [u8; 32],
+    pending_control_record_fingerprint: [u8; 32],
+    successor: CatalogHighWaterPointV1,
+    ready_revision: CatalogControlAuthorityRevisionV1,
+    ready_control_record_fingerprint: [u8; 32],
+}
+
+/// Terminal proof that one exact successor advanced the monotonic high-water.
+/// It intentionally cannot be converted back into a reusable guard; the next
+/// publication must acquire a fresh exact-current external control guard.
+pub(crate) struct AdvancedCatalogHighWaterV1 {
+    context: CatalogAuthorityContextV1,
+    bootstrap: CatalogBootstrapIdentityV1,
+    successor: CatalogHighWaterPointV1,
+    storage_authority_fingerprint: [u8; 32],
+    control_authority_fingerprint: [u8; 32],
+    ready_revision: CatalogControlAuthorityRevisionV1,
+    ready_control_record_fingerprint: [u8; 32],
+}
+
+impl std::fmt::Debug for AdvancedCatalogHighWaterV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AdvancedCatalogHighWaterV1")
+            .field("remote_prefix", &self.context.remote_prefix)
+            .field("sequence", &self.successor.sequence)
+            .field("control_generation", &self.ready_revision.generation)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum RemoteCatalogPublishingStateWireV1 {
@@ -1323,6 +1466,81 @@ struct RemoteCatalogPublicationObjectReferenceWireV1 {
     object_id: String,
     raw_bytes_len: u64,
     binding: RemoteCatalogObjectBindingWireV1,
+}
+
+const CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1: u32 = 1;
+const CATALOG_CONTROL_CONTRACT_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-control-contract.b3v1";
+const CATALOG_CONTROL_RECORD_DOMAIN_V1: &str = "tinyland.tcfs.remote-catalog-control-record.b3v1";
+
+fn catalog_control_contract_fingerprint_v1() -> [u8; 32] {
+    super::domain_object_id_v1(
+        CATALOG_CONTROL_CONTRACT_DOMAIN_V1,
+        b"ready-exact-current->publication-pending-exact-successor->ready-exact-current-v1",
+    )
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogControlBootstrapWireV1 {
+    head_revision: String,
+    publication_nonce: String,
+    complete_corpus_attestation: String,
+    writer_epoch: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogControlHeadPointWireV1 {
+    catalog_sequence: u64,
+    head_revision: String,
+    publication_nonce: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogControlPendingStateWireV1 {
+    ready_control_generation: u64,
+    ready_control_revision_fingerprint: String,
+    parent: CatalogControlHeadPointWireV1,
+    successor_catalog_sequence: u64,
+    successor_publication_nonce: String,
+    publishing_head_reservation_fingerprint: String,
+    predecessor_head_storage_binding_fingerprint: String,
+    predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1,
+    mutation_journal: RemoteCatalogPublicationObjectReferenceWireV1,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "state", rename_all = "kebab-case", deny_unknown_fields)]
+enum CatalogControlStateWireV1 {
+    Ready {
+        current: CatalogControlHeadPointWireV1,
+    },
+    PublicationPending {
+        pending: Box<CatalogControlPendingStateWireV1>,
+    },
+}
+
+/// Canonical external control-record representation. Parsing this wire never
+/// creates a trusted guard: only a future authenticated control backend may do
+/// that. The serialized lease value is explicitly a non-secret correlation
+/// fingerprint, never bearer authority.
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogControlRecordWireV1 {
+    version: u32,
+    remote_prefix: String,
+    context: RemoteCatalogContextWireV1,
+    control_contract_fingerprint: String,
+    control_authority_fingerprint: String,
+    storage_authority_fingerprint: String,
+    control_generation: u64,
+    control_revision_fingerprint: String,
+    lease_public_fingerprint: String,
+    bootstrap: CatalogControlBootstrapWireV1,
+    writer_epoch: String,
+    control_state: CatalogControlStateWireV1,
 }
 
 /// Visible root-wide fence installed before the first catalog-corpus write.
@@ -1339,16 +1557,25 @@ struct RemoteCatalogPublishingHeadWireV1 {
     storage_authority_fingerprint: String,
     control_authority_fingerprint: String,
     writer_epoch: String,
-    high_water_authority_revision: String,
-    high_water_lease_nonce: String,
-    writer_fence_authority_revision: String,
-    writer_fence_lease_nonce: String,
+    control_ready_generation: u64,
+    control_ready_revision_fingerprint: String,
+    control_pending_generation: u64,
+    control_pending_revision_fingerprint: String,
+    control_lease_public_fingerprint: String,
+    writer_fence_authority_revision_fingerprint: String,
+    writer_fence_lease_public_fingerprint: String,
+    predecessor_head_storage_binding_fingerprint: String,
     predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1,
     mutation_journal: RemoteCatalogPublicationObjectReferenceWireV1,
 }
 
+fn predecessor_head_storage_binding_fingerprint_v1(etag: &str) -> [u8; 32] {
+    super::domain_object_id_v1(PREDECESSOR_HEAD_STORAGE_BINDING_DOMAIN_V1, etag.as_bytes())
+}
+
 fn canonical_publishing_head_bytes_v1(
     successor: &PreparedCatalogPublicationFenceV1<'_>,
+    pending_revision: CatalogControlAuthorityRevisionV1,
 ) -> Vec<u8> {
     debug_assert!(
         successor
@@ -1373,15 +1600,61 @@ fn canonical_publishing_head_bytes_v1(
             &successor.storage_authority.authority_fingerprint,
         ),
         control_authority_fingerprint: lower_hex(
-            &successor.writer_fence_lease.control_authority_fingerprint,
+            &successor
+                .control_guard
+                .all_writers
+                .control_binding
+                .control_authority_fingerprint,
         ),
-        writer_epoch: lower_hex(&successor.writer_fence_lease.current_writer_epoch),
-        high_water_authority_revision: lower_hex(&successor.high_water_guard.authority_revision),
-        high_water_lease_nonce: lower_hex(&successor.high_water_guard.lease_nonce),
-        writer_fence_authority_revision: lower_hex(
-            &successor.writer_fence_lease.authority_revision,
+        writer_epoch: lower_hex(
+            &successor
+                .control_guard
+                .all_writers
+                .control_binding
+                .bootstrap
+                .writer_epoch,
         ),
-        writer_fence_lease_nonce: lower_hex(&successor.writer_fence_lease.lease_nonce),
+        control_ready_generation: successor
+            .control_guard
+            .high_water
+            .binding
+            .ready_revision
+            .generation
+            .get(),
+        control_ready_revision_fingerprint: lower_hex(
+            &successor
+                .control_guard
+                .high_water
+                .binding
+                .ready_revision
+                .fingerprint,
+        ),
+        control_pending_generation: pending_revision.generation.get(),
+        control_pending_revision_fingerprint: lower_hex(&pending_revision.fingerprint),
+        control_lease_public_fingerprint: lower_hex(
+            &successor
+                .control_guard
+                .high_water
+                .binding
+                .lease_public_fingerprint
+                .0,
+        ),
+        writer_fence_authority_revision_fingerprint: lower_hex(
+            &successor
+                .control_guard
+                .all_writers
+                .authority_revision_fingerprint,
+        ),
+        writer_fence_lease_public_fingerprint: lower_hex(
+            &successor
+                .control_guard
+                .all_writers
+                .lease_public_fingerprint
+                .0,
+        ),
+        predecessor_head_storage_binding_fingerprint: lower_hex(
+            &predecessor_head_storage_binding_fingerprint_v1(&successor.expected_parent_head_etag),
+        ),
         predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1 {
             object_id: lower_hex(&successor.predecessor_archive.object_id),
             raw_bytes_len: successor.predecessor_archive.raw_bytes_len.get(),
@@ -1394,6 +1667,337 @@ fn canonical_publishing_head_bytes_v1(
         },
     })
     .expect("catalog publishing wire is infallibly serializable")
+}
+
+fn control_bootstrap_wire_v1(
+    bootstrap: &CatalogBootstrapIdentityV1,
+) -> CatalogControlBootstrapWireV1 {
+    CatalogControlBootstrapWireV1 {
+        head_revision: lower_hex(&bootstrap.head_revision),
+        publication_nonce: lower_hex(&bootstrap.publication_nonce),
+        complete_corpus_attestation: lower_hex(&bootstrap.complete_corpus_attestation),
+        writer_epoch: lower_hex(&bootstrap.writer_epoch),
+    }
+}
+
+fn control_head_point_wire_v1(point: CatalogHighWaterPointV1) -> CatalogControlHeadPointWireV1 {
+    CatalogControlHeadPointWireV1 {
+        catalog_sequence: point.sequence.get(),
+        head_revision: lower_hex(&point.head_revision),
+        publication_nonce: lower_hex(&point.publication_nonce),
+    }
+}
+
+fn publication_reference_wire_v1(
+    object_id: &[u8; 32],
+    raw_bytes_len: NonZeroU64,
+    binding: &RegisteredRootRemoteObjectBindingV1,
+) -> RemoteCatalogPublicationObjectReferenceWireV1 {
+    RemoteCatalogPublicationObjectReferenceWireV1 {
+        object_id: lower_hex(object_id),
+        raw_bytes_len: raw_bytes_len.get(),
+        binding: binding_wire_v1(binding),
+    }
+}
+
+fn canonical_pending_control_record_bytes_v1(
+    publication: &PreparedCatalogPublicationFenceV1<'_>,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    publishing_head_reservation_fingerprint: [u8; 32],
+) -> Vec<u8> {
+    let binding = &publication.control_guard.high_water.binding;
+    serde_json::to_vec(&CatalogControlRecordWireV1 {
+        version: CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1,
+        remote_prefix: binding.context.remote_prefix.clone(),
+        context: binding.context.to_wire(),
+        control_contract_fingerprint: lower_hex(&catalog_control_contract_fingerprint_v1()),
+        control_authority_fingerprint: lower_hex(&binding.control_authority_fingerprint),
+        storage_authority_fingerprint: lower_hex(&binding.storage_authority_fingerprint),
+        control_generation: pending_revision.generation.get(),
+        control_revision_fingerprint: lower_hex(&pending_revision.fingerprint),
+        lease_public_fingerprint: lower_hex(&binding.lease_public_fingerprint.0),
+        bootstrap: control_bootstrap_wire_v1(&binding.bootstrap),
+        writer_epoch: lower_hex(&binding.bootstrap.writer_epoch),
+        control_state: CatalogControlStateWireV1::PublicationPending {
+            pending: Box::new(CatalogControlPendingStateWireV1 {
+                ready_control_generation: binding.ready_revision.generation.get(),
+                ready_control_revision_fingerprint: lower_hex(&binding.ready_revision.fingerprint),
+                parent: control_head_point_wire_v1(binding.current),
+                successor_catalog_sequence: publication.sequence.get(),
+                successor_publication_nonce: lower_hex(&publication.publication_nonce),
+                publishing_head_reservation_fingerprint: lower_hex(
+                    &publishing_head_reservation_fingerprint,
+                ),
+                predecessor_head_storage_binding_fingerprint: lower_hex(
+                    &predecessor_head_storage_binding_fingerprint_v1(
+                        &publication.expected_parent_head_etag,
+                    ),
+                ),
+                predecessor_head_archive: publication_reference_wire_v1(
+                    &publication.predecessor_archive.object_id,
+                    publication.predecessor_archive.raw_bytes_len,
+                    &publication.predecessor_archive.binding,
+                ),
+                mutation_journal: publication_reference_wire_v1(
+                    &publication.mutation_journal.object_id,
+                    publication.mutation_journal.raw_bytes_len,
+                    &publication.mutation_journal.binding,
+                ),
+            }),
+        },
+    })
+    .expect("catalog control wire is infallibly serializable")
+}
+
+fn canonical_ready_control_record_bytes_v1(
+    committed: &BoundCommittedCatalogSuccessorV1,
+    ready_revision: CatalogControlAuthorityRevisionV1,
+) -> Vec<u8> {
+    let binding = &committed.control_binding;
+    serde_json::to_vec(&CatalogControlRecordWireV1 {
+        version: CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1,
+        remote_prefix: binding.context.remote_prefix.clone(),
+        context: binding.context.to_wire(),
+        control_contract_fingerprint: lower_hex(&catalog_control_contract_fingerprint_v1()),
+        control_authority_fingerprint: lower_hex(&binding.control_authority_fingerprint),
+        storage_authority_fingerprint: lower_hex(&binding.storage_authority_fingerprint),
+        control_generation: ready_revision.generation.get(),
+        control_revision_fingerprint: lower_hex(&ready_revision.fingerprint),
+        lease_public_fingerprint: lower_hex(&binding.lease_public_fingerprint.0),
+        bootstrap: control_bootstrap_wire_v1(&binding.bootstrap),
+        writer_epoch: lower_hex(&binding.bootstrap.writer_epoch),
+        control_state: CatalogControlStateWireV1::Ready {
+            current: control_head_point_wire_v1(CatalogHighWaterPointV1 {
+                sequence: committed.sequence,
+                head_revision: committed.head_revision,
+                publication_nonce: committed.publication_nonce,
+            }),
+        },
+    })
+    .expect("catalog control wire is infallibly serializable")
+}
+
+/// Prepare the exact external control transition without acquiring authority.
+/// The future backend must CAS the authenticated predecessor `Ready` bytes to
+/// these exact `PublicationPending` bytes before any catalog `HEAD` write.
+pub(crate) fn prepare_catalog_control_transition_v1<'a>(
+    publication: PreparedCatalogPublicationFenceV1<'a>,
+    pending_revision_fingerprint: [u8; 32],
+) -> Result<PreparedCatalogControlTransitionV1<'a>, CatalogPublicationContractErrorV1> {
+    let expected_successor_sequence = publication
+        .control_guard
+        .high_water
+        .binding
+        .current
+        .sequence
+        .get()
+        .checked_add(1)
+        .and_then(NonZeroU64::new)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    if publication.control_guard.all_writers.control_binding
+        != publication.control_guard.high_water.binding
+        || publication.sequence != expected_successor_sequence
+        || publication.parent_head_revision
+            != publication
+                .control_guard
+                .high_water
+                .binding
+                .current
+                .head_revision
+        || publication.publication_nonce == [0; 32]
+        || publication.publication_nonce
+            == publication
+                .control_guard
+                .high_water
+                .binding
+                .current
+                .publication_nonce
+        || publication.bootstrap_head_revision
+            != publication
+                .control_guard
+                .high_water
+                .binding
+                .bootstrap
+                .head_revision
+        || pending_revision_fingerprint == [0; 32]
+        || pending_revision_fingerprint
+            == publication
+                .control_guard
+                .high_water
+                .binding
+                .ready_revision
+                .fingerprint
+    {
+        return Err(CatalogPublicationContractErrorV1::ControlTransitionMismatch);
+    }
+    let pending_generation = publication
+        .control_guard
+        .high_water
+        .binding
+        .ready_revision
+        .generation
+        .get()
+        .checked_add(1)
+        .and_then(NonZeroU64::new)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    let pending_revision = CatalogControlAuthorityRevisionV1 {
+        generation: pending_generation,
+        fingerprint: pending_revision_fingerprint,
+    };
+    let canonical_publishing_head_bytes =
+        canonical_publishing_head_bytes_v1(&publication, pending_revision);
+    let publishing_head_bytes_len = u64::try_from(canonical_publishing_head_bytes.len())
+        .map_err(|_| CatalogPublicationContractErrorV1::PublishingHeadTooLarge)?;
+    if publishing_head_bytes_len
+        > RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_head_object_bytes()
+    {
+        return Err(CatalogPublicationContractErrorV1::PublishingHeadTooLarge);
+    }
+    let publishing_head_reservation_fingerprint = super::domain_object_id_v1(
+        PUBLISHING_HEAD_RESERVATION_DOMAIN_V1,
+        &canonical_publishing_head_bytes,
+    );
+    let canonical_pending_control_record_bytes = canonical_pending_control_record_bytes_v1(
+        &publication,
+        pending_revision,
+        publishing_head_reservation_fingerprint,
+    );
+    let pending_control_record_fingerprint = super::domain_object_id_v1(
+        CATALOG_CONTROL_RECORD_DOMAIN_V1,
+        &canonical_pending_control_record_bytes,
+    );
+    Ok(PreparedCatalogControlTransitionV1 {
+        publication,
+        pending_revision,
+        canonical_publishing_head_bytes,
+        publishing_head_reservation_fingerprint,
+        canonical_pending_control_record_bytes,
+        pending_control_record_fingerprint,
+    })
+}
+
+/// Bind an externally authenticated `Ready -> PublicationPending` CAS receipt
+/// to the exact proposed successor. Field equality is necessary but not a
+/// production liveness proof; only the future backend may construct `receipt`.
+pub(crate) fn match_catalog_publication_pending_receipt_v1<'a>(
+    transition: PreparedCatalogControlTransitionV1<'a>,
+    receipt: TrustedCatalogPublicationPendingReceiptV1,
+) -> Result<BoundPendingCatalogControlV1<'a>, CatalogPublicationContractErrorV1> {
+    let binding = &transition.publication.control_guard.high_water.binding;
+    let expected_publishing_bytes =
+        canonical_publishing_head_bytes_v1(&transition.publication, transition.pending_revision);
+    let publishing_fingerprint = super::domain_object_id_v1(
+        PUBLISHING_HEAD_RESERVATION_DOMAIN_V1,
+        &expected_publishing_bytes,
+    );
+    let expected_control_bytes = canonical_pending_control_record_bytes_v1(
+        &transition.publication,
+        transition.pending_revision,
+        publishing_fingerprint,
+    );
+    let control_fingerprint =
+        super::domain_object_id_v1(CATALOG_CONTROL_RECORD_DOMAIN_V1, &expected_control_bytes);
+    if receipt.control_binding != *binding
+        || receipt.pending_revision != transition.pending_revision
+        || receipt.publishing_head_reservation_fingerprint
+            != transition.publishing_head_reservation_fingerprint
+        || receipt.pending_control_record_fingerprint
+            != transition.pending_control_record_fingerprint
+        || transition.canonical_publishing_head_bytes != expected_publishing_bytes
+        || transition.canonical_pending_control_record_bytes != expected_control_bytes
+        || publishing_fingerprint != transition.publishing_head_reservation_fingerprint
+        || control_fingerprint != transition.pending_control_record_fingerprint
+    {
+        return Err(CatalogPublicationContractErrorV1::ControlTransitionMismatch);
+    }
+    Ok(BoundPendingCatalogControlV1 {
+        transition,
+        pending_receipt: receipt,
+    })
+}
+
+/// Bind an exact committed successor to the external monotonic
+/// `PublicationPending -> Ready(n+1)` advance. This returns terminal evidence,
+/// never a reusable exact-current guard or action capability.
+pub(crate) fn match_catalog_high_water_advance_v1(
+    committed: BoundCommittedCatalogSuccessorV1,
+    receipt: TrustedCatalogHighWaterAdvanceReceiptV1,
+) -> Result<AdvancedCatalogHighWaterV1, CatalogPublicationContractErrorV1> {
+    let expected_pending_generation = committed
+        .control_binding
+        .ready_revision
+        .generation
+        .get()
+        .checked_add(1)
+        .and_then(NonZeroU64::new)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    let expected_successor_sequence = committed
+        .control_binding
+        .current
+        .sequence
+        .get()
+        .checked_add(1)
+        .and_then(NonZeroU64::new)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    let expected_ready_generation = committed
+        .pending_revision
+        .generation
+        .get()
+        .checked_add(1)
+        .and_then(NonZeroU64::new)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    let exact_successor = CatalogHighWaterPointV1 {
+        sequence: committed.sequence,
+        head_revision: committed.head_revision,
+        publication_nonce: committed.publication_nonce,
+    };
+    let committed_revision = super::catalog_head_revision_v1(&committed.committed_head_bytes);
+    let ready_bytes = canonical_ready_control_record_bytes_v1(&committed, receipt.ready_revision);
+    let ready_record_fingerprint =
+        super::domain_object_id_v1(CATALOG_CONTROL_RECORD_DOMAIN_V1, &ready_bytes);
+    if committed.context != committed.control_binding.context
+        || committed.pending_revision.generation != expected_pending_generation
+        || committed.pending_revision.fingerprint == [0; 32]
+        || committed.pending_revision.fingerprint
+            == committed.control_binding.ready_revision.fingerprint
+        || committed.publishing_head_reservation_fingerprint == [0; 32]
+        || committed.pending_control_record_fingerprint == [0; 32]
+        || committed.sequence != expected_successor_sequence
+        || committed.parent_head_revision != committed.control_binding.current.head_revision
+        || committed.publication_nonce == [0; 32]
+        || committed.publication_nonce == committed.control_binding.current.publication_nonce
+        || committed.head_revision == [0; 32]
+        || committed.head_revision == committed.control_binding.current.head_revision
+        || committed_revision != committed.head_revision
+        || receipt.control_binding != committed.control_binding
+        || receipt.pending_revision != committed.pending_revision
+        || receipt.publishing_head_reservation_fingerprint
+            != committed.publishing_head_reservation_fingerprint
+        || receipt.pending_control_record_fingerprint
+            != committed.pending_control_record_fingerprint
+        || receipt.successor != exact_successor
+        || receipt.ready_revision.generation != expected_ready_generation
+        || receipt.ready_revision.fingerprint == [0; 32]
+        || receipt.ready_revision.fingerprint == committed.pending_revision.fingerprint
+        || receipt.ready_revision.fingerprint
+            == committed.control_binding.ready_revision.fingerprint
+        || receipt.ready_control_record_fingerprint == [0; 32]
+        || receipt.ready_control_record_fingerprint == committed.pending_control_record_fingerprint
+        || receipt.ready_control_record_fingerprint != ready_record_fingerprint
+    {
+        return Err(CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch);
+    }
+    Ok(AdvancedCatalogHighWaterV1 {
+        context: committed.control_binding.context,
+        bootstrap: committed.control_binding.bootstrap,
+        successor: exact_successor,
+        storage_authority_fingerprint: committed.control_binding.storage_authority_fingerprint,
+        control_authority_fingerprint: committed.control_binding.control_authority_fingerprint,
+        ready_revision: receipt.ready_revision,
+        ready_control_record_fingerprint: ready_record_fingerprint,
+    })
 }
 
 pub(super) fn classify_publishing_head_v1(
@@ -1421,10 +2025,18 @@ pub(super) fn classify_publishing_head_v1(
         && valid_nonzero_hex(&wire.storage_authority_fingerprint)
         && valid_nonzero_hex(&wire.control_authority_fingerprint)
         && valid_nonzero_hex(&wire.writer_epoch)
-        && valid_nonzero_hex(&wire.high_water_authority_revision)
-        && valid_nonzero_hex(&wire.high_water_lease_nonce)
-        && valid_nonzero_hex(&wire.writer_fence_authority_revision)
-        && valid_nonzero_hex(&wire.writer_fence_lease_nonce)
+        && wire.control_ready_generation > 0
+        && valid_nonzero_hex(&wire.control_ready_revision_fingerprint)
+        && wire
+            .control_ready_generation
+            .checked_add(1)
+            .is_some_and(|next| next == wire.control_pending_generation)
+        && valid_nonzero_hex(&wire.control_pending_revision_fingerprint)
+        && wire.control_pending_revision_fingerprint != wire.control_ready_revision_fingerprint
+        && valid_nonzero_hex(&wire.control_lease_public_fingerprint)
+        && valid_nonzero_hex(&wire.writer_fence_authority_revision_fingerprint)
+        && valid_nonzero_hex(&wire.writer_fence_lease_public_fingerprint)
+        && valid_nonzero_hex(&wire.predecessor_head_storage_binding_fingerprint)
         && valid_nonzero_hex(&wire.predecessor_head_archive.object_id)
         && wire.predecessor_head_archive.raw_bytes_len > 0
         && super::validate_binding_wire_v1(&wire.predecessor_head_archive.binding).is_some()
@@ -1436,6 +2048,88 @@ pub(super) fn classify_publishing_head_v1(
     } else {
         Err(InvalidRemoteCatalogReasonV1::Lineage)
     })
+}
+
+#[cfg(test)]
+fn is_canonical_control_record_v1(
+    raw_bytes: &[u8],
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+) -> bool {
+    let Ok(raw_bytes_len) = u64::try_from(raw_bytes.len()) else {
+        return false;
+    };
+    if raw_bytes_len
+        > RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_page_object_bytes()
+    {
+        return false;
+    }
+    let Ok(wire) = serde_json::from_slice::<CatalogControlRecordWireV1>(raw_bytes) else {
+        return false;
+    };
+    if serde_json::to_vec(&wire).ok().as_deref() != Some(raw_bytes)
+        || wire.version != CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1
+        || wire.remote_prefix != selected.spec().remote_prefix
+        || validate_catalog_context_v1(&wire.context, selected).is_none()
+        || wire.control_contract_fingerprint
+            != lower_hex(&catalog_control_contract_fingerprint_v1())
+        || wire.control_generation == 0
+    {
+        return false;
+    }
+    let nonzero_hex = |value: &str| {
+        super::parse_lower_hex_32(value).is_some_and(|fingerprint| fingerprint != [0; 32])
+    };
+    if !nonzero_hex(&wire.control_authority_fingerprint)
+        || !nonzero_hex(&wire.storage_authority_fingerprint)
+        || !nonzero_hex(&wire.control_revision_fingerprint)
+        || !nonzero_hex(&wire.lease_public_fingerprint)
+        || !nonzero_hex(&wire.bootstrap.head_revision)
+        || !nonzero_hex(&wire.bootstrap.publication_nonce)
+        || !nonzero_hex(&wire.bootstrap.complete_corpus_attestation)
+        || !nonzero_hex(&wire.bootstrap.writer_epoch)
+        || wire.writer_epoch != wire.bootstrap.writer_epoch
+    {
+        return false;
+    }
+    let valid_point = |point: &CatalogControlHeadPointWireV1| {
+        point.catalog_sequence > 0
+            && nonzero_hex(&point.head_revision)
+            && nonzero_hex(&point.publication_nonce)
+            && (point.catalog_sequence != 1
+                || (point.head_revision == wire.bootstrap.head_revision
+                    && point.publication_nonce == wire.bootstrap.publication_nonce))
+    };
+    match &wire.control_state {
+        CatalogControlStateWireV1::Ready { current } => valid_point(current),
+        CatalogControlStateWireV1::PublicationPending { pending } => {
+            let valid_reference = |reference: &RemoteCatalogPublicationObjectReferenceWireV1| {
+                nonzero_hex(&reference.object_id)
+                    && reference.raw_bytes_len > 0
+                    && super::validate_binding_wire_v1(&reference.binding).is_some()
+            };
+            valid_point(&pending.parent)
+                && pending.ready_control_generation > 0
+                && pending
+                    .ready_control_generation
+                    .checked_add(1)
+                    .is_some_and(|next| next == wire.control_generation)
+                && nonzero_hex(&pending.ready_control_revision_fingerprint)
+                && pending.ready_control_revision_fingerprint != wire.control_revision_fingerprint
+                && pending
+                    .parent
+                    .catalog_sequence
+                    .checked_add(1)
+                    .is_some_and(|next| next == pending.successor_catalog_sequence)
+                && nonzero_hex(&pending.successor_publication_nonce)
+                && pending.successor_publication_nonce != pending.parent.publication_nonce
+                && nonzero_hex(&pending.publishing_head_reservation_fingerprint)
+                && nonzero_hex(&pending.predecessor_head_storage_binding_fingerprint)
+                && valid_reference(&pending.predecessor_head_archive)
+                && valid_reference(&pending.mutation_journal)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1461,10 +2155,14 @@ pub(super) fn canonical_publishing_head_bytes_for_test_v1(
         storage_authority_fingerprint: "99".repeat(32),
         control_authority_fingerprint: "9a".repeat(32),
         writer_epoch: "77".repeat(32),
-        high_water_authority_revision: "ab".repeat(32),
-        high_water_lease_nonce: "aa".repeat(32),
-        writer_fence_authority_revision: "89".repeat(32),
-        writer_fence_lease_nonce: "88".repeat(32),
+        control_ready_generation: 7,
+        control_ready_revision_fingerprint: "ab".repeat(32),
+        control_pending_generation: 8,
+        control_pending_revision_fingerprint: "ac".repeat(32),
+        control_lease_public_fingerprint: "aa".repeat(32),
+        writer_fence_authority_revision_fingerprint: "89".repeat(32),
+        writer_fence_lease_public_fingerprint: "88".repeat(32),
+        predecessor_head_storage_binding_fingerprint: "87".repeat(32),
         predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1 {
             object_id: "bb".repeat(32),
             raw_bytes_len: 1,
@@ -1541,6 +2239,31 @@ mod tests {
         Default
     );
     static_assertions::assert_not_impl_any!(
+        HeldReadyCatalogControlGuardV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogControlRecordWireV1:
+        Into<TrustedCatalogBootstrapReceiptV1>,
+        Into<HeldReadyCatalogControlGuardV1>,
+        Into<TrustedCatalogHighWaterGuardV1>,
+        Into<AllNamespaceWritersFencedLeaseV1>,
+        Into<TrustedCatalogPublicationPendingReceiptV1>,
+        Into<TrustedCatalogHighWaterAdvanceReceiptV1>,
+        Into<BoundPendingCatalogControlV1<'static>>,
+        Into<BoundCommittedCatalogSuccessorV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        RemoteCatalogPublishingHeadWireV1:
+        Into<TrustedCatalogBootstrapReceiptV1>,
+        Into<HeldReadyCatalogControlGuardV1>,
+        Into<TrustedCatalogPublicationPendingReceiptV1>,
+        Into<TrustedCatalogHighWaterAdvanceReceiptV1>,
+        Into<BoundPendingCatalogControlV1<'static>>,
+        Into<BoundCommittedCatalogSuccessorV1>
+    );
+    static_assertions::assert_not_impl_any!(
         BoundArchivedCatalogHeadV1: Clone,
         serde::Serialize,
         Default
@@ -1577,6 +2300,46 @@ mod tests {
         PreparedCatalogPublicationFenceV1<'static>: Clone,
         serde::Serialize,
         Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        PreparedCatalogControlTransitionV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        TrustedCatalogPublicationPendingReceiptV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        BoundPendingCatalogControlV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        BoundCommittedCatalogSuccessorV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        TrustedCatalogHighWaterAdvanceReceiptV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        AdvancedCatalogHighWaterV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<TrustedCatalogHighWaterGuardV1>,
+        Into<HeldReadyCatalogControlGuardV1>,
         Into<crate::reconcile::ReconcilePlan>,
         Into<Vec<crate::reconcile::ReconcileAction>>
     );
@@ -1621,41 +2384,44 @@ mod tests {
     ) {
         let bootstrap_head_revision = observed.head_revision;
         let bootstrap_writer_epoch = [0x21; 32];
-        let current_writer_epoch = [0x22; 32];
         let storage_authority_fingerprint = [0x99; 32];
         let control_authority_fingerprint = [0x9a; 32];
+        let bootstrap = CatalogBootstrapIdentityV1 {
+            head_revision: bootstrap_head_revision,
+            publication_nonce: observed.publication_nonce,
+            complete_corpus_attestation: [0x33; 32],
+            writer_epoch: bootstrap_writer_epoch,
+        };
+        let control_binding = CatalogControlAcquisitionBindingV1 {
+            context: observed.context.clone(),
+            bootstrap: bootstrap.clone(),
+            current: CatalogHighWaterPointV1 {
+                sequence: observed.sequence,
+                head_revision: observed.head_revision,
+                publication_nonce: observed.publication_nonce,
+            },
+            storage_authority_fingerprint,
+            control_authority_fingerprint,
+            ready_revision: CatalogControlAuthorityRevisionV1 {
+                generation: NonZeroU64::new(7).unwrap(),
+                fingerprint: [0xab; 32],
+            },
+            lease_public_fingerprint: NonSecretLeasePublicFingerprintV1([0xaa; 32]),
+        };
         (
             TrustedCatalogBootstrapReceiptV1 {
                 context: observed.context.clone(),
-                bootstrap_head_revision,
-                bootstrap_publication_nonce: observed.publication_nonce,
-                complete_corpus_attestation: [0x33; 32],
-                bootstrap_writer_epoch,
+                bootstrap,
                 storage_authority_fingerprint,
                 control_authority_fingerprint,
             },
             TrustedCatalogHighWaterGuardV1 {
-                context: observed.context.clone(),
-                bootstrap_head_revision,
-                bootstrap_publication_nonce: observed.publication_nonce,
-                complete_corpus_attestation: [0x33; 32],
-                current_writer_epoch,
-                current_sequence: observed.sequence,
-                current_head_revision: observed.head_revision,
-                current_publication_nonce: observed.publication_nonce,
-                storage_authority_fingerprint,
-                authority_revision: [0xab; 32],
-                lease_nonce: [0xaa; 32],
-                control_authority_fingerprint,
+                binding: control_binding.clone(),
             },
             AllNamespaceWritersFencedLeaseV1 {
-                context: observed.context.clone(),
-                bootstrap_head_revision,
-                current_writer_epoch,
-                authority_revision: [0x89; 32],
-                lease_nonce: [0x88; 32],
-                storage_authority_fingerprint,
-                control_authority_fingerprint,
+                control_binding,
+                authority_revision_fingerprint: [0x89; 32],
+                lease_public_fingerprint: NonSecretLeasePublicFingerprintV1([0x88; 32]),
             },
         )
     }
@@ -1667,6 +2433,16 @@ mod tests {
             operator: fixture.operator(),
             conditional_write_receipt: fixture.receipt(),
             authority_fingerprint: [0x99; 32],
+        }
+    }
+
+    fn held_control(
+        high_water: TrustedCatalogHighWaterGuardV1,
+        all_writers: AllNamespaceWritersFencedLeaseV1,
+    ) -> HeldReadyCatalogControlGuardV1 {
+        HeldReadyCatalogControlGuardV1 {
+            high_water,
+            all_writers,
         }
     }
 
@@ -1725,10 +2501,106 @@ mod tests {
             trusted_storage(fixture),
             observed,
             &bootstrap,
-            high_water,
-            writers,
+            held_control(high_water, writers),
         )
         .unwrap()
+    }
+
+    fn prepared_control_transition<'a>(
+        fixture: &'a SemanticRemoteCatalogFixtureV1,
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> PreparedCatalogControlTransitionV1<'a> {
+        let publication_nonce = [0x44; 32];
+        let (archive, journal) = bound_publication_objects(observed, publication_nonce);
+        let publication = prepare_catalog_publication_fence_v1(
+            matched(fixture, observed),
+            publication_nonce,
+            archive,
+            journal,
+        )
+        .unwrap();
+        prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap()
+    }
+
+    fn pending_receipt(
+        transition: &PreparedCatalogControlTransitionV1<'_>,
+    ) -> TrustedCatalogPublicationPendingReceiptV1 {
+        TrustedCatalogPublicationPendingReceiptV1 {
+            control_binding: transition
+                .publication
+                .control_guard
+                .high_water
+                .binding
+                .clone(),
+            pending_revision: transition.pending_revision,
+            publishing_head_reservation_fingerprint: transition
+                .publishing_head_reservation_fingerprint,
+            pending_control_record_fingerprint: transition.pending_control_record_fingerprint,
+        }
+    }
+
+    fn bound_pending<'a>(
+        fixture: &'a SemanticRemoteCatalogFixtureV1,
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> BoundPendingCatalogControlV1<'a> {
+        let transition = prepared_control_transition(fixture, observed);
+        let receipt = pending_receipt(&transition);
+        match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap()
+    }
+
+    fn committed_successor(
+        pending: BoundPendingCatalogControlV1<'_>,
+    ) -> BoundCommittedCatalogSuccessorV1 {
+        let committed_head_bytes = br#"{"catalog_sequence":2,"fixture":"committed"}"#.to_vec();
+        let head_revision = super::super::catalog_head_revision_v1(&committed_head_bytes);
+        BoundCommittedCatalogSuccessorV1 {
+            control_binding: pending
+                .transition
+                .publication
+                .control_guard
+                .high_water
+                .binding,
+            pending_revision: pending.transition.pending_revision,
+            publishing_head_reservation_fingerprint: pending
+                .pending_receipt
+                .publishing_head_reservation_fingerprint,
+            pending_control_record_fingerprint: pending
+                .pending_receipt
+                .pending_control_record_fingerprint,
+            context: pending.transition.publication.context,
+            sequence: pending.transition.publication.sequence,
+            publication_nonce: pending.transition.publication.publication_nonce,
+            parent_head_revision: pending.transition.publication.parent_head_revision,
+            head_revision,
+            committed_head_bytes,
+        }
+    }
+
+    fn high_water_advance_receipt(
+        committed: &BoundCommittedCatalogSuccessorV1,
+    ) -> TrustedCatalogHighWaterAdvanceReceiptV1 {
+        let ready_revision = CatalogControlAuthorityRevisionV1 {
+            generation: NonZeroU64::new(committed.pending_revision.generation.get() + 1).unwrap(),
+            fingerprint: [0xad; 32],
+        };
+        let ready_bytes = canonical_ready_control_record_bytes_v1(committed, ready_revision);
+        TrustedCatalogHighWaterAdvanceReceiptV1 {
+            control_binding: committed.control_binding.clone(),
+            pending_revision: committed.pending_revision,
+            publishing_head_reservation_fingerprint: committed
+                .publishing_head_reservation_fingerprint,
+            pending_control_record_fingerprint: committed.pending_control_record_fingerprint,
+            successor: CatalogHighWaterPointV1 {
+                sequence: committed.sequence,
+                head_revision: committed.head_revision,
+                publication_nonce: committed.publication_nonce,
+            },
+            ready_revision,
+            ready_control_record_fingerprint: super::super::domain_object_id_v1(
+                CATALOG_CONTROL_RECORD_DOMAIN_V1,
+                &ready_bytes,
+            ),
+        }
     }
 
     fn created_index_mutation(
@@ -2281,20 +3153,47 @@ mod tests {
             )
         );
 
-        let bytes = canonical_publishing_head_bytes_v1(&fence);
-        assert!(is_canonical_publishing_head_v1(&bytes, &test_selected()));
+        let transition = prepare_catalog_control_transition_v1(fence, [0xac; 32]).unwrap();
+        let pending_receipt = TrustedCatalogPublicationPendingReceiptV1 {
+            control_binding: transition
+                .publication
+                .control_guard
+                .high_water
+                .binding
+                .clone(),
+            pending_revision: transition.pending_revision,
+            publishing_head_reservation_fingerprint: transition
+                .publishing_head_reservation_fingerprint,
+            pending_control_record_fingerprint: transition.pending_control_record_fingerprint,
+        };
+        let bound =
+            match_catalog_publication_pending_receipt_v1(transition, pending_receipt).unwrap();
+        let bytes = &bound.transition.canonical_publishing_head_bytes;
+        assert!(is_canonical_publishing_head_v1(bytes, &test_selected()));
         assert!(
-            super::super::canonical_wire_v1::<super::super::RemoteCatalogHeadWireV1>(&bytes)
+            super::super::canonical_wire_v1::<super::super::RemoteCatalogHeadWireV1>(bytes)
                 .is_none()
         );
-        let wire = serde_json::from_slice::<RemoteCatalogPublishingHeadWireV1>(&bytes).unwrap();
+        let wire = serde_json::from_slice::<RemoteCatalogPublishingHeadWireV1>(bytes).unwrap();
         assert_eq!(wire.storage_authority_fingerprint, "99".repeat(32));
         assert_eq!(wire.control_authority_fingerprint, "9a".repeat(32));
-        assert_eq!(wire.writer_epoch, "22".repeat(32));
-        assert_eq!(wire.high_water_authority_revision, "ab".repeat(32));
-        assert_eq!(wire.high_water_lease_nonce, "aa".repeat(32));
-        assert_eq!(wire.writer_fence_authority_revision, "89".repeat(32));
-        assert_eq!(wire.writer_fence_lease_nonce, "88".repeat(32));
+        assert_eq!(wire.writer_epoch, "21".repeat(32));
+        assert_eq!(wire.control_ready_generation, 7);
+        assert_eq!(wire.control_ready_revision_fingerprint, "ab".repeat(32));
+        assert_eq!(wire.control_pending_generation, 8);
+        assert_eq!(wire.control_pending_revision_fingerprint, "ac".repeat(32));
+        assert_eq!(wire.control_lease_public_fingerprint, "aa".repeat(32));
+        assert_eq!(
+            wire.writer_fence_authority_revision_fingerprint,
+            "89".repeat(32)
+        );
+        assert_eq!(wire.writer_fence_lease_public_fingerprint, "88".repeat(32));
+        assert_eq!(
+            wire.predecessor_head_storage_binding_fingerprint,
+            lower_hex(&predecessor_head_storage_binding_fingerprint_v1(
+                "head-etag-a"
+            ))
+        );
         assert_eq!(
             wire.predecessor_head_archive.object_id,
             lower_hex(&super::super::domain_object_id_v1(
@@ -2304,8 +3203,380 @@ mod tests {
         );
         assert_eq!(
             wire.mutation_journal.object_id,
-            lower_hex(&fence.mutation_journal.object_id)
+            lower_hex(&bound.transition.publication.mutation_journal.object_id)
         );
+        assert_eq!(
+            bound.pending_receipt.pending_control_record_fingerprint,
+            bound.transition.pending_control_record_fingerprint
+        );
+        assert!(is_canonical_control_record_v1(
+            &bound.transition.canonical_pending_control_record_bytes,
+            &test_selected()
+        ));
+        let pending_text =
+            std::str::from_utf8(&bound.transition.canonical_pending_control_record_bytes).unwrap();
+        assert!(pending_text.contains("lease_public_fingerprint"));
+        assert!(!pending_text.contains("lease_nonce"));
+        assert!(!pending_text.contains("bearer"));
+    }
+
+    #[tokio::test]
+    async fn pending_control_record_is_canonical_bounded_and_fail_closed() {
+        let (fixture, observed) = observed_head().await;
+        let transition = prepared_control_transition(&fixture, &observed);
+        let canonical = transition.canonical_pending_control_record_bytes.clone();
+        assert!(is_canonical_control_record_v1(&canonical, &test_selected()));
+
+        let mut newline = canonical.clone();
+        newline.push(b'\n');
+        assert!(!is_canonical_control_record_v1(&newline, &test_selected()));
+
+        let mut unknown = serde_json::from_slice::<serde_json::Value>(&canonical).unwrap();
+        unknown
+            .as_object_mut()
+            .unwrap()
+            .insert("bearer_token".to_owned(), serde_json::json!("forbidden"));
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&unknown).unwrap(),
+            &test_selected()
+        ));
+
+        let mut wire = serde_json::from_slice::<CatalogControlRecordWireV1>(&canonical).unwrap();
+        wire.writer_epoch = "22".repeat(32);
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&wire).unwrap(),
+            &test_selected()
+        ));
+
+        let mut wire = serde_json::from_slice::<CatalogControlRecordWireV1>(&canonical).unwrap();
+        if let CatalogControlStateWireV1::PublicationPending { pending } = &mut wire.control_state {
+            pending.successor_catalog_sequence += 1;
+        }
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&wire).unwrap(),
+            &test_selected()
+        ));
+    }
+
+    #[tokio::test]
+    async fn exact_pending_receipt_rejects_crossed_acquisitions_and_proposals() {
+        let (fixture, observed) = observed_head().await;
+
+        {
+            let transition = prepared_control_transition(&fixture, &observed);
+            let mut receipt = pending_receipt(&transition);
+            receipt.control_binding.lease_public_fingerprint =
+                NonSecretLeasePublicFingerprintV1([0x45; 32]);
+            assert_eq!(
+                match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::ControlTransitionMismatch
+            );
+        }
+        {
+            let transition = prepared_control_transition(&fixture, &observed);
+            let mut receipt = pending_receipt(&transition);
+            receipt.pending_revision.fingerprint = [0x45; 32];
+            assert_eq!(
+                match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::ControlTransitionMismatch
+            );
+        }
+        {
+            let transition = prepared_control_transition(&fixture, &observed);
+            let mut receipt = pending_receipt(&transition);
+            receipt.publishing_head_reservation_fingerprint = [0x45; 32];
+            assert_eq!(
+                match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::ControlTransitionMismatch
+            );
+        }
+        {
+            let transition = prepared_control_transition(&fixture, &observed);
+            let mut receipt = pending_receipt(&transition);
+            receipt.pending_control_record_fingerprint = [0x45; 32];
+            assert_eq!(
+                match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::ControlTransitionMismatch
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn control_transition_rejects_revision_reuse_overflow_and_byte_tampering() {
+        let (fixture, observed) = observed_head().await;
+        let make_publication = || {
+            let publication_nonce = [0x44; 32];
+            let (archive, journal) = bound_publication_objects(&observed, publication_nonce);
+            prepare_catalog_publication_fence_v1(
+                matched(&fixture, &observed),
+                publication_nonce,
+                archive,
+                journal,
+            )
+            .unwrap()
+        };
+
+        assert_eq!(
+            prepare_catalog_control_transition_v1(make_publication(), [0; 32])
+                .err()
+                .expect("zero revision must fail"),
+            CatalogPublicationContractErrorV1::ControlTransitionMismatch
+        );
+        assert_eq!(
+            prepare_catalog_control_transition_v1(make_publication(), [0xab; 32])
+                .err()
+                .expect("ready revision reuse must fail"),
+            CatalogPublicationContractErrorV1::ControlTransitionMismatch
+        );
+
+        let mut overflow = make_publication();
+        overflow
+            .control_guard
+            .high_water
+            .binding
+            .ready_revision
+            .generation = NonZeroU64::new(u64::MAX).unwrap();
+        overflow
+            .control_guard
+            .all_writers
+            .control_binding
+            .ready_revision
+            .generation = NonZeroU64::new(u64::MAX).unwrap();
+        assert_eq!(
+            prepare_catalog_control_transition_v1(overflow, [0xac; 32])
+                .err()
+                .expect("control generation overflow must fail"),
+            CatalogPublicationContractErrorV1::SequenceOverflow
+        );
+
+        let mut oversized = make_publication();
+        let maximum_token = "v".repeat(
+            usize::try_from(
+                RegisteredRootPlanContractV1::strict_v1()
+                    .remote_contract()
+                    .max_binding_token_bytes(),
+            )
+            .unwrap(),
+        );
+        oversized.predecessor_archive.binding = RegisteredRootRemoteObjectBindingV1::Version {
+            version: maximum_token.clone(),
+            etag: Some(maximum_token.clone()),
+        };
+        oversized.mutation_journal.binding = RegisteredRootRemoteObjectBindingV1::Version {
+            version: maximum_token.clone(),
+            etag: Some(maximum_token),
+        };
+        assert_eq!(
+            prepare_catalog_control_transition_v1(oversized, [0xac; 32])
+                .err()
+                .expect("an unreadable publishing HEAD must fail before reservation"),
+            CatalogPublicationContractErrorV1::PublishingHeadTooLarge
+        );
+
+        let first = prepare_catalog_control_transition_v1(make_publication(), [0xac; 32]).unwrap();
+        let mut other_baseline = make_publication();
+        other_baseline.expected_parent_head_etag = "head-etag-b".to_owned();
+        let second = prepare_catalog_control_transition_v1(other_baseline, [0xac; 32]).unwrap();
+        assert_ne!(
+            first.publishing_head_reservation_fingerprint,
+            second.publishing_head_reservation_fingerprint,
+            "the durable reservation must bind the exact predecessor storage CAS baseline"
+        );
+        assert_ne!(
+            first.pending_control_record_fingerprint,
+            second.pending_control_record_fingerprint
+        );
+
+        let mut transition = prepared_control_transition(&fixture, &observed);
+        let receipt = pending_receipt(&transition);
+        transition.canonical_publishing_head_bytes.push(b' ');
+        assert_eq!(
+            match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap_err(),
+            CatalogPublicationContractErrorV1::ControlTransitionMismatch
+        );
+
+        let mut transition = prepared_control_transition(&fixture, &observed);
+        let receipt = pending_receipt(&transition);
+        transition.canonical_pending_control_record_bytes.push(b' ');
+        assert_eq!(
+            match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap_err(),
+            CatalogPublicationContractErrorV1::ControlTransitionMismatch
+        );
+    }
+
+    #[tokio::test]
+    async fn high_water_advance_accepts_only_exact_monotonic_successor() {
+        let (fixture, observed) = observed_head().await;
+        let make_committed = || committed_successor(bound_pending(&fixture, &observed));
+
+        let committed = make_committed();
+        let receipt = high_water_advance_receipt(&committed);
+        let ready_bytes =
+            canonical_ready_control_record_bytes_v1(&committed, receipt.ready_revision);
+        assert!(is_canonical_control_record_v1(
+            &ready_bytes,
+            &test_selected()
+        ));
+        let ready_text = std::str::from_utf8(&ready_bytes).unwrap();
+        assert!(ready_text.contains("lease_public_fingerprint"));
+        assert!(!ready_text.contains("lease_nonce"));
+        assert!(!ready_text.contains("bearer"));
+
+        let mut malformed_ready =
+            serde_json::from_slice::<CatalogControlRecordWireV1>(&ready_bytes).unwrap();
+        malformed_ready.bootstrap.writer_epoch = "00".repeat(32);
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&malformed_ready).unwrap(),
+            &test_selected()
+        ));
+
+        let mut wrong_bootstrap =
+            serde_json::from_slice::<CatalogControlRecordWireV1>(&ready_bytes).unwrap();
+        if let CatalogControlStateWireV1::Ready { current } = &mut wrong_bootstrap.control_state {
+            current.catalog_sequence = 1;
+        }
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&wrong_bootstrap).unwrap(),
+            &test_selected()
+        ));
+        let advanced = match_catalog_high_water_advance_v1(committed, receipt).unwrap();
+        assert_eq!(advanced.successor.sequence.get(), 2);
+        assert_eq!(advanced.ready_revision.generation.get(), 9);
+        assert_ne!(advanced.ready_control_record_fingerprint, [0; 32]);
+        assert_eq!(advanced.bootstrap.writer_epoch, [0x21; 32]);
+        assert_eq!(advanced.storage_authority_fingerprint, [0x99; 32]);
+        assert_eq!(advanced.control_authority_fingerprint, [0x9a; 32]);
+        assert_eq!(advanced.context, observed.context);
+
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.successor.sequence = NonZeroU64::new(3).unwrap();
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.ready_revision.generation = NonZeroU64::new(10).unwrap();
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let mut committed = make_committed();
+            committed.pending_revision.generation = NonZeroU64::new(10).unwrap();
+            let receipt = high_water_advance_receipt(&committed);
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.ready_revision.fingerprint = committed.pending_revision.fingerprint;
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.ready_revision.fingerprint =
+                committed.control_binding.ready_revision.fingerprint;
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let mut committed = make_committed();
+            let receipt = high_water_advance_receipt(&committed);
+            committed.committed_head_bytes.push(b' ');
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.ready_control_record_fingerprint = [0x45; 32];
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let mut committed = make_committed();
+            let receipt = high_water_advance_receipt(&committed);
+            committed.parent_head_revision = [0x45; 32];
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.successor.publication_nonce = [0x45; 32];
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.successor.head_revision = [0x45; 32];
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.publishing_head_reservation_fingerprint = [0x45; 32];
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.pending_control_record_fingerprint = [0x45; 32];
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            receipt.control_binding.lease_public_fingerprint =
+                NonSecretLeasePublicFingerprintV1([0x45; 32]);
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch
+            );
+        }
+        {
+            let mut committed = make_committed();
+            let mut receipt = high_water_advance_receipt(&committed);
+            committed.pending_revision.generation = NonZeroU64::new(u64::MAX).unwrap();
+            receipt.pending_revision = committed.pending_revision;
+            assert_eq!(
+                match_catalog_high_water_advance_v1(committed, receipt).unwrap_err(),
+                CatalogPublicationContractErrorV1::SequenceOverflow
+            );
+        }
     }
 
     #[tokio::test]
@@ -2550,14 +3821,13 @@ mod tests {
         let (fixture, observed) = observed_head().await;
         {
             let (mut bootstrap, high_water, writers) = trusted_receipts(&observed);
-            bootstrap.complete_corpus_attestation = [0; 32];
+            bootstrap.bootstrap.complete_corpus_attestation = [0; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::InvalidBootstrapReceipt
@@ -2565,16 +3835,15 @@ mod tests {
         }
         {
             let (mut bootstrap, mut high_water, mut writers) = trusted_receipts(&observed);
-            bootstrap.bootstrap_head_revision = [0x55; 32];
-            high_water.bootstrap_head_revision = [0x55; 32];
-            writers.bootstrap_head_revision = [0x55; 32];
+            bootstrap.bootstrap.head_revision = [0x55; 32];
+            high_water.binding.bootstrap.head_revision = [0x55; 32];
+            writers.control_binding.bootstrap.head_revision = [0x55; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::BootstrapMismatch,
@@ -2583,14 +3852,13 @@ mod tests {
         }
         {
             let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
-            high_water.current_head_revision = [0x66; 32];
+            high_water.binding.current.head_revision = [0x66; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::HighWaterMismatch
@@ -2598,14 +3866,13 @@ mod tests {
         }
         {
             let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
-            high_water.current_publication_nonce = [0x66; 32];
+            high_water.binding.current.publication_nonce = [0x66; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::HighWaterMismatch
@@ -2613,14 +3880,14 @@ mod tests {
         }
         {
             let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
-            high_water.current_sequence = NonZeroU64::new(observed.sequence.get() + 1).unwrap();
+            high_water.binding.current.sequence =
+                NonZeroU64::new(observed.sequence.get() + 1).unwrap();
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::HighWaterMismatch,
@@ -2629,14 +3896,13 @@ mod tests {
         }
         {
             let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
-            high_water.authority_revision = [0; 32];
+            high_water.binding.ready_revision.fingerprint = [0; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::HighWaterMismatch
@@ -2644,14 +3910,13 @@ mod tests {
         }
         {
             let (bootstrap, high_water, mut writers) = trusted_receipts(&observed);
-            writers.current_writer_epoch = [0x77; 32];
+            writers.control_binding.bootstrap.writer_epoch = [0x77; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::WriterFenceMismatch
@@ -2659,14 +3924,13 @@ mod tests {
         }
         {
             let (bootstrap, high_water, mut writers) = trusted_receipts(&observed);
-            writers.authority_revision = [0; 32];
+            writers.authority_revision_fingerprint = [0; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::WriterFenceMismatch
@@ -2682,14 +3946,13 @@ mod tests {
         observed.head_revision = [0x55; 32];
         observed.publication_nonce = [0x56; 32];
         let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
-        high_water.current_sequence = NonZeroU64::new(1).unwrap();
+        high_water.binding.current.sequence = NonZeroU64::new(1).unwrap();
         assert_eq!(
             match_catalog_publication_prerequisites_v1(
                 trusted_storage(&fixture),
                 &observed,
                 &bootstrap,
-                high_water,
-                writers,
+                held_control(high_water, writers),
             )
             .unwrap_err(),
             CatalogPublicationContractErrorV1::HighWaterMismatch,
@@ -2709,8 +3972,7 @@ mod tests {
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::StorageAuthorityMismatch
@@ -2718,14 +3980,13 @@ mod tests {
         }
         {
             let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
-            high_water.storage_authority_fingerprint = [0x98; 32];
+            high_water.binding.storage_authority_fingerprint = [0x98; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::StorageAuthorityMismatch
@@ -2733,14 +3994,13 @@ mod tests {
         }
         {
             let (bootstrap, high_water, mut writers) = trusted_receipts(&observed);
-            writers.storage_authority_fingerprint = [0x98; 32];
+            writers.control_binding.storage_authority_fingerprint = [0x98; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::StorageAuthorityMismatch
@@ -2748,14 +4008,13 @@ mod tests {
         }
         {
             let (bootstrap, mut high_water, writers) = trusted_receipts(&observed);
-            high_water.control_authority_fingerprint = [0x9b; 32];
+            high_water.binding.control_authority_fingerprint = [0x9b; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::ControlAuthorityMismatch
@@ -2763,14 +4022,13 @@ mod tests {
         }
         {
             let (bootstrap, high_water, mut writers) = trusted_receipts(&observed);
-            writers.control_authority_fingerprint = [0x9b; 32];
+            writers.control_binding.control_authority_fingerprint = [0x9b; 32];
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
                     trusted_storage(&fixture),
                     &observed,
                     &bootstrap,
-                    high_water,
-                    writers,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::ControlAuthorityMismatch
@@ -2791,7 +4049,10 @@ mod tests {
             };
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
-                    crossed, &observed, &bootstrap, high_water, writers,
+                    crossed,
+                    &observed,
+                    &bootstrap,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::StorageSemanticsUnverified
@@ -2806,7 +4067,10 @@ mod tests {
             };
             assert_eq!(
                 match_catalog_publication_prerequisites_v1(
-                    crossed, &observed, &bootstrap, high_water, writers,
+                    crossed,
+                    &observed,
+                    &bootstrap,
+                    held_control(high_water, writers),
                 )
                 .unwrap_err(),
                 CatalogPublicationContractErrorV1::StorageSemanticsUnverified
@@ -2838,10 +4102,14 @@ mod tests {
             storage_authority_fingerprint: "99".repeat(32),
             control_authority_fingerprint: "9a".repeat(32),
             writer_epoch: "77".repeat(32),
-            high_water_authority_revision: "ab".repeat(32),
-            high_water_lease_nonce: "aa".repeat(32),
-            writer_fence_authority_revision: "89".repeat(32),
-            writer_fence_lease_nonce: "88".repeat(32),
+            control_ready_generation: 7,
+            control_ready_revision_fingerprint: "ab".repeat(32),
+            control_pending_generation: 8,
+            control_pending_revision_fingerprint: "ac".repeat(32),
+            control_lease_public_fingerprint: "aa".repeat(32),
+            writer_fence_authority_revision_fingerprint: "89".repeat(32),
+            writer_fence_lease_public_fingerprint: "88".repeat(32),
+            predecessor_head_storage_binding_fingerprint: "87".repeat(32),
             predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1 {
                 object_id: "bb".repeat(32),
                 raw_bytes_len: 1,
@@ -2915,16 +4183,19 @@ mod tests {
         wire.control_authority_fingerprint = "00".repeat(32);
         reject(wire);
         let mut wire = fresh_wire();
-        wire.high_water_authority_revision = "00".repeat(32);
+        wire.control_ready_revision_fingerprint = "00".repeat(32);
         reject(wire);
         let mut wire = fresh_wire();
-        wire.high_water_lease_nonce = "00".repeat(32);
+        wire.control_lease_public_fingerprint = "00".repeat(32);
         reject(wire);
         let mut wire = fresh_wire();
-        wire.writer_fence_authority_revision = "00".repeat(32);
+        wire.writer_fence_authority_revision_fingerprint = "00".repeat(32);
         reject(wire);
         let mut wire = fresh_wire();
-        wire.writer_fence_lease_nonce = "00".repeat(32);
+        wire.writer_fence_lease_public_fingerprint = "00".repeat(32);
+        reject(wire);
+        let mut wire = fresh_wire();
+        wire.predecessor_head_storage_binding_fingerprint = "00".repeat(32);
         reject(wire);
         let mut wire = fresh_wire();
         wire.predecessor_head_archive.raw_bytes_len = 0;

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -16,11 +16,18 @@
 //! executes only the complete fact-bound journal, publishes a complete
 //! immutable successor catalog, finalizes committed HEAD, reconstructs exact
 //! recovery states, and advances the external high-water to `Ready(n+1)`.
-//! Every conditional write is bracketed by the retained live backend lease.
+//! Every authoritative mutable write must pass through one storage-side
+//! monotonic-fence request whose control identity, writer epoch, journal,
+//! ordinal, key, condition, and payload are exact-bound. Advisory liveness
+//! checks and raw object rereads never substitute for that backend receipt;
+//! immutable content-addressed archive, journal, payload, page, and root writes
+//! remain direct absent-only publications.
 //! A separately namespaced diagnostic draft remains non-authoritative and
-//! cannot convert into the authoritative journal. The lease and authenticated
-//! control receipts still have no production constructors or implementation,
-//! so this source path remains unreachable by deployed writers and cannot mint
+//! cannot convert into the authoritative journal. The lease, authenticated
+//! control receipts, and storage-enforced fence still have no production
+//! constructors or implementation, and this checkpoint does not claim
+//! cold-process reconstruction from persisted authenticated state. The source
+//! path therefore remains unreachable by deployed writers and cannot mint
 //! production authority, produce a plan digest, or authorize an action.
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -73,6 +80,8 @@ const PUBLISHING_HEAD_RESERVATION_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-publishing-head-reservation.b3v1";
 const PREDECESSOR_HEAD_STORAGE_BINDING_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-predecessor-head-storage-binding.b3v1";
+const FENCED_STORAGE_WRITE_REQUEST_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-fenced-storage-write-request.b3v1";
 const ARCHIVED_HEAD_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/archived-heads";
 const MUTATION_JOURNAL_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/mutation-journals";
 const UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_SUFFIX_V1: &str =
@@ -293,13 +302,152 @@ struct CatalogControlAuthorityRevisionV1 {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct NonSecretLeasePublicFingerprintV1([u8; 32]);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum CatalogFencedStorageWriteStageV1 {
+    PublishingHead,
+    NamespaceIndex,
+    NamespaceReservation,
+    NamespaceManifest,
+    CommittedHead,
+}
+
+impl CatalogFencedStorageWriteStageV1 {
+    fn for_namespace_kind(kind: RemoteCatalogObjectKindV1) -> Self {
+        match kind {
+            RemoteCatalogObjectKindV1::Index => Self::NamespaceIndex,
+            RemoteCatalogObjectKindV1::Reservation => Self::NamespaceReservation,
+            RemoteCatalogObjectKindV1::Manifest => Self::NamespaceManifest,
+        }
+    }
+
+    fn namespace_kind(self) -> Option<RemoteCatalogObjectKindV1> {
+        match self {
+            Self::NamespaceIndex => Some(RemoteCatalogObjectKindV1::Index),
+            Self::NamespaceReservation => Some(RemoteCatalogObjectKindV1::Reservation),
+            Self::NamespaceManifest => Some(RemoteCatalogObjectKindV1::Manifest),
+            Self::PublishingHead | Self::CommittedHead => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "condition", rename_all = "kebab-case")]
+enum CatalogFencedStorageWriteConditionV1 {
+    CreateIfAbsent,
+    ReplaceIfMatch { etag: String },
+}
+
+#[derive(Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogFencedStorageWriteRequestWireV1 {
+    version: u32,
+    context: RemoteCatalogContextWireV1,
+    storage_authority_fingerprint: String,
+    control_authority_fingerprint: String,
+    writer_epoch: String,
+    ready_control_generation: u64,
+    ready_control_revision_fingerprint: String,
+    pending_control_generation: u64,
+    pending_control_revision_fingerprint: String,
+    pending_control_record_fingerprint: String,
+    writer_fence_authority_revision_fingerprint: String,
+    writer_fence_lease_public_fingerprint: String,
+    mutation_journal_object_id: String,
+    mutation_count: u64,
+    ordinal: u64,
+    stage: CatalogFencedStorageWriteStageV1,
+    object_key: String,
+    condition: CatalogFencedStorageWriteConditionV1,
+    successor_raw_bytes_len: u64,
+    successor_raw_blake3: String,
+}
+
+/// Exact storage mutation submitted to the backend that owns the opaque
+/// monotonic fence token.
+///
+/// The OpenDAL operator is retained only so the source-only test backend can
+/// exercise the real conditional-write behavior. A production implementation
+/// must ignore or independently authenticate that caller-held accessor and
+/// perform the fence check and object mutation atomically at the storage
+/// authorization point. Checking a control record and then using this operator
+/// would not satisfy the trait contract.
+struct CatalogFencedStorageWriteRequestV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    pending_control_record_fingerprint: [u8; 32],
+    writer_fence_authority_revision_fingerprint: [u8; 32],
+    writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
+    mutation_journal_object_id: [u8; 32],
+    mutation_count: u64,
+    ordinal: u64,
+    stage: CatalogFencedStorageWriteStageV1,
+    object_key: String,
+    condition: CatalogFencedStorageWriteConditionV1,
+    successor_raw_bytes: Buffer,
+    successor_raw_bytes_len: NonZeroU64,
+    successor_raw_blake3: [u8; 32],
+    request_fingerprint: [u8; 32],
+    operator: Operator,
+}
+
+/// Opaque backend receipt proving that one exact request was admitted by the
+/// still-current storage-side monotonic fence and applied with its exact
+/// per-object condition.
+struct CatalogFencedStorageWriteReceiptV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    pending_control_record_fingerprint: [u8; 32],
+    ordinal: u64,
+    request_fingerprint: [u8; 32],
+    binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+struct CatalogControlPendingRequestV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    publishing_head_reservation_fingerprint: [u8; 32],
+    writer_fence_authority_revision_fingerprint: [u8; 32],
+    writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
+    canonical_pending_control_record_bytes: Vec<u8>,
+    pending_control_record_fingerprint: [u8; 32],
+}
+
+type CatalogControlPendingFutureV1<'a> = Pin<
+    Box<dyn Future<Output = AnyhowResult<TrustedCatalogPublicationPendingReceiptV1>> + Send + 'a>,
+>;
+type CatalogFencedStorageWriteFutureV1<'a> =
+    Pin<Box<dyn Future<Output = AnyhowResult<CatalogFencedStorageWriteReceiptV1>> + Send + 'a>>;
+
 /// Non-cloneable retained backend lease for one exact control acquisition.
 ///
 /// The public fingerprint serialized into catalog/control records is only a
-/// correlation identifier. This value is the separate live backend handle.
-/// There is deliberately no production constructor in this checkpoint.
-trait CatalogControlLeaseLivenessV1: Send + Sync {
+/// correlation identifier. The opaque token remains inside this backend
+/// object and is never serialized or supplied by the caller. `is_live_v1` is
+/// diagnostic/fail-fast only: it never authorizes a storage mutation.
+///
+/// Implementations must atomically compare the current monotonic fence and
+/// apply every `write_fenced_v1` request at the storage authorization point.
+/// An in-process mutex, boolean, or control-record read followed by raw
+/// OpenDAL I/O does not satisfy this contract. There is deliberately no
+/// production constructor or implementation in this checkpoint.
+trait CatalogMonotonicFenceLeaseV1: Send + Sync {
     fn is_live_v1(&self) -> bool;
+
+    /// Atomically replace the acquired exact Ready control revision with the
+    /// exact PublicationPending record that arms this fence epoch.
+    fn compare_and_swap_pending_v1<'a>(
+        &'a self,
+        request: CatalogControlPendingRequestV1,
+    ) -> CatalogControlPendingFutureV1<'a>;
+
+    /// Atomically reject a stale fence or apply one exact ordered catalog
+    /// mutation. Exact request replay must return the same authenticated
+    /// receipt; another request at the same ordinal must fail without I/O.
+    fn write_fenced_v1<'a>(
+        &'a self,
+        request: CatalogFencedStorageWriteRequestV1,
+    ) -> CatalogFencedStorageWriteFutureV1<'a>;
 
     /// Atomically replace the exact pending control revision with the exact
     /// ready record. Implementations must resolve ambiguous backend outcomes
@@ -314,9 +462,13 @@ struct RetainedCatalogControlLeaseV1 {
     control_binding: CatalogControlAcquisitionBindingV1,
     writer_fence_authority_revision_fingerprint: [u8; 32],
     writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
-    liveness: Box<dyn CatalogControlLeaseLivenessV1>,
+    liveness: Box<dyn CatalogMonotonicFenceLeaseV1>,
     #[cfg(test)]
     test_live: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    #[cfg(test)]
+    test_revoke_before_next_write: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    #[cfg(test)]
+    test_fail_after_next_backend_apply: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl RetainedCatalogControlLeaseV1 {
@@ -2824,6 +2976,8 @@ pub(crate) struct TrustedCatalogPublicationPendingReceiptV1 {
     control_binding: CatalogControlAcquisitionBindingV1,
     pending_revision: CatalogControlAuthorityRevisionV1,
     publishing_head_reservation_fingerprint: [u8; 32],
+    writer_fence_authority_revision_fingerprint: [u8; 32],
+    writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
     pending_control_record_fingerprint: [u8; 32],
 }
 
@@ -2979,6 +3133,303 @@ impl std::error::Error for FailedCatalogNamespaceMutationsV1<'_> {
     }
 }
 
+fn catalog_fenced_storage_write_request_fingerprint_v1(
+    wire: &CatalogFencedStorageWriteRequestWireV1,
+) -> AnyhowResult<[u8; 32]> {
+    let canonical =
+        serde_json::to_vec(wire).context("serializing canonical catalog fenced-storage request")?;
+    let canonical_len = u64::try_from(canonical.len())
+        .context("catalog fenced-storage request length does not fit u64")?;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(FENCED_STORAGE_WRITE_REQUEST_DOMAIN_V1.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(&canonical_len.to_be_bytes());
+    hasher.update(&canonical);
+    Ok(*hasher.finalize().as_bytes())
+}
+
+fn catalog_fenced_storage_write_request_wire_v1(
+    request: &CatalogFencedStorageWriteRequestV1,
+) -> CatalogFencedStorageWriteRequestWireV1 {
+    CatalogFencedStorageWriteRequestWireV1 {
+        version: 1,
+        context: request.control_binding.context.to_wire(),
+        storage_authority_fingerprint: lower_hex(
+            &request.control_binding.storage_authority_fingerprint,
+        ),
+        control_authority_fingerprint: lower_hex(
+            &request.control_binding.control_authority_fingerprint,
+        ),
+        writer_epoch: lower_hex(&request.control_binding.bootstrap.writer_epoch),
+        ready_control_generation: request.control_binding.ready_revision.generation.get(),
+        ready_control_revision_fingerprint: lower_hex(
+            &request.control_binding.ready_revision.fingerprint,
+        ),
+        pending_control_generation: request.pending_revision.generation.get(),
+        pending_control_revision_fingerprint: lower_hex(&request.pending_revision.fingerprint),
+        pending_control_record_fingerprint: lower_hex(&request.pending_control_record_fingerprint),
+        writer_fence_authority_revision_fingerprint: lower_hex(
+            &request.writer_fence_authority_revision_fingerprint,
+        ),
+        writer_fence_lease_public_fingerprint: lower_hex(
+            &request.writer_fence_lease_public_fingerprint.0,
+        ),
+        mutation_journal_object_id: lower_hex(&request.mutation_journal_object_id),
+        mutation_count: request.mutation_count,
+        ordinal: request.ordinal,
+        stage: request.stage,
+        object_key: request.object_key.clone(),
+        condition: request.condition.clone(),
+        successor_raw_bytes_len: request.successor_raw_bytes_len.get(),
+        successor_raw_blake3: lower_hex(&request.successor_raw_blake3),
+    }
+}
+
+fn catalog_fenced_storage_write_request_v1(
+    pending: &BoundPendingCatalogControlV1<'_>,
+    stage: CatalogFencedStorageWriteStageV1,
+    ordinal: u64,
+    object_key: String,
+    condition: CatalogFencedStorageWriteConditionV1,
+    successor_raw_bytes: Buffer,
+) -> AnyhowResult<CatalogFencedStorageWriteRequestV1> {
+    let transition = &pending.transition;
+    let publication = &transition.publication;
+    let journal = &publication.mutation_journal;
+    let successor_raw_bytes_len = NonZeroU64::new(
+        u64::try_from(successor_raw_bytes.len())
+            .context("catalog fenced-storage payload length does not fit u64")?,
+    )
+    .context("catalog fenced-storage payload must not be empty")?;
+    let successor_raw_blake3 = *blake3::hash(&successor_raw_bytes).as_bytes();
+    let journal_wire = validate_authoritative_catalog_mutation_journal_bytes_v1(
+        &journal.raw_bytes,
+        &publication.context,
+        publication.sequence,
+        publication.publication_nonce,
+        publication.parent_head_revision,
+    )
+    .map_err(|error| anyhow::anyhow!("authoritative mutation journal is invalid: {error:?}"))?;
+    let mutation_count = u64::try_from(journal_wire.mutations.len())
+        .context("catalog mutation count does not fit u64")?;
+    anyhow::ensure!(
+        mutation_count == journal_wire.mutation_count
+            && journal_wire.mutations.len() == journal.successor_payloads.len(),
+        "catalog fenced-storage request lost the complete authoritative journal"
+    );
+    let committed_ordinal = mutation_count
+        .checked_add(1)
+        .context("catalog fenced-storage committed ordinal overflow")?;
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    match stage {
+        CatalogFencedStorageWriteStageV1::PublishingHead => {
+            anyhow::ensure!(
+                ordinal == 0
+                    && object_key == head_key
+                    && successor_raw_bytes.as_ref()
+                        == transition.canonical_publishing_head_bytes.as_slice()
+                    && condition
+                        == CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+                            etag: publication.expected_parent_head_etag.clone(),
+                        },
+                "publishing HEAD request is not the exact first fenced transition"
+            );
+        }
+        CatalogFencedStorageWriteStageV1::CommittedHead => {
+            anyhow::ensure!(
+                ordinal == committed_ordinal
+                    && object_key == head_key
+                    && matches!(
+                        &condition,
+                        CatalogFencedStorageWriteConditionV1::ReplaceIfMatch { etag }
+                            if !etag.is_empty() && etag != "null"
+                    ),
+                "committed HEAD request is not the exact terminal fenced transition"
+            );
+        }
+        namespace_stage => {
+            let kind = namespace_stage
+                .namespace_kind()
+                .context("catalog namespace stage has no object kind")?;
+            let mutation_index = ordinal
+                .checked_sub(1)
+                .and_then(|index| usize::try_from(index).ok())
+                .context("catalog namespace ordinal is not positive or does not fit usize")?;
+            let mutation = journal_wire
+                .mutations
+                .get(mutation_index)
+                .context("catalog namespace ordinal exceeds the authoritative journal")?;
+            let expected_condition = match (&mutation.operation, &mutation.predecessor) {
+                (
+                    RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+                    RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+                ) => CatalogFencedStorageWriteConditionV1::CreateIfAbsent,
+                (
+                    RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+                    RemoteCatalogMutationPredecessorDraftWireV1::Present { binding, .. },
+                ) => CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+                    etag: wire_binding_etag_v1(binding)
+                        .context("authoritative replacement predecessor has no usable ETag")?
+                        .to_owned(),
+                },
+                _ => anyhow::bail!(
+                    "authoritative catalog journal contains an invalid storage operation"
+                ),
+            };
+            anyhow::ensure!(
+                ordinal >= 1
+                    && ordinal <= mutation_count
+                    && mutation.kind == kind
+                    && mutation.object_key == object_key
+                    && validate_catalog_object_route_v1(
+                        &publication.context.remote_prefix,
+                        kind,
+                        &object_key,
+                    )
+                    && condition == expected_condition,
+                "catalog namespace fenced request differs from its canonical journal ordinal"
+            );
+            anyhow::ensure!(
+                mutation.successor_payload.raw_bytes_len == successor_raw_bytes_len.get()
+                    && mutation.successor_payload.raw_blake3 == lower_hex(&successor_raw_blake3),
+                "catalog namespace fenced payload differs from its canonical journal ordinal"
+            );
+        }
+    }
+
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    match stage {
+        CatalogFencedStorageWriteStageV1::PublishingHead
+        | CatalogFencedStorageWriteStageV1::CommittedHead => anyhow::ensure!(
+            successor_raw_bytes_len.get() <= remote.max_catalog_head_object_bytes(),
+            "catalog fenced HEAD payload exceeds the object bound"
+        ),
+        namespace_stage => anyhow::ensure!(
+            validate_entry_size_v1(
+                namespace_stage
+                    .namespace_kind()
+                    .context("catalog namespace stage has no object kind")?,
+                successor_raw_bytes_len.get(),
+            ),
+            "catalog fenced namespace payload exceeds its kind bound"
+        ),
+    }
+
+    let control_binding = publication.control_guard.high_water.binding.clone();
+    let writers = &publication.control_guard.all_writers;
+    anyhow::ensure!(
+        writers.control_binding == control_binding
+            && pending.pending_receipt.control_binding == control_binding
+            && pending.pending_receipt.pending_revision == transition.pending_revision
+            && pending.pending_receipt.pending_control_record_fingerprint
+                == transition.pending_control_record_fingerprint
+            && pending
+                .pending_receipt
+                .writer_fence_authority_revision_fingerprint
+                == writers.authority_revision_fingerprint
+            && pending
+                .pending_receipt
+                .writer_fence_lease_public_fingerprint
+                == writers.lease_public_fingerprint
+            && writers.authority_revision_fingerprint != [0; 32]
+            && writers.lease_public_fingerprint.0 != [0; 32],
+        "catalog fenced-storage request lost its exact pending control acquisition"
+    );
+    let wire = CatalogFencedStorageWriteRequestWireV1 {
+        version: 1,
+        context: publication.context.to_wire(),
+        storage_authority_fingerprint: lower_hex(&control_binding.storage_authority_fingerprint),
+        control_authority_fingerprint: lower_hex(&control_binding.control_authority_fingerprint),
+        writer_epoch: lower_hex(&control_binding.bootstrap.writer_epoch),
+        ready_control_generation: control_binding.ready_revision.generation.get(),
+        ready_control_revision_fingerprint: lower_hex(&control_binding.ready_revision.fingerprint),
+        pending_control_generation: transition.pending_revision.generation.get(),
+        pending_control_revision_fingerprint: lower_hex(&transition.pending_revision.fingerprint),
+        pending_control_record_fingerprint: lower_hex(
+            &transition.pending_control_record_fingerprint,
+        ),
+        writer_fence_authority_revision_fingerprint: lower_hex(
+            &writers.authority_revision_fingerprint,
+        ),
+        writer_fence_lease_public_fingerprint: lower_hex(&writers.lease_public_fingerprint.0),
+        mutation_journal_object_id: lower_hex(&journal.object_id),
+        mutation_count,
+        ordinal,
+        stage,
+        object_key: object_key.clone(),
+        condition: condition.clone(),
+        successor_raw_bytes_len: successor_raw_bytes_len.get(),
+        successor_raw_blake3: lower_hex(&successor_raw_blake3),
+    };
+    let request_fingerprint = catalog_fenced_storage_write_request_fingerprint_v1(&wire)?;
+    Ok(CatalogFencedStorageWriteRequestV1 {
+        control_binding,
+        pending_revision: transition.pending_revision,
+        pending_control_record_fingerprint: transition.pending_control_record_fingerprint,
+        writer_fence_authority_revision_fingerprint: writers.authority_revision_fingerprint,
+        writer_fence_lease_public_fingerprint: writers.lease_public_fingerprint,
+        mutation_journal_object_id: journal.object_id,
+        mutation_count,
+        ordinal,
+        stage,
+        object_key,
+        condition,
+        successor_raw_bytes,
+        successor_raw_bytes_len,
+        successor_raw_blake3,
+        request_fingerprint,
+        operator: publication.storage_authority.operator.clone(),
+    })
+}
+
+async fn execute_catalog_fenced_storage_write_v1(
+    pending: &BoundPendingCatalogControlV1<'_>,
+    request: CatalogFencedStorageWriteRequestV1,
+) -> AnyhowResult<RegisteredRootRemoteObjectBindingV1> {
+    anyhow::ensure!(
+        catalog_fenced_storage_write_request_fingerprint_v1(
+            &catalog_fenced_storage_write_request_wire_v1(&request),
+        )? == request.request_fingerprint
+            && u64::try_from(request.successor_raw_bytes.len()).ok()
+                == Some(request.successor_raw_bytes_len.get())
+            && *blake3::hash(&request.successor_raw_bytes).as_bytes()
+                == request.successor_raw_blake3,
+        "catalog fenced-storage request fingerprint or payload identity changed"
+    );
+    let expected_control_binding = request.control_binding.clone();
+    let expected_pending_revision = request.pending_revision;
+    let expected_pending_record_fingerprint = request.pending_control_record_fingerprint;
+    let expected_ordinal = request.ordinal;
+    let expected_request_fingerprint = request.request_fingerprint;
+    let expected_stage = request.stage;
+    let receipt = pending
+        .transition
+        .publication
+        .control_guard
+        .all_writers
+        .retained_control_lease
+        .liveness
+        .write_fenced_v1(request)
+        .await
+        .context("applying catalog mutation through the storage-enforced monotonic fence")?;
+    anyhow::ensure!(
+        receipt.control_binding == expected_control_binding
+            && receipt.pending_revision == expected_pending_revision
+            && receipt.pending_control_record_fingerprint == expected_pending_record_fingerprint
+            && receipt.ordinal == expected_ordinal
+            && receipt.request_fingerprint == expected_request_fingerprint
+            && super::validate_binding_wire_v1(&binding_wire_v1(&receipt.binding)).is_some()
+            && (!matches!(
+                expected_stage,
+                CatalogFencedStorageWriteStageV1::PublishingHead
+                    | CatalogFencedStorageWriteStageV1::CommittedHead
+                    | CatalogFencedStorageWriteStageV1::NamespaceIndex
+            ) || mutable_head_etag_v1(&receipt.binding).is_some()),
+        "storage-enforced catalog fence returned a crossed or unusable receipt"
+    );
+    Ok(receipt.binding)
+}
+
 fn wire_binding_etag_v1(binding: &RemoteCatalogObjectBindingWireV1) -> Option<&str> {
     binding.etag.as_deref().filter(|etag| !etag.is_empty())
 }
@@ -3028,9 +3479,9 @@ async fn require_namespace_mutation_capability_live_v1(
 /// accessor while retaining the live lease.
 ///
 /// This is the only constructor for the namespace mutation capability.
-/// Conditional-write failure is treated as an ambiguous outcome until the
-/// bounded reread proves either the exact publishing bytes or a different
-/// state. Callers cannot provide HEAD bytes, keys, or predecessor bindings.
+/// A raw bounded reread is additional receipt validation only: backend
+/// rejection never becomes success merely because matching bytes are visible.
+/// Callers cannot provide HEAD bytes, keys, or predecessor bindings.
 pub(crate) async fn install_catalog_publishing_head_v1<'a>(
     pending: BoundPendingCatalogControlV1<'a>,
 ) -> Result<CatalogNamespaceMutationCapabilityV1<'a>, CatalogPublishingHeadInstallFailureV1<'a>> {
@@ -3062,13 +3513,21 @@ pub(crate) async fn install_catalog_publishing_head_v1<'a>(
             "publishing HEAD proposal no longer matches its exact pending transition"
         );
         let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
-        let write_result = publication
-            .storage_authority
-            .operator
-            .write_with(&head_key, expected_bytes.clone())
-            .if_match(&publication.expected_parent_head_etag)
+        let request = catalog_fenced_storage_write_request_v1(
+            &pending,
+            CatalogFencedStorageWriteStageV1::PublishingHead,
+            0,
+            head_key.clone(),
+            CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+                etag: publication.expected_parent_head_etag.clone(),
+            },
+            Buffer::from(expected_bytes.clone()),
+        )?;
+        let fenced_binding = execute_catalog_fenced_storage_write_v1(&pending, request)
             .await
-            .with_context(|| format!("conditionally installing catalog publishing HEAD: {head_key}"));
+            .with_context(|| {
+                format!("installing catalog publishing HEAD through the monotonic fence: {head_key}")
+            })?;
         let max_bytes = RegisteredRootPlanContractV1::strict_v1()
             .remote_contract()
             .max_catalog_head_object_bytes();
@@ -3082,21 +3541,15 @@ pub(crate) async fn install_catalog_publishing_head_v1<'a>(
         let exact_binding = match observed {
             Some(RawObjectReadV1::Bound(snapshot)) => {
                 let (raw_bytes, _, binding) = snapshot.into_parts();
-                (raw_bytes == expected_bytes).then(|| registered_binding_from_raw_v1(binding))
+                let binding = registered_binding_from_raw_v1(binding);
+                (raw_bytes == expected_bytes && binding == fenced_binding).then_some(binding)
             }
             None | Some(RawObjectReadV1::Unbound) => None,
         };
         let Some(binding) = exact_binding else {
-            return match write_result {
-                Ok(_) => anyhow::bail!(
-                    "catalog publishing HEAD changed after its successful compare-and-swap: {head_key}"
-                ),
-                Err(write_error) => Err(write_error).with_context(|| {
-                    format!(
-                        "catalog publishing HEAD compare-and-swap did not install the exact proposal: {head_key}"
-                    )
-                }),
-            };
+            anyhow::bail!(
+                "catalog publishing HEAD differs from its authenticated fenced-write receipt: {head_key}"
+            );
         };
         anyhow::ensure!(
             super::validate_binding_wire_v1(&binding_wire_v1(&binding)).is_some()
@@ -3115,6 +3568,19 @@ pub(crate) async fn install_catalog_publishing_head_v1<'a>(
         }),
         Err(error) => Err(CatalogPublishingHeadInstallFailureV1 { pending, error }),
     }
+}
+
+/// Retry an ambiguous or rejected publishing-HEAD installation with the exact
+/// retained pending transition.
+///
+/// Recovery replays ordinal zero through the backend and still requires the
+/// authenticated receipt to match a fresh raw reread. It never promotes
+/// matching raw bytes directly into a namespace-mutation capability.
+pub(crate) async fn recover_failed_catalog_publishing_head_install_v1<'a>(
+    failure: CatalogPublishingHeadInstallFailureV1<'a>,
+) -> Result<CatalogNamespaceMutationCapabilityV1<'a>, CatalogPublishingHeadInstallFailureV1<'a>> {
+    let CatalogPublishingHeadInstallFailureV1 { pending, error: _ } = failure;
+    install_catalog_publishing_head_v1(pending).await
 }
 
 async fn read_exact_catalog_successor_v1(
@@ -3149,6 +3615,7 @@ async fn read_exact_catalog_successor_v1(
 
 async fn apply_one_catalog_namespace_mutation_v1(
     capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+    ordinal: u64,
     mutation: &RemoteCatalogFactBoundMutationWireV1,
     payload: &BoundCatalogSuccessorPayloadV1,
 ) -> AnyhowResult<AppliedCatalogNamespaceObjectV1> {
@@ -3193,61 +3660,49 @@ async fn apply_one_catalog_namespace_mutation_v1(
     );
 
     require_namespace_mutation_capability_live_v1(capability).await?;
-    let operator = capability
-        .pending
-        .transition
-        .publication
-        .storage_authority
-        .operator;
-    let write_result = match (&mutation.operation, &mutation.predecessor) {
+    let condition = match (&mutation.operation, &mutation.predecessor) {
         (
             RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
             RemoteCatalogMutationPredecessorDraftWireV1::Absent,
-        ) => {
-            operator
-                .write_with(&mutation.object_key, payload.raw_bytes.clone())
-                .if_not_exists(true)
-                .await
-        }
+        ) => CatalogFencedStorageWriteConditionV1::CreateIfAbsent,
         (
             RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
             RemoteCatalogMutationPredecessorDraftWireV1::Present { binding, .. },
-        ) => {
-            let etag = wire_binding_etag_v1(binding)
-                .context("authoritative replacement predecessor has no usable ETag")?;
-            operator
-                .write_with(&mutation.object_key, payload.raw_bytes.clone())
-                .if_match(etag)
-                .await
-        }
+        ) => CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+            etag: wire_binding_etag_v1(binding)
+                .context("authoritative replacement predecessor has no usable ETag")?
+                .to_owned(),
+        },
         _ => anyhow::bail!("authoritative catalog journal contains an invalid operation"),
     };
-
+    let request = catalog_fenced_storage_write_request_v1(
+        &capability.pending,
+        CatalogFencedStorageWriteStageV1::for_namespace_kind(mutation.kind),
+        ordinal,
+        mutation.object_key.clone(),
+        condition,
+        payload.raw_bytes.clone(),
+    )?;
+    let fenced_binding =
+        execute_catalog_fenced_storage_write_v1(&capability.pending, request).await?;
     let rebound = read_exact_catalog_successor_v1(
         capability,
         mutation.kind,
         &mutation.object_key,
         &payload_bytes,
     )
-    .await;
-    let binding = match (write_result, rebound) {
-        (_, Ok(binding)) => binding,
-        (Err(write_error), Err(read_error)) => {
-            return Err(read_error).with_context(|| {
-                format!(
-                    "catalog namespace conditional write also failed ({write_error}): {}",
-                    mutation.object_key
-                )
-            })
-        }
-        (Ok(_), Err(read_error)) => return Err(read_error),
-    };
+    .await?;
+    anyhow::ensure!(
+        rebound == fenced_binding,
+        "catalog namespace reread differs from its authenticated fenced-write receipt: {}",
+        mutation.object_key
+    );
     require_namespace_mutation_capability_live_v1(capability).await?;
     Ok(AppliedCatalogNamespaceObjectV1 {
         kind: mutation.kind,
         object_key: mutation.object_key.clone(),
         raw_blake3: payload.raw_blake3,
-        binding,
+        binding: rebound,
     })
 }
 
@@ -3312,10 +3767,15 @@ pub(crate) async fn apply_authoritative_catalog_namespace_mutations_v1<'a>(
     }
 
     for ordinal in 0..wire.mutations.len() {
+        let fenced_ordinal = u64::try_from(ordinal)
+            .ok()
+            .and_then(|ordinal| ordinal.checked_add(1))
+            .expect("bounded authoritative journal ordinal must fit u64");
         let result = {
             let journal = &capability.pending.transition.publication.mutation_journal;
             apply_one_catalog_namespace_mutation_v1(
                 &capability,
+                fenced_ordinal,
                 &wire.mutations[ordinal],
                 &journal.successor_payloads[ordinal],
             )
@@ -3615,6 +4075,72 @@ async fn publish_catalog_successor_immutable_v1(
     Ok(binding)
 }
 
+/// Execute or exactly replay the terminal committed-HEAD mutation through the
+/// retained storage fence, then prove the currently visible bytes and binding
+/// equal that authenticated receipt.
+///
+/// This deliberately does not require the visible HEAD still to be
+/// `Publishing`: recovery after an apply-before-response failure observes the
+/// committed bytes first, then must replay this exact terminal request to
+/// recover the backend receipt. A raw committed closure cannot satisfy this
+/// helper by itself.
+async fn execute_and_revalidate_catalog_committed_head_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+    committed_head_bytes: &[u8],
+) -> AnyhowResult<RegisteredRootRemoteObjectBindingV1> {
+    let publication = &capability.pending.transition.publication;
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let publishing_etag = mutable_head_etag_v1(&capability.publishing_head_binding)
+        .context("visible publishing HEAD has no usable ETag")?;
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let committed_ordinal = u64::try_from(publication.mutation_journal.successor_payloads.len())
+        .context("catalog mutation count does not fit u64")?
+        .checked_add(1)
+        .context("catalog committed ordinal overflow")?;
+    let request = catalog_fenced_storage_write_request_v1(
+        &capability.pending,
+        CatalogFencedStorageWriteStageV1::CommittedHead,
+        committed_ordinal,
+        head_key.clone(),
+        CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+            etag: publishing_etag,
+        },
+        Buffer::from(committed_head_bytes.to_vec()),
+    )?;
+    let fenced_binding = execute_catalog_fenced_storage_write_v1(&capability.pending, request)
+        .await
+        .with_context(|| {
+            format!("finalizing catalog committed HEAD through the monotonic fence: {head_key}")
+        })?;
+    let observed = read_raw_object_snapshot_v1(
+        publication.storage_authority.operator,
+        &head_key,
+        remote.max_catalog_head_object_bytes(),
+    )
+    .await
+    .with_context(|| format!("revalidating committed catalog HEAD: {head_key}"))?;
+    let exact_binding = match observed {
+        Some(RawObjectReadV1::Bound(snapshot)) => {
+            let (raw_bytes, _, binding) = snapshot.into_parts();
+            let binding = registered_binding_from_raw_v1(binding);
+            (raw_bytes == committed_head_bytes && binding == fenced_binding).then_some(binding)
+        }
+        None | Some(RawObjectReadV1::Unbound) => None,
+    };
+    let Some(committed_head_binding) = exact_binding else {
+        anyhow::bail!(
+            "committed catalog HEAD differs from its authenticated fenced-write receipt: {head_key}"
+        );
+    };
+    anyhow::ensure!(
+        mutable_head_etag_v1(&committed_head_binding).is_some(),
+        "committed catalog HEAD has no usable exact ETag"
+    );
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    Ok(committed_head_binding)
+}
+
 async fn publish_catalog_successor_closure_v1(
     applied: &AppliedCatalogNamespaceMutationsV1<'_>,
 ) -> AnyhowResult<PublishedCatalogSuccessorClosureV1> {
@@ -3756,47 +4282,8 @@ async fn publish_catalog_successor_closure_v1(
             .is_some_and(|len| len <= remote.max_catalog_head_object_bytes()),
         "committed catalog HEAD exceeds the object bound"
     );
-    let publishing_etag = mutable_head_etag_v1(&capability.publishing_head_binding)
-        .context("visible publishing HEAD has no usable ETag")?;
-    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
-    let write_result = publication
-        .storage_authority
-        .operator
-        .write_with(&head_key, committed_head_bytes.clone())
-        .if_match(&publishing_etag)
-        .await;
-    let observed = read_raw_object_snapshot_v1(
-        publication.storage_authority.operator,
-        &head_key,
-        remote.max_catalog_head_object_bytes(),
-    )
-    .await
-    .with_context(|| format!("revalidating committed catalog HEAD: {head_key}"))?;
-    let exact_binding = match observed {
-        Some(RawObjectReadV1::Bound(snapshot)) => {
-            let (raw_bytes, _, binding) = snapshot.into_parts();
-            (raw_bytes == committed_head_bytes).then(|| registered_binding_from_raw_v1(binding))
-        }
-        None | Some(RawObjectReadV1::Unbound) => None,
-    };
-    let Some(committed_head_binding) = exact_binding else {
-        return match write_result {
-            Ok(_) => anyhow::bail!(
-                "committed catalog HEAD changed after successful finalization: {head_key}"
-            ),
-            Err(write_error) => Err(write_error).with_context(|| {
-                format!(
-                    "committed catalog HEAD compare-and-swap did not install exact bytes: {head_key}"
-                )
-            }),
-        };
-    };
-    anyhow::ensure!(
-        mutable_head_etag_v1(&committed_head_binding).is_some(),
-        "committed catalog HEAD has no usable exact ETag"
-    );
-    require_held_control_lease_live_v1(&publication.control_guard)
-        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    let committed_head_binding =
+        execute_and_revalidate_catalog_committed_head_v1(capability, &committed_head_bytes).await?;
     let head_revision = super::catalog_head_revision_v1(&committed_head_bytes);
     Ok(PublishedCatalogSuccessorClosureV1 {
         committed_head_bytes,
@@ -3810,8 +4297,10 @@ async fn publish_catalog_successor_closure_v1(
 ///
 /// Every unchanged entry comes from the retained semantic predecessor; every
 /// changed entry comes from terminal applied evidence. Immutable page/root
-/// collisions and ambiguous HEAD writes are accepted only after exact bounded
-/// rereads. Failure retains the complete capability and applied prefix.
+/// collisions are accepted only after exact bounded rereads. Mutable HEAD
+/// success additionally requires the matching storage-fence receipt; a raw
+/// reread cannot redeem backend rejection. Failure retains the complete
+/// capability and applied prefix.
 pub(crate) async fn finalize_catalog_committed_head_v1<'a>(
     applied: AppliedCatalogNamespaceMutationsV1<'a>,
 ) -> Result<BoundCommittedCatalogSuccessorV1, FailedCatalogCommittedFinalizationV1<'a>> {
@@ -4123,8 +4612,11 @@ async fn classify_catalog_committed_recovery_state_v1(
 ///
 /// An exact still-publishing HEAD resumes idempotent page/root publication and
 /// CAS. An exact committed successor is reconstructed through every immutable
-/// root/page reference and every named-object binding before being accepted.
-/// Any third state retains the complete applied evidence and fails closed.
+/// root/page reference and every named-object binding, then replays the exact
+/// terminal fenced-write request to obtain its authenticated backend receipt.
+/// The raw committed closure is never sufficient by itself. Any third state or
+/// missing fenced receipt retains the complete applied evidence and fails
+/// closed.
 pub(crate) async fn recover_failed_catalog_committed_finalization_v1<'a>(
     failure: FailedCatalogCommittedFinalizationV1<'a>,
 ) -> Result<BoundCommittedCatalogSuccessorV1, FailedCatalogCommittedFinalizationV1<'a>> {
@@ -4134,6 +4626,23 @@ pub(crate) async fn recover_failed_catalog_committed_finalization_v1<'a>(
             finalize_catalog_committed_head_v1(applied).await
         }
         Ok(CatalogCommittedRecoveryStateV1::Committed(published)) => {
+            let replayed_binding = match execute_and_revalidate_catalog_committed_head_v1(
+                &applied.capability,
+                &published.committed_head_bytes,
+            )
+            .await
+            {
+                Ok(binding) => binding,
+                Err(error) => return Err(FailedCatalogCommittedFinalizationV1 { applied, error }),
+            };
+            if replayed_binding != published.committed_head_binding {
+                return Err(FailedCatalogCommittedFinalizationV1 {
+                    applied,
+                    error: anyhow::anyhow!(
+                        "replayed terminal fenced receipt crossed the classified committed binding"
+                    ),
+                });
+            }
             Ok(bind_committed_catalog_successor_v1(applied, published))
         }
         Err(error) => Err(FailedCatalogCommittedFinalizationV1 { applied, error }),
@@ -4162,6 +4671,8 @@ pub(crate) struct BoundCommittedCatalogSuccessorV1 {
 /// There is intentionally no production constructor in this checkpoint.
 pub(crate) struct TrustedCatalogHighWaterAdvanceReceiptV1 {
     control_binding: CatalogControlAcquisitionBindingV1,
+    writer_fence_authority_revision_fingerprint: [u8; 32],
+    writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
     pending_revision: CatalogControlAuthorityRevisionV1,
     publishing_head_reservation_fingerprint: [u8; 32],
     pending_control_record_fingerprint: [u8; 32],
@@ -4172,6 +4683,8 @@ pub(crate) struct TrustedCatalogHighWaterAdvanceReceiptV1 {
 
 struct CatalogControlReadyAdvanceRequestV1 {
     control_binding: CatalogControlAcquisitionBindingV1,
+    writer_fence_authority_revision_fingerprint: [u8; 32],
+    writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
     pending_revision: CatalogControlAuthorityRevisionV1,
     publishing_head_reservation_fingerprint: [u8; 32],
     pending_control_record_fingerprint: [u8; 32],
@@ -4677,10 +5190,10 @@ pub(crate) fn prepare_catalog_control_transition_v1<'a>(
 /// Bind an externally authenticated `Ready -> PublicationPending` CAS receipt
 /// to the exact proposed successor. Field equality is necessary but not a
 /// production liveness proof; only the future backend may construct `receipt`.
-pub(crate) fn match_catalog_publication_pending_receipt_v1<'a>(
-    transition: PreparedCatalogControlTransitionV1<'a>,
-    receipt: TrustedCatalogPublicationPendingReceiptV1,
-) -> Result<BoundPendingCatalogControlV1<'a>, CatalogPublicationContractErrorV1> {
+fn validate_catalog_publication_pending_receipt_v1(
+    transition: &PreparedCatalogControlTransitionV1<'_>,
+    receipt: &TrustedCatalogPublicationPendingReceiptV1,
+) -> Result<(), CatalogPublicationContractErrorV1> {
     require_held_control_lease_live_v1(&transition.publication.control_guard)?;
     let binding = &transition.publication.control_guard.high_water.binding;
     let expected_publishing_bytes =
@@ -4696,10 +5209,14 @@ pub(crate) fn match_catalog_publication_pending_receipt_v1<'a>(
     );
     let control_fingerprint =
         super::domain_object_id_v1(CATALOG_CONTROL_RECORD_DOMAIN_V1, &expected_control_bytes);
+    let writers = &transition.publication.control_guard.all_writers;
     if receipt.control_binding != *binding
         || receipt.pending_revision != transition.pending_revision
         || receipt.publishing_head_reservation_fingerprint
             != transition.publishing_head_reservation_fingerprint
+        || receipt.writer_fence_authority_revision_fingerprint
+            != writers.authority_revision_fingerprint
+        || receipt.writer_fence_lease_public_fingerprint != writers.lease_public_fingerprint
         || receipt.pending_control_record_fingerprint
             != transition.pending_control_record_fingerprint
         || transition.canonical_publishing_head_bytes != expected_publishing_bytes
@@ -4709,10 +5226,125 @@ pub(crate) fn match_catalog_publication_pending_receipt_v1<'a>(
     {
         return Err(CatalogPublicationContractErrorV1::ControlTransitionMismatch);
     }
+    Ok(())
+}
+
+pub(crate) fn match_catalog_publication_pending_receipt_v1<'a>(
+    transition: PreparedCatalogControlTransitionV1<'a>,
+    receipt: TrustedCatalogPublicationPendingReceiptV1,
+) -> Result<BoundPendingCatalogControlV1<'a>, CatalogPublicationContractErrorV1> {
+    validate_catalog_publication_pending_receipt_v1(&transition, &receipt)?;
     Ok(BoundPendingCatalogControlV1 {
         transition,
         pending_receipt: receipt,
     })
+}
+
+/// Failed authenticated Ready-to-Pending installation retaining the exact
+/// proposal and opaque backend acquisition for exact retry.
+pub(crate) struct FailedCatalogPublicationPendingInstallV1<'a> {
+    transition: PreparedCatalogControlTransitionV1<'a>,
+    error: anyhow::Error,
+}
+
+impl std::fmt::Debug for FailedCatalogPublicationPendingInstallV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FailedCatalogPublicationPendingInstallV1")
+            .field("pending_revision", &self.transition.pending_revision)
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for FailedCatalogPublicationPendingInstallV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if formatter.alternate() {
+            write!(formatter, "{:#}", self.error)
+        } else {
+            std::fmt::Display::fmt(&self.error, formatter)
+        }
+    }
+}
+
+impl std::error::Error for FailedCatalogPublicationPendingInstallV1<'_> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error.as_ref())
+    }
+}
+
+/// Ask the retained authenticated backend to atomically install the exact
+/// PublicationPending control record that arms this fence epoch.
+///
+/// The opaque backend token never crosses this API. A successful receipt is
+/// regenerated and matched before the proposal can reach catalog HEAD. An
+/// ambiguous backend outcome remains retryable through the retained failure.
+pub(crate) async fn install_catalog_publication_pending_v1<'a>(
+    transition: PreparedCatalogControlTransitionV1<'a>,
+) -> Result<BoundPendingCatalogControlV1<'a>, FailedCatalogPublicationPendingInstallV1<'a>> {
+    let result = async {
+        require_held_control_lease_live_v1(&transition.publication.control_guard)
+            .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+        let writers = &transition.publication.control_guard.all_writers;
+        let request = CatalogControlPendingRequestV1 {
+            control_binding: transition
+                .publication
+                .control_guard
+                .high_water
+                .binding
+                .clone(),
+            pending_revision: transition.pending_revision,
+            publishing_head_reservation_fingerprint: transition
+                .publishing_head_reservation_fingerprint,
+            writer_fence_authority_revision_fingerprint: writers.authority_revision_fingerprint,
+            writer_fence_lease_public_fingerprint: writers.lease_public_fingerprint,
+            canonical_pending_control_record_bytes: transition
+                .canonical_pending_control_record_bytes
+                .clone(),
+            pending_control_record_fingerprint: transition.pending_control_record_fingerprint,
+        };
+        let receipt = transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .liveness
+            .compare_and_swap_pending_v1(request)
+            .await
+            .context("installing authenticated catalog PublicationPending control state")?;
+        require_held_control_lease_live_v1(&transition.publication.control_guard)
+            .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+        Ok::<_, anyhow::Error>(receipt)
+    }
+    .await;
+    match result {
+        Ok(receipt) => {
+            if let Err(error) =
+                validate_catalog_publication_pending_receipt_v1(&transition, &receipt)
+            {
+                return Err(FailedCatalogPublicationPendingInstallV1 {
+                    transition,
+                    error: anyhow::anyhow!("external pending receipt mismatch: {error:?}"),
+                });
+            }
+            Ok(BoundPendingCatalogControlV1 {
+                transition,
+                pending_receipt: receipt,
+            })
+        }
+        Err(error) => Err(FailedCatalogPublicationPendingInstallV1 { transition, error }),
+    }
+}
+
+/// Retry an ambiguous Pending installation with the exact retained proposal.
+pub(crate) async fn recover_failed_catalog_publication_pending_v1<'a>(
+    failure: FailedCatalogPublicationPendingInstallV1<'a>,
+) -> Result<BoundPendingCatalogControlV1<'a>, FailedCatalogPublicationPendingInstallV1<'a>> {
+    let FailedCatalogPublicationPendingInstallV1 {
+        transition,
+        error: _,
+    } = failure;
+    install_catalog_publication_pending_v1(transition).await
 }
 
 fn validate_catalog_high_water_advance_receipt_v1(
@@ -4776,6 +5408,13 @@ fn validate_catalog_high_water_advance_receipt_v1(
         || committed_revision != committed.head_revision
         || mutable_head_etag_v1(&committed.committed_head_binding).is_none()
         || receipt.control_binding != *control_binding
+        || receipt.writer_fence_authority_revision_fingerprint
+            != committed
+                .control_guard
+                .all_writers
+                .authority_revision_fingerprint
+        || receipt.writer_fence_lease_public_fingerprint
+            != committed.control_guard.all_writers.lease_public_fingerprint
         || receipt.pending_revision != committed.pending_revision
         || receipt.publishing_head_reservation_fingerprint
             != committed.publishing_head_reservation_fingerprint
@@ -4869,6 +5508,14 @@ pub(crate) async fn advance_catalog_high_water_v1(
         );
         let preview = TrustedCatalogHighWaterAdvanceReceiptV1 {
             control_binding: committed.control_guard.high_water.binding.clone(),
+            writer_fence_authority_revision_fingerprint: committed
+                .control_guard
+                .all_writers
+                .authority_revision_fingerprint,
+            writer_fence_lease_public_fingerprint: committed
+                .control_guard
+                .all_writers
+                .lease_public_fingerprint,
             pending_revision: committed.pending_revision,
             publishing_head_reservation_fingerprint: committed
                 .publishing_head_reservation_fingerprint,
@@ -4881,6 +5528,14 @@ pub(crate) async fn advance_catalog_high_water_v1(
             .map_err(|error| anyhow::anyhow!("invalid high-water proposal: {error:?}"))?;
         let request = CatalogControlReadyAdvanceRequestV1 {
             control_binding: committed.control_guard.high_water.binding.clone(),
+            writer_fence_authority_revision_fingerprint: committed
+                .control_guard
+                .all_writers
+                .authority_revision_fingerprint,
+            writer_fence_lease_public_fingerprint: committed
+                .control_guard
+                .all_writers
+                .lease_public_fingerprint,
             pending_revision: committed.pending_revision,
             publishing_head_reservation_fingerprint: committed
                 .publishing_head_reservation_fingerprint,
@@ -5128,13 +5783,354 @@ mod tests {
     use crate::registered_source_composition::validated_selected_registered_root_remote_context_for_test_v1;
     use tcfs_core::config::RootSpecV1Config;
 
-    struct TestCatalogControlLeaseLivenessV1 {
-        live: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    struct TestCatalogFencePendingV1 {
+        control_binding: CatalogControlAcquisitionBindingV1,
+        pending_revision: CatalogControlAuthorityRevisionV1,
+        pending_control_record_fingerprint: [u8; 32],
+        publishing_head_reservation_fingerprint: [u8; 32],
+        writer_fence_authority_revision_fingerprint: [u8; 32],
+        writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
+        mutation_count: Option<u64>,
+        next_ordinal: u64,
+        receipts: BTreeMap<u64, ([u8; 32], RegisteredRootRemoteObjectBindingV1)>,
     }
 
-    impl CatalogControlLeaseLivenessV1 for TestCatalogControlLeaseLivenessV1 {
+    struct TestCatalogReadyRequestV1 {
+        control_binding: CatalogControlAcquisitionBindingV1,
+        writer_fence_authority_revision_fingerprint: [u8; 32],
+        writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
+        pending_revision: CatalogControlAuthorityRevisionV1,
+        publishing_head_reservation_fingerprint: [u8; 32],
+        pending_control_record_fingerprint: [u8; 32],
+        canonical_pending_control_record_bytes: Vec<u8>,
+        successor: CatalogHighWaterPointV1,
+        ready_revision: CatalogControlAuthorityRevisionV1,
+        canonical_ready_control_record_bytes: Vec<u8>,
+        ready_control_record_fingerprint: [u8; 32],
+    }
+
+    impl TestCatalogReadyRequestV1 {
+        fn from_request(request: &CatalogControlReadyAdvanceRequestV1) -> Self {
+            Self {
+                control_binding: request.control_binding.clone(),
+                writer_fence_authority_revision_fingerprint: request
+                    .writer_fence_authority_revision_fingerprint,
+                writer_fence_lease_public_fingerprint: request
+                    .writer_fence_lease_public_fingerprint,
+                pending_revision: request.pending_revision,
+                publishing_head_reservation_fingerprint: request
+                    .publishing_head_reservation_fingerprint,
+                pending_control_record_fingerprint: request.pending_control_record_fingerprint,
+                canonical_pending_control_record_bytes: request
+                    .canonical_pending_control_record_bytes
+                    .clone(),
+                successor: request.successor,
+                ready_revision: request.ready_revision,
+                canonical_ready_control_record_bytes: request
+                    .canonical_ready_control_record_bytes
+                    .clone(),
+                ready_control_record_fingerprint: request.ready_control_record_fingerprint,
+            }
+        }
+
+        fn matches_request(&self, request: &CatalogControlReadyAdvanceRequestV1) -> bool {
+            self.control_binding == request.control_binding
+                && self.writer_fence_authority_revision_fingerprint
+                    == request.writer_fence_authority_revision_fingerprint
+                && self.writer_fence_lease_public_fingerprint
+                    == request.writer_fence_lease_public_fingerprint
+                && self.pending_revision == request.pending_revision
+                && self.publishing_head_reservation_fingerprint
+                    == request.publishing_head_reservation_fingerprint
+                && self.pending_control_record_fingerprint
+                    == request.pending_control_record_fingerprint
+                && self.canonical_pending_control_record_bytes
+                    == request.canonical_pending_control_record_bytes
+                && self.successor == request.successor
+                && self.ready_revision == request.ready_revision
+                && self.canonical_ready_control_record_bytes
+                    == request.canonical_ready_control_record_bytes
+                && self.ready_control_record_fingerprint == request.ready_control_record_fingerprint
+        }
+    }
+
+    fn test_ready_receipt_v1(
+        request: CatalogControlReadyAdvanceRequestV1,
+    ) -> TrustedCatalogHighWaterAdvanceReceiptV1 {
+        TrustedCatalogHighWaterAdvanceReceiptV1 {
+            control_binding: request.control_binding,
+            writer_fence_authority_revision_fingerprint: request
+                .writer_fence_authority_revision_fingerprint,
+            writer_fence_lease_public_fingerprint: request.writer_fence_lease_public_fingerprint,
+            pending_revision: request.pending_revision,
+            publishing_head_reservation_fingerprint: request
+                .publishing_head_reservation_fingerprint,
+            pending_control_record_fingerprint: request.pending_control_record_fingerprint,
+            successor: request.successor,
+            ready_revision: request.ready_revision,
+            ready_control_record_fingerprint: request.ready_control_record_fingerprint,
+        }
+    }
+
+    #[derive(Default)]
+    struct TestCatalogFenceStateV1 {
+        pending: Option<TestCatalogFencePendingV1>,
+        ready: Option<TestCatalogReadyRequestV1>,
+    }
+
+    struct TestCatalogMonotonicFenceLeaseV1 {
+        live: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        revoke_before_next_write: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        fail_after_next_backend_apply: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        state: std::sync::Arc<tokio::sync::Mutex<TestCatalogFenceStateV1>>,
+    }
+
+    impl CatalogMonotonicFenceLeaseV1 for TestCatalogMonotonicFenceLeaseV1 {
         fn is_live_v1(&self) -> bool {
             self.live.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn compare_and_swap_pending_v1<'a>(
+            &'a self,
+            request: CatalogControlPendingRequestV1,
+        ) -> CatalogControlPendingFutureV1<'a> {
+            Box::pin(async move {
+                anyhow::ensure!(self.is_live_v1(), "test catalog control lease is not live");
+                anyhow::ensure!(
+                    request.pending_revision.generation.get()
+                        == request
+                            .control_binding
+                            .ready_revision
+                            .generation
+                            .get()
+                            .checked_add(1)
+                            .context("test pending control generation overflow")?
+                        && request.pending_revision.fingerprint != [0; 32]
+                        && request.pending_revision.fingerprint
+                            != request.control_binding.ready_revision.fingerprint
+                        && request.publishing_head_reservation_fingerprint != [0; 32]
+                        && request.writer_fence_authority_revision_fingerprint != [0; 32]
+                        && request.writer_fence_lease_public_fingerprint.0 != [0; 32]
+                        && super::super::domain_object_id_v1(
+                            CATALOG_CONTROL_RECORD_DOMAIN_V1,
+                            &request.canonical_pending_control_record_bytes,
+                        ) == request.pending_control_record_fingerprint,
+                    "test pending control request is invalid"
+                );
+                let mut state = self.state.lock().await;
+                anyhow::ensure!(
+                    state.ready.is_none(),
+                    "test catalog control state already advanced to Ready"
+                );
+                let newly_applied = state.pending.is_none();
+                if let Some(pending) = &state.pending {
+                    anyhow::ensure!(
+                        pending.control_binding == request.control_binding
+                            && pending.pending_revision == request.pending_revision
+                            && pending.pending_control_record_fingerprint
+                                == request.pending_control_record_fingerprint
+                            && pending.publishing_head_reservation_fingerprint
+                                == request.publishing_head_reservation_fingerprint
+                            && pending.writer_fence_authority_revision_fingerprint
+                                == request.writer_fence_authority_revision_fingerprint
+                            && pending.writer_fence_lease_public_fingerprint
+                                == request.writer_fence_lease_public_fingerprint,
+                        "test pending control ordinal was reused by another proposal"
+                    );
+                } else {
+                    state.pending = Some(TestCatalogFencePendingV1 {
+                        control_binding: request.control_binding.clone(),
+                        pending_revision: request.pending_revision,
+                        pending_control_record_fingerprint: request
+                            .pending_control_record_fingerprint,
+                        publishing_head_reservation_fingerprint: request
+                            .publishing_head_reservation_fingerprint,
+                        writer_fence_authority_revision_fingerprint: request
+                            .writer_fence_authority_revision_fingerprint,
+                        writer_fence_lease_public_fingerprint: request
+                            .writer_fence_lease_public_fingerprint,
+                        mutation_count: None,
+                        next_ordinal: 0,
+                        receipts: BTreeMap::new(),
+                    });
+                }
+                if newly_applied
+                    && self
+                        .fail_after_next_backend_apply
+                        .swap(false, std::sync::atomic::Ordering::SeqCst)
+                {
+                    anyhow::bail!(
+                        "simulated test backend failure after applying pending control state"
+                    );
+                }
+                Ok(TrustedCatalogPublicationPendingReceiptV1 {
+                    control_binding: request.control_binding,
+                    pending_revision: request.pending_revision,
+                    publishing_head_reservation_fingerprint: request
+                        .publishing_head_reservation_fingerprint,
+                    writer_fence_authority_revision_fingerprint: request
+                        .writer_fence_authority_revision_fingerprint,
+                    writer_fence_lease_public_fingerprint: request
+                        .writer_fence_lease_public_fingerprint,
+                    pending_control_record_fingerprint: request.pending_control_record_fingerprint,
+                })
+            })
+        }
+
+        fn write_fenced_v1<'a>(
+            &'a self,
+            request: CatalogFencedStorageWriteRequestV1,
+        ) -> CatalogFencedStorageWriteFutureV1<'a> {
+            Box::pin(async move {
+                let mut state = self.state.lock().await;
+                if self
+                    .revoke_before_next_write
+                    .swap(false, std::sync::atomic::Ordering::SeqCst)
+                {
+                    self.live.store(false, std::sync::atomic::Ordering::SeqCst);
+                }
+                anyhow::ensure!(self.is_live_v1(), "test catalog control lease is not live");
+                anyhow::ensure!(
+                    state.ready.is_none()
+                        && catalog_fenced_storage_write_request_fingerprint_v1(
+                            &catalog_fenced_storage_write_request_wire_v1(&request),
+                        )? == request.request_fingerprint
+                        && u64::try_from(request.successor_raw_bytes.len()).ok()
+                            == Some(request.successor_raw_bytes_len.get())
+                        && *blake3::hash(&request.successor_raw_bytes).as_bytes()
+                            == request.successor_raw_blake3,
+                    "test fenced-storage request is invalid"
+                );
+                let pending = state
+                    .pending
+                    .as_mut()
+                    .context("test fenced storage write has no installed pending control state")?;
+                anyhow::ensure!(
+                    pending.control_binding == request.control_binding
+                        && pending.pending_revision == request.pending_revision
+                        && pending.pending_control_record_fingerprint
+                            == request.pending_control_record_fingerprint
+                        && pending.writer_fence_authority_revision_fingerprint
+                            == request.writer_fence_authority_revision_fingerprint
+                        && pending.writer_fence_lease_public_fingerprint
+                            == request.writer_fence_lease_public_fingerprint,
+                    "test fenced-storage request crossed its pending control state"
+                );
+                if let Some((known_fingerprint, known_binding)) =
+                    pending.receipts.get(&request.ordinal)
+                {
+                    anyhow::ensure!(
+                        *known_fingerprint == request.request_fingerprint,
+                        "test fenced-storage ordinal was reused by another request"
+                    );
+                    return Ok(CatalogFencedStorageWriteReceiptV1 {
+                        control_binding: request.control_binding,
+                        pending_revision: request.pending_revision,
+                        pending_control_record_fingerprint: request
+                            .pending_control_record_fingerprint,
+                        ordinal: request.ordinal,
+                        request_fingerprint: request.request_fingerprint,
+                        binding: known_binding.clone(),
+                    });
+                }
+                if let Some(mutation_count) = pending.mutation_count {
+                    anyhow::ensure!(
+                        mutation_count == request.mutation_count,
+                        "test fenced-storage request changed its mutation count"
+                    );
+                } else {
+                    anyhow::ensure!(
+                        request.ordinal == 0
+                            && request.stage == CatalogFencedStorageWriteStageV1::PublishingHead,
+                        "test fenced-storage sequence must start with publishing HEAD"
+                    );
+                    pending.mutation_count = Some(request.mutation_count);
+                }
+                let committed_ordinal = request
+                    .mutation_count
+                    .checked_add(1)
+                    .context("test fenced-storage committed ordinal overflow")?;
+                anyhow::ensure!(
+                    request.ordinal == pending.next_ordinal
+                        && match request.stage {
+                            CatalogFencedStorageWriteStageV1::PublishingHead => {
+                                request.ordinal == 0
+                            }
+                            CatalogFencedStorageWriteStageV1::CommittedHead => {
+                                request.ordinal == committed_ordinal
+                            }
+                            namespace_stage => {
+                                namespace_stage.namespace_kind().is_some()
+                                    && request.ordinal >= 1
+                                    && request.ordinal <= request.mutation_count
+                            }
+                        },
+                    "test fenced-storage request skipped or reordered an ordinal"
+                );
+                let write_result = match &request.condition {
+                    CatalogFencedStorageWriteConditionV1::CreateIfAbsent => {
+                        request
+                            .operator
+                            .write_with(&request.object_key, request.successor_raw_bytes.clone())
+                            .if_not_exists(true)
+                            .await
+                    }
+                    CatalogFencedStorageWriteConditionV1::ReplaceIfMatch { etag } => {
+                        request
+                            .operator
+                            .write_with(&request.object_key, request.successor_raw_bytes.clone())
+                            .if_match(etag)
+                            .await
+                    }
+                };
+                write_result.with_context(|| {
+                    format!(
+                        "test storage fence rejected catalog ordinal {}",
+                        request.ordinal
+                    )
+                })?;
+                let observed = read_raw_object_snapshot_v1(
+                    &request.operator,
+                    &request.object_key,
+                    request.successor_raw_bytes_len.get(),
+                )
+                .await
+                .context("test storage fence rereading exact successor")?;
+                let Some(RawObjectReadV1::Bound(observed)) = observed else {
+                    anyhow::bail!("test storage fence successor is missing or unbound");
+                };
+                let (raw_bytes, raw_blake3, binding) = observed.into_parts();
+                anyhow::ensure!(
+                    raw_bytes.as_slice() == request.successor_raw_bytes.as_ref()
+                        && *raw_blake3.as_bytes() == request.successor_raw_blake3,
+                    "test storage fence successor differs from its request"
+                );
+                let binding = registered_binding_from_raw_v1(binding);
+                pending.receipts.insert(
+                    request.ordinal,
+                    (request.request_fingerprint, binding.clone()),
+                );
+                pending.next_ordinal = pending
+                    .next_ordinal
+                    .checked_add(1)
+                    .context("test fenced-storage ordinal overflow")?;
+                if self
+                    .fail_after_next_backend_apply
+                    .swap(false, std::sync::atomic::Ordering::SeqCst)
+                {
+                    anyhow::bail!(
+                        "simulated test backend failure after applying fenced storage mutation"
+                    );
+                }
+                Ok(CatalogFencedStorageWriteReceiptV1 {
+                    control_binding: request.control_binding,
+                    pending_revision: request.pending_revision,
+                    pending_control_record_fingerprint: request.pending_control_record_fingerprint,
+                    ordinal: request.ordinal,
+                    request_fingerprint: request.request_fingerprint,
+                    binding,
+                })
+            })
         }
 
         fn compare_and_swap_ready_v1<'a>(
@@ -5154,16 +6150,48 @@ mod tests {
                         ) == request.ready_control_record_fingerprint,
                     "test control CAS request contains an invalid canonical record"
                 );
-                Ok(TrustedCatalogHighWaterAdvanceReceiptV1 {
-                    control_binding: request.control_binding,
-                    pending_revision: request.pending_revision,
-                    publishing_head_reservation_fingerprint: request
-                        .publishing_head_reservation_fingerprint,
-                    pending_control_record_fingerprint: request.pending_control_record_fingerprint,
-                    successor: request.successor,
-                    ready_revision: request.ready_revision,
-                    ready_control_record_fingerprint: request.ready_control_record_fingerprint,
-                })
+                let mut state = self.state.lock().await;
+                if let Some(ready) = &state.ready {
+                    anyhow::ensure!(
+                        ready.matches_request(&request),
+                        "test Ready control ordinal was reused by another proposal"
+                    );
+                    return Ok(test_ready_receipt_v1(request));
+                }
+                let pending = state
+                    .pending
+                    .as_ref()
+                    .context("test Ready advance has no installed pending control state")?;
+                let mutation_count = pending
+                    .mutation_count
+                    .context("test Ready advance has no fenced storage sequence")?;
+                anyhow::ensure!(
+                    pending.control_binding == request.control_binding
+                        && pending.pending_revision == request.pending_revision
+                        && pending.pending_control_record_fingerprint
+                            == request.pending_control_record_fingerprint
+                        && pending.publishing_head_reservation_fingerprint
+                            == request.publishing_head_reservation_fingerprint
+                        && pending.writer_fence_authority_revision_fingerprint
+                            == request.writer_fence_authority_revision_fingerprint
+                        && pending.writer_fence_lease_public_fingerprint
+                            == request.writer_fence_lease_public_fingerprint
+                        && pending.next_ordinal
+                            == mutation_count
+                                .checked_add(2)
+                                .context("test Ready terminal ordinal overflow")?,
+                    "test Ready advance does not follow the complete fenced storage sequence"
+                );
+                state.ready = Some(TestCatalogReadyRequestV1::from_request(&request));
+                if self
+                    .fail_after_next_backend_apply
+                    .swap(false, std::sync::atomic::Ordering::SeqCst)
+                {
+                    anyhow::bail!(
+                        "simulated test backend failure after applying Ready control state"
+                    );
+                }
+                Ok(test_ready_receipt_v1(request))
             })
         }
     }
@@ -5211,6 +6239,30 @@ mod tests {
     );
     static_assertions::assert_not_impl_any!(
         RetainedCatalogControlLeaseV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogFencedStorageWriteRequestV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogFencedStorageWriteReceiptV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogControlPendingRequestV1: Clone,
+        serde::Serialize,
+        Default
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogControlReadyAdvanceRequestV1: Clone,
         serde::Serialize,
         Default
     );
@@ -5327,6 +6379,14 @@ mod tests {
         BoundPendingCatalogControlV1<'static>: Clone,
         serde::Serialize,
         Default,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        FailedCatalogPublicationPendingInstallV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundPendingCatalogControlV1<'static>>,
         Into<crate::reconcile::ReconcilePlan>,
         Into<Vec<crate::reconcile::ReconcileAction>>
     );
@@ -5519,16 +6579,27 @@ mod tests {
             AllNamespaceWritersFencedLeaseV1 {
                 retained_control_lease: {
                     let live = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+                    let revoke_before_next_write =
+                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                    let fail_after_next_backend_apply =
+                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                     RetainedCatalogControlLeaseV1 {
                         control_binding: control_binding.clone(),
                         writer_fence_authority_revision_fingerprint: [0x89; 32],
                         writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1(
                             [0x88; 32],
                         ),
-                        liveness: Box::new(TestCatalogControlLeaseLivenessV1 {
+                        liveness: Box::new(TestCatalogMonotonicFenceLeaseV1 {
                             live: live.clone(),
+                            revoke_before_next_write: revoke_before_next_write.clone(),
+                            fail_after_next_backend_apply: fail_after_next_backend_apply.clone(),
+                            state: std::sync::Arc::new(tokio::sync::Mutex::new(
+                                TestCatalogFenceStateV1::default(),
+                            )),
                         }),
                         test_live: live,
+                        test_revoke_before_next_write: revoke_before_next_write,
+                        test_fail_after_next_backend_apply: fail_after_next_backend_apply,
                     }
                 },
                 control_binding,
@@ -5649,6 +6720,16 @@ mod tests {
             pending_revision: transition.pending_revision,
             publishing_head_reservation_fingerprint: transition
                 .publishing_head_reservation_fingerprint,
+            writer_fence_authority_revision_fingerprint: transition
+                .publication
+                .control_guard
+                .all_writers
+                .authority_revision_fingerprint,
+            writer_fence_lease_public_fingerprint: transition
+                .publication
+                .control_guard
+                .all_writers
+                .lease_public_fingerprint,
             pending_control_record_fingerprint: transition.pending_control_record_fingerprint,
         }
     }
@@ -5662,11 +6743,11 @@ mod tests {
         match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap()
     }
 
-    async fn authoritative_bound_pending<'a>(
+    async fn authoritative_control_transition<'a>(
         fixture: &'a SemanticRemoteCatalogFixtureV1,
         corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
         observed: &ObservedPublishedCatalogHeadV1,
-    ) -> BoundPendingCatalogControlV1<'a> {
+    ) -> PreparedCatalogControlTransitionV1<'a> {
         let publication_nonce = [0x44; 32];
         let prerequisites = matched(fixture, observed);
         let successor_bytes = deleted_index_bytes();
@@ -5705,9 +6786,18 @@ mod tests {
             journal,
         )
         .unwrap();
-        let transition = prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap();
-        let receipt = pending_receipt(&transition);
-        match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap()
+        prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap()
+    }
+
+    async fn authoritative_bound_pending<'a>(
+        fixture: &'a SemanticRemoteCatalogFixtureV1,
+        corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> BoundPendingCatalogControlV1<'a> {
+        let transition = authoritative_control_transition(fixture, corpus, observed).await;
+        install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap()
     }
 
     fn committed_successor(
@@ -5754,6 +6844,14 @@ mod tests {
         let ready_bytes = canonical_ready_control_record_bytes_v1(committed, ready_revision);
         TrustedCatalogHighWaterAdvanceReceiptV1 {
             control_binding: committed.control_guard.high_water.binding.clone(),
+            writer_fence_authority_revision_fingerprint: committed
+                .control_guard
+                .all_writers
+                .authority_revision_fingerprint,
+            writer_fence_lease_public_fingerprint: committed
+                .control_guard
+                .all_writers
+                .lease_public_fingerprint,
             pending_revision: committed.pending_revision,
             publishing_head_reservation_fingerprint: committed
                 .publishing_head_reservation_fingerprint,
@@ -5921,13 +7019,30 @@ mod tests {
             .await;
         let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
         let successor_bytes = deleted_index_bytes();
-
-        fixture
-            .operator()
-            .write("roots/index/added.txt", successor_bytes.clone())
-            .await
-            .unwrap();
         let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        let wire = {
+            let publication = &capability.pending.transition.publication;
+            validate_authoritative_catalog_mutation_journal_bytes_v1(
+                &publication.mutation_journal.raw_bytes,
+                &publication.context,
+                publication.sequence,
+                publication.publication_nonce,
+                publication.parent_head_revision,
+            )
+            .unwrap()
+        };
+        let replayed_first = {
+            let journal = &capability.pending.transition.publication.mutation_journal;
+            apply_one_catalog_namespace_mutation_v1(
+                &capability,
+                1,
+                &wire.mutations[0],
+                &journal.successor_payloads[0],
+            )
+            .await
+            .unwrap()
+        };
+        assert_eq!(replayed_first.object_key, "roots/index/added.txt");
         let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
             .await
             .unwrap();
@@ -5966,7 +7081,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn publishing_head_cas_is_exact_replay_safe_and_preserves_competitors() {
+    async fn publishing_head_requires_fenced_receipt_and_preserves_competitors() {
         {
             let (fixture, corpus, observed) =
                 observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
@@ -5987,6 +7102,29 @@ mod tests {
                 expected_bytes
             );
             assert!(mutable_head_etag_v1(&capability.publishing_head_binding).is_some());
+            let replay = catalog_fenced_storage_write_request_v1(
+                &capability.pending,
+                CatalogFencedStorageWriteStageV1::PublishingHead,
+                0,
+                "roots/.tcfs-catalog/v1/head".to_owned(),
+                CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+                    etag: capability
+                        .pending
+                        .transition
+                        .publication
+                        .expected_parent_head_etag
+                        .clone(),
+                },
+                Buffer::from(expected_bytes),
+            )
+            .unwrap();
+            assert_eq!(
+                execute_catalog_fenced_storage_write_v1(&capability.pending, replay)
+                    .await
+                    .unwrap(),
+                capability.publishing_head_binding,
+                "the backend must replay the exact authenticated ordinal receipt"
+            );
         }
 
         {
@@ -6009,10 +7147,20 @@ mod tests {
                 .await
                 .unwrap();
 
-            let capability = install_catalog_publishing_head_v1(pending)
+            let failure = install_catalog_publishing_head_v1(pending)
                 .await
-                .expect("an ambiguous exact replay must recover by bounded reread");
-            assert!(mutable_head_etag_v1(&capability.publishing_head_binding).is_some());
+                .expect_err("raw matching bytes without a fence receipt must not authorize replay");
+            assert!(format!("{failure:#}").contains("test storage fence rejected"));
+            assert_eq!(
+                fixture
+                    .operator()
+                    .read("roots/.tcfs-catalog/v1/head")
+                    .await
+                    .unwrap()
+                    .to_vec(),
+                failure.pending.transition.canonical_publishing_head_bytes,
+                "the rejected raw replay remains visible but cannot mint authority"
+            );
         }
 
         {
@@ -6046,6 +7194,95 @@ mod tests {
                 b"competing head"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn every_backend_transition_recovers_an_apply_before_response_failure() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let transition = authoritative_control_transition(&fixture, &corpus, &observed).await;
+        transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = install_catalog_publication_pending_v1(transition)
+            .await
+            .expect_err("pending install must retain an ambiguous applied transition");
+        let pending = recover_failed_catalog_publication_pending_v1(failure)
+            .await
+            .unwrap();
+
+        pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = install_catalog_publishing_head_v1(pending)
+            .await
+            .expect_err("publishing HEAD install must retain an ambiguous fenced write");
+        let capability = recover_failed_catalog_publishing_head_install_v1(failure)
+            .await
+            .unwrap();
+
+        capability
+            .pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .expect_err("namespace application must retain an ambiguous fenced write");
+        let applied = recover_failed_catalog_namespace_mutations_v1(failure)
+            .await
+            .unwrap();
+
+        applied
+            .capability
+            .pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = match finalize_catalog_committed_head_v1(applied).await {
+            Err(failure) => failure,
+            Ok(_) => {
+                panic!("committed HEAD finalization must retain an ambiguous fenced write")
+            }
+        };
+        let committed = recover_failed_catalog_committed_finalization_v1(failure)
+            .await
+            .unwrap();
+
+        committed
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = advance_catalog_high_water_v1(committed, [0xad; 32])
+            .await
+            .expect_err("Ready advance must retain an ambiguous applied transition");
+        let advanced = recover_failed_catalog_high_water_advance_v1(failure)
+            .await
+            .unwrap();
+        assert_eq!(advanced.successor.sequence.get(), 2);
+        assert_eq!(advanced.ready_revision.fingerprint, [0xad; 32]);
     }
 
     #[tokio::test]
@@ -6115,8 +7352,9 @@ mod tests {
             prepare_catalog_publication_fence_v1(prerequisites, [0x44; 32], archive, journal)
                 .unwrap();
         let transition = prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap();
-        let receipt = pending_receipt(&transition);
-        let pending = match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap();
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
         let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
         let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
             .await
@@ -6300,37 +7538,31 @@ mod tests {
             .await;
         let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
         let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
-        let (first_kind, first_key, first_bytes, first_blake3) = {
-            let first_payload = &capability
-                .pending
-                .transition
-                .publication
-                .mutation_journal
-                .successor_payloads[0];
-            (
-                first_payload.kind,
-                first_payload.object_key.clone(),
-                first_payload.raw_bytes.current(),
-                first_payload.raw_blake3,
+        let wire = {
+            let publication = &capability.pending.transition.publication;
+            validate_authoritative_catalog_mutation_journal_bytes_v1(
+                &publication.mutation_journal.raw_bytes,
+                &publication.context,
+                publication.sequence,
+                publication.publication_nonce,
+                publication.parent_head_revision,
             )
+            .unwrap()
         };
-        fixture
-            .operator()
-            .write(&first_key, first_bytes.clone())
+        let first_applied = {
+            let journal = &capability.pending.transition.publication.mutation_journal;
+            apply_one_catalog_namespace_mutation_v1(
+                &capability,
+                1,
+                &wire.mutations[0],
+                &journal.successor_payloads[0],
+            )
             .await
-            .unwrap();
-        let first_binding =
-            read_exact_catalog_successor_v1(&capability, first_kind, &first_key, &first_bytes)
-                .await
-                .unwrap();
+            .unwrap()
+        };
         let failure = FailedCatalogNamespaceMutationsV1 {
             capability,
-            applied: vec![AppliedCatalogNamespaceObjectV1 {
-                kind: first_kind,
-                object_key: first_key,
-                raw_blake3: first_blake3,
-                binding: first_binding,
-            }],
+            applied: vec![first_applied],
             error: anyhow::anyhow!("simulated crash after the first canonical mutation"),
         };
         let applied = recover_failed_catalog_namespace_mutations_v1(failure)
@@ -6376,6 +7608,51 @@ mod tests {
         };
         assert_eq!(reread.catalog_sequence().get(), 2);
         assert_eq!(reread.index_object_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn committed_recovery_requires_terminal_fenced_receipt_replay() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .unwrap();
+        let published = publish_catalog_successor_closure_v1(&applied)
+            .await
+            .unwrap();
+        applied
+            .capability
+            .pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_revoke_before_next_write
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = FailedCatalogCommittedFinalizationV1 {
+            applied,
+            error: anyhow::anyhow!("simulated lost terminal fenced-write response"),
+        };
+        let failure = match recover_failed_catalog_committed_finalization_v1(failure).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("raw committed closure must not replace the terminal fenced receipt"),
+        };
+        assert!(format!("{failure:#}").contains("catalog control lease is not live"));
+        assert_eq!(
+            fixture
+                .operator()
+                .read("roots/.tcfs-catalog/v1/head")
+                .await
+                .unwrap()
+                .to_vec(),
+            published.committed_head_bytes
+        );
     }
 
     #[tokio::test]
@@ -6493,7 +7770,7 @@ mod tests {
                 .retained_control_lease
                 .is_live_v1());
             assert!(
-                format!("{error:#}").contains("differs from its authoritative journal"),
+                format!("{error:#}").contains("test storage fence rejected catalog ordinal 1"),
                 "unexpected error: {error:#}"
             );
             assert_eq!(
@@ -6516,6 +7793,134 @@ mod tests {
                 "canonical key ordering must stop before the later replacement"
             );
         }
+
+        {
+            let (fixture, corpus, observed) =
+                observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                    "retained.txt".to_owned(),
+                )])
+                .await;
+            let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+            let exact_successor = deleted_index_bytes();
+            fixture
+                .operator()
+                .write("roots/index/added.txt", exact_successor.clone())
+                .await
+                .unwrap();
+            let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+            let error = apply_authoritative_catalog_namespace_mutations_v1(capability)
+                .await
+                .expect_err(
+                    "matching raw bytes without the fenced ordinal receipt must fail closed",
+                );
+            assert_eq!(error.applied.len(), 0);
+            assert!(
+                format!("{error:#}").contains("test storage fence rejected catalog ordinal 1"),
+                "unexpected error: {error:#}"
+            );
+            assert_eq!(
+                fixture
+                    .operator()
+                    .read("roots/index/added.txt")
+                    .await
+                    .unwrap()
+                    .to_vec(),
+                exact_successor,
+                "raw exact bytes stay visible but cannot mint mutation evidence"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn storage_fence_revocation_at_backend_boundary_has_zero_side_effect() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+        assert!(
+            pending
+                .transition
+                .publication
+                .control_guard
+                .all_writers
+                .retained_control_lease
+                .is_live_v1(),
+            "the advisory precheck must pass before the backend-side revocation hook"
+        );
+        pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_revoke_before_next_write
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let failure = install_catalog_publishing_head_v1(pending)
+            .await
+            .expect_err("backend-side revocation must reject before catalog HEAD mutation");
+        assert!(format!("{failure:#}").contains("test catalog control lease is not live"));
+        assert_eq!(
+            fixture
+                .operator()
+                .read("roots/.tcfs-catalog/v1/head")
+                .await
+                .unwrap()
+                .to_vec(),
+            observed.committed_head_bytes,
+            "a precheck/backend race must leave the mutable HEAD byte-exact"
+        );
+        assert!(!fixture
+            .operator()
+            .exists("roots/index/added.txt")
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn storage_fence_rejects_crossed_writer_identity_before_io() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let pending = authoritative_bound_pending(&fixture, &corpus, &observed).await;
+        let mut request = catalog_fenced_storage_write_request_v1(
+            &pending,
+            CatalogFencedStorageWriteStageV1::PublishingHead,
+            0,
+            "roots/.tcfs-catalog/v1/head".to_owned(),
+            CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+                etag: pending
+                    .transition
+                    .publication
+                    .expected_parent_head_etag
+                    .clone(),
+            },
+            Buffer::from(pending.transition.canonical_publishing_head_bytes.clone()),
+        )
+        .unwrap();
+        request.writer_fence_authority_revision_fingerprint = [0x42; 32];
+        request.request_fingerprint = catalog_fenced_storage_write_request_fingerprint_v1(
+            &catalog_fenced_storage_write_request_wire_v1(&request),
+        )
+        .unwrap();
+
+        let error = execute_catalog_fenced_storage_write_v1(&pending, request)
+            .await
+            .expect_err("a different writer-fence identity must not reach storage I/O");
+        assert!(format!("{error:#}").contains("crossed its pending control state"));
+        assert_eq!(
+            fixture
+                .operator()
+                .read("roots/.tcfs-catalog/v1/head")
+                .await
+                .unwrap()
+                .to_vec(),
+            observed.committed_head_bytes
+        );
     }
 
     #[tokio::test]
@@ -7407,6 +8812,16 @@ mod tests {
             pending_revision: transition.pending_revision,
             publishing_head_reservation_fingerprint: transition
                 .publishing_head_reservation_fingerprint,
+            writer_fence_authority_revision_fingerprint: transition
+                .publication
+                .control_guard
+                .all_writers
+                .authority_revision_fingerprint,
+            writer_fence_lease_public_fingerprint: transition
+                .publication
+                .control_guard
+                .all_writers
+                .lease_public_fingerprint,
             pending_control_record_fingerprint: transition.pending_control_record_fingerprint,
         };
         let bound =

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -25,8 +25,16 @@
 //! A separately namespaced diagnostic draft remains non-authoritative and
 //! cannot convert into the authoritative journal. The lease, authenticated
 //! control receipts, and storage-enforced fence still have no production
-//! constructors or implementation, and this checkpoint does not claim
-//! cold-process reconstruction from persisted authenticated state. The source
+//! constructors or implementation. This checkpoint additionally models
+//! bounded cold-process reconstruction from an exact authenticated Pending
+//! record, immutable archive/journal/payload evidence, and a fresh opaque
+//! handle to the same durable backend receipt ledger. Public fingerprints
+//! still cannot reconstruct that authority. Cold acknowledgement after the
+//! backend has already advanced Pending to Ready is deliberately a later
+//! authenticated gateway, not part of this Pending-only checkpoint.
+//! Production activation also remains gated on pre-Publishing byte-aware page
+//! packing and worst-case output-binding/aggregate-closure reservation; a
+//! late oversize rejection must never strand a live publication. The source
 //! path therefore remains unreachable by deployed writers and cannot mint
 //! production authority, produce a plan digest, or authorize an action.
 
@@ -44,22 +52,24 @@ use tcfs_core::config::{
 };
 
 use super::{
-    lower_hex, validate_catalog_context_v1, validate_catalog_object_route_v1,
-    validate_entry_size_v1, InvalidRemoteCatalogReasonV1, RemoteCatalogContextWireV1,
-    RemoteCatalogEntryWireV1, RemoteCatalogHeadWireV1, RemoteCatalogObjectBindingWireV1,
-    RemoteCatalogObjectKindV1, RemoteCatalogPageReferenceWireV1, RemoteCatalogPageWireV1,
-    RemoteCatalogRootReferenceWireV1, RemoteCatalogRootWireV1,
-    SemanticallyBoundRemoteCatalogCorpusV1, CATALOG_SCHEMA_VERSION_V1,
+    lower_hex, read_verified_remote_catalog_closure_from_archived_head_v1,
+    validate_catalog_context_v1, validate_catalog_object_route_v1, validate_entry_size_v1,
+    InvalidRemoteCatalogReasonV1, RemoteCatalogContextWireV1, RemoteCatalogEntryWireV1,
+    RemoteCatalogHeadWireV1, RemoteCatalogObjectBindingWireV1, RemoteCatalogObjectKindV1,
+    RemoteCatalogPageReferenceWireV1, RemoteCatalogPageWireV1, RemoteCatalogRootReferenceWireV1,
+    RemoteCatalogRootWireV1, SemanticallyBoundRemoteCatalogCorpusV1,
+    StrictRemoteCatalogClosureReadV1, CATALOG_SCHEMA_VERSION_V1,
 };
 use crate::blacklist::Blacklist;
 use crate::index_entry::{
-    read_raw_object_snapshot_v1, PortableNamespaceRole, RawObjectReadBindingV1, RawObjectReadV1,
+    read_expected_raw_object_snapshot_v1, read_raw_object_snapshot_v1, PortableNamespaceRole,
+    RawObjectReadBindingV1, RawObjectReadV1, RawObjectSnapshotV1,
 };
 use crate::registered_reconcile::{
-    validate_bound_catalog_manifest_references_v1, validate_catalog_index_payload_v1,
-    validate_catalog_manifest_payload_v1, validate_catalog_reservation_payload_v1,
-    validate_registered_remote_storage_key_bounds_v1, CatalogManifestReferenceV1,
-    CatalogValidatedIndexPayloadV1, CatalogValidatedIndexStateV1,
+    expected_raw_object_binding_v1, validate_bound_catalog_manifest_references_v1,
+    validate_catalog_index_payload_v1, validate_catalog_manifest_payload_v1,
+    validate_catalog_reservation_payload_v1, validate_registered_remote_storage_key_bounds_v1,
+    CatalogManifestReferenceV1, CatalogValidatedIndexPayloadV1, CatalogValidatedIndexStateV1,
     CatalogValidatedReservationPayloadV1, RegisteredRootRemoteObjectBindingV1,
 };
 use crate::registered_remote_observation::{
@@ -79,9 +89,13 @@ const CATALOG_SUCCESSOR_PAYLOAD_OBJECT_DOMAIN_V1: &str =
 const PUBLISHING_HEAD_RESERVATION_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-publishing-head-reservation.b3v1";
 const PREDECESSOR_HEAD_STORAGE_BINDING_DOMAIN_V1: &str =
-    "tinyland.tcfs.remote-catalog-predecessor-head-storage-binding.b3v1";
+    "tinyland.tcfs.remote-catalog-predecessor-head-storage-binding.b3v2";
 const FENCED_STORAGE_WRITE_REQUEST_DOMAIN_V1: &str =
     "tinyland.tcfs.remote-catalog-fenced-storage-write-request.b3v1";
+const READY_CONTROL_REVISION_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-ready-control-revision.b3v1";
+const PENDING_FENCE_REACQUISITION_REQUEST_DOMAIN_V1: &str =
+    "tinyland.tcfs.remote-catalog-pending-fence-reacquisition-request.b3v1";
 const ARCHIVED_HEAD_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/archived-heads";
 const MUTATION_JOURNAL_OBJECT_SUFFIX_V1: &str = ".tcfs-catalog/v1/publications/mutation-journals";
 const UNTRUSTED_MUTATION_JOURNAL_DRAFT_OBJECT_SUFFIX_V1: &str =
@@ -136,6 +150,18 @@ impl CatalogAuthorityContextV1 {
             plan_contract_fingerprint: self.plan_contract_fingerprint.to_string(),
         }
     }
+
+    fn from_selected(selected: &ValidatedSelectedRegisteredRootRemoteContextV1) -> Self {
+        Self {
+            remote_prefix: selected.spec().remote_prefix.clone(),
+            root_id: selected.root_id().to_owned(),
+            root_identity_fingerprint: selected.spec_identity_fingerprint().to_owned(),
+            root_generation: selected.spec().generation,
+            profile: selected.spec().profile,
+            profile_settings_fingerprint: selected.profile_settings_fingerprint(),
+            plan_contract_fingerprint: selected.plan_contract_fingerprint(),
+        }
+    }
 }
 
 /// Exact current `HEAD` selected by one semantically verified catalog corpus.
@@ -149,7 +175,7 @@ pub(crate) struct ObservedPublishedCatalogHeadV1 {
     parent_head_revision: Option<[u8; 32]>,
     head_revision: [u8; 32],
     committed_head_bytes: Vec<u8>,
-    current_head_etag: String,
+    current_head_binding: RegisteredRootRemoteObjectBindingV1,
 }
 
 impl std::fmt::Debug for ObservedPublishedCatalogHeadV1 {
@@ -225,17 +251,17 @@ fn mutable_head_etag_v1(binding: &RegisteredRootRemoteObjectBindingV1) -> Option
         RegisteredRootRemoteObjectBindingV1::Etag { etag }
         | RegisteredRootRemoteObjectBindingV1::Version {
             etag: Some(etag), ..
-        } if !etag.is_empty() => Some(etag.clone()),
+        } if !etag.is_empty() && etag != "null" => Some(etag.clone()),
         RegisteredRootRemoteObjectBindingV1::Etag { .. }
         | RegisteredRootRemoteObjectBindingV1::Version { .. } => None,
     }
 }
 
-/// Retain the exact mutable-HEAD ETag needed by a future pre-mutation CAS.
+/// Retain the exact mutable-HEAD binding needed by a future pre-mutation CAS.
 pub(crate) fn observe_published_catalog_head_v1(
     corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
 ) -> Result<ObservedPublishedCatalogHeadV1, CatalogPublicationContractErrorV1> {
-    let current_head_etag = mutable_head_etag_v1(corpus.closure.head_object.binding())
+    mutable_head_etag_v1(corpus.closure.head_object.binding())
         .ok_or(CatalogPublicationContractErrorV1::CurrentHeadWithoutEtag)?;
     Ok(ObservedPublishedCatalogHeadV1 {
         context: CatalogAuthorityContextV1::from_corpus(corpus),
@@ -244,7 +270,7 @@ pub(crate) fn observe_published_catalog_head_v1(
         parent_head_revision: corpus.closure.parent_head_revision,
         head_revision: corpus.closure.head_revision,
         committed_head_bytes: corpus.closure.head_raw_bytes.clone(),
-        current_head_etag,
+        current_head_binding: corpus.closure.head_object.binding().clone(),
     })
 }
 
@@ -413,11 +439,74 @@ struct CatalogControlPendingRequestV1 {
     pending_control_record_fingerprint: [u8; 32],
 }
 
+#[derive(Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogPendingFenceReacquisitionRequestWireV1 {
+    version: u32,
+    context: RemoteCatalogContextWireV1,
+    storage_authority_fingerprint: String,
+    control_authority_fingerprint: String,
+    writer_epoch: String,
+    ready_control_generation: u64,
+    ready_control_revision_fingerprint: String,
+    control_lease_public_fingerprint: String,
+    pending_control_generation: u64,
+    pending_control_revision_fingerprint: String,
+    pending_control_record_fingerprint: String,
+    canonical_pending_control_record_bytes_len: u64,
+    canonical_pending_control_record_blake3: String,
+    publishing_head_reservation_fingerprint: String,
+    writer_fence_authority_revision_fingerprint: String,
+    writer_fence_lease_public_fingerprint: String,
+}
+
+/// Untrusted exact-state proposal submitted to the control authority that
+/// already owns the durable Pending fence and ordinal receipt ledger.
+///
+/// The public fields are expectations only. They cannot create or reset a
+/// backend epoch, receipt prefix, lease, or bearer token.
+pub(crate) struct CatalogPendingFenceReacquisitionRequestV1 {
+    control_binding: CatalogControlAcquisitionBindingV1,
+    pending_revision: CatalogControlAuthorityRevisionV1,
+    publishing_head_reservation_fingerprint: [u8; 32],
+    writer_fence_authority_revision_fingerprint: [u8; 32],
+    writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
+    canonical_pending_control_record_bytes: Vec<u8>,
+    pending_control_record_fingerprint: [u8; 32],
+    request_fingerprint: [u8; 32],
+}
+
+/// Authenticated reopening of the same durable Pending fence epoch.
+///
+/// The returned opaque local handle may be fresh, but it must point to the
+/// already-existing backend ledger. Serialized public fingerprints never mint
+/// this value. There is deliberately no production implementation in this
+/// checkpoint.
+pub(crate) struct TrustedCatalogPendingFenceReacquisitionV1 {
+    request_fingerprint: [u8; 32],
+    pending_receipt: TrustedCatalogPublicationPendingReceiptV1,
+    retained_control_lease: RetainedCatalogControlLeaseV1,
+}
+
 type CatalogControlPendingFutureV1<'a> = Pin<
     Box<dyn Future<Output = AnyhowResult<TrustedCatalogPublicationPendingReceiptV1>> + Send + 'a>,
 >;
 type CatalogFencedStorageWriteFutureV1<'a> =
     Pin<Box<dyn Future<Output = AnyhowResult<CatalogFencedStorageWriteReceiptV1>> + Send + 'a>>;
+pub(crate) type CatalogPendingFenceReacquisitionFutureV1<'a> = Pin<
+    Box<dyn Future<Output = AnyhowResult<TrustedCatalogPendingFenceReacquisitionV1>> + Send + 'a>,
+>;
+
+pub(crate) trait CatalogPendingFenceReacquisitionAuthorityV1: Send + Sync {
+    /// Authenticate the exact current Pending record and reopen its existing
+    /// durable all-writer fence. Implementations must reject copied bytes,
+    /// another backend, a reset/missing receipt ledger, stale Pending after
+    /// Ready, or any field mismatch without creating a new epoch.
+    fn reacquire_pending_fence_v1<'a>(
+        &'a self,
+        request: CatalogPendingFenceReacquisitionRequestV1,
+    ) -> CatalogPendingFenceReacquisitionFutureV1<'a>;
+}
 
 /// Non-cloneable retained backend lease for one exact control acquisition.
 ///
@@ -449,9 +538,23 @@ trait CatalogMonotonicFenceLeaseV1: Send + Sync {
         request: CatalogFencedStorageWriteRequestV1,
     ) -> CatalogFencedStorageWriteFutureV1<'a>;
 
+    /// Return the already-durable receipt for this exact request without
+    /// performing storage I/O or creating a missing ledger ordinal.
+    ///
+    /// Cold committed-state recovery must use this operation: matching raw
+    /// objects are corroborating evidence, never authority to backfill a
+    /// missing receipt.
+    fn replay_fenced_receipt_v1<'a>(
+        &'a self,
+        request: CatalogFencedStorageWriteRequestV1,
+    ) -> CatalogFencedStorageWriteFutureV1<'a>;
+
     /// Atomically replace the exact pending control revision with the exact
-    /// ready record. Implementations must resolve ambiguous backend outcomes
-    /// by an exact authenticated reread and return the same receipt on replay.
+    /// ready record. Implementations must first prove a contiguous durable
+    /// `0..=terminal` fenced-write ledger and bind the Ready completion
+    /// provenance to its exact terminal request fingerprint and storage
+    /// binding. They must resolve ambiguous backend outcomes by an exact
+    /// authenticated reread and return the same receipt on replay.
     fn compare_and_swap_ready_v1<'a>(
         &'a self,
         request: CatalogControlReadyAdvanceRequestV1,
@@ -469,6 +572,8 @@ struct RetainedCatalogControlLeaseV1 {
     test_revoke_before_next_write: std::sync::Arc<std::sync::atomic::AtomicBool>,
     #[cfg(test)]
     test_fail_after_next_backend_apply: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    #[cfg(test)]
+    test_reacquisition_authority: std::sync::Arc<dyn CatalogPendingFenceReacquisitionAuthorityV1>,
 }
 
 impl RetainedCatalogControlLeaseV1 {
@@ -568,7 +673,7 @@ pub(crate) struct MatchedCatalogPublicationPrerequisitesV1<'a> {
     publication_nonce: [u8; 32],
     head_revision: [u8; 32],
     committed_head_bytes: Vec<u8>,
-    current_head_etag: String,
+    current_head_binding: RegisteredRootRemoteObjectBindingV1,
     bootstrap_head_revision: [u8; 32],
 }
 
@@ -657,7 +762,7 @@ pub(crate) fn match_catalog_publication_prerequisites_v1<'a>(
         publication_nonce: observed.publication_nonce,
         head_revision: observed.head_revision,
         committed_head_bytes: observed.committed_head_bytes.clone(),
-        current_head_etag: observed.current_head_etag.clone(),
+        current_head_binding: observed.current_head_binding.clone(),
         bootstrap_head_revision: bootstrap.bootstrap.head_revision,
     })
 }
@@ -1351,6 +1456,15 @@ fn type_catalog_successor_payload_v1(
     raw_bytes: Vec<u8>,
 ) -> Result<TypedCatalogSuccessorPayloadV1, CatalogPublicationContractErrorV1> {
     let context = CatalogAuthorityContextV1::from_corpus(corpus);
+    type_catalog_successor_payload_for_context_v1(&context, kind, object_key, raw_bytes)
+}
+
+fn type_catalog_successor_payload_for_context_v1(
+    context: &CatalogAuthorityContextV1,
+    kind: RemoteCatalogObjectKindV1,
+    object_key: String,
+    raw_bytes: Vec<u8>,
+) -> Result<TypedCatalogSuccessorPayloadV1, CatalogPublicationContractErrorV1> {
     if !validate_catalog_object_route_v1(&context.remote_prefix, kind, &object_key) {
         return Err(CatalogPublicationContractErrorV1::InvalidSuccessorPayload);
     }
@@ -1387,7 +1501,7 @@ fn type_catalog_successor_payload_v1(
         }
     };
     Ok(TypedCatalogSuccessorPayloadV1 {
-        context,
+        context: context.clone(),
         kind,
         object_key,
         raw_blake3: *blake3::hash(&raw_bytes).as_bytes(),
@@ -1694,6 +1808,117 @@ fn semantic_index_from_successor_v1(
     }
 }
 
+fn validate_catalog_semantic_objects_v1(
+    remote_prefix: &str,
+    objects: &BTreeMap<String, CatalogSemanticObjectV1<'_>>,
+) -> Result<(), CatalogPublicationContractErrorV1> {
+    let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let object_count = u64::try_from(objects.len())
+        .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+    if object_count > contract.max_catalog_entries() {
+        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+    }
+    let mut object_key_bytes = 0_u64;
+    let mut object_body_bytes = 0_u64;
+    for (object_key, object) in objects {
+        object_key_bytes = object_key_bytes
+            .checked_add(
+                u64::try_from(object_key.len())
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?,
+            )
+            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+        object_body_bytes = object_body_bytes
+            .checked_add(
+                object
+                    .raw_bytes_len()
+                    .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?,
+            )
+            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+    }
+    if object_key_bytes > contract.max_catalog_entry_key_bytes()
+        || object_body_bytes > contract.max_bound_object_bytes_per_pass()
+    {
+        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+    }
+    let mut claims = RemoteNamespaceClaimAccumulatorV1::new(contract);
+    let mut references = BTreeMap::<String, Vec<CatalogManifestReferenceV1>>::new();
+    let mut manifest_count = 0_usize;
+    for object in objects.values() {
+        match object {
+            CatalogSemanticObjectV1::Index(index) => {
+                if index.role == PortableNamespaceRole::Directory
+                    && index.origins == RemoteNamespaceClaimOriginsV1::CURRENT
+                    && Blacklist::default()
+                        .check_fixed_ingress_path_components(std::path::Path::new(
+                            &index.logical_path,
+                        ))
+                        .is_some()
+                {
+                    return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+                }
+                claims
+                    .observe_path(&index.logical_path, index.role, index.origins)
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+                if let Some(reference) = &index.committed {
+                    let manifest_key =
+                        format!("{remote_prefix}/manifests/{}", reference.manifest_hash());
+                    references
+                        .entry(manifest_key)
+                        .or_default()
+                        .push(reference.clone());
+                }
+            }
+            CatalogSemanticObjectV1::Reservation(reservation) => {
+                let expected = crate::index_entry::portable_casefold_path(&reservation.exact_path)
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+                if expected != reservation.folded_path {
+                    return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+                }
+                claims
+                    .observe_path(
+                        &reservation.exact_path,
+                        reservation.role,
+                        RemoteNamespaceClaimOriginsV1::RESERVATION,
+                    )
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+            }
+            CatalogSemanticObjectV1::ExistingManifest { .. }
+            | CatalogSemanticObjectV1::SuccessorManifest(_) => {
+                manifest_count = manifest_count
+                    .checked_add(1)
+                    .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+            }
+        }
+    }
+    if references.len() != manifest_count {
+        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
+    }
+    for (manifest_key, manifest_references) in &references {
+        let manifest = objects
+            .get(manifest_key)
+            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+        match manifest {
+            CatalogSemanticObjectV1::ExistingManifest { manifest, .. } => {
+                validate_bound_catalog_manifest_references_v1(
+                    manifest_key,
+                    manifest,
+                    manifest_references,
+                )
+                .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+            }
+            CatalogSemanticObjectV1::SuccessorManifest(raw_bytes) => {
+                validate_catalog_manifest_payload_v1(manifest_key, raw_bytes, manifest_references)
+                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
+            }
+            CatalogSemanticObjectV1::Index(_) | CatalogSemanticObjectV1::Reservation(_) => {
+                return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)
+            }
+        }
+    }
+    let _retained_claims = claims.into_retained_claims();
+    Ok(())
+}
+
 fn validate_complete_successor_semantic_closure_v1<'a>(
     corpus: &'a SemanticallyBoundRemoteCatalogCorpusV1,
     mutations: &'a [FactBoundCatalogMutationV1<'_, '_>],
@@ -1797,111 +2022,7 @@ fn validate_complete_successor_semantic_closure_v1<'a>(
         objects.insert(mutation.successor.object_key.clone(), semantic);
     }
 
-    let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
-    let object_count = u64::try_from(objects.len())
-        .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-    if object_count > contract.max_catalog_entries() {
-        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
-    }
-    let mut object_key_bytes = 0_u64;
-    let mut object_body_bytes = 0_u64;
-    for (object_key, object) in &objects {
-        object_key_bytes = object_key_bytes
-            .checked_add(
-                u64::try_from(object_key.len())
-                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?,
-            )
-            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-        object_body_bytes = object_body_bytes
-            .checked_add(
-                object
-                    .raw_bytes_len()
-                    .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?,
-            )
-            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-    }
-    if object_key_bytes > contract.max_catalog_entry_key_bytes()
-        || object_body_bytes > contract.max_bound_object_bytes_per_pass()
-    {
-        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
-    }
-    let mut claims = RemoteNamespaceClaimAccumulatorV1::new(contract);
-    let mut references = BTreeMap::<String, Vec<CatalogManifestReferenceV1>>::new();
-    let mut manifest_count = 0_usize;
-    for object in objects.values() {
-        match object {
-            CatalogSemanticObjectV1::Index(index) => {
-                if index.role == PortableNamespaceRole::Directory
-                    && index.origins == RemoteNamespaceClaimOriginsV1::CURRENT
-                    && Blacklist::default()
-                        .check_fixed_ingress_path_components(std::path::Path::new(
-                            &index.logical_path,
-                        ))
-                        .is_some()
-                {
-                    return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
-                }
-                claims
-                    .observe_path(&index.logical_path, index.role, index.origins)
-                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-                if let Some(reference) = &index.committed {
-                    let manifest_key =
-                        format!("{remote_prefix}/manifests/{}", reference.manifest_hash());
-                    references
-                        .entry(manifest_key)
-                        .or_default()
-                        .push(reference.clone());
-                }
-            }
-            CatalogSemanticObjectV1::Reservation(reservation) => {
-                let expected = crate::index_entry::portable_casefold_path(&reservation.exact_path)
-                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-                if expected != reservation.folded_path {
-                    return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
-                }
-                claims
-                    .observe_path(
-                        &reservation.exact_path,
-                        reservation.role,
-                        RemoteNamespaceClaimOriginsV1::RESERVATION,
-                    )
-                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-            }
-            CatalogSemanticObjectV1::ExistingManifest { .. }
-            | CatalogSemanticObjectV1::SuccessorManifest(_) => {
-                manifest_count = manifest_count
-                    .checked_add(1)
-                    .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-            }
-        }
-    }
-    if references.len() != manifest_count {
-        return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure);
-    }
-    for (manifest_key, manifest_references) in &references {
-        let manifest = objects
-            .get(manifest_key)
-            .ok_or(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-        match manifest {
-            CatalogSemanticObjectV1::ExistingManifest { manifest, .. } => {
-                validate_bound_catalog_manifest_references_v1(
-                    manifest_key,
-                    manifest,
-                    manifest_references,
-                )
-                .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-            }
-            CatalogSemanticObjectV1::SuccessorManifest(raw_bytes) => {
-                validate_catalog_manifest_payload_v1(manifest_key, raw_bytes, manifest_references)
-                    .map_err(|_| CatalogPublicationContractErrorV1::InvalidSuccessorClosure)?;
-            }
-            CatalogSemanticObjectV1::Index(_) | CatalogSemanticObjectV1::Reservation(_) => {
-                return Err(CatalogPublicationContractErrorV1::InvalidSuccessorClosure)
-            }
-        }
-    }
-    let _retained_claims = claims.into_retained_claims();
-    Ok(())
+    validate_catalog_semantic_objects_v1(remote_prefix, &objects)
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -2131,6 +2252,7 @@ pub(crate) struct BoundArchivedCatalogHeadV1 {
     predecessor_head_revision: [u8; 32],
     predecessor_head_bytes_blake3: [u8; 32],
     object_id: [u8; 32],
+    raw_bytes: Vec<u8>,
     raw_bytes_len: NonZeroU64,
     binding: RegisteredRootRemoteObjectBindingV1,
 }
@@ -2209,6 +2331,53 @@ fn untrusted_mutation_journal_draft_object_key_v1(
     )
 }
 
+async fn read_catalog_publication_artifact_exact_v1(
+    storage_authority: &TrustedCatalogStorageAuthorityV1<'_>,
+    context: &CatalogAuthorityContextV1,
+    reference: &RemoteCatalogPublicationObjectReferenceWireV1,
+    suffix: &str,
+    object_domain: &str,
+    max_bytes: u64,
+) -> AnyhowResult<RawObjectSnapshotV1> {
+    anyhow::ensure!(
+        storage_authority
+            .conditional_write_receipt
+            .authorizes(storage_authority.operator, &context.remote_prefix)?,
+        "catalog recovery artifact lost its exact accessor/prefix authority"
+    );
+    let object_id = super::parse_lower_hex_32(&reference.object_id)
+        .context("catalog recovery artifact object ID is invalid")?;
+    let raw_bytes_len = NonZeroU64::new(reference.raw_bytes_len)
+        .context("catalog recovery artifact cannot be empty")?;
+    anyhow::ensure!(
+        raw_bytes_len.get() <= max_bytes,
+        "catalog recovery artifact exceeds its object bound"
+    );
+    let binding = super::validate_binding_wire_v1(&reference.binding)
+        .context("catalog recovery artifact binding is invalid")?;
+    let object_key = publication_object_key_v1(context, suffix, &object_id)
+        .context("catalog recovery artifact key exceeds its bound")?;
+    let observed = read_expected_raw_object_snapshot_v1(
+        storage_authority.operator,
+        &object_key,
+        max_bytes,
+        expected_raw_object_binding_v1(&binding),
+    )
+    .await
+    .with_context(|| format!("reading exact catalog recovery artifact: {object_key}"))?;
+    let Some(RawObjectReadV1::Bound(observed)) = observed else {
+        anyhow::bail!("catalog recovery artifact is missing or unbound: {object_key}");
+    };
+    anyhow::ensure!(
+        u64::try_from(observed.raw_bytes().len()).ok() == Some(raw_bytes_len.get())
+            && super::domain_object_id_v1(object_domain, observed.raw_bytes()) == object_id
+            && binding_wire_v1(&registered_binding_from_raw_v1(observed.binding().clone()))
+                == reference.binding,
+        "catalog recovery artifact differs from its exact persisted reference: {object_key}"
+    );
+    Ok(observed)
+}
+
 fn binding_wire_v1(
     binding: &RegisteredRootRemoteObjectBindingV1,
 ) -> RemoteCatalogObjectBindingWireV1 {
@@ -2235,6 +2404,636 @@ fn registered_binding_from_raw_v1(
         }
         RawObjectReadBindingV1::Etag { etag } => RegisteredRootRemoteObjectBindingV1::Etag { etag },
     }
+}
+
+async fn read_reconstructed_named_object_exact_v1(
+    storage_authority: &TrustedCatalogStorageAuthorityV1<'_>,
+    entry: &RetainedCatalogPredecessorEntryV1,
+) -> AnyhowResult<Vec<u8>> {
+    let observed = read_expected_raw_object_snapshot_v1(
+        storage_authority.operator,
+        &entry.object_key,
+        catalog_named_object_max_bytes_v1(entry.kind),
+        expected_raw_object_binding_v1(&entry.binding),
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "reading exact unchanged catalog predecessor object: {}",
+            entry.object_key
+        )
+    })?;
+    let Some(RawObjectReadV1::Bound(observed)) = observed else {
+        anyhow::bail!(
+            "unchanged catalog predecessor object is missing or unbound: {}",
+            entry.object_key
+        );
+    };
+    let (raw_bytes, raw_blake3, binding) = observed.into_parts();
+    anyhow::ensure!(
+        u64::try_from(raw_bytes.len()).ok() == Some(entry.raw_bytes_len)
+            && *raw_blake3.as_bytes() == entry.raw_blake3
+            && registered_binding_from_raw_v1(binding) == entry.binding,
+        "unchanged catalog predecessor object differs from its archived inventory: {}",
+        entry.object_key
+    );
+    Ok(raw_bytes)
+}
+
+#[derive(Default)]
+struct ReconstructedCatalogSuccessorBudgetV1 {
+    object_count: u64,
+    object_key_bytes: u64,
+    object_body_bytes: u64,
+}
+
+impl ReconstructedCatalogSuccessorBudgetV1 {
+    fn observe(&mut self, object_key: &str, raw_bytes_len: u64) -> AnyhowResult<()> {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        self.object_count = self
+            .object_count
+            .checked_add(1)
+            .context("reconstructed successor object count overflow")?;
+        self.object_key_bytes = self
+            .object_key_bytes
+            .checked_add(
+                u64::try_from(object_key.len())
+                    .context("reconstructed successor object key length does not fit u64")?,
+            )
+            .context("reconstructed successor object-key total overflow")?;
+        self.object_body_bytes = self
+            .object_body_bytes
+            .checked_add(raw_bytes_len)
+            .context("reconstructed successor object-body total overflow")?;
+        anyhow::ensure!(
+            self.object_count <= remote.max_catalog_entries()
+                && self.object_key_bytes <= remote.max_catalog_entry_key_bytes()
+                && self.object_body_bytes <= remote.max_bound_object_bytes_per_pass(),
+            "reconstructed successor metadata exceeds the bounded semantic-read budget"
+        );
+        Ok(())
+    }
+}
+
+fn preflight_reconstructed_successor_semantic_overlay_v1<'a>(
+    predecessor_entries: &[RetainedCatalogPredecessorEntryV1],
+    journal: &'a RemoteCatalogMutationJournalWireV1,
+    successor_payloads: &[BoundCatalogSuccessorPayloadV1],
+) -> AnyhowResult<BTreeSet<&'a str>> {
+    anyhow::ensure!(
+        journal.mutations.len() == successor_payloads.len(),
+        "reconstructed catalog journal lost its complete successor payload set"
+    );
+    let mutation_keys = journal
+        .mutations
+        .iter()
+        .map(|mutation| mutation.object_key.as_str())
+        .collect::<BTreeSet<_>>();
+    anyhow::ensure!(
+        mutation_keys.len() == journal.mutations.len(),
+        "reconstructed catalog journal contains duplicate mutation keys"
+    );
+
+    let mut budget = ReconstructedCatalogSuccessorBudgetV1::default();
+    for predecessor in predecessor_entries {
+        if !mutation_keys.contains(predecessor.object_key.as_str()) {
+            budget.observe(&predecessor.object_key, predecessor.raw_bytes_len)?;
+        }
+    }
+    for (mutation, payload) in journal.mutations.iter().zip(successor_payloads) {
+        let payload_bytes = payload.raw_bytes.current();
+        anyhow::ensure!(
+            mutation.kind == payload.kind
+                && mutation.object_key == payload.object_key
+                && mutation.successor_payload.object_id == lower_hex(&payload.object_id)
+                && mutation.successor_payload.raw_bytes_len == payload.raw_bytes_len.get()
+                && mutation.successor_payload.raw_blake3 == lower_hex(&payload.raw_blake3)
+                && mutation.successor_payload.binding == binding_wire_v1(&payload.binding)
+                && u64::try_from(payload_bytes.len()).ok() == Some(payload.raw_bytes_len.get())
+                && *blake3::hash(&payload_bytes).as_bytes() == payload.raw_blake3,
+            "reconstructed catalog successor payload differs from its journal entry"
+        );
+        budget.observe(&mutation.object_key, payload.raw_bytes_len.get())?;
+    }
+    Ok(mutation_keys)
+}
+
+async fn validate_reconstructed_successor_semantic_overlay_v1(
+    storage_authority: &TrustedCatalogStorageAuthorityV1<'_>,
+    context: &CatalogAuthorityContextV1,
+    predecessor_entries: &[RetainedCatalogPredecessorEntryV1],
+    journal: &RemoteCatalogMutationJournalWireV1,
+    successor_payloads: &[BoundCatalogSuccessorPayloadV1],
+) -> AnyhowResult<()> {
+    // Preflight the complete final metadata projection before the first
+    // unchanged body read. Individually valid archived entries must not force
+    // process-sized reads or retention before their aggregate budget fails.
+    let mutation_keys = preflight_reconstructed_successor_semantic_overlay_v1(
+        predecessor_entries,
+        journal,
+        successor_payloads,
+    )?;
+
+    let mut final_objects = BTreeMap::<String, (RemoteCatalogObjectKindV1, Vec<u8>)>::new();
+    for predecessor in predecessor_entries {
+        if mutation_keys.contains(predecessor.object_key.as_str()) {
+            continue;
+        }
+        let raw_bytes =
+            read_reconstructed_named_object_exact_v1(storage_authority, predecessor).await?;
+        anyhow::ensure!(
+            final_objects
+                .insert(
+                    predecessor.object_key.clone(),
+                    (predecessor.kind, raw_bytes),
+                )
+                .is_none(),
+            "archived catalog predecessor inventory contains a duplicate key"
+        );
+    }
+    for (mutation, payload) in journal.mutations.iter().zip(successor_payloads) {
+        let payload_bytes = payload.raw_bytes.current();
+        anyhow::ensure!(
+            final_objects
+                .insert(
+                    mutation.object_key.clone(),
+                    (mutation.kind, payload_bytes.to_vec()),
+                )
+                .is_none(),
+            "reconstructed catalog successor overlay contains a duplicate key"
+        );
+    }
+
+    let mut semantic_objects = BTreeMap::<String, CatalogSemanticObjectV1<'_>>::new();
+    for (object_key, (kind, raw_bytes)) in &final_objects {
+        let semantic = match kind {
+            RemoteCatalogObjectKindV1::Index => {
+                let index = validate_catalog_index_payload_v1(
+                    &context.remote_prefix,
+                    object_key,
+                    raw_bytes,
+                )
+                .context("validating reconstructed catalog index payload")?;
+                CatalogSemanticObjectV1::Index(semantic_index_from_successor_v1(
+                    &context.remote_prefix,
+                    &index,
+                    u64::try_from(raw_bytes.len())
+                        .context("reconstructed index length does not fit u64")?,
+                ))
+            }
+            RemoteCatalogObjectKindV1::Reservation => {
+                let reservation = validate_catalog_reservation_payload_v1(
+                    &context.remote_prefix,
+                    object_key,
+                    raw_bytes,
+                )
+                .context("validating reconstructed catalog reservation payload")?;
+                CatalogSemanticObjectV1::Reservation(CatalogSemanticReservationV1 {
+                    exact_path: reservation.exact_path().to_owned(),
+                    folded_path: reservation.folded_path().to_owned(),
+                    role: reservation.role(),
+                    raw_bytes_len: u64::try_from(raw_bytes.len())
+                        .context("reconstructed reservation length does not fit u64")?,
+                })
+            }
+            RemoteCatalogObjectKindV1::Manifest => {
+                CatalogSemanticObjectV1::SuccessorManifest(raw_bytes)
+            }
+        };
+        anyhow::ensure!(
+            semantic_objects
+                .insert(object_key.clone(), semantic)
+                .is_none(),
+            "reconstructed catalog semantic successor contains a duplicate key"
+        );
+    }
+    validate_catalog_semantic_objects_v1(&context.remote_prefix, &semantic_objects)
+        .map_err(|error| anyhow::anyhow!("reconstructed successor closure is invalid: {error:?}"))
+}
+
+async fn reconstruct_archived_catalog_predecessor_v1(
+    storage_authority: &TrustedCatalogStorageAuthorityV1<'_>,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+    context: &CatalogAuthorityContextV1,
+    parent: CatalogHighWaterPointV1,
+    reference: &RemoteCatalogPublicationObjectReferenceWireV1,
+) -> AnyhowResult<(
+    BoundArchivedCatalogHeadV1,
+    Vec<RetainedCatalogPredecessorEntryV1>,
+)> {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let archive_snapshot = read_catalog_publication_artifact_exact_v1(
+        storage_authority,
+        context,
+        reference,
+        ARCHIVED_HEAD_OBJECT_SUFFIX_V1,
+        ARCHIVED_HEAD_OBJECT_DOMAIN_V1,
+        remote.max_catalog_head_object_bytes(),
+    )
+    .await?;
+    anyhow::ensure!(
+        super::catalog_head_revision_v1(archive_snapshot.raw_bytes()) == parent.head_revision,
+        "archived predecessor HEAD revision differs from authenticated Pending lineage"
+    );
+    let closure = match read_verified_remote_catalog_closure_from_archived_head_v1(
+        storage_authority.operator,
+        selected,
+        storage_authority.conditional_write_receipt,
+        archive_snapshot.clone(),
+    )
+    .await?
+    {
+        StrictRemoteCatalogClosureReadV1::Verified(closure) => closure,
+        StrictRemoteCatalogClosureReadV1::Incomplete(_) => {
+            anyhow::bail!("archived predecessor catalog closure is incomplete")
+        }
+    };
+    anyhow::ensure!(
+        closure.remote_prefix() == context.remote_prefix
+            && closure.root_id() == context.root_id
+            && closure.root_identity_fingerprint() == context.root_identity_fingerprint
+            && closure.root_generation() == context.root_generation
+            && closure.profile() == context.profile
+            && closure.profile_settings_fingerprint() == context.profile_settings_fingerprint
+            && closure.plan_contract_fingerprint() == context.plan_contract_fingerprint
+            && closure.catalog_sequence() == parent.sequence
+            && super::catalog_head_revision_v1(archive_snapshot.raw_bytes())
+                == parent.head_revision,
+        "archived predecessor catalog closure crossed its authenticated Pending context"
+    );
+    let archived_head =
+        serde_json::from_slice::<RemoteCatalogHeadWireV1>(archive_snapshot.raw_bytes())
+            .context("parsing canonical archived predecessor HEAD")?;
+    anyhow::ensure!(
+        serde_json::to_vec(&archived_head).ok().as_deref() == Some(archive_snapshot.raw_bytes())
+            && super::parse_lower_hex_32(&archived_head.publication_nonce)
+                == Some(parent.publication_nonce),
+        "archived predecessor catalog HEAD nonce differs from authenticated Pending lineage"
+    );
+
+    let mut predecessor_entries = Vec::new();
+    predecessor_entries
+        .try_reserve(closure.entries().len())
+        .context("reserving archived predecessor catalog inventory")?;
+    for entry in closure.entries() {
+        predecessor_entries.push(RetainedCatalogPredecessorEntryV1 {
+            kind: entry.kind(),
+            object_key: entry.object_key().to_owned(),
+            raw_bytes_len: entry.raw_bytes_len(),
+            raw_blake3: *entry.raw_blake3(),
+            binding: entry.binding().clone(),
+        });
+    }
+    anyhow::ensure!(
+        predecessor_entries
+            .windows(2)
+            .all(|entries| entries[0].object_key < entries[1].object_key),
+        "archived predecessor catalog inventory is not strictly ordered"
+    );
+    let archive_recheck = read_catalog_publication_artifact_exact_v1(
+        storage_authority,
+        context,
+        reference,
+        ARCHIVED_HEAD_OBJECT_SUFFIX_V1,
+        ARCHIVED_HEAD_OBJECT_DOMAIN_V1,
+        remote.max_catalog_head_object_bytes(),
+    )
+    .await?;
+    anyhow::ensure!(
+        archive_recheck == archive_snapshot,
+        "archived predecessor HEAD changed during cold reconstruction"
+    );
+    let object_id = super::parse_lower_hex_32(&reference.object_id)
+        .context("archived predecessor HEAD object ID is invalid")?;
+    let raw_bytes_len = NonZeroU64::new(reference.raw_bytes_len)
+        .context("archived predecessor HEAD cannot be empty")?;
+    let binding = super::validate_binding_wire_v1(&reference.binding)
+        .context("archived predecessor HEAD binding is invalid")?;
+    Ok((
+        BoundArchivedCatalogHeadV1 {
+            context: context.clone(),
+            storage_authority_fingerprint: storage_authority.authority_fingerprint,
+            predecessor_head_revision: parent.head_revision,
+            predecessor_head_bytes_blake3: *blake3::hash(archive_snapshot.raw_bytes()).as_bytes(),
+            object_id,
+            raw_bytes: archive_snapshot.raw_bytes().to_vec(),
+            raw_bytes_len,
+            binding,
+        },
+        predecessor_entries,
+    ))
+}
+
+async fn reconstruct_authoritative_catalog_journal_v1(
+    storage_authority: &TrustedCatalogStorageAuthorityV1<'_>,
+    context: &CatalogAuthorityContextV1,
+    sequence: NonZeroU64,
+    publication_nonce: [u8; 32],
+    parent_head_revision: [u8; 32],
+    reference: &RemoteCatalogPublicationObjectReferenceWireV1,
+    predecessor_entries: Vec<RetainedCatalogPredecessorEntryV1>,
+) -> AnyhowResult<BoundCatalogMutationJournalV1> {
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let journal_snapshot = read_catalog_publication_artifact_exact_v1(
+        storage_authority,
+        context,
+        reference,
+        MUTATION_JOURNAL_OBJECT_SUFFIX_V1,
+        MUTATION_JOURNAL_OBJECT_DOMAIN_V1,
+        remote.max_catalog_page_object_bytes(),
+    )
+    .await?;
+    let raw_bytes = journal_snapshot.raw_bytes().to_vec();
+    let wire = validate_authoritative_catalog_mutation_journal_bytes_v1(
+        &raw_bytes,
+        context,
+        sequence,
+        publication_nonce,
+        parent_head_revision,
+    )
+    .map_err(|error| anyhow::anyhow!("persisted authoritative journal is invalid: {error:?}"))?;
+
+    let predecessor_by_key = predecessor_entries
+        .iter()
+        .map(|entry| (entry.object_key.as_str(), entry))
+        .collect::<BTreeMap<_, _>>();
+    anyhow::ensure!(
+        predecessor_by_key.len() == predecessor_entries.len(),
+        "archived predecessor catalog inventory contains duplicate keys"
+    );
+    let mut successor_payloads = Vec::new();
+    successor_payloads
+        .try_reserve(wire.mutations.len())
+        .context("reserving reconstructed successor payloads")?;
+    for mutation in &wire.mutations {
+        match (&mutation.operation, &mutation.predecessor) {
+            (
+                RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+                RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+            ) => anyhow::ensure!(
+                !predecessor_by_key.contains_key(mutation.object_key.as_str()),
+                "reconstructed create is present in the archived predecessor inventory"
+            ),
+            (
+                RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+                RemoteCatalogMutationPredecessorDraftWireV1::Present {
+                    raw_bytes_len,
+                    raw_blake3,
+                    binding,
+                },
+            ) => {
+                let predecessor = predecessor_by_key
+                    .get(mutation.object_key.as_str())
+                    .context("reconstructed replacement predecessor is missing")?;
+                anyhow::ensure!(
+                    predecessor.kind == mutation.kind
+                        && predecessor.raw_bytes_len == *raw_bytes_len
+                        && lower_hex(&predecessor.raw_blake3) == *raw_blake3
+                        && binding_wire_v1(&predecessor.binding) == *binding,
+                    "reconstructed replacement predecessor differs from the archived inventory"
+                );
+            }
+            _ => anyhow::bail!("reconstructed authoritative mutation operation is invalid"),
+        }
+
+        let payload_reference = RemoteCatalogPublicationObjectReferenceWireV1 {
+            object_id: mutation.successor_payload.object_id.clone(),
+            raw_bytes_len: mutation.successor_payload.raw_bytes_len,
+            binding: mutation.successor_payload.binding.clone(),
+        };
+        let payload_snapshot = read_catalog_publication_artifact_exact_v1(
+            storage_authority,
+            context,
+            &payload_reference,
+            CATALOG_SUCCESSOR_PAYLOAD_OBJECT_SUFFIX_V1,
+            CATALOG_SUCCESSOR_PAYLOAD_OBJECT_DOMAIN_V1,
+            catalog_named_object_max_bytes_v1(mutation.kind),
+        )
+        .await?;
+        let (payload_bytes, payload_blake3, payload_binding) = payload_snapshot.into_parts();
+        let payload_binding = registered_binding_from_raw_v1(payload_binding);
+        let payload_object_id = super::parse_lower_hex_32(&mutation.successor_payload.object_id)
+            .context("reconstructed successor payload object ID is invalid")?;
+        let payload_raw_bytes_len = NonZeroU64::new(mutation.successor_payload.raw_bytes_len)
+            .context("reconstructed successor payload cannot be empty")?;
+        let typed = type_catalog_successor_payload_for_context_v1(
+            context,
+            mutation.kind,
+            mutation.object_key.clone(),
+            payload_bytes.clone(),
+        )
+        .map_err(|error| {
+            anyhow::anyhow!("reconstructed successor payload is invalid: {error:?}")
+        })?;
+        anyhow::ensure!(
+            typed.raw_bytes_len == payload_raw_bytes_len
+                && typed.raw_blake3 == *payload_blake3.as_bytes()
+                && mutation.successor_payload.raw_blake3 == lower_hex(&typed.raw_blake3)
+                && binding_wire_v1(&payload_binding) == mutation.successor_payload.binding,
+            "reconstructed successor payload differs from its authoritative journal"
+        );
+        successor_payloads.push(BoundCatalogSuccessorPayloadV1 {
+            kind: mutation.kind,
+            object_key: mutation.object_key.clone(),
+            object_id: payload_object_id,
+            raw_bytes: Buffer::from(payload_bytes),
+            raw_bytes_len: payload_raw_bytes_len,
+            raw_blake3: typed.raw_blake3,
+            binding: payload_binding,
+        });
+    }
+    validate_reconstructed_successor_semantic_overlay_v1(
+        storage_authority,
+        context,
+        &predecessor_entries,
+        &wire,
+        &successor_payloads,
+    )
+    .await?;
+    let journal_recheck = read_catalog_publication_artifact_exact_v1(
+        storage_authority,
+        context,
+        reference,
+        MUTATION_JOURNAL_OBJECT_SUFFIX_V1,
+        MUTATION_JOURNAL_OBJECT_DOMAIN_V1,
+        remote.max_catalog_page_object_bytes(),
+    )
+    .await?;
+    anyhow::ensure!(
+        journal_recheck == journal_snapshot,
+        "authoritative catalog journal changed during cold reconstruction"
+    );
+    Ok(BoundCatalogMutationJournalV1 {
+        context: context.clone(),
+        storage_authority_fingerprint: storage_authority.authority_fingerprint,
+        catalog_sequence: sequence,
+        publication_nonce,
+        parent_head_revision,
+        object_id: super::parse_lower_hex_32(&reference.object_id)
+            .context("authoritative catalog journal object ID is invalid")?,
+        raw_bytes_len: NonZeroU64::new(reference.raw_bytes_len)
+            .context("authoritative catalog journal cannot be empty")?,
+        raw_bytes,
+        binding: super::validate_binding_wire_v1(&reference.binding)
+            .context("authoritative catalog journal binding is invalid")?,
+        successor_payloads,
+        predecessor_entries,
+    })
+}
+
+async fn revalidate_reconstructed_catalog_publication_artifacts_v1(
+    publication: &PreparedCatalogPublicationFenceV1<'_>,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+) -> AnyhowResult<()> {
+    require_held_control_lease_live_v1(&publication.control_guard).map_err(|error| {
+        anyhow::anyhow!("reacquired catalog control lease is not live: {error:?}")
+    })?;
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let archive_reference = publication_reference_wire_v1(
+        &publication.predecessor_archive.object_id,
+        publication.predecessor_archive.raw_bytes_len,
+        &publication.predecessor_archive.binding,
+    );
+    let archive = read_catalog_publication_artifact_exact_v1(
+        &publication.storage_authority,
+        &publication.context,
+        &archive_reference,
+        ARCHIVED_HEAD_OBJECT_SUFFIX_V1,
+        ARCHIVED_HEAD_OBJECT_DOMAIN_V1,
+        remote.max_catalog_head_object_bytes(),
+    )
+    .await?;
+    anyhow::ensure!(
+        archive.raw_bytes() == publication.predecessor_archive.raw_bytes
+            && *blake3::hash(archive.raw_bytes()).as_bytes()
+                == publication
+                    .predecessor_archive
+                    .predecessor_head_bytes_blake3
+            && super::catalog_head_revision_v1(archive.raw_bytes())
+                == publication.predecessor_archive.predecessor_head_revision,
+        "archived predecessor HEAD changed after Pending-fence reacquisition"
+    );
+    let closure = match read_verified_remote_catalog_closure_from_archived_head_v1(
+        publication.storage_authority.operator,
+        selected,
+        publication.storage_authority.conditional_write_receipt,
+        archive.clone(),
+    )
+    .await?
+    {
+        StrictRemoteCatalogClosureReadV1::Verified(closure) => closure,
+        StrictRemoteCatalogClosureReadV1::Incomplete(_) => {
+            anyhow::bail!(
+                "archived predecessor catalog closure became incomplete after Pending-fence reacquisition"
+            )
+        }
+    };
+    anyhow::ensure!(
+        closure.remote_prefix() == publication.context.remote_prefix
+            && closure.root_id() == publication.context.root_id
+            && closure.root_identity_fingerprint() == publication.context.root_identity_fingerprint
+            && closure.root_generation() == publication.context.root_generation
+            && closure.profile() == publication.context.profile
+            && closure.profile_settings_fingerprint()
+                == publication.context.profile_settings_fingerprint
+            && closure.plan_contract_fingerprint() == publication.context.plan_contract_fingerprint
+            && closure.catalog_sequence()
+                == publication
+                    .control_guard
+                    .high_water
+                    .binding
+                    .current
+                    .sequence
+            && closure.entries().len() == publication.mutation_journal.predecessor_entries.len()
+            && closure
+                .entries()
+                .zip(publication.mutation_journal.predecessor_entries.iter())
+                .all(|(observed, expected)| {
+                    observed.kind() == expected.kind
+                        && observed.object_key() == expected.object_key
+                        && observed.raw_bytes_len() == expected.raw_bytes_len
+                        && observed.raw_blake3() == &expected.raw_blake3
+                        && observed.binding() == &expected.binding
+                }),
+        "archived predecessor root/page closure changed after Pending-fence reacquisition"
+    );
+
+    let journal_reference = publication_reference_wire_v1(
+        &publication.mutation_journal.object_id,
+        publication.mutation_journal.raw_bytes_len,
+        &publication.mutation_journal.binding,
+    );
+    let journal = read_catalog_publication_artifact_exact_v1(
+        &publication.storage_authority,
+        &publication.context,
+        &journal_reference,
+        MUTATION_JOURNAL_OBJECT_SUFFIX_V1,
+        MUTATION_JOURNAL_OBJECT_DOMAIN_V1,
+        remote.max_catalog_page_object_bytes(),
+    )
+    .await?;
+    anyhow::ensure!(
+        journal.raw_bytes() == publication.mutation_journal.raw_bytes,
+        "authoritative catalog journal changed after Pending-fence reacquisition"
+    );
+    let journal_wire = validate_authoritative_catalog_mutation_journal_bytes_v1(
+        &publication.mutation_journal.raw_bytes,
+        &publication.context,
+        publication.sequence,
+        publication.publication_nonce,
+        publication.parent_head_revision,
+    )
+    .map_err(|error| {
+        anyhow::anyhow!(
+            "authoritative catalog journal became invalid after Pending-fence reacquisition: {error:?}"
+        )
+    })?;
+    let mutation_keys = journal_wire
+        .mutations
+        .iter()
+        .map(|mutation| mutation.object_key.as_str())
+        .collect::<BTreeSet<_>>();
+    anyhow::ensure!(
+        mutation_keys.len() == journal_wire.mutations.len(),
+        "authoritative catalog journal gained duplicate keys after Pending-fence reacquisition"
+    );
+    for payload in &publication.mutation_journal.successor_payloads {
+        let reference = RemoteCatalogPublicationObjectReferenceWireV1 {
+            object_id: lower_hex(&payload.object_id),
+            raw_bytes_len: payload.raw_bytes_len.get(),
+            binding: binding_wire_v1(&payload.binding),
+        };
+        let observed = read_catalog_publication_artifact_exact_v1(
+            &publication.storage_authority,
+            &publication.context,
+            &reference,
+            CATALOG_SUCCESSOR_PAYLOAD_OBJECT_SUFFIX_V1,
+            CATALOG_SUCCESSOR_PAYLOAD_OBJECT_DOMAIN_V1,
+            catalog_named_object_max_bytes_v1(payload.kind),
+        )
+        .await?;
+        let payload_bytes = payload.raw_bytes.current();
+        anyhow::ensure!(
+            observed.raw_bytes() == payload_bytes.as_ref()
+                && *blake3::hash(observed.raw_bytes()).as_bytes() == payload.raw_blake3,
+            "catalog successor payload changed after Pending-fence reacquisition: {}",
+            payload.object_key
+        );
+    }
+    for predecessor in &publication.mutation_journal.predecessor_entries {
+        if !mutation_keys.contains(predecessor.object_key.as_str()) {
+            read_reconstructed_named_object_exact_v1(&publication.storage_authority, predecessor)
+                .await
+                .with_context(|| {
+                    format!(
+                        "revalidating unchanged predecessor after Pending-fence reacquisition: {}",
+                        predecessor.object_key
+                    )
+                })?;
+        }
+    }
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("reacquired catalog control lease is not live: {error:?}"))
 }
 
 async fn publish_immutable_catalog_artifact_if_absent_exact_v1(
@@ -2742,6 +3541,7 @@ pub(crate) async fn publish_predecessor_head_archive_v1(
         predecessor_head_bytes_blake3: *blake3::hash(&prerequisites.committed_head_bytes)
             .as_bytes(),
         object_id,
+        raw_bytes: prerequisites.committed_head_bytes.clone(),
         raw_bytes_len,
         binding,
     })
@@ -2833,7 +3633,7 @@ pub(crate) struct PreparedCatalogPublicationFenceV1<'a> {
     sequence: NonZeroU64,
     publication_nonce: [u8; 32],
     parent_head_revision: [u8; 32],
-    expected_parent_head_etag: String,
+    expected_parent_head_binding: RegisteredRootRemoteObjectBindingV1,
     bootstrap_head_revision: [u8; 32],
     predecessor_archive: BoundArchivedCatalogHeadV1,
     mutation_journal: BoundCatalogMutationJournalV1,
@@ -2893,6 +3693,7 @@ fn validate_catalog_successor_claim_v1<'a>(
         || predecessor_archive.predecessor_head_revision != prerequisites.head_revision
         || predecessor_archive.predecessor_head_bytes_blake3 != predecessor_bytes_blake3
         || predecessor_archive.object_id != predecessor_object_id
+        || predecessor_archive.raw_bytes != prerequisites.committed_head_bytes
         || predecessor_archive.raw_bytes_len.get() != predecessor_raw_bytes_len
         || archived_head_object_key_v1(&predecessor_archive).is_none()
         || super::validate_binding_wire_v1(&binding_wire_v1(&predecessor_archive.binding)).is_none()
@@ -2927,7 +3728,7 @@ fn validate_catalog_successor_claim_v1<'a>(
             .expect("checked nonzero successor of a nonzero sequence"),
         publication_nonce: claim.publication_nonce,
         parent_head_revision: claim.parent_head_revision,
-        expected_parent_head_etag: prerequisites.current_head_etag,
+        expected_parent_head_binding: prerequisites.current_head_binding,
         bootstrap_head_revision: prerequisites.bootstrap_head_revision,
         predecessor_archive,
         mutation_journal,
@@ -3002,6 +3803,51 @@ impl std::fmt::Debug for BoundPendingCatalogControlV1<'_> {
                 &self.transition.pending_revision.generation,
             )
             .finish_non_exhaustive()
+    }
+}
+
+/// Authenticated cold-recovery result after replaying the persisted Pending
+/// epoch against the backend's durable receipt ledger.
+pub(crate) enum ReconstructedCatalogPublicationV1<'a> {
+    /// Publishing HEAD is exact and the complete namespace journal has an
+    /// authenticated applied prefix. Final committed-HEAD publication remains.
+    Applied(Box<AppliedCatalogNamespaceMutationsV1<'a>>),
+    /// The exact committed closure and terminal fenced receipt were recovered.
+    Committed(Box<BoundCommittedCatalogSuccessorV1>),
+}
+
+/// Failed cold replay retaining the exact reacquired Pending capability.
+///
+/// Backend receipt progress is durable; retry starts from ordinal zero and
+/// cannot substitute saved raw-object observations for authenticated receipts.
+pub(crate) struct FailedCatalogPublicationReconstructionV1<'a> {
+    pending: BoundPendingCatalogControlV1<'a>,
+    error: anyhow::Error,
+}
+
+impl std::fmt::Debug for FailedCatalogPublicationReconstructionV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FailedCatalogPublicationReconstructionV1")
+            .field("sequence", &self.pending.transition.publication.sequence)
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for FailedCatalogPublicationReconstructionV1<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if formatter.alternate() {
+            write!(formatter, "{:#}", self.error)
+        } else {
+            std::fmt::Display::fmt(&self.error, formatter)
+        }
+    }
+}
+
+impl std::error::Error for FailedCatalogPublicationReconstructionV1<'_> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error.as_ref())
     }
 }
 
@@ -3135,6 +3981,54 @@ impl std::error::Error for FailedCatalogNamespaceMutationsV1<'_> {
 
 const CATALOG_BUFFER_VALIDATION_CHUNK_BYTES_V1: usize = 64 * 1024;
 
+fn catalog_pending_fence_reacquisition_request_wire_v1(
+    request: &CatalogPendingFenceReacquisitionRequestV1,
+) -> CatalogPendingFenceReacquisitionRequestWireV1 {
+    let binding = &request.control_binding;
+    CatalogPendingFenceReacquisitionRequestWireV1 {
+        version: CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1,
+        context: binding.context.to_wire(),
+        storage_authority_fingerprint: lower_hex(&binding.storage_authority_fingerprint),
+        control_authority_fingerprint: lower_hex(&binding.control_authority_fingerprint),
+        writer_epoch: lower_hex(&binding.bootstrap.writer_epoch),
+        ready_control_generation: binding.ready_revision.generation.get(),
+        ready_control_revision_fingerprint: lower_hex(&binding.ready_revision.fingerprint),
+        control_lease_public_fingerprint: lower_hex(&binding.lease_public_fingerprint.0),
+        pending_control_generation: request.pending_revision.generation.get(),
+        pending_control_revision_fingerprint: lower_hex(&request.pending_revision.fingerprint),
+        pending_control_record_fingerprint: lower_hex(&request.pending_control_record_fingerprint),
+        canonical_pending_control_record_bytes_len: u64::try_from(
+            request.canonical_pending_control_record_bytes.len(),
+        )
+        .unwrap_or(u64::MAX),
+        canonical_pending_control_record_blake3: lower_hex(
+            blake3::hash(&request.canonical_pending_control_record_bytes).as_bytes(),
+        ),
+        publishing_head_reservation_fingerprint: lower_hex(
+            &request.publishing_head_reservation_fingerprint,
+        ),
+        writer_fence_authority_revision_fingerprint: lower_hex(
+            &request.writer_fence_authority_revision_fingerprint,
+        ),
+        writer_fence_lease_public_fingerprint: lower_hex(
+            &request.writer_fence_lease_public_fingerprint.0,
+        ),
+    }
+}
+
+fn catalog_pending_fence_reacquisition_request_fingerprint_v1(
+    request: &CatalogPendingFenceReacquisitionRequestV1,
+) -> AnyhowResult<[u8; 32]> {
+    let canonical = serde_json::to_vec(&catalog_pending_fence_reacquisition_request_wire_v1(
+        request,
+    ))
+    .context("serializing canonical Pending-fence reacquisition request")?;
+    Ok(super::domain_object_id_v1(
+        PENDING_FENCE_REACQUISITION_REQUEST_DOMAIN_V1,
+        &canonical,
+    ))
+}
+
 fn catalog_buffer_blake3_v1(buffer: &Buffer) -> [u8; 32] {
     let mut hasher = blake3::Hasher::new();
     for chunk in buffer.chunks(CATALOG_BUFFER_VALIDATION_CHUNK_BYTES_V1) {
@@ -3249,6 +4143,8 @@ fn catalog_fenced_storage_write_request_v1(
         .checked_add(1)
         .context("catalog fenced-storage committed ordinal overflow")?;
     let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let expected_parent_head_etag = mutable_head_etag_v1(&publication.expected_parent_head_binding)
+        .context("catalog predecessor HEAD binding has no usable ETag")?;
     match stage {
         CatalogFencedStorageWriteStageV1::PublishingHead => {
             anyhow::ensure!(
@@ -3260,7 +4156,7 @@ fn catalog_fenced_storage_write_request_v1(
                     )
                     && condition
                         == CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
-                            etag: publication.expected_parent_head_etag.clone(),
+                            etag: expected_parent_head_etag,
                         },
                 "publishing HEAD request is not the exact first fenced transition"
             );
@@ -3460,8 +4356,77 @@ async fn execute_catalog_fenced_storage_write_v1(
     Ok(receipt.binding)
 }
 
+async fn replay_catalog_fenced_storage_receipt_v1(
+    pending: &BoundPendingCatalogControlV1<'_>,
+    request: CatalogFencedStorageWriteRequestV1,
+) -> AnyhowResult<RegisteredRootRemoteObjectBindingV1> {
+    anyhow::ensure!(
+        catalog_fenced_storage_write_request_fingerprint_v1(
+            &catalog_fenced_storage_write_request_wire_v1(&request),
+        )? == request.request_fingerprint
+            && u64::try_from(request.successor_raw_bytes.len()).ok()
+                == Some(request.successor_raw_bytes_len.get())
+            && catalog_buffer_blake3_v1(&request.successor_raw_bytes)
+                == request.successor_raw_blake3,
+        "catalog fenced-storage receipt replay request fingerprint or payload identity changed"
+    );
+    let expected_control_binding = request.control_binding.clone();
+    let expected_pending_revision = request.pending_revision;
+    let expected_pending_record_fingerprint = request.pending_control_record_fingerprint;
+    let expected_ordinal = request.ordinal;
+    let expected_request_fingerprint = request.request_fingerprint;
+    let expected_stage = request.stage;
+    let receipt = pending
+        .transition
+        .publication
+        .control_guard
+        .all_writers
+        .retained_control_lease
+        .liveness
+        .replay_fenced_receipt_v1(request)
+        .await
+        .context("replaying an existing catalog storage-fence receipt without storage I/O")?;
+    anyhow::ensure!(
+        receipt.control_binding == expected_control_binding
+            && receipt.pending_revision == expected_pending_revision
+            && receipt.pending_control_record_fingerprint == expected_pending_record_fingerprint
+            && receipt.ordinal == expected_ordinal
+            && receipt.request_fingerprint == expected_request_fingerprint
+            && super::validate_binding_wire_v1(&binding_wire_v1(&receipt.binding)).is_some()
+            && (!matches!(
+                expected_stage,
+                CatalogFencedStorageWriteStageV1::PublishingHead
+                    | CatalogFencedStorageWriteStageV1::CommittedHead
+                    | CatalogFencedStorageWriteStageV1::NamespaceIndex
+            ) || mutable_head_etag_v1(&receipt.binding).is_some()),
+        "storage-enforced catalog fence returned a crossed or unusable replay receipt"
+    );
+    Ok(receipt.binding)
+}
+
 fn wire_binding_etag_v1(binding: &RemoteCatalogObjectBindingWireV1) -> Option<&str> {
     binding.etag.as_deref().filter(|etag| !etag.is_empty())
+}
+
+fn catalog_namespace_write_condition_v1(
+    mutation: &RemoteCatalogFactBoundMutationWireV1,
+) -> AnyhowResult<CatalogFencedStorageWriteConditionV1> {
+    match (&mutation.operation, &mutation.predecessor) {
+        (
+            RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+            RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+        ) => Ok(CatalogFencedStorageWriteConditionV1::CreateIfAbsent),
+        (
+            RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+            RemoteCatalogMutationPredecessorDraftWireV1::Present { binding, .. },
+        ) => Ok(CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+            etag: wire_binding_etag_v1(binding)
+                .filter(|etag| *etag != "null")
+                .context("authoritative replacement predecessor has no usable ETag")?
+                .to_owned(),
+        }),
+        _ => anyhow::bail!("authoritative catalog journal contains an invalid operation"),
+    }
 }
 
 async fn require_namespace_mutation_capability_live_v1(
@@ -3504,6 +4469,64 @@ async fn require_namespace_mutation_capability_live_v1(
     Ok(())
 }
 
+fn catalog_publishing_head_request_v1(
+    pending: &BoundPendingCatalogControlV1<'_>,
+) -> AnyhowResult<CatalogFencedStorageWriteRequestV1> {
+    let transition = &pending.transition;
+    let publication = &transition.publication;
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    anyhow::ensure!(
+        publication
+            .storage_authority
+            .conditional_write_receipt
+            .authorizes(
+                publication.storage_authority.operator,
+                &publication.context.remote_prefix,
+            )?,
+        "publishing HEAD replay lost its exact accessor/prefix conditional-semantics authority"
+    );
+    let expected_bytes =
+        canonical_publishing_head_bytes_v1(publication, transition.pending_revision);
+    let expected_reservation =
+        super::domain_object_id_v1(PUBLISHING_HEAD_RESERVATION_DOMAIN_V1, &expected_bytes);
+    let expected_parent_head_etag = mutable_head_etag_v1(&publication.expected_parent_head_binding)
+        .context("catalog predecessor HEAD binding has no usable ETag")?;
+    anyhow::ensure!(
+        transition.canonical_publishing_head_bytes == expected_bytes
+            && transition.publishing_head_reservation_fingerprint == expected_reservation,
+        "publishing HEAD proposal no longer matches its exact pending transition"
+    );
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    catalog_fenced_storage_write_request_v1(
+        pending,
+        CatalogFencedStorageWriteStageV1::PublishingHead,
+        0,
+        head_key,
+        CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
+            etag: expected_parent_head_etag,
+        },
+        Buffer::from(expected_bytes),
+    )
+}
+
+async fn execute_or_replay_catalog_publishing_head_v1(
+    pending: &BoundPendingCatalogControlV1<'_>,
+) -> AnyhowResult<RegisteredRootRemoteObjectBindingV1> {
+    let request = catalog_publishing_head_request_v1(pending)?;
+    let binding = execute_catalog_fenced_storage_write_v1(pending, request)
+        .await
+        .context("replaying the catalog publishing HEAD through the monotonic fence")?;
+    anyhow::ensure!(
+        super::validate_binding_wire_v1(&binding_wire_v1(&binding)).is_some()
+            && mutable_head_etag_v1(&binding).is_some(),
+        "authenticated publishing HEAD receipt has no usable exact mutable-object binding"
+    );
+    require_held_control_lease_live_v1(&pending.transition.publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    Ok(binding)
+}
+
 /// Atomically replace the exact committed predecessor HEAD with the canonical
 /// publishing fence, then rebind the exact visible bytes through the same
 /// accessor while retaining the live lease.
@@ -3516,48 +4539,10 @@ pub(crate) async fn install_catalog_publishing_head_v1<'a>(
     pending: BoundPendingCatalogControlV1<'a>,
 ) -> Result<CatalogNamespaceMutationCapabilityV1<'a>, CatalogPublishingHeadInstallFailureV1<'a>> {
     let result: AnyhowResult<RegisteredRootRemoteObjectBindingV1> = async {
-        let transition = &pending.transition;
-        let publication = &transition.publication;
-        require_held_control_lease_live_v1(&publication.control_guard)
-            .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
-        anyhow::ensure!(
-            publication
-                .storage_authority
-                .conditional_write_receipt
-                .authorizes(
-                    publication.storage_authority.operator,
-                    &publication.context.remote_prefix,
-                )?,
-            "publishing HEAD install lost its exact accessor/prefix conditional-semantics authority"
-        );
-        let expected_bytes =
-            canonical_publishing_head_bytes_v1(publication, transition.pending_revision);
-        let expected_reservation = super::domain_object_id_v1(
-            PUBLISHING_HEAD_RESERVATION_DOMAIN_V1,
-            &expected_bytes,
-        );
-        anyhow::ensure!(
-            transition.canonical_publishing_head_bytes == expected_bytes
-                && transition.publishing_head_reservation_fingerprint == expected_reservation
-                && !publication.expected_parent_head_etag.is_empty(),
-            "publishing HEAD proposal no longer matches its exact pending transition"
-        );
+        let publication = &pending.transition.publication;
+        let expected_bytes = &pending.transition.canonical_publishing_head_bytes;
         let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
-        let request = catalog_fenced_storage_write_request_v1(
-            &pending,
-            CatalogFencedStorageWriteStageV1::PublishingHead,
-            0,
-            head_key.clone(),
-            CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
-                etag: publication.expected_parent_head_etag.clone(),
-            },
-            Buffer::from(expected_bytes.clone()),
-        )?;
-        let fenced_binding = execute_catalog_fenced_storage_write_v1(&pending, request)
-            .await
-            .with_context(|| {
-                format!("installing catalog publishing HEAD through the monotonic fence: {head_key}")
-            })?;
+        let fenced_binding = execute_or_replay_catalog_publishing_head_v1(&pending).await?;
         let max_bytes = RegisteredRootPlanContractV1::strict_v1()
             .remote_contract()
             .max_catalog_head_object_bytes();
@@ -3572,7 +4557,8 @@ pub(crate) async fn install_catalog_publishing_head_v1<'a>(
             Some(RawObjectReadV1::Bound(snapshot)) => {
                 let (raw_bytes, _, binding) = snapshot.into_parts();
                 let binding = registered_binding_from_raw_v1(binding);
-                (raw_bytes == expected_bytes && binding == fenced_binding).then_some(binding)
+                (raw_bytes.as_slice() == expected_bytes.as_slice() && binding == fenced_binding)
+                    .then_some(binding)
             }
             None | Some(RawObjectReadV1::Unbound) => None,
         };
@@ -3581,11 +4567,6 @@ pub(crate) async fn install_catalog_publishing_head_v1<'a>(
                 "catalog publishing HEAD differs from its authenticated fenced-write receipt: {head_key}"
             );
         };
-        anyhow::ensure!(
-            super::validate_binding_wire_v1(&binding_wire_v1(&binding)).is_some()
-                && mutable_head_etag_v1(&binding).is_some(),
-            "installed publishing HEAD has no usable exact mutable-object binding"
-        );
         require_held_control_lease_live_v1(&publication.control_guard)
             .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
         Ok(binding)
@@ -3690,21 +4671,7 @@ async fn apply_one_catalog_namespace_mutation_v1(
     );
 
     require_namespace_mutation_capability_live_v1(capability).await?;
-    let condition = match (&mutation.operation, &mutation.predecessor) {
-        (
-            RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
-            RemoteCatalogMutationPredecessorDraftWireV1::Absent,
-        ) => CatalogFencedStorageWriteConditionV1::CreateIfAbsent,
-        (
-            RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
-            RemoteCatalogMutationPredecessorDraftWireV1::Present { binding, .. },
-        ) => CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
-            etag: wire_binding_etag_v1(binding)
-                .context("authoritative replacement predecessor has no usable ETag")?
-                .to_owned(),
-        },
-        _ => anyhow::bail!("authoritative catalog journal contains an invalid operation"),
-    };
+    let condition = catalog_namespace_write_condition_v1(mutation)?;
     let request = catalog_fenced_storage_write_request_v1(
         &capability.pending,
         CatalogFencedStorageWriteStageV1::for_namespace_kind(mutation.kind),
@@ -3913,6 +4880,18 @@ impl std::error::Error for FailedCatalogCommittedFinalizationV1<'_> {
 struct PublishedCatalogSuccessorClosureV1 {
     committed_head_bytes: Vec<u8>,
     head_revision: [u8; 32],
+    committed_head_fenced_request_fingerprint: [u8; 32],
+    committed_head_binding: RegisteredRootRemoteObjectBindingV1,
+}
+
+/// Fully validated raw committed closure that still carries no terminal
+/// storage-fence authority.
+///
+/// This observation cannot be converted into a published successor until the
+/// exact durable terminal receipt is replayed through the opaque backend.
+struct ProvisionalObservedCatalogSuccessorV1 {
+    committed_head_bytes: Vec<u8>,
+    head_revision: [u8; 32],
     committed_head_binding: RegisteredRootRemoteObjectBindingV1,
 }
 
@@ -4105,21 +5084,11 @@ async fn publish_catalog_successor_immutable_v1(
     Ok(binding)
 }
 
-/// Execute or exactly replay the terminal committed-HEAD mutation through the
-/// retained storage fence, then prove the currently visible bytes and binding
-/// equal that authenticated receipt.
-///
-/// This deliberately does not require the visible HEAD still to be
-/// `Publishing`: recovery after an apply-before-response failure observes the
-/// committed bytes first, then must replay this exact terminal request to
-/// recover the backend receipt. A raw committed closure cannot satisfy this
-/// helper by itself.
-async fn execute_and_revalidate_catalog_committed_head_v1(
+fn catalog_committed_head_request_v1(
     capability: &CatalogNamespaceMutationCapabilityV1<'_>,
     committed_head_bytes: &[u8],
-) -> AnyhowResult<RegisteredRootRemoteObjectBindingV1> {
+) -> AnyhowResult<CatalogFencedStorageWriteRequestV1> {
     let publication = &capability.pending.transition.publication;
-    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
     let publishing_etag = mutable_head_etag_v1(&capability.publishing_head_binding)
         .context("visible publishing HEAD has no usable ETag")?;
     let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
@@ -4127,7 +5096,7 @@ async fn execute_and_revalidate_catalog_committed_head_v1(
         .context("catalog mutation count does not fit u64")?
         .checked_add(1)
         .context("catalog committed ordinal overflow")?;
-    let request = catalog_fenced_storage_write_request_v1(
+    catalog_fenced_storage_write_request_v1(
         &capability.pending,
         CatalogFencedStorageWriteStageV1::CommittedHead,
         committed_ordinal,
@@ -4136,7 +5105,27 @@ async fn execute_and_revalidate_catalog_committed_head_v1(
             etag: publishing_etag,
         },
         Buffer::from(committed_head_bytes.to_vec()),
-    )?;
+    )
+}
+
+/// Execute or exactly replay the terminal committed-HEAD mutation through the
+/// retained storage fence, then prove the currently visible bytes and binding
+/// equal that authenticated receipt.
+///
+/// This deliberately does not require the visible HEAD still to be
+/// `Publishing`: warm recovery after an apply-before-response failure observes
+/// the committed bytes first, then replays this exact terminal request. Cold
+/// recovery uses the receipt-only sibling and cannot backfill missing
+/// authority from raw storage.
+async fn execute_and_revalidate_catalog_committed_head_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+    committed_head_bytes: &[u8],
+) -> AnyhowResult<([u8; 32], RegisteredRootRemoteObjectBindingV1)> {
+    let publication = &capability.pending.transition.publication;
+    let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let request = catalog_committed_head_request_v1(capability, committed_head_bytes)?;
+    let committed_head_fenced_request_fingerprint = request.request_fingerprint;
     let fenced_binding = execute_catalog_fenced_storage_write_v1(&capability.pending, request)
         .await
         .with_context(|| {
@@ -4168,7 +5157,10 @@ async fn execute_and_revalidate_catalog_committed_head_v1(
     );
     require_held_control_lease_live_v1(&publication.control_guard)
         .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
-    Ok(committed_head_binding)
+    Ok((
+        committed_head_fenced_request_fingerprint,
+        committed_head_binding,
+    ))
 }
 
 async fn publish_catalog_successor_closure_v1(
@@ -4179,6 +5171,14 @@ async fn publish_catalog_successor_closure_v1(
     let publication = &capability.pending.transition.publication;
     let entries = complete_successor_catalog_entries_v1(applied)?;
     let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let mut successor_budget = super::RemoteCatalogBudgetV1::default();
+    for entry in &entries {
+        successor_budget.observe_entry(entry).map_err(|error| {
+            anyhow::anyhow!(
+                "successor catalog entries exceed the strict-reader inventory budget: {error:?}"
+            )
+        })?;
+    }
     let max_entries_per_page = usize::try_from(remote.max_catalog_entries_per_page())
         .context("catalog entries-per-page bound does not fit usize")?;
     anyhow::ensure!(
@@ -4229,12 +5229,24 @@ async fn publish_catalog_successor_closure_v1(
             remote.max_catalog_page_object_bytes(),
         )
         .await?;
+        let binding_wire = binding_wire_v1(&binding);
+        successor_budget
+            .observe_page(
+                u64::try_from(page_bytes.len())
+                    .context("successor catalog page length does not fit u64")?,
+                &binding_wire,
+            )
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "successor catalog pages exceed the strict-reader closure budget: {error:?}"
+                )
+            })?;
         page_references.push(RemoteCatalogPageReferenceWireV1 {
             ordinal,
             object_id: lower_hex(&page_object_id),
             raw_bytes_len: u64::try_from(page_bytes.len())
                 .context("successor catalog page length does not fit u64")?,
-            binding: binding_wire_v1(&binding),
+            binding: binding_wire,
             entry_count,
             entry_key_bytes,
         });
@@ -4286,6 +5298,17 @@ async fn publish_catalog_successor_closure_v1(
         remote.max_catalog_root_object_bytes(),
     )
     .await?;
+    successor_budget
+        .observe_root(
+            u64::try_from(root_bytes.len())
+                .context("successor catalog root length does not fit u64")?,
+            &binding_wire_v1(&root_binding),
+        )
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "successor catalog root exceeds the strict-reader closure budget: {error:?}"
+            )
+        })?;
     require_namespace_mutation_capability_live_v1(capability).await?;
 
     let committed_head = RemoteCatalogHeadWireV1 {
@@ -4312,12 +5335,13 @@ async fn publish_catalog_successor_closure_v1(
             .is_some_and(|len| len <= remote.max_catalog_head_object_bytes()),
         "committed catalog HEAD exceeds the object bound"
     );
-    let committed_head_binding =
+    let (committed_head_fenced_request_fingerprint, committed_head_binding) =
         execute_and_revalidate_catalog_committed_head_v1(capability, &committed_head_bytes).await?;
     let head_revision = super::catalog_head_revision_v1(&committed_head_bytes);
     Ok(PublishedCatalogSuccessorClosureV1 {
         committed_head_bytes,
         head_revision,
+        committed_head_fenced_request_fingerprint,
         committed_head_binding,
     })
 }
@@ -4385,13 +5409,51 @@ fn bind_committed_catalog_successor_v1(
         parent_head_revision: publication.parent_head_revision,
         head_revision: published.head_revision,
         committed_head_bytes: published.committed_head_bytes,
+        committed_head_fenced_request_fingerprint: published
+            .committed_head_fenced_request_fingerprint,
         committed_head_binding: published.committed_head_binding,
     }
 }
 
 enum CatalogCommittedRecoveryStateV1 {
     Publishing,
-    Committed(PublishedCatalogSuccessorClosureV1),
+    Committed(ProvisionalObservedCatalogSuccessorV1),
+}
+
+#[derive(Default)]
+struct CatalogCommittedRecoveryTotalsV1 {
+    entry_count: u64,
+    entry_key_bytes: u64,
+}
+
+impl CatalogCommittedRecoveryTotalsV1 {
+    fn observe_page(
+        &mut self,
+        page_entry_count: u64,
+        page_entry_key_bytes: u64,
+        advertised_entry_count: u64,
+        advertised_entry_key_bytes: u64,
+    ) -> AnyhowResult<()> {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let next_entry_count = self
+            .entry_count
+            .checked_add(page_entry_count)
+            .context("committed catalog entry count overflow")?;
+        let next_entry_key_bytes = self
+            .entry_key_bytes
+            .checked_add(page_entry_key_bytes)
+            .context("committed catalog entry-key total overflow")?;
+        anyhow::ensure!(
+            next_entry_count <= advertised_entry_count
+                && next_entry_count <= remote.max_catalog_entries()
+                && next_entry_key_bytes <= advertised_entry_key_bytes
+                && next_entry_key_bytes <= remote.max_catalog_entry_key_bytes(),
+            "committed catalog page totals exceed the advertised bounded root totals"
+        );
+        self.entry_count = next_entry_count;
+        self.entry_key_bytes = next_entry_key_bytes;
+        Ok(())
+    }
 }
 
 async fn classify_catalog_committed_recovery_state_v1(
@@ -4502,18 +5564,71 @@ async fn classify_catalog_committed_recovery_state_v1(
             && root.page_count == head.catalog_root.page_count
             && root.page_count <= remote.max_catalog_pages()
             && root.entry_count == head.catalog_root.entry_count
-            && root.entry_key_bytes == head.catalog_root.entry_key_bytes,
+            && root.entry_count <= remote.max_catalog_entries()
+            && root.entry_key_bytes == head.catalog_root.entry_key_bytes
+            && root.entry_key_bytes <= remote.max_catalog_entry_key_bytes(),
         "committed catalog root lineage or totals are invalid"
     );
 
-    let mut observed_entries = Vec::new();
-    let expected_capacity =
-        usize::try_from(root.entry_count).context("committed entry count does not fit usize")?;
-    observed_entries
-        .try_reserve(expected_capacity)
-        .context("reserving committed recovery entries")?;
-    let mut total_entry_count = 0_u64;
-    let mut total_entry_key_bytes = 0_u64;
+    let expected_entry_count = u64::try_from(expected_entries.len())
+        .context("expected committed entry count does not fit u64")?;
+    let expected_entry_key_bytes = expected_entries.iter().try_fold(0_u64, |total, entry| {
+        total
+            .checked_add(
+                u64::try_from(entry.object_key.len())
+                    .context("expected committed entry key length does not fit u64")?,
+            )
+            .context("expected committed entry-key total overflow")
+    })?;
+    anyhow::ensure!(
+        expected_entry_count == root.entry_count
+            && expected_entry_key_bytes == root.entry_key_bytes,
+        "committed catalog root totals differ from the complete applied successor inventory"
+    );
+
+    // Charge the exact root plus every advertised page length/binding before
+    // the first page read. A set of individually bounded references must not
+    // force tens of GiB of reads before the aggregate closure limit fails.
+    let mut resource_budget = super::RemoteCatalogBudgetV1::default();
+    resource_budget
+        .observe_root(
+            u64::try_from(root_bytes.len())
+                .context("committed catalog root length does not fit u64")?,
+            &head.catalog_root.binding,
+        )
+        .map_err(|error| anyhow::anyhow!("committed catalog root exceeds its budget: {error:?}"))?;
+    let mut referenced_totals = CatalogCommittedRecoveryTotalsV1::default();
+    for (ordinal, reference) in root.pages.iter().enumerate() {
+        anyhow::ensure!(
+            reference.ordinal == u64::try_from(ordinal).unwrap_or(u64::MAX)
+                && super::parse_lower_hex_32(&reference.object_id).is_some()
+                && reference.raw_bytes_len > 0
+                && reference.raw_bytes_len <= remote.max_catalog_page_object_bytes()
+                && reference.entry_count <= remote.max_catalog_entries_per_page()
+                && super::validate_binding_wire_v1(&reference.binding).is_some(),
+            "committed catalog page reference is invalid"
+        );
+        referenced_totals.observe_page(
+            reference.entry_count,
+            reference.entry_key_bytes,
+            root.entry_count,
+            root.entry_key_bytes,
+        )?;
+        resource_budget
+            .observe_page(reference.raw_bytes_len, &reference.binding)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "committed catalog page references exceed the aggregate closure budget: {error:?}"
+                )
+            })?;
+    }
+    anyhow::ensure!(
+        referenced_totals.entry_count == root.entry_count
+            && referenced_totals.entry_key_bytes == root.entry_key_bytes,
+        "committed catalog page references do not exhaust the advertised root totals"
+    );
+
+    let mut expected_entry_offset = 0_usize;
     for (ordinal, reference) in root.pages.iter().enumerate() {
         let ordinal = u64::try_from(ordinal).context("catalog page ordinal does not fit u64")?;
         let page_object_id = super::parse_lower_hex_32(&reference.object_id)
@@ -4584,18 +5699,25 @@ async fn classify_catalog_committed_recovery_state_v1(
                 }),
             "committed catalog page lineage, order, or totals are invalid"
         );
-        total_entry_count = total_entry_count
-            .checked_add(page.entry_count)
-            .context("committed catalog entry count overflow")?;
-        total_entry_key_bytes = total_entry_key_bytes
-            .checked_add(page.entry_key_bytes)
-            .context("committed catalog entry-key total overflow")?;
-        observed_entries.extend(page.entries);
+        for entry in &page.entries {
+            resource_budget.observe_entry(entry).map_err(|error| {
+                anyhow::anyhow!(
+                    "committed catalog page entries exceed the aggregate inventory budget: {error:?}"
+                )
+            })?;
+        }
+        let next_expected_entry_offset = expected_entry_offset
+            .checked_add(page.entries.len())
+            .context("committed recovery expected-entry offset overflow")?;
+        anyhow::ensure!(
+            expected_entries.get(expected_entry_offset..next_expected_entry_offset)
+                == Some(page.entries.as_slice()),
+            "committed catalog page does not equal its ordered applied-successor slice"
+        );
+        expected_entry_offset = next_expected_entry_offset;
     }
     anyhow::ensure!(
-        total_entry_count == root.entry_count
-            && total_entry_key_bytes == root.entry_key_bytes
-            && observed_entries == expected_entries,
+        expected_entry_offset == expected_entries.len(),
         "committed catalog closure does not equal the complete applied successor inventory"
     );
 
@@ -4627,10 +5749,28 @@ async fn classify_catalog_committed_recovery_state_v1(
             entry.object_key
         );
     }
+    let observed_head_again = read_raw_object_snapshot_v1(
+        publication.storage_authority.operator,
+        &head_key,
+        remote.max_catalog_head_object_bytes(),
+    )
+    .await
+    .with_context(|| format!("rereading catalog HEAD after committed closure: {head_key}"))?;
+    let Some(RawObjectReadV1::Bound(observed_head_again)) = observed_head_again else {
+        anyhow::bail!(
+            "catalog HEAD is missing or unbound after committed closure validation: {head_key}"
+        );
+    };
+    let (head_bytes_again, _, head_binding_again) = observed_head_again.into_parts();
+    anyhow::ensure!(
+        head_bytes_again == head_bytes
+            && registered_binding_from_raw_v1(head_binding_again) == head_binding,
+        "catalog HEAD changed while validating the committed closure: {head_key}"
+    );
     require_held_control_lease_live_v1(&publication.control_guard)
         .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
     Ok(CatalogCommittedRecoveryStateV1::Committed(
-        PublishedCatalogSuccessorClosureV1 {
+        ProvisionalObservedCatalogSuccessorV1 {
             head_revision: super::catalog_head_revision_v1(&head_bytes),
             committed_head_bytes: head_bytes,
             committed_head_binding: head_binding,
@@ -4655,17 +5795,20 @@ pub(crate) async fn recover_failed_catalog_committed_finalization_v1<'a>(
         Ok(CatalogCommittedRecoveryStateV1::Publishing) => {
             finalize_catalog_committed_head_v1(applied).await
         }
-        Ok(CatalogCommittedRecoveryStateV1::Committed(published)) => {
-            let replayed_binding = match execute_and_revalidate_catalog_committed_head_v1(
-                &applied.capability,
-                &published.committed_head_bytes,
-            )
-            .await
-            {
-                Ok(binding) => binding,
-                Err(error) => return Err(FailedCatalogCommittedFinalizationV1 { applied, error }),
-            };
-            if replayed_binding != published.committed_head_binding {
+        Ok(CatalogCommittedRecoveryStateV1::Committed(observed)) => {
+            let (replayed_request_fingerprint, replayed_binding) =
+                match execute_and_revalidate_catalog_committed_head_v1(
+                    &applied.capability,
+                    &observed.committed_head_bytes,
+                )
+                .await
+                {
+                    Ok(replayed) => replayed,
+                    Err(error) => {
+                        return Err(FailedCatalogCommittedFinalizationV1 { applied, error })
+                    }
+                };
+            if replayed_binding != observed.committed_head_binding {
                 return Err(FailedCatalogCommittedFinalizationV1 {
                     applied,
                     error: anyhow::anyhow!(
@@ -4673,6 +5816,12 @@ pub(crate) async fn recover_failed_catalog_committed_finalization_v1<'a>(
                     ),
                 });
             }
+            let published = PublishedCatalogSuccessorClosureV1 {
+                committed_head_bytes: observed.committed_head_bytes,
+                head_revision: observed.head_revision,
+                committed_head_fenced_request_fingerprint: replayed_request_fingerprint,
+                committed_head_binding: replayed_binding,
+            };
             Ok(bind_committed_catalog_successor_v1(applied, published))
         }
         Err(error) => Err(FailedCatalogCommittedFinalizationV1 { applied, error }),
@@ -4693,6 +5842,7 @@ pub(crate) struct BoundCommittedCatalogSuccessorV1 {
     parent_head_revision: [u8; 32],
     head_revision: [u8; 32],
     committed_head_bytes: Vec<u8>,
+    committed_head_fenced_request_fingerprint: [u8; 32],
     committed_head_binding: RegisteredRootRemoteObjectBindingV1,
 }
 
@@ -4733,7 +5883,6 @@ type CatalogControlReadyAdvanceFutureV1<'a> = Pin<
 /// and live lease for an authenticated retry.
 pub(crate) struct FailedCatalogHighWaterAdvanceV1 {
     committed: BoundCommittedCatalogSuccessorV1,
-    ready_revision_fingerprint: [u8; 32],
     error: anyhow::Error,
 }
 
@@ -4806,15 +5955,17 @@ struct RemoteCatalogPublicationObjectReferenceWireV1 {
     binding: RemoteCatalogObjectBindingWireV1,
 }
 
-const CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1: u32 = 1;
+// The source-only contract has no production records. Version two closes the
+// cold-recovery omissions before any constructor or deployment exists.
+const CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1: u32 = 2;
 const CATALOG_CONTROL_CONTRACT_DOMAIN_V1: &str =
-    "tinyland.tcfs.remote-catalog-control-contract.b3v1";
-const CATALOG_CONTROL_RECORD_DOMAIN_V1: &str = "tinyland.tcfs.remote-catalog-control-record.b3v1";
+    "tinyland.tcfs.remote-catalog-control-contract.b3v2";
+const CATALOG_CONTROL_RECORD_DOMAIN_V1: &str = "tinyland.tcfs.remote-catalog-control-record.b3v2";
 
 fn catalog_control_contract_fingerprint_v1() -> [u8; 32] {
     super::domain_object_id_v1(
         CATALOG_CONTROL_CONTRACT_DOMAIN_V1,
-        b"ready-exact-current->publication-pending-exact-successor->ready-exact-current-v1",
+        b"ready-exact-current->publication-pending-cold-recoverable-exact-successor->ready-provenance-exact-current-v2",
     )
 }
 
@@ -4844,9 +5995,25 @@ struct CatalogControlPendingStateWireV1 {
     successor_catalog_sequence: u64,
     successor_publication_nonce: String,
     publishing_head_reservation_fingerprint: String,
+    writer_fence_authority_revision_fingerprint: String,
+    writer_fence_lease_public_fingerprint: String,
+    predecessor_head_storage_binding: RemoteCatalogObjectBindingWireV1,
     predecessor_head_storage_binding_fingerprint: String,
     predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1,
     mutation_journal: RemoteCatalogPublicationObjectReferenceWireV1,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogControlCompletedPublicationWireV1 {
+    pending_control_generation: u64,
+    pending_control_revision_fingerprint: String,
+    pending_control_record_fingerprint: String,
+    publishing_head_reservation_fingerprint: String,
+    writer_fence_authority_revision_fingerprint: String,
+    writer_fence_lease_public_fingerprint: String,
+    committed_head_fenced_request_fingerprint: String,
+    committed_head_storage_binding: RemoteCatalogObjectBindingWireV1,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -4854,6 +6021,7 @@ struct CatalogControlPendingStateWireV1 {
 enum CatalogControlStateWireV1 {
     Ready {
         current: CatalogControlHeadPointWireV1,
+        completed_publication: Option<Box<CatalogControlCompletedPublicationWireV1>>,
     },
     PublicationPending {
         pending: Box<CatalogControlPendingStateWireV1>,
@@ -4875,6 +6043,22 @@ struct CatalogControlRecordWireV1 {
     storage_authority_fingerprint: String,
     control_generation: u64,
     control_revision_fingerprint: String,
+    lease_public_fingerprint: String,
+    bootstrap: CatalogControlBootstrapWireV1,
+    writer_epoch: String,
+    control_state: CatalogControlStateWireV1,
+}
+
+#[derive(Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogReadyControlRevisionSeedWireV1 {
+    version: u32,
+    remote_prefix: String,
+    context: RemoteCatalogContextWireV1,
+    control_contract_fingerprint: String,
+    control_authority_fingerprint: String,
+    storage_authority_fingerprint: String,
+    control_generation: u64,
     lease_public_fingerprint: String,
     bootstrap: CatalogControlBootstrapWireV1,
     writer_epoch: String,
@@ -4907,8 +6091,15 @@ struct RemoteCatalogPublishingHeadWireV1 {
     mutation_journal: RemoteCatalogPublicationObjectReferenceWireV1,
 }
 
-fn predecessor_head_storage_binding_fingerprint_v1(etag: &str) -> [u8; 32] {
-    super::domain_object_id_v1(PREDECESSOR_HEAD_STORAGE_BINDING_DOMAIN_V1, etag.as_bytes())
+fn predecessor_head_storage_binding_fingerprint_v1(
+    binding: &RegisteredRootRemoteObjectBindingV1,
+) -> [u8; 32] {
+    let canonical_binding = serde_json::to_vec(&binding_wire_v1(binding))
+        .expect("catalog predecessor binding wire is infallibly serializable");
+    super::domain_object_id_v1(
+        PREDECESSOR_HEAD_STORAGE_BINDING_DOMAIN_V1,
+        &canonical_binding,
+    )
 }
 
 fn canonical_publishing_head_bytes_v1(
@@ -4991,7 +6182,9 @@ fn canonical_publishing_head_bytes_v1(
                 .0,
         ),
         predecessor_head_storage_binding_fingerprint: lower_hex(
-            &predecessor_head_storage_binding_fingerprint_v1(&successor.expected_parent_head_etag),
+            &predecessor_head_storage_binding_fingerprint_v1(
+                &successor.expected_parent_head_binding,
+            ),
         ),
         predecessor_head_archive: RemoteCatalogPublicationObjectReferenceWireV1 {
             object_id: lower_hex(&successor.predecessor_archive.object_id),
@@ -5066,9 +6259,25 @@ fn canonical_pending_control_record_bytes_v1(
                 publishing_head_reservation_fingerprint: lower_hex(
                     &publishing_head_reservation_fingerprint,
                 ),
+                writer_fence_authority_revision_fingerprint: lower_hex(
+                    &publication
+                        .control_guard
+                        .all_writers
+                        .authority_revision_fingerprint,
+                ),
+                writer_fence_lease_public_fingerprint: lower_hex(
+                    &publication
+                        .control_guard
+                        .all_writers
+                        .lease_public_fingerprint
+                        .0,
+                ),
+                predecessor_head_storage_binding: binding_wire_v1(
+                    &publication.expected_parent_head_binding,
+                ),
                 predecessor_head_storage_binding_fingerprint: lower_hex(
                     &predecessor_head_storage_binding_fingerprint_v1(
-                        &publication.expected_parent_head_etag,
+                        &publication.expected_parent_head_binding,
                     ),
                 ),
                 predecessor_head_archive: publication_reference_wire_v1(
@@ -5085,6 +6294,94 @@ fn canonical_pending_control_record_bytes_v1(
         },
     })
     .expect("catalog control wire is infallibly serializable")
+}
+
+fn completed_catalog_publication_wire_v1(
+    committed: &BoundCommittedCatalogSuccessorV1,
+) -> CatalogControlCompletedPublicationWireV1 {
+    let writers = &committed.control_guard.all_writers;
+    CatalogControlCompletedPublicationWireV1 {
+        pending_control_generation: committed.pending_revision.generation.get(),
+        pending_control_revision_fingerprint: lower_hex(&committed.pending_revision.fingerprint),
+        pending_control_record_fingerprint: lower_hex(
+            &committed.pending_control_record_fingerprint,
+        ),
+        publishing_head_reservation_fingerprint: lower_hex(
+            &committed.publishing_head_reservation_fingerprint,
+        ),
+        writer_fence_authority_revision_fingerprint: lower_hex(
+            &writers.authority_revision_fingerprint,
+        ),
+        writer_fence_lease_public_fingerprint: lower_hex(&writers.lease_public_fingerprint.0),
+        committed_head_fenced_request_fingerprint: lower_hex(
+            &committed.committed_head_fenced_request_fingerprint,
+        ),
+        committed_head_storage_binding: binding_wire_v1(&committed.committed_head_binding),
+    }
+}
+
+fn ready_catalog_control_state_wire_v1(
+    committed: &BoundCommittedCatalogSuccessorV1,
+) -> CatalogControlStateWireV1 {
+    CatalogControlStateWireV1::Ready {
+        current: control_head_point_wire_v1(CatalogHighWaterPointV1 {
+            sequence: committed.sequence,
+            head_revision: committed.head_revision,
+            publication_nonce: committed.publication_nonce,
+        }),
+        completed_publication: Some(Box::new(completed_catalog_publication_wire_v1(committed))),
+    }
+}
+
+fn derive_ready_control_revision_v1(
+    committed: &BoundCommittedCatalogSuccessorV1,
+) -> Result<CatalogControlAuthorityRevisionV1, CatalogPublicationContractErrorV1> {
+    let ready_generation = committed
+        .pending_revision
+        .generation
+        .get()
+        .checked_add(1)
+        .and_then(NonZeroU64::new)
+        .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    let binding = &committed.control_guard.high_water.binding;
+    let writers = &committed.control_guard.all_writers;
+    if committed.pending_revision.fingerprint == [0; 32]
+        || committed.pending_control_record_fingerprint == [0; 32]
+        || committed.publishing_head_reservation_fingerprint == [0; 32]
+        || committed.committed_head_fenced_request_fingerprint == [0; 32]
+        || committed.head_revision == [0; 32]
+        || writers.authority_revision_fingerprint == [0; 32]
+        || writers.lease_public_fingerprint.0 == [0; 32]
+        || mutable_head_etag_v1(&committed.committed_head_binding).is_none()
+    {
+        return Err(CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch);
+    }
+    let seed = CatalogReadyControlRevisionSeedWireV1 {
+        version: CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1,
+        remote_prefix: binding.context.remote_prefix.clone(),
+        context: binding.context.to_wire(),
+        control_contract_fingerprint: lower_hex(&catalog_control_contract_fingerprint_v1()),
+        control_authority_fingerprint: lower_hex(&binding.control_authority_fingerprint),
+        storage_authority_fingerprint: lower_hex(&binding.storage_authority_fingerprint),
+        control_generation: ready_generation.get(),
+        lease_public_fingerprint: lower_hex(&binding.lease_public_fingerprint.0),
+        bootstrap: control_bootstrap_wire_v1(&binding.bootstrap),
+        writer_epoch: lower_hex(&binding.bootstrap.writer_epoch),
+        control_state: ready_catalog_control_state_wire_v1(committed),
+    };
+    let seed =
+        serde_json::to_vec(&seed).expect("catalog Ready revision seed is infallibly serializable");
+    let fingerprint = super::domain_object_id_v1(READY_CONTROL_REVISION_DOMAIN_V1, &seed);
+    if fingerprint == [0; 32]
+        || fingerprint == committed.pending_revision.fingerprint
+        || fingerprint == binding.ready_revision.fingerprint
+    {
+        return Err(CatalogPublicationContractErrorV1::HighWaterAdvanceMismatch);
+    }
+    Ok(CatalogControlAuthorityRevisionV1 {
+        generation: ready_generation,
+        fingerprint,
+    })
 }
 
 fn canonical_ready_control_record_bytes_v1(
@@ -5104,15 +6401,39 @@ fn canonical_ready_control_record_bytes_v1(
         lease_public_fingerprint: lower_hex(&binding.lease_public_fingerprint.0),
         bootstrap: control_bootstrap_wire_v1(&binding.bootstrap),
         writer_epoch: lower_hex(&binding.bootstrap.writer_epoch),
-        control_state: CatalogControlStateWireV1::Ready {
-            current: control_head_point_wire_v1(CatalogHighWaterPointV1 {
-                sequence: committed.sequence,
-                head_revision: committed.head_revision,
-                publication_nonce: committed.publication_nonce,
-            }),
-        },
+        control_state: ready_catalog_control_state_wire_v1(committed),
     })
     .expect("catalog control wire is infallibly serializable")
+}
+
+fn ready_control_revision_fingerprint_from_wire_v1(
+    wire: &CatalogControlRecordWireV1,
+) -> Option<[u8; 32]> {
+    let CatalogControlStateWireV1::Ready {
+        completed_publication: Some(_),
+        ..
+    } = &wire.control_state
+    else {
+        return None;
+    };
+    let seed = CatalogReadyControlRevisionSeedWireV1 {
+        version: wire.version,
+        remote_prefix: wire.remote_prefix.clone(),
+        context: wire.context.clone(),
+        control_contract_fingerprint: wire.control_contract_fingerprint.clone(),
+        control_authority_fingerprint: wire.control_authority_fingerprint.clone(),
+        storage_authority_fingerprint: wire.storage_authority_fingerprint.clone(),
+        control_generation: wire.control_generation,
+        lease_public_fingerprint: wire.lease_public_fingerprint.clone(),
+        bootstrap: wire.bootstrap.clone(),
+        writer_epoch: wire.writer_epoch.clone(),
+        control_state: wire.control_state.clone(),
+    };
+    let canonical_seed = serde_json::to_vec(&seed).ok()?;
+    Some(super::domain_object_id_v1(
+        READY_CONTROL_REVISION_DOMAIN_V1,
+        &canonical_seed,
+    ))
 }
 
 /// Prepare the exact external control transition without acquiring authority.
@@ -5410,6 +6731,7 @@ fn validate_catalog_high_water_advance_receipt_v1(
         .checked_add(1)
         .and_then(NonZeroU64::new)
         .ok_or(CatalogPublicationContractErrorV1::SequenceOverflow)?;
+    let expected_ready_revision = derive_ready_control_revision_v1(committed)?;
     let exact_successor = CatalogHighWaterPointV1 {
         sequence: committed.sequence,
         head_revision: committed.head_revision,
@@ -5436,6 +6758,7 @@ fn validate_catalog_high_water_advance_receipt_v1(
         || committed.head_revision == [0; 32]
         || committed.head_revision == control_binding.current.head_revision
         || committed_revision != committed.head_revision
+        || committed.committed_head_fenced_request_fingerprint == [0; 32]
         || mutable_head_etag_v1(&committed.committed_head_binding).is_none()
         || receipt.control_binding != *control_binding
         || receipt.writer_fence_authority_revision_fingerprint
@@ -5452,9 +6775,7 @@ fn validate_catalog_high_water_advance_receipt_v1(
             != committed.pending_control_record_fingerprint
         || receipt.successor != exact_successor
         || receipt.ready_revision.generation != expected_ready_generation
-        || receipt.ready_revision.fingerprint == [0; 32]
-        || receipt.ready_revision.fingerprint == committed.pending_revision.fingerprint
-        || receipt.ready_revision.fingerprint == control_binding.ready_revision.fingerprint
+        || receipt.ready_revision != expected_ready_revision
         || receipt.ready_control_record_fingerprint == [0; 32]
         || receipt.ready_control_record_fingerprint == committed.pending_control_record_fingerprint
         || receipt.ready_control_record_fingerprint != ready_record_fingerprint
@@ -5509,22 +6830,12 @@ pub(crate) fn match_catalog_high_water_advance_v1(
 /// authenticated retry; success is terminal and cannot mint a fresh guard.
 pub(crate) async fn advance_catalog_high_water_v1(
     committed: BoundCommittedCatalogSuccessorV1,
-    ready_revision_fingerprint: [u8; 32],
 ) -> Result<AdvancedCatalogHighWaterV1, FailedCatalogHighWaterAdvanceV1> {
     let result = async {
         require_held_control_lease_live_v1(&committed.control_guard)
             .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
-        let ready_generation = committed
-            .pending_revision
-            .generation
-            .get()
-            .checked_add(1)
-            .and_then(NonZeroU64::new)
-            .context("catalog control generation overflow")?;
-        let ready_revision = CatalogControlAuthorityRevisionV1 {
-            generation: ready_generation,
-            fingerprint: ready_revision_fingerprint,
-        };
+        let ready_revision = derive_ready_control_revision_v1(&committed)
+            .map_err(|error| anyhow::anyhow!("invalid deterministic Ready revision: {error:?}"))?;
         let successor = CatalogHighWaterPointV1 {
             sequence: committed.sequence,
             head_revision: committed.head_revision,
@@ -5595,25 +6906,21 @@ pub(crate) async fn advance_catalog_high_water_v1(
     .await;
     match result {
         Ok(receipt) => Ok(finish_catalog_high_water_advance_v1(committed, receipt)),
-        Err(error) => Err(FailedCatalogHighWaterAdvanceV1 {
-            committed,
-            ready_revision_fingerprint,
-            error,
-        }),
+        Err(error) => Err(FailedCatalogHighWaterAdvanceV1 { committed, error }),
     }
 }
 
 /// Retry an ambiguous or rejected external high-water CAS with the exact same
-/// committed successor and ready revision fingerprint.
+/// committed successor. The Ready revision is rederived from its persisted
+/// transition provenance, never retained as caller-selected retry state.
 pub(crate) async fn recover_failed_catalog_high_water_advance_v1(
     failure: FailedCatalogHighWaterAdvanceV1,
 ) -> Result<AdvancedCatalogHighWaterV1, FailedCatalogHighWaterAdvanceV1> {
     let FailedCatalogHighWaterAdvanceV1 {
         committed,
-        ready_revision_fingerprint,
         error: _,
     } = failure;
-    advance_catalog_high_water_v1(committed, ready_revision_fingerprint).await
+    advance_catalog_high_water_v1(committed).await
 }
 
 pub(super) fn classify_publishing_head_v1(
@@ -5666,23 +6973,28 @@ pub(super) fn classify_publishing_head_v1(
     })
 }
 
-#[cfg(test)]
-fn is_canonical_control_record_v1(
+/// Parse one bounded canonical control record as untrusted persisted state.
+///
+/// This never creates storage authority, a retained lease, a fenced receipt,
+/// or a publication capability. A cold process may use the returned wire only
+/// after an authenticated backend acquisition matches its exact bytes.
+fn parse_canonical_control_record_v1(
     raw_bytes: &[u8],
     selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
-) -> bool {
+) -> Option<CatalogControlRecordWireV1> {
     let Ok(raw_bytes_len) = u64::try_from(raw_bytes.len()) else {
-        return false;
+        return None;
     };
-    if raw_bytes_len
-        > RegisteredRootPlanContractV1::strict_v1()
-            .remote_contract()
-            .max_catalog_page_object_bytes()
+    if raw_bytes_len == 0
+        || raw_bytes_len
+            > RegisteredRootPlanContractV1::strict_v1()
+                .remote_contract()
+                .max_catalog_page_object_bytes()
     {
-        return false;
+        return None;
     }
     let Ok(wire) = serde_json::from_slice::<CatalogControlRecordWireV1>(raw_bytes) else {
-        return false;
+        return None;
     };
     if serde_json::to_vec(&wire).ok().as_deref() != Some(raw_bytes)
         || wire.version != CATALOG_CONTROL_RECORD_SCHEMA_VERSION_V1
@@ -5692,7 +7004,7 @@ fn is_canonical_control_record_v1(
             != lower_hex(&catalog_control_contract_fingerprint_v1())
         || wire.control_generation == 0
     {
-        return false;
+        return None;
     }
     let nonzero_hex = |value: &str| {
         super::parse_lower_hex_32(value).is_some_and(|fingerprint| fingerprint != [0; 32])
@@ -5707,7 +7019,7 @@ fn is_canonical_control_record_v1(
         || !nonzero_hex(&wire.bootstrap.writer_epoch)
         || wire.writer_epoch != wire.bootstrap.writer_epoch
     {
-        return false;
+        return None;
     }
     let valid_point = |point: &CatalogControlHeadPointWireV1| {
         point.catalog_sequence > 0
@@ -5717,8 +7029,40 @@ fn is_canonical_control_record_v1(
                 || (point.head_revision == wire.bootstrap.head_revision
                     && point.publication_nonce == wire.bootstrap.publication_nonce))
     };
-    match &wire.control_state {
-        CatalogControlStateWireV1::Ready { current } => valid_point(current),
+    let valid = match &wire.control_state {
+        CatalogControlStateWireV1::Ready {
+            current,
+            completed_publication,
+        } => {
+            valid_point(current)
+                && match completed_publication.as_deref() {
+                    None => current.catalog_sequence == 1,
+                    Some(completed) => {
+                        current.catalog_sequence >= 2
+                            && completed.pending_control_generation > 0
+                            && completed
+                                .pending_control_generation
+                                .checked_add(1)
+                                .is_some_and(|next| next == wire.control_generation)
+                            && nonzero_hex(&completed.pending_control_revision_fingerprint)
+                            && completed.pending_control_revision_fingerprint
+                                != wire.control_revision_fingerprint
+                            && nonzero_hex(&completed.pending_control_record_fingerprint)
+                            && nonzero_hex(&completed.publishing_head_reservation_fingerprint)
+                            && nonzero_hex(&completed.writer_fence_authority_revision_fingerprint)
+                            && nonzero_hex(&completed.writer_fence_lease_public_fingerprint)
+                            && nonzero_hex(&completed.committed_head_fenced_request_fingerprint)
+                            && super::validate_binding_wire_v1(
+                                &completed.committed_head_storage_binding,
+                            )
+                            .is_some()
+                            && wire_binding_etag_v1(&completed.committed_head_storage_binding)
+                                .is_some_and(|etag| etag != "null")
+                            && super::parse_lower_hex_32(&wire.control_revision_fingerprint)
+                                == ready_control_revision_fingerprint_from_wire_v1(&wire)
+                    }
+                }
+        }
         CatalogControlStateWireV1::PublicationPending { pending } => {
             let valid_reference = |reference: &RemoteCatalogPublicationObjectReferenceWireV1| {
                 nonzero_hex(&reference.object_id)
@@ -5741,11 +7085,642 @@ fn is_canonical_control_record_v1(
                 && nonzero_hex(&pending.successor_publication_nonce)
                 && pending.successor_publication_nonce != pending.parent.publication_nonce
                 && nonzero_hex(&pending.publishing_head_reservation_fingerprint)
+                && nonzero_hex(&pending.writer_fence_authority_revision_fingerprint)
+                && nonzero_hex(&pending.writer_fence_lease_public_fingerprint)
                 && nonzero_hex(&pending.predecessor_head_storage_binding_fingerprint)
+                && super::validate_binding_wire_v1(&pending.predecessor_head_storage_binding)
+                    .is_some_and(|binding| {
+                        mutable_head_etag_v1(&binding).is_some()
+                            && lower_hex(&predecessor_head_storage_binding_fingerprint_v1(&binding))
+                                == pending.predecessor_head_storage_binding_fingerprint
+                    })
                 && valid_reference(&pending.predecessor_head_archive)
                 && valid_reference(&pending.mutation_journal)
         }
+    };
+    valid.then_some(wire)
+}
+
+/// Reconstruct one exact Pending publication after a process restart.
+///
+/// Persisted bytes contribute only bounded, untrusted facts. Immutable
+/// archive/journal/payload evidence is fully rebound first; only then may the
+/// authenticated backend reopen the already-existing Pending fence and its
+/// durable ordinal ledger. The returned capability is unavailable without
+/// that fresh opaque acquisition and still has no plan/action conversion.
+pub(crate) async fn reconstruct_catalog_publication_from_authenticated_pending_v1<'a>(
+    storage_authority: TrustedCatalogStorageAuthorityV1<'a>,
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+    canonical_pending_control_record_bytes: Vec<u8>,
+    reacquisition_authority: &dyn CatalogPendingFenceReacquisitionAuthorityV1,
+) -> AnyhowResult<BoundPendingCatalogControlV1<'a>> {
+    let wire = parse_canonical_control_record_v1(&canonical_pending_control_record_bytes, selected)
+        .context("catalog cold recovery requires one bounded canonical control record")?;
+    let CatalogControlStateWireV1::PublicationPending { pending } = &wire.control_state else {
+        anyhow::bail!("catalog cold recovery requires authenticated PublicationPending state");
+    };
+    let context = CatalogAuthorityContextV1::from_selected(selected);
+    let storage_authority_fingerprint =
+        super::parse_lower_hex_32(&wire.storage_authority_fingerprint)
+            .context("catalog Pending storage authority fingerprint is invalid")?;
+    let control_authority_fingerprint =
+        super::parse_lower_hex_32(&wire.control_authority_fingerprint)
+            .context("catalog Pending control authority fingerprint is invalid")?;
+    anyhow::ensure!(
+        storage_authority.authority_fingerprint == storage_authority_fingerprint
+            && storage_authority
+                .conditional_write_receipt
+                .authorizes(storage_authority.operator, &context.remote_prefix)?,
+        "catalog cold recovery crossed its authenticated storage authority"
+    );
+    let bootstrap = CatalogBootstrapIdentityV1 {
+        head_revision: super::parse_lower_hex_32(&wire.bootstrap.head_revision)
+            .context("catalog Pending bootstrap HEAD revision is invalid")?,
+        publication_nonce: super::parse_lower_hex_32(&wire.bootstrap.publication_nonce)
+            .context("catalog Pending bootstrap nonce is invalid")?,
+        complete_corpus_attestation: super::parse_lower_hex_32(
+            &wire.bootstrap.complete_corpus_attestation,
+        )
+        .context("catalog Pending bootstrap attestation is invalid")?,
+        writer_epoch: super::parse_lower_hex_32(&wire.bootstrap.writer_epoch)
+            .context("catalog Pending writer epoch is invalid")?,
+    };
+    let parent = CatalogHighWaterPointV1 {
+        sequence: NonZeroU64::new(pending.parent.catalog_sequence)
+            .context("catalog Pending parent sequence cannot be zero")?,
+        head_revision: super::parse_lower_hex_32(&pending.parent.head_revision)
+            .context("catalog Pending parent HEAD revision is invalid")?,
+        publication_nonce: super::parse_lower_hex_32(&pending.parent.publication_nonce)
+            .context("catalog Pending parent nonce is invalid")?,
+    };
+    let ready_revision = CatalogControlAuthorityRevisionV1 {
+        generation: NonZeroU64::new(pending.ready_control_generation)
+            .context("catalog Pending predecessor Ready generation cannot be zero")?,
+        fingerprint: super::parse_lower_hex_32(&pending.ready_control_revision_fingerprint)
+            .context("catalog Pending predecessor Ready revision is invalid")?,
+    };
+    let pending_revision = CatalogControlAuthorityRevisionV1 {
+        generation: NonZeroU64::new(wire.control_generation)
+            .context("catalog Pending generation cannot be zero")?,
+        fingerprint: super::parse_lower_hex_32(&wire.control_revision_fingerprint)
+            .context("catalog Pending revision is invalid")?,
+    };
+    let control_binding = CatalogControlAcquisitionBindingV1 {
+        context: context.clone(),
+        bootstrap,
+        current: parent,
+        storage_authority_fingerprint,
+        control_authority_fingerprint,
+        ready_revision,
+        lease_public_fingerprint: NonSecretLeasePublicFingerprintV1(
+            super::parse_lower_hex_32(&wire.lease_public_fingerprint)
+                .context("catalog Pending control lease fingerprint is invalid")?,
+        ),
+    };
+    let writer_fence_authority_revision_fingerprint =
+        super::parse_lower_hex_32(&pending.writer_fence_authority_revision_fingerprint)
+            .context("catalog Pending writer-fence authority revision is invalid")?;
+    let writer_fence_lease_public_fingerprint = NonSecretLeasePublicFingerprintV1(
+        super::parse_lower_hex_32(&pending.writer_fence_lease_public_fingerprint)
+            .context("catalog Pending writer-fence lease fingerprint is invalid")?,
+    );
+    let publishing_head_reservation_fingerprint =
+        super::parse_lower_hex_32(&pending.publishing_head_reservation_fingerprint)
+            .context("catalog Pending publishing-HEAD reservation is invalid")?;
+    let successor_sequence = NonZeroU64::new(pending.successor_catalog_sequence)
+        .context("catalog Pending successor sequence cannot be zero")?;
+    let successor_publication_nonce =
+        super::parse_lower_hex_32(&pending.successor_publication_nonce)
+            .context("catalog Pending successor nonce is invalid")?;
+    let expected_parent_head_binding =
+        super::validate_binding_wire_v1(&pending.predecessor_head_storage_binding)
+            .context("catalog Pending predecessor HEAD binding is invalid")?;
+    mutable_head_etag_v1(&expected_parent_head_binding)
+        .context("catalog Pending predecessor HEAD binding has no usable ETag")?;
+    anyhow::ensure!(
+        predecessor_head_storage_binding_fingerprint_v1(&expected_parent_head_binding)
+            == super::parse_lower_hex_32(&pending.predecessor_head_storage_binding_fingerprint,)
+                .context("catalog Pending predecessor HEAD binding fingerprint is invalid")?,
+        "catalog Pending predecessor HEAD binding does not match its fingerprint"
+    );
+
+    let (predecessor_archive, predecessor_entries) = reconstruct_archived_catalog_predecessor_v1(
+        &storage_authority,
+        selected,
+        &context,
+        parent,
+        &pending.predecessor_head_archive,
+    )
+    .await?;
+    let mutation_journal = reconstruct_authoritative_catalog_journal_v1(
+        &storage_authority,
+        &context,
+        successor_sequence,
+        successor_publication_nonce,
+        parent.head_revision,
+        &pending.mutation_journal,
+        predecessor_entries,
+    )
+    .await?;
+
+    let pending_control_record_fingerprint = super::domain_object_id_v1(
+        CATALOG_CONTROL_RECORD_DOMAIN_V1,
+        &canonical_pending_control_record_bytes,
+    );
+    let mut reacquisition_request = CatalogPendingFenceReacquisitionRequestV1 {
+        control_binding: control_binding.clone(),
+        pending_revision,
+        publishing_head_reservation_fingerprint,
+        writer_fence_authority_revision_fingerprint,
+        writer_fence_lease_public_fingerprint,
+        canonical_pending_control_record_bytes: canonical_pending_control_record_bytes.clone(),
+        pending_control_record_fingerprint,
+        request_fingerprint: [0; 32],
+    };
+    reacquisition_request.request_fingerprint =
+        catalog_pending_fence_reacquisition_request_fingerprint_v1(&reacquisition_request)?;
+    anyhow::ensure!(
+        reacquisition_request.request_fingerprint != [0; 32],
+        "catalog Pending-fence reacquisition request fingerprint cannot be zero"
+    );
+    let expected_reacquisition_request_fingerprint = reacquisition_request.request_fingerprint;
+    let reacquired = reacquisition_authority
+        .reacquire_pending_fence_v1(reacquisition_request)
+        .await
+        .context("reacquiring authenticated catalog Pending fence")?;
+    let expected_pending_receipt = &reacquired.pending_receipt;
+    anyhow::ensure!(
+        reacquired.request_fingerprint == expected_reacquisition_request_fingerprint
+            && expected_pending_receipt.control_binding == control_binding
+            && expected_pending_receipt.pending_revision == pending_revision
+            && expected_pending_receipt.publishing_head_reservation_fingerprint
+                == publishing_head_reservation_fingerprint
+            && expected_pending_receipt.writer_fence_authority_revision_fingerprint
+                == writer_fence_authority_revision_fingerprint
+            && expected_pending_receipt.writer_fence_lease_public_fingerprint
+                == writer_fence_lease_public_fingerprint
+            && expected_pending_receipt.pending_control_record_fingerprint
+                == pending_control_record_fingerprint
+            && reacquired.retained_control_lease.control_binding == control_binding
+            && reacquired
+                .retained_control_lease
+                .writer_fence_authority_revision_fingerprint
+                == writer_fence_authority_revision_fingerprint
+            && reacquired
+                .retained_control_lease
+                .writer_fence_lease_public_fingerprint
+                == writer_fence_lease_public_fingerprint
+            && reacquired.retained_control_lease.is_live_v1(),
+        "authenticated catalog Pending-fence reacquisition crossed persisted state"
+    );
+
+    let bootstrap_head_revision = control_binding.bootstrap.head_revision;
+    let control_guard = HeldReadyCatalogControlGuardV1 {
+        high_water: TrustedCatalogHighWaterGuardV1 {
+            binding: control_binding.clone(),
+        },
+        all_writers: AllNamespaceWritersFencedLeaseV1 {
+            control_binding,
+            authority_revision_fingerprint: writer_fence_authority_revision_fingerprint,
+            lease_public_fingerprint: writer_fence_lease_public_fingerprint,
+            retained_control_lease: reacquired.retained_control_lease,
+        },
+    };
+    let publication = PreparedCatalogPublicationFenceV1 {
+        storage_authority,
+        control_guard,
+        context,
+        sequence: successor_sequence,
+        publication_nonce: successor_publication_nonce,
+        parent_head_revision: parent.head_revision,
+        expected_parent_head_binding,
+        bootstrap_head_revision,
+        predecessor_archive,
+        mutation_journal,
+    };
+    let transition =
+        prepare_catalog_control_transition_v1(publication, pending_revision.fingerprint).map_err(
+            |error| {
+                anyhow::anyhow!("reconstructed catalog Pending transition is invalid: {error:?}")
+            },
+        )?;
+    anyhow::ensure!(
+        transition.pending_revision == pending_revision
+            && transition.publishing_head_reservation_fingerprint
+                == publishing_head_reservation_fingerprint
+            && transition.pending_control_record_fingerprint == pending_control_record_fingerprint
+            && transition.canonical_pending_control_record_bytes
+                == canonical_pending_control_record_bytes,
+        "reconstructed catalog Pending transition differs from authenticated control bytes"
+    );
+    revalidate_reconstructed_catalog_publication_artifacts_v1(&transition.publication, selected)
+        .await?;
+    match_catalog_publication_pending_receipt_v1(transition, reacquired.pending_receipt).map_err(
+        |error| anyhow::anyhow!("reacquired catalog Pending receipt is invalid: {error:?}"),
+    )
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CatalogPublicationResumeHeadV1 {
+    ExactPredecessor,
+    ExactPublishingBytes,
+    ProvisionalCommitted,
+}
+
+async fn observe_catalog_publication_resume_head_v1(
+    pending: &BoundPendingCatalogControlV1<'_>,
+) -> AnyhowResult<CatalogPublicationResumeHeadV1> {
+    let publication = &pending.transition.publication;
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    anyhow::ensure!(
+        publication
+            .storage_authority
+            .conditional_write_receipt
+            .authorizes(
+                publication.storage_authority.operator,
+                &publication.context.remote_prefix,
+            )?,
+        "catalog cold resume lost its exact accessor/prefix conditional-semantics authority"
+    );
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_catalog_head_object_bytes();
+    let observed =
+        read_raw_object_snapshot_v1(publication.storage_authority.operator, &head_key, max_bytes)
+            .await
+            .with_context(|| format!("observing catalog HEAD before cold resume: {head_key}"))?;
+    let Some(RawObjectReadV1::Bound(observed)) = observed else {
+        anyhow::bail!("catalog HEAD is missing or unbound before cold resume: {head_key}");
+    };
+    let (raw_bytes, _, binding) = observed.into_parts();
+    let binding = registered_binding_from_raw_v1(binding);
+    anyhow::ensure!(
+        super::validate_binding_wire_v1(&binding_wire_v1(&binding)).is_some()
+            && mutable_head_etag_v1(&binding).is_some(),
+        "catalog HEAD has no usable exact mutable-object binding before cold resume"
+    );
+    if raw_bytes == publication.predecessor_archive.raw_bytes {
+        anyhow::ensure!(
+            binding == publication.expected_parent_head_binding,
+            "catalog predecessor HEAD bytes have a different exact binding"
+        );
+        return Ok(CatalogPublicationResumeHeadV1::ExactPredecessor);
     }
+    if raw_bytes == pending.transition.canonical_publishing_head_bytes {
+        return Ok(CatalogPublicationResumeHeadV1::ExactPublishingBytes);
+    }
+    Ok(CatalogPublicationResumeHeadV1::ProvisionalCommitted)
+}
+
+async fn reconstructed_catalog_publishing_head_is_current_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+) -> AnyhowResult<bool> {
+    let publication = &capability.pending.transition.publication;
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_catalog_head_object_bytes();
+    let observed =
+        read_raw_object_snapshot_v1(publication.storage_authority.operator, &head_key, max_bytes)
+            .await
+            .with_context(|| format!("classifying catalog HEAD during cold resume: {head_key}"))?;
+    let Some(RawObjectReadV1::Bound(observed)) = observed else {
+        anyhow::bail!("catalog HEAD is missing or unbound during cold resume: {head_key}");
+    };
+    let (raw_bytes, _, binding) = observed.into_parts();
+    let binding = registered_binding_from_raw_v1(binding);
+    if raw_bytes
+        == capability
+            .pending
+            .transition
+            .canonical_publishing_head_bytes
+    {
+        anyhow::ensure!(
+            binding == capability.publishing_head_binding,
+            "visible catalog Publishing bytes crossed their authenticated ordinal-zero receipt"
+        );
+        return Ok(true);
+    }
+    anyhow::ensure!(
+        raw_bytes != publication.predecessor_archive.raw_bytes,
+        "catalog HEAD remained or reverted to its predecessor after ordinal-zero authentication"
+    );
+    Ok(false)
+}
+
+async fn observe_reconstructed_catalog_namespace_successors_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+) -> AnyhowResult<Vec<AppliedCatalogNamespaceObjectV1>> {
+    let publication = &capability.pending.transition.publication;
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    anyhow::ensure!(
+        publication
+            .storage_authority
+            .conditional_write_receipt
+            .authorizes(
+                publication.storage_authority.operator,
+                &publication.context.remote_prefix,
+            )?,
+        "catalog cold successor observation lost its exact storage authority"
+    );
+    let journal = &publication.mutation_journal;
+    let wire = validate_authoritative_catalog_mutation_journal_bytes_v1(
+        &journal.raw_bytes,
+        &publication.context,
+        publication.sequence,
+        publication.publication_nonce,
+        publication.parent_head_revision,
+    )
+    .map_err(|error| anyhow::anyhow!("authoritative mutation journal is invalid: {error:?}"))?;
+    anyhow::ensure!(
+        wire.mutations.len() == journal.successor_payloads.len(),
+        "authoritative mutation journal lost its complete successor payload set"
+    );
+    let mut observed = Vec::new();
+    observed
+        .try_reserve(wire.mutations.len())
+        .context("reserving cold catalog successor observations")?;
+    for (mutation, payload) in wire.mutations.iter().zip(&journal.successor_payloads) {
+        let payload_bytes = payload.raw_bytes.current();
+        anyhow::ensure!(
+            mutation.kind == payload.kind
+                && mutation.object_key == payload.object_key
+                && mutation.successor_payload.object_id == lower_hex(&payload.object_id)
+                && mutation.successor_payload.raw_bytes_len == payload.raw_bytes_len.get()
+                && mutation.successor_payload.raw_blake3 == lower_hex(&payload.raw_blake3)
+                && mutation.successor_payload.binding == binding_wire_v1(&payload.binding)
+                && u64::try_from(payload_bytes.len()).ok() == Some(payload.raw_bytes_len.get())
+                && *blake3::hash(&payload_bytes).as_bytes() == payload.raw_blake3,
+            "catalog cold successor observation lost an immutable journal payload"
+        );
+        let binding = read_exact_catalog_successor_v1(
+            capability,
+            mutation.kind,
+            &mutation.object_key,
+            &payload_bytes,
+        )
+        .await?;
+        observed.push(AppliedCatalogNamespaceObjectV1 {
+            kind: mutation.kind,
+            object_key: mutation.object_key.clone(),
+            raw_blake3: payload.raw_blake3,
+            binding,
+        });
+    }
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    Ok(observed)
+}
+
+async fn authenticate_reconstructed_catalog_namespace_receipts_v1(
+    applied: &AppliedCatalogNamespaceMutationsV1<'_>,
+) -> AnyhowResult<()> {
+    let capability = &applied.capability;
+    let publication = &capability.pending.transition.publication;
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    let _ = complete_successor_catalog_entries_v1(applied)?;
+    let journal = &publication.mutation_journal;
+    let wire = validate_authoritative_catalog_mutation_journal_bytes_v1(
+        &journal.raw_bytes,
+        &publication.context,
+        publication.sequence,
+        publication.publication_nonce,
+        publication.parent_head_revision,
+    )
+    .map_err(|error| anyhow::anyhow!("authoritative mutation journal is invalid: {error:?}"))?;
+    anyhow::ensure!(
+        wire.mutations.len() == journal.successor_payloads.len()
+            && wire.mutations.len() == applied.applied.len(),
+        "catalog cold receipt replay does not cover the complete journal"
+    );
+    for (index, ((mutation, payload), evidence)) in wire
+        .mutations
+        .iter()
+        .zip(&journal.successor_payloads)
+        .zip(&applied.applied)
+        .enumerate()
+    {
+        let ordinal = u64::try_from(index)
+            .context("catalog cold receipt ordinal does not fit u64")?
+            .checked_add(1)
+            .context("catalog cold receipt ordinal overflow")?;
+        let request = catalog_fenced_storage_write_request_v1(
+            &capability.pending,
+            CatalogFencedStorageWriteStageV1::for_namespace_kind(mutation.kind),
+            ordinal,
+            mutation.object_key.clone(),
+            catalog_namespace_write_condition_v1(mutation)?,
+            payload.raw_bytes.clone(),
+        )?;
+        let receipt_binding =
+            replay_catalog_fenced_storage_receipt_v1(&capability.pending, request).await?;
+        anyhow::ensure!(
+            receipt_binding == evidence.binding,
+            "catalog cold namespace observation crossed its durable receipt: {}",
+            mutation.object_key
+        );
+    }
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))
+}
+
+async fn replay_and_revalidate_catalog_committed_head_receipt_v1(
+    capability: &CatalogNamespaceMutationCapabilityV1<'_>,
+    committed_head_bytes: &[u8],
+) -> AnyhowResult<([u8; 32], RegisteredRootRemoteObjectBindingV1)> {
+    let publication = &capability.pending.transition.publication;
+    let request = catalog_committed_head_request_v1(capability, committed_head_bytes)?;
+    let request_fingerprint = request.request_fingerprint;
+    anyhow::ensure!(
+        request_fingerprint != [0; 32],
+        "catalog terminal fenced-request fingerprint cannot be zero"
+    );
+    let receipt_binding =
+        replay_catalog_fenced_storage_receipt_v1(&capability.pending, request).await?;
+    let head_key = super::catalog_head_key_v1(&publication.context.remote_prefix);
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .remote_contract()
+        .max_catalog_head_object_bytes();
+    let observed =
+        read_raw_object_snapshot_v1(publication.storage_authority.operator, &head_key, max_bytes)
+            .await
+            .with_context(|| {
+                format!("revalidating cold committed catalog HEAD receipt: {head_key}")
+            })?;
+    let Some(RawObjectReadV1::Bound(observed)) = observed else {
+        anyhow::bail!("cold committed catalog HEAD is missing or unbound: {head_key}");
+    };
+    let (raw_bytes, _, binding) = observed.into_parts();
+    let binding = registered_binding_from_raw_v1(binding);
+    anyhow::ensure!(
+        raw_bytes == committed_head_bytes && binding == receipt_binding,
+        "cold committed catalog HEAD differs from its durable terminal receipt: {head_key}"
+    );
+    require_held_control_lease_live_v1(&publication.control_guard)
+        .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
+    Ok((request_fingerprint, binding))
+}
+
+/// Resume one authenticated reconstructed Pending publication without
+/// allowing raw storage to mint missing backend authority.
+///
+/// An exact predecessor may execute ordinal zero. Visible Publishing must
+/// authenticate ordinal zero by receipt-only replay before the live Pending
+/// fence may continue any still-missing ordered namespace ordinals. A
+/// provisional committed successor is receipt-only at every ordinal. Raw
+/// storage state never backfills a missing receipt; failure retains the exact
+/// Pending capability for retry.
+pub(crate) async fn resume_reconstructed_catalog_publication_v1<'a>(
+    pending: BoundPendingCatalogControlV1<'a>,
+) -> Result<ReconstructedCatalogPublicationV1<'a>, FailedCatalogPublicationReconstructionV1<'a>> {
+    let initial_head = match observe_catalog_publication_resume_head_v1(&pending).await {
+        Ok(head) => head,
+        Err(error) => {
+            return Err(FailedCatalogPublicationReconstructionV1 { pending, error });
+        }
+    };
+    let publishing_head_binding = match initial_head {
+        CatalogPublicationResumeHeadV1::ExactPredecessor => {
+            execute_or_replay_catalog_publishing_head_v1(&pending).await
+        }
+        CatalogPublicationResumeHeadV1::ExactPublishingBytes
+        | CatalogPublicationResumeHeadV1::ProvisionalCommitted => {
+            let request = match catalog_publishing_head_request_v1(&pending) {
+                Ok(request) => request,
+                Err(error) => {
+                    return Err(FailedCatalogPublicationReconstructionV1 { pending, error });
+                }
+            };
+            replay_catalog_fenced_storage_receipt_v1(&pending, request).await
+        }
+    };
+    let publishing_head_binding = match publishing_head_binding {
+        Ok(binding) => binding,
+        Err(error) => {
+            return Err(FailedCatalogPublicationReconstructionV1 { pending, error });
+        }
+    };
+    let capability = CatalogNamespaceMutationCapabilityV1 {
+        pending,
+        publishing_head_binding,
+    };
+    let publishing_is_current =
+        match reconstructed_catalog_publishing_head_is_current_v1(&capability).await {
+            Ok(current) => current,
+            Err(error) => {
+                return Err(FailedCatalogPublicationReconstructionV1 {
+                    pending: capability.pending,
+                    error,
+                });
+            }
+        };
+    if publishing_is_current {
+        return match apply_authoritative_catalog_namespace_mutations_v1(capability).await {
+            Ok(applied) => Ok(ReconstructedCatalogPublicationV1::Applied(Box::new(
+                applied,
+            ))),
+            Err(FailedCatalogNamespaceMutationsV1 {
+                capability,
+                applied: _,
+                error,
+            }) => Err(FailedCatalogPublicationReconstructionV1 {
+                pending: capability.pending,
+                error,
+            }),
+        };
+    }
+
+    let observed = match observe_reconstructed_catalog_namespace_successors_v1(&capability).await {
+        Ok(observed) => observed,
+        Err(error) => {
+            return Err(FailedCatalogPublicationReconstructionV1 {
+                pending: capability.pending,
+                error,
+            });
+        }
+    };
+    let applied = AppliedCatalogNamespaceMutationsV1 {
+        capability,
+        applied: observed,
+    };
+    if let Err(error) = authenticate_reconstructed_catalog_namespace_receipts_v1(&applied).await {
+        return Err(FailedCatalogPublicationReconstructionV1 {
+            pending: applied.capability.pending,
+            error,
+        });
+    }
+    let observed = match classify_catalog_committed_recovery_state_v1(&applied).await {
+        Ok(CatalogCommittedRecoveryStateV1::Committed(observed)) => observed,
+        Ok(CatalogCommittedRecoveryStateV1::Publishing) => {
+            return Err(FailedCatalogPublicationReconstructionV1 {
+                pending: applied.capability.pending,
+                error: anyhow::anyhow!(
+                    "catalog HEAD changed from provisional committed back to Publishing"
+                ),
+            });
+        }
+        Err(error) => {
+            return Err(FailedCatalogPublicationReconstructionV1 {
+                pending: applied.capability.pending,
+                error,
+            });
+        }
+    };
+    let (request_fingerprint, committed_head_binding) =
+        match replay_and_revalidate_catalog_committed_head_receipt_v1(
+            &applied.capability,
+            &observed.committed_head_bytes,
+        )
+        .await
+        {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                return Err(FailedCatalogPublicationReconstructionV1 {
+                    pending: applied.capability.pending,
+                    error,
+                });
+            }
+        };
+    if committed_head_binding != observed.committed_head_binding {
+        return Err(FailedCatalogPublicationReconstructionV1 {
+            pending: applied.capability.pending,
+            error: anyhow::anyhow!(
+                "cold terminal receipt crossed the fully validated committed HEAD binding"
+            ),
+        });
+    }
+    let published = PublishedCatalogSuccessorClosureV1 {
+        committed_head_bytes: observed.committed_head_bytes,
+        head_revision: observed.head_revision,
+        committed_head_fenced_request_fingerprint: request_fingerprint,
+        committed_head_binding,
+    };
+    Ok(ReconstructedCatalogPublicationV1::Committed(Box::new(
+        bind_committed_catalog_successor_v1(applied, published),
+    )))
+}
+
+/// Retry cold recovery from ordinal zero with the exact retained Pending
+/// capability. The backend ledger, not this failure value, owns progress.
+pub(crate) async fn recover_failed_catalog_publication_reconstruction_v1<'a>(
+    failure: FailedCatalogPublicationReconstructionV1<'a>,
+) -> Result<ReconstructedCatalogPublicationV1<'a>, FailedCatalogPublicationReconstructionV1<'a>> {
+    let FailedCatalogPublicationReconstructionV1 { pending, error: _ } = failure;
+    resume_reconstructed_catalog_publication_v1(pending).await
+}
+
+#[cfg(test)]
+fn is_canonical_control_record_v1(
+    raw_bytes: &[u8],
+    selected: &ValidatedSelectedRegisteredRootRemoteContextV1,
+) -> bool {
+    parse_canonical_control_record_v1(raw_bytes, selected).is_some()
 }
 
 #[cfg(test)]
@@ -5817,6 +7792,7 @@ mod tests {
         control_binding: CatalogControlAcquisitionBindingV1,
         pending_revision: CatalogControlAuthorityRevisionV1,
         pending_control_record_fingerprint: [u8; 32],
+        canonical_pending_control_record_bytes: Vec<u8>,
         publishing_head_reservation_fingerprint: [u8; 32],
         writer_fence_authority_revision_fingerprint: [u8; 32],
         writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1,
@@ -5902,10 +7878,25 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum TestCatalogFenceCallV1 {
+        Write(u64),
+        Replay(u64),
+    }
+
+    struct TestCatalogReacquisitionMutationV1 {
+        operator: Operator,
+        object_key: String,
+        raw_bytes: Vec<u8>,
+    }
+
     #[derive(Default)]
     struct TestCatalogFenceStateV1 {
+        predecessor_ready: Option<CatalogControlAcquisitionBindingV1>,
         pending: Option<TestCatalogFencePendingV1>,
         ready: Option<TestCatalogReadyRequestV1>,
+        calls: Vec<TestCatalogFenceCallV1>,
+        reacquisition_mutation: Option<TestCatalogReacquisitionMutationV1>,
     }
 
     struct TestCatalogMonotonicFenceLeaseV1 {
@@ -5913,6 +7904,125 @@ mod tests {
         revoke_before_next_write: std::sync::Arc<std::sync::atomic::AtomicBool>,
         fail_after_next_backend_apply: std::sync::Arc<std::sync::atomic::AtomicBool>,
         state: std::sync::Arc<tokio::sync::Mutex<TestCatalogFenceStateV1>>,
+    }
+
+    struct TestCatalogPendingFenceReacquisitionAuthorityV1 {
+        live: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        revoke_before_next_write: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        fail_after_next_backend_apply: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        state: std::sync::Arc<tokio::sync::Mutex<TestCatalogFenceStateV1>>,
+    }
+
+    impl TestCatalogPendingFenceReacquisitionAuthorityV1 {
+        fn clone_authority(
+            &self,
+        ) -> std::sync::Arc<dyn CatalogPendingFenceReacquisitionAuthorityV1> {
+            std::sync::Arc::new(Self {
+                live: self.live.clone(),
+                revoke_before_next_write: self.revoke_before_next_write.clone(),
+                fail_after_next_backend_apply: self.fail_after_next_backend_apply.clone(),
+                state: self.state.clone(),
+            })
+        }
+    }
+
+    impl CatalogPendingFenceReacquisitionAuthorityV1
+        for TestCatalogPendingFenceReacquisitionAuthorityV1
+    {
+        fn reacquire_pending_fence_v1<'a>(
+            &'a self,
+            request: CatalogPendingFenceReacquisitionRequestV1,
+        ) -> CatalogPendingFenceReacquisitionFutureV1<'a> {
+            Box::pin(async move {
+                anyhow::ensure!(
+                    self.live.load(std::sync::atomic::Ordering::SeqCst),
+                    "test catalog fence epoch is not live"
+                );
+                anyhow::ensure!(
+                    catalog_pending_fence_reacquisition_request_fingerprint_v1(&request)?
+                        == request.request_fingerprint
+                        && super::super::domain_object_id_v1(
+                            CATALOG_CONTROL_RECORD_DOMAIN_V1,
+                            &request.canonical_pending_control_record_bytes,
+                        ) == request.pending_control_record_fingerprint,
+                    "test Pending-fence reacquisition request is invalid"
+                );
+                let mut state = self.state.lock().await;
+                anyhow::ensure!(
+                    state.ready.is_none(),
+                    "test catalog fence already advanced beyond Pending"
+                );
+                let pending = state
+                    .pending
+                    .as_ref()
+                    .context("test catalog fence has no durable Pending epoch")?;
+                anyhow::ensure!(
+                    state.predecessor_ready.is_none()
+                        && pending.control_binding == request.control_binding
+                        && pending.pending_revision == request.pending_revision
+                        && pending.pending_control_record_fingerprint
+                            == request.pending_control_record_fingerprint
+                        && pending.canonical_pending_control_record_bytes
+                            == request.canonical_pending_control_record_bytes
+                        && pending.publishing_head_reservation_fingerprint
+                            == request.publishing_head_reservation_fingerprint
+                        && pending.writer_fence_authority_revision_fingerprint
+                            == request.writer_fence_authority_revision_fingerprint
+                        && pending.writer_fence_lease_public_fingerprint
+                            == request.writer_fence_lease_public_fingerprint
+                        && usize::try_from(pending.next_ordinal).ok()
+                            == Some(pending.receipts.len())
+                        && pending.receipts.keys().copied().eq(0..pending.next_ordinal),
+                    "test Pending-fence reacquisition crossed or reset its durable epoch"
+                );
+                let reacquisition_mutation = state.reacquisition_mutation.take();
+                let control_binding = request.control_binding.clone();
+                let writer_fence_authority_revision_fingerprint =
+                    request.writer_fence_authority_revision_fingerprint;
+                let writer_fence_lease_public_fingerprint =
+                    request.writer_fence_lease_public_fingerprint;
+                let pending_receipt = TrustedCatalogPublicationPendingReceiptV1 {
+                    control_binding: request.control_binding,
+                    pending_revision: request.pending_revision,
+                    publishing_head_reservation_fingerprint: request
+                        .publishing_head_reservation_fingerprint,
+                    writer_fence_authority_revision_fingerprint,
+                    writer_fence_lease_public_fingerprint,
+                    pending_control_record_fingerprint: request.pending_control_record_fingerprint,
+                };
+                drop(state);
+                if let Some(mutation) = reacquisition_mutation {
+                    mutation
+                        .operator
+                        .write(&mutation.object_key, mutation.raw_bytes)
+                        .await
+                        .context("test mutating catalog artifact during Pending reacquisition")?;
+                }
+                Ok(TrustedCatalogPendingFenceReacquisitionV1 {
+                    request_fingerprint: request.request_fingerprint,
+                    pending_receipt,
+                    retained_control_lease: RetainedCatalogControlLeaseV1 {
+                        control_binding,
+                        writer_fence_authority_revision_fingerprint,
+                        writer_fence_lease_public_fingerprint,
+                        liveness: Box::new(TestCatalogMonotonicFenceLeaseV1 {
+                            live: self.live.clone(),
+                            revoke_before_next_write: self.revoke_before_next_write.clone(),
+                            fail_after_next_backend_apply: self
+                                .fail_after_next_backend_apply
+                                .clone(),
+                            state: self.state.clone(),
+                        }),
+                        test_live: self.live.clone(),
+                        test_revoke_before_next_write: self.revoke_before_next_write.clone(),
+                        test_fail_after_next_backend_apply: self
+                            .fail_after_next_backend_apply
+                            .clone(),
+                        test_reacquisition_authority: self.clone_authority(),
+                    },
+                })
+            })
+        }
     }
 
     impl CatalogMonotonicFenceLeaseV1 for TestCatalogMonotonicFenceLeaseV1 {
@@ -5955,10 +8065,13 @@ mod tests {
                 let newly_applied = state.pending.is_none();
                 if let Some(pending) = &state.pending {
                     anyhow::ensure!(
-                        pending.control_binding == request.control_binding
+                        state.predecessor_ready.is_none()
+                            && pending.control_binding == request.control_binding
                             && pending.pending_revision == request.pending_revision
                             && pending.pending_control_record_fingerprint
                                 == request.pending_control_record_fingerprint
+                            && pending.canonical_pending_control_record_bytes
+                                == request.canonical_pending_control_record_bytes
                             && pending.publishing_head_reservation_fingerprint
                                 == request.publishing_head_reservation_fingerprint
                             && pending.writer_fence_authority_revision_fingerprint
@@ -5968,11 +8081,19 @@ mod tests {
                         "test pending control ordinal was reused by another proposal"
                     );
                 } else {
+                    anyhow::ensure!(
+                        state.predecessor_ready.as_ref() == Some(&request.control_binding),
+                        "test pending control request crossed its exact predecessor Ready"
+                    );
+                    state.predecessor_ready = None;
                     state.pending = Some(TestCatalogFencePendingV1 {
                         control_binding: request.control_binding.clone(),
                         pending_revision: request.pending_revision,
                         pending_control_record_fingerprint: request
                             .pending_control_record_fingerprint,
+                        canonical_pending_control_record_bytes: request
+                            .canonical_pending_control_record_bytes
+                            .clone(),
                         publishing_head_reservation_fingerprint: request
                             .publishing_head_reservation_fingerprint,
                         writer_fence_authority_revision_fingerprint: request
@@ -6031,6 +8152,9 @@ mod tests {
                             == request.successor_raw_blake3,
                     "test fenced-storage request is invalid"
                 );
+                state
+                    .calls
+                    .push(TestCatalogFenceCallV1::Write(request.ordinal));
                 let pending = state
                     .pending
                     .as_mut()
@@ -6165,6 +8289,65 @@ mod tests {
             })
         }
 
+        fn replay_fenced_receipt_v1<'a>(
+            &'a self,
+            request: CatalogFencedStorageWriteRequestV1,
+        ) -> CatalogFencedStorageWriteFutureV1<'a> {
+            Box::pin(async move {
+                anyhow::ensure!(self.is_live_v1(), "test catalog control lease is not live");
+                anyhow::ensure!(
+                    catalog_fenced_storage_write_request_fingerprint_v1(
+                        &catalog_fenced_storage_write_request_wire_v1(&request),
+                    )? == request.request_fingerprint
+                        && u64::try_from(request.successor_raw_bytes.len()).ok()
+                            == Some(request.successor_raw_bytes_len.get())
+                        && catalog_buffer_blake3_v1(&request.successor_raw_bytes)
+                            == request.successor_raw_blake3,
+                    "test fenced-storage receipt replay request is invalid"
+                );
+                let mut state = self.state.lock().await;
+                anyhow::ensure!(
+                    state.ready.is_none(),
+                    "test catalog fence already advanced beyond Pending"
+                );
+                state
+                    .calls
+                    .push(TestCatalogFenceCallV1::Replay(request.ordinal));
+                let pending = state
+                    .pending
+                    .as_ref()
+                    .context("test receipt replay has no installed Pending state")?;
+                anyhow::ensure!(
+                    pending.control_binding == request.control_binding
+                        && pending.pending_revision == request.pending_revision
+                        && pending.pending_control_record_fingerprint
+                            == request.pending_control_record_fingerprint
+                        && pending.writer_fence_authority_revision_fingerprint
+                            == request.writer_fence_authority_revision_fingerprint
+                        && pending.writer_fence_lease_public_fingerprint
+                            == request.writer_fence_lease_public_fingerprint
+                        && pending.mutation_count == Some(request.mutation_count),
+                    "test receipt replay crossed its durable Pending epoch"
+                );
+                let (known_fingerprint, known_binding) = pending
+                    .receipts
+                    .get(&request.ordinal)
+                    .context("test receipt replay cannot create a missing ledger ordinal")?;
+                anyhow::ensure!(
+                    *known_fingerprint == request.request_fingerprint,
+                    "test receipt replay request differs at its durable ordinal"
+                );
+                Ok(CatalogFencedStorageWriteReceiptV1 {
+                    control_binding: request.control_binding,
+                    pending_revision: request.pending_revision,
+                    pending_control_record_fingerprint: request.pending_control_record_fingerprint,
+                    ordinal: request.ordinal,
+                    request_fingerprint: request.request_fingerprint,
+                    binding: known_binding.clone(),
+                })
+            })
+        }
+
         fn compare_and_swap_ready_v1<'a>(
             &'a self,
             request: CatalogControlReadyAdvanceRequestV1,
@@ -6197,6 +8380,9 @@ mod tests {
                 let mutation_count = pending
                     .mutation_count
                     .context("test Ready advance has no fenced storage sequence")?;
+                let terminal_ordinal = mutation_count
+                    .checked_add(1)
+                    .context("test Ready terminal receipt ordinal overflow")?;
                 anyhow::ensure!(
                     pending.control_binding == request.control_binding
                         && pending.pending_revision == request.pending_revision
@@ -6211,8 +8397,33 @@ mod tests {
                         && pending.next_ordinal
                             == mutation_count
                                 .checked_add(2)
-                                .context("test Ready terminal ordinal overflow")?,
+                                .context("test Ready terminal ordinal overflow")?
+                        && usize::try_from(pending.next_ordinal).ok()
+                            == Some(pending.receipts.len())
+                        && pending.receipts.keys().copied().eq(0..pending.next_ordinal),
                     "test Ready advance does not follow the complete fenced storage sequence"
+                );
+                let (terminal_request_fingerprint, terminal_binding) = pending
+                    .receipts
+                    .get(&terminal_ordinal)
+                    .context("test Ready advance has no durable terminal receipt")?;
+                let ready_wire = serde_json::from_slice::<CatalogControlRecordWireV1>(
+                    &request.canonical_ready_control_record_bytes,
+                )
+                .context("test Ready advance record is not canonical control wire")?;
+                let CatalogControlStateWireV1::Ready {
+                    completed_publication: Some(completed),
+                    ..
+                } = ready_wire.control_state
+                else {
+                    anyhow::bail!("test Ready advance has no completion provenance");
+                };
+                anyhow::ensure!(
+                    completed.committed_head_fenced_request_fingerprint
+                        == lower_hex(terminal_request_fingerprint)
+                        && completed.committed_head_storage_binding
+                            == binding_wire_v1(terminal_binding),
+                    "test Ready completion provenance crossed the durable terminal receipt"
                 );
                 state.ready = Some(TestCatalogReadyRequestV1::from_request(&request));
                 if self
@@ -6294,6 +8505,24 @@ mod tests {
         Default
     );
     static_assertions::assert_not_impl_any!(
+        CatalogPendingFenceReacquisitionRequestV1:
+        Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundPendingCatalogControlV1<'static>>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        TrustedCatalogPendingFenceReacquisitionV1:
+        Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundPendingCatalogControlV1<'static>>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
         CatalogControlReadyAdvanceRequestV1: Clone,
         serde::Serialize,
         Default
@@ -6310,6 +8539,7 @@ mod tests {
         Into<TrustedCatalogHighWaterGuardV1>,
         Into<AllNamespaceWritersFencedLeaseV1>,
         Into<TrustedCatalogPublicationPendingReceiptV1>,
+        Into<TrustedCatalogPendingFenceReacquisitionV1>,
         Into<TrustedCatalogHighWaterAdvanceReceiptV1>,
         Into<BoundPendingCatalogControlV1<'static>>,
         Into<BoundCommittedCatalogSuccessorV1>
@@ -6415,6 +8645,24 @@ mod tests {
         Into<Vec<crate::reconcile::ReconcileAction>>
     );
     static_assertions::assert_not_impl_any!(
+        ReconstructedCatalogPublicationV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundPendingCatalogControlV1<'static>>,
+        Into<BoundCommittedCatalogSuccessorV1>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        FailedCatalogPublicationReconstructionV1<'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<BoundPendingCatalogControlV1<'static>>,
+        Into<ReconstructedCatalogPublicationV1<'static>>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
         FailedCatalogPublicationPendingInstallV1<'static>: Clone,
         serde::Serialize,
         Default,
@@ -6459,6 +8707,15 @@ mod tests {
         serde::Serialize,
         Default,
         Into<AppliedCatalogNamespaceMutationsV1<'static>>,
+        Into<BoundCommittedCatalogSuccessorV1>,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>
+    );
+    static_assertions::assert_not_impl_any!(
+        ProvisionalObservedCatalogSuccessorV1: Clone,
+        serde::Serialize,
+        Default,
+        Into<PublishedCatalogSuccessorClosureV1>,
         Into<BoundCommittedCatalogSuccessorV1>,
         Into<crate::reconcile::ReconcilePlan>,
         Into<Vec<crate::reconcile::ReconcileAction>>
@@ -6565,12 +8822,13 @@ mod tests {
         .into_bytes()
     }
 
-    fn trusted_receipts(
+    fn trusted_receipts_with_state(
         observed: &ObservedPublishedCatalogHeadV1,
     ) -> (
         TrustedCatalogBootstrapReceiptV1,
         TrustedCatalogHighWaterGuardV1,
         AllNamespaceWritersFencedLeaseV1,
+        std::sync::Arc<tokio::sync::Mutex<TestCatalogFenceStateV1>>,
     ) {
         let bootstrap_head_revision = observed.head_revision;
         let bootstrap_writer_epoch = [0x21; 32];
@@ -6598,6 +8856,38 @@ mod tests {
             },
             lease_public_fingerprint: NonSecretLeasePublicFingerprintV1([0xaa; 32]),
         };
+        let live = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let revoke_before_next_write =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let fail_after_next_backend_apply =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let state = std::sync::Arc::new(tokio::sync::Mutex::new(TestCatalogFenceStateV1 {
+            predecessor_ready: Some(control_binding.clone()),
+            ..TestCatalogFenceStateV1::default()
+        }));
+        let reacquisition_authority: std::sync::Arc<
+            dyn CatalogPendingFenceReacquisitionAuthorityV1,
+        > = std::sync::Arc::new(TestCatalogPendingFenceReacquisitionAuthorityV1 {
+            live: live.clone(),
+            revoke_before_next_write: revoke_before_next_write.clone(),
+            fail_after_next_backend_apply: fail_after_next_backend_apply.clone(),
+            state: state.clone(),
+        });
+        let retained_control_lease = RetainedCatalogControlLeaseV1 {
+            control_binding: control_binding.clone(),
+            writer_fence_authority_revision_fingerprint: [0x89; 32],
+            writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1([0x88; 32]),
+            liveness: Box::new(TestCatalogMonotonicFenceLeaseV1 {
+                live: live.clone(),
+                revoke_before_next_write: revoke_before_next_write.clone(),
+                fail_after_next_backend_apply: fail_after_next_backend_apply.clone(),
+                state: state.clone(),
+            }),
+            test_live: live,
+            test_revoke_before_next_write: revoke_before_next_write,
+            test_fail_after_next_backend_apply: fail_after_next_backend_apply,
+            test_reacquisition_authority: reacquisition_authority,
+        };
         (
             TrustedCatalogBootstrapReceiptV1 {
                 context: observed.context.clone(),
@@ -6609,36 +8899,24 @@ mod tests {
                 binding: control_binding.clone(),
             },
             AllNamespaceWritersFencedLeaseV1 {
-                retained_control_lease: {
-                    let live = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-                    let revoke_before_next_write =
-                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-                    let fail_after_next_backend_apply =
-                        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-                    RetainedCatalogControlLeaseV1 {
-                        control_binding: control_binding.clone(),
-                        writer_fence_authority_revision_fingerprint: [0x89; 32],
-                        writer_fence_lease_public_fingerprint: NonSecretLeasePublicFingerprintV1(
-                            [0x88; 32],
-                        ),
-                        liveness: Box::new(TestCatalogMonotonicFenceLeaseV1 {
-                            live: live.clone(),
-                            revoke_before_next_write: revoke_before_next_write.clone(),
-                            fail_after_next_backend_apply: fail_after_next_backend_apply.clone(),
-                            state: std::sync::Arc::new(tokio::sync::Mutex::new(
-                                TestCatalogFenceStateV1::default(),
-                            )),
-                        }),
-                        test_live: live,
-                        test_revoke_before_next_write: revoke_before_next_write,
-                        test_fail_after_next_backend_apply: fail_after_next_backend_apply,
-                    }
-                },
+                retained_control_lease,
                 control_binding,
                 authority_revision_fingerprint: [0x89; 32],
                 lease_public_fingerprint: NonSecretLeasePublicFingerprintV1([0x88; 32]),
             },
+            state,
         )
+    }
+
+    fn trusted_receipts(
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> (
+        TrustedCatalogBootstrapReceiptV1,
+        TrustedCatalogHighWaterGuardV1,
+        AllNamespaceWritersFencedLeaseV1,
+    ) {
+        let (bootstrap, high_water, writers, _) = trusted_receipts_with_state(observed);
+        (bootstrap, high_water, writers)
     }
 
     fn trusted_storage(
@@ -6682,6 +8960,7 @@ mod tests {
                 predecessor_head_bytes_blake3: *blake3::hash(&observed.committed_head_bytes)
                     .as_bytes(),
                 object_id: archive_object_id,
+                raw_bytes: observed.committed_head_bytes.clone(),
                 raw_bytes_len: NonZeroU64::new(
                     u64::try_from(observed.committed_head_bytes.len()).unwrap(),
                 )
@@ -6709,18 +8988,31 @@ mod tests {
         )
     }
 
+    fn matched_with_state<'a>(
+        fixture: &'a SemanticRemoteCatalogFixtureV1,
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> (
+        MatchedCatalogPublicationPrerequisitesV1<'a>,
+        std::sync::Arc<tokio::sync::Mutex<TestCatalogFenceStateV1>>,
+    ) {
+        let (bootstrap, high_water, writers, state) = trusted_receipts_with_state(observed);
+        (
+            match_catalog_publication_prerequisites_v1(
+                trusted_storage(fixture),
+                observed,
+                &bootstrap,
+                held_control(high_water, writers),
+            )
+            .unwrap(),
+            state,
+        )
+    }
+
     fn matched<'a>(
         fixture: &'a SemanticRemoteCatalogFixtureV1,
         observed: &ObservedPublishedCatalogHeadV1,
     ) -> MatchedCatalogPublicationPrerequisitesV1<'a> {
-        let (bootstrap, high_water, writers) = trusted_receipts(observed);
-        match_catalog_publication_prerequisites_v1(
-            trusted_storage(fixture),
-            observed,
-            &bootstrap,
-            held_control(high_water, writers),
-        )
-        .unwrap()
+        matched_with_state(fixture, observed).0
     }
 
     fn prepared_control_transition<'a>(
@@ -6775,13 +9067,16 @@ mod tests {
         match_catalog_publication_pending_receipt_v1(transition, receipt).unwrap()
     }
 
-    async fn authoritative_control_transition<'a>(
+    async fn authoritative_control_transition_with_state<'a>(
         fixture: &'a SemanticRemoteCatalogFixtureV1,
         corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
         observed: &ObservedPublishedCatalogHeadV1,
-    ) -> PreparedCatalogControlTransitionV1<'a> {
+    ) -> (
+        PreparedCatalogControlTransitionV1<'a>,
+        std::sync::Arc<tokio::sync::Mutex<TestCatalogFenceStateV1>>,
+    ) {
         let publication_nonce = [0x44; 32];
-        let prerequisites = matched(fixture, observed);
+        let (prerequisites, state) = matched_with_state(fixture, observed);
         let successor_bytes = deleted_index_bytes();
         let mut batch =
             begin_authoritative_catalog_mutation_batch_v1(&prerequisites, corpus).unwrap();
@@ -6818,7 +9113,121 @@ mod tests {
             journal,
         )
         .unwrap();
-        prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap()
+        (
+            prepare_catalog_control_transition_v1(publication, [0xac; 32]).unwrap(),
+            state,
+        )
+    }
+
+    async fn empty_authoritative_control_transition_with_state<'a>(
+        fixture: &'a SemanticRemoteCatalogFixtureV1,
+        corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> (
+        PreparedCatalogControlTransitionV1<'a>,
+        std::sync::Arc<tokio::sync::Mutex<TestCatalogFenceStateV1>>,
+    ) {
+        let publication_nonce = [0x45; 32];
+        let (prerequisites, state) = matched_with_state(fixture, observed);
+        let batch = begin_authoritative_catalog_mutation_batch_v1(&prerequisites, corpus).unwrap();
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1(publication_nonce, batch)
+            .await
+            .unwrap();
+        let journal = publish_authoritative_catalog_mutation_journal_v1(&prerequisites, prepared)
+            .await
+            .unwrap();
+        let archive = publish_predecessor_head_archive_v1(&prerequisites)
+            .await
+            .unwrap();
+        let publication = prepare_catalog_publication_fence_v1(
+            prerequisites,
+            publication_nonce,
+            archive,
+            journal,
+        )
+        .unwrap();
+        (
+            prepare_catalog_control_transition_v1(publication, [0xad; 32]).unwrap(),
+            state,
+        )
+    }
+
+    async fn authoritative_control_transition<'a>(
+        fixture: &'a SemanticRemoteCatalogFixtureV1,
+        corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
+        observed: &ObservedPublishedCatalogHeadV1,
+    ) -> PreparedCatalogControlTransitionV1<'a> {
+        authoritative_control_transition_with_state(fixture, corpus, observed)
+            .await
+            .0
+    }
+
+    async fn cold_committed_recovery_fixture() -> (
+        SemanticRemoteCatalogFixtureV1,
+        Vec<u8>,
+        std::sync::Arc<dyn CatalogPendingFenceReacquisitionAuthorityV1>,
+        std::sync::Arc<tokio::sync::Mutex<TestCatalogFenceStateV1>>,
+        BTreeMap<u64, ([u8; 32], RegisteredRootRemoteObjectBindingV1)>,
+    ) {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .unwrap();
+        applied
+            .capability
+            .pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = match finalize_catalog_committed_head_v1(applied).await {
+            Err(failure) => failure,
+            Ok(_) => {
+                panic!("fixture terminal write must apply before its simulated response failure")
+            }
+        };
+        drop(failure);
+        let receipts = {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.next_ordinal, 4);
+            assert!(pending.receipts.keys().copied().eq(0..4));
+            let receipts = pending.receipts.clone();
+            state.calls.clear();
+            receipts
+        };
+        (
+            fixture,
+            persisted_pending,
+            reacquisition_authority,
+            state,
+            receipts,
+        )
     }
 
     async fn authoritative_bound_pending<'a>(
@@ -6860,6 +9269,7 @@ mod tests {
             parent_head_revision: publication.parent_head_revision,
             head_revision,
             committed_head_bytes,
+            committed_head_fenced_request_fingerprint: [0x86; 32],
             committed_head_binding: RegisteredRootRemoteObjectBindingV1::Etag {
                 etag: "committed-head-etag".to_owned(),
             },
@@ -6869,10 +9279,7 @@ mod tests {
     fn high_water_advance_receipt(
         committed: &BoundCommittedCatalogSuccessorV1,
     ) -> TrustedCatalogHighWaterAdvanceReceiptV1 {
-        let ready_revision = CatalogControlAuthorityRevisionV1 {
-            generation: NonZeroU64::new(committed.pending_revision.generation.get() + 1).unwrap(),
-            fingerprint: [0xad; 32],
-        };
+        let ready_revision = derive_ready_control_revision_v1(committed).unwrap();
         let ready_bytes = canonical_ready_control_record_bytes_v1(committed, ready_revision);
         TrustedCatalogHighWaterAdvanceReceiptV1 {
             control_binding: committed.control_guard.high_water.binding.clone(),
@@ -6956,13 +9363,152 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn observed_head_retains_exact_current_etag_and_lineage() {
+    async fn observed_head_retains_exact_current_binding_and_lineage() {
         let (_fixture, observed) = observed_head().await;
         assert_eq!(observed.sequence.get(), 1);
         assert_eq!(observed.parent_head_revision, None);
         assert_ne!(observed.publication_nonce, [0; 32]);
         assert_ne!(observed.head_revision, [0; 32]);
-        assert_eq!(observed.current_head_etag, "head-etag-a");
+        assert_eq!(
+            observed.current_head_binding,
+            RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "head-etag-a".to_owned(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn version_plus_etag_predecessor_binding_is_persisted_and_rebound_exactly() {
+        let (fixture, corpus, mut observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let exact_binding = RegisteredRootRemoteObjectBindingV1::Version {
+            version: "head-version-a".to_owned(),
+            etag: Some("head-etag-a".to_owned()),
+        };
+        observed.current_head_binding = exact_binding.clone();
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        assert_eq!(
+            transition.publication.expected_parent_head_binding,
+            exact_binding
+        );
+        let control_wire = serde_json::from_slice::<CatalogControlRecordWireV1>(
+            &transition.canonical_pending_control_record_bytes,
+        )
+        .unwrap();
+        let CatalogControlStateWireV1::PublicationPending { pending: persisted } =
+            control_wire.control_state
+        else {
+            panic!("expected persisted PublicationPending control state");
+        };
+        assert_eq!(
+            persisted.predecessor_head_storage_binding,
+            binding_wire_v1(&exact_binding)
+        );
+        assert_eq!(
+            persisted.predecessor_head_storage_binding_fingerprint,
+            lower_hex(&predecessor_head_storage_binding_fingerprint_v1(
+                &exact_binding
+            ))
+        );
+
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        drop(pending);
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            reconstructed
+                .transition
+                .publication
+                .expected_parent_head_binding,
+            exact_binding
+        );
+        let failure = match resume_reconstructed_catalog_publication_v1(reconstructed).await {
+            Err(failure) => failure,
+            Ok(_) => {
+                panic!("an ETag-only reread must not satisfy Version+ETag predecessor identity")
+            }
+        };
+        assert!(format!("{failure:#}").contains("different exact binding"));
+        assert!(
+            state.lock().await.calls.is_empty(),
+            "binding mismatch must fail before any fenced storage ordinal"
+        );
+    }
+
+    #[test]
+    fn reconstructed_successor_budget_rejects_aggregate_bodies_before_reads() {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let per_object = remote.max_manifest_object_bytes();
+        let accepted = remote.max_bound_object_bytes_per_pass() / per_object;
+        assert!(accepted < remote.max_catalog_entries());
+        let mut budget = ReconstructedCatalogSuccessorBudgetV1::default();
+        for ordinal in 0..accepted {
+            budget
+                .observe(&format!("roots/manifests/{ordinal:016x}"), per_object)
+                .unwrap();
+        }
+        let error = budget
+            .observe("roots/manifests/aggregate-overrun", per_object)
+            .expect_err("individually bounded bodies must not exceed the aggregate read budget");
+        assert!(error.to_string().contains("bounded semantic-read budget"));
+    }
+
+    #[test]
+    fn committed_recovery_rejects_page_totals_before_retention() {
+        let mut totals = CatalogCommittedRecoveryTotalsV1::default();
+        totals.observe_page(2, 20, 3, 30).unwrap();
+        let error = totals
+            .observe_page(2, 20, 3, 30)
+            .expect_err("contradictory page totals must not exceed the advertised root");
+        assert!(error.to_string().contains("advertised bounded root totals"));
+        assert_eq!(totals.entry_count, 2);
+        assert_eq!(totals.entry_key_bytes, 20);
+    }
+
+    #[test]
+    fn committed_recovery_preflights_aggregate_closure_bytes_before_page_reads() {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let binding = RemoteCatalogObjectBindingWireV1 {
+            version: None,
+            etag: Some("bounded-etag".to_owned()),
+        };
+        let mut budget = super::super::RemoteCatalogBudgetV1::default();
+        budget.observe_root(1, &binding).unwrap();
+        let page_bytes = remote.max_catalog_page_object_bytes();
+        let accepted = (remote.max_catalog_closure_object_bytes() - 1) / page_bytes;
+        assert!(accepted < remote.max_catalog_pages());
+        for _ in 0..accepted {
+            budget.observe_page(page_bytes, &binding).unwrap();
+        }
+        let error = budget
+            .observe_page(page_bytes, &binding)
+            .expect_err("individually bounded pages must not exceed the aggregate closure budget");
+        assert!(format!("{error:?}").contains("ClosureBytes"));
     }
 
     #[tokio::test]
@@ -7140,12 +9686,14 @@ mod tests {
                 0,
                 "roots/.tcfs-catalog/v1/head".to_owned(),
                 CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
-                    etag: capability
-                        .pending
-                        .transition
-                        .publication
-                        .expected_parent_head_etag
-                        .clone(),
+                    etag: mutable_head_etag_v1(
+                        &capability
+                            .pending
+                            .transition
+                            .publication
+                            .expected_parent_head_binding,
+                    )
+                    .unwrap(),
                 },
                 Buffer::from(expected_bytes),
             )
@@ -7170,8 +9718,9 @@ mod tests {
             let expected_parent_etag = pending
                 .transition
                 .publication
-                .expected_parent_head_etag
+                .expected_parent_head_binding
                 .clone();
+            let expected_parent_etag = mutable_head_etag_v1(&expected_parent_etag).unwrap();
             fixture
                 .operator()
                 .write_with("roots/.tcfs-catalog/v1/head", expected_bytes)
@@ -7307,14 +9856,947 @@ mod tests {
             .retained_control_lease
             .test_fail_after_next_backend_apply
             .store(true, std::sync::atomic::Ordering::SeqCst);
-        let failure = advance_catalog_high_water_v1(committed, [0xad; 32])
+        let expected_ready_revision = derive_ready_control_revision_v1(&committed).unwrap();
+        let failure = advance_catalog_high_water_v1(committed)
             .await
             .expect_err("Ready advance must retain an ambiguous applied transition");
         let advanced = recover_failed_catalog_high_water_advance_v1(failure)
             .await
             .unwrap();
         assert_eq!(advanced.successor.sequence.get(), 2);
-        assert_eq!(advanced.ready_revision.fingerprint, [0xad; 32]);
+        assert_eq!(advanced.ready_revision, expected_ready_revision);
+    }
+
+    #[tokio::test]
+    async fn fresh_process_reconstructs_authenticated_pending_without_warm_capabilities() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        drop(pending);
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending.clone(),
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            reconstructed
+                .transition
+                .canonical_pending_control_record_bytes,
+            persisted_pending
+        );
+        let applied = match resume_reconstructed_catalog_publication_v1(reconstructed)
+            .await
+            .unwrap()
+        {
+            ReconstructedCatalogPublicationV1::Applied(applied) => *applied,
+            ReconstructedCatalogPublicationV1::Committed(_) => {
+                panic!("pre-ordinal-zero cold recovery must resume through Publishing")
+            }
+        };
+        {
+            let state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.mutation_count, Some(2));
+            assert_eq!(pending.next_ordinal, 3);
+            assert!(pending.receipts.keys().copied().eq(0..3));
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Write(0),
+                    TestCatalogFenceCallV1::Write(1),
+                    TestCatalogFenceCallV1::Write(2),
+                ]
+            );
+            assert!(state.ready.is_none());
+        }
+        let committed = finalize_catalog_committed_head_v1(applied).await.unwrap();
+        let expected_ready_revision = derive_ready_control_revision_v1(&committed).unwrap();
+        let advanced = advance_catalog_high_water_v1(committed).await.unwrap();
+        assert_eq!(advanced.ready_revision, expected_ready_revision);
+        assert_eq!(advanced.successor.sequence.get(), 2);
+    }
+
+    #[tokio::test]
+    async fn cold_reconstruction_rejects_an_artifact_changed_during_fence_reacquisition() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let archived_head = serde_json::from_slice::<RemoteCatalogHeadWireV1>(
+            &pending.transition.publication.predecessor_archive.raw_bytes,
+        )
+        .unwrap();
+        let root_key = super::super::catalog_root_key_v1(
+            &pending.transition.publication.context.remote_prefix,
+            &archived_head.catalog_root.object_id,
+        );
+        let root_bytes = fixture.operator().read(&root_key).await.unwrap().to_vec();
+        let root = serde_json::from_slice::<RemoteCatalogRootWireV1>(&root_bytes).unwrap();
+        let page_key = super::super::catalog_page_key_v1(
+            &pending.transition.publication.context.remote_prefix,
+            &root.pages.first().unwrap().object_id,
+        );
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        state.lock().await.reacquisition_mutation = Some(TestCatalogReacquisitionMutationV1 {
+            operator: fixture.operator().clone(),
+            object_key: page_key,
+            raw_bytes: b"changed during Pending-fence reacquisition".to_vec(),
+        });
+        drop(pending);
+
+        let error = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .expect_err("post-reacquisition closure drift must fail before ordinal zero");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("after Pending-fence reacquisition")
+                || rendered.contains("revalidating archived catalog page"),
+            "unexpected cold-reconstruction error: {rendered}"
+        );
+        let state = state.lock().await;
+        let pending = state.pending.as_ref().unwrap();
+        assert_eq!(pending.next_ordinal, 0);
+        assert!(pending.receipts.is_empty());
+        assert!(state.ready.is_none());
+        assert!(state.calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_journal_cold_lifecycle_uses_only_publishing_and_terminal_ordinals() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            empty_authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        drop(pending);
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending.clone(),
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let applied = match resume_reconstructed_catalog_publication_v1(reconstructed)
+            .await
+            .unwrap()
+        {
+            ReconstructedCatalogPublicationV1::Applied(applied) => *applied,
+            ReconstructedCatalogPublicationV1::Committed(_) => {
+                panic!("empty pre-ordinal-zero recovery must first install Publishing")
+            }
+        };
+        {
+            let state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.mutation_count, Some(0));
+            assert_eq!(pending.next_ordinal, 1);
+            assert!(pending.receipts.keys().copied().eq(0..1));
+            assert_eq!(state.calls, [TestCatalogFenceCallV1::Write(0)]);
+        }
+        applied
+            .capability
+            .pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = match finalize_catalog_committed_head_v1(applied).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("empty-journal terminal apply must survive response loss"),
+        };
+        drop(failure);
+        {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.mutation_count, Some(0));
+            assert_eq!(pending.next_ordinal, 2);
+            assert!(pending.receipts.keys().copied().eq(0..2));
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Write(0),
+                    TestCatalogFenceCallV1::Write(1),
+                ]
+            );
+            state.calls.clear();
+        }
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let committed = match resume_reconstructed_catalog_publication_v1(reconstructed)
+            .await
+            .unwrap()
+        {
+            ReconstructedCatalogPublicationV1::Committed(committed) => *committed,
+            ReconstructedCatalogPublicationV1::Applied(_) => {
+                panic!("empty-journal terminal replay must recover committed authority")
+            }
+        };
+        assert_eq!(
+            state.lock().await.calls,
+            [
+                TestCatalogFenceCallV1::Replay(0),
+                TestCatalogFenceCallV1::Replay(1),
+            ]
+        );
+        let advanced = advance_catalog_high_water_v1(committed).await.unwrap();
+        assert_eq!(advanced.successor.sequence.get(), 2);
+        assert!(state.lock().await.ready.is_some());
+    }
+
+    #[tokio::test]
+    async fn cold_publishing_reuses_partial_namespace_receipt_prefix_without_skips() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        capability
+            .pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .expect_err("the first namespace ordinal must apply before response loss");
+        drop(failure);
+        let durable_prefix = {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.next_ordinal, 2);
+            assert!(pending.receipts.keys().copied().eq(0..2));
+            let receipts = pending.receipts.clone();
+            state.calls.clear();
+            receipts
+        };
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let applied = match resume_reconstructed_catalog_publication_v1(reconstructed)
+            .await
+            .unwrap()
+        {
+            ReconstructedCatalogPublicationV1::Applied(applied) => *applied,
+            ReconstructedCatalogPublicationV1::Committed(_) => {
+                panic!("partial namespace prefix must resume the ordered journal")
+            }
+        };
+        {
+            let state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.receipts.get(&0), durable_prefix.get(&0));
+            assert_eq!(pending.receipts.get(&1), durable_prefix.get(&1));
+            assert_eq!(pending.next_ordinal, 3);
+            assert!(pending.receipts.keys().copied().eq(0..3));
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Write(1),
+                    TestCatalogFenceCallV1::Write(2),
+                ]
+            );
+            assert!(state.ready.is_none());
+        }
+        drop(applied);
+    }
+
+    #[tokio::test]
+    async fn stale_pending_reconstruction_after_ready_performs_no_storage_ordinal() {
+        let (fixture, persisted_pending, reacquisition_authority, state, _) =
+            cold_committed_recovery_fixture().await;
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending.clone(),
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let committed = match resume_reconstructed_catalog_publication_v1(reconstructed)
+            .await
+            .unwrap()
+        {
+            ReconstructedCatalogPublicationV1::Committed(committed) => *committed,
+            ReconstructedCatalogPublicationV1::Applied(_) => {
+                panic!("complete durable terminal evidence must recover committed authority")
+            }
+        };
+        advance_catalog_high_water_v1(committed).await.unwrap();
+        state.lock().await.calls.clear();
+
+        let error = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .expect_err("stale Pending must not reopen an epoch already advanced to Ready");
+        assert!(format!("{error:#}").contains("advanced beyond Pending"));
+        let state = state.lock().await;
+        assert!(state.calls.is_empty());
+        assert!(state.ready.is_some());
+    }
+
+    #[tokio::test]
+    async fn cold_third_state_replays_only_existing_prefix_and_never_terminal_or_ready() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .unwrap();
+        fixture
+            .operator()
+            .write(
+                "roots/.tcfs-catalog/v1/head",
+                br#"{"state":"corrupt-third-state"}"#.to_vec(),
+            )
+            .await
+            .unwrap();
+        drop(applied);
+        state.lock().await.calls.clear();
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let failure = match resume_reconstructed_catalog_publication_v1(reconstructed).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("a corrupt third HEAD state must not recover publication authority"),
+        };
+        assert!(format!("{failure:#}").contains("neither publishing nor a committed HEAD"));
+        let state = state.lock().await;
+        assert_eq!(
+            state.calls,
+            [
+                TestCatalogFenceCallV1::Replay(0),
+                TestCatalogFenceCallV1::Replay(1),
+                TestCatalogFenceCallV1::Replay(2),
+            ]
+        );
+        assert!(state.ready.is_none());
+        assert_eq!(state.pending.as_ref().unwrap().next_ordinal, 3);
+    }
+
+    #[tokio::test]
+    async fn fresh_process_replays_durable_publishing_and_terminal_receipts() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = install_catalog_publishing_head_v1(pending)
+            .await
+            .expect_err("publishing HEAD apply-before-response must retain warm state");
+        drop(failure);
+        let ordinal_zero_receipt = {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.mutation_count, Some(2));
+            assert_eq!(pending.next_ordinal, 1);
+            assert!(pending.receipts.keys().copied().eq(0..1));
+            let receipt = pending.receipts.get(&0).unwrap().clone();
+            assert_eq!(state.calls, [TestCatalogFenceCallV1::Write(0)]);
+            state.calls.clear();
+            receipt
+        };
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending.clone(),
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let applied = match resume_reconstructed_catalog_publication_v1(reconstructed)
+            .await
+            .unwrap()
+        {
+            ReconstructedCatalogPublicationV1::Applied(applied) => *applied,
+            ReconstructedCatalogPublicationV1::Committed(_) => {
+                panic!("publishing apply-before-response must resume the namespace journal")
+            }
+        };
+        {
+            let state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.receipts.get(&0), Some(&ordinal_zero_receipt));
+            assert_eq!(pending.next_ordinal, 3);
+            assert!(pending.receipts.keys().copied().eq(0..3));
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Write(1),
+                    TestCatalogFenceCallV1::Write(2),
+                ]
+            );
+            assert!(state.ready.is_none());
+        }
+        applied
+            .capability
+            .pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = match finalize_catalog_committed_head_v1(applied).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("committed HEAD apply-before-response must retain warm state"),
+        };
+        drop(failure);
+        let durable_receipts = {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.next_ordinal, 4);
+            assert!(pending.receipts.keys().copied().eq(0..4));
+            let receipts = pending.receipts.clone();
+            state.calls.clear();
+            receipts
+        };
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let committed = match resume_reconstructed_catalog_publication_v1(reconstructed)
+            .await
+            .unwrap()
+        {
+            ReconstructedCatalogPublicationV1::Committed(committed) => *committed,
+            ReconstructedCatalogPublicationV1::Applied(_) => {
+                panic!("terminal apply-before-response must recover committed authority")
+            }
+        };
+        let terminal_receipt = durable_receipts.get(&3).unwrap();
+        assert_eq!(
+            committed.committed_head_fenced_request_fingerprint,
+            terminal_receipt.0
+        );
+        assert_eq!(committed.committed_head_binding, terminal_receipt.1);
+        {
+            let state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.receipts, durable_receipts);
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Replay(1),
+                    TestCatalogFenceCallV1::Replay(2),
+                    TestCatalogFenceCallV1::Replay(3),
+                ]
+            );
+            assert!(state.ready.is_none());
+        }
+        let advanced = advance_catalog_high_water_v1(committed).await.unwrap();
+        assert_eq!(advanced.successor.sequence.get(), 2);
+        assert!(state.lock().await.ready.is_some());
+    }
+
+    #[tokio::test]
+    async fn cold_publishing_bytes_cannot_backfill_a_missing_ordinal_zero_receipt() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let reacquisition_authority = pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        pending
+            .transition
+            .publication
+            .control_guard
+            .all_writers
+            .retained_control_lease
+            .test_fail_after_next_backend_apply
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failure = install_catalog_publishing_head_v1(pending)
+            .await
+            .expect_err(
+                "fixture Publishing write must apply before its simulated response failure",
+            );
+        drop(failure);
+        let ordinal_zero_receipt = {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_mut().unwrap();
+            let receipt = pending.receipts.remove(&0).unwrap();
+            pending.next_ordinal = 0;
+            state.calls.clear();
+            receipt
+        };
+
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let failure = match resume_reconstructed_catalog_publication_v1(reconstructed).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("raw Publishing bytes must not mint a missing ordinal-zero receipt"),
+        };
+        assert!(format!("{failure:#}").contains("missing ledger ordinal"));
+        {
+            let mut state = state.lock().await;
+            assert_eq!(state.calls, [TestCatalogFenceCallV1::Replay(0)]);
+            assert!(state.ready.is_none());
+            let pending = state.pending.as_mut().unwrap();
+            assert_eq!(pending.next_ordinal, 0);
+            assert!(pending.receipts.is_empty());
+            pending.receipts.insert(0, ordinal_zero_receipt.clone());
+            pending.next_ordinal = 1;
+            state.calls.clear();
+        }
+        let applied = match recover_failed_catalog_publication_reconstruction_v1(failure).await {
+            Ok(ReconstructedCatalogPublicationV1::Applied(applied)) => *applied,
+            Ok(ReconstructedCatalogPublicationV1::Committed(_)) => {
+                panic!("repaired Publishing recovery must resume the namespace journal")
+            }
+            Err(failure) => panic!("repaired ordinal-zero receipt must recover: {failure:#}"),
+        };
+        {
+            let state = state.lock().await;
+            let pending = state.pending.as_ref().unwrap();
+            assert_eq!(pending.receipts.get(&0), Some(&ordinal_zero_receipt));
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Write(1),
+                    TestCatalogFenceCallV1::Write(2),
+                ]
+            );
+            assert!(state.ready.is_none());
+        }
+        drop(applied);
+    }
+
+    #[tokio::test]
+    async fn cold_committed_bytes_cannot_backfill_a_missing_namespace_receipt() {
+        let (fixture, persisted_pending, reacquisition_authority, state, durable_receipts) =
+            cold_committed_recovery_fixture().await;
+        {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_mut().unwrap();
+            pending.receipts.retain(|ordinal, _| *ordinal == 0);
+            pending.next_ordinal = 1;
+            state.calls.clear();
+        }
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let failure = match resume_reconstructed_catalog_publication_v1(reconstructed).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("raw committed closure must not mint a missing namespace receipt"),
+        };
+        assert!(format!("{failure:#}").contains("missing ledger ordinal"));
+        {
+            let mut state = state.lock().await;
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Replay(1),
+                ]
+            );
+            assert!(state.ready.is_none());
+            let pending = state.pending.as_mut().unwrap();
+            assert_eq!(pending.next_ordinal, 1);
+            assert!(pending.receipts.keys().copied().eq(0..1));
+            pending.receipts = durable_receipts.clone();
+            pending.next_ordinal = 4;
+            state.calls.clear();
+        }
+        let committed = match recover_failed_catalog_publication_reconstruction_v1(failure).await {
+            Ok(ReconstructedCatalogPublicationV1::Committed(committed)) => *committed,
+            Ok(ReconstructedCatalogPublicationV1::Applied(_)) => {
+                panic!("repaired committed recovery must not return Publishing")
+            }
+            Err(failure) => panic!("repaired namespace receipt prefix must recover: {failure:#}"),
+        };
+        assert_eq!(
+            committed.committed_head_fenced_request_fingerprint,
+            durable_receipts.get(&3).unwrap().0
+        );
+        {
+            let state = state.lock().await;
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Replay(1),
+                    TestCatalogFenceCallV1::Replay(2),
+                    TestCatalogFenceCallV1::Replay(3),
+                ]
+            );
+            assert!(state.ready.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn cold_committed_terminal_cannot_mask_a_crossed_namespace_receipt() {
+        let (fixture, persisted_pending, reacquisition_authority, state, durable_receipts) =
+            cold_committed_recovery_fixture().await;
+        {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_mut().unwrap();
+            pending.receipts.get_mut(&1).unwrap().0 = [0x5c; 32];
+            state.calls.clear();
+        }
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let failure = match resume_reconstructed_catalog_publication_v1(reconstructed).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("crossed namespace request fingerprint must fail cold recovery"),
+        };
+        assert!(format!("{failure:#}").contains("differs at its durable ordinal"));
+        {
+            let mut state = state.lock().await;
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Replay(1),
+                ]
+            );
+            assert!(state.ready.is_none());
+            let pending = state.pending.as_mut().unwrap();
+            pending.receipts.get_mut(&1).unwrap().0 = durable_receipts.get(&1).unwrap().0;
+            pending.receipts.get_mut(&1).unwrap().1 = RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "crossed-namespace-etag".to_owned(),
+            };
+            state.calls.clear();
+        }
+        let failure = match recover_failed_catalog_publication_reconstruction_v1(failure).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("crossed namespace receipt binding must fail cold recovery"),
+        };
+        assert!(format!("{failure:#}").contains("crossed its durable receipt"));
+        {
+            let mut state = state.lock().await;
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Replay(1),
+                ]
+            );
+            assert!(state.ready.is_none());
+            state.pending.as_mut().unwrap().receipts = durable_receipts.clone();
+            state.calls.clear();
+        }
+        let committed = match recover_failed_catalog_publication_reconstruction_v1(failure).await {
+            Ok(ReconstructedCatalogPublicationV1::Committed(committed)) => *committed,
+            Ok(ReconstructedCatalogPublicationV1::Applied(_)) => {
+                panic!("repaired namespace receipt must recover committed state")
+            }
+            Err(failure) => panic!("repaired namespace receipt must recover: {failure:#}"),
+        };
+        assert_eq!(
+            committed.committed_head_fenced_request_fingerprint,
+            durable_receipts.get(&3).unwrap().0
+        );
+        assert!(state.lock().await.ready.is_none());
+    }
+
+    #[tokio::test]
+    async fn cold_committed_bytes_cannot_backfill_a_missing_or_crossed_terminal_receipt() {
+        let (fixture, persisted_pending, reacquisition_authority, state, durable_receipts) =
+            cold_committed_recovery_fixture().await;
+        let terminal_receipt = durable_receipts.get(&3).unwrap().clone();
+        {
+            let mut state = state.lock().await;
+            let pending = state.pending.as_mut().unwrap();
+            pending.receipts.remove(&3);
+            pending.next_ordinal = 3;
+            state.calls.clear();
+        }
+        let reconstructed = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            reacquisition_authority.as_ref(),
+        )
+        .await
+        .unwrap();
+        let failure = match resume_reconstructed_catalog_publication_v1(reconstructed).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("raw committed closure must not mint a missing terminal receipt"),
+        };
+        assert!(format!("{failure:#}").contains("missing ledger ordinal"));
+        {
+            let mut state = state.lock().await;
+            assert_eq!(
+                state.calls,
+                [
+                    TestCatalogFenceCallV1::Replay(0),
+                    TestCatalogFenceCallV1::Replay(1),
+                    TestCatalogFenceCallV1::Replay(2),
+                    TestCatalogFenceCallV1::Replay(3),
+                ]
+            );
+            assert!(state.ready.is_none());
+            let pending = state.pending.as_mut().unwrap();
+            assert_eq!(pending.next_ordinal, 3);
+            assert!(pending.receipts.keys().copied().eq(0..3));
+            pending.receipts.insert(
+                3,
+                (
+                    terminal_receipt.0,
+                    RegisteredRootRemoteObjectBindingV1::Etag {
+                        etag: "crossed-terminal-etag".to_owned(),
+                    },
+                ),
+            );
+            pending.next_ordinal = 4;
+            state.calls.clear();
+        }
+        let failure = match recover_failed_catalog_publication_reconstruction_v1(failure).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("crossed terminal binding must not authorize committed state"),
+        };
+        assert!(format!("{failure:#}").contains("differs from its durable terminal receipt"));
+        {
+            let mut state = state.lock().await;
+            assert!(state.ready.is_none());
+            let pending = state.pending.as_mut().unwrap();
+            pending.receipts.insert(3, terminal_receipt.clone());
+            state.calls.clear();
+        }
+        let committed = match recover_failed_catalog_publication_reconstruction_v1(failure).await {
+            Ok(ReconstructedCatalogPublicationV1::Committed(committed)) => *committed,
+            Ok(ReconstructedCatalogPublicationV1::Applied(_)) => {
+                panic!("repaired terminal receipt must recover committed state")
+            }
+            Err(failure) => panic!("repaired terminal receipt must recover: {failure:#}"),
+        };
+        assert_eq!(
+            committed.committed_head_fenced_request_fingerprint,
+            terminal_receipt.0
+        );
+        assert_eq!(committed.committed_head_binding, terminal_receipt.1);
+        assert!(state.lock().await.ready.is_none());
+    }
+
+    #[tokio::test]
+    async fn copied_pending_bytes_cannot_create_or_reset_a_backend_fence_epoch() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let transition = authoritative_control_transition(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let persisted_pending = pending
+            .transition
+            .canonical_pending_control_record_bytes
+            .clone();
+        let (_, _, unrelated_writers) = trusted_receipts(&observed);
+        let unrelated_authority = unrelated_writers
+            .retained_control_lease
+            .test_reacquisition_authority
+            .clone();
+        drop(pending);
+        let error = reconstruct_catalog_publication_from_authenticated_pending_v1(
+            trusted_storage(&fixture),
+            &test_selected(),
+            persisted_pending,
+            unrelated_authority.as_ref(),
+        )
+        .await
+        .expect_err("copied Pending bytes must not mint a durable backend epoch");
+        assert!(format!("{error:#}").contains("durable Pending epoch"));
     }
 
     #[tokio::test]
@@ -7925,11 +11407,10 @@ mod tests {
             0,
             "roots/.tcfs-catalog/v1/head".to_owned(),
             CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
-                etag: pending
-                    .transition
-                    .publication
-                    .expected_parent_head_etag
-                    .clone(),
+                etag: mutable_head_etag_v1(
+                    &pending.transition.publication.expected_parent_head_binding,
+                )
+                .unwrap(),
             },
             Buffer::from(pending.transition.canonical_publishing_head_bytes.clone()),
         )
@@ -8366,6 +11847,19 @@ mod tests {
             mutable_head_etag_v1(&RegisteredRootRemoteObjectBindingV1::Version {
                 version: "head-version".to_owned(),
                 etag: None,
+            }),
+            None
+        );
+        assert_eq!(
+            mutable_head_etag_v1(&RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "null".to_owned(),
+            }),
+            None
+        );
+        assert_eq!(
+            mutable_head_etag_v1(&RegisteredRootRemoteObjectBindingV1::Version {
+                version: "head-version".to_owned(),
+                etag: Some("null".to_owned()),
             }),
             None
         );
@@ -8815,7 +12309,12 @@ mod tests {
         .unwrap();
         assert_eq!(fence.sequence.get(), 2);
         assert_eq!(fence.parent_head_revision, observed.head_revision);
-        assert_eq!(fence.expected_parent_head_etag, "head-etag-a");
+        assert_eq!(
+            fence.expected_parent_head_binding,
+            RegisteredRootRemoteObjectBindingV1::Etag {
+                etag: "head-etag-a".to_owned(),
+            }
+        );
         assert_eq!(
             archived_head_object_key_v1(&fence.predecessor_archive).unwrap(),
             format!(
@@ -8881,7 +12380,9 @@ mod tests {
         assert_eq!(
             wire.predecessor_head_storage_binding_fingerprint,
             lower_hex(&predecessor_head_storage_binding_fingerprint_v1(
-                "head-etag-a"
+                &RegisteredRootRemoteObjectBindingV1::Etag {
+                    etag: "head-etag-a".to_owned(),
+                }
             ))
         );
         assert_eq!(
@@ -8903,6 +12404,36 @@ mod tests {
             &bound.transition.canonical_pending_control_record_bytes,
             &test_selected()
         ));
+        let control_wire = serde_json::from_slice::<CatalogControlRecordWireV1>(
+            &bound.transition.canonical_pending_control_record_bytes,
+        )
+        .unwrap();
+        let CatalogControlStateWireV1::PublicationPending {
+            pending: persisted_pending,
+        } = control_wire.control_state
+        else {
+            panic!("expected persisted PublicationPending control state");
+        };
+        assert_eq!(
+            persisted_pending.writer_fence_authority_revision_fingerprint,
+            "89".repeat(32)
+        );
+        assert_eq!(
+            persisted_pending.writer_fence_lease_public_fingerprint,
+            "88".repeat(32)
+        );
+        assert_eq!(
+            persisted_pending.predecessor_head_storage_binding.etag,
+            Some("head-etag-a".to_owned())
+        );
+        assert_eq!(
+            persisted_pending.predecessor_head_storage_binding_fingerprint,
+            lower_hex(&predecessor_head_storage_binding_fingerprint_v1(
+                &RegisteredRootRemoteObjectBindingV1::Etag {
+                    etag: "head-etag-a".to_owned(),
+                }
+            ))
+        );
         let pending_text =
             std::str::from_utf8(&bound.transition.canonical_pending_control_record_bytes).unwrap();
         assert!(pending_text.contains("lease_public_fingerprint"));
@@ -8941,6 +12472,25 @@ mod tests {
         let mut wire = serde_json::from_slice::<CatalogControlRecordWireV1>(&canonical).unwrap();
         if let CatalogControlStateWireV1::PublicationPending { pending } = &mut wire.control_state {
             pending.successor_catalog_sequence += 1;
+        }
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&wire).unwrap(),
+            &test_selected()
+        ));
+
+        let mut wire = serde_json::from_slice::<CatalogControlRecordWireV1>(&canonical).unwrap();
+        if let CatalogControlStateWireV1::PublicationPending { pending } = &mut wire.control_state {
+            pending.writer_fence_authority_revision_fingerprint = "00".repeat(32);
+        }
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&wire).unwrap(),
+            &test_selected()
+        ));
+
+        let mut wire = serde_json::from_slice::<CatalogControlRecordWireV1>(&canonical).unwrap();
+        if let CatalogControlStateWireV1::PublicationPending { pending } = &mut wire.control_state {
+            pending.predecessor_head_storage_binding.etag =
+                Some("crossed-predecessor-etag".to_owned());
         }
         assert!(!is_canonical_control_record_v1(
             &serde_json::to_vec(&wire).unwrap(),
@@ -8989,6 +12539,36 @@ mod tests {
                 CatalogPublicationContractErrorV1::ControlTransitionMismatch
             );
         }
+    }
+
+    #[tokio::test]
+    async fn pending_backend_compares_the_exact_predecessor_ready_before_installing_an_epoch() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        state
+            .lock()
+            .await
+            .predecessor_ready
+            .as_mut()
+            .unwrap()
+            .ready_revision
+            .fingerprint = [0xcd; 32];
+
+        let failure = install_catalog_publication_pending_v1(transition)
+            .await
+            .expect_err("a crossed predecessor Ready must not install Pending");
+        assert!(format!("{failure:#}")
+            .contains("test pending control request crossed its exact predecessor Ready"));
+        let state = state.lock().await;
+        assert!(state.predecessor_ready.is_some());
+        assert!(state.pending.is_none());
+        assert!(state.ready.is_none());
+        assert!(state.calls.is_empty());
     }
 
     #[tokio::test]
@@ -9072,7 +12652,9 @@ mod tests {
 
         let first = prepare_catalog_control_transition_v1(make_publication(), [0xac; 32]).unwrap();
         let mut other_baseline = make_publication();
-        other_baseline.expected_parent_head_etag = "head-etag-b".to_owned();
+        other_baseline.expected_parent_head_binding = RegisteredRootRemoteObjectBindingV1::Etag {
+            etag: "head-etag-b".to_owned(),
+        };
         let second = prepare_catalog_control_transition_v1(other_baseline, [0xac; 32]).unwrap();
         assert_ne!(
             first.publishing_head_reservation_fingerprint,
@@ -9114,22 +12696,24 @@ mod tests {
             .await
             .unwrap();
         let committed = finalize_catalog_committed_head_v1(applied).await.unwrap();
-        let advanced = advance_catalog_high_water_v1(committed, [0xad; 32])
-            .await
-            .unwrap();
+        let advanced = advance_catalog_high_water_v1(committed).await.unwrap();
 
         assert_eq!(advanced.successor.sequence.get(), 2);
         assert_eq!(advanced.ready_revision.generation.get(), 9);
-        assert_eq!(advanced.ready_revision.fingerprint, [0xad; 32]);
+        assert_ne!(advanced.ready_revision.fingerprint, [0; 32]);
         assert!(advanced.retained_control_lease.is_live_v1());
 
-        let committed = committed_successor(bound_pending(&fixture, &observed));
-        let failure = match advance_catalog_high_water_v1(committed, [0; 32]).await {
+        let mut committed = committed_successor(bound_pending(&fixture, &observed));
+        committed.committed_head_fenced_request_fingerprint = [0; 32];
+        let failure = match advance_catalog_high_water_v1(committed).await {
             Err(failure) => failure,
-            Ok(_) => panic!("zero ready revision must not reach the control backend"),
+            Ok(_) => panic!("incomplete terminal provenance must not reach the control backend"),
         };
         assert_eq!(failure.committed.sequence.get(), 2);
-        assert_eq!(failure.ready_revision_fingerprint, [0; 32]);
+        assert_eq!(
+            failure.committed.committed_head_fenced_request_fingerprint,
+            [0; 32]
+        );
         assert!(failure
             .committed
             .control_guard
@@ -9144,6 +12728,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ready_backend_cross_checks_completion_against_the_terminal_receipt() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let (transition, state) =
+            authoritative_control_transition_with_state(&fixture, &corpus, &observed).await;
+        let pending = install_catalog_publication_pending_v1(transition)
+            .await
+            .unwrap();
+        let capability = install_catalog_publishing_head_v1(pending).await.unwrap();
+        let applied = apply_authoritative_catalog_namespace_mutations_v1(capability)
+            .await
+            .unwrap();
+        let mut committed = finalize_catalog_committed_head_v1(applied).await.unwrap();
+        let terminal_fingerprint = committed.committed_head_fenced_request_fingerprint;
+        let terminal_binding = committed.committed_head_binding.clone();
+
+        committed.committed_head_fenced_request_fingerprint = [0x77; 32];
+        let failure = match advance_catalog_high_water_v1(committed).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("crossed terminal fingerprint must not advance Ready"),
+        };
+        assert!(format!("{failure:#}").contains("crossed the durable terminal receipt"));
+        assert!(state.lock().await.ready.is_none());
+
+        let mut committed = failure.committed;
+        committed.committed_head_fenced_request_fingerprint = terminal_fingerprint;
+        committed.committed_head_binding = RegisteredRootRemoteObjectBindingV1::Etag {
+            etag: "crossed-ready-etag".to_owned(),
+        };
+        let failure = match advance_catalog_high_water_v1(committed).await {
+            Err(failure) => failure,
+            Ok(_) => panic!("crossed terminal binding must not advance Ready"),
+        };
+        assert!(format!("{failure:#}").contains("crossed the durable terminal receipt"));
+        assert!(state.lock().await.ready.is_none());
+
+        let mut committed = failure.committed;
+        committed.committed_head_binding = terminal_binding;
+        let advanced = advance_catalog_high_water_v1(committed).await.unwrap();
+        assert_eq!(advanced.successor.sequence.get(), 2);
+        assert!(state.lock().await.ready.is_some());
+    }
+
+    #[tokio::test]
     async fn high_water_advance_accepts_only_exact_monotonic_successor() {
         let (fixture, observed) = observed_head().await;
         let make_committed = || committed_successor(bound_pending(&fixture, &observed));
@@ -9152,6 +12783,10 @@ mod tests {
         let receipt = high_water_advance_receipt(&committed);
         let ready_bytes =
             canonical_ready_control_record_bytes_v1(&committed, receipt.ready_revision);
+        assert_eq!(
+            receipt.ready_revision,
+            derive_ready_control_revision_v1(&committed).unwrap()
+        );
         assert!(is_canonical_control_record_v1(
             &ready_bytes,
             &test_selected()
@@ -9160,6 +12795,52 @@ mod tests {
         assert!(ready_text.contains("lease_public_fingerprint"));
         assert!(!ready_text.contains("lease_nonce"));
         assert!(!ready_text.contains("bearer"));
+        let ready_wire =
+            serde_json::from_slice::<CatalogControlRecordWireV1>(&ready_bytes).unwrap();
+        let ready_seed = CatalogReadyControlRevisionSeedWireV1 {
+            version: ready_wire.version,
+            remote_prefix: ready_wire.remote_prefix.clone(),
+            context: ready_wire.context.clone(),
+            control_contract_fingerprint: ready_wire.control_contract_fingerprint.clone(),
+            control_authority_fingerprint: ready_wire.control_authority_fingerprint.clone(),
+            storage_authority_fingerprint: ready_wire.storage_authority_fingerprint.clone(),
+            control_generation: ready_wire.control_generation,
+            lease_public_fingerprint: ready_wire.lease_public_fingerprint.clone(),
+            bootstrap: ready_wire.bootstrap.clone(),
+            writer_epoch: ready_wire.writer_epoch.clone(),
+            control_state: ready_wire.control_state.clone(),
+        };
+        let mut ready_without_revision = serde_json::to_value(&ready_wire).unwrap();
+        ready_without_revision
+            .as_object_mut()
+            .unwrap()
+            .remove("control_revision_fingerprint");
+        assert_eq!(
+            serde_json::to_value(&ready_seed).unwrap(),
+            ready_without_revision,
+            "Ready revision seed must equal the complete Ready record minus only its revision"
+        );
+
+        let mut crossed_ready_revision =
+            serde_json::from_slice::<CatalogControlRecordWireV1>(&ready_bytes).unwrap();
+        crossed_ready_revision.control_revision_fingerprint = "ef".repeat(32);
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&crossed_ready_revision).unwrap(),
+            &test_selected()
+        ));
+        let mut stale_ready_revision =
+            serde_json::from_slice::<CatalogControlRecordWireV1>(&ready_bytes).unwrap();
+        if let CatalogControlStateWireV1::Ready {
+            completed_publication: Some(completed),
+            ..
+        } = &mut stale_ready_revision.control_state
+        {
+            completed.committed_head_fenced_request_fingerprint = "ed".repeat(32);
+        }
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&stale_ready_revision).unwrap(),
+            &test_selected()
+        ));
 
         let mut malformed_ready =
             serde_json::from_slice::<CatalogControlRecordWireV1>(&ready_bytes).unwrap();
@@ -9171,11 +12852,25 @@ mod tests {
 
         let mut wrong_bootstrap =
             serde_json::from_slice::<CatalogControlRecordWireV1>(&ready_bytes).unwrap();
-        if let CatalogControlStateWireV1::Ready { current } = &mut wrong_bootstrap.control_state {
+        if let CatalogControlStateWireV1::Ready { current, .. } = &mut wrong_bootstrap.control_state
+        {
             current.catalog_sequence = 1;
         }
         assert!(!is_canonical_control_record_v1(
             &serde_json::to_vec(&wrong_bootstrap).unwrap(),
+            &test_selected()
+        ));
+        let mut stripped_provenance =
+            serde_json::from_slice::<CatalogControlRecordWireV1>(&ready_bytes).unwrap();
+        if let CatalogControlStateWireV1::Ready {
+            completed_publication,
+            ..
+        } = &mut stripped_provenance.control_state
+        {
+            *completed_publication = None;
+        }
+        assert!(!is_canonical_control_record_v1(
+            &serde_json::to_vec(&stripped_provenance).unwrap(),
             &test_selected()
         ));
         let advanced = match_catalog_high_water_advance_v1(committed, receipt).unwrap();
@@ -9187,6 +12882,69 @@ mod tests {
         assert_eq!(advanced.control_authority_fingerprint, [0x9a; 32]);
         assert_eq!(advanced.context, observed.context);
         assert!(advanced.retained_control_lease.is_live_v1());
+
+        let baseline = {
+            let committed = make_committed();
+            derive_ready_control_revision_v1(&committed)
+                .unwrap()
+                .fingerprint
+        };
+        let changed = [
+            {
+                let mut committed = make_committed();
+                committed.pending_control_record_fingerprint = [0x51; 32];
+                derive_ready_control_revision_v1(&committed)
+                    .unwrap()
+                    .fingerprint
+            },
+            {
+                let mut committed = make_committed();
+                committed.publishing_head_reservation_fingerprint = [0x52; 32];
+                derive_ready_control_revision_v1(&committed)
+                    .unwrap()
+                    .fingerprint
+            },
+            {
+                let mut committed = make_committed();
+                committed
+                    .control_guard
+                    .all_writers
+                    .authority_revision_fingerprint = [0x53; 32];
+                derive_ready_control_revision_v1(&committed)
+                    .unwrap()
+                    .fingerprint
+            },
+            {
+                let mut committed = make_committed();
+                committed.committed_head_fenced_request_fingerprint = [0x54; 32];
+                derive_ready_control_revision_v1(&committed)
+                    .unwrap()
+                    .fingerprint
+            },
+            {
+                let mut committed = make_committed();
+                committed.committed_head_binding = RegisteredRootRemoteObjectBindingV1::Etag {
+                    etag: "other-committed-etag".to_owned(),
+                };
+                derive_ready_control_revision_v1(&committed)
+                    .unwrap()
+                    .fingerprint
+            },
+            {
+                let mut committed = make_committed();
+                committed
+                    .control_guard
+                    .high_water
+                    .binding
+                    .lease_public_fingerprint = NonSecretLeasePublicFingerprintV1([0x55; 32]);
+                derive_ready_control_revision_v1(&committed)
+                    .unwrap()
+                    .fingerprint
+            },
+        ];
+        assert!(changed
+            .into_iter()
+            .all(|changed_fingerprint| changed_fingerprint != baseline));
 
         {
             let committed = make_committed();

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -23,13 +23,13 @@
 //! so this source path remains unreachable by deployed writers and cannot mint
 //! production authority, produce a plan digest, or authorize an action.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::num::NonZeroU64;
 use std::pin::Pin;
 
 use anyhow::{Context, Result as AnyhowResult};
-use opendal::Operator;
+use opendal::{Buffer, Operator};
 use serde::{Deserialize, Serialize};
 use tcfs_core::config::{
     RegisteredRootPlanContractFingerprintV1, RegisteredRootPlanContractV1,
@@ -174,6 +174,7 @@ pub(crate) enum CatalogMutationJournalResourceV1 {
     Bytes,
     Mutations,
     KeyBytes,
+    PayloadBytes,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -721,6 +722,26 @@ fn mutation_journal_resource(
     CatalogPublicationContractErrorV1::MutationJournalResource(resource)
 }
 
+fn checked_catalog_mutation_payload_bytes_v1(
+    lengths: impl IntoIterator<Item = u64>,
+) -> Result<u64, CatalogPublicationContractErrorV1> {
+    let total = lengths.into_iter().try_fold(0_u64, |total, length| {
+        total.checked_add(length).ok_or_else(|| {
+            mutation_journal_resource(CatalogMutationJournalResourceV1::PayloadBytes)
+        })
+    })?;
+    if total
+        > RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_mutation_payload_bytes()
+    {
+        return Err(mutation_journal_resource(
+            CatalogMutationJournalResourceV1::PayloadBytes,
+        ));
+    }
+    Ok(total)
+}
+
 fn binding_has_usable_etag_v1(binding: &RemoteCatalogObjectBindingWireV1) -> bool {
     binding
         .etag
@@ -1147,7 +1168,7 @@ enum TypedCatalogSuccessorSemanticsV1 {
 /// Exact successor bytes parsed into their catalog kind before they can enter
 /// a fact-bound mutation. Fields are private so a raw byte vector cannot
 /// masquerade as a typed successor.
-pub(crate) struct TypedCatalogSuccessorPayloadV1 {
+struct TypedCatalogSuccessorPayloadV1 {
     context: CatalogAuthorityContextV1,
     kind: RemoteCatalogObjectKindV1,
     object_key: String,
@@ -1171,7 +1192,7 @@ impl std::fmt::Debug for TypedCatalogSuccessorPayloadV1 {
 /// Parse one proposed successor through the strict registered-root validator
 /// for its kind. Manifest reference closure is completed only after every
 /// mutation has been applied to the in-memory successor catalog.
-pub(crate) fn type_catalog_successor_payload_v1(
+fn type_catalog_successor_payload_v1(
     corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
     kind: RemoteCatalogObjectKindV1,
     object_key: String,
@@ -1231,7 +1252,7 @@ enum FactBoundCatalogMutationPredecessorV1<'attempt, 'storage> {
 
 /// One final-key mutation whose before fact comes only from the exact semantic
 /// corpus or a same-attempt missing-object witness.
-pub(crate) struct FactBoundCatalogMutationV1<'attempt, 'storage> {
+struct FactBoundCatalogMutationV1<'attempt, 'storage> {
     prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
     predecessor: FactBoundCatalogMutationPredecessorV1<'attempt, 'storage>,
     successor: TypedCatalogSuccessorPayloadV1,
@@ -1249,7 +1270,7 @@ impl std::fmt::Debug for FactBoundCatalogMutationV1<'_, '_> {
 
 /// Derive replacement predecessor identity and binding exclusively from the
 /// semantic corpus. Callers provide only the already-typed successor.
-pub(crate) fn fact_bind_catalog_replacement_v1<'attempt, 'storage>(
+fn fact_bind_catalog_replacement_v1<'attempt, 'storage>(
     prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
     corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
     successor: TypedCatalogSuccessorPayloadV1,
@@ -1278,7 +1299,7 @@ pub(crate) fn fact_bind_catalog_replacement_v1<'attempt, 'storage>(
 }
 
 /// Bind a create to one consumed same-attempt absence witness.
-pub(crate) fn fact_bind_catalog_create_v1<'attempt, 'storage>(
+fn fact_bind_catalog_create_v1<'attempt, 'storage>(
     prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
     corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
     absence: ProvenCatalogObjectAbsenceV1<'attempt, 'storage>,
@@ -1301,6 +1322,148 @@ pub(crate) fn fact_bind_catalog_create_v1<'attempt, 'storage>(
         predecessor: FactBoundCatalogMutationPredecessorV1::Absent(absence),
         successor,
     })
+}
+
+/// Fallible, resource-bounded intake for one authoritative mutation journal.
+///
+/// The private mutation vector is reachable only through the incremental
+/// methods below, so callers cannot hand publication a process-sized batch of
+/// already-retained successor bodies. A rejected addition consumes and drops
+/// only that one candidate body.
+pub(crate) struct AuthoritativeCatalogMutationBatchV1<'attempt, 'storage, 'corpus> {
+    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
+    corpus: &'corpus SemanticallyBoundRemoteCatalogCorpusV1,
+    keys: BTreeSet<String>,
+    mutation_count: u64,
+    mutation_key_bytes: u64,
+    mutation_payload_bytes: u64,
+    mutations: Vec<FactBoundCatalogMutationV1<'attempt, 'storage>>,
+}
+
+impl std::fmt::Debug for AuthoritativeCatalogMutationBatchV1<'_, '_, '_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthoritativeCatalogMutationBatchV1")
+            .field("mutation_count", &self.mutation_count)
+            .field("mutation_key_bytes", &self.mutation_key_bytes)
+            .field("mutation_payload_bytes", &self.mutation_payload_bytes)
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) fn begin_authoritative_catalog_mutation_batch_v1<'attempt, 'storage, 'corpus>(
+    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
+    corpus: &'corpus SemanticallyBoundRemoteCatalogCorpusV1,
+) -> Result<
+    AuthoritativeCatalogMutationBatchV1<'attempt, 'storage, 'corpus>,
+    CatalogPublicationContractErrorV1,
+> {
+    if !mutation_inputs_match_corpus_v1(prerequisites, corpus) {
+        return Err(CatalogPublicationContractErrorV1::MutationCorpusMismatch);
+    }
+    Ok(AuthoritativeCatalogMutationBatchV1 {
+        prerequisites,
+        corpus,
+        keys: BTreeSet::new(),
+        mutation_count: 0,
+        mutation_key_bytes: 0,
+        mutation_payload_bytes: 0,
+        mutations: Vec::new(),
+    })
+}
+
+impl<'attempt, 'storage> AuthoritativeCatalogMutationBatchV1<'attempt, 'storage, '_> {
+    fn reserve_candidate_v1(
+        &mut self,
+        kind: RemoteCatalogObjectKindV1,
+        object_key: &str,
+        raw_bytes_len: usize,
+    ) -> Result<(u64, u64, u64), CatalogPublicationContractErrorV1> {
+        let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let mutation_count = self.mutation_count.checked_add(1).ok_or_else(|| {
+            mutation_journal_resource(CatalogMutationJournalResourceV1::Mutations)
+        })?;
+        if mutation_count > remote.max_catalog_entries_per_page() {
+            return Err(mutation_journal_resource(
+                CatalogMutationJournalResourceV1::Mutations,
+            ));
+        }
+        if self.keys.contains(object_key) {
+            return Err(invalid_mutation_journal(
+                InvalidCatalogMutationJournalReasonV1::Order,
+            ));
+        }
+        let object_key_bytes = u64::try_from(object_key.len())
+            .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::KeyBytes))?;
+        let mutation_key_bytes = self
+            .mutation_key_bytes
+            .checked_add(object_key_bytes)
+            .ok_or_else(|| mutation_journal_resource(CatalogMutationJournalResourceV1::KeyBytes))?;
+        if mutation_key_bytes > max_catalog_mutation_draft_key_bytes_v1() {
+            return Err(mutation_journal_resource(
+                CatalogMutationJournalResourceV1::KeyBytes,
+            ));
+        }
+        let raw_bytes_len = u64::try_from(raw_bytes_len).map_err(|_| {
+            mutation_journal_resource(CatalogMutationJournalResourceV1::PayloadBytes)
+        })?;
+        if !validate_entry_size_v1(kind, raw_bytes_len) {
+            return Err(CatalogPublicationContractErrorV1::InvalidSuccessorPayload);
+        }
+        let mutation_payload_bytes = checked_catalog_mutation_payload_bytes_v1([
+            self.mutation_payload_bytes,
+            raw_bytes_len,
+        ])?;
+        self.mutations
+            .try_reserve(1)
+            .map_err(|_| mutation_journal_resource(CatalogMutationJournalResourceV1::Mutations))?;
+        Ok((mutation_count, mutation_key_bytes, mutation_payload_bytes))
+    }
+
+    pub(crate) fn try_add_replacement_v1(
+        &mut self,
+        kind: RemoteCatalogObjectKindV1,
+        object_key: String,
+        raw_bytes: Vec<u8>,
+    ) -> Result<(), CatalogPublicationContractErrorV1> {
+        let (mutation_count, mutation_key_bytes, mutation_payload_bytes) =
+            self.reserve_candidate_v1(kind, &object_key, raw_bytes.len())?;
+        let successor =
+            type_catalog_successor_payload_v1(self.corpus, kind, object_key, raw_bytes)?;
+        let mutation =
+            fact_bind_catalog_replacement_v1(self.prerequisites, self.corpus, successor)?;
+        let inserted = self.keys.insert(mutation.successor.object_key.clone());
+        debug_assert!(inserted, "candidate key was checked before insertion");
+        self.mutations.push(mutation);
+        self.mutation_count = mutation_count;
+        self.mutation_key_bytes = mutation_key_bytes;
+        self.mutation_payload_bytes = mutation_payload_bytes;
+        Ok(())
+    }
+
+    pub(crate) fn try_add_create_v1(
+        &mut self,
+        absence: ProvenCatalogObjectAbsenceV1<'attempt, 'storage>,
+        raw_bytes: Vec<u8>,
+    ) -> Result<(), CatalogPublicationContractErrorV1> {
+        let (mutation_count, mutation_key_bytes, mutation_payload_bytes) =
+            self.reserve_candidate_v1(absence.kind, &absence.object_key, raw_bytes.len())?;
+        let successor = type_catalog_successor_payload_v1(
+            self.corpus,
+            absence.kind,
+            absence.object_key.clone(),
+            raw_bytes,
+        )?;
+        let mutation =
+            fact_bind_catalog_create_v1(self.prerequisites, self.corpus, absence, successor)?;
+        let inserted = self.keys.insert(mutation.successor.object_key.clone());
+        debug_assert!(inserted, "candidate key was checked before insertion");
+        self.mutations.push(mutation);
+        self.mutation_count = mutation_count;
+        self.mutation_key_bytes = mutation_key_bytes;
+        self.mutation_payload_bytes = mutation_payload_bytes;
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1618,6 +1781,7 @@ struct RemoteCatalogMutationJournalWireV1 {
     parent_head_revision: String,
     mutation_count: u64,
     mutation_key_bytes: u64,
+    mutation_payload_bytes: u64,
     mutations: Vec<RemoteCatalogFactBoundMutationWireV1>,
 }
 
@@ -1625,7 +1789,8 @@ struct BoundCatalogSuccessorPayloadV1 {
     kind: RemoteCatalogObjectKindV1,
     object_key: String,
     object_id: [u8; 32],
-    raw_bytes: Vec<u8>,
+    /// Contiguous shared storage; writer clones are refcount-only.
+    raw_bytes: Buffer,
     raw_bytes_len: NonZeroU64,
     raw_blake3: [u8; 32],
     binding: RegisteredRootRemoteObjectBindingV1,
@@ -1719,6 +1884,16 @@ fn validate_authoritative_catalog_mutation_journal_bytes_v1(
         ));
     }
     if wire.mutation_count != mutation_count {
+        return Err(invalid_mutation_journal(
+            InvalidCatalogMutationJournalReasonV1::Totals,
+        ));
+    }
+    let payload_bytes = checked_catalog_mutation_payload_bytes_v1(
+        wire.mutations
+            .iter()
+            .map(|mutation| mutation.successor_payload.raw_bytes_len),
+    )?;
+    if wire.mutation_payload_bytes != payload_bytes {
         return Err(invalid_mutation_journal(
             InvalidCatalogMutationJournalReasonV1::Totals,
         ));
@@ -2012,11 +2187,18 @@ async fn publish_immutable_catalog_artifact_if_absent_exact_v1(
 /// and publish every exact successor body into the immutable payload
 /// namespace. No live namespace key or mutable HEAD is written here.
 pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 'storage>(
-    prerequisites: &'attempt MatchedCatalogPublicationPrerequisitesV1<'storage>,
-    corpus: &SemanticallyBoundRemoteCatalogCorpusV1,
     publication_nonce: [u8; 32],
-    mut mutations: Vec<FactBoundCatalogMutationV1<'attempt, 'storage>>,
+    batch: AuthoritativeCatalogMutationBatchV1<'attempt, 'storage, '_>,
 ) -> AnyhowResult<PreparedAuthoritativeCatalogMutationJournalV1> {
+    let AuthoritativeCatalogMutationBatchV1 {
+        prerequisites,
+        corpus,
+        keys: mutation_keys,
+        mutation_count: bounded_mutation_count,
+        mutation_key_bytes: bounded_mutation_key_bytes,
+        mutation_payload_bytes,
+        mut mutations,
+    } = batch;
     require_held_control_lease_live_v1(&prerequisites.control_guard)
         .map_err(|error| anyhow::anyhow!("catalog control lease is not live: {error:?}"))?;
     anyhow::ensure!(
@@ -2035,11 +2217,31 @@ pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 
         .context("catalog sequence overflow")?;
     let remote = RegisteredRootPlanContractV1::strict_v1().remote_contract();
     anyhow::ensure!(
-        u64::try_from(mutations.len()).ok() <= Some(remote.max_catalog_entries_per_page()),
-        "authoritative mutation count exceeds the catalog page bound"
+        u64::try_from(mutations.len()).ok() == Some(bounded_mutation_count)
+            && mutation_keys.len() == mutations.len()
+            && bounded_mutation_count <= remote.max_catalog_entries_per_page(),
+        "authoritative mutation count changed after bounded intake"
+    );
+    let validated_mutation_payload_bytes = checked_catalog_mutation_payload_bytes_v1(
+        mutations
+            .iter()
+            .map(|mutation| mutation.successor.raw_bytes_len.get()),
+    )
+    .map_err(|error| {
+        anyhow::anyhow!("authoritative mutation payload bytes are invalid: {error:?}")
+    })?;
+    anyhow::ensure!(
+        mutation_payload_bytes == validated_mutation_payload_bytes,
+        "authoritative mutation payload accounting changed after bounded intake"
     );
     mutations
         .sort_unstable_by(|left, right| left.successor.object_key.cmp(&right.successor.object_key));
+    anyhow::ensure!(
+        mutation_keys.iter().map(String::as_str).eq(mutations
+            .iter()
+            .map(|mutation| mutation.successor.object_key.as_str())),
+        "authoritative mutation keys changed after bounded intake"
+    );
     let mut mutation_key_bytes = 0_u64;
     let mut previous_key: Option<&str> = None;
     for mutation in &mutations {
@@ -2094,6 +2296,10 @@ pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 
             }
         }
     }
+    anyhow::ensure!(
+        mutation_key_bytes == bounded_mutation_key_bytes,
+        "authoritative mutation key-byte accounting changed after bounded intake"
+    );
 
     validate_complete_successor_semantic_closure_v1(corpus, &mutations)
         .map_err(|error| anyhow::anyhow!("successor semantic closure is invalid: {error:?}"))?;
@@ -2163,63 +2369,75 @@ pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 
     successor_payloads
         .try_reserve(mutations.len())
         .context("reserving authoritative successor payload bindings")?;
-    for mutation in &mutations {
+    let mut wire_mutations = Vec::new();
+    wire_mutations
+        .try_reserve(mutations.len())
+        .context("reserving authoritative mutation wire entries")?;
+    for mutation in mutations {
+        let FactBoundCatalogMutationV1 {
+            prerequisites: _,
+            predecessor,
+            successor,
+        } = mutation;
+        let TypedCatalogSuccessorPayloadV1 {
+            context: _,
+            kind,
+            object_key,
+            raw_bytes,
+            raw_bytes_len: expected_raw_bytes_len,
+            raw_blake3,
+            semantics: _,
+        } = successor;
+        let (operation, predecessor) = match predecessor {
+            FactBoundCatalogMutationPredecessorV1::Absent(_) => (
+                RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
+                RemoteCatalogMutationPredecessorDraftWireV1::Absent,
+            ),
+            FactBoundCatalogMutationPredecessorV1::Present(predecessor) => (
+                RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
+                RemoteCatalogMutationPredecessorDraftWireV1::Present {
+                    raw_bytes_len: predecessor.raw_bytes_len.get(),
+                    raw_blake3: lower_hex(&predecessor.raw_blake3),
+                    binding: binding_wire_v1(&predecessor.binding),
+                },
+            ),
+        };
         let (object_id, raw_bytes_len, binding) =
             publish_immutable_catalog_artifact_if_absent_exact_v1(
                 prerequisites,
                 CATALOG_SUCCESSOR_PAYLOAD_OBJECT_SUFFIX_V1,
                 CATALOG_SUCCESSOR_PAYLOAD_OBJECT_DOMAIN_V1,
-                &mutation.successor.raw_bytes,
-                catalog_named_object_max_bytes_v1(mutation.successor.kind),
+                &raw_bytes,
+                catalog_named_object_max_bytes_v1(kind),
             )
             .await?;
         anyhow::ensure!(
-            raw_bytes_len == mutation.successor.raw_bytes_len,
+            raw_bytes_len == expected_raw_bytes_len,
             "immutable successor payload length does not match its typed bytes"
         );
-        successor_payloads.push(BoundCatalogSuccessorPayloadV1 {
-            kind: mutation.successor.kind,
-            object_key: mutation.successor.object_key.clone(),
+        let payload = BoundCatalogSuccessorPayloadV1 {
+            kind,
+            object_key: object_key.clone(),
             object_id,
-            raw_bytes: mutation.successor.raw_bytes.clone(),
+            raw_bytes: raw_bytes.into(),
             raw_bytes_len,
-            raw_blake3: mutation.successor.raw_blake3,
+            raw_blake3,
             binding,
+        };
+        wire_mutations.push(RemoteCatalogFactBoundMutationWireV1 {
+            kind,
+            object_key,
+            operation,
+            predecessor,
+            successor_payload: RemoteCatalogSuccessorPayloadReferenceWireV1 {
+                object_id: lower_hex(&payload.object_id),
+                raw_bytes_len: payload.raw_bytes_len.get(),
+                raw_blake3: lower_hex(&payload.raw_blake3),
+                binding: binding_wire_v1(&payload.binding),
+            },
         });
+        successor_payloads.push(payload);
     }
-
-    let wire_mutations = mutations
-        .iter()
-        .zip(&successor_payloads)
-        .map(|(mutation, payload)| {
-            let (operation, predecessor) = match &mutation.predecessor {
-                FactBoundCatalogMutationPredecessorV1::Absent(_) => (
-                    RemoteCatalogMutationOperationDraftWireV1::CreateIfAbsent,
-                    RemoteCatalogMutationPredecessorDraftWireV1::Absent,
-                ),
-                FactBoundCatalogMutationPredecessorV1::Present(predecessor) => (
-                    RemoteCatalogMutationOperationDraftWireV1::ReplaceIfMatch,
-                    RemoteCatalogMutationPredecessorDraftWireV1::Present {
-                        raw_bytes_len: predecessor.raw_bytes_len.get(),
-                        raw_blake3: lower_hex(&predecessor.raw_blake3),
-                        binding: binding_wire_v1(&predecessor.binding),
-                    },
-                ),
-            };
-            RemoteCatalogFactBoundMutationWireV1 {
-                kind: mutation.successor.kind,
-                object_key: mutation.successor.object_key.clone(),
-                operation,
-                predecessor,
-                successor_payload: RemoteCatalogSuccessorPayloadReferenceWireV1 {
-                    object_id: lower_hex(&payload.object_id),
-                    raw_bytes_len: payload.raw_bytes_len.get(),
-                    raw_blake3: lower_hex(&payload.raw_blake3),
-                    binding: binding_wire_v1(&payload.binding),
-                },
-            }
-        })
-        .collect::<Vec<_>>();
     let wire = RemoteCatalogMutationJournalWireV1 {
         version: CATALOG_MUTATION_JOURNAL_SCHEMA_VERSION_V1,
         context: prerequisites.context.to_wire(),
@@ -2229,6 +2447,7 @@ pub(crate) async fn prepare_authoritative_catalog_mutation_journal_v1<'attempt, 
         mutation_count: u64::try_from(wire_mutations.len())
             .context("authoritative mutation count does not fit u64")?,
         mutation_key_bytes,
+        mutation_payload_bytes,
         mutations: wire_mutations,
     };
     let raw_bytes =
@@ -2305,12 +2524,13 @@ pub(crate) async fn publish_authoritative_catalog_mutation_journal_v1(
         wire.mutations.len() == prepared.successor_payloads.len()
             && wire.mutations.iter().zip(&prepared.successor_payloads).all(
                 |(mutation, payload)| {
+                    let payload_bytes = payload.raw_bytes.current();
                     mutation.kind == payload.kind
                         && mutation.object_key == payload.object_key
                         && mutation.successor_payload.object_id == lower_hex(&payload.object_id)
-                        && u64::try_from(payload.raw_bytes.len()).ok()
+                        && u64::try_from(payload_bytes.len()).ok()
                             == Some(payload.raw_bytes_len.get())
-                        && *blake3::hash(&payload.raw_bytes).as_bytes() == payload.raw_blake3
+                        && *blake3::hash(&payload_bytes).as_bytes() == payload.raw_blake3
                         && mutation.successor_payload.raw_bytes_len == payload.raw_bytes_len.get()
                         && mutation.successor_payload.raw_blake3 == lower_hex(&payload.raw_blake3)
                         && mutation.successor_payload.binding == binding_wire_v1(&payload.binding)
@@ -2932,6 +3152,7 @@ async fn apply_one_catalog_namespace_mutation_v1(
     mutation: &RemoteCatalogFactBoundMutationWireV1,
     payload: &BoundCatalogSuccessorPayloadV1,
 ) -> AnyhowResult<AppliedCatalogNamespaceObjectV1> {
+    let payload_bytes = payload.raw_bytes.current();
     anyhow::ensure!(
         mutation.kind == payload.kind
             && mutation.object_key == payload.object_key
@@ -2939,13 +3160,13 @@ async fn apply_one_catalog_namespace_mutation_v1(
             && mutation.successor_payload.raw_bytes_len == payload.raw_bytes_len.get()
             && mutation.successor_payload.raw_blake3 == lower_hex(&payload.raw_blake3)
             && mutation.successor_payload.binding == binding_wire_v1(&payload.binding)
-            && u64::try_from(payload.raw_bytes.len()).ok() == Some(payload.raw_bytes_len.get())
-            && *blake3::hash(&payload.raw_bytes).as_bytes() == payload.raw_blake3,
+            && u64::try_from(payload_bytes.len()).ok() == Some(payload.raw_bytes_len.get())
+            && *blake3::hash(&payload_bytes).as_bytes() == payload.raw_blake3,
         "catalog namespace mutation lost its exact immutable successor payload"
     );
     let payload_key = successor_payload_object_key_v1(
         &capability.pending.transition.publication.context,
-        &payload.raw_bytes,
+        &payload_bytes,
     )
     .context("catalog successor payload key exceeds the storage-key bound")?;
     let immutable_payload = read_raw_object_snapshot_v1(
@@ -2965,8 +3186,8 @@ async fn apply_one_catalog_namespace_mutation_v1(
     };
     let (immutable_bytes, immutable_blake3, immutable_binding) = immutable_payload.into_parts();
     anyhow::ensure!(
-        immutable_bytes == payload.raw_bytes
-            && immutable_blake3 == blake3::hash(&payload.raw_bytes)
+        immutable_bytes.as_slice() == payload_bytes.as_ref()
+            && immutable_blake3 == blake3::hash(&payload_bytes)
             && registered_binding_from_raw_v1(immutable_binding) == payload.binding,
         "immutable catalog successor payload changed before namespace mutation: {payload_key}"
     );
@@ -3006,7 +3227,7 @@ async fn apply_one_catalog_namespace_mutation_v1(
         capability,
         mutation.kind,
         &mutation.object_key,
-        &payload.raw_bytes,
+        &payload_bytes,
     )
     .await;
     let binding = match (write_result, rebound) {
@@ -5046,6 +5267,13 @@ mod tests {
         Into<BoundCatalogMutationJournalV1>
     );
     static_assertions::assert_not_impl_any!(
+        AuthoritativeCatalogMutationBatchV1<'static, 'static, 'static>: Clone,
+        serde::Serialize,
+        Default,
+        Into<Vec<FactBoundCatalogMutationV1<'static, 'static>>>,
+        Into<BoundCatalogMutationJournalV1>
+    );
+    static_assertions::assert_not_impl_any!(
         PreparedAuthoritativeCatalogMutationJournalV1: Clone,
         serde::Serialize,
         Default,
@@ -5442,18 +5670,15 @@ mod tests {
         let publication_nonce = [0x44; 32];
         let prerequisites = matched(fixture, observed);
         let successor_bytes = deleted_index_bytes();
-        let replacement = fact_bind_catalog_replacement_v1(
-            &prerequisites,
-            corpus,
-            type_catalog_successor_payload_v1(
-                corpus,
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, corpus).unwrap();
+        batch
+            .try_add_replacement_v1(
                 RemoteCatalogObjectKindV1::Index,
                 "roots/index/retained.txt".to_owned(),
                 successor_bytes.clone(),
             )
-            .unwrap(),
-        )
-        .unwrap();
+            .unwrap();
         let create_key = "roots/index/added.txt".to_owned();
         let absence = prove_catalog_object_absence_v1(
             &prerequisites,
@@ -5463,27 +5688,10 @@ mod tests {
         )
         .await
         .unwrap();
-        let create = fact_bind_catalog_create_v1(
-            &prerequisites,
-            corpus,
-            absence,
-            type_catalog_successor_payload_v1(
-                corpus,
-                RemoteCatalogObjectKindV1::Index,
-                create_key,
-                successor_bytes,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        let prepared = prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            corpus,
-            publication_nonce,
-            vec![replacement, create],
-        )
-        .await
-        .unwrap();
+        batch.try_add_create_v1(absence, successor_bytes).unwrap();
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1(publication_nonce, batch)
+            .await
+            .unwrap();
         let journal = publish_authoritative_catalog_mutation_journal_v1(&prerequisites, prepared)
             .await
             .unwrap();
@@ -5636,18 +5844,15 @@ mod tests {
             .await;
         let prerequisites = matched(&fixture, &observed);
         let replacement_bytes = deleted_index_bytes();
-        let replacement = fact_bind_catalog_replacement_v1(
-            &prerequisites,
-            &corpus,
-            type_catalog_successor_payload_v1(
-                &corpus,
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        batch
+            .try_add_replacement_v1(
                 RemoteCatalogObjectKindV1::Index,
                 "roots/index/retained.txt".to_owned(),
                 replacement_bytes.clone(),
             )
-            .unwrap(),
-        )
-        .unwrap();
+            .unwrap();
         let create_key = "roots/index/added.txt".to_owned();
         let absence = prove_catalog_object_absence_v1(
             &prerequisites,
@@ -5657,28 +5862,13 @@ mod tests {
         )
         .await
         .unwrap();
-        let create = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Index,
-                create_key,
-                replacement_bytes.clone(),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        batch
+            .try_add_create_v1(absence, replacement_bytes.clone())
+            .unwrap();
 
-        let prepared = prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            &corpus,
-            [0x44; 32],
-            vec![replacement, create],
-        )
-        .await
-        .unwrap();
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1([0x44; 32], batch)
+            .await
+            .unwrap();
         let wire =
             serde_json::from_slice::<RemoteCatalogMutationJournalWireV1>(&prepared.raw_bytes)
                 .unwrap();
@@ -5901,53 +6091,20 @@ mod tests {
         )
         .await
         .unwrap();
-        let index = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            index_absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Index,
-                index_key.clone(),
-                committed_index_bytes(&manifest_id),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        let reservation = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            reservation_absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Reservation,
-                reservation_key.clone(),
-                reservation_bytes.clone(),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        let manifest = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            manifest_absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Manifest,
-                manifest_key.clone(),
-                manifest_bytes.clone(),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        let prepared = prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            &corpus,
-            [0x44; 32],
-            vec![manifest, reservation, index],
-        )
-        .await
-        .unwrap();
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        batch
+            .try_add_create_v1(index_absence, committed_index_bytes(&manifest_id))
+            .unwrap();
+        batch
+            .try_add_create_v1(reservation_absence, reservation_bytes.clone())
+            .unwrap();
+        batch
+            .try_add_create_v1(manifest_absence, manifest_bytes.clone())
+            .unwrap();
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1([0x44; 32], batch)
+            .await
+            .unwrap();
         let journal = publish_authoritative_catalog_mutation_journal_v1(&prerequisites, prepared)
             .await
             .unwrap();
@@ -6153,7 +6310,7 @@ mod tests {
             (
                 first_payload.kind,
                 first_payload.object_key.clone(),
-                first_payload.raw_bytes.clone(),
+                first_payload.raw_bytes.current(),
                 first_payload.raw_blake3,
             )
         };
@@ -6366,7 +6523,10 @@ mod tests {
         let (fixture, corpus, observed) = observed_corpus(&[]).await;
         let prerequisites = matched(&fixture, &observed);
         let manifest_bytes = regular_manifest_bytes("new.txt");
+        let manifest_payload_pointer = manifest_bytes.as_ptr();
         let manifest_id = crate::index_entry::manifest_object_id(&manifest_bytes);
+        let index_bytes = committed_index_bytes(&manifest_id);
+        let index_payload_pointer = index_bytes.as_ptr();
         let index_key = "roots/index/new.txt".to_owned();
         let manifest_key = format!("roots/manifests/{manifest_id}");
 
@@ -6386,46 +6546,78 @@ mod tests {
         )
         .await
         .unwrap();
-        let index = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            index_absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Index,
-                index_key,
-                committed_index_bytes(&manifest_id),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        let manifest = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            manifest_absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Manifest,
-                manifest_key,
-                manifest_bytes,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        let prepared = prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            &corpus,
-            [0x44; 32],
-            vec![manifest, index],
-        )
-        .await
-        .unwrap();
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        batch.try_add_create_v1(index_absence, index_bytes).unwrap();
+        batch
+            .try_add_create_v1(manifest_absence, manifest_bytes)
+            .unwrap();
+        let prepared = prepare_authoritative_catalog_mutation_journal_v1([0x44; 32], batch)
+            .await
+            .unwrap();
         let wire =
             serde_json::from_slice::<RemoteCatalogMutationJournalWireV1>(&prepared.raw_bytes)
                 .unwrap();
         assert_eq!(wire.mutation_count, 2);
+        assert_eq!(
+            wire.mutation_payload_bytes,
+            wire.mutations
+                .iter()
+                .map(|mutation| mutation.successor_payload.raw_bytes_len)
+                .sum::<u64>()
+        );
         assert_eq!(wire.mutations[0].object_key, "roots/index/new.txt");
         assert!(wire.mutations[1].object_key.starts_with("roots/manifests/"));
+        assert_eq!(
+            prepared.successor_payloads[0].raw_bytes.current().as_ptr(),
+            index_payload_pointer,
+            "authoritative preparation must move index bytes instead of cloning them"
+        );
+        assert_eq!(
+            prepared.successor_payloads[1].raw_bytes.current().as_ptr(),
+            manifest_payload_pointer,
+            "authoritative preparation must move manifest bytes instead of cloning them"
+        );
+
+        let mut wrong_total = wire;
+        wrong_total.mutation_payload_bytes += 1;
+        let wrong_total_bytes = serde_json::to_vec(&wrong_total).unwrap();
+        assert_eq!(
+            validate_authoritative_catalog_mutation_journal_bytes_v1(
+                &wrong_total_bytes,
+                &prerequisites.context,
+                NonZeroU64::new(2).unwrap(),
+                [0x44; 32],
+                observed.head_revision,
+            )
+            .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidMutationJournal(
+                InvalidCatalogMutationJournalReasonV1::Totals
+            )
+        );
+    }
+
+    #[test]
+    fn authoritative_mutation_payload_total_is_bounded_and_overflow_safe() {
+        let maximum = RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_mutation_payload_bytes();
+        assert_eq!(
+            checked_catalog_mutation_payload_bytes_v1([maximum]),
+            Ok(maximum)
+        );
+        assert_eq!(
+            checked_catalog_mutation_payload_bytes_v1([maximum, 1]),
+            Err(CatalogPublicationContractErrorV1::MutationJournalResource(
+                CatalogMutationJournalResourceV1::PayloadBytes
+            ))
+        );
+        assert_eq!(
+            checked_catalog_mutation_payload_bytes_v1([u64::MAX, 1]),
+            Err(CatalogPublicationContractErrorV1::MutationJournalResource(
+                CatalogMutationJournalResourceV1::PayloadBytes
+            ))
+        );
     }
 
     #[tokio::test]
@@ -6436,36 +6628,137 @@ mod tests {
             )])
             .await;
         let prerequisites = matched(&fixture, &observed);
-        let missing = type_catalog_successor_payload_v1(
-            &corpus,
-            RemoteCatalogObjectKindV1::Index,
-            "roots/index/missing.txt".to_owned(),
-            deleted_index_bytes(),
-        )
-        .unwrap();
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
         assert_eq!(
-            fact_bind_catalog_replacement_v1(&prerequisites, &corpus, missing).unwrap_err(),
+            batch
+                .try_add_replacement_v1(
+                    RemoteCatalogObjectKindV1::Index,
+                    "roots/index/missing.txt".to_owned(),
+                    deleted_index_bytes(),
+                )
+                .unwrap_err(),
             CatalogPublicationContractErrorV1::MutationPredecessorMissing
         );
         assert_eq!(
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Index,
-                "roots/index/retained.txt".to_owned(),
-                b"{}".to_vec(),
-            )
-            .unwrap_err(),
+            batch
+                .try_add_replacement_v1(
+                    RemoteCatalogObjectKindV1::Index,
+                    "roots/index/retained.txt".to_owned(),
+                    b"{}".to_vec(),
+                )
+                .unwrap_err(),
             CatalogPublicationContractErrorV1::InvalidSuccessorPayload
         );
         assert_eq!(
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Reservation,
-                "roots/index/retained.txt".to_owned(),
+            batch
+                .try_add_replacement_v1(
+                    RemoteCatalogObjectKindV1::Reservation,
+                    "roots/index/retained.txt".to_owned(),
+                    deleted_index_bytes(),
+                )
+                .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidSuccessorPayload
+        );
+        assert_eq!(batch.mutation_count, 0);
+        assert_eq!(batch.mutation_key_bytes, 0);
+        assert_eq!(batch.mutation_payload_bytes, 0);
+        assert!(batch.keys.is_empty());
+        assert!(batch.mutations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn authoritative_batch_rejects_duplicate_keys_without_advancing_accounting() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let prerequisites = matched(&fixture, &observed);
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        let key = "roots/index/retained.txt".to_owned();
+        batch
+            .try_add_replacement_v1(
+                RemoteCatalogObjectKindV1::Index,
+                key.clone(),
                 deleted_index_bytes(),
             )
-            .unwrap_err(),
-            CatalogPublicationContractErrorV1::InvalidSuccessorPayload
+            .unwrap();
+        let retained_accounting = (
+            batch.mutation_count,
+            batch.mutation_key_bytes,
+            batch.mutation_payload_bytes,
+            batch.keys.len(),
+            batch.mutations.len(),
+        );
+        assert_eq!(
+            batch
+                .try_add_replacement_v1(
+                    RemoteCatalogObjectKindV1::Index,
+                    key,
+                    deleted_index_bytes(),
+                )
+                .unwrap_err(),
+            CatalogPublicationContractErrorV1::InvalidMutationJournal(
+                InvalidCatalogMutationJournalReasonV1::Order
+            )
+        );
+        assert_eq!(
+            (
+                batch.mutation_count,
+                batch.mutation_key_bytes,
+                batch.mutation_payload_bytes,
+                batch.keys.len(),
+                batch.mutations.len(),
+            ),
+            retained_accounting
+        );
+    }
+
+    #[tokio::test]
+    async fn authoritative_batch_payload_limit_rejection_is_transactional() {
+        let (fixture, corpus, observed) =
+            observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
+                "retained.txt".to_owned(),
+            )])
+            .await;
+        let prerequisites = matched(&fixture, &observed);
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        // Exercise the private running-total boundary without retaining a
+        // limit-sized test fixture.
+        batch.mutation_payload_bytes = RegisteredRootPlanContractV1::strict_v1()
+            .remote_contract()
+            .max_catalog_mutation_payload_bytes();
+        let retained_accounting = (
+            batch.mutation_count,
+            batch.mutation_key_bytes,
+            batch.mutation_payload_bytes,
+            batch.keys.len(),
+            batch.mutations.len(),
+        );
+        assert_eq!(
+            batch
+                .try_add_replacement_v1(
+                    RemoteCatalogObjectKindV1::Index,
+                    "roots/index/retained.txt".to_owned(),
+                    deleted_index_bytes(),
+                )
+                .unwrap_err(),
+            CatalogPublicationContractErrorV1::MutationJournalResource(
+                CatalogMutationJournalResourceV1::PayloadBytes
+            )
+        );
+        assert_eq!(
+            (
+                batch.mutation_count,
+                batch.mutation_key_bytes,
+                batch.mutation_payload_bytes,
+                batch.keys.len(),
+                batch.mutations.len(),
+            ),
+            retained_accounting
         );
     }
 
@@ -6486,32 +6779,19 @@ mod tests {
         )
         .await
         .unwrap();
-        let create = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Index,
-                key.clone(),
-                deleted_index_bytes(),
-            )
-            .unwrap(),
-        )
-        .unwrap();
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        batch
+            .try_add_create_v1(absence, deleted_index_bytes())
+            .unwrap();
         fixture
             .operator()
             .write(&key, deleted_index_bytes())
             .await
             .unwrap();
-        let error = prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            &corpus,
-            [0x44; 32],
-            vec![create],
-        )
-        .await
-        .unwrap_err();
+        let error = prepare_authoritative_catalog_mutation_journal_v1([0x44; 32], batch)
+            .await
+            .unwrap_err();
         assert!(format!("{error:#}").contains("absence witness is stale"));
     }
 
@@ -6524,26 +6804,20 @@ mod tests {
             )])
             .await;
         let prerequisites = matched(&fixture, &observed);
-        let missing_manifest_index = fact_bind_catalog_replacement_v1(
-            &prerequisites,
-            &corpus,
-            type_catalog_successor_payload_v1(
-                &corpus,
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        batch
+            .try_add_replacement_v1(
                 RemoteCatalogObjectKindV1::Index,
                 "roots/index/file.txt".to_owned(),
                 committed_index_bytes(&"f".repeat(64)),
             )
-            .unwrap(),
-        )
-        .unwrap();
-        assert!(prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            &corpus,
-            [0x44; 32],
-            vec![missing_manifest_index],
-        )
-        .await
-        .is_err());
+            .unwrap();
+        assert!(
+            prepare_authoritative_catalog_mutation_journal_v1([0x44; 32], batch)
+                .await
+                .is_err()
+        );
 
         let (fixture, corpus, observed) =
             observed_corpus(&[SemanticRemoteCatalogFixtureRowV1::DeletedFile(
@@ -6564,27 +6838,16 @@ mod tests {
         )
         .await
         .unwrap();
-        let orphan = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            orphan_absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Manifest,
-                orphan_key,
-                orphan_bytes,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        assert!(prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            &corpus,
-            [0x45; 32],
-            vec![orphan],
-        )
-        .await
-        .is_err());
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        batch
+            .try_add_create_v1(orphan_absence, orphan_bytes)
+            .unwrap();
+        assert!(
+            prepare_authoritative_catalog_mutation_journal_v1([0x45; 32], batch)
+                .await
+                .is_err()
+        );
 
         let exact_path = "retained.txt";
         let folded_path = crate::index_entry::portable_casefold_path(exact_path).unwrap();
@@ -6604,27 +6867,16 @@ mod tests {
         )
         .await
         .unwrap();
-        let reservation = fact_bind_catalog_create_v1(
-            &prerequisites,
-            &corpus,
-            reservation_absence,
-            type_catalog_successor_payload_v1(
-                &corpus,
-                RemoteCatalogObjectKindV1::Reservation,
-                reservation_key,
-                reservation_bytes,
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        assert!(prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            &corpus,
-            [0x46; 32],
-            vec![reservation],
-        )
-        .await
-        .is_err());
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        batch
+            .try_add_create_v1(reservation_absence, reservation_bytes)
+            .unwrap();
+        assert!(
+            prepare_authoritative_catalog_mutation_journal_v1([0x46; 32], batch)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -6643,26 +6895,18 @@ mod tests {
             .write(&payload_key, b"wrong".to_vec())
             .await
             .unwrap();
-        let replacement = fact_bind_catalog_replacement_v1(
-            &prerequisites,
-            &corpus,
-            type_catalog_successor_payload_v1(
-                &corpus,
+        let mut batch =
+            begin_authoritative_catalog_mutation_batch_v1(&prerequisites, &corpus).unwrap();
+        batch
+            .try_add_replacement_v1(
                 RemoteCatalogObjectKindV1::Index,
                 "roots/index/retained.txt".to_owned(),
                 successor_bytes,
             )
-            .unwrap(),
-        )
-        .unwrap();
-        let error = prepare_authoritative_catalog_mutation_journal_v1(
-            &prerequisites,
-            &corpus,
-            [0x44; 32],
-            vec![replacement],
-        )
-        .await
-        .unwrap_err();
+            .unwrap();
+        let error = prepare_authoritative_catalog_mutation_journal_v1([0x44; 32], batch)
+            .await
+            .unwrap_err();
         assert!(format!("{error:#}").contains("different bytes"));
     }
 

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -3147,7 +3147,7 @@ fn catalog_buffer_equals_slice_v1(buffer: &Buffer, expected: &[u8]) -> bool {
     if buffer.len() != expected.len() {
         return false;
     }
-    let mut offset = 0;
+    let mut offset = 0_usize;
     for chunk in buffer.chunks(CATALOG_BUFFER_VALIDATION_CHUNK_BYTES_V1) {
         let chunk = chunk.to_bytes();
         let Some(end) = offset.checked_add(chunk.len()) else {

--- a/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
+++ b/crates/tcfs-sync/src/registered_remote_catalog/publication.rs
@@ -3133,6 +3133,34 @@ impl std::error::Error for FailedCatalogNamespaceMutationsV1<'_> {
     }
 }
 
+const CATALOG_BUFFER_VALIDATION_CHUNK_BYTES_V1: usize = 64 * 1024;
+
+fn catalog_buffer_blake3_v1(buffer: &Buffer) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    for chunk in buffer.chunks(CATALOG_BUFFER_VALIDATION_CHUNK_BYTES_V1) {
+        hasher.update(&chunk.to_bytes());
+    }
+    *hasher.finalize().as_bytes()
+}
+
+fn catalog_buffer_equals_slice_v1(buffer: &Buffer, expected: &[u8]) -> bool {
+    if buffer.len() != expected.len() {
+        return false;
+    }
+    let mut offset = 0;
+    for chunk in buffer.chunks(CATALOG_BUFFER_VALIDATION_CHUNK_BYTES_V1) {
+        let chunk = chunk.to_bytes();
+        let Some(end) = offset.checked_add(chunk.len()) else {
+            return false;
+        };
+        if expected.get(offset..end) != Some(chunk.as_ref()) {
+            return false;
+        }
+        offset = end;
+    }
+    offset == expected.len()
+}
+
 fn catalog_fenced_storage_write_request_fingerprint_v1(
     wire: &CatalogFencedStorageWriteRequestWireV1,
 ) -> AnyhowResult<[u8; 32]> {
@@ -3201,7 +3229,7 @@ fn catalog_fenced_storage_write_request_v1(
             .context("catalog fenced-storage payload length does not fit u64")?,
     )
     .context("catalog fenced-storage payload must not be empty")?;
-    let successor_raw_blake3 = *blake3::hash(&successor_raw_bytes).as_bytes();
+    let successor_raw_blake3 = catalog_buffer_blake3_v1(&successor_raw_bytes);
     let journal_wire = validate_authoritative_catalog_mutation_journal_bytes_v1(
         &journal.raw_bytes,
         &publication.context,
@@ -3226,8 +3254,10 @@ fn catalog_fenced_storage_write_request_v1(
             anyhow::ensure!(
                 ordinal == 0
                     && object_key == head_key
-                    && successor_raw_bytes.as_ref()
-                        == transition.canonical_publishing_head_bytes.as_slice()
+                    && catalog_buffer_equals_slice_v1(
+                        &successor_raw_bytes,
+                        &transition.canonical_publishing_head_bytes,
+                    )
                     && condition
                         == CatalogFencedStorageWriteConditionV1::ReplaceIfMatch {
                             etag: publication.expected_parent_head_etag.clone(),
@@ -3392,7 +3422,7 @@ async fn execute_catalog_fenced_storage_write_v1(
         )? == request.request_fingerprint
             && u64::try_from(request.successor_raw_bytes.len()).ok()
                 == Some(request.successor_raw_bytes_len.get())
-            && *blake3::hash(&request.successor_raw_bytes).as_bytes()
+            && catalog_buffer_blake3_v1(&request.successor_raw_bytes)
                 == request.successor_raw_blake3,
         "catalog fenced-storage request fingerprint or payload identity changed"
     );
@@ -5997,7 +6027,7 @@ mod tests {
                         )? == request.request_fingerprint
                         && u64::try_from(request.successor_raw_bytes.len()).ok()
                             == Some(request.successor_raw_bytes_len.get())
-                        && *blake3::hash(&request.successor_raw_bytes).as_bytes()
+                        && catalog_buffer_blake3_v1(&request.successor_raw_bytes)
                             == request.successor_raw_blake3,
                     "test fenced-storage request is invalid"
                 );
@@ -6101,8 +6131,10 @@ mod tests {
                 };
                 let (raw_bytes, raw_blake3, binding) = observed.into_parts();
                 anyhow::ensure!(
-                    raw_bytes.as_slice() == request.successor_raw_bytes.as_ref()
-                        && *raw_blake3.as_bytes() == request.successor_raw_blake3,
+                    catalog_buffer_equals_slice_v1(
+                        &request.successor_raw_bytes,
+                        raw_bytes.as_slice(),
+                    ) && *raw_blake3.as_bytes() == request.successor_raw_blake3,
                     "test storage fence successor differs from its request"
                 );
                 let binding = registered_binding_from_raw_v1(binding);

--- a/crates/tcfs-sync/src/registered_remote_observation.rs
+++ b/crates/tcfs-sync/src/registered_remote_observation.rs
@@ -1761,6 +1761,8 @@ pub(crate) mod tests {
         }
     }
 
+    type FirstListWriteV1 = Option<(std::path::PathBuf, Vec<u8>)>;
+
     #[derive(Clone, Debug)]
     struct ScriptedListBackend {
         info: Arc<AccessorInfo>,
@@ -1768,6 +1770,7 @@ pub(crate) mod tests {
         observed: Arc<Mutex<Vec<ObservedListCall>>>,
         objects: Arc<Mutex<BTreeMap<String, ScriptedBoundObject>>>,
         events: Arc<Mutex<Vec<ObservationEvent>>>,
+        first_list_write: Arc<Mutex<FirstListWriteV1>>,
     }
 
     impl Access for ScriptedListBackend {
@@ -1781,6 +1784,15 @@ pub(crate) mod tests {
         }
 
         async fn list(&self, path: &str, args: OpList) -> opendal::Result<(RpList, Self::Lister)> {
+            if let Some((target, bytes)) = self.first_list_write.lock().unwrap().take() {
+                std::fs::write(&target, bytes).map_err(|error| {
+                    Error::new(
+                        ErrorKind::Unexpected,
+                        "scripted first-list local write failed",
+                    )
+                    .set_source(error)
+                })?;
+            }
             self.events
                 .lock()
                 .unwrap()
@@ -1920,6 +1932,7 @@ pub(crate) mod tests {
             observed: Arc::new(Mutex::new(Vec::new())),
             objects: Arc::new(Mutex::new(BTreeMap::new())),
             events: Arc::new(Mutex::new(Vec::new())),
+            first_list_write: Arc::new(Mutex::new(None)),
         };
         (OperatorBuilder::new(backend.clone()).finish(), backend)
     }
@@ -2045,6 +2058,24 @@ pub(crate) mod tests {
     pub(crate) fn matching_remote_fixture_operator_v1(
         rows: &[RemoteNamespaceFixtureRowV1],
     ) -> Operator {
+        matching_remote_fixture_operator_with_optional_first_list_write_v1(rows, None)
+    }
+
+    pub(crate) fn matching_remote_fixture_operator_with_first_list_write_v1(
+        rows: &[RemoteNamespaceFixtureRowV1],
+        target: std::path::PathBuf,
+        bytes: Vec<u8>,
+    ) -> Operator {
+        matching_remote_fixture_operator_with_optional_first_list_write_v1(
+            rows,
+            Some((target, bytes)),
+        )
+    }
+
+    fn matching_remote_fixture_operator_with_optional_first_list_write_v1(
+        rows: &[RemoteNamespaceFixtureRowV1],
+        first_list_write: FirstListWriteV1,
+    ) -> Operator {
         let mut index_keys = Vec::new();
         let mut reservation_keys = Vec::new();
         let mut objects = Vec::new();
@@ -2105,6 +2136,7 @@ pub(crate) mod tests {
         }
         let (op, backend) =
             scripted_list_operator(two_bound_pass_list_calls(&index_keys, &reservation_keys));
+        *backend.first_list_write.lock().unwrap() = first_list_write;
         for (key, object) in objects {
             install_bound_object(&backend, key, object);
         }

--- a/crates/tcfs-sync/src/registered_remote_observation.rs
+++ b/crates/tcfs-sync/src/registered_remote_observation.rs
@@ -1,23 +1,38 @@
-//! Listed-key acquisition primitives for strict registered-root planning.
+//! Strict registered-root remote-observation primitives.
 //!
-//! This module deliberately stops before reading object bodies. Matching
-//! keysets from two non-atomic backend listings are not a namespace snapshot,
-//! do not satisfy `CompleteOrNoDigestV1`, and cannot mint any digest or plan
-//! input. This artifact is diagnostic and must be discarded. A complete
-//! acquisition must freshly rerun pass A list+bind and pass B list+bind for
-//! every index, marker, reservation, and referenced manifest object.
+//! The key-only repeated-listing artifact remains diagnostic and must be
+//! discarded: matching non-atomic keysets are not a namespace snapshot, do not
+//! satisfy `CompleteOrNoDigestV1`, and cannot mint a digest or plan input. The
+//! bound reader separately performs fresh sequential pass A list+bind and pass
+//! B list+bind work for every index, marker, reservation, and referenced
+//! manifest. Matching bound evidence is still non-atomic observation evidence,
+//! not planner authority.
 
 use futures::TryStreamExt;
 use opendal::{EntryMode, Operator};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
+use std::path::Path;
 use tcfs_core::config::{RegisteredRootPlanContractV1, RootRemoteContractV1};
 
+use crate::blacklist::Blacklist;
 use crate::index_entry::{
-    namespace_index_prefix, namespace_logical_entry_from_index_path, namespace_reservation_prefix,
-    validate_canonical_namespace_remote_prefix, PortableNamespaceRole,
+    namespace_claims_for_path, namespace_index_prefix, namespace_logical_entry_from_index_path,
+    namespace_reservation_prefix, validate_canonical_namespace_remote_prefix,
+    PortableNamespaceReservationV1, PortableNamespaceRole,
 };
-use crate::registered_reconcile::validate_registered_remote_logical_path_bounds_v1;
+use crate::registered_reconcile::{
+    read_exact_observed_namespace_reservation_v1, read_exact_observed_raw_directory_marker_v1,
+    read_exact_observed_raw_index_entry_v1, read_observed_strict_remote_manifest_for_references_v1,
+    validate_registered_remote_logical_path_bounds_v1, BoundNamespaceReservationV1,
+    BoundRemoteObjectSnapshotV1, ExactObservedNamespaceReservationReadV1,
+    ExactObservedRawDirectoryMarkerReadV1, ExactObservedRawIndexEntryReadV1,
+    RawCommittedIndexEntryV1, RawDeletedDirectoryMarkerV1, RawDeletedIndexEntryV1,
+    RawLiveDirectoryMarkerV1, RegisteredRootRemoteObjectBindingV1,
+    StrictNamespaceReservationIncompleteV1, StrictObservedRemoteManifestReadV1,
+    StrictRemoteDirectoryMarkerIncompleteV1, StrictRemoteIndexIncompleteV1,
+    StrictRemoteManifestIncompleteV1, StrictRemoteManifestV1,
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RemoteNamespaceCorpusV1 {
@@ -176,6 +191,193 @@ pub(crate) enum StrictRemoteNamespaceKeyReadV1 {
     Incomplete(StrictRemoteNamespaceKeyIncompleteV1),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum BoundRemoteIndexObjectV1 {
+    Committed(Box<RawCommittedIndexEntryV1>),
+    Deleted(Box<RawDeletedIndexEntryV1>),
+    LiveMarker(Box<RawLiveDirectoryMarkerV1>),
+    DeletedMarker(Box<RawDeletedDirectoryMarkerV1>),
+}
+
+impl BoundRemoteIndexObjectV1 {
+    fn object(&self) -> &BoundRemoteObjectSnapshotV1 {
+        match self {
+            Self::Committed(index) => index.object(),
+            Self::Deleted(index) => index.object(),
+            Self::LiveMarker(marker) => marker.object(),
+            Self::DeletedMarker(marker) => marker.object(),
+        }
+    }
+
+    fn logical_path(&self) -> &str {
+        match self {
+            Self::Committed(index) => index.rel_path(),
+            Self::Deleted(index) => index.route().rel_path(),
+            Self::LiveMarker(marker) => marker.route().logical_dir(),
+            Self::DeletedMarker(marker) => marker.route().logical_dir(),
+        }
+    }
+
+    fn physical_key(&self) -> &str {
+        match self {
+            Self::Committed(index) => index.index_key(),
+            Self::Deleted(index) => index.route().index_key(),
+            Self::LiveMarker(marker) => marker.route().marker_key(),
+            Self::DeletedMarker(marker) => marker.route().marker_key(),
+        }
+    }
+
+    const fn role(&self) -> PortableNamespaceRole {
+        match self {
+            Self::Committed(_) | Self::Deleted(_) => PortableNamespaceRole::File,
+            Self::LiveMarker(_) | Self::DeletedMarker(_) => PortableNamespaceRole::Directory,
+        }
+    }
+
+    fn committed(&self) -> Option<&RawCommittedIndexEntryV1> {
+        match self {
+            Self::Committed(index) => Some(index),
+            Self::Deleted(_) | Self::LiveMarker(_) | Self::DeletedMarker(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct BoundRemoteManifestObservationV1 {
+    /// Ordinal of the first committed index reference in the canonical
+    /// physical-index ordering. The manifest ID is available from that index,
+    /// so the full storage key is not duplicated per retained manifest.
+    source_index_ordinal: usize,
+    manifest: Box<StrictRemoteManifestV1>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RetainedRemoteNamespaceClaimV1 {
+    folded_path: String,
+    exact_path: String,
+    role: PortableNamespaceRole,
+}
+
+/// One sequential list-and-bind pass over a registered remote namespace.
+///
+/// This is intentionally private, non-cloneable, and non-serializable. It is
+/// observation evidence only and has no digest or planner conversion.
+#[derive(Debug, PartialEq, Eq)]
+struct FullyDrainedBoundRemotePassV1 {
+    index_objects: Vec<BoundRemoteIndexObjectV1>,
+    reservations: Vec<BoundNamespaceReservationV1>,
+    manifests: Vec<BoundRemoteManifestObservationV1>,
+    claims: Vec<RetainedRemoteNamespaceClaimV1>,
+}
+
+/// Matching evidence from two fresh, fully drained, identity-bound passes.
+///
+/// Equality still does not imply a transactionally complete remote snapshot.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct MatchingTwoPassBoundRemoteEvidenceV1 {
+    remote_prefix: String,
+    evidence: FullyDrainedBoundRemotePassV1,
+}
+
+impl MatchingTwoPassBoundRemoteEvidenceV1 {
+    pub(crate) fn remote_prefix(&self) -> &str {
+        &self.remote_prefix
+    }
+
+    pub(crate) fn index_object_count(&self) -> usize {
+        self.evidence.index_objects.len()
+    }
+
+    pub(crate) fn reservation_count(&self) -> usize {
+        self.evidence.reservations.len()
+    }
+
+    pub(crate) fn manifest_count(&self) -> usize {
+        self.evidence.manifests.len()
+    }
+
+    pub(crate) fn claim_count(&self) -> usize {
+        self.evidence.claims.len()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BoundRemoteObjectKindV1 {
+    OrdinaryIndex,
+    DirectoryMarker,
+    NamespaceReservation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BoundRemotePassResourceV1 {
+    BoundObjectBytes,
+    RetainedBindingBytes,
+    GeneratedClaims,
+    GeneratedClaimBytes,
+    RetainedClaims,
+    RetainedClaimBytes,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteNamespaceClaimConflictV1 {
+    InvalidPath,
+    FoldedSpellingAlias,
+    FileDirectoryRole,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StrictBoundRemoteObservationIncompleteV1 {
+    InvalidRemotePrefix,
+    Listing(StrictRemoteNamespaceKeyIncompleteV1),
+    ListedObjectMissing {
+        pass: RemoteNamespaceListingPassV1,
+        kind: BoundRemoteObjectKindV1,
+    },
+    ListedRouteMismatch {
+        pass: RemoteNamespaceListingPassV1,
+        kind: BoundRemoteObjectKindV1,
+    },
+    Index {
+        pass: RemoteNamespaceListingPassV1,
+        reason: StrictRemoteIndexIncompleteV1,
+    },
+    Marker {
+        pass: RemoteNamespaceListingPassV1,
+        reason: StrictRemoteDirectoryMarkerIncompleteV1,
+    },
+    LiveMarkerExcluded {
+        pass: RemoteNamespaceListingPassV1,
+    },
+    Reservation {
+        pass: RemoteNamespaceListingPassV1,
+        reason: StrictNamespaceReservationIncompleteV1,
+    },
+    Manifest {
+        pass: RemoteNamespaceListingPassV1,
+        reason: StrictRemoteManifestIncompleteV1,
+    },
+    Claim {
+        pass: RemoteNamespaceListingPassV1,
+        reason: RemoteNamespaceClaimConflictV1,
+    },
+    ResourceLimit {
+        pass: RemoteNamespaceListingPassV1,
+        resource: BoundRemotePassResourceV1,
+    },
+    PassesDisagreed {
+        index_objects: bool,
+        reservations: bool,
+        manifests: bool,
+        claims: bool,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum StrictBoundRemoteObservationReadV1 {
+    Matched(MatchingTwoPassBoundRemoteEvidenceV1),
+    Incomplete(StrictBoundRemoteObservationIncompleteV1),
+}
+
 #[derive(Debug, Default, Eq, PartialEq)]
 struct RemoteNamespaceKeyPassV1 {
     index_objects: BTreeSet<ListedRemoteIndexKeyV1>,
@@ -313,6 +515,192 @@ impl RemoteListingBudgetV1 {
             }
         }
     }
+}
+
+#[derive(Debug, Default)]
+struct BoundRemotePassBudgetV1 {
+    bound_object_bytes: u64,
+    retained_binding_bytes: u64,
+    generated_claims: u64,
+    generated_claim_bytes: u64,
+    retained_claims: u64,
+    retained_claim_bytes: u64,
+}
+
+#[derive(Debug)]
+struct RetainedRemoteNamespaceClaimValueV1 {
+    exact_path: String,
+    role: PortableNamespaceRole,
+}
+
+fn bound_pass_resource_limit(
+    pass: RemoteNamespaceListingPassV1,
+    resource: BoundRemotePassResourceV1,
+) -> StrictBoundRemoteObservationIncompleteV1 {
+    StrictBoundRemoteObservationIncompleteV1::ResourceLimit { pass, resource }
+}
+
+fn checked_bound_pass_increment_v1(
+    value: &mut u64,
+    increment: u64,
+    maximum: u64,
+    pass: RemoteNamespaceListingPassV1,
+    resource: BoundRemotePassResourceV1,
+) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
+    *value = value
+        .checked_add(increment)
+        .ok_or_else(|| bound_pass_resource_limit(pass, resource))?;
+    if *value > maximum {
+        return Err(bound_pass_resource_limit(pass, resource));
+    }
+    Ok(())
+}
+
+fn binding_bytes_v1(
+    object: &BoundRemoteObjectSnapshotV1,
+    pass: RemoteNamespaceListingPassV1,
+) -> Result<u64, StrictBoundRemoteObservationIncompleteV1> {
+    let token_bytes = match object.binding() {
+        RegisteredRootRemoteObjectBindingV1::Version { version, etag } => version
+            .len()
+            .checked_add(etag.as_ref().map_or(0, String::len)),
+        RegisteredRootRemoteObjectBindingV1::Etag { etag } => Some(etag.len()),
+    }
+    .ok_or_else(|| {
+        bound_pass_resource_limit(pass, BoundRemotePassResourceV1::RetainedBindingBytes)
+    })?;
+    u64::try_from(token_bytes).map_err(|_| {
+        bound_pass_resource_limit(pass, BoundRemotePassResourceV1::RetainedBindingBytes)
+    })
+}
+
+impl BoundRemotePassBudgetV1 {
+    fn observe_object_accounting(
+        &mut self,
+        pass: RemoteNamespaceListingPassV1,
+        raw_bytes: u64,
+        binding_bytes: u64,
+        contract: RootRemoteContractV1,
+    ) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
+        checked_bound_pass_increment_v1(
+            &mut self.bound_object_bytes,
+            raw_bytes,
+            contract.max_bound_object_bytes_per_pass(),
+            pass,
+            BoundRemotePassResourceV1::BoundObjectBytes,
+        )?;
+        checked_bound_pass_increment_v1(
+            &mut self.retained_binding_bytes,
+            binding_bytes,
+            contract.max_retained_binding_bytes_per_pass(),
+            pass,
+            BoundRemotePassResourceV1::RetainedBindingBytes,
+        )
+    }
+
+    fn observe_object(
+        &mut self,
+        pass: RemoteNamespaceListingPassV1,
+        object: &BoundRemoteObjectSnapshotV1,
+        contract: RootRemoteContractV1,
+    ) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
+        self.observe_object_accounting(
+            pass,
+            object.raw_bytes_len(),
+            binding_bytes_v1(object, pass)?,
+            contract,
+        )
+    }
+
+    fn observe_claim(
+        &mut self,
+        pass: RemoteNamespaceListingPassV1,
+        claim: &PortableNamespaceReservationV1,
+        claims: &mut BTreeMap<String, RetainedRemoteNamespaceClaimValueV1>,
+        contract: RootRemoteContractV1,
+    ) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
+        let claim_bytes = claim
+            .exact_path()
+            .len()
+            .checked_add(claim.folded_path().len())
+            .and_then(|length| u64::try_from(length).ok())
+            .ok_or_else(|| {
+                bound_pass_resource_limit(pass, BoundRemotePassResourceV1::GeneratedClaimBytes)
+            })?;
+        checked_bound_pass_increment_v1(
+            &mut self.generated_claims,
+            1,
+            contract.max_generated_claim_observations_per_pass(),
+            pass,
+            BoundRemotePassResourceV1::GeneratedClaims,
+        )?;
+        checked_bound_pass_increment_v1(
+            &mut self.generated_claim_bytes,
+            claim_bytes,
+            contract.max_generated_claim_bytes_per_pass(),
+            pass,
+            BoundRemotePassResourceV1::GeneratedClaimBytes,
+        )?;
+
+        if let Some(existing) = claims.get(claim.folded_path()) {
+            if existing.exact_path != claim.exact_path() {
+                return Err(StrictBoundRemoteObservationIncompleteV1::Claim {
+                    pass,
+                    reason: RemoteNamespaceClaimConflictV1::FoldedSpellingAlias,
+                });
+            }
+            if existing.role != claim.role() {
+                return Err(StrictBoundRemoteObservationIncompleteV1::Claim {
+                    pass,
+                    reason: RemoteNamespaceClaimConflictV1::FileDirectoryRole,
+                });
+            }
+            return Ok(());
+        }
+
+        checked_bound_pass_increment_v1(
+            &mut self.retained_claims,
+            1,
+            contract.max_retained_unique_claims_per_pass(),
+            pass,
+            BoundRemotePassResourceV1::RetainedClaims,
+        )?;
+        checked_bound_pass_increment_v1(
+            &mut self.retained_claim_bytes,
+            claim_bytes,
+            contract.max_retained_unique_claim_bytes_per_pass(),
+            pass,
+            BoundRemotePassResourceV1::RetainedClaimBytes,
+        )?;
+        claims.insert(
+            claim.folded_path().to_owned(),
+            RetainedRemoteNamespaceClaimValueV1 {
+                exact_path: claim.exact_path().to_owned(),
+                role: claim.role(),
+            },
+        );
+        Ok(())
+    }
+}
+
+fn observe_claim_chain_v1(
+    budget: &mut BoundRemotePassBudgetV1,
+    pass: RemoteNamespaceListingPassV1,
+    claims: &mut BTreeMap<String, RetainedRemoteNamespaceClaimValueV1>,
+    rel_path: &str,
+    role: PortableNamespaceRole,
+    contract: RootRemoteContractV1,
+) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
+    let generated = namespace_claims_for_path(rel_path, role).map_err(|_| {
+        StrictBoundRemoteObservationIncompleteV1::Claim {
+            pass,
+            reason: RemoteNamespaceClaimConflictV1::InvalidPath,
+        }
+    })?;
+    for claim in &generated {
+        budget.observe_claim(pass, claim, claims, contract)?;
+    }
+    Ok(())
 }
 
 fn is_lower_hex_64(value: &str) -> bool {
@@ -662,6 +1050,360 @@ async fn read_remote_namespace_key_pass_v1(
     Ok(pass)
 }
 
+async fn read_fully_drained_bound_remote_pass_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    listing_pass: RemoteNamespaceListingPassV1,
+    contract: RootRemoteContractV1,
+) -> anyhow::Result<Result<FullyDrainedBoundRemotePassV1, StrictBoundRemoteObservationIncompleteV1>>
+{
+    let listed =
+        match read_remote_namespace_key_pass_v1(op, remote_prefix, listing_pass, contract).await {
+            Ok(listed) => listed,
+            Err(incomplete) => {
+                return Ok(Err(StrictBoundRemoteObservationIncompleteV1::Listing(
+                    incomplete,
+                )));
+            }
+        };
+    let RemoteNamespaceKeyPassV1 {
+        index_objects: listed_index_objects,
+        reservation_objects: listed_reservation_objects,
+        index_directory_rows: _,
+        reservation_directory_rows: _,
+    } = listed;
+
+    let mut budget = BoundRemotePassBudgetV1::default();
+    let mut claims = BTreeMap::<String, RetainedRemoteNamespaceClaimValueV1>::new();
+    let mut index_objects = Vec::with_capacity(listed_index_objects.len());
+
+    for listed in listed_index_objects {
+        let (kind, observed) = match listed.class() {
+            ListedRemoteIndexKeyClassV1::OrdinaryIndexObject => {
+                let read = read_exact_observed_raw_index_entry_v1(
+                    op,
+                    remote_prefix,
+                    listed.logical_path(),
+                )
+                .await?;
+                let observed = match read {
+                    ExactObservedRawIndexEntryReadV1::Missing => {
+                        return Ok(Err(
+                            StrictBoundRemoteObservationIncompleteV1::ListedObjectMissing {
+                                pass: listing_pass,
+                                kind: BoundRemoteObjectKindV1::OrdinaryIndex,
+                            },
+                        ));
+                    }
+                    ExactObservedRawIndexEntryReadV1::Incomplete {
+                        reason,
+                        observed_object,
+                    } => {
+                        if let Some(object) = observed_object {
+                            if let Err(incomplete) =
+                                budget.observe_object(listing_pass, &object, contract)
+                            {
+                                return Ok(Err(incomplete));
+                            }
+                        }
+                        return Ok(Err(StrictBoundRemoteObservationIncompleteV1::Index {
+                            pass: listing_pass,
+                            reason,
+                        }));
+                    }
+                    ExactObservedRawIndexEntryReadV1::Deleted(index) => {
+                        BoundRemoteIndexObjectV1::Deleted(Box::new(index))
+                    }
+                    ExactObservedRawIndexEntryReadV1::Committed(index) => {
+                        BoundRemoteIndexObjectV1::Committed(Box::new(index))
+                    }
+                };
+                (BoundRemoteObjectKindV1::OrdinaryIndex, observed)
+            }
+            ListedRemoteIndexKeyClassV1::DirectoryMarkerCandidate => {
+                let read = read_exact_observed_raw_directory_marker_v1(
+                    op,
+                    remote_prefix,
+                    listed.logical_path(),
+                )
+                .await?;
+                let observed = match read {
+                    ExactObservedRawDirectoryMarkerReadV1::Missing => {
+                        return Ok(Err(
+                            StrictBoundRemoteObservationIncompleteV1::ListedObjectMissing {
+                                pass: listing_pass,
+                                kind: BoundRemoteObjectKindV1::DirectoryMarker,
+                            },
+                        ));
+                    }
+                    ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                        reason,
+                        observed_object,
+                    } => {
+                        if let Some(object) = observed_object {
+                            if let Err(incomplete) =
+                                budget.observe_object(listing_pass, &object, contract)
+                            {
+                                return Ok(Err(incomplete));
+                            }
+                        }
+                        return Ok(Err(StrictBoundRemoteObservationIncompleteV1::Marker {
+                            pass: listing_pass,
+                            reason,
+                        }));
+                    }
+                    ExactObservedRawDirectoryMarkerReadV1::Live(marker) => {
+                        BoundRemoteIndexObjectV1::LiveMarker(Box::new(marker))
+                    }
+                    ExactObservedRawDirectoryMarkerReadV1::Deleted(marker) => {
+                        BoundRemoteIndexObjectV1::DeletedMarker(Box::new(marker))
+                    }
+                };
+                (BoundRemoteObjectKindV1::DirectoryMarker, observed)
+            }
+        };
+        if observed.physical_key() != listed.object_key() {
+            return Ok(Err(
+                StrictBoundRemoteObservationIncompleteV1::ListedRouteMismatch {
+                    pass: listing_pass,
+                    kind,
+                },
+            ));
+        }
+        if let Err(incomplete) = budget.observe_object(listing_pass, observed.object(), contract) {
+            return Ok(Err(incomplete));
+        }
+        if matches!(&observed, BoundRemoteIndexObjectV1::LiveMarker(_))
+            && Blacklist::default()
+                .check_fixed_ingress_path_components(Path::new(observed.logical_path()))
+                .is_some()
+        {
+            return Ok(Err(
+                StrictBoundRemoteObservationIncompleteV1::LiveMarkerExcluded { pass: listing_pass },
+            ));
+        }
+        if let Err(incomplete) = observe_claim_chain_v1(
+            &mut budget,
+            listing_pass,
+            &mut claims,
+            observed.logical_path(),
+            observed.role(),
+            contract,
+        ) {
+            return Ok(Err(incomplete));
+        }
+        index_objects.push(observed);
+    }
+
+    let mut reservations = Vec::with_capacity(listed_reservation_objects.len());
+    for listed in listed_reservation_objects {
+        let reservation = match read_exact_observed_namespace_reservation_v1(
+            op,
+            remote_prefix,
+            listed.object_id(),
+        )
+        .await?
+        {
+            ExactObservedNamespaceReservationReadV1::Missing => {
+                return Ok(Err(
+                    StrictBoundRemoteObservationIncompleteV1::ListedObjectMissing {
+                        pass: listing_pass,
+                        kind: BoundRemoteObjectKindV1::NamespaceReservation,
+                    },
+                ));
+            }
+            ExactObservedNamespaceReservationReadV1::Incomplete {
+                reason,
+                observed_object,
+            } => {
+                if let Some(object) = observed_object {
+                    if let Err(incomplete) = budget.observe_object(listing_pass, &object, contract)
+                    {
+                        return Ok(Err(incomplete));
+                    }
+                }
+                return Ok(Err(StrictBoundRemoteObservationIncompleteV1::Reservation {
+                    pass: listing_pass,
+                    reason,
+                }));
+            }
+            ExactObservedNamespaceReservationReadV1::Bound(reservation) => reservation,
+        };
+        if reservation.object_key() != listed.object_key() {
+            return Ok(Err(
+                StrictBoundRemoteObservationIncompleteV1::ListedRouteMismatch {
+                    pass: listing_pass,
+                    kind: BoundRemoteObjectKindV1::NamespaceReservation,
+                },
+            ));
+        }
+        if let Err(incomplete) = budget.observe_object(listing_pass, reservation.object(), contract)
+        {
+            return Ok(Err(incomplete));
+        }
+        if let Err(incomplete) = observe_claim_chain_v1(
+            &mut budget,
+            listing_pass,
+            &mut claims,
+            reservation.exact_path(),
+            reservation.role(),
+            contract,
+        ) {
+            return Ok(Err(incomplete));
+        }
+        reservations.push(reservation);
+    }
+
+    // Borrow manifest IDs from the now-immobile canonical index vector. The
+    // retained observation stores only a source ordinal, not a duplicate full
+    // manifest storage key for every object.
+    let mut manifest_references = BTreeMap::<&str, Vec<usize>>::new();
+    for (index_ordinal, observed) in index_objects.iter().enumerate() {
+        if let Some(committed) = observed.committed() {
+            manifest_references
+                .entry(committed.current().manifest_hash())
+                .or_default()
+                .push(index_ordinal);
+        }
+    }
+    let mut manifests = Vec::with_capacity(manifest_references.len());
+    for (_manifest_id, index_ordinals) in manifest_references {
+        let source_index_ordinal = *index_ordinals
+            .first()
+            .expect("manifest reference group is non-empty");
+        let references = index_ordinals
+            .iter()
+            .map(|ordinal| {
+                index_objects[*ordinal]
+                    .committed()
+                    .expect("manifest reference ordinal names a committed index")
+            })
+            .collect::<Vec<_>>();
+        let manifest = match read_observed_strict_remote_manifest_for_references_v1(op, &references)
+            .await?
+        {
+            StrictObservedRemoteManifestReadV1::Complete(manifest) => manifest,
+            StrictObservedRemoteManifestReadV1::Incomplete {
+                reason,
+                observed_object,
+            } => {
+                if let Some(object) = observed_object {
+                    if let Err(incomplete) = budget.observe_object(listing_pass, &object, contract)
+                    {
+                        return Ok(Err(incomplete));
+                    }
+                }
+                return Ok(Err(StrictBoundRemoteObservationIncompleteV1::Manifest {
+                    pass: listing_pass,
+                    reason,
+                }));
+            }
+        };
+        if let Err(incomplete) = budget.observe_object(listing_pass, manifest.object(), contract) {
+            return Ok(Err(incomplete));
+        }
+        manifests.push(BoundRemoteManifestObservationV1 {
+            source_index_ordinal,
+            manifest,
+        });
+    }
+
+    let claims = claims
+        .into_iter()
+        .map(
+            |(folded_path, RetainedRemoteNamespaceClaimValueV1 { exact_path, role })| {
+                RetainedRemoteNamespaceClaimV1 {
+                    folded_path,
+                    exact_path,
+                    role,
+                }
+            },
+        )
+        .collect();
+    Ok(Ok(FullyDrainedBoundRemotePassV1 {
+        index_objects,
+        reservations,
+        manifests,
+        claims,
+    }))
+}
+
+async fn read_bound_remote_observation_with_between_passes_v1<F, Fut>(
+    op: &Operator,
+    remote_prefix: &str,
+    between_passes: F,
+) -> anyhow::Result<StrictBoundRemoteObservationReadV1>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let remote_prefix = match validate_canonical_namespace_remote_prefix(remote_prefix) {
+        Ok(prefix) => prefix,
+        Err(_) => {
+            return Ok(StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::InvalidRemotePrefix,
+            ));
+        }
+    };
+    let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let first = match read_fully_drained_bound_remote_pass_v1(
+        op,
+        remote_prefix,
+        RemoteNamespaceListingPassV1::First,
+        contract,
+    )
+    .await?
+    {
+        Ok(pass) => pass,
+        Err(incomplete) => {
+            return Ok(StrictBoundRemoteObservationReadV1::Incomplete(incomplete));
+        }
+    };
+    between_passes().await;
+    let second = match read_fully_drained_bound_remote_pass_v1(
+        op,
+        remote_prefix,
+        RemoteNamespaceListingPassV1::Second,
+        contract,
+    )
+    .await?
+    {
+        Ok(pass) => pass,
+        Err(incomplete) => {
+            return Ok(StrictBoundRemoteObservationReadV1::Incomplete(incomplete));
+        }
+    };
+
+    let index_objects = first.index_objects != second.index_objects;
+    let reservations = first.reservations != second.reservations;
+    let manifests = first.manifests != second.manifests;
+    let claims = first.claims != second.claims;
+    if index_objects || reservations || manifests || claims {
+        return Ok(StrictBoundRemoteObservationReadV1::Incomplete(
+            StrictBoundRemoteObservationIncompleteV1::PassesDisagreed {
+                index_objects,
+                reservations,
+                manifests,
+                claims,
+            },
+        ));
+    }
+
+    Ok(StrictBoundRemoteObservationReadV1::Matched(
+        MatchingTwoPassBoundRemoteEvidenceV1 {
+            remote_prefix: remote_prefix.to_owned(),
+            evidence: second,
+        },
+    ))
+}
+
+pub(crate) async fn read_bound_remote_observation_two_pass_v1(
+    op: &Operator,
+    remote_prefix: &str,
+) -> anyhow::Result<StrictBoundRemoteObservationReadV1> {
+    read_bound_remote_observation_with_between_passes_v1(op, remote_prefix, || async {}).await
+}
+
 async fn read_remote_namespace_keys_with_between_passes_v1<F, Fut>(
     op: &Operator,
     remote_prefix: &str,
@@ -734,9 +1476,10 @@ pub(crate) async fn list_remote_namespace_keys_two_pass_v1(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opendal::raw::{oio, Access, AccessorInfo, OpList, RpList};
+    use crate::index_entry::{manifest_object_id, namespace_reservation_object_id};
+    use opendal::raw::{oio, Access, AccessorInfo, OpList, OpRead, OpStat, RpList, RpRead, RpStat};
     use opendal::services::Memory;
-    use opendal::{Capability, Error, ErrorKind, Metadata, OperatorBuilder};
+    use opendal::{Buffer, Capability, Error, ErrorKind, Metadata, OperatorBuilder};
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
@@ -761,16 +1504,49 @@ mod tests {
         deleted: bool,
     }
 
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    enum ObservationEvent {
+        ListOpen(String),
+        ListRow(String),
+        ListEof(String),
+        Stat(String),
+        Read(String),
+        BetweenPasses,
+    }
+
+    #[derive(Clone, Debug)]
+    struct ScriptedBoundObject {
+        bytes: Vec<u8>,
+        etag: Option<String>,
+        version: Option<String>,
+    }
+
     #[derive(Debug)]
     struct ScriptedLister {
+        path: String,
         rows: VecDeque<ScriptedListRow>,
+        events: Arc<Mutex<Vec<ObservationEvent>>>,
+        finished: bool,
     }
 
     impl oio::List for ScriptedLister {
         async fn next(&mut self) -> opendal::Result<Option<oio::Entry>> {
             match self.rows.pop_front() {
-                None => Ok(None),
+                None => {
+                    if !self.finished {
+                        self.events
+                            .lock()
+                            .unwrap()
+                            .push(ObservationEvent::ListEof(self.path.clone()));
+                        self.finished = true;
+                    }
+                    Ok(None)
+                }
                 Some(ScriptedListRow::Entry(path, mode)) => {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(ObservationEvent::ListRow(path.clone()));
                     Ok(Some(oio::Entry::new(&path, Metadata::new(mode))))
                 }
                 Some(ScriptedListRow::Error) => Err(Error::new(
@@ -786,10 +1562,12 @@ mod tests {
         info: Arc<AccessorInfo>,
         calls: Arc<Mutex<VecDeque<ScriptedListCall>>>,
         observed: Arc<Mutex<Vec<ObservedListCall>>>,
+        objects: Arc<Mutex<BTreeMap<String, ScriptedBoundObject>>>,
+        events: Arc<Mutex<Vec<ObservationEvent>>>,
     }
 
     impl Access for ScriptedListBackend {
-        type Reader = ();
+        type Reader = Buffer;
         type Writer = ();
         type Lister = ScriptedLister;
         type Deleter = ();
@@ -799,6 +1577,10 @@ mod tests {
         }
 
         async fn list(&self, path: &str, args: OpList) -> opendal::Result<(RpList, Self::Lister)> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(ObservationEvent::ListOpen(path.to_owned()));
             self.observed.lock().unwrap().push(ObservedListCall {
                 path: path.to_owned(),
                 limit: args.limit(),
@@ -818,7 +1600,87 @@ mod tests {
                     "scripted list path did not match",
                 ));
             }
-            Ok((RpList::default(), ScriptedLister { rows: call.rows }))
+            Ok((
+                RpList::default(),
+                ScriptedLister {
+                    path: path.to_owned(),
+                    rows: call.rows,
+                    events: self.events.clone(),
+                    finished: false,
+                },
+            ))
+        }
+
+        async fn stat(&self, path: &str, _: OpStat) -> opendal::Result<RpStat> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(ObservationEvent::Stat(path.to_owned()));
+            let object = self
+                .objects
+                .lock()
+                .unwrap()
+                .get(path)
+                .cloned()
+                .ok_or_else(|| Error::new(ErrorKind::NotFound, "scripted object is missing"))?;
+            let mut metadata = Metadata::new(EntryMode::FILE)
+                .with_content_length(u64::try_from(object.bytes.len()).unwrap());
+            if let Some(etag) = object.etag {
+                metadata = metadata.with_etag(etag);
+            }
+            if let Some(version) = object.version {
+                metadata = metadata.with_version(version);
+            }
+            Ok(RpStat::new(metadata))
+        }
+
+        async fn read(&self, path: &str, args: OpRead) -> opendal::Result<(RpRead, Buffer)> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(ObservationEvent::Read(path.to_owned()));
+            let object = self
+                .objects
+                .lock()
+                .unwrap()
+                .get(path)
+                .cloned()
+                .ok_or_else(|| Error::new(ErrorKind::NotFound, "scripted object is missing"))?;
+            if args
+                .version()
+                .is_some_and(|expected| object.version.as_deref() != Some(expected))
+            {
+                return Err(Error::new(
+                    ErrorKind::ConditionNotMatch,
+                    "scripted object version changed",
+                ));
+            }
+            if args
+                .if_match()
+                .is_some_and(|expected| object.etag.as_deref() != Some(expected))
+            {
+                return Err(Error::new(
+                    ErrorKind::ConditionNotMatch,
+                    "scripted object ETag changed",
+                ));
+            }
+            let range = args.range();
+            let start = usize::try_from(range.offset()).unwrap_or(usize::MAX);
+            let end = range
+                .size()
+                .and_then(|size| usize::try_from(size).ok())
+                .map(|size| start.saturating_add(size))
+                .unwrap_or(object.bytes.len())
+                .min(object.bytes.len());
+            let selected = if start <= end {
+                object.bytes[start..end].to_vec()
+            } else {
+                Vec::new()
+            };
+            Ok((
+                RpRead::new().with_size(Some(u64::try_from(selected.len()).unwrap())),
+                Buffer::from(selected),
+            ))
         }
     }
 
@@ -842,14 +1704,123 @@ mod tests {
                 list: true,
                 list_with_limit: true,
                 list_with_recursive: true,
+                stat: true,
+                read: true,
+                read_with_if_match: true,
+                read_with_version: true,
                 ..Default::default()
             });
         let backend = ScriptedListBackend {
             info: Arc::new(info),
             calls: Arc::new(Mutex::new(calls.into())),
             observed: Arc::new(Mutex::new(Vec::new())),
+            objects: Arc::new(Mutex::new(BTreeMap::new())),
+            events: Arc::new(Mutex::new(Vec::new())),
         };
         (OperatorBuilder::new(backend.clone()).finish(), backend)
+    }
+
+    fn bound_object(bytes: Vec<u8>, etag: &str) -> ScriptedBoundObject {
+        ScriptedBoundObject {
+            bytes,
+            etag: Some(etag.to_owned()),
+            version: None,
+        }
+    }
+
+    fn versioned_bound_object(bytes: Vec<u8>, version: &str, etag: &str) -> ScriptedBoundObject {
+        ScriptedBoundObject {
+            bytes,
+            etag: Some(etag.to_owned()),
+            version: Some(version.to_owned()),
+        }
+    }
+
+    fn install_bound_object(
+        backend: &ScriptedListBackend,
+        key: impl Into<String>,
+        object: ScriptedBoundObject,
+    ) {
+        backend.objects.lock().unwrap().insert(key.into(), object);
+    }
+
+    fn regular_manifest_json(rel_path: &str) -> Vec<u8> {
+        format!(
+            r#"{{
+  "version": 2,
+  "file_hash": "{file_hash}",
+  "file_size": 4,
+  "chunks": ["{chunk_hash}"],
+  "vclock": {{ "clocks": {{ "sting": 1 }} }},
+  "written_by": "sting",
+  "written_at": 7,
+  "rel_path": "{rel_path}",
+  "mode": 420,
+  "mtime": [8, 9]
+}}"#,
+            file_hash = "d".repeat(64),
+            chunk_hash = "e".repeat(64),
+        )
+        .into_bytes()
+    }
+
+    fn committed_index_json(manifest_hash: &str) -> Vec<u8> {
+        format!(
+            r#"{{"version":2,"state":"committed","current":{{"manifest_hash":"{manifest_hash}","size":4,"chunks":1}},"pending":null}}"#
+        )
+        .into_bytes()
+    }
+
+    fn deleted_index_json(safety_copy_key: Option<&str>) -> Vec<u8> {
+        match safety_copy_key {
+            Some(safety_copy_key) => format!(
+                r#"{{"version":4,"state":"deleted","current":null,"pending":null,"deletion_evidence":{{"safety_copy_key":"{safety_copy_key}","safety_copy_blake3":"{digest}"}}}}"#,
+                digest = "a".repeat(64),
+            )
+            .into_bytes(),
+            None => {
+                br#"{"version":4,"state":"deleted","current":null,"pending":null}"#.to_vec()
+            }
+        }
+    }
+
+    fn canonical_reservation_json(exact_path: &str, folded_path: &str, role: &str) -> Vec<u8> {
+        format!(
+            r#"{{"version":1,"exact_path":"{exact_path}","folded_path":"{folded_path}","role":"{role}"}}"#
+        )
+        .into_bytes()
+    }
+
+    fn two_bound_pass_list_calls(
+        index_keys: &[String],
+        reservation_keys: &[String],
+    ) -> Vec<ScriptedListCall> {
+        bound_pass_list_calls(index_keys, reservation_keys, index_keys, reservation_keys)
+    }
+
+    fn bound_pass_list_calls(
+        first_index_keys: &[String],
+        first_reservation_keys: &[String],
+        second_index_keys: &[String],
+        second_reservation_keys: &[String],
+    ) -> Vec<ScriptedListCall> {
+        let corpus_rows = |keys: &[String]| {
+            keys.iter()
+                .map(|key| ScriptedListRow::Entry(key.clone(), EntryMode::FILE))
+                .collect()
+        };
+        vec![
+            scripted_list_call("roots/index/", corpus_rows(first_index_keys)),
+            scripted_list_call(
+                "roots/.tcfs-namespace/v1/",
+                corpus_rows(first_reservation_keys),
+            ),
+            scripted_list_call("roots/index/", corpus_rows(second_index_keys)),
+            scripted_list_call(
+                "roots/.tcfs-namespace/v1/",
+                corpus_rows(second_reservation_keys),
+            ),
+        ]
     }
 
     fn observe_one_row(
@@ -1584,5 +2555,1640 @@ mod tests {
         assert_eq!(budget.listing_key_bytes, key.len() as u64);
         assert_eq!(budget.index_objects, 1);
         assert!(budget.index_key_bytes > contract.max_retained_index_key_bytes_per_pass());
+    }
+
+    #[test]
+    fn bound_body_and_binding_aggregate_limits_accept_exact_and_reject_plus_one() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let pass = RemoteNamespaceListingPassV1::First;
+        let mut exact = BoundRemotePassBudgetV1::default();
+        assert_eq!(
+            exact.observe_object_accounting(
+                pass,
+                contract.max_bound_object_bytes_per_pass(),
+                contract.max_retained_binding_bytes_per_pass(),
+                contract,
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            exact.bound_object_bytes,
+            contract.max_bound_object_bytes_per_pass()
+        );
+        assert_eq!(
+            exact.retained_binding_bytes,
+            contract.max_retained_binding_bytes_per_pass()
+        );
+
+        let mut body_over = BoundRemotePassBudgetV1 {
+            bound_object_bytes: contract.max_bound_object_bytes_per_pass(),
+            ..BoundRemotePassBudgetV1::default()
+        };
+        assert_eq!(
+            body_over.observe_object_accounting(pass, 1, 0, contract),
+            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+                pass,
+                resource: BoundRemotePassResourceV1::BoundObjectBytes,
+            })
+        );
+
+        let mut binding_over = BoundRemotePassBudgetV1 {
+            retained_binding_bytes: contract.max_retained_binding_bytes_per_pass(),
+            ..BoundRemotePassBudgetV1::default()
+        };
+        assert_eq!(
+            binding_over.observe_object_accounting(pass, 0, 1, contract),
+            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+                pass,
+                resource: BoundRemotePassResourceV1::RetainedBindingBytes,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn bound_object_budget_uses_actual_version_and_etag_token_lengths() {
+        let bytes = deleted_index_json(None);
+        let version = "version-token";
+        let etag = "etag-token";
+        let index_key = "roots/index/file";
+        let (op, backend) = scripted_list_operator(vec![]);
+        install_bound_object(
+            &backend,
+            index_key,
+            versioned_bound_object(bytes.clone(), version, etag),
+        );
+        let deleted = match read_exact_observed_raw_index_entry_v1(&op, "roots", "file")
+            .await
+            .unwrap()
+        {
+            ExactObservedRawIndexEntryReadV1::Deleted(deleted) => deleted,
+            other => panic!("expected a version-bound deleted index, got {other:?}"),
+        };
+        assert_eq!(
+            deleted.object().binding(),
+            &RegisteredRootRemoteObjectBindingV1::Version {
+                version: version.to_owned(),
+                etag: Some(etag.to_owned()),
+            }
+        );
+
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let pass = RemoteNamespaceListingPassV1::First;
+        let body_bytes = u64::try_from(bytes.len()).unwrap();
+        let binding_bytes = u64::try_from(version.len() + etag.len()).unwrap();
+        let mut exact = BoundRemotePassBudgetV1 {
+            bound_object_bytes: contract.max_bound_object_bytes_per_pass() - body_bytes,
+            retained_binding_bytes: contract.max_retained_binding_bytes_per_pass() - binding_bytes,
+            ..BoundRemotePassBudgetV1::default()
+        };
+        assert_eq!(
+            exact.observe_object(pass, deleted.object(), contract),
+            Ok(())
+        );
+        assert_eq!(
+            exact.bound_object_bytes,
+            contract.max_bound_object_bytes_per_pass()
+        );
+        assert_eq!(
+            exact.retained_binding_bytes,
+            contract.max_retained_binding_bytes_per_pass()
+        );
+
+        let mut body_over = BoundRemotePassBudgetV1 {
+            bound_object_bytes: contract.max_bound_object_bytes_per_pass() - body_bytes + 1,
+            ..BoundRemotePassBudgetV1::default()
+        };
+        assert_eq!(
+            body_over.observe_object(pass, deleted.object(), contract),
+            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+                pass,
+                resource: BoundRemotePassResourceV1::BoundObjectBytes,
+            })
+        );
+
+        let mut binding_over = BoundRemotePassBudgetV1 {
+            retained_binding_bytes: contract.max_retained_binding_bytes_per_pass() - binding_bytes
+                + 1,
+            ..BoundRemotePassBudgetV1::default()
+        };
+        assert_eq!(
+            binding_over.observe_object(pass, deleted.object(), contract),
+            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+                pass,
+                resource: BoundRemotePassResourceV1::RetainedBindingBytes,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn observed_invalid_body_readers_retain_bound_accounting_evidence() {
+        let (op, backend) = scripted_list_operator(vec![]);
+
+        let invalid_index_key = "roots/index/invalid-index";
+        let invalid_index_bytes = b"not-an-index".to_vec();
+        install_bound_object(
+            &backend,
+            invalid_index_key,
+            bound_object(invalid_index_bytes.clone(), "invalid-index"),
+        );
+        match read_exact_observed_raw_index_entry_v1(&op, "roots", "invalid-index")
+            .await
+            .unwrap()
+        {
+            ExactObservedRawIndexEntryReadV1::Incomplete {
+                reason: StrictRemoteIndexIncompleteV1::InvalidIndexRecord,
+                observed_object: Some(object),
+            } => assert_eq!(object.raw_bytes_len(), invalid_index_bytes.len() as u64),
+            other => panic!("expected bound invalid-index evidence, got {other:?}"),
+        }
+        install_bound_object(
+            &backend,
+            "roots/index/unbound-index",
+            ScriptedBoundObject {
+                bytes: deleted_index_json(None),
+                etag: None,
+                version: None,
+            },
+        );
+        assert_eq!(
+            read_exact_observed_raw_index_entry_v1(&op, "roots", "unbound-index")
+                .await
+                .unwrap(),
+            ExactObservedRawIndexEntryReadV1::Incomplete {
+                reason: StrictRemoteIndexIncompleteV1::UnboundObject,
+                observed_object: None,
+            }
+        );
+        assert_eq!(
+            read_exact_observed_raw_index_entry_v1(&op, "roots", "missing-index")
+                .await
+                .unwrap(),
+            ExactObservedRawIndexEntryReadV1::Missing
+        );
+
+        let invalid_marker_bytes = b"not-a-marker".to_vec();
+        install_bound_object(
+            &backend,
+            "roots/index/invalid-marker/.tcfs_dir",
+            bound_object(invalid_marker_bytes.clone(), "invalid-marker"),
+        );
+        match read_exact_observed_raw_directory_marker_v1(&op, "roots", "invalid-marker")
+            .await
+            .unwrap()
+        {
+            ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                reason: StrictRemoteDirectoryMarkerIncompleteV1::InvalidMarkerRecord,
+                observed_object: Some(object),
+            } => assert_eq!(object.raw_bytes_len(), invalid_marker_bytes.len() as u64),
+            other => panic!("expected bound invalid-marker evidence, got {other:?}"),
+        }
+        install_bound_object(
+            &backend,
+            "roots/index/unbound-marker/.tcfs_dir",
+            ScriptedBoundObject {
+                bytes: crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec(),
+                etag: None,
+                version: None,
+            },
+        );
+        assert_eq!(
+            read_exact_observed_raw_directory_marker_v1(&op, "roots", "unbound-marker")
+                .await
+                .unwrap(),
+            ExactObservedRawDirectoryMarkerReadV1::Incomplete {
+                reason: StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
+                observed_object: None,
+            }
+        );
+        assert_eq!(
+            read_exact_observed_raw_directory_marker_v1(&op, "roots", "missing-marker")
+                .await
+                .unwrap(),
+            ExactObservedRawDirectoryMarkerReadV1::Missing
+        );
+
+        let invalid_reservation_id = namespace_reservation_object_id("invalid-reservation");
+        let invalid_reservation_bytes = b"not-a-reservation".to_vec();
+        install_bound_object(
+            &backend,
+            format!("roots/.tcfs-namespace/v1/{invalid_reservation_id}"),
+            bound_object(invalid_reservation_bytes.clone(), "invalid-reservation"),
+        );
+        match read_exact_observed_namespace_reservation_v1(&op, "roots", &invalid_reservation_id)
+            .await
+            .unwrap()
+        {
+            ExactObservedNamespaceReservationReadV1::Incomplete {
+                reason: StrictNamespaceReservationIncompleteV1::InvalidReservation,
+                observed_object: Some(object),
+            } => assert_eq!(
+                object.raw_bytes_len(),
+                invalid_reservation_bytes.len() as u64
+            ),
+            other => panic!("expected bound invalid-reservation evidence, got {other:?}"),
+        }
+        let unbound_reservation_id = namespace_reservation_object_id("unbound-reservation");
+        install_bound_object(
+            &backend,
+            format!("roots/.tcfs-namespace/v1/{unbound_reservation_id}"),
+            ScriptedBoundObject {
+                bytes: canonical_reservation_json(
+                    "unbound-reservation",
+                    "unbound-reservation",
+                    "file",
+                ),
+                etag: None,
+                version: None,
+            },
+        );
+        assert_eq!(
+            read_exact_observed_namespace_reservation_v1(&op, "roots", &unbound_reservation_id)
+                .await
+                .unwrap(),
+            ExactObservedNamespaceReservationReadV1::Incomplete {
+                reason: StrictNamespaceReservationIncompleteV1::UnboundObject,
+                observed_object: None,
+            }
+        );
+        let missing_reservation_id = namespace_reservation_object_id("missing-reservation");
+        assert_eq!(
+            read_exact_observed_namespace_reservation_v1(&op, "roots", &missing_reservation_id)
+                .await
+                .unwrap(),
+            ExactObservedNamespaceReservationReadV1::Missing
+        );
+    }
+
+    #[tokio::test]
+    async fn observed_manifest_reader_retains_only_identity_bound_invalid_bytes() {
+        let (op, backend) = scripted_list_operator(vec![]);
+        let invalid_manifest_id = "a".repeat(64);
+        let unbound_manifest_id = "b".repeat(64);
+        let missing_manifest_id = "c".repeat(64);
+        for (rel_path, manifest_id) in [
+            ("invalid-manifest", &invalid_manifest_id),
+            ("unbound-manifest", &unbound_manifest_id),
+            ("missing-manifest", &missing_manifest_id),
+        ] {
+            install_bound_object(
+                &backend,
+                format!("roots/index/{rel_path}"),
+                bound_object(committed_index_json(manifest_id), rel_path),
+            );
+        }
+        let invalid_index =
+            match read_exact_observed_raw_index_entry_v1(&op, "roots", "invalid-manifest")
+                .await
+                .unwrap()
+            {
+                ExactObservedRawIndexEntryReadV1::Committed(index) => index,
+                other => panic!("expected invalid-manifest index reference, got {other:?}"),
+            };
+        let unbound_index =
+            match read_exact_observed_raw_index_entry_v1(&op, "roots", "unbound-manifest")
+                .await
+                .unwrap()
+            {
+                ExactObservedRawIndexEntryReadV1::Committed(index) => index,
+                other => panic!("expected unbound-manifest index reference, got {other:?}"),
+            };
+        let missing_index =
+            match read_exact_observed_raw_index_entry_v1(&op, "roots", "missing-manifest")
+                .await
+                .unwrap()
+            {
+                ExactObservedRawIndexEntryReadV1::Committed(index) => index,
+                other => panic!("expected missing-manifest index reference, got {other:?}"),
+            };
+
+        let invalid_manifest_bytes = b"not-the-addressed-manifest".to_vec();
+        install_bound_object(
+            &backend,
+            format!("roots/manifests/{invalid_manifest_id}"),
+            bound_object(invalid_manifest_bytes.clone(), "invalid-manifest"),
+        );
+        match read_observed_strict_remote_manifest_for_references_v1(&op, &[&invalid_index])
+            .await
+            .unwrap()
+        {
+            StrictObservedRemoteManifestReadV1::Incomplete {
+                reason: StrictRemoteManifestIncompleteV1::AddressMismatch,
+                observed_object: Some(object),
+            } => assert_eq!(object.raw_bytes_len(), invalid_manifest_bytes.len() as u64),
+            other => panic!("expected bound invalid-manifest evidence, got {other:?}"),
+        }
+
+        install_bound_object(
+            &backend,
+            format!("roots/manifests/{unbound_manifest_id}"),
+            ScriptedBoundObject {
+                bytes: regular_manifest_json("unbound-manifest"),
+                etag: None,
+                version: None,
+            },
+        );
+        assert_eq!(
+            read_observed_strict_remote_manifest_for_references_v1(&op, &[&unbound_index])
+                .await
+                .unwrap(),
+            StrictObservedRemoteManifestReadV1::Incomplete {
+                reason: StrictRemoteManifestIncompleteV1::UnboundObject,
+                observed_object: None,
+            }
+        );
+        assert_eq!(
+            read_observed_strict_remote_manifest_for_references_v1(&op, &[&missing_index])
+                .await
+                .unwrap(),
+            StrictObservedRemoteManifestReadV1::Incomplete {
+                reason: StrictRemoteManifestIncompleteV1::MissingObject,
+                observed_object: None,
+            }
+        );
+    }
+
+    #[test]
+    fn claim_aggregate_limits_charge_generated_before_dedupe_and_bound_retention() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let pass = RemoteNamespaceListingPassV1::Second;
+        let claim = PortableNamespaceReservationV1::from_json_bytes(&canonical_reservation_json(
+            "path", "path", "file",
+        ))
+        .unwrap();
+        let claim_bytes = u64::try_from(claim.exact_path().len() + claim.folded_path().len())
+            .expect("test claim length fits u64");
+
+        let mut exact = BoundRemotePassBudgetV1 {
+            generated_claims: contract.max_generated_claim_observations_per_pass() - 1,
+            generated_claim_bytes: contract.max_generated_claim_bytes_per_pass() - claim_bytes,
+            retained_claims: contract.max_retained_unique_claims_per_pass() - 1,
+            retained_claim_bytes: contract.max_retained_unique_claim_bytes_per_pass() - claim_bytes,
+            ..BoundRemotePassBudgetV1::default()
+        };
+        let mut exact_claims = BTreeMap::new();
+        assert_eq!(
+            exact.observe_claim(pass, &claim, &mut exact_claims, contract),
+            Ok(())
+        );
+        assert_eq!(
+            exact.generated_claims,
+            contract.max_generated_claim_observations_per_pass()
+        );
+        assert_eq!(
+            exact.generated_claim_bytes,
+            contract.max_generated_claim_bytes_per_pass()
+        );
+        assert_eq!(
+            exact.retained_claims,
+            contract.max_retained_unique_claims_per_pass()
+        );
+        assert_eq!(
+            exact.retained_claim_bytes,
+            contract.max_retained_unique_claim_bytes_per_pass()
+        );
+
+        let retained_before = exact.retained_claims;
+        assert_eq!(
+            exact.observe_claim(pass, &claim, &mut exact_claims, contract),
+            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+                pass,
+                resource: BoundRemotePassResourceV1::GeneratedClaims,
+            })
+        );
+        assert_eq!(exact.retained_claims, retained_before);
+
+        let mut generated_bytes_over = BoundRemotePassBudgetV1 {
+            generated_claim_bytes: contract.max_generated_claim_bytes_per_pass(),
+            ..BoundRemotePassBudgetV1::default()
+        };
+        assert_eq!(
+            generated_bytes_over.observe_claim(pass, &claim, &mut BTreeMap::new(), contract),
+            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+                pass,
+                resource: BoundRemotePassResourceV1::GeneratedClaimBytes,
+            })
+        );
+
+        let mut retained_count_over = BoundRemotePassBudgetV1 {
+            retained_claims: contract.max_retained_unique_claims_per_pass(),
+            ..BoundRemotePassBudgetV1::default()
+        };
+        assert_eq!(
+            retained_count_over.observe_claim(pass, &claim, &mut BTreeMap::new(), contract),
+            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+                pass,
+                resource: BoundRemotePassResourceV1::RetainedClaims,
+            })
+        );
+
+        let mut retained_bytes_over = BoundRemotePassBudgetV1 {
+            retained_claim_bytes: contract.max_retained_unique_claim_bytes_per_pass(),
+            ..BoundRemotePassBudgetV1::default()
+        };
+        assert_eq!(
+            retained_bytes_over.observe_claim(pass, &claim, &mut BTreeMap::new(), contract),
+            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+                pass,
+                resource: BoundRemotePassResourceV1::RetainedClaimBytes,
+            })
+        );
+
+        let mut duplicate_budget = BoundRemotePassBudgetV1::default();
+        let mut duplicate_claims = BTreeMap::new();
+        duplicate_budget
+            .observe_claim(pass, &claim, &mut duplicate_claims, contract)
+            .unwrap();
+        duplicate_budget
+            .observe_claim(pass, &claim, &mut duplicate_claims, contract)
+            .unwrap();
+        assert_eq!(duplicate_budget.generated_claims, 2);
+        assert_eq!(duplicate_budget.generated_claim_bytes, claim_bytes * 2);
+        assert_eq!(duplicate_budget.retained_claims, 1);
+        assert_eq!(duplicate_budget.retained_claim_bytes, claim_bytes);
+        assert_eq!(duplicate_claims.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn full_passes_finish_every_body_before_starting_the_second_listing() {
+        let manifest_bytes = regular_manifest_json("file");
+        let manifest_id = manifest_object_id(&manifest_bytes);
+        let index_key = "roots/index/file".to_owned();
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &index_key,
+            bound_object(committed_index_json(&manifest_id), "index-v1"),
+        );
+        install_bound_object(
+            &backend,
+            &manifest_key,
+            bound_object(manifest_bytes, "manifest-v1"),
+        );
+        let events = backend.events.clone();
+
+        let result = read_bound_remote_observation_with_between_passes_v1(
+            &op,
+            "roots",
+            move || async move {
+                events.lock().unwrap().push(ObservationEvent::BetweenPasses);
+            },
+        )
+        .await
+        .unwrap();
+        let evidence = match result {
+            StrictBoundRemoteObservationReadV1::Matched(evidence) => evidence,
+            other => panic!("expected matching bound evidence, got {other:?}"),
+        };
+        assert_eq!(evidence.remote_prefix(), "roots");
+        assert_eq!(evidence.index_object_count(), 1);
+        assert_eq!(evidence.reservation_count(), 0);
+        assert_eq!(evidence.manifest_count(), 1);
+        assert_eq!(evidence.claim_count(), 1);
+
+        assert_eq!(
+            *backend.events.lock().unwrap(),
+            vec![
+                ObservationEvent::ListOpen("roots/index/".to_owned()),
+                ObservationEvent::ListRow(index_key.clone()),
+                ObservationEvent::ListEof("roots/index/".to_owned()),
+                ObservationEvent::ListOpen("roots/.tcfs-namespace/v1/".to_owned()),
+                ObservationEvent::ListEof("roots/.tcfs-namespace/v1/".to_owned()),
+                ObservationEvent::Stat(index_key.clone()),
+                ObservationEvent::Read(index_key.clone()),
+                ObservationEvent::Stat(manifest_key.clone()),
+                ObservationEvent::Read(manifest_key.clone()),
+                ObservationEvent::BetweenPasses,
+                ObservationEvent::ListOpen("roots/index/".to_owned()),
+                ObservationEvent::ListRow(index_key.clone()),
+                ObservationEvent::ListEof("roots/index/".to_owned()),
+                ObservationEvent::ListOpen("roots/.tcfs-namespace/v1/".to_owned()),
+                ObservationEvent::ListEof("roots/.tcfs-namespace/v1/".to_owned()),
+                ObservationEvent::Stat(index_key.clone()),
+                ObservationEvent::Read(index_key),
+                ObservationEvent::Stat(manifest_key.clone()),
+                ObservationEvent::Read(manifest_key.clone()),
+            ]
+        );
+        assert!(backend.calls.lock().unwrap().is_empty());
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Stat(manifest_key.clone()))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Read(manifest_key.clone()))
+                .count(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn second_pass_uses_a_fresh_index_listing_without_retry() {
+        let first_key = "roots/index/a".to_owned();
+        let second_key = "roots/index/b".to_owned();
+        let (op, backend) = scripted_list_operator(bound_pass_list_calls(
+            std::slice::from_ref(&first_key),
+            &[],
+            std::slice::from_ref(&second_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &first_key,
+            bound_object(deleted_index_json(None), "index-a"),
+        );
+        install_bound_object(
+            &backend,
+            &second_key,
+            bound_object(deleted_index_json(None), "index-b"),
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::PassesDisagreed {
+                    index_objects: true,
+                    reservations: false,
+                    manifests: false,
+                    claims: true,
+                }
+            )
+        );
+        assert!(backend.calls.lock().unwrap().is_empty());
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Stat(_)))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Read(_)))
+                .count(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn second_pass_uses_a_fresh_reservation_listing_without_retry() {
+        let first_id = namespace_reservation_object_id("a");
+        let second_id = namespace_reservation_object_id("b");
+        let first_key = format!("roots/.tcfs-namespace/v1/{first_id}");
+        let second_key = format!("roots/.tcfs-namespace/v1/{second_id}");
+        let (op, backend) = scripted_list_operator(bound_pass_list_calls(
+            &[],
+            std::slice::from_ref(&first_key),
+            &[],
+            std::slice::from_ref(&second_key),
+        ));
+        install_bound_object(
+            &backend,
+            &first_key,
+            bound_object(canonical_reservation_json("a", "a", "file"), "res-a"),
+        );
+        install_bound_object(
+            &backend,
+            &second_key,
+            bound_object(canonical_reservation_json("b", "b", "file"), "res-b"),
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::PassesDisagreed {
+                    index_objects: false,
+                    reservations: true,
+                    manifests: false,
+                    claims: true,
+                }
+            )
+        );
+        assert!(backend.calls.lock().unwrap().is_empty());
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Stat(_)))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Read(_)))
+                .count(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn manifest_binding_change_between_passes_is_observed_without_retry() {
+        let manifest_bytes = regular_manifest_json("file");
+        let manifest_id = manifest_object_id(&manifest_bytes);
+        let index_key = "roots/index/file".to_owned();
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &index_key,
+            bound_object(committed_index_json(&manifest_id), "index-v1"),
+        );
+        install_bound_object(
+            &backend,
+            &manifest_key,
+            bound_object(manifest_bytes.clone(), "manifest-v1"),
+        );
+        let mutation_backend = backend.clone();
+        let mutation_key = manifest_key.clone();
+
+        let result = read_bound_remote_observation_with_between_passes_v1(
+            &op,
+            "roots",
+            move || async move {
+                install_bound_object(
+                    &mutation_backend,
+                    mutation_key,
+                    bound_object(manifest_bytes, "manifest-v2"),
+                );
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            result,
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::PassesDisagreed {
+                    index_objects: false,
+                    reservations: false,
+                    manifests: true,
+                    claims: false,
+                }
+            )
+        );
+        assert!(backend.calls.lock().unwrap().is_empty());
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Stat(manifest_key.clone()))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Read(manifest_key.clone()))
+                .count(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn same_binding_semantically_equal_index_rewrite_changes_body_evidence() {
+        let manifest_bytes = regular_manifest_json("file");
+        let manifest_id = manifest_object_id(&manifest_bytes);
+        let index_key = "roots/index/file".to_owned();
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let initial_index = committed_index_json(&manifest_id);
+        let rewritten_index = String::from_utf8(initial_index.clone())
+            .unwrap()
+            .replace(",\"state\"", ",\n  \"state\"")
+            .into_bytes();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &index_key,
+            bound_object(initial_index, "index-v1"),
+        );
+        install_bound_object(
+            &backend,
+            &manifest_key,
+            bound_object(manifest_bytes, "manifest-v1"),
+        );
+        let mutation_backend = backend.clone();
+        let mutation_key = index_key.clone();
+
+        let result = read_bound_remote_observation_with_between_passes_v1(
+            &op,
+            "roots",
+            move || async move {
+                install_bound_object(
+                    &mutation_backend,
+                    mutation_key,
+                    bound_object(rewritten_index, "index-v1"),
+                );
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            result,
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::PassesDisagreed {
+                    index_objects: true,
+                    reservations: false,
+                    manifests: false,
+                    claims: false,
+                }
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn live_marker_to_deleted_marker_transition_disagrees() {
+        let marker_key = "roots/index/dir/.tcfs_dir".to_owned();
+        let deleted_marker =
+            br#"{"version":4,"state":"deleted","current":null,"pending":null}"#.to_vec();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&marker_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &marker_key,
+            bound_object(
+                crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec(),
+                "marker-v1",
+            ),
+        );
+        let mutation_backend = backend.clone();
+        let mutation_key = marker_key.clone();
+
+        let result = read_bound_remote_observation_with_between_passes_v1(
+            &op,
+            "roots",
+            move || async move {
+                install_bound_object(
+                    &mutation_backend,
+                    mutation_key,
+                    bound_object(deleted_marker, "marker-v2"),
+                );
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            result,
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::PassesDisagreed {
+                    index_objects: true,
+                    reservations: false,
+                    manifests: false,
+                    claims: false,
+                }
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn canonical_reservation_alias_mutation_disagrees() {
+        let folded_path = "doc.txt";
+        let reservation_id = namespace_reservation_object_id(folded_path);
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[],
+            std::slice::from_ref(&reservation_key),
+        ));
+        install_bound_object(
+            &backend,
+            &reservation_key,
+            bound_object(
+                canonical_reservation_json("Doc.txt", folded_path, "file"),
+                "reservation-v1",
+            ),
+        );
+        let mutation_backend = backend.clone();
+        let mutation_key = reservation_key.clone();
+
+        let result = read_bound_remote_observation_with_between_passes_v1(
+            &op,
+            "roots",
+            move || async move {
+                install_bound_object(
+                    &mutation_backend,
+                    mutation_key,
+                    bound_object(
+                        canonical_reservation_json("DOC.txt", folded_path, "file"),
+                        "reservation-v2",
+                    ),
+                );
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            result,
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::PassesDisagreed {
+                    index_objects: false,
+                    reservations: true,
+                    manifests: false,
+                    claims: true,
+                }
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn ordinary_file_and_same_path_marker_fail_the_role_claim() {
+        let file_key = "roots/index/a".to_owned();
+        let marker_key = "roots/index/a/.tcfs_dir".to_owned();
+        let manifest_id = "a".repeat(64);
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[file_key.clone(), marker_key.clone()],
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &file_key,
+            bound_object(committed_index_json(&manifest_id), "index-v1"),
+        );
+        install_bound_object(
+            &backend,
+            &marker_key,
+            bound_object(
+                crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec(),
+                "marker-v1",
+            ),
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Claim {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: RemoteNamespaceClaimConflictV1::FileDirectoryRole,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn standalone_descendant_reservation_preserves_ancestor_role_history() {
+        let file_key = "roots/index/a".to_owned();
+        let folded_path = "a/b";
+        let reservation_id = namespace_reservation_object_id(folded_path);
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&file_key),
+            std::slice::from_ref(&reservation_key),
+        ));
+        install_bound_object(
+            &backend,
+            &file_key,
+            bound_object(committed_index_json(&"a".repeat(64)), "index-v1"),
+        );
+        install_bound_object(
+            &backend,
+            &reservation_key,
+            bound_object(
+                canonical_reservation_json(folded_path, folded_path, "file"),
+                "reservation-v1",
+            ),
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Claim {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: RemoteNamespaceClaimConflictV1::FileDirectoryRole,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn live_marker_on_fixed_ingress_path_is_typed_incomplete() {
+        let marker_key = "roots/index/home/.SSH/.tcfs_dir".to_owned();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&marker_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            marker_key,
+            bound_object(
+                crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec(),
+                "marker-v1",
+            ),
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::LiveMarkerExcluded {
+                    pass: RemoteNamespaceListingPassV1::First,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn deleted_fixed_ingress_marker_remains_historical_claim_evidence() {
+        let marker_key = "roots/index/home/.SSH/.tcfs_dir".to_owned();
+        let deleted_marker =
+            br#"{"version":4,"state":"deleted","current":null,"pending":null}"#.to_vec();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&marker_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            marker_key,
+            bound_object(deleted_marker, "marker-v1"),
+        );
+
+        let evidence = match read_bound_remote_observation_two_pass_v1(&op, "roots")
+            .await
+            .unwrap()
+        {
+            StrictBoundRemoteObservationReadV1::Matched(evidence) => evidence,
+            other => panic!("expected historical marker evidence, got {other:?}"),
+        };
+        assert_eq!(evidence.index_object_count(), 1);
+        assert_eq!(evidence.manifest_count(), 0);
+        assert_eq!(evidence.claim_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn reservation_only_remote_history_is_complete_bound_evidence() {
+        let folded_path = "archive/file";
+        let reservation_id = namespace_reservation_object_id(folded_path);
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[],
+            std::slice::from_ref(&reservation_key),
+        ));
+        install_bound_object(
+            &backend,
+            &reservation_key,
+            bound_object(
+                canonical_reservation_json(folded_path, folded_path, "file"),
+                "reservation-v1",
+            ),
+        );
+
+        let evidence = match read_bound_remote_observation_two_pass_v1(&op, "roots")
+            .await
+            .unwrap()
+        {
+            StrictBoundRemoteObservationReadV1::Matched(evidence) => evidence,
+            other => panic!("expected reservation-only historical evidence, got {other:?}"),
+        };
+        assert_eq!(evidence.index_object_count(), 0);
+        assert_eq!(evidence.reservation_count(), 1);
+        assert_eq!(evidence.manifest_count(), 0);
+        assert_eq!(evidence.claim_count(), 2);
+        assert!(backend.calls.lock().unwrap().is_empty());
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Stat(reservation_key.clone()))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Read(reservation_key.clone()))
+                .count(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn fixed_ingress_reservation_remains_historical_claim_evidence() {
+        let exact_path = "home/.SSH/key";
+        let folded_path = "home/.ssh/key";
+        let reservation_id = namespace_reservation_object_id(folded_path);
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[],
+            std::slice::from_ref(&reservation_key),
+        ));
+        install_bound_object(
+            &backend,
+            reservation_key,
+            bound_object(
+                canonical_reservation_json(exact_path, folded_path, "file"),
+                "reservation-v1",
+            ),
+        );
+
+        let evidence = match read_bound_remote_observation_two_pass_v1(&op, "roots")
+            .await
+            .unwrap()
+        {
+            StrictBoundRemoteObservationReadV1::Matched(evidence) => evidence,
+            other => panic!("expected fixed-ingress reservation history, got {other:?}"),
+        };
+        assert_eq!(evidence.index_object_count(), 0);
+        assert_eq!(evidence.reservation_count(), 1);
+        assert_eq!(evidence.manifest_count(), 0);
+        assert_eq!(evidence.claim_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn same_pass_folded_spelling_aliases_fail_closed() {
+        let upper_key = "roots/index/DOC.txt".to_owned();
+        let lower_key = "roots/index/Doc.txt".to_owned();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[upper_key.clone(), lower_key.clone()],
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            upper_key,
+            bound_object(deleted_index_json(None), "index-upper"),
+        );
+        install_bound_object(
+            &backend,
+            lower_key,
+            bound_object(deleted_index_json(None), "index-lower"),
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Claim {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: RemoteNamespaceClaimConflictV1::FoldedSpellingAlias,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Stat(_)))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Read(_)))
+                .count(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn deleted_index_evidence_is_retained_without_fetching_the_safety_copy() {
+        let index_key = "roots/index/dir/file".to_owned();
+        let safety_copy_key = "roots/.tcfs-trash/123-00000000-0000-4000-8000-000000000000/dir/file";
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &index_key,
+            bound_object(
+                deleted_index_json(Some(safety_copy_key)),
+                "deleted-index-v1",
+            ),
+        );
+
+        let evidence = match read_bound_remote_observation_two_pass_v1(&op, "roots")
+            .await
+            .unwrap()
+        {
+            StrictBoundRemoteObservationReadV1::Matched(evidence) => evidence,
+            other => panic!("expected evidence-bearing tombstone, got {other:?}"),
+        };
+        assert_eq!(evidence.index_object_count(), 1);
+        assert_eq!(evidence.reservation_count(), 0);
+        assert_eq!(evidence.manifest_count(), 0);
+        assert_eq!(evidence.claim_count(), 2);
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Stat(index_key.clone()))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Read(index_key.clone()))
+                .count(),
+            2
+        );
+        assert!(!events.iter().any(|event| {
+            matches!(
+                event,
+                ObservationEvent::Stat(key) | ObservationEvent::Read(key)
+                    if key == safety_copy_key
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn directory_ancestor_and_child_file_claims_are_compatible() {
+        let marker_key = "roots/index/a/.tcfs_dir".to_owned();
+        let file_key = "roots/index/a/b".to_owned();
+        let manifest_bytes = regular_manifest_json("a/b");
+        let manifest_id = manifest_object_id(&manifest_bytes);
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[marker_key.clone(), file_key.clone()],
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            marker_key,
+            bound_object(
+                crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec(),
+                "marker-v1",
+            ),
+        );
+        install_bound_object(
+            &backend,
+            file_key,
+            bound_object(committed_index_json(&manifest_id), "index-v1"),
+        );
+        install_bound_object(
+            &backend,
+            manifest_key,
+            bound_object(manifest_bytes, "manifest-v1"),
+        );
+
+        let evidence = match read_bound_remote_observation_two_pass_v1(&op, "roots")
+            .await
+            .unwrap()
+        {
+            StrictBoundRemoteObservationReadV1::Matched(evidence) => evidence,
+            other => panic!("expected compatible directory ancestry, got {other:?}"),
+        };
+        assert_eq!(evidence.index_object_count(), 2);
+        assert_eq!(evidence.manifest_count(), 1);
+        assert_eq!(evidence.claim_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn shared_manifest_is_fetched_once_then_validated_against_every_route() {
+        let manifest_bytes = regular_manifest_json("a");
+        let manifest_id = manifest_object_id(&manifest_bytes);
+        let a_key = "roots/index/a".to_owned();
+        let b_key = "roots/index/b".to_owned();
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[a_key.clone(), b_key.clone()],
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &a_key,
+            bound_object(committed_index_json(&manifest_id), "index-a"),
+        );
+        install_bound_object(
+            &backend,
+            &b_key,
+            bound_object(committed_index_json(&manifest_id), "index-b"),
+        );
+        install_bound_object(
+            &backend,
+            &manifest_key,
+            bound_object(manifest_bytes, "manifest-v1"),
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Manifest {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: StrictRemoteManifestIncompleteV1::InvalidManifest,
+                }
+            )
+        );
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Stat(manifest_key.clone()))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Read(manifest_key.clone()))
+                .count(),
+            1
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn missing_directory_marker_is_typed_and_never_retried() {
+        let marker_key = "roots/index/dir/.tcfs_dir".to_owned();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&marker_key),
+            &[],
+        ));
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::ListedObjectMissing {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    kind: BoundRemoteObjectKindV1::DirectoryMarker,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+        assert_eq!(
+            *backend.events.lock().unwrap(),
+            vec![
+                ObservationEvent::ListOpen("roots/index/".to_owned()),
+                ObservationEvent::ListRow(marker_key.clone()),
+                ObservationEvent::ListEof("roots/index/".to_owned()),
+                ObservationEvent::ListOpen("roots/.tcfs-namespace/v1/".to_owned()),
+                ObservationEvent::ListEof("roots/.tcfs-namespace/v1/".to_owned()),
+                ObservationEvent::Stat(marker_key),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn unbound_directory_marker_is_typed_without_reading_bytes() {
+        let marker_key = "roots/index/dir/.tcfs_dir".to_owned();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&marker_key),
+            &[],
+        ));
+        backend.objects.lock().unwrap().insert(
+            marker_key.clone(),
+            ScriptedBoundObject {
+                bytes: crate::index_entry::DIRECTORY_MARKER_BYTES.to_vec(),
+                etag: None,
+                version: None,
+            },
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Marker {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: StrictRemoteDirectoryMarkerIncompleteV1::UnboundObject,
+                }
+            )
+        );
+        let events = backend.events.lock().unwrap();
+        assert_eq!(events.last(), Some(&ObservationEvent::Stat(marker_key)));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, ObservationEvent::Read(_))));
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn missing_namespace_reservation_is_typed_and_never_retried() {
+        let reservation_id = namespace_reservation_object_id("file");
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[],
+            std::slice::from_ref(&reservation_key),
+        ));
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::ListedObjectMissing {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    kind: BoundRemoteObjectKindV1::NamespaceReservation,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Stat(reservation_key.clone()))
+                .count(),
+            1
+        );
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, ObservationEvent::Read(_))));
+    }
+
+    #[tokio::test]
+    async fn unbound_namespace_reservation_is_typed_without_reading_bytes() {
+        let folded_path = "file";
+        let reservation_id = namespace_reservation_object_id(folded_path);
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            &[],
+            std::slice::from_ref(&reservation_key),
+        ));
+        backend.objects.lock().unwrap().insert(
+            reservation_key.clone(),
+            ScriptedBoundObject {
+                bytes: canonical_reservation_json(folded_path, folded_path, "file"),
+                etag: None,
+                version: None,
+            },
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Reservation {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: StrictNamespaceReservationIncompleteV1::UnboundObject,
+                }
+            )
+        );
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events.last(),
+            Some(&ObservationEvent::Stat(reservation_key))
+        );
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, ObservationEvent::Read(_))));
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn missing_manifest_is_typed_after_one_bound_index_read() {
+        let manifest_id = "a".repeat(64);
+        let index_key = "roots/index/file".to_owned();
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &index_key,
+            bound_object(committed_index_json(&manifest_id), "index-v1"),
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Manifest {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: StrictRemoteManifestIncompleteV1::MissingObject,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+        assert_eq!(
+            *backend.events.lock().unwrap(),
+            vec![
+                ObservationEvent::ListOpen("roots/index/".to_owned()),
+                ObservationEvent::ListRow(index_key.clone()),
+                ObservationEvent::ListEof("roots/index/".to_owned()),
+                ObservationEvent::ListOpen("roots/.tcfs-namespace/v1/".to_owned()),
+                ObservationEvent::ListEof("roots/.tcfs-namespace/v1/".to_owned()),
+                ObservationEvent::Stat(index_key.clone()),
+                ObservationEvent::Read(index_key),
+                ObservationEvent::Stat(manifest_key),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn unbound_manifest_is_typed_without_reading_manifest_bytes() {
+        let manifest_bytes = regular_manifest_json("file");
+        let manifest_id = manifest_object_id(&manifest_bytes);
+        let index_key = "roots/index/file".to_owned();
+        let manifest_key = format!("roots/manifests/{manifest_id}");
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &index_key,
+            bound_object(committed_index_json(&manifest_id), "index-v1"),
+        );
+        backend.objects.lock().unwrap().insert(
+            manifest_key.clone(),
+            ScriptedBoundObject {
+                bytes: manifest_bytes,
+                etag: None,
+                version: None,
+            },
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Manifest {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: StrictRemoteManifestIncompleteV1::UnboundObject,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| **event == ObservationEvent::Stat(manifest_key.clone()))
+                .count(),
+            1
+        );
+        assert!(!events
+            .iter()
+            .any(|event| *event == ObservationEvent::Read(manifest_key.clone())));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Read(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn listed_missing_object_is_typed_and_never_retried() {
+        let index_key = "roots/index/file".to_owned();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::ListedObjectMissing {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    kind: BoundRemoteObjectKindV1::OrdinaryIndex,
+                }
+            )
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
+        assert_eq!(
+            backend.events.lock().unwrap().last(),
+            Some(&ObservationEvent::Stat(index_key))
+        );
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Stat(_)))
+                .count(),
+            1
+        );
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, ObservationEvent::Read(_))));
+    }
+
+    #[tokio::test]
+    async fn second_pass_disappearance_is_typed_without_a_third_attempt() {
+        let index_key = "roots/index/file".to_owned();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+        install_bound_object(
+            &backend,
+            &index_key,
+            bound_object(deleted_index_json(None), "index-v1"),
+        );
+        let mutation_backend = backend.clone();
+        let mutation_key = index_key.clone();
+
+        assert_eq!(
+            read_bound_remote_observation_with_between_passes_v1(
+                &op,
+                "roots",
+                move || async move {
+                    mutation_backend
+                        .objects
+                        .lock()
+                        .unwrap()
+                        .remove(&mutation_key);
+                }
+            )
+            .await
+            .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::ListedObjectMissing {
+                    pass: RemoteNamespaceListingPassV1::Second,
+                    kind: BoundRemoteObjectKindV1::OrdinaryIndex,
+                }
+            )
+        );
+        assert!(backend.calls.lock().unwrap().is_empty());
+        let events = backend.events.lock().unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Stat(_)))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Read(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn unbound_listed_object_is_typed_without_reading_bytes() {
+        let index_key = "roots/index/file".to_owned();
+        let (op, backend) = scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ));
+        backend.objects.lock().unwrap().insert(
+            index_key.clone(),
+            ScriptedBoundObject {
+                bytes: committed_index_json(&"a".repeat(64)),
+                etag: None,
+                version: None,
+            },
+        );
+
+        assert_eq!(
+            read_bound_remote_observation_two_pass_v1(&op, "roots")
+                .await
+                .unwrap(),
+            StrictBoundRemoteObservationReadV1::Incomplete(
+                StrictBoundRemoteObservationIncompleteV1::Index {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    reason: StrictRemoteIndexIncompleteV1::UnboundObject,
+                }
+            )
+        );
+        let events = backend.events.lock().unwrap();
+        assert_eq!(events.last(), Some(&ObservationEvent::Stat(index_key)));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, ObservationEvent::Read(_))));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ObservationEvent::Stat(_)))
+                .count(),
+            1
+        );
+        assert_eq!(backend.calls.lock().unwrap().len(), 2);
     }
 }

--- a/crates/tcfs-sync/src/registered_remote_observation.rs
+++ b/crates/tcfs-sync/src/registered_remote_observation.rs
@@ -1,0 +1,1588 @@
+//! Listed-key acquisition primitives for strict registered-root planning.
+//!
+//! This module deliberately stops before reading object bodies. Matching
+//! keysets from two non-atomic backend listings are not a namespace snapshot,
+//! do not satisfy `CompleteOrNoDigestV1`, and cannot mint any digest or plan
+//! input. This artifact is diagnostic and must be discarded. A complete
+//! acquisition must freshly rerun pass A list+bind and pass B list+bind for
+//! every index, marker, reservation, and referenced manifest object.
+
+use futures::TryStreamExt;
+use opendal::{EntryMode, Operator};
+use std::collections::BTreeSet;
+use std::future::Future;
+use tcfs_core::config::{RegisteredRootPlanContractV1, RootRemoteContractV1};
+
+use crate::index_entry::{
+    namespace_index_prefix, namespace_logical_entry_from_index_path, namespace_reservation_prefix,
+    validate_canonical_namespace_remote_prefix, PortableNamespaceRole,
+};
+use crate::registered_reconcile::validate_registered_remote_logical_path_bounds_v1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteNamespaceCorpusV1 {
+    Index,
+    Reservation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteNamespaceListingPassV1 {
+    First,
+    Second,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteNamespaceKeyResourceV1 {
+    ListingRows,
+    ListingKeyBytes,
+    StorageKeyBytes,
+    IndexObjects,
+    IndexKeyBytes,
+    ReservationObjects,
+    ReservationKeyBytes,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InvalidRemoteNamespaceKeyReasonV1 {
+    DeletedListingEntry,
+    NonCurrentListingEntry,
+    InvalidEntryMode,
+    ModePathMismatch,
+    OutsideRequestedPrefix,
+    EmptyObjectSuffix,
+    InvalidIndexPath,
+    InvalidReservationObjectId,
+    UnexpectedReservationDirectory,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StrictRemoteNamespaceKeyIncompleteV1 {
+    InvalidRemotePrefix,
+    UnsupportedListing {
+        pass: RemoteNamespaceListingPassV1,
+    },
+    ListingFailed {
+        pass: RemoteNamespaceListingPassV1,
+        corpus: RemoteNamespaceCorpusV1,
+    },
+    ResourceLimit {
+        pass: RemoteNamespaceListingPassV1,
+        corpus: RemoteNamespaceCorpusV1,
+        resource: RemoteNamespaceKeyResourceV1,
+    },
+    InvalidEntry {
+        pass: RemoteNamespaceListingPassV1,
+        corpus: RemoteNamespaceCorpusV1,
+        reason: InvalidRemoteNamespaceKeyReasonV1,
+    },
+    DuplicateObjectKey {
+        pass: RemoteNamespaceListingPassV1,
+        corpus: RemoteNamespaceCorpusV1,
+    },
+    PassesDisagreed {
+        index: bool,
+        reservations: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum ListedRemoteIndexKeyClassV1 {
+    OrdinaryIndexObject,
+    DirectoryMarkerCandidate,
+}
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct ListedRemoteIndexKeyV1 {
+    object_key: String,
+    index_rel_offset: usize,
+    logical_rel_len: usize,
+    class: ListedRemoteIndexKeyClassV1,
+}
+
+impl ListedRemoteIndexKeyV1 {
+    pub(crate) fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub(crate) fn index_rel_path(&self) -> &str {
+        self.object_key
+            .get(self.index_rel_offset..)
+            .expect("listed index-key offset is an internal invariant")
+    }
+
+    pub(crate) fn logical_path(&self) -> &str {
+        let end = self
+            .index_rel_offset
+            .checked_add(self.logical_rel_len)
+            .expect("listed logical-path length is an internal invariant");
+        self.object_key
+            .get(self.index_rel_offset..end)
+            .expect("listed logical-path bounds are an internal invariant")
+    }
+
+    pub(crate) const fn class(&self) -> ListedRemoteIndexKeyClassV1 {
+        self.class
+    }
+}
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct ListedRemoteReservationKeyV1 {
+    object_key: String,
+    object_id_offset: usize,
+}
+
+impl ListedRemoteReservationKeyV1 {
+    pub(crate) fn object_key(&self) -> &str {
+        &self.object_key
+    }
+
+    pub(crate) fn object_id(&self) -> &str {
+        self.object_key
+            .get(self.object_id_offset..)
+            .expect("listed reservation-key offset is an internal invariant")
+    }
+}
+
+/// Matching classified FILE-object keys from two fully drained listings only.
+///
+/// Synthetic DIR rows are validated in each pass but excluded from the object
+/// comparison. This is intentionally not named an observation snapshot or
+/// stable namespace. It carries no fingerprint, is not cloneable, and has no
+/// conversion into a complete planner input.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct MatchingTwoPassListedRemoteKeysV1 {
+    remote_prefix: String,
+    index_objects: Vec<ListedRemoteIndexKeyV1>,
+    reservation_objects: Vec<ListedRemoteReservationKeyV1>,
+}
+
+impl MatchingTwoPassListedRemoteKeysV1 {
+    pub(crate) fn remote_prefix(&self) -> &str {
+        &self.remote_prefix
+    }
+
+    pub(crate) fn index_objects(&self) -> &[ListedRemoteIndexKeyV1] {
+        &self.index_objects
+    }
+
+    pub(crate) fn reservation_objects(&self) -> &[ListedRemoteReservationKeyV1] {
+        &self.reservation_objects
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum StrictRemoteNamespaceKeyReadV1 {
+    Matched(MatchingTwoPassListedRemoteKeysV1),
+    Incomplete(StrictRemoteNamespaceKeyIncompleteV1),
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct RemoteNamespaceKeyPassV1 {
+    index_objects: BTreeSet<ListedRemoteIndexKeyV1>,
+    reservation_objects: BTreeSet<ListedRemoteReservationKeyV1>,
+    index_directory_rows: BTreeSet<String>,
+    reservation_directory_rows: BTreeSet<String>,
+}
+
+#[derive(Debug, Default)]
+struct RemoteListingBudgetV1 {
+    listing_rows: u64,
+    listing_key_bytes: u64,
+    index_objects: u64,
+    index_key_bytes: u64,
+    reservation_objects: u64,
+    reservation_key_bytes: u64,
+}
+
+impl RemoteListingBudgetV1 {
+    fn checked_increment(
+        value: &mut u64,
+        increment: u64,
+        maximum: u64,
+        pass: RemoteNamespaceListingPassV1,
+        corpus: RemoteNamespaceCorpusV1,
+        resource: RemoteNamespaceKeyResourceV1,
+    ) -> Result<(), StrictRemoteNamespaceKeyIncompleteV1> {
+        *value = value.checked_add(increment).ok_or(
+            StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                pass,
+                corpus,
+                resource,
+            },
+        )?;
+        if *value > maximum {
+            return Err(StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                pass,
+                corpus,
+                resource,
+            });
+        }
+        Ok(())
+    }
+
+    fn observe_raw_row(
+        &mut self,
+        pass: RemoteNamespaceListingPassV1,
+        corpus: RemoteNamespaceCorpusV1,
+        key: &str,
+        contract: RootRemoteContractV1,
+    ) -> Result<(), StrictRemoteNamespaceKeyIncompleteV1> {
+        Self::checked_increment(
+            &mut self.listing_rows,
+            1,
+            contract.max_listing_rows_per_pass(),
+            pass,
+            corpus,
+            RemoteNamespaceKeyResourceV1::ListingRows,
+        )?;
+        Self::checked_increment(
+            &mut self.listing_key_bytes,
+            u64::try_from(key.len()).map_err(|_| {
+                StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                    pass,
+                    corpus,
+                    resource: RemoteNamespaceKeyResourceV1::ListingKeyBytes,
+                }
+            })?,
+            contract.max_listing_key_bytes_per_pass(),
+            pass,
+            corpus,
+            RemoteNamespaceKeyResourceV1::ListingKeyBytes,
+        )?;
+        if u64::try_from(key.len()).map_or(true, |length| length > contract.max_storage_key_bytes())
+        {
+            return Err(StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                pass,
+                corpus,
+                resource: RemoteNamespaceKeyResourceV1::StorageKeyBytes,
+            });
+        }
+        Ok(())
+    }
+
+    fn observe_corpus_object(
+        &mut self,
+        pass: RemoteNamespaceListingPassV1,
+        corpus: RemoteNamespaceCorpusV1,
+        key: &str,
+        contract: RootRemoteContractV1,
+    ) -> Result<(), StrictRemoteNamespaceKeyIncompleteV1> {
+        let key_bytes = u64::try_from(key.len()).map_err(|_| {
+            StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                pass,
+                corpus,
+                resource: RemoteNamespaceKeyResourceV1::ListingKeyBytes,
+            }
+        })?;
+        match corpus {
+            RemoteNamespaceCorpusV1::Index => {
+                Self::checked_increment(
+                    &mut self.index_objects,
+                    1,
+                    contract.max_index_observations_per_pass(),
+                    pass,
+                    corpus,
+                    RemoteNamespaceKeyResourceV1::IndexObjects,
+                )?;
+                Self::checked_increment(
+                    &mut self.index_key_bytes,
+                    key_bytes,
+                    contract.max_retained_index_key_bytes_per_pass(),
+                    pass,
+                    corpus,
+                    RemoteNamespaceKeyResourceV1::IndexKeyBytes,
+                )
+            }
+            RemoteNamespaceCorpusV1::Reservation => {
+                Self::checked_increment(
+                    &mut self.reservation_objects,
+                    1,
+                    contract.max_reservation_observations_per_pass(),
+                    pass,
+                    corpus,
+                    RemoteNamespaceKeyResourceV1::ReservationObjects,
+                )?;
+                Self::checked_increment(
+                    &mut self.reservation_key_bytes,
+                    key_bytes,
+                    contract.max_retained_reservation_key_bytes_per_pass(),
+                    pass,
+                    corpus,
+                    RemoteNamespaceKeyResourceV1::ReservationKeyBytes,
+                )
+            }
+        }
+    }
+}
+
+fn is_lower_hex_64(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn namespace_prefix_storage_bytes(remote_prefix: &str, suffix: &str) -> Option<u64> {
+    let remote_bytes = u64::try_from(remote_prefix.len()).ok()?;
+    let suffix_bytes = u64::try_from(suffix.len()).ok()?;
+    remote_bytes
+        .checked_add(u64::from(!remote_prefix.is_empty()))?
+        .checked_add(suffix_bytes)?
+        .checked_add(1)
+}
+
+fn invalid_entry(
+    pass: RemoteNamespaceListingPassV1,
+    corpus: RemoteNamespaceCorpusV1,
+    reason: InvalidRemoteNamespaceKeyReasonV1,
+) -> StrictRemoteNamespaceKeyIncompleteV1 {
+    StrictRemoteNamespaceKeyIncompleteV1::InvalidEntry {
+        pass,
+        corpus,
+        reason,
+    }
+}
+
+fn validate_listing_metadata_v1(
+    listing_pass: RemoteNamespaceListingPassV1,
+    corpus: RemoteNamespaceCorpusV1,
+    is_deleted: bool,
+    is_current: Option<bool>,
+) -> Result<(), StrictRemoteNamespaceKeyIncompleteV1> {
+    if is_deleted {
+        return Err(invalid_entry(
+            listing_pass,
+            corpus,
+            InvalidRemoteNamespaceKeyReasonV1::DeletedListingEntry,
+        ));
+    }
+    if is_current == Some(false) {
+        return Err(invalid_entry(
+            listing_pass,
+            corpus,
+            InvalidRemoteNamespaceKeyReasonV1::NonCurrentListingEntry,
+        ));
+    }
+    Ok(())
+}
+
+fn record_unique_directory_row_v1(
+    key_pass: &mut RemoteNamespaceKeyPassV1,
+    listing_pass: RemoteNamespaceListingPassV1,
+    corpus: RemoteNamespaceCorpusV1,
+    key: &str,
+) -> Result<(), StrictRemoteNamespaceKeyIncompleteV1> {
+    let seen_rows = match corpus {
+        RemoteNamespaceCorpusV1::Index => &mut key_pass.index_directory_rows,
+        RemoteNamespaceCorpusV1::Reservation => &mut key_pass.reservation_directory_rows,
+    };
+    if !seen_rows.insert(key.to_owned()) {
+        return Err(StrictRemoteNamespaceKeyIncompleteV1::DuplicateObjectKey {
+            pass: listing_pass,
+            corpus,
+        });
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn observe_listing_row_v1(
+    key_pass: &mut RemoteNamespaceKeyPassV1,
+    budget: &mut RemoteListingBudgetV1,
+    listing_pass: RemoteNamespaceListingPassV1,
+    corpus: RemoteNamespaceCorpusV1,
+    requested_prefix: &str,
+    key: &str,
+    mode: EntryMode,
+    is_deleted: bool,
+    is_current: Option<bool>,
+    contract: RootRemoteContractV1,
+) -> Result<(), StrictRemoteNamespaceKeyIncompleteV1> {
+    // This is deliberately first: malformed, duplicate, synthetic-directory,
+    // and out-of-prefix entries all consume the raw backend budget.
+    budget.observe_raw_row(listing_pass, corpus, key, contract)?;
+
+    match mode {
+        EntryMode::DIR => {
+            if !key.ends_with('/') {
+                return Err(invalid_entry(
+                    listing_pass,
+                    corpus,
+                    InvalidRemoteNamespaceKeyReasonV1::ModePathMismatch,
+                ));
+            }
+            validate_listing_metadata_v1(listing_pass, corpus, is_deleted, is_current)?;
+            let suffix = key.strip_prefix(requested_prefix).ok_or_else(|| {
+                invalid_entry(
+                    listing_pass,
+                    corpus,
+                    InvalidRemoteNamespaceKeyReasonV1::OutsideRequestedPrefix,
+                )
+            })?;
+            if corpus == RemoteNamespaceCorpusV1::Reservation && !suffix.is_empty() {
+                return Err(invalid_entry(
+                    listing_pass,
+                    corpus,
+                    InvalidRemoteNamespaceKeyReasonV1::UnexpectedReservationDirectory,
+                ));
+            }
+            if corpus == RemoteNamespaceCorpusV1::Index && !suffix.is_empty() {
+                let logical_dir = suffix.strip_suffix('/').ok_or_else(|| {
+                    invalid_entry(
+                        listing_pass,
+                        corpus,
+                        InvalidRemoteNamespaceKeyReasonV1::ModePathMismatch,
+                    )
+                })?;
+                if logical_dir.is_empty()
+                    || validate_registered_remote_logical_path_bounds_v1(logical_dir).is_err()
+                {
+                    return Err(invalid_entry(
+                        listing_pass,
+                        corpus,
+                        InvalidRemoteNamespaceKeyReasonV1::InvalidIndexPath,
+                    ));
+                }
+            }
+            record_unique_directory_row_v1(key_pass, listing_pass, corpus, key)?;
+            return Ok(());
+        }
+        EntryMode::FILE => {
+            if key.ends_with('/') {
+                return Err(invalid_entry(
+                    listing_pass,
+                    corpus,
+                    InvalidRemoteNamespaceKeyReasonV1::ModePathMismatch,
+                ));
+            }
+        }
+        EntryMode::Unknown => {
+            return Err(invalid_entry(
+                listing_pass,
+                corpus,
+                InvalidRemoteNamespaceKeyReasonV1::InvalidEntryMode,
+            ));
+        }
+    }
+
+    // Corpus-specific resources count every file-shaped row before prefix,
+    // metadata, grammar, or duplicate rejection.
+    budget.observe_corpus_object(listing_pass, corpus, key, contract)?;
+    validate_listing_metadata_v1(listing_pass, corpus, is_deleted, is_current)?;
+    let suffix = key.strip_prefix(requested_prefix).ok_or_else(|| {
+        invalid_entry(
+            listing_pass,
+            corpus,
+            InvalidRemoteNamespaceKeyReasonV1::OutsideRequestedPrefix,
+        )
+    })?;
+    if suffix.is_empty() {
+        return Err(invalid_entry(
+            listing_pass,
+            corpus,
+            InvalidRemoteNamespaceKeyReasonV1::EmptyObjectSuffix,
+        ));
+    }
+
+    match corpus {
+        RemoteNamespaceCorpusV1::Index => {
+            let (logical_path, logical_role) = namespace_logical_entry_from_index_path(suffix)
+                .map_err(|_| {
+                    invalid_entry(
+                        listing_pass,
+                        corpus,
+                        InvalidRemoteNamespaceKeyReasonV1::InvalidIndexPath,
+                    )
+                })?;
+            validate_registered_remote_logical_path_bounds_v1(&logical_path).map_err(|_| {
+                invalid_entry(
+                    listing_pass,
+                    corpus,
+                    InvalidRemoteNamespaceKeyReasonV1::InvalidIndexPath,
+                )
+            })?;
+            let index_rel_offset = requested_prefix.len();
+            let logical_rel_len = logical_path.len();
+            let listed_key = ListedRemoteIndexKeyV1 {
+                object_key: key.to_owned(),
+                index_rel_offset,
+                logical_rel_len,
+                class: match logical_role {
+                    PortableNamespaceRole::File => ListedRemoteIndexKeyClassV1::OrdinaryIndexObject,
+                    PortableNamespaceRole::Directory => {
+                        ListedRemoteIndexKeyClassV1::DirectoryMarkerCandidate
+                    }
+                },
+            };
+            if !key_pass.index_objects.insert(listed_key) {
+                return Err(StrictRemoteNamespaceKeyIncompleteV1::DuplicateObjectKey {
+                    pass: listing_pass,
+                    corpus,
+                });
+            }
+        }
+        RemoteNamespaceCorpusV1::Reservation => {
+            if !is_lower_hex_64(suffix) {
+                return Err(invalid_entry(
+                    listing_pass,
+                    corpus,
+                    InvalidRemoteNamespaceKeyReasonV1::InvalidReservationObjectId,
+                ));
+            }
+            let listed_key = ListedRemoteReservationKeyV1 {
+                object_key: key.to_owned(),
+                object_id_offset: requested_prefix.len(),
+            };
+            if !key_pass.reservation_objects.insert(listed_key) {
+                return Err(StrictRemoteNamespaceKeyIncompleteV1::DuplicateObjectKey {
+                    pass: listing_pass,
+                    corpus,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn list_corpus_v1(
+    op: &Operator,
+    pass: &mut RemoteNamespaceKeyPassV1,
+    budget: &mut RemoteListingBudgetV1,
+    listing_pass: RemoteNamespaceListingPassV1,
+    corpus: RemoteNamespaceCorpusV1,
+    requested_prefix: &str,
+    contract: RootRemoteContractV1,
+) -> Result<(), StrictRemoteNamespaceKeyIncompleteV1> {
+    let limit = usize::try_from(contract.listing_page_request_limit()).map_err(|_| {
+        StrictRemoteNamespaceKeyIncompleteV1::ListingFailed {
+            pass: listing_pass,
+            corpus,
+        }
+    })?;
+    // `limit` is only a per-request backend hint. OpenDAL's CompleteLayer can
+    // emulate recursive listing and a backend can ignore the hint; the manual
+    // aggregate row/key ceilings above are the only safety boundary.
+    let request = op
+        .lister_with(requested_prefix)
+        .recursive(true)
+        .limit(limit)
+        .versions(false)
+        .deleted(false);
+    let mut lister =
+        request
+            .await
+            .map_err(|_| StrictRemoteNamespaceKeyIncompleteV1::ListingFailed {
+                pass: listing_pass,
+                corpus,
+            })?;
+    loop {
+        let entry = match lister.try_next().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(_) => {
+                return Err(StrictRemoteNamespaceKeyIncompleteV1::ListingFailed {
+                    pass: listing_pass,
+                    corpus,
+                });
+            }
+        };
+        observe_listing_row_v1(
+            pass,
+            budget,
+            listing_pass,
+            corpus,
+            requested_prefix,
+            entry.path(),
+            entry.metadata().mode(),
+            entry.metadata().is_deleted(),
+            entry.metadata().is_current(),
+            contract,
+        )?;
+    }
+    Ok(())
+}
+
+async fn read_remote_namespace_key_pass_v1(
+    op: &Operator,
+    remote_prefix: &str,
+    listing_pass: RemoteNamespaceListingPassV1,
+    contract: RootRemoteContractV1,
+) -> Result<RemoteNamespaceKeyPassV1, StrictRemoteNamespaceKeyIncompleteV1> {
+    for (corpus, suffix) in [
+        (RemoteNamespaceCorpusV1::Index, "index"),
+        (RemoteNamespaceCorpusV1::Reservation, ".tcfs-namespace/v1"),
+    ] {
+        if namespace_prefix_storage_bytes(remote_prefix, suffix)
+            .is_none_or(|length| length > contract.max_storage_key_bytes())
+        {
+            return Err(StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                pass: listing_pass,
+                corpus,
+                resource: RemoteNamespaceKeyResourceV1::StorageKeyBytes,
+            });
+        }
+    }
+    let capability = op.info().full_capability();
+    if !capability.list {
+        return Err(StrictRemoteNamespaceKeyIncompleteV1::UnsupportedListing {
+            pass: listing_pass,
+        });
+    }
+    // Lengths were checked before either allocation, so an oversized
+    // caller-supplied prefix cannot be cloned into requested-prefix strings.
+    let index_prefix = namespace_index_prefix(remote_prefix);
+    let reservation_prefix = namespace_reservation_prefix(remote_prefix);
+
+    let mut pass = RemoteNamespaceKeyPassV1::default();
+    let mut budget = RemoteListingBudgetV1::default();
+    list_corpus_v1(
+        op,
+        &mut pass,
+        &mut budget,
+        listing_pass,
+        RemoteNamespaceCorpusV1::Index,
+        &index_prefix,
+        contract,
+    )
+    .await?;
+    // Seen rows exist only to reject duplicates within this one lister. Drop
+    // their strings before opening the next corpus or retaining this pass.
+    pass.index_directory_rows.clear();
+    list_corpus_v1(
+        op,
+        &mut pass,
+        &mut budget,
+        listing_pass,
+        RemoteNamespaceCorpusV1::Reservation,
+        &reservation_prefix,
+        contract,
+    )
+    .await?;
+    pass.reservation_directory_rows.clear();
+    Ok(pass)
+}
+
+async fn read_remote_namespace_keys_with_between_passes_v1<F, Fut>(
+    op: &Operator,
+    remote_prefix: &str,
+    between_passes: F,
+) -> StrictRemoteNamespaceKeyReadV1
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let remote_prefix = match validate_canonical_namespace_remote_prefix(remote_prefix) {
+        Ok(prefix) => prefix,
+        Err(_) => {
+            return StrictRemoteNamespaceKeyReadV1::Incomplete(
+                StrictRemoteNamespaceKeyIncompleteV1::InvalidRemotePrefix,
+            );
+        }
+    };
+    let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+    let first = match read_remote_namespace_key_pass_v1(
+        op,
+        remote_prefix,
+        RemoteNamespaceListingPassV1::First,
+        contract,
+    )
+    .await
+    {
+        Ok(pass) => pass,
+        Err(incomplete) => return StrictRemoteNamespaceKeyReadV1::Incomplete(incomplete),
+    };
+    between_passes().await;
+    let second = match read_remote_namespace_key_pass_v1(
+        op,
+        remote_prefix,
+        RemoteNamespaceListingPassV1::Second,
+        contract,
+    )
+    .await
+    {
+        Ok(pass) => pass,
+        Err(incomplete) => return StrictRemoteNamespaceKeyReadV1::Incomplete(incomplete),
+    };
+    // Synthetic directory rows are traversal scaffolding, not physical
+    // namespace objects. Only the classified FILE keys participate in the
+    // two-pass comparison.
+    let index_disagreed = first.index_objects != second.index_objects;
+    let reservations_disagreed = first.reservation_objects != second.reservation_objects;
+    if index_disagreed || reservations_disagreed {
+        return StrictRemoteNamespaceKeyReadV1::Incomplete(
+            StrictRemoteNamespaceKeyIncompleteV1::PassesDisagreed {
+                index: index_disagreed,
+                reservations: reservations_disagreed,
+            },
+        );
+    }
+
+    StrictRemoteNamespaceKeyReadV1::Matched(MatchingTwoPassListedRemoteKeysV1 {
+        remote_prefix: remote_prefix.to_owned(),
+        index_objects: second.index_objects.into_iter().collect(),
+        reservation_objects: second.reservation_objects.into_iter().collect(),
+    })
+}
+
+pub(crate) async fn list_remote_namespace_keys_two_pass_v1(
+    op: &Operator,
+    remote_prefix: &str,
+) -> StrictRemoteNamespaceKeyReadV1 {
+    read_remote_namespace_keys_with_between_passes_v1(op, remote_prefix, || async {}).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal::raw::{oio, Access, AccessorInfo, OpList, RpList};
+    use opendal::services::Memory;
+    use opendal::{Capability, Error, ErrorKind, Metadata, OperatorBuilder};
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug)]
+    enum ScriptedListRow {
+        Entry(String, EntryMode),
+        Error,
+    }
+
+    #[derive(Debug)]
+    struct ScriptedListCall {
+        expected_path: String,
+        rows: VecDeque<ScriptedListRow>,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct ObservedListCall {
+        path: String,
+        limit: Option<usize>,
+        recursive: bool,
+        versions: bool,
+        deleted: bool,
+    }
+
+    #[derive(Debug)]
+    struct ScriptedLister {
+        rows: VecDeque<ScriptedListRow>,
+    }
+
+    impl oio::List for ScriptedLister {
+        async fn next(&mut self) -> opendal::Result<Option<oio::Entry>> {
+            match self.rows.pop_front() {
+                None => Ok(None),
+                Some(ScriptedListRow::Entry(path, mode)) => {
+                    Ok(Some(oio::Entry::new(&path, Metadata::new(mode))))
+                }
+                Some(ScriptedListRow::Error) => Err(Error::new(
+                    ErrorKind::Unexpected,
+                    "scripted list stream failed",
+                )),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct ScriptedListBackend {
+        info: Arc<AccessorInfo>,
+        calls: Arc<Mutex<VecDeque<ScriptedListCall>>>,
+        observed: Arc<Mutex<Vec<ObservedListCall>>>,
+    }
+
+    impl Access for ScriptedListBackend {
+        type Reader = ();
+        type Writer = ();
+        type Lister = ScriptedLister;
+        type Deleter = ();
+
+        fn info(&self) -> Arc<AccessorInfo> {
+            self.info.clone()
+        }
+
+        async fn list(&self, path: &str, args: OpList) -> opendal::Result<(RpList, Self::Lister)> {
+            self.observed.lock().unwrap().push(ObservedListCall {
+                path: path.to_owned(),
+                limit: args.limit(),
+                recursive: args.recursive(),
+                versions: args.versions(),
+                deleted: args.deleted(),
+            });
+            let call = self
+                .calls
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| Error::new(ErrorKind::Unexpected, "unexpected list call"))?;
+            if call.expected_path != path {
+                return Err(Error::new(
+                    ErrorKind::Unexpected,
+                    "scripted list path did not match",
+                ));
+            }
+            Ok((RpList::default(), ScriptedLister { rows: call.rows }))
+        }
+    }
+
+    fn memory_operator() -> Operator {
+        Operator::new(Memory::default()).unwrap().finish()
+    }
+
+    fn scripted_list_call(expected_path: &str, rows: Vec<ScriptedListRow>) -> ScriptedListCall {
+        ScriptedListCall {
+            expected_path: expected_path.to_owned(),
+            rows: rows.into(),
+        }
+    }
+
+    fn scripted_list_operator(calls: Vec<ScriptedListCall>) -> (Operator, ScriptedListBackend) {
+        let info = AccessorInfo::default();
+        info.set_scheme("registered-remote-list-test")
+            .set_root("/")
+            .set_name("registered-remote-list-test")
+            .set_native_capability(Capability {
+                list: true,
+                list_with_limit: true,
+                list_with_recursive: true,
+                ..Default::default()
+            });
+        let backend = ScriptedListBackend {
+            info: Arc::new(info),
+            calls: Arc::new(Mutex::new(calls.into())),
+            observed: Arc::new(Mutex::new(Vec::new())),
+        };
+        (OperatorBuilder::new(backend.clone()).finish(), backend)
+    }
+
+    fn observe_one_row(
+        corpus: RemoteNamespaceCorpusV1,
+        requested_prefix: &str,
+        key: &str,
+        mode: EntryMode,
+    ) -> Result<RemoteNamespaceKeyPassV1, StrictRemoteNamespaceKeyIncompleteV1> {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let mut pass = RemoteNamespaceKeyPassV1::default();
+        let mut budget = RemoteListingBudgetV1::default();
+        observe_listing_row_v1(
+            &mut pass,
+            &mut budget,
+            RemoteNamespaceListingPassV1::First,
+            corpus,
+            requested_prefix,
+            key,
+            mode,
+            false,
+            None,
+            contract,
+        )?;
+        Ok(pass)
+    }
+
+    #[tokio::test]
+    async fn empty_prefix_and_empty_keysets_are_matching_listed_outputs() {
+        let op = memory_operator();
+
+        let observed = match list_remote_namespace_keys_two_pass_v1(&op, "").await {
+            StrictRemoteNamespaceKeyReadV1::Matched(observed) => observed,
+            other => panic!("expected matching empty listed outputs, got {other:?}"),
+        };
+
+        assert_eq!(observed.remote_prefix(), "");
+        assert!(observed.index_objects().is_empty());
+        assert!(observed.reservation_objects().is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_prefix_lists_only_the_root_namespace_prefixes() {
+        let op = memory_operator();
+        let reservation_id = "b".repeat(64);
+        op.write("index/file", b"untrusted-index-body".to_vec())
+            .await
+            .unwrap();
+        op.write(
+            &format!(".tcfs-namespace/v1/{reservation_id}"),
+            b"untrusted-reservation-body".to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let observed = match list_remote_namespace_keys_two_pass_v1(&op, "").await {
+            StrictRemoteNamespaceKeyReadV1::Matched(observed) => observed,
+            other => panic!("expected matching root listed outputs, got {other:?}"),
+        };
+
+        assert_eq!(observed.index_objects().len(), 1);
+        assert_eq!(observed.index_objects()[0].object_key(), "index/file");
+        assert_eq!(
+            observed.reservation_objects()[0].object_key(),
+            format!(".tcfs-namespace/v1/{reservation_id}")
+        );
+    }
+
+    #[tokio::test]
+    async fn matching_memory_keysets_are_listed_twice_without_a_digest() {
+        let op = memory_operator();
+        let reservation_id = "a".repeat(64);
+        op.write("roots/index/file", b"index".to_vec())
+            .await
+            .unwrap();
+        op.write("roots/index/dir/.tcfs_dir", b"marker".to_vec())
+            .await
+            .unwrap();
+        op.write(
+            &format!("roots/.tcfs-namespace/v1/{reservation_id}"),
+            b"reservation".to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let observed = match list_remote_namespace_keys_two_pass_v1(&op, "roots").await {
+            StrictRemoteNamespaceKeyReadV1::Matched(observed) => observed,
+            other => panic!("expected matching two-pass keys, got {other:?}"),
+        };
+        assert_eq!(observed.remote_prefix(), "roots");
+        assert_eq!(observed.index_objects().len(), 2);
+        assert_eq!(observed.index_objects()[0].logical_path(), "dir");
+        assert_eq!(
+            observed.index_objects()[0].index_rel_path(),
+            "dir/.tcfs_dir"
+        );
+        assert_eq!(
+            observed.index_objects()[0].class(),
+            ListedRemoteIndexKeyClassV1::DirectoryMarkerCandidate
+        );
+        assert_eq!(observed.index_objects()[1].logical_path(), "file");
+        assert_eq!(observed.reservation_objects().len(), 1);
+        assert_eq!(
+            observed.reservation_objects()[0].object_id(),
+            reservation_id
+        );
+    }
+
+    #[tokio::test]
+    async fn keyset_mutation_between_passes_is_typed_incomplete() {
+        let op = memory_operator();
+        op.write("roots/index/file", b"index".to_vec())
+            .await
+            .unwrap();
+        let mutation_op = op.clone();
+        let result =
+            read_remote_namespace_keys_with_between_passes_v1(&op, "roots", move || async move {
+                mutation_op
+                    .write("roots/index/new", b"index".to_vec())
+                    .await
+                    .unwrap();
+            })
+            .await;
+        assert_eq!(
+            result,
+            StrictRemoteNamespaceKeyReadV1::Incomplete(
+                StrictRemoteNamespaceKeyIncompleteV1::PassesDisagreed {
+                    index: true,
+                    reservations: false,
+                }
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn reservation_disagreement_is_reported_separately() {
+        let op = memory_operator();
+        let mutation_op = op.clone();
+        let result =
+            read_remote_namespace_keys_with_between_passes_v1(&op, "roots", move || async move {
+                mutation_op
+                    .write(
+                        &format!("roots/.tcfs-namespace/v1/{}", "c".repeat(64)),
+                        b"reservation".to_vec(),
+                    )
+                    .await
+                    .unwrap();
+            })
+            .await;
+        assert_eq!(
+            result,
+            StrictRemoteNamespaceKeyReadV1::Incomplete(
+                StrictRemoteNamespaceKeyIncompleteV1::PassesDisagreed {
+                    index: false,
+                    reservations: true,
+                }
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn both_corpora_can_disagree_without_collapsing_the_evidence() {
+        let op = memory_operator();
+        let mutation_op = op.clone();
+        let result =
+            read_remote_namespace_keys_with_between_passes_v1(&op, "roots", move || async move {
+                mutation_op
+                    .write("roots/index/new", b"index".to_vec())
+                    .await
+                    .unwrap();
+                mutation_op
+                    .write(
+                        &format!("roots/.tcfs-namespace/v1/{}", "e".repeat(64)),
+                        b"reservation".to_vec(),
+                    )
+                    .await
+                    .unwrap();
+            })
+            .await;
+        assert_eq!(
+            result,
+            StrictRemoteNamespaceKeyReadV1::Incomplete(
+                StrictRemoteNamespaceKeyIncompleteV1::PassesDisagreed {
+                    index: true,
+                    reservations: true,
+                }
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn same_key_body_rewrite_is_outside_this_key_only_stage() {
+        let op = memory_operator();
+        op.write("roots/index/file", b"first-body".to_vec())
+            .await
+            .unwrap();
+        let mutation_op = op.clone();
+        let result =
+            read_remote_namespace_keys_with_between_passes_v1(&op, "roots", move || async move {
+                mutation_op
+                    .write("roots/index/file", b"second-body".to_vec())
+                    .await
+                    .unwrap();
+            })
+            .await;
+        let observed = match result {
+            StrictRemoteNamespaceKeyReadV1::Matched(observed) => observed,
+            other => panic!("body-only rewrite must remain outside key listing: {other:?}"),
+        };
+        assert_eq!(observed.index_objects().len(), 1);
+        assert_eq!(observed.index_objects()[0].object_key(), "roots/index/file");
+    }
+
+    #[tokio::test]
+    async fn synthetic_directory_row_difference_is_not_object_key_disagreement() {
+        let op = memory_operator();
+        let mutation_op = op.clone();
+        let result =
+            read_remote_namespace_keys_with_between_passes_v1(&op, "roots", move || async move {
+                mutation_op
+                    .create_dir("roots/index/scaffolding/")
+                    .await
+                    .unwrap();
+            })
+            .await;
+        let observed = match result {
+            StrictRemoteNamespaceKeyReadV1::Matched(observed) => observed,
+            other => panic!("synthetic directory rows are not object keys: {other:?}"),
+        };
+        assert!(observed.index_objects().is_empty());
+        assert!(observed.reservation_objects().is_empty());
+    }
+
+    #[tokio::test]
+    async fn scripted_reordered_rows_match_in_fixed_four_call_order() {
+        let (op, backend) = scripted_list_operator(vec![
+            scripted_list_call(
+                "roots/index/",
+                vec![
+                    ScriptedListRow::Entry("roots/index/b".to_owned(), EntryMode::FILE),
+                    ScriptedListRow::Entry("roots/index/a".to_owned(), EntryMode::FILE),
+                ],
+            ),
+            scripted_list_call("roots/.tcfs-namespace/v1/", vec![]),
+            scripted_list_call(
+                "roots/index/",
+                vec![
+                    ScriptedListRow::Entry("roots/index/a".to_owned(), EntryMode::FILE),
+                    ScriptedListRow::Entry("roots/index/b".to_owned(), EntryMode::FILE),
+                ],
+            ),
+            scripted_list_call("roots/.tcfs-namespace/v1/", vec![]),
+        ]);
+
+        let observed = match list_remote_namespace_keys_two_pass_v1(&op, "roots").await {
+            StrictRemoteNamespaceKeyReadV1::Matched(observed) => observed,
+            other => panic!("reordered raw rows should match by physical key: {other:?}"),
+        };
+        assert_eq!(
+            observed
+                .index_objects()
+                .iter()
+                .map(ListedRemoteIndexKeyV1::logical_path)
+                .collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+        assert!(backend.calls.lock().unwrap().is_empty());
+
+        let request_limit = usize::try_from(
+            RegisteredRootPlanContractV1::strict_v1()
+                .remote_contract()
+                .listing_page_request_limit(),
+        )
+        .unwrap();
+        let expected = [
+            "roots/index/",
+            "roots/.tcfs-namespace/v1/",
+            "roots/index/",
+            "roots/.tcfs-namespace/v1/",
+        ]
+        .into_iter()
+        .map(|path| ObservedListCall {
+            path: path.to_owned(),
+            limit: Some(request_limit),
+            recursive: true,
+            versions: false,
+            deleted: false,
+        })
+        .collect::<Vec<_>>();
+        assert_eq!(*backend.observed.lock().unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn scripted_duplicate_directory_row_stops_during_first_index_pass() {
+        let duplicate = "roots/index/dir/".to_owned();
+        let (op, backend) = scripted_list_operator(vec![scripted_list_call(
+            "roots/index/",
+            vec![
+                ScriptedListRow::Entry(duplicate.clone(), EntryMode::DIR),
+                ScriptedListRow::Entry(duplicate, EntryMode::DIR),
+            ],
+        )]);
+
+        assert_eq!(
+            list_remote_namespace_keys_two_pass_v1(&op, "roots").await,
+            StrictRemoteNamespaceKeyReadV1::Incomplete(
+                StrictRemoteNamespaceKeyIncompleteV1::DuplicateObjectKey {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    corpus: RemoteNamespaceCorpusV1::Index,
+                }
+            )
+        );
+        assert_eq!(backend.observed.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn scripted_midstream_failure_carries_second_reservation_context() {
+        let reservation_key = format!("roots/.tcfs-namespace/v1/{}", "f".repeat(64));
+        let (op, backend) = scripted_list_operator(vec![
+            scripted_list_call("roots/index/", vec![]),
+            scripted_list_call("roots/.tcfs-namespace/v1/", vec![]),
+            scripted_list_call("roots/index/", vec![]),
+            scripted_list_call(
+                "roots/.tcfs-namespace/v1/",
+                vec![
+                    ScriptedListRow::Entry(reservation_key, EntryMode::FILE),
+                    ScriptedListRow::Error,
+                ],
+            ),
+        ]);
+
+        assert_eq!(
+            list_remote_namespace_keys_two_pass_v1(&op, "roots").await,
+            StrictRemoteNamespaceKeyReadV1::Incomplete(
+                StrictRemoteNamespaceKeyIncompleteV1::ListingFailed {
+                    pass: RemoteNamespaceListingPassV1::Second,
+                    corpus: RemoteNamespaceCorpusV1::Reservation,
+                }
+            )
+        );
+        assert_eq!(backend.observed.lock().unwrap().len(), 4);
+        assert!(backend.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_remote_prefix_is_rejected_before_listing() {
+        let result = list_remote_namespace_keys_two_pass_v1(&memory_operator(), "roots/").await;
+        assert_eq!(
+            result,
+            StrictRemoteNamespaceKeyReadV1::Incomplete(
+                StrictRemoteNamespaceKeyIncompleteV1::InvalidRemotePrefix
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_derived_prefix_fails_before_backend_listing() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let remote_prefix = "r".repeat(usize::try_from(contract.max_storage_key_bytes()).unwrap());
+        let (op, backend) = scripted_list_operator(vec![]);
+
+        assert_eq!(
+            list_remote_namespace_keys_two_pass_v1(&op, &remote_prefix).await,
+            StrictRemoteNamespaceKeyReadV1::Incomplete(
+                StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    corpus: RemoteNamespaceCorpusV1::Index,
+                    resource: RemoteNamespaceKeyResourceV1::StorageKeyBytes,
+                }
+            )
+        );
+        assert!(backend.observed.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn row_validation_counts_before_rejecting_and_detects_duplicates() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let mut pass = RemoteNamespaceKeyPassV1::default();
+        let mut budget = RemoteListingBudgetV1::default();
+        let prefix = "roots/index/";
+        observe_listing_row_v1(
+            &mut pass,
+            &mut budget,
+            RemoteNamespaceListingPassV1::First,
+            RemoteNamespaceCorpusV1::Index,
+            prefix,
+            "roots/index/file",
+            EntryMode::FILE,
+            false,
+            None,
+            contract,
+        )
+        .unwrap();
+        assert_eq!(budget.listing_rows, 1);
+        assert_eq!(budget.index_objects, 1);
+
+        assert_eq!(
+            observe_listing_row_v1(
+                &mut pass,
+                &mut budget,
+                RemoteNamespaceListingPassV1::First,
+                RemoteNamespaceCorpusV1::Index,
+                prefix,
+                "roots/index/file",
+                EntryMode::FILE,
+                false,
+                None,
+                contract,
+            ),
+            Err(StrictRemoteNamespaceKeyIncompleteV1::DuplicateObjectKey {
+                pass: RemoteNamespaceListingPassV1::First,
+                corpus: RemoteNamespaceCorpusV1::Index
+            })
+        );
+        assert_eq!(budget.listing_rows, 2);
+        assert_eq!(budget.index_objects, 2);
+
+        let rows_before_invalid = budget.listing_rows;
+        let listing_bytes_before_invalid = budget.listing_key_bytes;
+        let objects_before_invalid = budget.index_objects;
+        let retained_bytes_before_invalid = budget.index_key_bytes;
+        assert!(matches!(
+            observe_listing_row_v1(
+                &mut pass,
+                &mut budget,
+                RemoteNamespaceListingPassV1::First,
+                RemoteNamespaceCorpusV1::Index,
+                prefix,
+                "outside/file",
+                EntryMode::FILE,
+                false,
+                None,
+                contract,
+            ),
+            Err(StrictRemoteNamespaceKeyIncompleteV1::InvalidEntry {
+                reason: InvalidRemoteNamespaceKeyReasonV1::OutsideRequestedPrefix,
+                ..
+            })
+        ));
+        assert_eq!(budget.listing_rows, rows_before_invalid + 1);
+        assert_eq!(
+            budget.listing_key_bytes,
+            listing_bytes_before_invalid + "outside/file".len() as u64
+        );
+        assert_eq!(budget.index_objects, objects_before_invalid + 1);
+        assert_eq!(
+            budget.index_key_bytes,
+            retained_bytes_before_invalid + "outside/file".len() as u64
+        );
+    }
+
+    #[test]
+    fn requested_prefix_directories_are_accepted_but_reservations_stay_flat() {
+        assert!(observe_one_row(
+            RemoteNamespaceCorpusV1::Index,
+            "roots/index/",
+            "roots/index/",
+            EntryMode::DIR,
+        )
+        .is_ok());
+        assert!(observe_one_row(
+            RemoteNamespaceCorpusV1::Reservation,
+            "roots/.tcfs-namespace/v1/",
+            "roots/.tcfs-namespace/v1/",
+            EntryMode::DIR,
+        )
+        .is_ok());
+        assert_eq!(
+            observe_one_row(
+                RemoteNamespaceCorpusV1::Reservation,
+                "roots/.tcfs-namespace/v1/",
+                "roots/.tcfs-namespace/v1/nested/",
+                EntryMode::DIR,
+            ),
+            Err(StrictRemoteNamespaceKeyIncompleteV1::InvalidEntry {
+                pass: RemoteNamespaceListingPassV1::First,
+                corpus: RemoteNamespaceCorpusV1::Reservation,
+                reason: InvalidRemoteNamespaceKeyReasonV1::UnexpectedReservationDirectory,
+            })
+        );
+    }
+
+    #[test]
+    fn duplicate_synthetic_directory_rows_are_rejected_after_accounting() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let mut pass = RemoteNamespaceKeyPassV1::default();
+        let mut budget = RemoteListingBudgetV1::default();
+        for expected in [
+            Ok(()),
+            Err(StrictRemoteNamespaceKeyIncompleteV1::DuplicateObjectKey {
+                pass: RemoteNamespaceListingPassV1::First,
+                corpus: RemoteNamespaceCorpusV1::Index,
+            }),
+        ] {
+            assert_eq!(
+                observe_listing_row_v1(
+                    &mut pass,
+                    &mut budget,
+                    RemoteNamespaceListingPassV1::First,
+                    RemoteNamespaceCorpusV1::Index,
+                    "roots/index/",
+                    "roots/index/dir/",
+                    EntryMode::DIR,
+                    false,
+                    None,
+                    contract,
+                ),
+                expected
+            );
+        }
+        assert_eq!(budget.listing_rows, 2);
+        assert_eq!(budget.index_objects, 0);
+    }
+
+    #[test]
+    fn directory_marker_keys_remain_candidates_and_aliases_fail_closed() {
+        let valid = observe_one_row(
+            RemoteNamespaceCorpusV1::Index,
+            "roots/index/",
+            "roots/index/dir/.tcfs_dir",
+            EntryMode::FILE,
+        )
+        .unwrap();
+        let candidate = valid.index_objects.iter().next().unwrap();
+        assert_eq!(candidate.logical_path(), "dir");
+        assert_eq!(
+            candidate.class(),
+            ListedRemoteIndexKeyClassV1::DirectoryMarkerCandidate
+        );
+
+        for key in [
+            "roots/index/.tcfs_dir",
+            "roots/index/dir/.TCFS_DIR",
+            "roots/index/dir/.tcfs_dir/file",
+        ] {
+            assert_eq!(
+                observe_one_row(
+                    RemoteNamespaceCorpusV1::Index,
+                    "roots/index/",
+                    key,
+                    EntryMode::FILE,
+                ),
+                Err(StrictRemoteNamespaceKeyIncompleteV1::InvalidEntry {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    corpus: RemoteNamespaceCorpusV1::Index,
+                    reason: InvalidRemoteNamespaceKeyReasonV1::InvalidIndexPath,
+                }),
+                "unexpected marker-key result for {key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reservation_object_ids_require_one_lowercase_hex_component() {
+        let valid_id = "d".repeat(64);
+        let valid = observe_one_row(
+            RemoteNamespaceCorpusV1::Reservation,
+            "roots/.tcfs-namespace/v1/",
+            &format!("roots/.tcfs-namespace/v1/{valid_id}"),
+            EntryMode::FILE,
+        )
+        .unwrap();
+        assert_eq!(
+            valid.reservation_objects.iter().next().unwrap().object_id(),
+            valid_id
+        );
+
+        for invalid_id in [
+            "d".repeat(63),
+            "d".repeat(65),
+            "D".repeat(64),
+            format!("{}g", "d".repeat(63)),
+            format!("{}/child", "d".repeat(64)),
+        ] {
+            let key = format!("roots/.tcfs-namespace/v1/{invalid_id}");
+            assert_eq!(
+                observe_one_row(
+                    RemoteNamespaceCorpusV1::Reservation,
+                    "roots/.tcfs-namespace/v1/",
+                    &key,
+                    EntryMode::FILE,
+                ),
+                Err(StrictRemoteNamespaceKeyIncompleteV1::InvalidEntry {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    corpus: RemoteNamespaceCorpusV1::Reservation,
+                    reason: InvalidRemoteNamespaceKeyReasonV1::InvalidReservationObjectId,
+                }),
+                "unexpected reservation-key result for {key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn directory_rows_and_reservation_key_grammar_fail_closed() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let mut pass = RemoteNamespaceKeyPassV1::default();
+        let mut budget = RemoteListingBudgetV1::default();
+        assert!(observe_listing_row_v1(
+            &mut pass,
+            &mut budget,
+            RemoteNamespaceListingPassV1::First,
+            RemoteNamespaceCorpusV1::Index,
+            "roots/index/",
+            "roots/index/dir/",
+            EntryMode::DIR,
+            false,
+            None,
+            contract,
+        )
+        .is_ok());
+        assert!(matches!(
+            observe_listing_row_v1(
+                &mut pass,
+                &mut budget,
+                RemoteNamespaceListingPassV1::First,
+                RemoteNamespaceCorpusV1::Reservation,
+                "roots/.tcfs-namespace/v1/",
+                "roots/.tcfs-namespace/v1/not-flat/id",
+                EntryMode::FILE,
+                false,
+                None,
+                contract,
+            ),
+            Err(StrictRemoteNamespaceKeyIncompleteV1::InvalidEntry {
+                reason: InvalidRemoteNamespaceKeyReasonV1::InvalidReservationObjectId,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn file_metadata_rejections_consume_raw_and_corpus_budgets() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let key = "roots/index/file";
+        for (is_deleted, is_current, reason) in [
+            (
+                true,
+                None,
+                InvalidRemoteNamespaceKeyReasonV1::DeletedListingEntry,
+            ),
+            (
+                false,
+                Some(false),
+                InvalidRemoteNamespaceKeyReasonV1::NonCurrentListingEntry,
+            ),
+        ] {
+            let mut pass = RemoteNamespaceKeyPassV1::default();
+            let mut budget = RemoteListingBudgetV1::default();
+            assert_eq!(
+                observe_listing_row_v1(
+                    &mut pass,
+                    &mut budget,
+                    RemoteNamespaceListingPassV1::First,
+                    RemoteNamespaceCorpusV1::Index,
+                    "roots/index/",
+                    key,
+                    EntryMode::FILE,
+                    is_deleted,
+                    is_current,
+                    contract,
+                ),
+                Err(StrictRemoteNamespaceKeyIncompleteV1::InvalidEntry {
+                    pass: RemoteNamespaceListingPassV1::First,
+                    corpus: RemoteNamespaceCorpusV1::Index,
+                    reason,
+                })
+            );
+            assert_eq!(budget.listing_rows, 1);
+            assert_eq!(budget.listing_key_bytes, key.len() as u64);
+            assert_eq!(budget.index_objects, 1);
+            assert_eq!(budget.index_key_bytes, key.len() as u64);
+        }
+    }
+
+    #[test]
+    fn raw_listing_limits_are_checked_before_entry_validation() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let mut pass = RemoteNamespaceKeyPassV1::default();
+        let mut budget = RemoteListingBudgetV1 {
+            listing_rows: contract.max_listing_rows_per_pass(),
+            ..RemoteListingBudgetV1::default()
+        };
+        assert_eq!(
+            observe_listing_row_v1(
+                &mut pass,
+                &mut budget,
+                RemoteNamespaceListingPassV1::First,
+                RemoteNamespaceCorpusV1::Reservation,
+                "roots/.tcfs-namespace/v1/",
+                "malformed",
+                EntryMode::Unknown,
+                false,
+                None,
+                contract,
+            ),
+            Err(StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                pass: RemoteNamespaceListingPassV1::First,
+                corpus: RemoteNamespaceCorpusV1::Reservation,
+                resource: RemoteNamespaceKeyResourceV1::ListingRows,
+            })
+        );
+    }
+
+    #[test]
+    fn retained_corpus_key_limits_are_typed_after_raw_accounting() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let mut pass = RemoteNamespaceKeyPassV1::default();
+        let mut budget = RemoteListingBudgetV1 {
+            index_key_bytes: contract.max_retained_index_key_bytes_per_pass(),
+            ..RemoteListingBudgetV1::default()
+        };
+        let key = "roots/index/file";
+        assert_eq!(
+            observe_listing_row_v1(
+                &mut pass,
+                &mut budget,
+                RemoteNamespaceListingPassV1::Second,
+                RemoteNamespaceCorpusV1::Index,
+                "roots/index/",
+                key,
+                EntryMode::FILE,
+                false,
+                None,
+                contract,
+            ),
+            Err(StrictRemoteNamespaceKeyIncompleteV1::ResourceLimit {
+                pass: RemoteNamespaceListingPassV1::Second,
+                corpus: RemoteNamespaceCorpusV1::Index,
+                resource: RemoteNamespaceKeyResourceV1::IndexKeyBytes,
+            })
+        );
+        assert_eq!(budget.listing_rows, 1);
+        assert_eq!(budget.listing_key_bytes, key.len() as u64);
+        assert_eq!(budget.index_objects, 1);
+        assert!(budget.index_key_bytes > contract.max_retained_index_key_bytes_per_pass());
+    }
+}

--- a/crates/tcfs-sync/src/registered_remote_observation.rs
+++ b/crates/tcfs-sync/src/registered_remote_observation.rs
@@ -258,12 +258,35 @@ struct BoundRemoteManifestObservationV1 {
     manifest: Box<StrictRemoteManifestV1>,
 }
 
+/// One unique, compatible remote namespace claim retained in canonical
+/// folded-path order by [`RemoteNamespaceClaimAccumulatorV1`].
+///
+/// Fields remain private so callers cannot manufacture claim evidence without
+/// passing through the bounded conflict checks below.
 #[derive(Debug, PartialEq, Eq)]
-struct RetainedRemoteNamespaceClaimV1 {
+pub(crate) struct RetainedRemoteNamespaceClaimV1 {
     folded_path: String,
     exact_path: String,
     role: PortableNamespaceRole,
     origins: RemoteNamespaceClaimOriginsV1,
+}
+
+impl RetainedRemoteNamespaceClaimV1 {
+    pub(crate) fn folded_path(&self) -> &str {
+        &self.folded_path
+    }
+
+    pub(crate) fn exact_path(&self) -> &str {
+        &self.exact_path
+    }
+
+    pub(crate) const fn role(&self) -> PortableNamespaceRole {
+        self.role
+    }
+
+    pub(crate) const fn origins(&self) -> RemoteNamespaceClaimOriginsV1 {
+        self.origins
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -274,17 +297,17 @@ pub(crate) struct RemoteNamespaceClaimOriginsV1 {
 }
 
 impl RemoteNamespaceClaimOriginsV1 {
-    const CURRENT: Self = Self {
+    pub(crate) const CURRENT: Self = Self {
         current: true,
         historical: false,
         reservation: false,
     };
-    const HISTORICAL: Self = Self {
+    pub(crate) const HISTORICAL: Self = Self {
         current: false,
         historical: true,
         reservation: false,
     };
-    const RESERVATION: Self = Self {
+    pub(crate) const RESERVATION: Self = Self {
         current: false,
         historical: false,
         reservation: true,
@@ -372,10 +395,10 @@ impl MatchingTwoPassBoundRemoteEvidenceV1 {
     > {
         self.evidence.claims.iter().map(|claim| {
             (
-                claim.folded_path.as_str(),
-                claim.exact_path.as_str(),
-                claim.role,
-                claim.origins,
+                claim.folded_path(),
+                claim.exact_path(),
+                claim.role(),
+                claim.origins(),
             )
         })
     }
@@ -403,6 +426,20 @@ pub(crate) enum RemoteNamespaceClaimConflictV1 {
     InvalidPath,
     FoldedSpellingAlias,
     FileDirectoryRole,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteNamespaceClaimResourceV1 {
+    GeneratedClaims,
+    GeneratedClaimBytes,
+    RetainedClaims,
+    RetainedClaimBytes,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RemoteNamespaceClaimAccumulatorErrorV1 {
+    Conflict(RemoteNamespaceClaimConflictV1),
+    ResourceLimit(RemoteNamespaceClaimResourceV1),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -601,10 +638,6 @@ impl RemoteListingBudgetV1 {
 struct BoundRemotePassBudgetV1 {
     bound_object_bytes: u64,
     retained_binding_bytes: u64,
-    generated_claims: u64,
-    generated_claim_bytes: u64,
-    retained_claims: u64,
-    retained_claim_bytes: u64,
 }
 
 #[derive(Debug)]
@@ -612,6 +645,163 @@ struct RetainedRemoteNamespaceClaimValueV1 {
     exact_path: String,
     role: PortableNamespaceRole,
     origins: RemoteNamespaceClaimOriginsV1,
+}
+
+/// Neutral, bounded accumulator for semantic namespace claims.
+///
+/// It deliberately carries no LIST-pass label. Catalog and other exact
+/// inventory readers can feed semantic paths directly, while the repeated-LIST
+/// observer maps neutral failures back onto its pass-specific error surface.
+/// Successful output is unique and ordered by folded path.
+#[derive(Debug)]
+pub(crate) struct RemoteNamespaceClaimAccumulatorV1 {
+    contract: RootRemoteContractV1,
+    generated_claims: u64,
+    generated_claim_bytes: u64,
+    retained_claims: u64,
+    retained_claim_bytes: u64,
+    claims: BTreeMap<String, RetainedRemoteNamespaceClaimValueV1>,
+}
+
+impl RemoteNamespaceClaimAccumulatorV1 {
+    pub(crate) fn new(contract: RootRemoteContractV1) -> Self {
+        Self {
+            contract,
+            generated_claims: 0,
+            generated_claim_bytes: 0,
+            retained_claims: 0,
+            retained_claim_bytes: 0,
+            claims: BTreeMap::new(),
+        }
+    }
+
+    /// Observe every prefix claim implied by one exact logical path and leaf
+    /// role. Each generated claim consumes count and byte budget before
+    /// compatibility deduplication, matching the existing LIST-pass contract.
+    pub(crate) fn observe_path(
+        &mut self,
+        rel_path: &str,
+        role: PortableNamespaceRole,
+        origin: RemoteNamespaceClaimOriginsV1,
+    ) -> Result<(), RemoteNamespaceClaimAccumulatorErrorV1> {
+        let generated = namespace_claims_for_path(rel_path, role).map_err(|_| {
+            RemoteNamespaceClaimAccumulatorErrorV1::Conflict(
+                RemoteNamespaceClaimConflictV1::InvalidPath,
+            )
+        })?;
+        for claim in &generated {
+            self.observe_claim(claim, origin)?;
+        }
+        Ok(())
+    }
+
+    /// Finish the accumulator without cloning claim evidence.
+    ///
+    /// `BTreeMap::into_iter()` is the sole projection, so the returned vector is
+    /// deterministically ordered by folded path.
+    pub(crate) fn into_retained_claims(self) -> Vec<RetainedRemoteNamespaceClaimV1> {
+        self.claims
+            .into_iter()
+            .map(
+                |(
+                    folded_path,
+                    RetainedRemoteNamespaceClaimValueV1 {
+                        exact_path,
+                        role,
+                        origins,
+                    },
+                )| {
+                    RetainedRemoteNamespaceClaimV1 {
+                        folded_path,
+                        exact_path,
+                        role,
+                        origins,
+                    }
+                },
+            )
+            .collect()
+    }
+
+    fn checked_increment(
+        value: &mut u64,
+        increment: u64,
+        maximum: u64,
+        resource: RemoteNamespaceClaimResourceV1,
+    ) -> Result<(), RemoteNamespaceClaimAccumulatorErrorV1> {
+        *value = value.checked_add(increment).ok_or(
+            RemoteNamespaceClaimAccumulatorErrorV1::ResourceLimit(resource),
+        )?;
+        if *value > maximum {
+            return Err(RemoteNamespaceClaimAccumulatorErrorV1::ResourceLimit(
+                resource,
+            ));
+        }
+        Ok(())
+    }
+
+    fn observe_claim(
+        &mut self,
+        claim: &PortableNamespaceReservationV1,
+        origin: RemoteNamespaceClaimOriginsV1,
+    ) -> Result<(), RemoteNamespaceClaimAccumulatorErrorV1> {
+        let claim_bytes = claim
+            .exact_path()
+            .len()
+            .checked_add(claim.folded_path().len())
+            .and_then(|length| u64::try_from(length).ok())
+            .ok_or(RemoteNamespaceClaimAccumulatorErrorV1::ResourceLimit(
+                RemoteNamespaceClaimResourceV1::GeneratedClaimBytes,
+            ))?;
+        Self::checked_increment(
+            &mut self.generated_claims,
+            1,
+            self.contract.max_generated_claim_observations_per_pass(),
+            RemoteNamespaceClaimResourceV1::GeneratedClaims,
+        )?;
+        Self::checked_increment(
+            &mut self.generated_claim_bytes,
+            claim_bytes,
+            self.contract.max_generated_claim_bytes_per_pass(),
+            RemoteNamespaceClaimResourceV1::GeneratedClaimBytes,
+        )?;
+
+        if let Some(existing) = self.claims.get_mut(claim.folded_path()) {
+            if existing.exact_path != claim.exact_path() {
+                return Err(RemoteNamespaceClaimAccumulatorErrorV1::Conflict(
+                    RemoteNamespaceClaimConflictV1::FoldedSpellingAlias,
+                ));
+            }
+            if existing.role != claim.role() {
+                return Err(RemoteNamespaceClaimAccumulatorErrorV1::Conflict(
+                    RemoteNamespaceClaimConflictV1::FileDirectoryRole,
+                ));
+            }
+            existing.origins.merge(origin);
+            return Ok(());
+        }
+
+        Self::checked_increment(
+            &mut self.retained_claims,
+            1,
+            self.contract.max_retained_unique_claims_per_pass(),
+            RemoteNamespaceClaimResourceV1::RetainedClaims,
+        )?;
+        Self::checked_increment(
+            &mut self.retained_claim_bytes,
+            claim_bytes,
+            self.contract.max_retained_unique_claim_bytes_per_pass(),
+            RemoteNamespaceClaimResourceV1::RetainedClaimBytes,
+        )?;
+        self.claims.insert(
+            claim.folded_path().to_owned(),
+            RetainedRemoteNamespaceClaimValueV1 {
+                exact_path: claim.exact_path().to_owned(),
+                role: claim.role(),
+                origins: origin,
+            },
+        );
+        Ok(())
+    }
 }
 
 fn bound_pass_resource_limit(
@@ -692,100 +882,34 @@ impl BoundRemotePassBudgetV1 {
             contract,
         )
     }
-
-    fn observe_claim(
-        &mut self,
-        pass: RemoteNamespaceListingPassV1,
-        claim: &PortableNamespaceReservationV1,
-        origin: RemoteNamespaceClaimOriginsV1,
-        claims: &mut BTreeMap<String, RetainedRemoteNamespaceClaimValueV1>,
-        contract: RootRemoteContractV1,
-    ) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
-        let claim_bytes = claim
-            .exact_path()
-            .len()
-            .checked_add(claim.folded_path().len())
-            .and_then(|length| u64::try_from(length).ok())
-            .ok_or_else(|| {
-                bound_pass_resource_limit(pass, BoundRemotePassResourceV1::GeneratedClaimBytes)
-            })?;
-        checked_bound_pass_increment_v1(
-            &mut self.generated_claims,
-            1,
-            contract.max_generated_claim_observations_per_pass(),
-            pass,
-            BoundRemotePassResourceV1::GeneratedClaims,
-        )?;
-        checked_bound_pass_increment_v1(
-            &mut self.generated_claim_bytes,
-            claim_bytes,
-            contract.max_generated_claim_bytes_per_pass(),
-            pass,
-            BoundRemotePassResourceV1::GeneratedClaimBytes,
-        )?;
-
-        if let Some(existing) = claims.get_mut(claim.folded_path()) {
-            if existing.exact_path != claim.exact_path() {
-                return Err(StrictBoundRemoteObservationIncompleteV1::Claim {
-                    pass,
-                    reason: RemoteNamespaceClaimConflictV1::FoldedSpellingAlias,
-                });
-            }
-            if existing.role != claim.role() {
-                return Err(StrictBoundRemoteObservationIncompleteV1::Claim {
-                    pass,
-                    reason: RemoteNamespaceClaimConflictV1::FileDirectoryRole,
-                });
-            }
-            existing.origins.merge(origin);
-            return Ok(());
-        }
-
-        checked_bound_pass_increment_v1(
-            &mut self.retained_claims,
-            1,
-            contract.max_retained_unique_claims_per_pass(),
-            pass,
-            BoundRemotePassResourceV1::RetainedClaims,
-        )?;
-        checked_bound_pass_increment_v1(
-            &mut self.retained_claim_bytes,
-            claim_bytes,
-            contract.max_retained_unique_claim_bytes_per_pass(),
-            pass,
-            BoundRemotePassResourceV1::RetainedClaimBytes,
-        )?;
-        claims.insert(
-            claim.folded_path().to_owned(),
-            RetainedRemoteNamespaceClaimValueV1 {
-                exact_path: claim.exact_path().to_owned(),
-                role: claim.role(),
-                origins: origin,
-            },
-        );
-        Ok(())
-    }
 }
 
-fn observe_claim_chain_v1(
-    budget: &mut BoundRemotePassBudgetV1,
+fn map_claim_accumulator_error_v1(
     pass: RemoteNamespaceListingPassV1,
-    claims: &mut BTreeMap<String, RetainedRemoteNamespaceClaimValueV1>,
-    rel_path: &str,
-    role: PortableNamespaceRole,
-    origin: RemoteNamespaceClaimOriginsV1,
-    contract: RootRemoteContractV1,
-) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
-    let generated = namespace_claims_for_path(rel_path, role).map_err(|_| {
-        StrictBoundRemoteObservationIncompleteV1::Claim {
-            pass,
-            reason: RemoteNamespaceClaimConflictV1::InvalidPath,
+    error: RemoteNamespaceClaimAccumulatorErrorV1,
+) -> StrictBoundRemoteObservationIncompleteV1 {
+    match error {
+        RemoteNamespaceClaimAccumulatorErrorV1::Conflict(reason) => {
+            StrictBoundRemoteObservationIncompleteV1::Claim { pass, reason }
         }
-    })?;
-    for claim in &generated {
-        budget.observe_claim(pass, claim, origin, claims, contract)?;
+        RemoteNamespaceClaimAccumulatorErrorV1::ResourceLimit(resource) => {
+            let resource = match resource {
+                RemoteNamespaceClaimResourceV1::GeneratedClaims => {
+                    BoundRemotePassResourceV1::GeneratedClaims
+                }
+                RemoteNamespaceClaimResourceV1::GeneratedClaimBytes => {
+                    BoundRemotePassResourceV1::GeneratedClaimBytes
+                }
+                RemoteNamespaceClaimResourceV1::RetainedClaims => {
+                    BoundRemotePassResourceV1::RetainedClaims
+                }
+                RemoteNamespaceClaimResourceV1::RetainedClaimBytes => {
+                    BoundRemotePassResourceV1::RetainedClaimBytes
+                }
+            };
+            StrictBoundRemoteObservationIncompleteV1::ResourceLimit { pass, resource }
+        }
     }
-    Ok(())
 }
 
 fn is_lower_hex_64(value: &str) -> bool {
@@ -1159,7 +1283,7 @@ async fn read_fully_drained_bound_remote_pass_v1(
     } = listed;
 
     let mut budget = BoundRemotePassBudgetV1::default();
-    let mut claims = BTreeMap::<String, RetainedRemoteNamespaceClaimValueV1>::new();
+    let mut claim_accumulator = RemoteNamespaceClaimAccumulatorV1::new(contract);
     let mut index_objects = Vec::with_capacity(listed_index_objects.len());
 
     for listed in listed_index_objects {
@@ -1267,16 +1391,12 @@ async fn read_fully_drained_bound_remote_pass_v1(
                 StrictBoundRemoteObservationIncompleteV1::LiveMarkerExcluded { pass: listing_pass },
             ));
         }
-        if let Err(incomplete) = observe_claim_chain_v1(
-            &mut budget,
-            listing_pass,
-            &mut claims,
+        if let Err(error) = claim_accumulator.observe_path(
             observed.logical_path(),
             observed.role(),
             observed.claim_origin(),
-            contract,
         ) {
-            return Ok(Err(incomplete));
+            return Ok(Err(map_claim_accumulator_error_v1(listing_pass, error)));
         }
         index_objects.push(observed);
     }
@@ -1327,16 +1447,12 @@ async fn read_fully_drained_bound_remote_pass_v1(
         {
             return Ok(Err(incomplete));
         }
-        if let Err(incomplete) = observe_claim_chain_v1(
-            &mut budget,
-            listing_pass,
-            &mut claims,
+        if let Err(error) = claim_accumulator.observe_path(
             reservation.exact_path(),
             reservation.role(),
             RemoteNamespaceClaimOriginsV1::RESERVATION,
-            contract,
         ) {
-            return Ok(Err(incomplete));
+            return Ok(Err(map_claim_accumulator_error_v1(listing_pass, error)));
         }
         reservations.push(reservation);
     }
@@ -1395,26 +1511,7 @@ async fn read_fully_drained_bound_remote_pass_v1(
         });
     }
 
-    let claims = claims
-        .into_iter()
-        .map(
-            |(
-                folded_path,
-                RetainedRemoteNamespaceClaimValueV1 {
-                    exact_path,
-                    role,
-                    origins,
-                },
-            )| {
-                RetainedRemoteNamespaceClaimV1 {
-                    folded_path,
-                    exact_path,
-                    role,
-                    origins,
-                }
-            },
-        )
-        .collect();
+    let claims = claim_accumulator.into_retained_claims();
     Ok(Ok(FullyDrainedBoundRemotePassV1 {
         index_objects,
         reservations,
@@ -1580,6 +1677,15 @@ pub(crate) mod tests {
     use opendal::{Buffer, Capability, Error, ErrorKind, Metadata, OperatorBuilder};
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
+
+    static_assertions::assert_not_impl_any!(
+        RemoteNamespaceClaimAccumulatorV1: Clone,
+        serde::Serialize
+    );
+    static_assertions::assert_not_impl_any!(
+        RetainedRemoteNamespaceClaimV1: Clone,
+        serde::Serialize
+    );
 
     #[derive(Debug)]
     enum ScriptedListRow {
@@ -2868,7 +2974,6 @@ pub(crate) mod tests {
         let mut exact = BoundRemotePassBudgetV1 {
             bound_object_bytes: contract.max_bound_object_bytes_per_pass() - body_bytes,
             retained_binding_bytes: contract.max_retained_binding_bytes_per_pass() - binding_bytes,
-            ..BoundRemotePassBudgetV1::default()
         };
         assert_eq!(
             exact.observe_object(pass, deleted.object(), contract),
@@ -3147,22 +3252,16 @@ pub(crate) mod tests {
         let claim_bytes = u64::try_from(claim.exact_path().len() + claim.folded_path().len())
             .expect("test claim length fits u64");
 
-        let mut exact = BoundRemotePassBudgetV1 {
+        let mut exact = RemoteNamespaceClaimAccumulatorV1 {
+            contract,
             generated_claims: contract.max_generated_claim_observations_per_pass() - 1,
             generated_claim_bytes: contract.max_generated_claim_bytes_per_pass() - claim_bytes,
             retained_claims: contract.max_retained_unique_claims_per_pass() - 1,
             retained_claim_bytes: contract.max_retained_unique_claim_bytes_per_pass() - claim_bytes,
-            ..BoundRemotePassBudgetV1::default()
+            claims: BTreeMap::new(),
         };
-        let mut exact_claims = BTreeMap::new();
         assert_eq!(
-            exact.observe_claim(
-                pass,
-                &claim,
-                RemoteNamespaceClaimOriginsV1::CURRENT,
-                &mut exact_claims,
-                contract,
-            ),
+            exact.observe_claim(&claim, RemoteNamespaceClaimOriginsV1::CURRENT),
             Ok(())
         );
         assert_eq!(
@@ -3183,104 +3282,145 @@ pub(crate) mod tests {
         );
 
         let retained_before = exact.retained_claims;
+        let error = exact
+            .observe_claim(&claim, RemoteNamespaceClaimOriginsV1::CURRENT)
+            .unwrap_err();
         assert_eq!(
-            exact.observe_claim(
-                pass,
-                &claim,
-                RemoteNamespaceClaimOriginsV1::CURRENT,
-                &mut exact_claims,
-                contract,
-            ),
-            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
+            error,
+            RemoteNamespaceClaimAccumulatorErrorV1::ResourceLimit(
+                RemoteNamespaceClaimResourceV1::GeneratedClaims
+            )
+        );
+        assert_eq!(
+            map_claim_accumulator_error_v1(pass, error),
+            StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
                 pass,
                 resource: BoundRemotePassResourceV1::GeneratedClaims,
-            })
+            }
         );
         assert_eq!(exact.retained_claims, retained_before);
 
-        let mut generated_bytes_over = BoundRemotePassBudgetV1 {
+        let mut generated_bytes_over = RemoteNamespaceClaimAccumulatorV1 {
+            contract,
+            generated_claims: 0,
             generated_claim_bytes: contract.max_generated_claim_bytes_per_pass(),
-            ..BoundRemotePassBudgetV1::default()
+            retained_claims: 0,
+            retained_claim_bytes: 0,
+            claims: BTreeMap::new(),
         };
         assert_eq!(
-            generated_bytes_over.observe_claim(
-                pass,
-                &claim,
-                RemoteNamespaceClaimOriginsV1::CURRENT,
-                &mut BTreeMap::new(),
-                contract,
-            ),
-            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
-                pass,
-                resource: BoundRemotePassResourceV1::GeneratedClaimBytes,
-            })
+            generated_bytes_over.observe_claim(&claim, RemoteNamespaceClaimOriginsV1::CURRENT),
+            Err(RemoteNamespaceClaimAccumulatorErrorV1::ResourceLimit(
+                RemoteNamespaceClaimResourceV1::GeneratedClaimBytes
+            ))
         );
 
-        let mut retained_count_over = BoundRemotePassBudgetV1 {
+        let mut retained_count_over = RemoteNamespaceClaimAccumulatorV1 {
+            contract,
+            generated_claims: 0,
+            generated_claim_bytes: 0,
             retained_claims: contract.max_retained_unique_claims_per_pass(),
-            ..BoundRemotePassBudgetV1::default()
+            retained_claim_bytes: 0,
+            claims: BTreeMap::new(),
         };
         assert_eq!(
-            retained_count_over.observe_claim(
-                pass,
-                &claim,
-                RemoteNamespaceClaimOriginsV1::CURRENT,
-                &mut BTreeMap::new(),
-                contract,
-            ),
-            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
-                pass,
-                resource: BoundRemotePassResourceV1::RetainedClaims,
-            })
+            retained_count_over.observe_claim(&claim, RemoteNamespaceClaimOriginsV1::CURRENT),
+            Err(RemoteNamespaceClaimAccumulatorErrorV1::ResourceLimit(
+                RemoteNamespaceClaimResourceV1::RetainedClaims
+            ))
         );
 
-        let mut retained_bytes_over = BoundRemotePassBudgetV1 {
+        let mut retained_bytes_over = RemoteNamespaceClaimAccumulatorV1 {
+            contract,
+            generated_claims: 0,
+            generated_claim_bytes: 0,
+            retained_claims: 0,
             retained_claim_bytes: contract.max_retained_unique_claim_bytes_per_pass(),
-            ..BoundRemotePassBudgetV1::default()
+            claims: BTreeMap::new(),
         };
         assert_eq!(
-            retained_bytes_over.observe_claim(
-                pass,
-                &claim,
-                RemoteNamespaceClaimOriginsV1::CURRENT,
-                &mut BTreeMap::new(),
-                contract,
-            ),
-            Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
-                pass,
-                resource: BoundRemotePassResourceV1::RetainedClaimBytes,
-            })
+            retained_bytes_over.observe_claim(&claim, RemoteNamespaceClaimOriginsV1::CURRENT),
+            Err(RemoteNamespaceClaimAccumulatorErrorV1::ResourceLimit(
+                RemoteNamespaceClaimResourceV1::RetainedClaimBytes
+            ))
         );
 
-        let mut duplicate_budget = BoundRemotePassBudgetV1::default();
-        let mut duplicate_claims = BTreeMap::new();
-        duplicate_budget
-            .observe_claim(
-                pass,
-                &claim,
-                RemoteNamespaceClaimOriginsV1::CURRENT,
-                &mut duplicate_claims,
-                contract,
-            )
+        let mut duplicate_accumulator = RemoteNamespaceClaimAccumulatorV1::new(contract);
+        duplicate_accumulator
+            .observe_claim(&claim, RemoteNamespaceClaimOriginsV1::CURRENT)
             .unwrap();
-        duplicate_budget
-            .observe_claim(
-                pass,
-                &claim,
-                RemoteNamespaceClaimOriginsV1::HISTORICAL,
-                &mut duplicate_claims,
-                contract,
-            )
+        duplicate_accumulator
+            .observe_claim(&claim, RemoteNamespaceClaimOriginsV1::HISTORICAL)
             .unwrap();
-        assert_eq!(duplicate_budget.generated_claims, 2);
-        assert_eq!(duplicate_budget.generated_claim_bytes, claim_bytes * 2);
-        assert_eq!(duplicate_budget.retained_claims, 1);
-        assert_eq!(duplicate_budget.retained_claim_bytes, claim_bytes);
-        assert_eq!(duplicate_claims.len(), 1);
-        let origins = duplicate_claims.get("path").unwrap().origins;
+        assert_eq!(duplicate_accumulator.generated_claims, 2);
+        assert_eq!(duplicate_accumulator.generated_claim_bytes, claim_bytes * 2);
+        assert_eq!(duplicate_accumulator.retained_claims, 1);
+        assert_eq!(duplicate_accumulator.retained_claim_bytes, claim_bytes);
+        assert_eq!(duplicate_accumulator.claims.len(), 1);
+        let origins = duplicate_accumulator.claims.get("path").unwrap().origins;
         assert!(origins.current());
         assert!(origins.historical());
         assert!(!origins.reservation());
+    }
+
+    #[test]
+    fn neutral_claim_accumulator_orders_output_and_reports_unlabeled_conflicts() {
+        let contract = RegisteredRootPlanContractV1::strict_v1().remote_contract();
+        let mut accumulator = RemoteNamespaceClaimAccumulatorV1::new(contract);
+        accumulator
+            .observe_path(
+                "zeta/leaf",
+                PortableNamespaceRole::File,
+                RemoteNamespaceClaimOriginsV1::CURRENT,
+            )
+            .unwrap();
+        accumulator
+            .observe_path(
+                "alpha",
+                PortableNamespaceRole::Directory,
+                RemoteNamespaceClaimOriginsV1::RESERVATION,
+            )
+            .unwrap();
+        let claims = accumulator.into_retained_claims();
+        assert_eq!(
+            claims
+                .iter()
+                .map(RetainedRemoteNamespaceClaimV1::folded_path)
+                .collect::<Vec<_>>(),
+            vec!["alpha", "zeta", "zeta/leaf"]
+        );
+        assert_eq!(claims[0].exact_path(), "alpha");
+        assert_eq!(claims[0].role(), PortableNamespaceRole::Directory);
+        assert!(claims[0].origins().reservation());
+
+        let mut alias = RemoteNamespaceClaimAccumulatorV1::new(contract);
+        alias
+            .observe_path(
+                "Alias",
+                PortableNamespaceRole::File,
+                RemoteNamespaceClaimOriginsV1::CURRENT,
+            )
+            .unwrap();
+        let error = alias
+            .observe_path(
+                "alias",
+                PortableNamespaceRole::File,
+                RemoteNamespaceClaimOriginsV1::HISTORICAL,
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            RemoteNamespaceClaimAccumulatorErrorV1::Conflict(
+                RemoteNamespaceClaimConflictV1::FoldedSpellingAlias
+            )
+        );
+        assert_eq!(
+            map_claim_accumulator_error_v1(RemoteNamespaceListingPassV1::First, error),
+            StrictBoundRemoteObservationIncompleteV1::Claim {
+                pass: RemoteNamespaceListingPassV1::First,
+                reason: RemoteNamespaceClaimConflictV1::FoldedSpellingAlias,
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/registered_remote_observation.rs
+++ b/crates/tcfs-sync/src/registered_remote_observation.rs
@@ -234,6 +234,13 @@ impl BoundRemoteIndexObjectV1 {
         }
     }
 
+    const fn claim_origin(&self) -> RemoteNamespaceClaimOriginsV1 {
+        match self {
+            Self::Committed(_) | Self::LiveMarker(_) => RemoteNamespaceClaimOriginsV1::CURRENT,
+            Self::Deleted(_) | Self::DeletedMarker(_) => RemoteNamespaceClaimOriginsV1::HISTORICAL,
+        }
+    }
+
     fn committed(&self) -> Option<&RawCommittedIndexEntryV1> {
         match self {
             Self::Committed(index) => Some(index),
@@ -256,6 +263,54 @@ struct RetainedRemoteNamespaceClaimV1 {
     folded_path: String,
     exact_path: String,
     role: PortableNamespaceRole,
+    origins: RemoteNamespaceClaimOriginsV1,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RemoteNamespaceClaimOriginsV1 {
+    current: bool,
+    historical: bool,
+    reservation: bool,
+}
+
+impl RemoteNamespaceClaimOriginsV1 {
+    const CURRENT: Self = Self {
+        current: true,
+        historical: false,
+        reservation: false,
+    };
+    const HISTORICAL: Self = Self {
+        current: false,
+        historical: true,
+        reservation: false,
+    };
+    const RESERVATION: Self = Self {
+        current: false,
+        historical: false,
+        reservation: true,
+    };
+
+    fn merge(&mut self, other: Self) {
+        self.current |= other.current;
+        self.historical |= other.historical;
+        self.reservation |= other.reservation;
+    }
+
+    pub(crate) const fn current(self) -> bool {
+        self.current
+    }
+
+    pub(crate) const fn historical(self) -> bool {
+        self.historical
+    }
+
+    pub(crate) const fn reservation(self) -> bool {
+        self.reservation
+    }
+
+    pub(crate) const fn is_empty(self) -> bool {
+        !self.current && !self.historical && !self.reservation
+    }
 }
 
 /// One sequential list-and-bind pass over a registered remote namespace.
@@ -298,6 +353,31 @@ impl MatchingTwoPassBoundRemoteEvidenceV1 {
 
     pub(crate) fn claim_count(&self) -> usize {
         self.evidence.claims.len()
+    }
+
+    /// Iterate the unique retained claims in ascending folded-path order.
+    ///
+    /// Held-window composition relies on this ordering for its O(1)-extra-
+    /// memory three-way merge. Construction therefore remains a direct
+    /// `BTreeMap::into_iter()` projection, and tests pin the invariant.
+    pub(crate) fn namespace_safety_claims(
+        &self,
+    ) -> impl ExactSizeIterator<
+        Item = (
+            &str,
+            &str,
+            PortableNamespaceRole,
+            RemoteNamespaceClaimOriginsV1,
+        ),
+    > {
+        self.evidence.claims.iter().map(|claim| {
+            (
+                claim.folded_path.as_str(),
+                claim.exact_path.as_str(),
+                claim.role,
+                claim.origins,
+            )
+        })
     }
 }
 
@@ -531,6 +611,7 @@ struct BoundRemotePassBudgetV1 {
 struct RetainedRemoteNamespaceClaimValueV1 {
     exact_path: String,
     role: PortableNamespaceRole,
+    origins: RemoteNamespaceClaimOriginsV1,
 }
 
 fn bound_pass_resource_limit(
@@ -616,6 +697,7 @@ impl BoundRemotePassBudgetV1 {
         &mut self,
         pass: RemoteNamespaceListingPassV1,
         claim: &PortableNamespaceReservationV1,
+        origin: RemoteNamespaceClaimOriginsV1,
         claims: &mut BTreeMap<String, RetainedRemoteNamespaceClaimValueV1>,
         contract: RootRemoteContractV1,
     ) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
@@ -642,7 +724,7 @@ impl BoundRemotePassBudgetV1 {
             BoundRemotePassResourceV1::GeneratedClaimBytes,
         )?;
 
-        if let Some(existing) = claims.get(claim.folded_path()) {
+        if let Some(existing) = claims.get_mut(claim.folded_path()) {
             if existing.exact_path != claim.exact_path() {
                 return Err(StrictBoundRemoteObservationIncompleteV1::Claim {
                     pass,
@@ -655,6 +737,7 @@ impl BoundRemotePassBudgetV1 {
                     reason: RemoteNamespaceClaimConflictV1::FileDirectoryRole,
                 });
             }
+            existing.origins.merge(origin);
             return Ok(());
         }
 
@@ -677,6 +760,7 @@ impl BoundRemotePassBudgetV1 {
             RetainedRemoteNamespaceClaimValueV1 {
                 exact_path: claim.exact_path().to_owned(),
                 role: claim.role(),
+                origins: origin,
             },
         );
         Ok(())
@@ -689,6 +773,7 @@ fn observe_claim_chain_v1(
     claims: &mut BTreeMap<String, RetainedRemoteNamespaceClaimValueV1>,
     rel_path: &str,
     role: PortableNamespaceRole,
+    origin: RemoteNamespaceClaimOriginsV1,
     contract: RootRemoteContractV1,
 ) -> Result<(), StrictBoundRemoteObservationIncompleteV1> {
     let generated = namespace_claims_for_path(rel_path, role).map_err(|_| {
@@ -698,7 +783,7 @@ fn observe_claim_chain_v1(
         }
     })?;
     for claim in &generated {
-        budget.observe_claim(pass, claim, claims, contract)?;
+        budget.observe_claim(pass, claim, origin, claims, contract)?;
     }
     Ok(())
 }
@@ -1188,6 +1273,7 @@ async fn read_fully_drained_bound_remote_pass_v1(
             &mut claims,
             observed.logical_path(),
             observed.role(),
+            observed.claim_origin(),
             contract,
         ) {
             return Ok(Err(incomplete));
@@ -1247,6 +1333,7 @@ async fn read_fully_drained_bound_remote_pass_v1(
             &mut claims,
             reservation.exact_path(),
             reservation.role(),
+            RemoteNamespaceClaimOriginsV1::RESERVATION,
             contract,
         ) {
             return Ok(Err(incomplete));
@@ -1311,11 +1398,19 @@ async fn read_fully_drained_bound_remote_pass_v1(
     let claims = claims
         .into_iter()
         .map(
-            |(folded_path, RetainedRemoteNamespaceClaimValueV1 { exact_path, role })| {
+            |(
+                folded_path,
+                RetainedRemoteNamespaceClaimValueV1 {
+                    exact_path,
+                    role,
+                    origins,
+                },
+            )| {
                 RetainedRemoteNamespaceClaimV1 {
                     folded_path,
                     exact_path,
                     role,
+                    origins,
                 }
             },
         )
@@ -1474,9 +1569,12 @@ pub(crate) async fn list_remote_namespace_keys_two_pass_v1(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
-    use crate::index_entry::{manifest_object_id, namespace_reservation_object_id};
+    use crate::index_entry::{
+        manifest_object_id, namespace_reservation_object_id, portable_casefold_path,
+        DIRECTORY_MARKER_BYTES,
+    };
     use opendal::raw::{oio, Access, AccessorInfo, OpList, OpRead, OpStat, RpList, RpRead, RpStat};
     use opendal::services::Memory;
     use opendal::{Buffer, Capability, Error, ErrorKind, Metadata, OperatorBuilder};
@@ -1821,6 +1919,137 @@ mod tests {
                 corpus_rows(second_reservation_keys),
             ),
         ]
+    }
+
+    #[derive(Clone, Debug)]
+    pub(crate) enum RemoteNamespaceFixtureRowV1 {
+        CurrentFile(String),
+        DeletedFile(String),
+        CurrentDirectory(String),
+        DeletedDirectory(String),
+        Reservation {
+            exact_path: String,
+            role: PortableNamespaceRole,
+        },
+    }
+
+    /// Build one conditional scripted backend that the production two-pass
+    /// reader can consume. Callers select semantic rows, not raw evidence
+    /// constructors, so tests cannot bypass list/body/binding acquisition.
+    pub(crate) fn matching_remote_fixture_operator_v1(
+        rows: &[RemoteNamespaceFixtureRowV1],
+    ) -> Operator {
+        let mut index_keys = Vec::new();
+        let mut reservation_keys = Vec::new();
+        let mut objects = Vec::new();
+        for (ordinal, row) in rows.iter().enumerate() {
+            let etag = format!("fixture-{ordinal}");
+            match row {
+                RemoteNamespaceFixtureRowV1::CurrentFile(rel_path) => {
+                    let manifest_bytes = regular_manifest_json(rel_path);
+                    let manifest_id = manifest_object_id(&manifest_bytes);
+                    let index_key = format!("roots/index/{rel_path}");
+                    index_keys.push(index_key.clone());
+                    objects.push((
+                        index_key,
+                        bound_object(committed_index_json(&manifest_id), &etag),
+                    ));
+                    objects.push((
+                        format!("roots/manifests/{manifest_id}"),
+                        bound_object(manifest_bytes, &format!("manifest-{ordinal}")),
+                    ));
+                }
+                RemoteNamespaceFixtureRowV1::DeletedFile(rel_path) => {
+                    let index_key = format!("roots/index/{rel_path}");
+                    index_keys.push(index_key.clone());
+                    objects.push((index_key, bound_object(deleted_index_json(None), &etag)));
+                }
+                RemoteNamespaceFixtureRowV1::CurrentDirectory(rel_path) => {
+                    let index_key = format!("roots/index/{rel_path}/.tcfs_dir");
+                    index_keys.push(index_key.clone());
+                    objects.push((
+                        index_key,
+                        bound_object(DIRECTORY_MARKER_BYTES.to_vec(), &etag),
+                    ));
+                }
+                RemoteNamespaceFixtureRowV1::DeletedDirectory(rel_path) => {
+                    let index_key = format!("roots/index/{rel_path}/.tcfs_dir");
+                    index_keys.push(index_key.clone());
+                    objects.push((index_key, bound_object(deleted_index_json(None), &etag)));
+                }
+                RemoteNamespaceFixtureRowV1::Reservation { exact_path, role } => {
+                    let folded_path = portable_casefold_path(exact_path)
+                        .expect("remote fixture reservation path must be canonical");
+                    let reservation_id = namespace_reservation_object_id(&folded_path);
+                    let reservation_key = format!("roots/.tcfs-namespace/v1/{reservation_id}");
+                    reservation_keys.push(reservation_key.clone());
+                    let role = match role {
+                        PortableNamespaceRole::File => "file",
+                        PortableNamespaceRole::Directory => "directory",
+                    };
+                    objects.push((
+                        reservation_key,
+                        bound_object(
+                            canonical_reservation_json(exact_path, &folded_path, role),
+                            &etag,
+                        ),
+                    ));
+                }
+            }
+        }
+        let (op, backend) =
+            scripted_list_operator(two_bound_pass_list_calls(&index_keys, &reservation_keys));
+        for (key, object) in objects {
+            install_bound_object(&backend, key, object);
+        }
+        op
+    }
+
+    pub(crate) fn missing_remote_index_fixture_operator_v1(rel_path: &str) -> Operator {
+        let index_key = format!("roots/index/{rel_path}");
+        scripted_list_operator(two_bound_pass_list_calls(
+            std::slice::from_ref(&index_key),
+            &[],
+        ))
+        .0
+    }
+
+    #[tokio::test]
+    async fn fixture_reader_merges_current_historical_and_reservation_origins() {
+        let op = matching_remote_fixture_operator_v1(&[
+            RemoteNamespaceFixtureRowV1::CurrentFile("path/child".to_owned()),
+            RemoteNamespaceFixtureRowV1::DeletedDirectory("path".to_owned()),
+            RemoteNamespaceFixtureRowV1::Reservation {
+                exact_path: "path".to_owned(),
+                role: PortableNamespaceRole::Directory,
+            },
+        ]);
+        let evidence = match read_bound_remote_observation_two_pass_v1(&op, "roots")
+            .await
+            .unwrap()
+        {
+            StrictBoundRemoteObservationReadV1::Matched(evidence) => evidence,
+            other => panic!("expected matching fixture evidence, got {other:?}"),
+        };
+        let (_, exact_path, role, origins) = evidence
+            .namespace_safety_claims()
+            .find(|(folded_path, _, _, _)| *folded_path == "path")
+            .expect("fixture must retain its shared ancestor claim");
+        assert_eq!(exact_path, "path");
+        assert_eq!(role, PortableNamespaceRole::Directory);
+        assert!(origins.current());
+        assert!(origins.historical());
+        assert!(origins.reservation());
+        assert!(!origins.is_empty());
+
+        let folded_paths = evidence
+            .namespace_safety_claims()
+            .map(|(folded_path, _, _, _)| folded_path)
+            .collect::<Vec<_>>();
+        assert!(
+            folded_paths.windows(2).all(|pair| pair[0] < pair[1]),
+            "remote claim iterator must remain sorted and unique"
+        );
     }
 
     fn observe_one_row(
@@ -2927,7 +3156,13 @@ mod tests {
         };
         let mut exact_claims = BTreeMap::new();
         assert_eq!(
-            exact.observe_claim(pass, &claim, &mut exact_claims, contract),
+            exact.observe_claim(
+                pass,
+                &claim,
+                RemoteNamespaceClaimOriginsV1::CURRENT,
+                &mut exact_claims,
+                contract,
+            ),
             Ok(())
         );
         assert_eq!(
@@ -2949,7 +3184,13 @@ mod tests {
 
         let retained_before = exact.retained_claims;
         assert_eq!(
-            exact.observe_claim(pass, &claim, &mut exact_claims, contract),
+            exact.observe_claim(
+                pass,
+                &claim,
+                RemoteNamespaceClaimOriginsV1::CURRENT,
+                &mut exact_claims,
+                contract,
+            ),
             Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
                 pass,
                 resource: BoundRemotePassResourceV1::GeneratedClaims,
@@ -2962,7 +3203,13 @@ mod tests {
             ..BoundRemotePassBudgetV1::default()
         };
         assert_eq!(
-            generated_bytes_over.observe_claim(pass, &claim, &mut BTreeMap::new(), contract),
+            generated_bytes_over.observe_claim(
+                pass,
+                &claim,
+                RemoteNamespaceClaimOriginsV1::CURRENT,
+                &mut BTreeMap::new(),
+                contract,
+            ),
             Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
                 pass,
                 resource: BoundRemotePassResourceV1::GeneratedClaimBytes,
@@ -2974,7 +3221,13 @@ mod tests {
             ..BoundRemotePassBudgetV1::default()
         };
         assert_eq!(
-            retained_count_over.observe_claim(pass, &claim, &mut BTreeMap::new(), contract),
+            retained_count_over.observe_claim(
+                pass,
+                &claim,
+                RemoteNamespaceClaimOriginsV1::CURRENT,
+                &mut BTreeMap::new(),
+                contract,
+            ),
             Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
                 pass,
                 resource: BoundRemotePassResourceV1::RetainedClaims,
@@ -2986,7 +3239,13 @@ mod tests {
             ..BoundRemotePassBudgetV1::default()
         };
         assert_eq!(
-            retained_bytes_over.observe_claim(pass, &claim, &mut BTreeMap::new(), contract),
+            retained_bytes_over.observe_claim(
+                pass,
+                &claim,
+                RemoteNamespaceClaimOriginsV1::CURRENT,
+                &mut BTreeMap::new(),
+                contract,
+            ),
             Err(StrictBoundRemoteObservationIncompleteV1::ResourceLimit {
                 pass,
                 resource: BoundRemotePassResourceV1::RetainedClaimBytes,
@@ -2996,16 +3255,32 @@ mod tests {
         let mut duplicate_budget = BoundRemotePassBudgetV1::default();
         let mut duplicate_claims = BTreeMap::new();
         duplicate_budget
-            .observe_claim(pass, &claim, &mut duplicate_claims, contract)
+            .observe_claim(
+                pass,
+                &claim,
+                RemoteNamespaceClaimOriginsV1::CURRENT,
+                &mut duplicate_claims,
+                contract,
+            )
             .unwrap();
         duplicate_budget
-            .observe_claim(pass, &claim, &mut duplicate_claims, contract)
+            .observe_claim(
+                pass,
+                &claim,
+                RemoteNamespaceClaimOriginsV1::HISTORICAL,
+                &mut duplicate_claims,
+                contract,
+            )
             .unwrap();
         assert_eq!(duplicate_budget.generated_claims, 2);
         assert_eq!(duplicate_budget.generated_claim_bytes, claim_bytes * 2);
         assert_eq!(duplicate_budget.retained_claims, 1);
         assert_eq!(duplicate_budget.retained_claim_bytes, claim_bytes);
         assert_eq!(duplicate_claims.len(), 1);
+        let origins = duplicate_claims.get("path").unwrap().origins;
+        assert!(origins.current());
+        assert!(origins.historical());
+        assert!(!origins.reservation());
     }
 
     #[tokio::test]
@@ -3356,7 +3631,7 @@ mod tests {
                     index_objects: true,
                     reservations: false,
                     manifests: false,
-                    claims: false,
+                    claims: true,
                 }
             )
         );

--- a/crates/tcfs-sync/src/registered_source_composition.rs
+++ b/crates/tcfs-sync/src/registered_source_composition.rs
@@ -137,11 +137,92 @@ pub(crate) enum StrictRegisteredRootSourcesReadV1 {
 /// eventual daemon integration must move or expose construction behind the
 /// selector that owns authorization, overlap, ownership, ACL, and state-fence
 /// checks; raw config plus path arguments are not an authority capability.
-struct ValidatedSelectedRegisteredRootRouteV1 {
+pub(crate) struct ValidatedSelectedRegisteredRootRouteV1 {
     root_id: String,
     selected: RegisteredRootV1Config,
     canonical_local_root: PathBuf,
     canonical_state_path: PathBuf,
+}
+
+/// Opaque remote identity projected from the daemon-authenticated selected
+/// root route.
+///
+/// Catalog bytes may describe themselves, but they are never authority to
+/// choose which registered root the daemon selected. Production construction
+/// therefore remains private to this module and requires the selector-owned
+/// route capability above.
+pub(crate) struct ValidatedSelectedRegisteredRootRemoteContextV1 {
+    root_id: String,
+    spec: RootSpecV1Config,
+    spec_identity_fingerprint: String,
+    profile_settings_fingerprint: RootProfileSettingsFingerprintV1,
+    plan_contract_fingerprint: RegisteredRootPlanContractFingerprintV1,
+}
+
+impl ValidatedSelectedRegisteredRootRemoteContextV1 {
+    fn from_selected_route(selected_route: &ValidatedSelectedRegisteredRootRouteV1) -> Self {
+        let root_id = selected_route.root_id.clone();
+        let spec = selected_route.selected.spec.clone();
+        Self {
+            spec_identity_fingerprint: spec.identity_fingerprint(&root_id),
+            profile_settings_fingerprint: spec.profile.policy().settings_fingerprint(),
+            plan_contract_fingerprint: RegisteredRootPlanContractV1::strict_v1().fingerprint(),
+            root_id,
+            spec,
+        }
+    }
+
+    pub(crate) fn root_id(&self) -> &str {
+        &self.root_id
+    }
+
+    pub(crate) const fn spec(&self) -> &RootSpecV1Config {
+        &self.spec
+    }
+
+    pub(crate) fn spec_identity_fingerprint(&self) -> &str {
+        &self.spec_identity_fingerprint
+    }
+
+    pub(crate) const fn profile_settings_fingerprint(&self) -> RootProfileSettingsFingerprintV1 {
+        self.profile_settings_fingerprint
+    }
+
+    pub(crate) const fn plan_contract_fingerprint(
+        &self,
+    ) -> RegisteredRootPlanContractFingerprintV1 {
+        self.plan_contract_fingerprint
+    }
+}
+
+impl ValidatedSelectedRegisteredRootRouteV1 {
+    fn remote_context(&self) -> ValidatedSelectedRegisteredRootRemoteContextV1 {
+        ValidatedSelectedRegisteredRootRemoteContextV1::from_selected_route(self)
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn validated_selected_registered_root_remote_context_for_test_v1(
+    root_id: &str,
+    spec: &RootSpecV1Config,
+) -> std::result::Result<
+    ValidatedSelectedRegisteredRootRemoteContextV1,
+    StrictRegisteredRootSourcesIncompleteV1,
+> {
+    let selected = RegisteredRootV1Config {
+        spec: spec.clone(),
+        binding: None,
+    };
+    if selected.validate_shape(root_id).is_err() {
+        return Err(StrictRegisteredRootSourcesIncompleteV1::InvalidSelectedRoot);
+    }
+    Ok(ValidatedSelectedRegisteredRootRemoteContextV1 {
+        root_id: root_id.to_owned(),
+        spec: spec.clone(),
+        spec_identity_fingerprint: spec.identity_fingerprint(root_id),
+        profile_settings_fingerprint: spec.profile.policy().settings_fingerprint(),
+        plan_contract_fingerprint: RegisteredRootPlanContractV1::strict_v1().fingerprint(),
+    })
 }
 
 /// Opaque, non-authoritative observation of one AgentStatic selected root.

--- a/crates/tcfs-sync/src/registered_source_composition.rs
+++ b/crates/tcfs-sync/src/registered_source_composition.rs
@@ -1,9 +1,11 @@
 //! Held-window composition for one selected registered root.
 //!
 //! This module deliberately stops before planning. Matching remote A/B passes
-//! are non-atomic observation evidence, and namespace-safety history is not an
-//! actionable payload projection. The opaque artifact below therefore exposes
-//! no digest, serialization, clone, or action conversion.
+//! remain non-atomic diagnostic evidence. A sibling catalog-bound observation
+//! retains one internally closed immutable catalog revision, but still cannot
+//! prove writer fencing, externally complete bootstrap, or currentness. Neither
+//! artifact is an actionable payload projection; both expose no digest,
+//! serialization, clone, or action conversion.
 
 use anyhow::Result;
 use opendal::Operator;
@@ -16,6 +18,7 @@ use tcfs_core::config::{
     RootBindingV1Config, RootProfilePolicyV1, RootProfileSettingsFingerprintV1, RootProfileV1,
     RootSpecV1Config,
 };
+use tcfs_storage::ConditionalWriteSemanticsReceipt;
 
 use crate::index_entry::PortableNamespaceRole;
 use crate::registered_git_topology::{
@@ -29,6 +32,10 @@ use crate::registered_local_snapshot::{
 use crate::registered_reconcile::{
     read_and_bind_strict_primary_state_for_pending_root_v1, StrictPrimaryStateIncompleteV1,
     StrictPrimaryStateReadV1, StrictPrimaryStateSnapshotV1,
+};
+use crate::registered_remote_catalog::{
+    read_semantically_bound_remote_catalog_corpus_v1, SemanticallyBoundRemoteCatalogCorpusV1,
+    StrictSemanticallyBoundRemoteCatalogIncompleteV1, StrictSemanticallyBoundRemoteCatalogReadV1,
 };
 use crate::registered_remote_observation::{
     read_bound_remote_observation_two_pass_v1, MatchingTwoPassBoundRemoteEvidenceV1,
@@ -127,11 +134,18 @@ pub(crate) enum StrictRegisteredRootSourcesIncompleteV1 {
     NamespaceSafetyResourceLimit,
     RemoteClaimWithoutOrigin,
     GitTopology(StrictGitRawTopologyIncompleteV1),
+    Catalog(StrictSemanticallyBoundRemoteCatalogIncompleteV1),
 }
 
 pub(crate) enum StrictRegisteredRootSourcesReadV1 {
     Observed(Box<AgentStaticNamespaceSafetyObservationV1>),
     GitRawLocalTopologyObserved(Box<GitRawLocalTopologyObservationV1>),
+    Incomplete(StrictRegisteredRootSourcesIncompleteV1),
+}
+
+pub(crate) enum CatalogBoundRegisteredRootSourcesReadV1 {
+    AgentStatic(Box<CatalogBoundAgentStaticSourceObservationV1>),
+    GitRaw(Box<CatalogBoundGitRawSourceObservationV1>),
     Incomplete(StrictRegisteredRootSourcesIncompleteV1),
 }
 
@@ -384,6 +398,195 @@ impl fmt::Debug for GitRawLocalTopologyObservationV1 {
     }
 }
 
+/// Common held inputs for one catalog-bound selected-root observation.
+///
+/// The catalog corpus proves the internal closure of one observed immutable
+/// revision only. It does not prove that every writer used the catalog, that
+/// sequence one was bootstrapped from complete truth, or that the selected
+/// HEAD is the latest non-replayed revision.
+struct CatalogBoundRegisteredRootSourceBaseV1 {
+    root_id: String,
+    spec: RootSpecV1Config,
+    binding: RootBindingV1Config,
+    spec_identity_fingerprint: String,
+    binding_identity_fingerprint: String,
+    profile_policy: RootProfilePolicyV1,
+    plan_contract: RegisteredRootPlanContractV1,
+    canonical_state_path: PathBuf,
+    local: RevalidatedStrictLocalSnapshotV1,
+    state: StrictPrimaryStateSnapshotV1,
+    remote: SemanticallyBoundRemoteCatalogCorpusV1,
+    namespace_safety_summary: NamespaceSafetySummaryV1,
+}
+
+impl CatalogBoundRegisteredRootSourceBaseV1 {
+    fn root_id(&self) -> &str {
+        &self.root_id
+    }
+
+    fn canonical_local_root(&self) -> &Path {
+        self.local.canonical_local_root()
+    }
+
+    fn canonical_state_path(&self) -> &Path {
+        &self.canonical_state_path
+    }
+
+    fn remote_prefix(&self) -> &str {
+        self.remote.remote_prefix()
+    }
+
+    const fn namespace_safety_claim_count(&self) -> u64 {
+        self.namespace_safety_summary.unique_claims
+    }
+
+    #[cfg(test)]
+    const fn namespace_safety_source_claim_count(
+        &self,
+        source: NamespaceSafetyClaimSourceV1,
+    ) -> u64 {
+        self.namespace_safety_summary.source_claim_count(source)
+    }
+
+    #[cfg(test)]
+    const fn catalog_sequence(&self) -> u64 {
+        self.remote.catalog_sequence().get()
+    }
+}
+
+impl fmt::Debug for CatalogBoundRegisteredRootSourceBaseV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CatalogBoundRegisteredRootSourceBaseV1")
+            .field("root_id", &self.root_id)
+            .field("spec", &self.spec)
+            .field("binding", &self.binding)
+            .field("spec_identity_fingerprint", &self.spec_identity_fingerprint)
+            .field(
+                "binding_identity_fingerprint",
+                &self.binding_identity_fingerprint,
+            )
+            .field("profile_policy", &self.profile_policy)
+            .field("plan_contract", &self.plan_contract)
+            .field("canonical_local_root", &self.local.canonical_local_root())
+            .field("canonical_state_path", &self.canonical_state_path)
+            .field("state_entry_count", &self.state.entries().len())
+            .field("remote", &self.remote)
+            .field(
+                "namespace_safety_claim_count",
+                &self.namespace_safety_summary.unique_claims,
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+/// Digestless held-source observation for an AgentStatic root and one
+/// internally closed catalog revision.
+///
+/// This remains non-authoritative until writer fencing, trusted bootstrap, and
+/// monotonic currentness are independently established. It must not gain a
+/// plan digest or action projection.
+pub(crate) struct CatalogBoundAgentStaticSourceObservationV1 {
+    base: CatalogBoundRegisteredRootSourceBaseV1,
+}
+
+impl CatalogBoundAgentStaticSourceObservationV1 {
+    pub(crate) fn root_id(&self) -> &str {
+        self.base.root_id()
+    }
+
+    pub(crate) fn canonical_local_root(&self) -> &Path {
+        self.base.canonical_local_root()
+    }
+
+    pub(crate) fn canonical_state_path(&self) -> &Path {
+        self.base.canonical_state_path()
+    }
+
+    pub(crate) fn remote_prefix(&self) -> &str {
+        self.base.remote_prefix()
+    }
+
+    pub(crate) const fn namespace_safety_claim_count(&self) -> u64 {
+        self.base.namespace_safety_claim_count()
+    }
+
+    #[cfg(test)]
+    const fn namespace_safety_source_claim_count(
+        &self,
+        source: NamespaceSafetyClaimSourceV1,
+    ) -> u64 {
+        self.base.namespace_safety_source_claim_count(source)
+    }
+
+    #[cfg(test)]
+    const fn catalog_sequence(&self) -> u64 {
+        self.base.catalog_sequence()
+    }
+}
+
+impl fmt::Debug for CatalogBoundAgentStaticSourceObservationV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CatalogBoundAgentStaticSourceObservationV1")
+            .field("base", &self.base)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Digestless held-source observation for a GitRaw root and one internally
+/// closed catalog revision.
+///
+/// The retained Git topology is the checkpoint-14 immutable raw-metadata
+/// shadow. It does not prove object existence/kind, ancestry, fast-forward, or
+/// a continuous native-Git writer fence. This type must not gain a plan digest
+/// or action projection.
+pub(crate) struct CatalogBoundGitRawSourceObservationV1 {
+    base: CatalogBoundRegisteredRootSourceBaseV1,
+    git_topology: HeldStrictGitRawTopologyV1,
+}
+
+impl CatalogBoundGitRawSourceObservationV1 {
+    pub(crate) fn root_id(&self) -> &str {
+        self.base.root_id()
+    }
+
+    pub(crate) fn canonical_local_root(&self) -> &Path {
+        self.base.canonical_local_root()
+    }
+
+    pub(crate) fn canonical_state_path(&self) -> &Path {
+        self.base.canonical_state_path()
+    }
+
+    pub(crate) fn remote_prefix(&self) -> &str {
+        self.base.remote_prefix()
+    }
+
+    pub(crate) const fn namespace_safety_claim_count(&self) -> u64 {
+        self.base.namespace_safety_claim_count()
+    }
+
+    pub(crate) fn git_topology(&self) -> &HeldStrictGitRawTopologyV1 {
+        &self.git_topology
+    }
+
+    #[cfg(test)]
+    const fn catalog_sequence(&self) -> u64 {
+        self.base.catalog_sequence()
+    }
+}
+
+impl fmt::Debug for CatalogBoundGitRawSourceObservationV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CatalogBoundGitRawSourceObservationV1")
+            .field("base", &self.base)
+            .field("git_topology", &self.git_topology)
+            .finish_non_exhaustive()
+    }
+}
+
 struct ExpectedRegisteredSourceRouteV1<'a> {
     canonical_local_root: &'a Path,
     canonical_state_path: &'a Path,
@@ -524,14 +727,20 @@ fn checked_summary_increment_v1(
     Ok(())
 }
 
-fn compose_namespace_safety_summary_v1(
+fn compose_namespace_safety_summary_from_remote_claims_v1<'a>(
     local: &RevalidatedStrictLocalSnapshotV1,
     state: &StrictPrimaryStateSnapshotV1,
-    remote: &MatchingTwoPassBoundRemoteEvidenceV1,
+    mut remote_claims: impl Iterator<
+        Item = (
+            &'a str,
+            &'a str,
+            PortableNamespaceRole,
+            RemoteNamespaceClaimOriginsV1,
+        ),
+    >,
 ) -> std::result::Result<NamespaceSafetySummaryV1, ComposeNamespaceSafetyErrorV1> {
     let mut local_claims = local.snapshot().namespace_claims();
     let mut state_claims = state.namespace_claims();
-    let mut remote_claims = remote.namespace_safety_claims();
     let mut local_current = local_claims.next();
     let mut state_current = state_claims.next();
     let mut remote_current = remote_claims.next();
@@ -631,6 +840,30 @@ fn compose_namespace_safety_summary_v1(
         }
     }
     Ok(summary)
+}
+
+fn compose_namespace_safety_summary_v1(
+    local: &RevalidatedStrictLocalSnapshotV1,
+    state: &StrictPrimaryStateSnapshotV1,
+    remote: &MatchingTwoPassBoundRemoteEvidenceV1,
+) -> std::result::Result<NamespaceSafetySummaryV1, ComposeNamespaceSafetyErrorV1> {
+    compose_namespace_safety_summary_from_remote_claims_v1(
+        local,
+        state,
+        remote.namespace_safety_claims(),
+    )
+}
+
+fn compose_catalog_namespace_safety_summary_v1(
+    local: &RevalidatedStrictLocalSnapshotV1,
+    state: &StrictPrimaryStateSnapshotV1,
+    remote: &SemanticallyBoundRemoteCatalogCorpusV1,
+) -> std::result::Result<NamespaceSafetySummaryV1, ComposeNamespaceSafetyErrorV1> {
+    compose_namespace_safety_summary_from_remote_claims_v1(
+        local,
+        state,
+        remote.namespace_safety_claims(),
+    )
 }
 
 #[cfg(test)]
@@ -903,10 +1136,222 @@ async fn observe_validated_registered_root_sources_v1(
     }
 }
 
+#[cfg(test)]
+async fn observe_catalog_bound_selected_registered_root_sources_for_test_v1(
+    root_id: &str,
+    selected: &RegisteredRootV1Config,
+    canonical_local_root: &Path,
+    canonical_state_path: &Path,
+    op: &Operator,
+    receipt: &ConditionalWriteSemanticsReceipt,
+) -> Result<CatalogBoundRegisteredRootSourcesReadV1> {
+    let selected = match validated_selection_for_test_v1(
+        root_id,
+        selected,
+        canonical_local_root,
+        canonical_state_path,
+    ) {
+        Ok(selected) => selected,
+        Err(incomplete) => {
+            return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                incomplete,
+            ));
+        }
+    };
+    observe_catalog_bound_validated_registered_root_sources_v1(selected, op, receipt).await
+}
+
+/// Observe one daemon-validated selected-root route and one internally closed
+/// immutable catalog revision through the same held local acquisition window.
+///
+/// Receipt acquisition is deliberately outside this function. The catalog
+/// reader verifies that the non-Clone receipt belongs to this exact accessor
+/// and prefix. Even a successful result remains digestless because writer
+/// fencing, trusted bootstrap, and monotonic currentness are not established.
+async fn observe_catalog_bound_validated_registered_root_sources_v1(
+    selected_route: ValidatedSelectedRegisteredRootRouteV1,
+    op: &Operator,
+    receipt: &ConditionalWriteSemanticsReceipt,
+) -> Result<CatalogBoundRegisteredRootSourcesReadV1> {
+    let remote_context = selected_route.remote_context();
+    let ValidatedSelectedRegisteredRootRouteV1 {
+        root_id,
+        selected,
+        canonical_local_root,
+        canonical_state_path,
+    } = selected_route;
+    let binding = selected
+        .binding
+        .as_ref()
+        .expect("validated selected-root capability always carries a binding");
+    let profile_policy = selected.spec.profile.policy();
+    let plan_contract = RegisteredRootPlanContractV1::strict_v1();
+    let plan_contract_fingerprint = plan_contract.fingerprint();
+    let spec_identity_fingerprint = selected.spec.identity_fingerprint(&root_id);
+    let binding_identity_fingerprint =
+        match binding.binding_fingerprint(&canonical_local_root, &canonical_state_path) {
+            Ok(fingerprint) => fingerprint,
+            Err(_) => {
+                return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::InvalidSelectedRoot,
+                ));
+            }
+        };
+
+    let mut pending =
+        match begin_strict_local_snapshot_v1(&canonical_local_root, selected.spec.profile)? {
+            StrictLocalSnapshotHoldReadV1::Pending(pending) => pending,
+            StrictLocalSnapshotHoldReadV1::Incomplete(incomplete) => {
+                return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::Local(incomplete),
+                ));
+            }
+        };
+    let pending_git = if selected.spec.profile == RootProfileV1::GitRawV1 {
+        match begin_strict_git_raw_topology_v1(&mut pending) {
+            StrictGitRawTopologyBeginV1::Pending(git) => Some(*git),
+            StrictGitRawTopologyBeginV1::Incomplete(incomplete) => {
+                return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+                ));
+            }
+        }
+    } else {
+        None
+    };
+    let state = match read_and_bind_strict_primary_state_for_pending_root_v1(
+        &canonical_state_path,
+        &pending,
+        &selected.spec.remote_prefix,
+    )? {
+        StrictPrimaryStateReadV1::Complete(state) => state,
+        StrictPrimaryStateReadV1::Incomplete(incomplete) => {
+            return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::State(incomplete),
+            ));
+        }
+    };
+    let remote =
+        match read_semantically_bound_remote_catalog_corpus_v1(op, &remote_context, receipt).await?
+        {
+            StrictSemanticallyBoundRemoteCatalogReadV1::Verified(remote) => *remote,
+            StrictSemanticallyBoundRemoteCatalogReadV1::Incomplete(incomplete) => {
+                return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::Catalog(incomplete),
+                ));
+            }
+        };
+    let local = match pending.revalidate_inventory_c()? {
+        StrictLocalSnapshotFinishV1::Complete(local) => local,
+        StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
+            return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::Local(incomplete),
+            ));
+        }
+    };
+    let (git_topology, local) = match pending_git {
+        Some(git) => match git.revalidate_after_external_reads(local) {
+            StrictGitRawTopologyFinishV1::Held { topology, local } => (Some(topology), local),
+            StrictGitRawTopologyFinishV1::Incomplete(incomplete) => {
+                return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+                ));
+            }
+        },
+        None => (None, local),
+    };
+    if let Some(git) = &git_topology {
+        if let Err(incomplete) = git.revalidate_capabilities() {
+            return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+            ));
+        }
+    }
+
+    let expected_route = ExpectedRegisteredSourceRouteV1 {
+        canonical_local_root: &canonical_local_root,
+        canonical_state_path: &canonical_state_path,
+        remote_prefix: &selected.spec.remote_prefix,
+        profile: selected.spec.profile,
+        profile_settings_fingerprint: profile_policy.settings_fingerprint(),
+        plan_contract_fingerprint,
+    };
+    let observed_route = ObservedRegisteredSourceRouteV1 {
+        held_local_root: local.canonical_local_root(),
+        state_path: state.selected_state_path(),
+        state_local_root: state.canonical_local_root(),
+        state_remote_prefix: state.remote_prefix(),
+        remote_prefix: remote.remote_prefix(),
+        profile: local.snapshot().profile(),
+        profile_settings_fingerprint: local.snapshot().profile_settings_fingerprint(),
+        plan_contract_fingerprint: local.snapshot().plan_contract_fingerprint(),
+    };
+    if let Err(mismatch) = validate_observed_source_route_v1(&expected_route, &observed_route) {
+        return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+            StrictRegisteredRootSourcesIncompleteV1::RouteMismatch(mismatch),
+        ));
+    }
+
+    let namespace_safety_summary =
+        match compose_catalog_namespace_safety_summary_v1(&local, &state, &remote) {
+            Ok(summary) => summary,
+            Err(ComposeNamespaceSafetyErrorV1::Conflict(conflict)) => {
+                return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyConflict(conflict),
+                ));
+            }
+            Err(ComposeNamespaceSafetyErrorV1::ResourceLimit) => {
+                return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyResourceLimit,
+                ));
+            }
+            Err(ComposeNamespaceSafetyErrorV1::RemoteClaimWithoutOrigin) => {
+                return Ok(CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::RemoteClaimWithoutOrigin,
+                ));
+            }
+        };
+
+    let base = CatalogBoundRegisteredRootSourceBaseV1 {
+        root_id,
+        spec: selected.spec.clone(),
+        binding: binding.clone(),
+        spec_identity_fingerprint,
+        binding_identity_fingerprint,
+        profile_policy,
+        plan_contract,
+        canonical_state_path,
+        local,
+        state,
+        remote,
+        namespace_safety_summary,
+    };
+    match selected.spec.profile {
+        RootProfileV1::AgentStaticV1 => {
+            debug_assert!(git_topology.is_none());
+            Ok(CatalogBoundRegisteredRootSourcesReadV1::AgentStatic(
+                Box::new(CatalogBoundAgentStaticSourceObservationV1 { base }),
+            ))
+        }
+        RootProfileV1::GitRawV1 => {
+            let git_topology =
+                git_topology.expect("GitRaw acquisition retains exact topology evidence");
+            Ok(CatalogBoundRegisteredRootSourcesReadV1::GitRaw(Box::new(
+                CatalogBoundGitRawSourceObservationV1 { base, git_topology },
+            )))
+        }
+    }
+}
+
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
     use crate::registered_local_snapshot::StrictLocalSnapshotIncompleteKindV1;
+    use crate::registered_remote_catalog::tests::{
+        semantic_remote_catalog_fixture_for_test_v1,
+        semantic_remote_catalog_fixture_with_first_read_write_for_test_v1,
+        SemanticRemoteCatalogFixtureRowV1,
+    };
     use crate::registered_remote_observation::tests::{
         matching_remote_fixture_operator_v1,
         matching_remote_fixture_operator_with_first_list_write_v1,
@@ -932,6 +1377,34 @@ mod tests {
         Into<Vec<crate::reconcile::ReconcileAction>>,
         Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
         Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogBoundAgentStaticSourceObservationV1: Clone,
+        serde::Serialize,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>,
+        Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
+        Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogBoundGitRawSourceObservationV1: Clone,
+        serde::Serialize,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>,
+        Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
+        Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        CatalogBoundRegisteredRootSourcesReadV1: Clone,
+        serde::Serialize,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>,
+        Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
+        Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        SemanticallyBoundRemoteCatalogCorpusV1: Clone,
+        serde::Serialize
     );
     static_assertions::assert_not_impl_any!(
         MatchingTwoPassBoundRemoteEvidenceV1: Clone,
@@ -1029,6 +1502,65 @@ mod tests {
         .unwrap()
     }
 
+    async fn observe_catalog_fixture(
+        profile: RootProfileV1,
+        local_files: &[&str],
+        state_paths: &[&str],
+        remote_rows: &[SemanticRemoteCatalogFixtureRowV1],
+    ) -> CatalogBoundRegisteredRootSourcesReadV1 {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        if profile == RootProfileV1::GitRawV1 {
+            initialize_isolated_git_repository(&root, dir.path());
+        }
+        for rel_path in local_files {
+            let path = root.join(rel_path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"payload").unwrap();
+        }
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, &state_json(&root, state_paths));
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, profile);
+        let remote =
+            semantic_remote_catalog_fixture_for_test_v1("work", &selected.spec, remote_rows).await;
+        observe_catalog_bound_selected_registered_root_sources_for_test_v1(
+            "work",
+            &selected,
+            &root,
+            &state_path,
+            remote.operator(),
+            remote.receipt(),
+        )
+        .await
+        .unwrap()
+    }
+
+    fn initialize_isolated_git_repository(root: &Path, sandbox: &Path) {
+        let home = sandbox.join("git-home");
+        let xdg_config_home = sandbox.join("git-xdg-config");
+        let template_dir = sandbox.join("git-empty-template");
+        fs::create_dir(&home).unwrap();
+        fs::create_dir(&xdg_config_home).unwrap();
+        fs::create_dir(&template_dir).unwrap();
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["init", "--quiet", "--initial-branch=main"])
+            .env("HOME", home)
+            .env("XDG_CONFIG_HOME", xdg_config_home)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_TEMPLATE_DIR", template_dir)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
     fn observed(
         read: StrictRegisteredRootSourcesReadV1,
     ) -> Box<AgentStaticNamespaceSafetyObservationV1> {
@@ -1056,6 +1588,39 @@ mod tests {
             }
             StrictRegisteredRootSourcesReadV1::Incomplete(other) => {
                 panic!("expected a namespace-safety conflict, got {other:?}")
+            }
+        }
+    }
+
+    fn catalog_agent_observed(
+        read: CatalogBoundRegisteredRootSourcesReadV1,
+    ) -> Box<CatalogBoundAgentStaticSourceObservationV1> {
+        match read {
+            CatalogBoundRegisteredRootSourcesReadV1::AgentStatic(observed) => observed,
+            CatalogBoundRegisteredRootSourcesReadV1::GitRaw(observed) => {
+                panic!("expected catalog-bound AgentStatic sources, got GitRaw: {observed:?}")
+            }
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(incomplete) => {
+                panic!("expected catalog-bound sources, got {incomplete:?}")
+            }
+        }
+    }
+
+    fn catalog_conflict(
+        read: CatalogBoundRegisteredRootSourcesReadV1,
+    ) -> NamespaceSafetyClaimConflictV1 {
+        match read {
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyConflict(conflict),
+            ) => conflict,
+            CatalogBoundRegisteredRootSourcesReadV1::AgentStatic(_) => {
+                panic!("expected a catalog-bound namespace conflict, got AgentStatic sources")
+            }
+            CatalogBoundRegisteredRootSourcesReadV1::GitRaw(_) => {
+                panic!("expected a catalog-bound namespace conflict, got GitRaw sources")
+            }
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(other) => {
+                panic!("expected a catalog-bound namespace conflict, got {other:?}")
             }
         }
     }
@@ -1099,6 +1664,251 @@ mod tests {
                 .namespace_safety_source_claim_count(NamespaceSafetyClaimSourceV1::LocalCurrent),
             0
         );
+    }
+
+    #[tokio::test]
+    async fn catalog_bound_agent_static_retains_one_closed_empty_revision_without_plan() {
+        let observed = catalog_agent_observed(
+            observe_catalog_fixture(RootProfileV1::AgentStaticV1, &[], &[], &[]).await,
+        );
+        assert_eq!(observed.root_id(), "work");
+        assert_eq!(observed.remote_prefix(), "roots");
+        assert_eq!(observed.catalog_sequence(), 1);
+        assert_eq!(observed.namespace_safety_claim_count(), 0);
+        assert_eq!(
+            observed
+                .namespace_safety_source_claim_count(NamespaceSafetyClaimSourceV1::RemoteCurrent),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_bound_claims_join_local_state_and_remote_in_one_lattice() {
+        let observed = catalog_agent_observed(
+            observe_catalog_fixture(
+                RootProfileV1::AgentStaticV1,
+                &["same"],
+                &["same"],
+                &[SemanticRemoteCatalogFixtureRowV1::CurrentFile(
+                    "same".to_owned(),
+                )],
+            )
+            .await,
+        );
+        assert_eq!(observed.namespace_safety_claim_count(), 1);
+        for source in [
+            NamespaceSafetyClaimSourceV1::LocalCurrent,
+            NamespaceSafetyClaimSourceV1::StateBaseline,
+            NamespaceSafetyClaimSourceV1::RemoteCurrent,
+        ] {
+            assert_eq!(observed.namespace_safety_source_claim_count(source), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_bound_cross_source_alias_fails_closed() {
+        let conflict = catalog_conflict(
+            observe_catalog_fixture(
+                RootProfileV1::AgentStaticV1,
+                &["Readme"],
+                &[],
+                &[SemanticRemoteCatalogFixtureRowV1::CurrentFile(
+                    "README".to_owned(),
+                )],
+            )
+            .await,
+        );
+        assert_eq!(
+            conflict.kind(),
+            NamespaceSafetyClaimConflictKindV1::FoldedSpellingAlias
+        );
+        assert_eq!(
+            conflict.first_source(),
+            NamespaceSafetyClaimSourceV1::LocalCurrent
+        );
+        assert_eq!(
+            conflict.conflicting_source(),
+            NamespaceSafetyClaimSourceV1::RemoteCurrent
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_reads_remain_inside_local_inventory_a_c_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join("guard"), b"before").unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::AgentStaticV1);
+        let remote = semantic_remote_catalog_fixture_with_first_read_write_for_test_v1(
+            "work",
+            &selected.spec,
+            &[],
+            root.join("guard"),
+            b"after".to_vec(),
+        )
+        .await;
+
+        match observe_catalog_bound_selected_registered_root_sources_for_test_v1(
+            "work",
+            &selected,
+            &root,
+            &state_path,
+            remote.operator(),
+            remote.receipt(),
+        )
+        .await
+        .unwrap()
+        {
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::Local(incomplete),
+            ) if incomplete.kind() == StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead => {}
+            other => {
+                let _ = other;
+                panic!("catalog-window local mutation must fail at inventory C");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_bound_git_raw_retains_the_exact_acquisition_shadow() {
+        let observed = match observe_catalog_fixture(RootProfileV1::GitRawV1, &[], &[], &[]).await {
+            CatalogBoundRegisteredRootSourcesReadV1::GitRaw(observed) => observed,
+            CatalogBoundRegisteredRootSourcesReadV1::AgentStatic(_) => {
+                panic!("expected catalog-bound GitRaw sources")
+            }
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(incomplete) => {
+                panic!("expected catalog-bound GitRaw sources, got {incomplete:?}")
+            }
+        };
+        assert_eq!(observed.root_id(), "work");
+        assert_eq!(observed.remote_prefix(), "roots");
+        assert_eq!(observed.catalog_sequence(), 1);
+        assert_eq!(
+            observed.git_topology().head().symbolic_target(),
+            Some("refs/heads/main")
+        );
+    }
+
+    #[tokio::test]
+    async fn catalog_bound_git_raw_rejects_head_change_inside_catalog_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        initialize_isolated_git_repository(&root, dir.path());
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::GitRawV1);
+        let remote = semantic_remote_catalog_fixture_with_first_read_write_for_test_v1(
+            "work",
+            &selected.spec,
+            &[],
+            root.join(".git/HEAD"),
+            b"ref: refs/heads/other\n".to_vec(),
+        )
+        .await;
+
+        match observe_catalog_bound_selected_registered_root_sources_for_test_v1(
+            "work",
+            &selected,
+            &root,
+            &state_path,
+            remote.operator(),
+            remote.receipt(),
+        )
+        .await
+        .unwrap()
+        {
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::Local(incomplete),
+            ) if incomplete.kind() == StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead => {}
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+            ) if incomplete.kind()
+                == crate::registered_git_topology::StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged => {
+            }
+            other => {
+                let _ = other;
+                panic!("Git HEAD mutation during the catalog window must fail closed");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn catalog_bound_composition_rejects_a_receipt_for_another_accessor() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::AgentStaticV1);
+        let remote = semantic_remote_catalog_fixture_for_test_v1("work", &selected.spec, &[]).await;
+        let other = semantic_remote_catalog_fixture_for_test_v1("work", &selected.spec, &[]).await;
+
+        assert!(matches!(
+            observe_catalog_bound_selected_registered_root_sources_for_test_v1(
+                "work",
+                &selected,
+                &root,
+                &state_path,
+                remote.operator(),
+                other.receipt(),
+            )
+            .await
+            .unwrap(),
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::Catalog(
+                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::Catalog(
+                        crate::registered_remote_catalog::StrictRemoteCatalogIncompleteV1::StorageSemanticsUnverified
+                    )
+                )
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn catalog_bound_composition_rejects_catalog_route_context_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::AgentStaticV1);
+        let mut other_spec = selected.spec.clone();
+        other_spec.generation = NonZeroU64::new(2).unwrap();
+        let remote = semantic_remote_catalog_fixture_for_test_v1("work", &other_spec, &[]).await;
+
+        assert!(matches!(
+            observe_catalog_bound_selected_registered_root_sources_for_test_v1(
+                "work",
+                &selected,
+                &root,
+                &state_path,
+                remote.operator(),
+                remote.receipt(),
+            )
+            .await
+            .unwrap(),
+            CatalogBoundRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::Catalog(
+                    StrictSemanticallyBoundRemoteCatalogIncompleteV1::Catalog(
+                        crate::registered_remote_catalog::StrictRemoteCatalogIncompleteV1::Invalid {
+                            kind: crate::registered_remote_catalog::RemoteCatalogClosureObjectKindV1::Head,
+                            reason: crate::registered_remote_catalog::InvalidRemoteCatalogReasonV1::Context,
+                        }
+                    )
+                )
+            )
+        ));
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/registered_source_composition.rs
+++ b/crates/tcfs-sync/src/registered_source_composition.rs
@@ -18,6 +18,10 @@ use tcfs_core::config::{
 };
 
 use crate::index_entry::PortableNamespaceRole;
+use crate::registered_git_topology::{
+    begin_strict_git_raw_topology_v1, HeldStrictGitRawTopologyV1, StrictGitRawTopologyBeginV1,
+    StrictGitRawTopologyFinishV1, StrictGitRawTopologyIncompleteV1,
+};
 use crate::registered_local_snapshot::{
     begin_strict_local_snapshot_v1, RevalidatedStrictLocalSnapshotV1, StrictLocalNamespaceRoleV1,
     StrictLocalSnapshotFinishV1, StrictLocalSnapshotHoldReadV1, StrictLocalSnapshotIncompleteV1,
@@ -122,11 +126,12 @@ pub(crate) enum StrictRegisteredRootSourcesIncompleteV1 {
     NamespaceSafetyConflict(NamespaceSafetyClaimConflictV1),
     NamespaceSafetyResourceLimit,
     RemoteClaimWithoutOrigin,
-    GitTopologyRequired,
+    GitTopology(StrictGitRawTopologyIncompleteV1),
 }
 
 pub(crate) enum StrictRegisteredRootSourcesReadV1 {
     Observed(Box<AgentStaticNamespaceSafetyObservationV1>),
+    GitRawLocalTopologyObserved(Box<GitRawLocalTopologyObservationV1>),
     Incomplete(StrictRegisteredRootSourcesIncompleteV1),
 }
 
@@ -293,6 +298,81 @@ impl fmt::Debug for AgentStaticNamespaceSafetyObservationV1 {
             .field("canonical_state_path", &self.canonical_state_path)
             .field("state_entry_count", &self.state.entries().len())
             .field("remote_prefix", &self.remote.remote_prefix())
+            .field(
+                "namespace_safety_claim_count",
+                &self.namespace_safety_summary.unique_claims,
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+/// Opaque, non-authoritative observation of one GitRaw selected root.
+///
+/// The local Git topology and sorted refs were descriptor-anchored and equal
+/// across two bounded passes, but remote Git semantics, catalog authority,
+/// bootstrap, high-water, and writer fencing are still absent. This type must
+/// not gain a plan digest or action projection.
+pub(crate) struct GitRawLocalTopologyObservationV1 {
+    root_id: String,
+    spec: RootSpecV1Config,
+    binding: RootBindingV1Config,
+    spec_identity_fingerprint: String,
+    binding_identity_fingerprint: String,
+    profile_policy: RootProfilePolicyV1,
+    plan_contract: RegisteredRootPlanContractV1,
+    canonical_state_path: PathBuf,
+    local: RevalidatedStrictLocalSnapshotV1,
+    state: StrictPrimaryStateSnapshotV1,
+    remote: MatchingTwoPassBoundRemoteEvidenceV1,
+    git_topology: HeldStrictGitRawTopologyV1,
+    namespace_safety_summary: NamespaceSafetySummaryV1,
+}
+
+impl GitRawLocalTopologyObservationV1 {
+    pub(crate) fn root_id(&self) -> &str {
+        &self.root_id
+    }
+
+    pub(crate) fn canonical_local_root(&self) -> &Path {
+        self.local.canonical_local_root()
+    }
+
+    pub(crate) fn canonical_state_path(&self) -> &Path {
+        &self.canonical_state_path
+    }
+
+    pub(crate) fn remote_prefix(&self) -> &str {
+        &self.spec.remote_prefix
+    }
+
+    pub(crate) const fn namespace_safety_claim_count(&self) -> u64 {
+        self.namespace_safety_summary.unique_claims
+    }
+
+    pub(crate) fn git_topology(&self) -> &HeldStrictGitRawTopologyV1 {
+        &self.git_topology
+    }
+}
+
+impl fmt::Debug for GitRawLocalTopologyObservationV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GitRawLocalTopologyObservationV1")
+            .field("root_id", &self.root_id)
+            .field("spec", &self.spec)
+            .field("binding", &self.binding)
+            .field("spec_identity_fingerprint", &self.spec_identity_fingerprint)
+            .field(
+                "binding_identity_fingerprint",
+                &self.binding_identity_fingerprint,
+            )
+            .field("profile_policy", &self.profile_policy)
+            .field("plan_contract", &self.plan_contract)
+            .field("canonical_local_root", &self.local.canonical_local_root())
+            .field("canonical_state_path", &self.canonical_state_path)
+            .field("state_entry_count", &self.state.entries().len())
+            .field("remote_prefix", &self.remote.remote_prefix())
+            .field("git_topology", &self.git_topology)
             .field(
                 "namespace_safety_claim_count",
                 &self.namespace_safety_summary.unique_claims,
@@ -670,6 +750,18 @@ async fn observe_validated_registered_root_sources_v1(
                 ));
             }
         };
+    let pending_git = if selected.spec.profile == RootProfileV1::GitRawV1 {
+        match begin_strict_git_raw_topology_v1(&pending) {
+            StrictGitRawTopologyBeginV1::Pending(git) => Some(*git),
+            StrictGitRawTopologyBeginV1::Incomplete(incomplete) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+                ));
+            }
+        }
+    } else {
+        None
+    };
     let state = match read_and_bind_strict_primary_state_for_pending_root_v1(
         &canonical_state_path,
         &pending,
@@ -691,6 +783,17 @@ async fn observe_validated_registered_root_sources_v1(
                 ));
             }
         };
+    let git_topology = match pending_git {
+        Some(git) => match git.revalidate_after_external_reads() {
+            StrictGitRawTopologyFinishV1::Held(git) => Some(git),
+            StrictGitRawTopologyFinishV1::Incomplete(incomplete) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+                ));
+            }
+        },
+        None => None,
+    };
     let local = match pending.revalidate_inventory_c()? {
         StrictLocalSnapshotFinishV1::Complete(local) => local,
         StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
@@ -699,6 +802,13 @@ async fn observe_validated_registered_root_sources_v1(
             ));
         }
     };
+    if let Some(git) = &git_topology {
+        if let Err(incomplete) = git.revalidate_capabilities() {
+            return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+            ));
+        }
+    }
 
     let expected_route = ExpectedRegisteredSourceRouteV1 {
         canonical_local_root: &canonical_local_root,
@@ -724,50 +834,70 @@ async fn observe_validated_registered_root_sources_v1(
         ));
     }
 
-    let namespace_safety_summary = match selected.spec.profile {
-        RootProfileV1::GitRawV1 => {
-            return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
-                StrictRegisteredRootSourcesIncompleteV1::GitTopologyRequired,
-            ));
-        }
-        RootProfileV1::AgentStaticV1 => {
-            match compose_namespace_safety_summary_v1(&local, &state, &remote) {
-                Ok(summary) => summary,
-                Err(ComposeNamespaceSafetyErrorV1::Conflict(conflict)) => {
-                    return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
-                        StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyConflict(conflict),
-                    ));
-                }
-                Err(ComposeNamespaceSafetyErrorV1::ResourceLimit) => {
-                    return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
-                        StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyResourceLimit,
-                    ));
-                }
-                Err(ComposeNamespaceSafetyErrorV1::RemoteClaimWithoutOrigin) => {
-                    return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
-                        StrictRegisteredRootSourcesIncompleteV1::RemoteClaimWithoutOrigin,
-                    ));
-                }
+    let namespace_safety_summary =
+        match compose_namespace_safety_summary_v1(&local, &state, &remote) {
+            Ok(summary) => summary,
+            Err(ComposeNamespaceSafetyErrorV1::Conflict(conflict)) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyConflict(conflict),
+                ));
             }
-        }
-    };
+            Err(ComposeNamespaceSafetyErrorV1::ResourceLimit) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyResourceLimit,
+                ));
+            }
+            Err(ComposeNamespaceSafetyErrorV1::RemoteClaimWithoutOrigin) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::RemoteClaimWithoutOrigin,
+                ));
+            }
+        };
 
-    Ok(StrictRegisteredRootSourcesReadV1::Observed(Box::new(
-        AgentStaticNamespaceSafetyObservationV1 {
-            root_id,
-            spec: selected.spec.clone(),
-            binding: binding.clone(),
-            spec_identity_fingerprint,
-            binding_identity_fingerprint,
-            profile_policy,
-            plan_contract,
-            canonical_state_path,
-            local,
-            state,
-            remote,
-            namespace_safety_summary,
-        },
-    )))
+    match selected.spec.profile {
+        RootProfileV1::AgentStaticV1 => {
+            debug_assert!(git_topology.is_none());
+            Ok(StrictRegisteredRootSourcesReadV1::Observed(Box::new(
+                AgentStaticNamespaceSafetyObservationV1 {
+                    root_id,
+                    spec: selected.spec.clone(),
+                    binding: binding.clone(),
+                    spec_identity_fingerprint,
+                    binding_identity_fingerprint,
+                    profile_policy,
+                    plan_contract,
+                    canonical_state_path,
+                    local,
+                    state,
+                    remote,
+                    namespace_safety_summary,
+                },
+            )))
+        }
+        RootProfileV1::GitRawV1 => {
+            let git_topology =
+                git_topology.expect("GitRaw acquisition retains exact topology evidence");
+            Ok(
+                StrictRegisteredRootSourcesReadV1::GitRawLocalTopologyObserved(Box::new(
+                    GitRawLocalTopologyObservationV1 {
+                        root_id,
+                        spec: selected.spec.clone(),
+                        binding: binding.clone(),
+                        spec_identity_fingerprint,
+                        binding_identity_fingerprint,
+                        profile_policy,
+                        plan_contract,
+                        canonical_state_path,
+                        local,
+                        state,
+                        remote,
+                        git_topology,
+                        namespace_safety_summary,
+                    },
+                )),
+            )
+        }
+    }
 }
 
 #[cfg(all(test, target_os = "linux"))]
@@ -775,18 +905,25 @@ mod tests {
     use super::*;
     use crate::registered_local_snapshot::StrictLocalSnapshotIncompleteKindV1;
     use crate::registered_remote_observation::tests::{
-        matching_remote_fixture_operator_v1, missing_remote_index_fixture_operator_v1,
-        RemoteNamespaceFixtureRowV1,
+        matching_remote_fixture_operator_v1,
+        matching_remote_fixture_operator_with_first_list_write_v1,
+        missing_remote_index_fixture_operator_v1, RemoteNamespaceFixtureRowV1,
     };
     use std::fs;
     use std::num::NonZeroU64;
     use std::os::unix::fs::PermissionsExt;
-    use tcfs_core::config::{
-        RegisteredRootPolicy, RootBindingV1Config, RootLifecyclePolicyV1, RootSpecV1Config,
-    };
+    use tcfs_core::config::{RegisteredRootPolicy, RootLifecyclePolicyV1};
 
     static_assertions::assert_not_impl_any!(
         AgentStaticNamespaceSafetyObservationV1: Clone,
+        serde::Serialize,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>,
+        Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
+        Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        GitRawLocalTopologyObservationV1: Clone,
         serde::Serialize,
         Into<crate::reconcile::ReconcilePlan>,
         Into<Vec<crate::reconcile::ReconcileAction>>,
@@ -894,6 +1031,9 @@ mod tests {
     ) -> Box<AgentStaticNamespaceSafetyObservationV1> {
         match read {
             StrictRegisteredRootSourcesReadV1::Observed(observed) => observed,
+            StrictRegisteredRootSourcesReadV1::GitRawLocalTopologyObserved(observed) => {
+                panic!("expected AgentStatic sources, got GitRaw sources: {observed:?}")
+            }
             StrictRegisteredRootSourcesReadV1::Incomplete(incomplete) => {
                 panic!("expected observed sources, got {incomplete:?}")
             }
@@ -907,6 +1047,9 @@ mod tests {
             ) => conflict,
             StrictRegisteredRootSourcesReadV1::Observed(_) => {
                 panic!("expected a namespace-safety conflict, got observed sources")
+            }
+            StrictRegisteredRootSourcesReadV1::GitRawLocalTopologyObserved(_) => {
+                panic!("expected a namespace-safety conflict, got GitRaw sources")
             }
             StrictRegisteredRootSourcesReadV1::Incomplete(other) => {
                 panic!("expected a namespace-safety conflict, got {other:?}")
@@ -936,6 +1079,9 @@ mod tests {
         .unwrap()
         {
             StrictRegisteredRootSourcesReadV1::Observed(observed) => observed,
+            StrictRegisteredRootSourcesReadV1::GitRawLocalTopologyObserved(observed) => {
+                panic!("expected AgentStatic sources, got GitRaw sources: {observed:?}")
+            }
             StrictRegisteredRootSourcesReadV1::Incomplete(incomplete) => {
                 panic!("expected observed sources, got {incomplete:?}")
             }
@@ -953,31 +1099,105 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn git_raw_without_held_topology_is_typed_incomplete_without_plan() {
+    async fn git_raw_retains_held_local_topology_without_plan() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("root");
-        fs::create_dir_all(root.join(".git")).unwrap();
-        fs::write(root.join(".git/HEAD"), b"ref: refs/heads/main\n").unwrap();
+        fs::create_dir(&root).unwrap();
+        let status = std::process::Command::new("git")
+            .args([
+                "-C",
+                root.to_str().unwrap(),
+                "init",
+                "--quiet",
+                "--initial-branch=main",
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success());
         let root = fs::canonicalize(root).unwrap();
         let state_path = dir.path().join("state.json");
         write_private(&state_path, empty_state_json());
         let state_path = fs::canonicalize(state_path).unwrap();
         let selected = selected_root(&root, &state_path, RootProfileV1::GitRawV1);
 
-        assert!(matches!(
-            observe_selected_registered_root_sources_for_test_v1(
-                "work",
-                &selected,
-                &root,
-                &state_path,
-                &matching_remote_fixture_operator_v1(&[]),
-            )
-            .await
-            .unwrap(),
+        let observed = match observe_selected_registered_root_sources_for_test_v1(
+            "work",
+            &selected,
+            &root,
+            &state_path,
+            &matching_remote_fixture_operator_v1(&[]),
+        )
+        .await
+        .unwrap()
+        {
+            StrictRegisteredRootSourcesReadV1::GitRawLocalTopologyObserved(observed) => observed,
+            StrictRegisteredRootSourcesReadV1::Observed(_) => {
+                panic!("expected GitRaw local topology, got AgentStatic sources")
+            }
+            StrictRegisteredRootSourcesReadV1::Incomplete(incomplete) => {
+                panic!("expected GitRaw local topology, got {incomplete:?}")
+            }
+        };
+        assert_eq!(observed.root_id(), "work");
+        assert_eq!(observed.canonical_local_root(), root);
+        assert_eq!(observed.canonical_state_path(), state_path);
+        assert_eq!(observed.remote_prefix(), "roots");
+        assert_eq!(
+            observed.git_topology().head().symbolic_target(),
+            Some("refs/heads/main")
+        );
+        assert_eq!(observed.git_topology().refs().len(), 0);
+        assert!(observed.namespace_safety_claim_count() > 0);
+    }
+
+    #[tokio::test]
+    async fn git_topology_brackets_remote_reads_before_local_inventory_c() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let status = std::process::Command::new("git")
+            .args([
+                "-C",
+                root.to_str().unwrap(),
+                "init",
+                "--quiet",
+                "--initial-branch=main",
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::GitRawV1);
+        let remote = matching_remote_fixture_operator_with_first_list_write_v1(
+            &[],
+            root.join(".git/HEAD"),
+            b"ref: refs/heads/other\n".to_vec(),
+        );
+
+        match observe_selected_registered_root_sources_for_test_v1(
+            "work",
+            &selected,
+            &root,
+            &state_path,
+            &remote,
+        )
+        .await
+        .unwrap()
+        {
             StrictRegisteredRootSourcesReadV1::Incomplete(
-                StrictRegisteredRootSourcesIncompleteV1::GitTopologyRequired
-            )
-        ));
+                StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+            ) if incomplete.kind()
+                == crate::registered_git_topology::StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged =>
+            {
+            }
+            other => {
+                let _ = other;
+                panic!("remote-window Git mutation must fail at topology B");
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/registered_source_composition.rs
+++ b/crates/tcfs-sync/src/registered_source_composition.rs
@@ -308,10 +308,13 @@ impl fmt::Debug for AgentStaticNamespaceSafetyObservationV1 {
 
 /// Opaque, non-authoritative observation of one GitRaw selected root.
 ///
-/// The local Git topology and sorted refs were descriptor-anchored and equal
-/// across two bounded passes, but remote Git semantics, catalog authority,
-/// bootstrap, high-water, and writer fencing are still absent. This type must
-/// not gain a plan digest or action projection.
+/// The local Git config, HEAD, and sorted refs were captured through the held
+/// root into process-owned bytes and derived identically twice without
+/// reopening live config, HEAD, or ref contents. Inventory C and the held root
+/// and `.git` identities are still revalidated. Object semantics, remote Git
+/// semantics, catalog authority, bootstrap, high-water, and an execution-time
+/// writer fence are absent. This type must not gain a plan digest or action
+/// projection.
 pub(crate) struct GitRawLocalTopologyObservationV1 {
     root_id: String,
     spec: RootSpecV1Config,
@@ -741,7 +744,7 @@ async fn observe_validated_registered_root_sources_v1(
             }
         };
 
-    let pending =
+    let mut pending =
         match begin_strict_local_snapshot_v1(&canonical_local_root, selected.spec.profile)? {
             StrictLocalSnapshotHoldReadV1::Pending(pending) => pending,
             StrictLocalSnapshotHoldReadV1::Incomplete(incomplete) => {
@@ -751,7 +754,7 @@ async fn observe_validated_registered_root_sources_v1(
             }
         };
     let pending_git = if selected.spec.profile == RootProfileV1::GitRawV1 {
-        match begin_strict_git_raw_topology_v1(&pending) {
+        match begin_strict_git_raw_topology_v1(&mut pending) {
             StrictGitRawTopologyBeginV1::Pending(git) => Some(*git),
             StrictGitRawTopologyBeginV1::Incomplete(incomplete) => {
                 return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
@@ -783,17 +786,6 @@ async fn observe_validated_registered_root_sources_v1(
                 ));
             }
         };
-    let git_topology = match pending_git {
-        Some(git) => match git.revalidate_after_external_reads() {
-            StrictGitRawTopologyFinishV1::Held(git) => Some(git),
-            StrictGitRawTopologyFinishV1::Incomplete(incomplete) => {
-                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
-                    StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
-                ));
-            }
-        },
-        None => None,
-    };
     let local = match pending.revalidate_inventory_c()? {
         StrictLocalSnapshotFinishV1::Complete(local) => local,
         StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
@@ -801,6 +793,17 @@ async fn observe_validated_registered_root_sources_v1(
                 StrictRegisteredRootSourcesIncompleteV1::Local(incomplete),
             ));
         }
+    };
+    let (git_topology, local) = match pending_git {
+        Some(git) => match git.revalidate_after_external_reads(local) {
+            StrictGitRawTopologyFinishV1::Held { topology, local } => (Some(topology), local),
+            StrictGitRawTopologyFinishV1::Incomplete(incomplete) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
+                ));
+            }
+        },
+        None => (None, local),
     };
     if let Some(git) = &git_topology {
         if let Err(incomplete) = git.revalidate_capabilities() {
@@ -1151,7 +1154,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn git_topology_brackets_remote_reads_before_local_inventory_c() {
+    async fn local_inventory_c_brackets_remote_reads_before_git_shadow_promotion() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("root");
         fs::create_dir(&root).unwrap();
@@ -1188,14 +1191,11 @@ mod tests {
         .unwrap()
         {
             StrictRegisteredRootSourcesReadV1::Incomplete(
-                StrictRegisteredRootSourcesIncompleteV1::GitTopology(incomplete),
-            ) if incomplete.kind()
-                == crate::registered_git_topology::StrictGitRawTopologyIncompleteKindV1::ReferenceSetChanged =>
-            {
-            }
+                StrictRegisteredRootSourcesIncompleteV1::Local(incomplete),
+            ) if incomplete.kind() == StrictLocalSnapshotIncompleteKindV1::ChangedDuringRead => {}
             other => {
                 let _ = other;
-                panic!("remote-window Git mutation must fail at topology B");
+                panic!("remote-window Git mutation must fail at local inventory C");
             }
         }
     }

--- a/crates/tcfs-sync/src/registered_source_composition.rs
+++ b/crates/tcfs-sync/src/registered_source_composition.rs
@@ -1,0 +1,1553 @@
+//! Held-window composition for one selected registered root.
+//!
+//! This module deliberately stops before planning. Matching remote A/B passes
+//! are non-atomic observation evidence, and namespace-safety history is not an
+//! actionable payload projection. The opaque artifact below therefore exposes
+//! no digest, serialization, clone, or action conversion.
+
+use anyhow::Result;
+use opendal::Operator;
+use std::fmt;
+use std::path::{Path, PathBuf};
+#[cfg(test)]
+use tcfs_core::config::expand_tilde;
+use tcfs_core::config::{
+    RegisteredRootPlanContractFingerprintV1, RegisteredRootPlanContractV1, RegisteredRootV1Config,
+    RootBindingV1Config, RootProfilePolicyV1, RootProfileSettingsFingerprintV1, RootProfileV1,
+    RootSpecV1Config,
+};
+
+use crate::index_entry::PortableNamespaceRole;
+use crate::registered_local_snapshot::{
+    begin_strict_local_snapshot_v1, RevalidatedStrictLocalSnapshotV1, StrictLocalNamespaceRoleV1,
+    StrictLocalSnapshotFinishV1, StrictLocalSnapshotHoldReadV1, StrictLocalSnapshotIncompleteV1,
+};
+use crate::registered_reconcile::{
+    read_and_bind_strict_primary_state_for_pending_root_v1, StrictPrimaryStateIncompleteV1,
+    StrictPrimaryStateReadV1, StrictPrimaryStateSnapshotV1,
+};
+use crate::registered_remote_observation::{
+    read_bound_remote_observation_two_pass_v1, MatchingTwoPassBoundRemoteEvidenceV1,
+    RemoteNamespaceClaimOriginsV1, StrictBoundRemoteObservationIncompleteV1,
+    StrictBoundRemoteObservationReadV1,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NamespaceSafetyClaimSourceV1 {
+    LocalCurrent,
+    StateBaseline,
+    RemoteCurrent,
+    RemoteHistorical,
+    RemoteReservation,
+}
+
+/// Fixed-size result of validating the three already-bounded claim sources.
+///
+/// The composer deliberately does not retain a second owned union of paths.
+/// Remote history and reservations are counted here as namespace-safety
+/// evidence, but this summary is not a payload or action projection.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct NamespaceSafetySummaryV1 {
+    unique_claims: u64,
+    unique_claim_bytes: u64,
+    local_current_claims: u64,
+    state_baseline_claims: u64,
+    remote_current_claims: u64,
+    remote_historical_claims: u64,
+    remote_reservation_claims: u64,
+}
+
+impl NamespaceSafetySummaryV1 {
+    #[cfg(test)]
+    const fn source_claim_count(self, source: NamespaceSafetyClaimSourceV1) -> u64 {
+        match source {
+            NamespaceSafetyClaimSourceV1::LocalCurrent => self.local_current_claims,
+            NamespaceSafetyClaimSourceV1::StateBaseline => self.state_baseline_claims,
+            NamespaceSafetyClaimSourceV1::RemoteCurrent => self.remote_current_claims,
+            NamespaceSafetyClaimSourceV1::RemoteHistorical => self.remote_historical_claims,
+            NamespaceSafetyClaimSourceV1::RemoteReservation => self.remote_reservation_claims,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NamespaceSafetyClaimConflictKindV1 {
+    FoldedSpellingAlias,
+    FileDirectoryRole,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NamespaceSafetyClaimConflictV1 {
+    kind: NamespaceSafetyClaimConflictKindV1,
+    first_source: NamespaceSafetyClaimSourceV1,
+    conflicting_source: NamespaceSafetyClaimSourceV1,
+}
+
+impl NamespaceSafetyClaimConflictV1 {
+    pub(crate) const fn kind(self) -> NamespaceSafetyClaimConflictKindV1 {
+        self.kind
+    }
+
+    pub(crate) const fn first_source(self) -> NamespaceSafetyClaimSourceV1 {
+        self.first_source
+    }
+
+    pub(crate) const fn conflicting_source(self) -> NamespaceSafetyClaimSourceV1 {
+        self.conflicting_source
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RegisteredSourceRouteMismatchV1 {
+    ConfiguredLocalRoot,
+    ConfiguredStatePath,
+    HeldLocalRoot,
+    StatePath,
+    StateLocalRoot,
+    StateRemotePrefix,
+    RemotePrefix,
+    Profile,
+    ProfileSettingsFingerprint,
+    PlanContractFingerprint,
+}
+
+#[derive(Debug)]
+pub(crate) enum StrictRegisteredRootSourcesIncompleteV1 {
+    InvalidSelectedRoot,
+    BindingMissing,
+    RouteMismatch(RegisteredSourceRouteMismatchV1),
+    Local(StrictLocalSnapshotIncompleteV1),
+    State(StrictPrimaryStateIncompleteV1),
+    Remote(StrictBoundRemoteObservationIncompleteV1),
+    NamespaceSafetyConflict(NamespaceSafetyClaimConflictV1),
+    NamespaceSafetyResourceLimit,
+    RemoteClaimWithoutOrigin,
+    GitTopologyRequired,
+}
+
+pub(crate) enum StrictRegisteredRootSourcesReadV1 {
+    Observed(Box<AgentStaticNamespaceSafetyObservationV1>),
+    Incomplete(StrictRegisteredRootSourcesIncompleteV1),
+}
+
+/// Opaque proof that the daemon-owned selector authenticated one exact
+/// root-registry entry and its runtime-canonical host binding.
+///
+/// This module intentionally provides no production constructor yet. The
+/// eventual daemon integration must move or expose construction behind the
+/// selector that owns authorization, overlap, ownership, ACL, and state-fence
+/// checks; raw config plus path arguments are not an authority capability.
+struct ValidatedSelectedRegisteredRootRouteV1 {
+    root_id: String,
+    selected: RegisteredRootV1Config,
+    canonical_local_root: PathBuf,
+    canonical_state_path: PathBuf,
+}
+
+/// Opaque, non-authoritative observation of one AgentStatic selected root.
+///
+/// The retained inputs prove their own acquisition properties and keep the
+/// local root descriptor alive. They do not prove a transactionally complete
+/// remote universe. This type must not gain a plan digest or action projection.
+pub(crate) struct AgentStaticNamespaceSafetyObservationV1 {
+    root_id: String,
+    spec: RootSpecV1Config,
+    binding: RootBindingV1Config,
+    spec_identity_fingerprint: String,
+    binding_identity_fingerprint: String,
+    profile_policy: RootProfilePolicyV1,
+    plan_contract: RegisteredRootPlanContractV1,
+    canonical_state_path: PathBuf,
+    local: RevalidatedStrictLocalSnapshotV1,
+    state: StrictPrimaryStateSnapshotV1,
+    remote: MatchingTwoPassBoundRemoteEvidenceV1,
+    namespace_safety_summary: NamespaceSafetySummaryV1,
+}
+
+impl AgentStaticNamespaceSafetyObservationV1 {
+    pub(crate) fn root_id(&self) -> &str {
+        &self.root_id
+    }
+
+    pub(crate) fn canonical_local_root(&self) -> &Path {
+        self.local.canonical_local_root()
+    }
+
+    pub(crate) fn canonical_state_path(&self) -> &Path {
+        &self.canonical_state_path
+    }
+
+    pub(crate) fn remote_prefix(&self) -> &str {
+        &self.spec.remote_prefix
+    }
+
+    pub(crate) const fn namespace_safety_claim_count(&self) -> u64 {
+        self.namespace_safety_summary.unique_claims
+    }
+
+    #[cfg(test)]
+    const fn namespace_safety_source_claim_count(
+        &self,
+        source: NamespaceSafetyClaimSourceV1,
+    ) -> u64 {
+        self.namespace_safety_summary.source_claim_count(source)
+    }
+}
+
+impl fmt::Debug for AgentStaticNamespaceSafetyObservationV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AgentStaticNamespaceSafetyObservationV1")
+            .field("root_id", &self.root_id)
+            .field("spec", &self.spec)
+            .field("binding", &self.binding)
+            .field("spec_identity_fingerprint", &self.spec_identity_fingerprint)
+            .field(
+                "binding_identity_fingerprint",
+                &self.binding_identity_fingerprint,
+            )
+            .field("profile_policy", &self.profile_policy)
+            .field("plan_contract", &self.plan_contract)
+            .field("canonical_local_root", &self.local.canonical_local_root())
+            .field("canonical_state_path", &self.canonical_state_path)
+            .field("state_entry_count", &self.state.entries().len())
+            .field("remote_prefix", &self.remote.remote_prefix())
+            .field(
+                "namespace_safety_claim_count",
+                &self.namespace_safety_summary.unique_claims,
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+struct ExpectedRegisteredSourceRouteV1<'a> {
+    canonical_local_root: &'a Path,
+    canonical_state_path: &'a Path,
+    remote_prefix: &'a str,
+    profile: RootProfileV1,
+    profile_settings_fingerprint: RootProfileSettingsFingerprintV1,
+    plan_contract_fingerprint: RegisteredRootPlanContractFingerprintV1,
+}
+
+struct ObservedRegisteredSourceRouteV1<'a> {
+    held_local_root: &'a Path,
+    state_path: &'a Path,
+    state_local_root: &'a Path,
+    state_remote_prefix: &'a str,
+    remote_prefix: &'a str,
+    profile: RootProfileV1,
+    profile_settings_fingerprint: RootProfileSettingsFingerprintV1,
+    plan_contract_fingerprint: RegisteredRootPlanContractFingerprintV1,
+}
+
+fn validate_observed_source_route_v1(
+    expected: &ExpectedRegisteredSourceRouteV1<'_>,
+    observed: &ObservedRegisteredSourceRouteV1<'_>,
+) -> std::result::Result<(), RegisteredSourceRouteMismatchV1> {
+    let checks = [
+        (
+            observed.held_local_root == expected.canonical_local_root,
+            RegisteredSourceRouteMismatchV1::HeldLocalRoot,
+        ),
+        (
+            observed.state_path == expected.canonical_state_path,
+            RegisteredSourceRouteMismatchV1::StatePath,
+        ),
+        (
+            observed.state_local_root == expected.canonical_local_root,
+            RegisteredSourceRouteMismatchV1::StateLocalRoot,
+        ),
+        (
+            observed.state_remote_prefix == expected.remote_prefix,
+            RegisteredSourceRouteMismatchV1::StateRemotePrefix,
+        ),
+        (
+            observed.remote_prefix == expected.remote_prefix,
+            RegisteredSourceRouteMismatchV1::RemotePrefix,
+        ),
+        (
+            observed.profile == expected.profile,
+            RegisteredSourceRouteMismatchV1::Profile,
+        ),
+        (
+            observed.profile_settings_fingerprint == expected.profile_settings_fingerprint,
+            RegisteredSourceRouteMismatchV1::ProfileSettingsFingerprint,
+        ),
+        (
+            observed.plan_contract_fingerprint == expected.plan_contract_fingerprint,
+            RegisteredSourceRouteMismatchV1::PlanContractFingerprint,
+        ),
+    ];
+    checks
+        .into_iter()
+        .find_map(|(matches, mismatch)| (!matches).then_some(mismatch))
+        .map_or(Ok(()), Err)
+}
+
+fn compare_namespace_safety_claim_v1<'a>(
+    first: &mut Option<(&'a str, PortableNamespaceRole, NamespaceSafetyClaimSourceV1)>,
+    source: NamespaceSafetyClaimSourceV1,
+    exact_path: &'a str,
+    role: PortableNamespaceRole,
+) -> std::result::Result<(), NamespaceSafetyClaimConflictV1> {
+    if let Some((first_exact_path, first_role, first_source)) = *first {
+        let kind = if first_exact_path != exact_path {
+            Some(NamespaceSafetyClaimConflictKindV1::FoldedSpellingAlias)
+        } else if first_role != role {
+            Some(NamespaceSafetyClaimConflictKindV1::FileDirectoryRole)
+        } else {
+            None
+        };
+        if let Some(kind) = kind {
+            return Err(NamespaceSafetyClaimConflictV1 {
+                kind,
+                first_source,
+                conflicting_source: source,
+            });
+        }
+        return Ok(());
+    }
+    *first = Some((exact_path, role, source));
+    Ok(())
+}
+
+fn compare_remote_namespace_safety_claim_v1<'a>(
+    first: &mut Option<(&'a str, PortableNamespaceRole, NamespaceSafetyClaimSourceV1)>,
+    exact_path: &'a str,
+    role: PortableNamespaceRole,
+    origins: RemoteNamespaceClaimOriginsV1,
+) -> std::result::Result<(), NamespaceSafetyClaimConflictV1> {
+    for (present, source) in [
+        (
+            origins.current(),
+            NamespaceSafetyClaimSourceV1::RemoteCurrent,
+        ),
+        (
+            origins.historical(),
+            NamespaceSafetyClaimSourceV1::RemoteHistorical,
+        ),
+        (
+            origins.reservation(),
+            NamespaceSafetyClaimSourceV1::RemoteReservation,
+        ),
+    ] {
+        if present {
+            compare_namespace_safety_claim_v1(first, source, exact_path, role)?;
+        }
+    }
+    Ok(())
+}
+
+enum ComposeNamespaceSafetyErrorV1 {
+    Conflict(NamespaceSafetyClaimConflictV1),
+    ResourceLimit,
+    RemoteClaimWithoutOrigin,
+}
+
+impl From<NamespaceSafetyClaimConflictV1> for ComposeNamespaceSafetyErrorV1 {
+    fn from(conflict: NamespaceSafetyClaimConflictV1) -> Self {
+        Self::Conflict(conflict)
+    }
+}
+
+fn checked_summary_increment_v1(
+    value: &mut u64,
+    increment: u64,
+) -> std::result::Result<(), ComposeNamespaceSafetyErrorV1> {
+    *value = value
+        .checked_add(increment)
+        .ok_or(ComposeNamespaceSafetyErrorV1::ResourceLimit)?;
+    Ok(())
+}
+
+fn compose_namespace_safety_summary_v1(
+    local: &RevalidatedStrictLocalSnapshotV1,
+    state: &StrictPrimaryStateSnapshotV1,
+    remote: &MatchingTwoPassBoundRemoteEvidenceV1,
+) -> std::result::Result<NamespaceSafetySummaryV1, ComposeNamespaceSafetyErrorV1> {
+    let mut local_claims = local.snapshot().namespace_claims();
+    let mut state_claims = state.namespace_claims();
+    let mut remote_claims = remote.namespace_safety_claims();
+    let mut local_current = local_claims.next();
+    let mut state_current = state_claims.next();
+    let mut remote_current = remote_claims.next();
+    let mut summary = NamespaceSafetySummaryV1::default();
+
+    while local_current.is_some() || state_current.is_some() || remote_current.is_some() {
+        let folded_path = [
+            local_current.as_ref().map(|(path, _)| *path),
+            state_current.as_ref().map(|(path, _)| *path),
+            remote_current.as_ref().map(|(path, _, _, _)| *path),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .expect("at least one ordered claim cursor is populated");
+        let take_local = local_current
+            .as_ref()
+            .is_some_and(|(path, _)| *path == folded_path);
+        let take_state = state_current
+            .as_ref()
+            .is_some_and(|(path, _)| *path == folded_path);
+        let take_remote = remote_current
+            .as_ref()
+            .is_some_and(|(path, _, _, _)| *path == folded_path);
+        let mut first = None;
+
+        if take_local {
+            let (_, claim) = local_current
+                .as_ref()
+                .expect("matching local cursor remains populated");
+            let role = match claim.role() {
+                StrictLocalNamespaceRoleV1::File => PortableNamespaceRole::File,
+                StrictLocalNamespaceRoleV1::Directory => PortableNamespaceRole::Directory,
+            };
+            compare_namespace_safety_claim_v1(
+                &mut first,
+                NamespaceSafetyClaimSourceV1::LocalCurrent,
+                claim.exact_path(),
+                role,
+            )?;
+            checked_summary_increment_v1(&mut summary.local_current_claims, 1)?;
+        }
+        if take_state {
+            let (_, claim) = state_current
+                .as_ref()
+                .expect("matching state cursor remains populated");
+            compare_namespace_safety_claim_v1(
+                &mut first,
+                NamespaceSafetyClaimSourceV1::StateBaseline,
+                claim.exact_path(),
+                claim.role(),
+            )?;
+            checked_summary_increment_v1(&mut summary.state_baseline_claims, 1)?;
+        }
+        if take_remote {
+            let (_, exact_path, role, origins) = remote_current
+                .as_ref()
+                .expect("matching remote cursor remains populated");
+            if origins.is_empty() {
+                return Err(ComposeNamespaceSafetyErrorV1::RemoteClaimWithoutOrigin);
+            }
+            compare_remote_namespace_safety_claim_v1(&mut first, exact_path, *role, *origins)?;
+            checked_summary_increment_v1(
+                &mut summary.remote_current_claims,
+                u64::from(origins.current()),
+            )?;
+            checked_summary_increment_v1(
+                &mut summary.remote_historical_claims,
+                u64::from(origins.historical()),
+            )?;
+            checked_summary_increment_v1(
+                &mut summary.remote_reservation_claims,
+                u64::from(origins.reservation()),
+            )?;
+        }
+
+        let (exact_path, _, _) =
+            first.expect("every retained claim has at least one authenticated source");
+        let unique_claim_bytes = u64::try_from(folded_path.len())
+            .ok()
+            .and_then(|folded_bytes| {
+                u64::try_from(exact_path.len())
+                    .ok()
+                    .and_then(|exact_bytes| folded_bytes.checked_add(exact_bytes))
+            })
+            .ok_or(ComposeNamespaceSafetyErrorV1::ResourceLimit)?;
+        checked_summary_increment_v1(&mut summary.unique_claims, 1)?;
+        checked_summary_increment_v1(&mut summary.unique_claim_bytes, unique_claim_bytes)?;
+        if take_local {
+            local_current = local_claims.next();
+        }
+        if take_state {
+            state_current = state_claims.next();
+        }
+        if take_remote {
+            remote_current = remote_claims.next();
+        }
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+fn canonicalize_test_route_path_v1(path: &Path, allow_missing_leaf: bool) -> Option<PathBuf> {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return Some(canonical);
+    }
+    if !allow_missing_leaf {
+        return None;
+    }
+    let parent = std::fs::canonicalize(path.parent()?).ok()?;
+    Some(parent.join(path.file_name()?))
+}
+
+#[cfg(test)]
+fn configured_path_matches_canonical_v1(
+    configured: &Path,
+    canonical: &Path,
+    allow_missing_leaf: bool,
+) -> bool {
+    canonical.is_absolute()
+        && canonicalize_test_route_path_v1(canonical, allow_missing_leaf).as_deref()
+            == Some(canonical)
+        && canonicalize_test_route_path_v1(&expand_tilde(configured), allow_missing_leaf).as_deref()
+            == Some(canonical)
+}
+
+#[cfg(test)]
+fn validated_selection_for_test_v1(
+    root_id: &str,
+    selected: &RegisteredRootV1Config,
+    canonical_local_root: &Path,
+    canonical_state_path: &Path,
+) -> std::result::Result<
+    ValidatedSelectedRegisteredRootRouteV1,
+    StrictRegisteredRootSourcesIncompleteV1,
+> {
+    if selected.validate_shape(root_id).is_err() {
+        return Err(StrictRegisteredRootSourcesIncompleteV1::InvalidSelectedRoot);
+    }
+    let Some(binding) = selected.binding.as_ref() else {
+        return Err(StrictRegisteredRootSourcesIncompleteV1::BindingMissing);
+    };
+    if !configured_path_matches_canonical_v1(&binding.local_root, canonical_local_root, false) {
+        return Err(StrictRegisteredRootSourcesIncompleteV1::RouteMismatch(
+            RegisteredSourceRouteMismatchV1::ConfiguredLocalRoot,
+        ));
+    }
+    if !configured_path_matches_canonical_v1(&binding.state_path, canonical_state_path, true) {
+        return Err(StrictRegisteredRootSourcesIncompleteV1::RouteMismatch(
+            RegisteredSourceRouteMismatchV1::ConfiguredStatePath,
+        ));
+    }
+    Ok(ValidatedSelectedRegisteredRootRouteV1 {
+        root_id: root_id.to_owned(),
+        selected: selected.clone(),
+        canonical_local_root: canonical_local_root.to_owned(),
+        canonical_state_path: canonical_state_path.to_owned(),
+    })
+}
+
+#[cfg(test)]
+async fn observe_selected_registered_root_sources_for_test_v1(
+    root_id: &str,
+    selected: &RegisteredRootV1Config,
+    canonical_local_root: &Path,
+    canonical_state_path: &Path,
+    op: &Operator,
+) -> Result<StrictRegisteredRootSourcesReadV1> {
+    let selected = match validated_selection_for_test_v1(
+        root_id,
+        selected,
+        canonical_local_root,
+        canonical_state_path,
+    ) {
+        Ok(selected) => selected,
+        Err(incomplete) => {
+            return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(incomplete));
+        }
+    };
+    observe_validated_registered_root_sources_v1(selected, op).await
+}
+
+/// Observe one daemon-validated selected-root route through one held local
+/// acquisition window.
+async fn observe_validated_registered_root_sources_v1(
+    selected_route: ValidatedSelectedRegisteredRootRouteV1,
+    op: &Operator,
+) -> Result<StrictRegisteredRootSourcesReadV1> {
+    let ValidatedSelectedRegisteredRootRouteV1 {
+        root_id,
+        selected,
+        canonical_local_root,
+        canonical_state_path,
+    } = selected_route;
+    let binding = selected
+        .binding
+        .as_ref()
+        .expect("validated selected-root capability always carries a binding");
+    let profile_policy = selected.spec.profile.policy();
+    let plan_contract = RegisteredRootPlanContractV1::strict_v1();
+    let plan_contract_fingerprint = plan_contract.fingerprint();
+    let spec_identity_fingerprint = selected.spec.identity_fingerprint(&root_id);
+    let binding_identity_fingerprint =
+        match binding.binding_fingerprint(&canonical_local_root, &canonical_state_path) {
+            Ok(fingerprint) => fingerprint,
+            Err(_) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::InvalidSelectedRoot,
+                ));
+            }
+        };
+
+    let pending =
+        match begin_strict_local_snapshot_v1(&canonical_local_root, selected.spec.profile)? {
+            StrictLocalSnapshotHoldReadV1::Pending(pending) => pending,
+            StrictLocalSnapshotHoldReadV1::Incomplete(incomplete) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::Local(incomplete),
+                ));
+            }
+        };
+    let state = match read_and_bind_strict_primary_state_for_pending_root_v1(
+        &canonical_state_path,
+        &pending,
+        &selected.spec.remote_prefix,
+    )? {
+        StrictPrimaryStateReadV1::Complete(state) => state,
+        StrictPrimaryStateReadV1::Incomplete(incomplete) => {
+            return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::State(incomplete),
+            ));
+        }
+    };
+    let remote =
+        match read_bound_remote_observation_two_pass_v1(op, &selected.spec.remote_prefix).await? {
+            StrictBoundRemoteObservationReadV1::Matched(remote) => remote,
+            StrictBoundRemoteObservationReadV1::Incomplete(incomplete) => {
+                return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::Remote(incomplete),
+                ));
+            }
+        };
+    let local = match pending.revalidate_inventory_c()? {
+        StrictLocalSnapshotFinishV1::Complete(local) => local,
+        StrictLocalSnapshotFinishV1::Incomplete(incomplete) => {
+            return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::Local(incomplete),
+            ));
+        }
+    };
+
+    let expected_route = ExpectedRegisteredSourceRouteV1 {
+        canonical_local_root: &canonical_local_root,
+        canonical_state_path: &canonical_state_path,
+        remote_prefix: &selected.spec.remote_prefix,
+        profile: selected.spec.profile,
+        profile_settings_fingerprint: profile_policy.settings_fingerprint(),
+        plan_contract_fingerprint,
+    };
+    let observed_route = ObservedRegisteredSourceRouteV1 {
+        held_local_root: local.canonical_local_root(),
+        state_path: state.selected_state_path(),
+        state_local_root: state.canonical_local_root(),
+        state_remote_prefix: state.remote_prefix(),
+        remote_prefix: remote.remote_prefix(),
+        profile: local.snapshot().profile(),
+        profile_settings_fingerprint: local.snapshot().profile_settings_fingerprint(),
+        plan_contract_fingerprint: local.snapshot().plan_contract_fingerprint(),
+    };
+    if let Err(mismatch) = validate_observed_source_route_v1(&expected_route, &observed_route) {
+        return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+            StrictRegisteredRootSourcesIncompleteV1::RouteMismatch(mismatch),
+        ));
+    }
+
+    let namespace_safety_summary = match selected.spec.profile {
+        RootProfileV1::GitRawV1 => {
+            return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::GitTopologyRequired,
+            ));
+        }
+        RootProfileV1::AgentStaticV1 => {
+            match compose_namespace_safety_summary_v1(&local, &state, &remote) {
+                Ok(summary) => summary,
+                Err(ComposeNamespaceSafetyErrorV1::Conflict(conflict)) => {
+                    return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                        StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyConflict(conflict),
+                    ));
+                }
+                Err(ComposeNamespaceSafetyErrorV1::ResourceLimit) => {
+                    return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                        StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyResourceLimit,
+                    ));
+                }
+                Err(ComposeNamespaceSafetyErrorV1::RemoteClaimWithoutOrigin) => {
+                    return Ok(StrictRegisteredRootSourcesReadV1::Incomplete(
+                        StrictRegisteredRootSourcesIncompleteV1::RemoteClaimWithoutOrigin,
+                    ));
+                }
+            }
+        }
+    };
+
+    Ok(StrictRegisteredRootSourcesReadV1::Observed(Box::new(
+        AgentStaticNamespaceSafetyObservationV1 {
+            root_id,
+            spec: selected.spec.clone(),
+            binding: binding.clone(),
+            spec_identity_fingerprint,
+            binding_identity_fingerprint,
+            profile_policy,
+            plan_contract,
+            canonical_state_path,
+            local,
+            state,
+            remote,
+            namespace_safety_summary,
+        },
+    )))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use crate::registered_local_snapshot::StrictLocalSnapshotIncompleteKindV1;
+    use crate::registered_remote_observation::tests::{
+        matching_remote_fixture_operator_v1, missing_remote_index_fixture_operator_v1,
+        RemoteNamespaceFixtureRowV1,
+    };
+    use std::fs;
+    use std::num::NonZeroU64;
+    use std::os::unix::fs::PermissionsExt;
+    use tcfs_core::config::{
+        RegisteredRootPolicy, RootBindingV1Config, RootLifecyclePolicyV1, RootSpecV1Config,
+    };
+
+    static_assertions::assert_not_impl_any!(
+        AgentStaticNamespaceSafetyObservationV1: Clone,
+        serde::Serialize,
+        Into<crate::reconcile::ReconcilePlan>,
+        Into<Vec<crate::reconcile::ReconcileAction>>,
+        Into<crate::registered_local_snapshot::StrictLocalSnapshotDigestV1>,
+        Into<crate::registered_reconcile::StrictPrimaryStateBytesDigestV1>
+    );
+    static_assertions::assert_not_impl_any!(
+        MatchingTwoPassBoundRemoteEvidenceV1: Clone,
+        serde::Serialize
+    );
+    static_assertions::assert_not_impl_any!(
+        StrictPrimaryStateSnapshotV1: Clone,
+        serde::Serialize
+    );
+
+    fn write_private(path: &Path, bytes: &[u8]) {
+        fs::write(path, bytes).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    fn empty_state_json() -> &'static [u8] {
+        br#"{"last_nats_seq":0,"device_id":"sting","entries":{}}"#
+    }
+
+    fn selected_root(
+        local_root: &Path,
+        state_path: &Path,
+        profile: RootProfileV1,
+    ) -> RegisteredRootV1Config {
+        RegisteredRootV1Config {
+            spec: RootSpecV1Config {
+                version: RootSpecV1Config::VERSION,
+                remote_prefix: "roots".to_owned(),
+                profile,
+                generation: NonZeroU64::new(1).unwrap(),
+            },
+            binding: Some(RootBindingV1Config {
+                version: RootBindingV1Config::VERSION,
+                local_root: local_root.to_owned(),
+                state_path: state_path.to_owned(),
+                lifecycle_policy: RootLifecyclePolicyV1::InspectOnly,
+                resolution_policy: RegisteredRootPolicy::InspectOnly,
+            }),
+        }
+    }
+
+    fn state_json(local_root: &Path, rel_paths: &[&str]) -> Vec<u8> {
+        let mut entries = serde_json::Map::new();
+        for rel_path in rel_paths {
+            let cache_key = local_root.join(rel_path).to_string_lossy().into_owned();
+            entries.insert(
+                cache_key,
+                serde_json::json!({
+                    "blake3": "a".repeat(64),
+                    "size": 4,
+                    "mtime": 5,
+                    "chunk_count": 1,
+                    "remote_path": format!("roots/manifests/{}", "b".repeat(64)),
+                    "last_synced": 6,
+                    "vclock": { "clocks": { "sting": 1 } },
+                    "device_id": "sting",
+                    "status": "synced"
+                }),
+            );
+        }
+        serde_json::to_vec(&serde_json::json!({
+            "last_nats_seq": 7,
+            "device_id": "sting",
+            "entries": entries,
+        }))
+        .unwrap()
+    }
+
+    async fn observe_fixture(
+        local_files: &[&str],
+        state_paths: &[&str],
+        remote_rows: &[RemoteNamespaceFixtureRowV1],
+    ) -> StrictRegisteredRootSourcesReadV1 {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        for rel_path in local_files {
+            let path = root.join(rel_path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, b"payload").unwrap();
+        }
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, &state_json(&root, state_paths));
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::AgentStaticV1);
+        observe_selected_registered_root_sources_for_test_v1(
+            "work",
+            &selected,
+            &root,
+            &state_path,
+            &matching_remote_fixture_operator_v1(remote_rows),
+        )
+        .await
+        .unwrap()
+    }
+
+    fn observed(
+        read: StrictRegisteredRootSourcesReadV1,
+    ) -> Box<AgentStaticNamespaceSafetyObservationV1> {
+        match read {
+            StrictRegisteredRootSourcesReadV1::Observed(observed) => observed,
+            StrictRegisteredRootSourcesReadV1::Incomplete(incomplete) => {
+                panic!("expected observed sources, got {incomplete:?}")
+            }
+        }
+    }
+
+    fn conflict(read: StrictRegisteredRootSourcesReadV1) -> NamespaceSafetyClaimConflictV1 {
+        match read {
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::NamespaceSafetyConflict(conflict),
+            ) => conflict,
+            StrictRegisteredRootSourcesReadV1::Observed(_) => {
+                panic!("expected a namespace-safety conflict, got observed sources")
+            }
+            StrictRegisteredRootSourcesReadV1::Incomplete(other) => {
+                panic!("expected a namespace-safety conflict, got {other:?}")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_static_exact_route_observes_empty_state_and_remote_without_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::AgentStaticV1);
+
+        let observed = match observe_selected_registered_root_sources_for_test_v1(
+            "work",
+            &selected,
+            &root,
+            &state_path,
+            &matching_remote_fixture_operator_v1(&[]),
+        )
+        .await
+        .unwrap()
+        {
+            StrictRegisteredRootSourcesReadV1::Observed(observed) => observed,
+            StrictRegisteredRootSourcesReadV1::Incomplete(incomplete) => {
+                panic!("expected observed sources, got {incomplete:?}")
+            }
+        };
+        assert_eq!(observed.root_id(), "work");
+        assert_eq!(observed.canonical_local_root(), root);
+        assert_eq!(observed.canonical_state_path(), state_path);
+        assert_eq!(observed.remote_prefix(), "roots");
+        assert_eq!(observed.namespace_safety_claim_count(), 0);
+        assert_eq!(
+            observed
+                .namespace_safety_source_claim_count(NamespaceSafetyClaimSourceV1::LocalCurrent),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn git_raw_without_held_topology_is_typed_incomplete_without_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join(".git/HEAD"), b"ref: refs/heads/main\n").unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::GitRawV1);
+
+        assert!(matches!(
+            observe_selected_registered_root_sources_for_test_v1(
+                "work",
+                &selected,
+                &root,
+                &state_path,
+                &matching_remote_fixture_operator_v1(&[]),
+            )
+            .await
+            .unwrap(),
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::GitTopologyRequired
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn source_presence_lattice_uses_all_three_production_adapters() {
+        let sources = [
+            NamespaceSafetyClaimSourceV1::LocalCurrent,
+            NamespaceSafetyClaimSourceV1::StateBaseline,
+            NamespaceSafetyClaimSourceV1::RemoteCurrent,
+        ];
+        for mask in 0_u8..8 {
+            let local = if mask & 0b001 == 0 {
+                &[][..]
+            } else {
+                &["same"][..]
+            };
+            let state = if mask & 0b010 == 0 {
+                &[][..]
+            } else {
+                &["same"][..]
+            };
+            let remote = if mask & 0b100 == 0 {
+                Vec::new()
+            } else {
+                vec![RemoteNamespaceFixtureRowV1::CurrentFile("same".to_owned())]
+            };
+            let observed = observed(observe_fixture(local, state, &remote).await);
+            assert_eq!(
+                observed.namespace_safety_claim_count(),
+                u64::from(mask != 0)
+            );
+            for (bit, source) in sources.into_iter().enumerate() {
+                assert_eq!(
+                    observed.namespace_safety_source_claim_count(source),
+                    u64::from(mask & (1 << bit) != 0),
+                    "source mask {mask:03b}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn every_cross_source_pair_rejects_real_alias_conflicts() {
+        let cases = [
+            (
+                vec!["Readme"],
+                vec!["README"],
+                Vec::new(),
+                NamespaceSafetyClaimSourceV1::LocalCurrent,
+                NamespaceSafetyClaimSourceV1::StateBaseline,
+            ),
+            (
+                vec!["Readme"],
+                Vec::new(),
+                vec![RemoteNamespaceFixtureRowV1::CurrentFile(
+                    "README".to_owned(),
+                )],
+                NamespaceSafetyClaimSourceV1::LocalCurrent,
+                NamespaceSafetyClaimSourceV1::RemoteCurrent,
+            ),
+            (
+                Vec::new(),
+                vec!["Readme"],
+                vec![RemoteNamespaceFixtureRowV1::CurrentFile(
+                    "README".to_owned(),
+                )],
+                NamespaceSafetyClaimSourceV1::StateBaseline,
+                NamespaceSafetyClaimSourceV1::RemoteCurrent,
+            ),
+        ];
+        for (local, state, remote, first, conflicting) in cases {
+            let alias = conflict(observe_fixture(&local, &state, &remote).await);
+            assert_eq!(
+                alias.kind(),
+                NamespaceSafetyClaimConflictKindV1::FoldedSpellingAlias
+            );
+            assert_eq!(alias.first_source(), first);
+            assert_eq!(alias.conflicting_source(), conflicting);
+        }
+    }
+
+    #[tokio::test]
+    async fn historical_and_reservation_pairs_reject_all_conflict_geometries() {
+        let remote_alias = |historical: bool| {
+            if historical {
+                RemoteNamespaceFixtureRowV1::DeletedFile("README".to_owned())
+            } else {
+                RemoteNamespaceFixtureRowV1::Reservation {
+                    exact_path: "README".to_owned(),
+                    role: PortableNamespaceRole::File,
+                }
+            }
+        };
+        let remote_directory = |historical: bool, path: &str| {
+            if historical {
+                RemoteNamespaceFixtureRowV1::DeletedDirectory(path.to_owned())
+            } else {
+                RemoteNamespaceFixtureRowV1::Reservation {
+                    exact_path: path.to_owned(),
+                    role: PortableNamespaceRole::Directory,
+                }
+            }
+        };
+        let remote_file = |historical: bool, path: &str| {
+            if historical {
+                RemoteNamespaceFixtureRowV1::DeletedFile(path.to_owned())
+            } else {
+                RemoteNamespaceFixtureRowV1::Reservation {
+                    exact_path: path.to_owned(),
+                    role: PortableNamespaceRole::File,
+                }
+            }
+        };
+
+        for (historical, remote_source) in [
+            (true, NamespaceSafetyClaimSourceV1::RemoteHistorical),
+            (false, NamespaceSafetyClaimSourceV1::RemoteReservation),
+        ] {
+            for (local, state, first_source) in [
+                (
+                    vec!["Readme"],
+                    Vec::new(),
+                    NamespaceSafetyClaimSourceV1::LocalCurrent,
+                ),
+                (
+                    Vec::new(),
+                    vec!["Readme"],
+                    NamespaceSafetyClaimSourceV1::StateBaseline,
+                ),
+            ] {
+                let alias =
+                    conflict(observe_fixture(&local, &state, &[remote_alias(historical)]).await);
+                assert_eq!(
+                    alias.kind(),
+                    NamespaceSafetyClaimConflictKindV1::FoldedSpellingAlias
+                );
+                assert_eq!(alias.first_source(), first_source);
+                assert_eq!(alias.conflicting_source(), remote_source);
+            }
+
+            for (local, state, first_source) in [
+                (
+                    vec!["path"],
+                    Vec::new(),
+                    NamespaceSafetyClaimSourceV1::LocalCurrent,
+                ),
+                (
+                    Vec::new(),
+                    vec!["path"],
+                    NamespaceSafetyClaimSourceV1::StateBaseline,
+                ),
+            ] {
+                for remote in [
+                    remote_directory(historical, "path"),
+                    remote_file(historical, "path/child"),
+                ] {
+                    let role = conflict(
+                        observe_fixture(&local, &state, std::slice::from_ref(&remote)).await,
+                    );
+                    assert_eq!(
+                        role.kind(),
+                        NamespaceSafetyClaimConflictKindV1::FileDirectoryRole
+                    );
+                    assert_eq!(role.first_source(), first_source);
+                    assert_eq!(role.conflicting_source(), remote_source);
+                }
+            }
+
+            for (local, state, first_source) in [
+                (
+                    vec!["path/child"],
+                    Vec::new(),
+                    NamespaceSafetyClaimSourceV1::LocalCurrent,
+                ),
+                (
+                    Vec::new(),
+                    vec!["path/child"],
+                    NamespaceSafetyClaimSourceV1::StateBaseline,
+                ),
+            ] {
+                let role = conflict(
+                    observe_fixture(&local, &state, &[remote_file(historical, "path")]).await,
+                );
+                assert_eq!(
+                    role.kind(),
+                    NamespaceSafetyClaimConflictKindV1::FileDirectoryRole
+                );
+                assert_eq!(role.first_source(), first_source);
+                assert_eq!(role.conflicting_source(), remote_source);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn remote_origin_pairs_fail_closed_inside_the_remote_reader() {
+        use crate::registered_remote_observation::RemoteNamespaceClaimConflictV1;
+
+        let cases = [
+            (
+                vec![
+                    RemoteNamespaceFixtureRowV1::CurrentFile("Readme".to_owned()),
+                    RemoteNamespaceFixtureRowV1::DeletedFile("README".to_owned()),
+                ],
+                RemoteNamespaceClaimConflictV1::FoldedSpellingAlias,
+            ),
+            (
+                vec![
+                    RemoteNamespaceFixtureRowV1::CurrentFile("path".to_owned()),
+                    RemoteNamespaceFixtureRowV1::Reservation {
+                        exact_path: "path".to_owned(),
+                        role: PortableNamespaceRole::Directory,
+                    },
+                ],
+                RemoteNamespaceClaimConflictV1::FileDirectoryRole,
+            ),
+            (
+                vec![
+                    RemoteNamespaceFixtureRowV1::DeletedFile("parent".to_owned()),
+                    RemoteNamespaceFixtureRowV1::Reservation {
+                        exact_path: "parent/child".to_owned(),
+                        role: PortableNamespaceRole::File,
+                    },
+                ],
+                RemoteNamespaceClaimConflictV1::FileDirectoryRole,
+            ),
+            (
+                vec![
+                    RemoteNamespaceFixtureRowV1::DeletedFile("parent/child".to_owned()),
+                    RemoteNamespaceFixtureRowV1::Reservation {
+                        exact_path: "parent".to_owned(),
+                        role: PortableNamespaceRole::File,
+                    },
+                ],
+                RemoteNamespaceClaimConflictV1::FileDirectoryRole,
+            ),
+        ];
+        for (rows, expected_reason) in cases {
+            assert!(matches!(
+                observe_fixture(&[], &[], &rows).await,
+                StrictRegisteredRootSourcesReadV1::Incomplete(
+                    StrictRegisteredRootSourcesIncompleteV1::Remote(
+                        StrictBoundRemoteObservationIncompleteV1::Claim {
+                            reason,
+                            ..
+                        }
+                    )
+                ) if reason == expected_reason
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn every_cross_source_pair_rejects_real_role_and_ancestor_conflicts() {
+        let cases = [
+            (
+                vec!["path/child"],
+                vec!["path"],
+                Vec::new(),
+                NamespaceSafetyClaimSourceV1::LocalCurrent,
+                NamespaceSafetyClaimSourceV1::StateBaseline,
+            ),
+            (
+                vec!["path"],
+                Vec::new(),
+                vec![RemoteNamespaceFixtureRowV1::CurrentDirectory(
+                    "path".to_owned(),
+                )],
+                NamespaceSafetyClaimSourceV1::LocalCurrent,
+                NamespaceSafetyClaimSourceV1::RemoteCurrent,
+            ),
+            (
+                Vec::new(),
+                vec!["path"],
+                vec![RemoteNamespaceFixtureRowV1::CurrentDirectory(
+                    "path".to_owned(),
+                )],
+                NamespaceSafetyClaimSourceV1::StateBaseline,
+                NamespaceSafetyClaimSourceV1::RemoteCurrent,
+            ),
+            (
+                vec!["path"],
+                vec!["path/child"],
+                Vec::new(),
+                NamespaceSafetyClaimSourceV1::LocalCurrent,
+                NamespaceSafetyClaimSourceV1::StateBaseline,
+            ),
+            (
+                vec!["path"],
+                Vec::new(),
+                vec![RemoteNamespaceFixtureRowV1::CurrentFile(
+                    "path/child".to_owned(),
+                )],
+                NamespaceSafetyClaimSourceV1::LocalCurrent,
+                NamespaceSafetyClaimSourceV1::RemoteCurrent,
+            ),
+            (
+                Vec::new(),
+                vec!["path"],
+                vec![RemoteNamespaceFixtureRowV1::CurrentFile(
+                    "path/child".to_owned(),
+                )],
+                NamespaceSafetyClaimSourceV1::StateBaseline,
+                NamespaceSafetyClaimSourceV1::RemoteCurrent,
+            ),
+        ];
+        for (local, state, remote, first, conflicting) in cases {
+            let role = conflict(observe_fixture(&local, &state, &remote).await);
+            assert_eq!(
+                role.kind(),
+                NamespaceSafetyClaimConflictKindV1::FileDirectoryRole
+            );
+            assert_eq!(role.first_source(), first);
+            assert_eq!(role.conflicting_source(), conflicting);
+        }
+    }
+
+    #[tokio::test]
+    async fn namespace_history_counts_authentic_remote_temporal_origins_without_actions() {
+        let observed = observed(
+            observe_fixture(
+                &[],
+                &[],
+                &[
+                    RemoteNamespaceFixtureRowV1::CurrentFile("path/child".to_owned()),
+                    RemoteNamespaceFixtureRowV1::DeletedDirectory("path".to_owned()),
+                    RemoteNamespaceFixtureRowV1::Reservation {
+                        exact_path: "path".to_owned(),
+                        role: PortableNamespaceRole::Directory,
+                    },
+                ],
+            )
+            .await,
+        );
+        assert_eq!(observed.namespace_safety_claim_count(), 2);
+        assert_eq!(
+            observed
+                .namespace_safety_source_claim_count(NamespaceSafetyClaimSourceV1::RemoteCurrent),
+            2
+        );
+        assert_eq!(
+            observed.namespace_safety_source_claim_count(
+                NamespaceSafetyClaimSourceV1::RemoteHistorical
+            ),
+            1
+        );
+        assert_eq!(
+            observed.namespace_safety_source_claim_count(
+                NamespaceSafetyClaimSourceV1::RemoteReservation
+            ),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn fixed_ingress_exclusion_does_not_erase_remote_namespace_history() {
+        let observed = observed(
+            observe_fixture(
+                &["home/.ssh/id_ed25519"],
+                &[],
+                &[
+                    RemoteNamespaceFixtureRowV1::DeletedDirectory("home/.ssh".to_owned()),
+                    RemoteNamespaceFixtureRowV1::Reservation {
+                        exact_path: "home/.ssh".to_owned(),
+                        role: PortableNamespaceRole::Directory,
+                    },
+                ],
+            )
+            .await,
+        );
+        assert_eq!(
+            observed
+                .namespace_safety_source_claim_count(NamespaceSafetyClaimSourceV1::LocalCurrent),
+            1,
+            "only the safe `home` ancestor remains; `.ssh` and its leaf are excluded"
+        );
+        assert_eq!(
+            observed
+                .namespace_safety_source_claim_count(NamespaceSafetyClaimSourceV1::RemoteCurrent),
+            0
+        );
+        assert_eq!(
+            observed.namespace_safety_source_claim_count(
+                NamespaceSafetyClaimSourceV1::RemoteHistorical
+            ),
+            2
+        );
+        assert_eq!(
+            observed.namespace_safety_source_claim_count(
+                NamespaceSafetyClaimSourceV1::RemoteReservation
+            ),
+            2
+        );
+    }
+
+    #[test]
+    fn route_provenance_mismatch_is_typed_even_for_empty_inputs() {
+        let profile = RootProfileV1::AgentStaticV1.policy();
+        let git_profile = RootProfileV1::GitRawV1.policy();
+        let contract = RegisteredRootPlanContractV1::strict_v1();
+        let expected = ExpectedRegisteredSourceRouteV1 {
+            canonical_local_root: Path::new("/root-a"),
+            canonical_state_path: Path::new("/state-a.json"),
+            remote_prefix: "roots-a",
+            profile: RootProfileV1::AgentStaticV1,
+            profile_settings_fingerprint: profile.settings_fingerprint(),
+            plan_contract_fingerprint: contract.fingerprint(),
+        };
+        let base = || ObservedRegisteredSourceRouteV1 {
+            held_local_root: Path::new("/root-a"),
+            state_path: Path::new("/state-a.json"),
+            state_local_root: Path::new("/root-a"),
+            state_remote_prefix: "roots-a",
+            remote_prefix: "roots-a",
+            profile: RootProfileV1::AgentStaticV1,
+            profile_settings_fingerprint: profile.settings_fingerprint(),
+            plan_contract_fingerprint: contract.fingerprint(),
+        };
+        assert_eq!(
+            validate_observed_source_route_v1(&expected, &base()),
+            Ok(())
+        );
+
+        let cases = [
+            (
+                ObservedRegisteredSourceRouteV1 {
+                    held_local_root: Path::new("/root-b"),
+                    ..base()
+                },
+                RegisteredSourceRouteMismatchV1::HeldLocalRoot,
+            ),
+            (
+                ObservedRegisteredSourceRouteV1 {
+                    state_path: Path::new("/state-b.json"),
+                    ..base()
+                },
+                RegisteredSourceRouteMismatchV1::StatePath,
+            ),
+            (
+                ObservedRegisteredSourceRouteV1 {
+                    state_local_root: Path::new("/root-b"),
+                    ..base()
+                },
+                RegisteredSourceRouteMismatchV1::StateLocalRoot,
+            ),
+            (
+                ObservedRegisteredSourceRouteV1 {
+                    state_remote_prefix: "roots-b",
+                    ..base()
+                },
+                RegisteredSourceRouteMismatchV1::StateRemotePrefix,
+            ),
+            (
+                ObservedRegisteredSourceRouteV1 {
+                    remote_prefix: "roots-b",
+                    ..base()
+                },
+                RegisteredSourceRouteMismatchV1::RemotePrefix,
+            ),
+            (
+                ObservedRegisteredSourceRouteV1 {
+                    profile: RootProfileV1::GitRawV1,
+                    ..base()
+                },
+                RegisteredSourceRouteMismatchV1::Profile,
+            ),
+            (
+                ObservedRegisteredSourceRouteV1 {
+                    profile_settings_fingerprint: git_profile.settings_fingerprint(),
+                    ..base()
+                },
+                RegisteredSourceRouteMismatchV1::ProfileSettingsFingerprint,
+            ),
+        ];
+        for (observed, expected_mismatch) in cases {
+            assert_eq!(
+                validate_observed_source_route_v1(&expected, &observed),
+                Err(expected_mismatch)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn configured_route_mismatch_stops_before_acquisition() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        let other = dir.path().join("other");
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&other).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let other = fs::canonicalize(other).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::AgentStaticV1);
+
+        assert!(matches!(
+            observe_selected_registered_root_sources_for_test_v1(
+                "work",
+                &selected,
+                &other,
+                &state_path,
+                &matching_remote_fixture_operator_v1(&[]),
+            )
+            .await
+            .unwrap(),
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::RouteMismatch(
+                    RegisteredSourceRouteMismatchV1::ConfiguredLocalRoot
+                )
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn selected_route_shape_binding_and_state_failures_are_typed() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::AgentStaticV1);
+        let op = matching_remote_fixture_operator_v1(&[]);
+
+        assert!(matches!(
+            observe_selected_registered_root_sources_for_test_v1(
+                "INVALID",
+                &selected,
+                &root,
+                &state_path,
+                &op,
+            )
+            .await
+            .unwrap(),
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::InvalidSelectedRoot
+            )
+        ));
+
+        let mut missing_binding = selected.clone();
+        missing_binding.binding = None;
+        assert!(matches!(
+            observe_selected_registered_root_sources_for_test_v1(
+                "work",
+                &missing_binding,
+                &root,
+                &state_path,
+                &op,
+            )
+            .await
+            .unwrap(),
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::BindingMissing
+            )
+        ));
+
+        let other_state_path = dir.path().join("other-state.json");
+        write_private(&other_state_path, empty_state_json());
+        let other_state_path = fs::canonicalize(other_state_path).unwrap();
+        assert!(matches!(
+            observe_selected_registered_root_sources_for_test_v1(
+                "work",
+                &selected,
+                &root,
+                &other_state_path,
+                &op,
+            )
+            .await
+            .unwrap(),
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::RouteMismatch(
+                    RegisteredSourceRouteMismatchV1::ConfiguredStatePath
+                )
+            )
+        ));
+
+        let missing_state_path = dir.path().join("missing-state.json");
+        let missing_state_selected =
+            selected_root(&root, &missing_state_path, RootProfileV1::AgentStaticV1);
+        assert!(matches!(
+            observe_selected_registered_root_sources_for_test_v1(
+                "work",
+                &missing_state_selected,
+                &root,
+                &missing_state_path,
+                &op,
+            )
+            .await
+            .unwrap(),
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::State(
+                    StrictPrimaryStateIncompleteV1::PrimaryMissing
+                )
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn local_and_remote_acquisition_failures_are_typed() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join("first"), b"same inode").unwrap();
+        fs::hard_link(root.join("first"), root.join("second")).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private(&state_path, empty_state_json());
+        let state_path = fs::canonicalize(state_path).unwrap();
+        let selected = selected_root(&root, &state_path, RootProfileV1::AgentStaticV1);
+        assert!(matches!(
+            observe_selected_registered_root_sources_for_test_v1(
+                "work",
+                &selected,
+                &root,
+                &state_path,
+                &matching_remote_fixture_operator_v1(&[]),
+            )
+            .await
+            .unwrap(),
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::Local(incomplete)
+            ) if incomplete.kind() == StrictLocalSnapshotIncompleteKindV1::HardlinkRejected
+        ));
+
+        let clean_dir = tempfile::tempdir().unwrap();
+        let clean_root = clean_dir.path().join("root");
+        fs::create_dir(&clean_root).unwrap();
+        let clean_root = fs::canonicalize(clean_root).unwrap();
+        let clean_state_path = clean_dir.path().join("state.json");
+        write_private(&clean_state_path, empty_state_json());
+        let clean_state_path = fs::canonicalize(clean_state_path).unwrap();
+        let clean_selected =
+            selected_root(&clean_root, &clean_state_path, RootProfileV1::AgentStaticV1);
+        assert!(matches!(
+            observe_selected_registered_root_sources_for_test_v1(
+                "work",
+                &clean_selected,
+                &clean_root,
+                &clean_state_path,
+                &missing_remote_index_fixture_operator_v1("ghost"),
+            )
+            .await
+            .unwrap(),
+            StrictRegisteredRootSourcesReadV1::Incomplete(
+                StrictRegisteredRootSourcesIncompleteV1::Remote(
+                    StrictBoundRemoteObservationIncompleteV1::ListedObjectMissing {
+                        kind: crate::registered_remote_observation::BoundRemoteObjectKindV1::OrdinaryIndex,
+                        ..
+                    }
+                )
+            )
+        ));
+    }
+}

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -17,6 +17,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tcfs_core::config::RegisteredRootPlanContractV1;
 
 use crate::conflict::VectorClock;
 
@@ -188,17 +189,18 @@ fn secure_read_file_bytes(path: &Path) -> Result<Vec<u8>> {
     read_opened_state_file(secure_open_state_file(path)?, path)
 }
 
-const REGISTERED_ROOT_STATE_MAX_BYTES_V1: u64 = 64 * 1024 * 1024;
-
 fn secure_read_file_bytes_bounded_v1(path: &Path) -> Result<Vec<u8>> {
+    let max_bytes = RegisteredRootPlanContractV1::strict_v1()
+        .state_contract()
+        .max_primary_bytes();
     let mut file = secure_open_state_file(path)?;
     let metadata = file
         .metadata()
         .with_context(|| format!("reading private state file metadata: {}", path.display()))?;
     anyhow::ensure!(
-        metadata.len() <= REGISTERED_ROOT_STATE_MAX_BYTES_V1,
+        metadata.len() <= max_bytes,
         "registered-root V1 state primary exceeds {} bytes: {}",
-        REGISTERED_ROOT_STATE_MAX_BYTES_V1,
+        max_bytes,
         path.display()
     );
 
@@ -207,15 +209,15 @@ fn secure_read_file_bytes_bounded_v1(path: &Path) -> Result<Vec<u8>> {
             .context("registered-root V1 state primary length does not fit memory")?,
     );
     (&mut file)
-        .take(REGISTERED_ROOT_STATE_MAX_BYTES_V1 + 1)
+        .take(max_bytes + 1)
         .read_to_end(&mut contents)
         .with_context(|| format!("reading private state file: {}", path.display()))?;
     anyhow::ensure!(
         u64::try_from(contents.len())
             .context("registered-root V1 state primary read length does not fit u64")?
-            <= REGISTERED_ROOT_STATE_MAX_BYTES_V1,
+            <= max_bytes,
         "registered-root V1 state primary grew beyond {} bytes while reading: {}",
-        REGISTERED_ROOT_STATE_MAX_BYTES_V1,
+        max_bytes,
         path.display()
     );
     validate_opened_state_file(&file, path)?;

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -188,6 +188,40 @@ fn secure_read_file_bytes(path: &Path) -> Result<Vec<u8>> {
     read_opened_state_file(secure_open_state_file(path)?, path)
 }
 
+const REGISTERED_ROOT_STATE_MAX_BYTES_V1: u64 = 64 * 1024 * 1024;
+
+fn secure_read_file_bytes_bounded_v1(path: &Path) -> Result<Vec<u8>> {
+    let mut file = secure_open_state_file(path)?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("reading private state file metadata: {}", path.display()))?;
+    anyhow::ensure!(
+        metadata.len() <= REGISTERED_ROOT_STATE_MAX_BYTES_V1,
+        "registered-root V1 state primary exceeds {} bytes: {}",
+        REGISTERED_ROOT_STATE_MAX_BYTES_V1,
+        path.display()
+    );
+
+    let mut contents = Vec::with_capacity(
+        usize::try_from(metadata.len())
+            .context("registered-root V1 state primary length does not fit memory")?,
+    );
+    (&mut file)
+        .take(REGISTERED_ROOT_STATE_MAX_BYTES_V1 + 1)
+        .read_to_end(&mut contents)
+        .with_context(|| format!("reading private state file: {}", path.display()))?;
+    anyhow::ensure!(
+        u64::try_from(contents.len())
+            .context("registered-root V1 state primary read length does not fit u64")?
+            <= REGISTERED_ROOT_STATE_MAX_BYTES_V1,
+        "registered-root V1 state primary grew beyond {} bytes while reading: {}",
+        REGISTERED_ROOT_STATE_MAX_BYTES_V1,
+        path.display()
+    );
+    validate_opened_state_file(&file, path)?;
+    Ok(contents)
+}
+
 fn secure_read_file(path: &Path) -> Result<String> {
     String::from_utf8(secure_read_file_bytes(path)?)
         .with_context(|| format!("decoding private state file as UTF-8: {}", path.display()))
@@ -404,6 +438,142 @@ impl StateFileLock {
             Err(std::fs::TryLockError::Error(error)) => Err(error).with_context(|| {
                 format!("locking existing state cache via {}", lock_path.display())
             }),
+        }
+    }
+}
+
+/// Exact digest of one securely read registered-root V1 primary state file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct PrimaryStateBytesDigestV1([u8; 32]);
+
+impl PrimaryStateBytesDigestV1 {
+    pub(crate) const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Exact primary-state bytes observed without consulting compatibility
+/// recovery or creating a writer sidecar.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ReadOnlyPrimaryStateBytesSnapshotV1 {
+    raw_bytes: Arc<[u8]>,
+    raw_bytes_digest: PrimaryStateBytesDigestV1,
+}
+
+impl std::fmt::Debug for ReadOnlyPrimaryStateBytesSnapshotV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ReadOnlyPrimaryStateBytesSnapshotV1")
+            .field("raw_bytes_len", &self.raw_bytes.len())
+            .field(
+                "raw_bytes_digest",
+                &blake3::Hash::from_bytes(*self.raw_bytes_digest.as_bytes()),
+            )
+            .finish()
+    }
+}
+
+impl ReadOnlyPrimaryStateBytesSnapshotV1 {
+    pub(crate) fn raw_bytes(&self) -> &[u8] {
+        &self.raw_bytes
+    }
+
+    pub(crate) const fn raw_bytes_digest(&self) -> PrimaryStateBytesDigestV1 {
+        self.raw_bytes_digest
+    }
+
+    pub(crate) fn into_parts(self) -> (Arc<[u8]>, PrimaryStateBytesDigestV1) {
+        (self.raw_bytes, self.raw_bytes_digest)
+    }
+}
+
+/// Result of one cooperative, non-creating read of a V1 state primary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReadOnlyPrimaryStateBytesV1 {
+    Missing,
+    WriterActive,
+    Unstable,
+    Snapshot(ReadOnlyPrimaryStateBytesSnapshotV1),
+}
+
+fn primary_state_bytes_digest_v1(bytes: &[u8]) -> PrimaryStateBytesDigestV1 {
+    let mut hasher =
+        blake3::Hasher::new_derive_key("tinyland.tcfs.registered-root-state-primary-bytes.b3v1");
+    let length =
+        u64::try_from(bytes.len()).expect("registered-root V1 state primary length must fit u64");
+    hasher.update(&length.to_be_bytes());
+    hasher.update(bytes);
+    PrimaryStateBytesDigestV1(*hasher.finalize().as_bytes())
+}
+
+fn read_primary_state_bytes_once_v1(
+    state_path: &Path,
+) -> Result<Option<ReadOnlyPrimaryStateBytesSnapshotV1>> {
+    if !state_path_entry_exists(state_path)? {
+        return Ok(None);
+    }
+    let raw_bytes: Arc<[u8]> = secure_read_file_bytes_bounded_v1(state_path)?.into();
+    let raw_bytes_digest = primary_state_bytes_digest_v1(&raw_bytes);
+    Ok(Some(ReadOnlyPrimaryStateBytesSnapshotV1 {
+        raw_bytes,
+        raw_bytes_digest,
+    }))
+}
+
+/// Read only the selected registered-root primary state bytes.
+///
+/// This never creates a lock, reads a backup, invokes compatibility parsing,
+/// or writes state. A missing lock is probed again after the read because V1
+/// writers create a persistent sidecar before their full transaction. If a
+/// sidecar appears, the first observation is discarded and either reported as
+/// contended or repeated while holding the newly observed lock. A writer that
+/// bypasses this persistent-sidecar protocol is outside the registered-root V1
+/// consistency contract.
+pub(crate) fn read_primary_state_bytes_read_only_v1(
+    state_path: &Path,
+) -> Result<ReadOnlyPrimaryStateBytesV1> {
+    read_primary_state_bytes_read_only_v1_inner(state_path, || ())
+}
+
+fn read_primary_state_bytes_read_only_v1_inner<T>(
+    state_path: &Path,
+    after_unlocked_read: impl FnOnce() -> T,
+) -> Result<ReadOnlyPrimaryStateBytesV1> {
+    match StateFileLock::try_acquire_existing(state_path)? {
+        ExistingStateFileLock::Contended => Ok(ReadOnlyPrimaryStateBytesV1::WriterActive),
+        ExistingStateFileLock::Acquired(_guard) => {
+            Ok(match read_primary_state_bytes_once_v1(state_path)? {
+                Some(snapshot) => ReadOnlyPrimaryStateBytesV1::Snapshot(snapshot),
+                None => ReadOnlyPrimaryStateBytesV1::Missing,
+            })
+        }
+        ExistingStateFileLock::Missing => {
+            let first_observation = read_primary_state_bytes_once_v1(state_path);
+            // Keep any test-injected writer guard alive through the second
+            // probe. Production passes `()`, so this seam performs no action.
+            let _between_probes = after_unlocked_read();
+            match StateFileLock::try_acquire_existing(state_path)? {
+                ExistingStateFileLock::Contended => Ok(ReadOnlyPrimaryStateBytesV1::WriterActive),
+                ExistingStateFileLock::Acquired(_guard) => {
+                    Ok(match read_primary_state_bytes_once_v1(state_path)? {
+                        Some(snapshot) => ReadOnlyPrimaryStateBytesV1::Snapshot(snapshot),
+                        None => ReadOnlyPrimaryStateBytesV1::Missing,
+                    })
+                }
+                ExistingStateFileLock::Missing => {
+                    let first_observation = first_observation?;
+                    let second_observation = read_primary_state_bytes_once_v1(state_path)?;
+                    Ok(match (first_observation, second_observation) {
+                        (None, None) => ReadOnlyPrimaryStateBytesV1::Missing,
+                        (Some(first), Some(second)) if first == second => {
+                            ReadOnlyPrimaryStateBytesV1::Snapshot(second)
+                        }
+                        (None, Some(_)) | (Some(_), None) | (Some(_), Some(_)) => {
+                            ReadOnlyPrimaryStateBytesV1::Unstable
+                        }
+                    })
+                }
+            }
         }
     }
 }
@@ -2177,6 +2347,119 @@ mod tests {
             StateFileLock::try_acquire_existing(&state_path).unwrap(),
             ExistingStateFileLock::Acquired(_)
         ));
+    }
+
+    #[test]
+    fn registered_root_primary_bytes_read_is_non_creating_and_exact() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let lock_path = StateFileLock::lock_path(&state_path);
+
+        assert!(matches!(
+            read_primary_state_bytes_read_only_v1(&state_path).unwrap(),
+            ReadOnlyPrimaryStateBytesV1::Missing
+        ));
+        assert!(!state_path.exists());
+        assert!(!lock_path.exists());
+
+        let expected = br#"{"last_nats_seq":0,"device_id":"sting","entries":{}}"#;
+        write_private_state_file(&state_path, expected);
+        let before = std::fs::metadata(&state_path).unwrap();
+        let snapshot = match read_primary_state_bytes_read_only_v1(&state_path).unwrap() {
+            ReadOnlyPrimaryStateBytesV1::Snapshot(snapshot) => snapshot,
+            other => panic!("expected exact primary snapshot, got {other:?}"),
+        };
+        assert_eq!(snapshot.raw_bytes(), expected);
+        assert_eq!(
+            blake3::Hash::from_bytes(*snapshot.raw_bytes_digest().as_bytes())
+                .to_hex()
+                .to_string(),
+            "37f6cf98f5e05f65ef93f97fcc116492d7be88a1a3b7b30e0f2c9ffb345639d3"
+        );
+        let after = std::fs::metadata(&state_path).unwrap();
+        assert_eq!(before.len(), after.len());
+        assert_eq!(before.modified().unwrap(), after.modified().unwrap());
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn registered_root_primary_bytes_debug_never_discloses_state_payload() {
+        let sentinel = b"state-secret-sentinel-that-must-not-appear";
+        let snapshot = ReadOnlyPrimaryStateBytesSnapshotV1 {
+            raw_bytes: Arc::from(sentinel.as_slice()),
+            raw_bytes_digest: primary_state_bytes_digest_v1(sentinel),
+        };
+
+        let snapshot_debug = format!("{snapshot:?}");
+        let result_debug = format!("{:?}", ReadOnlyPrimaryStateBytesV1::Snapshot(snapshot));
+        for debug in [&snapshot_debug, &result_debug] {
+            assert!(!debug.contains("state-secret-sentinel"));
+            assert!(debug.contains("raw_bytes_len"));
+            assert!(debug.contains(&sentinel.len().to_string()));
+            assert!(debug.contains("raw_bytes_digest"));
+        }
+    }
+
+    #[test]
+    fn registered_root_primary_bytes_read_reports_writer_and_preserves_existing_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let lock_path = StateFileLock::lock_path(&state_path);
+        write_private_state_file(&state_path, b"state-sentinel");
+
+        let writer = StateFileLock::acquire(&state_path).expect("writer lock");
+        assert!(matches!(
+            read_primary_state_bytes_read_only_v1(&state_path).unwrap(),
+            ReadOnlyPrimaryStateBytesV1::WriterActive
+        ));
+        drop(writer);
+
+        let lock_bytes = std::fs::read(&lock_path).unwrap();
+        let lock_before = std::fs::metadata(&lock_path).unwrap();
+        let snapshot = match read_primary_state_bytes_read_only_v1(&state_path).unwrap() {
+            ReadOnlyPrimaryStateBytesV1::Snapshot(snapshot) => snapshot,
+            other => panic!("expected primary snapshot under existing lock, got {other:?}"),
+        };
+        assert_eq!(snapshot.raw_bytes(), b"state-sentinel");
+        assert_eq!(std::fs::read(&lock_path).unwrap(), lock_bytes);
+        let lock_after = std::fs::metadata(&lock_path).unwrap();
+        assert_eq!(lock_before.len(), lock_after.len());
+        assert_eq!(
+            lock_before.modified().unwrap(),
+            lock_after.modified().unwrap()
+        );
+    }
+
+    #[test]
+    fn registered_root_primary_bytes_discards_unlocked_read_when_writer_lock_appears() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let lock_path = StateFileLock::lock_path(&state_path);
+        write_private_state_file(&state_path, b"first-observation-must-not-escape");
+        assert!(!lock_path.exists());
+
+        let result = read_primary_state_bytes_read_only_v1_inner(&state_path, || {
+            StateFileLock::acquire(&state_path).expect("writer appears between probes")
+        })
+        .unwrap();
+
+        assert!(matches!(result, ReadOnlyPrimaryStateBytesV1::WriterActive));
+        assert!(lock_path.exists(), "writer created its persistent sidecar");
+    }
+
+    #[test]
+    fn registered_root_primary_bytes_rejects_unlocked_generation_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        write_private_state_file(&state_path, b"first-generation");
+
+        let result = read_primary_state_bytes_read_only_v1_inner(&state_path, || {
+            write_private_state_file(&state_path, b"second-generation");
+        })
+        .unwrap();
+
+        assert!(matches!(result, ReadOnlyPrimaryStateBytesV1::Unstable));
+        assert!(!StateFileLock::lock_path(&state_path).exists());
     }
 
     #[cfg(unix)]

--- a/crates/tcfs-vfs/src/driver.rs
+++ b/crates/tcfs-vfs/src/driver.rs
@@ -972,7 +972,7 @@ impl VirtualFilesystem for TcfsVfs {
         let manifest = SymlinkManifest::from_bytes(&manifest_bytes)
             .with_context(|| format!("parsing symlink manifest for {path}"))?;
         tcfs_sync::engine::validate_indexed_symlink_target(
-            Path::new(path),
+            Path::new(&resolved.logical_rel_path),
             &manifest.symlink_target,
         )?;
         Ok(manifest.symlink_target)

--- a/crates/tcfs-vfs/tests/vfs_lifecycle_test.rs
+++ b/crates/tcfs-vfs/tests/vfs_lifecycle_test.rs
@@ -252,6 +252,7 @@ async fn readdir_getattr_and_readlink_preserve_symlink_entries() {
     let vfs = memory_vfs_with_op(op.clone(), "test", cache.path().join("cache"));
 
     publish_symlink(&op, "test", "link.txt", "target.txt").await;
+    publish_symlink(&op, "test", "nested/link.txt", "../target.txt").await;
 
     let entries = vfs.readdir("/").await.expect("readdir root");
     let link = entries
@@ -266,6 +267,12 @@ async fn readdir_getattr_and_readlink_preserve_symlink_entries() {
 
     let target = vfs.readlink("/link.txt").await.expect("readlink");
     assert_eq!(target, "target.txt");
+
+    let nested_target = vfs
+        .readlink("/nested/link.txt")
+        .await
+        .expect("readlink with safe logical-root parent traversal");
+    assert_eq!(nested_target, "../target.txt");
 }
 
 #[tokio::test]

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,8 @@
           "aarch64-apple-darwin"
           "aarch64-apple-ios"
           "aarch64-apple-ios-sim"
+        ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+          "x86_64-pc-windows-gnu"
         ];
         rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = [ "rust-src" "rust-analyzer" "clippy" "rustfmt" ];
@@ -215,6 +217,7 @@
             cargo-watch
             cargo-deny
             cargo-audit
+            gitleaks
             shellcheck
             jq
 
@@ -237,13 +240,21 @@
             git
             just
             yq-go
-          ]);
+          ]) ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.pkgsCross.mingwW64.stdenv.cc
+          ];
           TCFS_RUST_TOOLCHAIN = rustVersion;
 
           shellHook = ''
             # Home Manager user profiles may carry an older rustc/cargo ahead
             # of Nix's shell paths. Keep the project-pinned toolchain first.
             export PATH="$PWD/target/debug:$PWD/target/release:${pkgs.lib.makeBinPath [ rustToolchain pkgs.go-task pkgs.just pkgs.shellcheck pkgs.jq.bin pkgs.awscli2 pkgs.s5cmd pkgs.minio-client ]}:$PATH"
+
+            if command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1; then
+              export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc
+              export CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc
+              export AR_x86_64_pc_windows_gnu=x86_64-w64-mingw32-ar
+            fi
 
             echo "tcfs devShell (tummycrypt monorepo)"
             echo "  rustc --version  # pinned toolchain should report ${rustVersion}"

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
           filter = path: type:
             (protoFilter path type) || (craneLib.filterCargoSources path type);
         in pkgs.lib.cleanSourceWith {
-          src = craneLib.path ./.;
+          src = ./.;
           inherit filter;
         };
 

--- a/scripts/test-ci-authority-contract.py
+++ b/scripts/test-ci-authority-contract.py
@@ -1,0 +1,905 @@
+#!/usr/bin/env python3
+"""Fail-closed source contract for TCFS first-party CI authority."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+import unittest
+
+sys.dont_write_bytecode = True
+
+PENDING_GF_REVISION = "TIN_3127_SIGNED_MERGE_REVISION_PENDING"
+GF_ACTION_ROOT = "tinyland-inc/GloriousFlywheel/.github/actions/"
+PUBLIC_KEY_EXPRESSION = "${{ vars.ATTIC_PUBLIC_KEY || '' }}"
+EXPECTED_SHA_EXPRESSION = (
+    "${{ github.event_name == 'pull_request' && "
+    "github.event.pull_request.head.sha || github.sha }}"
+)
+DISABLED_JOB_CONDITION = "${{ github.repository == '__TIN_2538_DISABLED__' }}"
+HOSTED_RUNNER_PATTERN = re.compile(
+    r"(?:ubuntu|macos|windows)-(?:latest|[0-9][A-Za-z0-9.-]*)",
+    re.IGNORECASE,
+)
+FORBIDDEN_CACHE_OR_BOOTSTRAP_TOKENS = (
+    "actions/cache",
+    "Swatinem/rust-cache",
+    "type=gha",
+    "ACTIONS_CACHE_URL",
+    "ACTIONS_RESULTS_URL",
+    "cachix/install-nix-action",
+    "DeterminateSystems/flakehub-cache-action",
+    "bazel-contrib/setup-bazel",
+)
+SEAWEED_IMAGE = (
+    "chrislusf/seaweedfs:4.40@"
+    "sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602"
+)
+NATS_IMAGE = (
+    "nats:2.10.29-alpine3.22@"
+    "sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927"
+)
+PUBLIC_READ_SITES = {
+    (".github/workflows/ci.yml", "linux-source"): "tcfs-linux-source",
+    (".github/workflows/ci.yml", "windows-cross"): "tcfs-windows-cross",
+    (".github/workflows/nix-ci.yml", "nix-linux"): "tcfs-nix-linux",
+    (".github/workflows/ci-live-storage.yml", "fleet-live"): ("tcfs-live-storage"),
+}
+
+
+class ContractError(ValueError):
+    """The checked-in CI authority contract is unsafe or incomplete."""
+
+
+class PromotionHold(ContractError):
+    """The source shape is reviewable but cannot be promoted."""
+
+
+def find_repo_root() -> Path:
+    for candidate in [Path.cwd(), Path(__file__).resolve()]:
+        for parent in [candidate, *candidate.parents]:
+            if (parent / "config/ci-authority-policy.json").is_file():
+                return parent
+    raise ContractError("cannot locate repository root")
+
+
+def load_policy(root: Path) -> dict[str, Any]:
+    loaded = json.loads(
+        (root / "config/ci-authority-policy.json").read_text(encoding="utf-8")
+    )
+    if not isinstance(loaded, dict):
+        raise ContractError("CI authority policy must be a JSON object")
+    return loaded
+
+
+def reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    loaded: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in loaded:
+            raise ContractError(f"yq JSON contains a duplicate mapping key: {key!r}")
+        loaded[key] = value
+    return loaded
+
+
+def yq_json(path: Path, expression: str = ".") -> Any:
+    try:
+        completed = subprocess.run(
+            ["yq", "--output-format=json", "--no-colors", expression, str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ContractError("mikefarah yq v4 is required") from error
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or error.stdout.strip()
+        raise ContractError(f"{path} is not valid YAML: {detail}") from error
+
+    try:
+        return json.loads(
+            completed.stdout,
+            object_pairs_hook=reject_duplicate_pairs,
+        )
+    except json.JSONDecodeError as error:
+        raise ContractError(
+            f"{path} did not produce one strict JSON document: {error}"
+        ) from error
+
+
+def load_workflow(path: Path) -> tuple[dict[str, Any], str]:
+    source = path.read_text(encoding="utf-8")
+    document = yq_json(path)
+    if not isinstance(document, dict):
+        raise ContractError(f"{path} must contain one top-level mapping")
+
+    references = yq_json(
+        path,
+        ('[.. | select(anchor != "") | {"anchor": anchor, "path": path}]'),
+    )
+    if references:
+        raise ContractError(f"{path} must not use YAML anchors, aliases, or merges")
+
+    styled_keys = yq_json(
+        path,
+        (
+            '[.. | select(tag == "!!map") | to_entries | .[] | '
+            'select((.key | style) != "") | '
+            '{"key": (.key | tostring), "style": (.key | style)}]'
+        ),
+    )
+    if styled_keys:
+        raise ContractError(
+            f"{path} must use canonical unquoted mapping keys: {styled_keys!r}"
+        )
+
+    return document, source
+
+
+def scrub_topology(value: Any, *, key: str | None = None) -> Any:
+    if key in {"run", "command"}:
+        return "<script>"
+    if key == "uses" and isinstance(value, str) and value.startswith(GF_ACTION_ROOT):
+        return f"{value.rsplit('@', 1)[0]}@<GF_REVISION>"
+    if isinstance(value, dict):
+        return {
+            item_key: scrub_topology(item_value, key=item_key)
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list):
+        return [scrub_topology(item) for item in value]
+    return value
+
+
+def topology_sha256(document: dict[str, Any]) -> str:
+    topology = scrub_topology(document)
+    encoded = json.dumps(
+        topology,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_topology(
+    document: dict[str, Any],
+    contract: dict[str, Any],
+) -> None:
+    expected = contract.get("topology_sha256")
+    if not isinstance(expected, str) or re.fullmatch(r"[0-9a-f]{64}", expected) is None:
+        raise ContractError(f"{contract['path']} lacks a reviewed topology digest")
+    actual = topology_sha256(document)
+    if actual != expected:
+        raise ContractError(
+            f"{contract['path']} workflow topology drifted "
+            f"(actual={actual}, expected={expected})"
+        )
+
+
+def workflow_jobs(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict) or not jobs:
+        raise ContractError("workflow jobs must be a non-empty mapping")
+    for job_name, job in jobs.items():
+        if not isinstance(job_name, str) or not isinstance(job, dict):
+            raise ContractError("every workflow job must be a named mapping")
+    return jobs
+
+
+def workflow_steps(job_name: str, job: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = job.get("steps")
+    if not isinstance(steps, list) or not steps:
+        raise ContractError(f"{job_name} must contain a non-empty steps list")
+    for step in steps:
+        if not isinstance(step, dict):
+            raise ContractError(f"{job_name} contains a non-mapping step")
+    return steps
+
+
+def workflow_triggers(document: dict[str, Any]) -> list[str]:
+    triggers = document.get("on")
+    if not isinstance(triggers, dict) or not triggers:
+        raise ContractError("workflow on must be a non-empty mapping")
+    if not all(isinstance(trigger, str) for trigger in triggers):
+        raise ContractError("every workflow trigger must be a string key")
+    return list(triggers)
+
+
+def validate_permissions(document: dict[str, Any]) -> None:
+    if document.get("permissions") != {"contents": "read"}:
+        raise ContractError(
+            "protected workflow permissions must be exactly contents: read"
+        )
+
+
+def all_action_steps(
+    jobs: dict[str, dict[str, Any]],
+) -> list[tuple[str, dict[str, Any]]]:
+    found: list[tuple[str, dict[str, Any]]] = []
+    for job_name, job in jobs.items():
+        if "uses" in job:
+            raise ContractError(f"job-level reusable workflow is forbidden: {job_name}")
+        for step in workflow_steps(job_name, job):
+            if "uses" in step:
+                found.append((job_name, step))
+    return found
+
+
+def validate_action_refs(
+    jobs: dict[str, dict[str, Any]],
+    *,
+    checkout_revision: str,
+    gf_revision: str,
+    front_door: str,
+) -> None:
+    allowed = {
+        f"actions/checkout@{checkout_revision}",
+        f"{GF_ACTION_ROOT}{front_door}@{gf_revision}",
+    }
+    action_steps = all_action_steps(jobs)
+    if not action_steps:
+        raise ContractError("protected workflow must use reviewed actions")
+    for job_name, step in action_steps:
+        action_ref = step.get("uses")
+        if not isinstance(action_ref, str) or action_ref not in allowed:
+            raise ContractError(
+                f"{job_name} contains an unreviewed action reference: {action_ref!r}"
+            )
+        revision = action_ref.rsplit("@", 1)[-1]
+        if action_ref.startswith("actions/checkout@"):
+            if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+                raise ContractError("checkout action revision must be immutable")
+        elif (
+            revision != PENDING_GF_REVISION
+            and re.fullmatch(r"[0-9a-f]{40}", revision) is None
+        ):
+            raise ContractError("GloriousFlywheel action revision must be immutable")
+
+
+def unique_step(
+    job_name: str,
+    steps: list[dict[str, Any]],
+    *,
+    name: str | None = None,
+    uses: str | None = None,
+) -> tuple[int, dict[str, Any]]:
+    matches: list[tuple[int, dict[str, Any]]] = []
+    for index, step in enumerate(steps):
+        if name is not None and step.get("name") != name:
+            continue
+        if uses is not None and step.get("uses") != uses:
+            continue
+        matches.append((index, step))
+    if len(matches) != 1:
+        identity = name if name is not None else uses
+        raise ContractError(f"{job_name} must contain exactly one step {identity!r}")
+    return matches[0]
+
+
+def validate_public_read_tuple(
+    path: str,
+    job_name: str,
+    job: dict[str, Any],
+    *,
+    checkout_revision: str,
+    gf_revision: str,
+) -> None:
+    expected_action = f"{GF_ACTION_ROOT}nix-job@{gf_revision}"
+    steps = workflow_steps(job_name, job)
+    checkout_index, checkout = unique_step(
+        job_name,
+        steps,
+        uses=f"actions/checkout@{checkout_revision}",
+    )
+    action_index, action = unique_step(
+        job_name,
+        steps,
+        uses=expected_action,
+    )
+    nix_index, require_nix = unique_step(
+        job_name,
+        steps,
+        name="Require the preinstalled GF Nix runtime",
+    )
+    if not checkout_index < nix_index < action_index:
+        raise ContractError(
+            f"{job_name} must verify preinstalled Nix before entering GF"
+        )
+    if require_nix.get("run") != "command -v nix":
+        raise ContractError(f"{job_name} Nix preflight must fail closed")
+
+    checkout_with = checkout.get("with")
+    if not isinstance(checkout_with, dict):
+        raise ContractError(f"{job_name} checkout must define a with mapping")
+    if checkout_with != {
+        "fetch-depth": 0,
+        "ref": EXPECTED_SHA_EXPRESSION,
+        "persist-credentials": False,
+    }:
+        raise ContractError(f"{job_name} checkout authority tuple drifted")
+
+    unique_step(
+        job_name,
+        steps,
+        name="Verify exact checked out revision",
+    )
+    revision_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Verify exact checked out revision"
+    )
+    if revision_step.get("env") != {"EXPECTED_SHA": EXPECTED_SHA_EXPRESSION}:
+        raise ContractError(f"{job_name} revision identity drifted")
+    if 'test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"' not in str(
+        revision_step.get("run", "")
+    ):
+        raise ContractError(f"{job_name} does not verify the checked-out revision")
+
+    expected_site = PUBLIC_READ_SITES.get((path, job_name))
+    if expected_site is None:
+        raise ContractError(f"{path}:{job_name} has no reviewed public-read site")
+    action_env = action.get("env")
+    action_with = action.get("with")
+    if not isinstance(action_env, dict) or not isinstance(action_with, dict):
+        raise ContractError(f"{job_name} GF action must define env and with mappings")
+    if action_env.get("ATTIC_TOKEN") != "":
+        raise ContractError(f"{job_name} must explicitly clear ATTIC_TOKEN")
+    if action_env.get("GF_EXPECTED_RUNNER_ENVIRONMENT") != (
+        "${{ runner.environment }}"
+    ):
+        raise ContractError(f"{job_name} must bind runner.environment explicitly")
+
+    exact_public_values = {
+        "attic-enabled": "true",
+        "attic-public-key": PUBLIC_KEY_EXPRESSION,
+        "attic-public-read-only": "true",
+        "attic-public-read-site": expected_site,
+        "push-cache": "false",
+        "require-cache-push": "false",
+    }
+    for key, expected in exact_public_values.items():
+        if action_with.get(key) != expected:
+            raise ContractError(
+                f"{job_name} must set public-read input {key}: {expected!r}"
+            )
+    for forbidden in ("attic-server", "attic-cache"):
+        if forbidden in action_with:
+            raise ContractError(f"{job_name} must not override {forbidden}")
+    command = action_with.get("command")
+    if not isinstance(command, str) or not command:
+        raise ContractError(f"{job_name} GF command is missing")
+    for required in (
+        'test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted',
+        'test "${ATTIC_TOKEN:-}" = ""',
+        'test -n "${ATTIC_SERVER:-}"',
+        'test "${ATTIC_CACHE:-}" = main',
+        'test -n "${ATTIC_PUBLIC_KEY:-}"',
+        'test -n "${BAZEL_REMOTE_CACHE:-}"',
+        'test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed',
+        'test "${NIX_USER_CONF_FILES:-}" = /dev/null',
+        'test "${NETRC:-}" = /dev/null',
+        'test "$(nix config show netrc-file)" = /dev/null',
+        'grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"',
+    ):
+        if required not in command:
+            raise ContractError(f"{job_name} lacks public-read check: {required}")
+    lowered = command.lower()
+    for forbidden in ("attic login", "attic push", "secrets.attic_token", "type=gha"):
+        if forbidden in lowered:
+            raise ContractError(
+                f"{job_name} public-read command contains {forbidden!r}"
+            )
+
+
+def validate_held_job(job_name: str, job: dict[str, Any], issue: str) -> None:
+    if "if" in job or "uses" in job:
+        raise ContractError(f"{job_name} must be an unconditional held job")
+    steps = workflow_steps(job_name, job)
+    if len(steps) != 1:
+        raise ContractError(f"{job_name} must contain one fail-closed step")
+    step = steps[0]
+    name = step.get("name")
+    run = step.get("run")
+    if not isinstance(name, str) or not name.startswith("Hold until "):
+        raise ContractError(f"{job_name} held step name drifted")
+    if not isinstance(run, str) or issue not in run:
+        raise ContractError(f"{job_name} must name its prerequisite {issue}")
+    if not run.rstrip().endswith("exit 1"):
+        raise ContractError(f"{job_name} must end at fail-closed exit 1")
+    if re.search(r"(?m)^\s+exit 0\s*$|\|\|\s*true", run):
+        raise ContractError(f"{job_name} contains a success bypass")
+
+
+def validate_live_storage_images(source: str) -> None:
+    image_values = re.findall(r"(?m)^\s+image:\s*(\S+)\s*$", source)
+    expected = [SEAWEED_IMAGE] * 5 + [NATS_IMAGE]
+    if sorted(image_values) != sorted(expected):
+        raise ContractError(
+            "live-storage service images must match the reviewed digests"
+        )
+    for image in image_values:
+        if re.fullmatch(r"[^@\s]+@sha256:[0-9a-f]{64}", image) is None:
+            raise ContractError(f"live-storage image is not digest-pinned: {image}")
+
+
+def validate_protected_workflow(
+    document: dict[str, Any],
+    source: str,
+    contract: dict[str, Any],
+    policy: dict[str, Any],
+) -> None:
+    validate_topology(document, contract)
+    validate_permissions(document)
+    path = contract["path"]
+    expected_jobs = contract["jobs"]
+    held_jobs = contract["held_jobs"]
+    front_door = contract["front_door"]
+    if not isinstance(path, str) or not isinstance(expected_jobs, dict):
+        raise ContractError("protected policy entry has an invalid shape")
+    if not isinstance(held_jobs, dict) or front_door != "nix-job":
+        raise ContractError("protected workflows must use the nix-job front door")
+
+    if HOSTED_RUNNER_PATTERN.search(source):
+        raise ContractError("GitHub-hosted runner label is forbidden")
+    normalized = re.sub(r"\s+", "", source.lower())
+    if "type=gha" in normalized:
+        raise ContractError("GitHub cache provider is forbidden")
+    for token in FORBIDDEN_CACHE_OR_BOOTSTRAP_TOKENS:
+        if token.lower() in source.lower():
+            raise ContractError(f"forbidden cache/bootstrap path: {token}")
+
+    if document.get("env", {}).get("ATTIC_TOKEN") != "":
+        raise ContractError(
+            "protected workflow must clear ambient Attic credentials globally"
+        )
+    if policy.get("credential_boundary") != {
+        "attic": "public-read-only; ATTIC_TOKEN empty; inherited netrc disabled",
+        "github": (
+            "repository-scoped contents:read token may remain available to "
+            "Nix source fetches"
+        ),
+        "claim": "not globally credential-free",
+    }:
+        raise ContractError("credential claim boundary drifted")
+    for required_claim in (
+        "Attic authentication",
+        "contents:read GitHub token",
+    ):
+        if required_claim not in source:
+            raise ContractError(
+                f"protected workflow omits credential boundary: {required_claim}"
+            )
+
+    jobs = workflow_jobs(document)
+    if set(jobs) != set(expected_jobs):
+        raise ContractError(
+            "protected job inventory drifted "
+            f"(actual={sorted(jobs)}, expected={sorted(expected_jobs)})"
+        )
+    for job_name, expected_runner in expected_jobs.items():
+        job = jobs[job_name]
+        if job.get("runs-on") != expected_runner or not isinstance(
+            job.get("runs-on"), str
+        ):
+            raise ContractError(
+                f"{job_name} must use literal runner {expected_runner!r}"
+            )
+        if job_name in held_jobs:
+            validate_held_job(job_name, job, held_jobs[job_name])
+        else:
+            if "if" in job or "uses" in job:
+                raise ContractError(f"{job_name} must execute without a bypass")
+            validate_public_read_tuple(
+                path,
+                job_name,
+                job,
+                checkout_revision=policy["checkout_revision"],
+                gf_revision=policy["gloriousflywheel_revision"],
+            )
+
+    validate_action_refs(
+        jobs,
+        checkout_revision=policy["checkout_revision"],
+        gf_revision=policy["gloriousflywheel_revision"],
+        front_door=front_door,
+    )
+
+    conditions = [
+        step["if"]
+        for job_name, job in jobs.items()
+        for step in workflow_steps(job_name, job)
+        if "if" in step
+    ]
+    allowed_conditions = (
+        ["failure()", "always()"]
+        if path == ".github/workflows/ci-live-storage.yml"
+        else []
+    )
+    if conditions != allowed_conditions:
+        raise ContractError("protected proof contains an unaudited conditional")
+
+    if path == ".github/workflows/ci-live-storage.yml":
+        validate_live_storage_images(source)
+        live_command = next(
+            step["with"]["command"]
+            for step in workflow_steps("fleet-live", jobs["fleet-live"])
+            if step.get("uses", "").startswith(GF_ACTION_ROOT)
+        )
+        for required in (
+            'test -n "${DOCKER_HOST:-}"',
+            "docker version",
+            "docker info",
+        ):
+            if required not in live_command:
+                raise ContractError(f"live-storage lacks DinD check: {required}")
+    if path == ".github/workflows/ci.yml" and (
+        "--target x86_64-pc-windows-gnu" not in source
+    ):
+        raise ContractError("Windows source proof must use the reviewed cross target")
+
+
+def validate_disabled_workflow(
+    document: dict[str, Any],
+    contract: dict[str, Any],
+) -> None:
+    validate_topology(document, contract)
+    expected_triggers = contract["triggers"]
+    actual_triggers = workflow_triggers(document)
+    if actual_triggers != expected_triggers:
+        raise ContractError(
+            "disabled workflow trigger inventory drifted "
+            f"(actual={actual_triggers}, expected={expected_triggers})"
+        )
+    jobs = workflow_jobs(document)
+    for job_name, job in jobs.items():
+        if job.get("if") != DISABLED_JOB_CONDITION:
+            raise ContractError(
+                f"disabled workflow job can allocate a runner: {job_name}"
+            )
+
+
+def validate_inventory(root: Path, policy: dict[str, Any]) -> None:
+    protected = policy["protected_proof"]
+    disabled = policy["disabled_legacy_workflows"]
+    protected_paths = [entry["path"] for entry in protected]
+    disabled_paths = [entry["path"] for entry in disabled]
+    declared = protected_paths + disabled_paths
+    if len(declared) != len(set(declared)):
+        raise ContractError("workflow authority ledger has duplicate paths")
+    actual = sorted(
+        str(path.relative_to(root))
+        for path in (root / ".github/workflows").iterdir()
+        if path.suffix in {".yml", ".yaml"}
+    )
+    if sorted(declared) != actual:
+        raise ContractError(
+            "workflow authority ledger is not closed "
+            f"(undeclared={sorted(set(actual) - set(declared))}, "
+            f"missing={sorted(set(declared) - set(actual))})"
+        )
+
+    for entry in disabled:
+        if entry.get("owner") != policy["issue"]:
+            raise ContractError(
+                "every disabled workflow must retain explicit issue ownership"
+            )
+        document, _ = load_workflow(root / entry["path"])
+        validate_disabled_workflow(document, entry)
+
+
+def validate_actionlint_labels(root: Path, policy: dict[str, Any]) -> None:
+    expected = sorted(
+        {
+            runner
+            for contract in policy["protected_proof"]
+            for runner in contract["jobs"].values()
+        }
+    )
+    config = (root / ".github/actionlint.yaml").read_text(encoding="utf-8")
+    rendered = "self-hosted-runner:\n  labels:\n" + "".join(
+        f"    - {label}\n" for label in expected
+    )
+    if config != rendered:
+        raise ContractError(
+            "actionlint labels must exactly match protected capability lanes"
+        )
+
+
+def validate_current_tree(root: Path, policy: dict[str, Any]) -> None:
+    live_hold = policy.get("live_proof_hold")
+    if (
+        not isinstance(live_hold, dict)
+        or live_hold.get("issue") != "TIN-3120"
+        or "GitHub-hosted capacity is never a fallback"
+        not in str(live_hold.get("reason", ""))
+    ):
+        raise ContractError("TIN-3120 live-proof hold or no-fallback claim drifted")
+    validate_inventory(root, policy)
+    validate_actionlint_labels(root, policy)
+    for contract in policy["protected_proof"]:
+        document, source = load_workflow(root / contract["path"])
+        validate_protected_workflow(document, source, contract, policy)
+
+
+def validate_promotable_revision(policy: dict[str, Any]) -> None:
+    revision = policy.get("gloriousflywheel_revision")
+    hold = policy.get("promotion_hold")
+    if revision == PENDING_GF_REVISION:
+        if not isinstance(hold, dict) or hold.get("issue") != "TIN-3127":
+            raise ContractError("pending GF revision lacks its exact TIN-3127 hold")
+        raise PromotionHold(
+            "TIN-3127 signed merge revision is unavailable; "
+            "the protected workflows are intentionally non-promotable"
+        )
+    if not isinstance(revision, str) or re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        raise ContractError("GloriousFlywheel revision must be a full commit SHA")
+    if hold is not None:
+        raise ContractError("resolved GloriousFlywheel revision retains a stale hold")
+
+
+class CiAuthorityContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root = find_repo_root()
+        cls.policy = load_policy(cls.root)
+        cls.contracts = {
+            entry["path"]: entry for entry in cls.policy["protected_proof"]
+        }
+        cls.sources = {
+            path: (cls.root / path).read_text(encoding="utf-8")
+            for path in cls.contracts
+        }
+
+    def assert_protected_rejected(self, path: str, unsafe: str) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = Path(temporary) / "workflow.yml"
+            candidate.write_text(unsafe, encoding="utf-8")
+            with self.assertRaises(ContractError):
+                document, source = load_workflow(candidate)
+                validate_protected_workflow(
+                    document,
+                    source,
+                    self.contracts[path],
+                    self.policy,
+                )
+
+    def test_current_tree_is_closed_and_fail_closed(self) -> None:
+        validate_current_tree(self.root, self.policy)
+
+    def test_revision_promotion_state_is_explicit(self) -> None:
+        if self.policy["gloriousflywheel_revision"] == PENDING_GF_REVISION:
+            with self.assertRaisesRegex(PromotionHold, "TIN-3127"):
+                validate_promotable_revision(self.policy)
+        else:
+            validate_promotable_revision(self.policy)
+
+    def test_quoted_job_and_trigger_keys_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        variants = [
+            source.replace("  linux-source:\n", '  "linux-source":\n', 1),
+            source.replace(
+                "  linux-source:\n",
+                '  "linux\\u002dsource":\n',
+                1,
+            ),
+            source.replace("  pull_request:\n", '  "pull_request":\n', 1),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_escaped_uses_and_runs_on_keys_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        variants = [
+            source.replace(
+                "        uses:",
+                '        "u\\u0073es":',
+                1,
+            ),
+            source.replace(
+                "    runs-on:",
+                '    "r\\u0075ns-on":',
+                1,
+            ),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_alias_duplicate_and_extra_topology_is_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        variants = [
+            source.replace(
+                "    runs-on: tinyland-nix",
+                "    runs-on: &authority-lane tinyland-nix",
+                1,
+            ),
+            source.replace(
+                "  linux-source:\n",
+                "  linux-source: &linux-job\n",
+                1,
+            ).replace(
+                "  windows-cross:\n",
+                "  windows-cross:\n    <<: *linux-job\n",
+                1,
+            ),
+            source.replace(
+                "jobs:\n  linux-source:",
+                "jobs:\n  linux-source: {}\n  linux-source:",
+                1,
+            ),
+            source
+            + (
+                "\n  bypass:\n"
+                "    runs-on: tinyland-nix\n"
+                "    steps:\n"
+                "      - name: Bypass\n"
+                "        run: 'true'\n"
+            ),
+            source.replace(
+                "      - name: Verify exact checked out revision",
+                "      - name: Extra step\n"
+                "        run: 'true'\n\n"
+                "      - name: Verify exact checked out revision",
+                1,
+            ),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_dynamic_list_and_reusable_runners_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        variants = [
+            source.replace(
+                "runs-on: tinyland-nix",
+                "runs-on: ${{ vars.RUNNER || 'tinyland-nix' }}",
+                1,
+            ),
+            source.replace(
+                "runs-on: tinyland-nix",
+                "runs-on: [self-hosted, tinyland-nix]",
+                1,
+            ),
+            source.replace(
+                "    runs-on: tinyland-nix",
+                "    uses: example/repository/.github/workflows/ci.yml@main\n"
+                "    runs-on: tinyland-nix",
+                1,
+            ),
+            source.replace("runs-on: tinyland-nix", "runs-on: ubuntu-latest", 1),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_cache_and_action_authority_regressions_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        checkout = self.policy["checkout_revision"]
+        gf_revision = self.policy["gloriousflywheel_revision"]
+        variants = [
+            source + "\n# actions/cache@" + "0" * 40 + "\n",
+            source + "\n# cache-to: type=gha,mode=max\n",
+            source.replace(f"actions/checkout@{checkout}", "actions/checkout@main"),
+            source.replace(
+                f"{GF_ACTION_ROOT}nix-job@{gf_revision}",
+                f"{GF_ACTION_ROOT}nix-job@{'0' * 40}",
+                1,
+            ),
+            source.replace("persist-credentials: false", "persist-credentials: true"),
+            source.replace(
+                '          require-cache-push: "false"',
+                '          require-cache-push: "true"',
+                1,
+            ),
+            source.replace(
+                '          ATTIC_TOKEN: ""',
+                "          ATTIC_TOKEN: inherited",
+                1,
+            ),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_held_platform_gate_cannot_turn_green(self) -> None:
+        path = ".github/workflows/ci.yml"
+        unsafe = self.sources[path].replace(
+            "          exit 1\n",
+            "          exit 0\n",
+            1,
+        )
+        self.assert_protected_rejected(path, unsafe)
+
+    def test_live_storage_image_tags_are_rejected(self) -> None:
+        path = ".github/workflows/ci-live-storage.yml"
+        unsafe = self.sources[path].replace(
+            SEAWEED_IMAGE,
+            "chrislusf/seaweedfs:latest",
+        )
+        self.assert_protected_rejected(path, unsafe)
+
+    def test_new_workflow_requires_ledger_classification(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["disabled_legacy_workflows"] = policy["disabled_legacy_workflows"][:-1]
+        with self.assertRaises(ContractError):
+            validate_inventory(self.root, policy)
+
+    def test_disabled_workflow_cannot_reactivate_or_grow(self) -> None:
+        entry = self.policy["disabled_legacy_workflows"][0]
+        path = self.root / entry["path"]
+        source = path.read_text(encoding="utf-8")
+        variants = [
+            source.replace(
+                f"if: {DISABLED_JOB_CONDITION}",
+                "if: ${{ github.repository == github.repository }}",
+                1,
+            ),
+            source
+            + (
+                "\n  extra-disabled:\n"
+                f"    if: {DISABLED_JOB_CONDITION}\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - run: 'true'\n"
+            ),
+        ]
+        for unsafe in variants:
+            with tempfile.TemporaryDirectory() as temporary:
+                candidate = Path(temporary) / "workflow.yml"
+                candidate.write_text(unsafe, encoding="utf-8")
+                with self.assertRaises(ContractError):
+                    document, _ = load_workflow(candidate)
+                    validate_disabled_workflow(document, entry)
+
+
+def print_topology(root: Path, policy: dict[str, Any]) -> None:
+    entries = policy["protected_proof"] + policy["disabled_legacy_workflows"]
+    report = {}
+    for entry in entries:
+        document, _ = load_workflow(root / entry["path"])
+        report[entry["path"]] = topology_sha256(document)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source-hold-ok",
+        action="store_true",
+        help="validate the source shape while retaining the explicit TIN-3127 hold",
+    )
+    parser.add_argument(
+        "--print-topology",
+        action="store_true",
+        help="print reviewed workflow topology digests",
+    )
+    args = parser.parse_args()
+    root = find_repo_root()
+    policy = load_policy(root)
+    if args.print_topology:
+        print_topology(root, policy)
+        return 0
+
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(CiAuthorityContractTest)
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    if not result.wasSuccessful():
+        return 1
+    try:
+        validate_promotable_revision(policy)
+    except PromotionHold as hold:
+        print(f"HOLD: {hold}", file=sys.stderr)
+        return 0 if args.source_hold_ok else 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-ci-authority-contract.py
+++ b/scripts/test-ci-authority-contract.py
@@ -53,6 +53,36 @@ PUBLIC_READ_SITES = {
     (".github/workflows/nix-ci.yml", "nix-linux"): "tcfs-nix-linux",
     (".github/workflows/ci-live-storage.yml", "fleet-live"): ("tcfs-live-storage"),
 }
+LIVE_STORAGE_PATHS = [
+    "crates/**",
+    "tests/**",
+    "Cargo.toml",
+    "Cargo.lock",
+    "docker-compose.yml",
+    "config/**",
+    ".github/workflows/ci-live-storage.yml",
+    "scripts/test-ci-authority-contract.py",
+    "config/ci-authority-policy.json",
+]
+PROTECTED_TRIGGER_CONTRACTS: dict[str, dict[str, Any]] = {
+    ".github/workflows/ci.yml": {
+        "push": {"branches": ["main", "dev", "sid/**", "1-*"]},
+        "pull_request": None,
+    },
+    ".github/workflows/ci-live-storage.yml": {
+        "pull_request": {"paths": LIVE_STORAGE_PATHS},
+        "push": {
+            "branches": ["main"],
+            "paths": LIVE_STORAGE_PATHS,
+        },
+        "workflow_dispatch": None,
+    },
+    ".github/workflows/nix-ci.yml": {
+        "push": {"branches": ["main", "dev"]},
+        "pull_request": None,
+        "workflow_dispatch": None,
+    },
+}
 
 
 class ContractError(ValueError):
@@ -211,6 +241,25 @@ def workflow_triggers(document: dict[str, Any]) -> list[str]:
     if not all(isinstance(trigger, str) for trigger in triggers):
         raise ContractError("every workflow trigger must be a string key")
     return list(triggers)
+
+
+def validate_protected_triggers(
+    document: dict[str, Any],
+    contract: dict[str, Any],
+) -> None:
+    path = contract.get("path")
+    if contract.get("pull_request_all_bases") is not True:
+        raise ContractError(f"{path} lacks the reviewed all-PR-base contract")
+
+    triggers = document.get("on")
+    expected = PROTECTED_TRIGGER_CONTRACTS.get(path)
+    if expected is None:
+        raise ContractError(f"{path} lacks a source-owned protected trigger contract")
+    if triggers != expected:
+        raise ContractError(
+            f"{path} protected trigger contract drifted "
+            f"(actual={triggers!r}, expected={expected!r})"
+        )
 
 
 def validate_permissions(document: dict[str, Any]) -> None:
@@ -437,6 +486,7 @@ def validate_protected_workflow(
     policy: dict[str, Any],
 ) -> None:
     validate_topology(document, contract)
+    validate_protected_triggers(document, contract)
     validate_permissions(document)
     path = contract["path"]
     expected_jobs = contract["jobs"]
@@ -695,6 +745,43 @@ class CiAuthorityContractTest(unittest.TestCase):
         ]
         for unsafe in variants:
             self.assert_protected_rejected(path, unsafe)
+
+    def test_protected_trigger_contract_rejects_narrowing_and_expansion(self) -> None:
+        for path in sorted(self.contracts):
+            document, parsed_source = load_workflow(self.root / path)
+            pull_request_variants = [
+                {"branches": ["main"]},
+                {"branches-ignore": ["dev"]},
+                {"types": ["closed"]},
+                {"paths": ["README.md"]},
+                {"paths-ignore": ["**"]},
+            ]
+            unsafe_documents: list[dict[str, Any]] = []
+            for pull_request in pull_request_variants:
+                unsafe = copy.deepcopy(document)
+                unsafe["on"]["pull_request"] = pull_request
+                unsafe_documents.append(unsafe)
+            for trigger, value in (
+                ("pull_request_target", None),
+                ("schedule", [{"cron": "0 0 * * *"}]),
+            ):
+                unsafe = copy.deepcopy(document)
+                unsafe["on"][trigger] = value
+                unsafe_documents.append(unsafe)
+
+            for unsafe in unsafe_documents:
+                contract = copy.deepcopy(self.contracts[path])
+                contract["topology_sha256"] = topology_sha256(unsafe)
+                with self.assertRaisesRegex(
+                    ContractError,
+                    "protected trigger contract drifted",
+                ):
+                    validate_protected_workflow(
+                        unsafe,
+                        parsed_source,
+                        contract,
+                        self.policy,
+                    )
 
     def test_escaped_uses_and_runs_on_keys_are_rejected(self) -> None:
         path = ".github/workflows/ci.yml"


### PR DESCRIPTION
## Summary

Publishes the clean TIN-2864 registered-root reconciliation lane for canonical CI and independent review.

- binds immutable planner policy and strict reconciliation inputs
- captures held local snapshots and remote observation resources
- composes immutable GitRaw/catalog source state
- closes the source-only catalog publication, mutation-journal, monotonic-fence, and authenticated cold-recovery contracts
- composes current `main` and the TIN-2538 GF-only CI-authority source checkpoint

## Exact source state

- signed and GitHub-verified head: `0a3a9ceceeab497af614e07e80e91780c7f3be47`
- head commit: `fix(ci): run protected proof on stacked PRs`
- branch: `codex/tin-2864-root-plan-20260719`
- draft PR: 34 commits, 44 files, +43,368/-692
- Neo, Sting, upstream, and live remote are clean and exact at tree `6a1f26d6c00e478cbd007895aa364664d374f9f8`

## CP21 storage-fence closure

Every authoritative mutable Publishing `HEAD`, Index, Reservation, Manifest, and committed `HEAD` write must pass through one retained backend fence.

Each request exact-binds the selected root context, storage/control authorities, writer epoch and writer-fence fingerprints, Pending revision/record, mutation-journal ID and count, ordinal, stage, key, conditional-write predicate, payload length, and BLAKE3. The backend contract must atomically reject a stale fence or apply the exact write at the storage authorization point. Advisory liveness checks, an in-process mutex, or a control read followed by raw OpenDAL I/O do not satisfy it.

Raw rereads are receipt validation only and cannot redeem backend rejection. Exact replay and failure retention cover Pending, Publishing `HEAD`, namespace mutations, committed `HEAD`, and Ready.

## CP22 authenticated cold reconstruction

A fresh process can now reconstruct one exact canonical `PublicationPending` epoch without reusing warm planner/executor objects or treating copied bytes as authority.

- persists and reconstructs the complete predecessor storage binding, including Version+ETag
- fingerprints the canonical full binding and rejects ETag-only or crossed baselines
- reacquires an opaque handle to the same durable Pending fence and contiguous receipt ledger
- preflights aggregate count, key, body, binding, page, root, and per-kind budgets before untrusted bulk reads or retention
- reconstructs the immutable archived predecessor closure, authoritative journal, successor payloads, and exact unchanged named objects
- repeats archive/root/page/journal/payload/unchanged-object validation after fence reacquisition and before ordinal zero
- resumes fresh, partial-prefix, terminal, and third-state cases through authenticated receipt replay only
- compares recovered committed pages directly to exact expected ordered slices
- derives canonical Ready bytes/revision and requires terminal ledger/provenance continuity

The adversarial backend fixture now models a one-time exact Ready→Pending CAS. It rejects crossed Ready without state movement and mutates an archived page during reacquisition to prove post-reacquisition rejection with zero receipts, ordinals, or Ready progress.

## Claim boundary

This remains **SOURCE_ONLY_DIGESTLESS**. No production selector, authenticated backend constructor, or live storage-fence implementation exists. The code cannot mint deployed authority, mutate live `HEAD` or namespace state, emit a plan digest, authorize an action, deploy, activate, reconcile live state, access credentials, enroll a device, or enter a crypto ceremony.

The only direct source-path writes outside the fence are content-addressed absent-only immutable archive, journal, payload, page, and root publications. The fence and reacquisition traits have only `cfg(test)` implementations.

## Exact-head validation

Exact head `0b7b789b121cbbadcc6c970fc6cfa8230ac0cc83` passed on Sting inside the repo-managed `nix develop --accept-flake-config` shell with the pinned Rust 1.93.0 toolchain:

- focused publication contract: 60/60
- `tcfs-core` unit tests: 44/44
- `tcfs-sync` unit tests: 698/698
- every `tcfs-core`/`tcfs-sync` all-target integration test
- strict affected-crate all-target `clippy -D warnings`
- `cargo fmt --all -- --check`
- exact predecessor Neo/Sting/upstream/live-remote clean-head and tree seal
- current exact head `0a3a9ceceeab497af614e07e80e91780c7f3be47`: 12/12 CI-authority contract tests, Ruff check/format, JSON/Python parse, local `actionlint`, Sting diff check, and clean exact tree seal
- three independent exact-diff Rust, security, and test reviews: no remaining P0/P1

This is strong exact-head local source/build evidence, not durable CI authority.

## Durable CI state

Fresh exact-head checks instantiated automatically at `2026-07-25T14:14:55Z` on the corrected workflow topology:

- CI, Nix CI, and CI Live Storage all instantiated at the exact head
- six executable jobs are queue-bound on sanctioned `tinyland-nix` / `tinyland-dind` labels; `matrix.surface` is intentionally skipped
- runner assignment and durable authority remain pending live TCFS registration scope
- no hosted runner or GitHub-capacity fallback is authorized or observed

Both Darwin jobs remain explicitly `HELD` and deliberately exit nonzero when scheduled. TIN-2998 is Done; TCFS topology integration and durable native authority remain separate gates.

## Remaining promotion gates

- land the sealed authenticated post-Ready acknowledgement slice in stacked PR #568 after #567
- land the sealed byte-aware successor-layout slice in stacked PR #567 after this PR
- implement the production storage-side fence/gateway and revoke or epoch-fence every raw writer credential/path
- retain and recheck the exact control guard across final registered-source composition
- prove Git object presence/kind, reachability, ancestry, fast-forward safety, and enduring writer exclusion
- add authenticated root selection, cross-root admission, bootstrap/high-water, and all-writer production constructors
- bind chunk closure and selected-device decryptability; strict manifest parsing still drops version/wrapped-key envelopes after shape validation
- add conditional-write freshness/backend epoch, credential-epoch rotation, and registered-catalog GC
- close strict local acquisition beyond Linux

## Coordination and holds

This lane owns registered-root planning/publication surfaces in `tcfs-core` and `tcfs-sync`. Do not stack unrelated CLI/MCP work onto it; both dirty primary checkouts remain untouched.

TIN-2864 stays In Progress and TIN-2865 remains blocked. TIN-2801 remains the authoritative fleet/live-runtime freeze. TIN-3120/TIN-2538 own durable personal-owner multi-capability listener proof; TIN-2998 owns native Darwin authority.

Keep this PR draft. Do not mark ready or merge until exact-head sanctioned CI is durable, the held Darwin topology is resolved, and the selected landing scope’s review findings are dispositioned. No auto-merge or bypass.

Linear: TIN-2864
Related: TIN-2538, TIN-3120, TIN-2998, TIN-2801


## 2026-08-16 convergence rebind

Source head remains unchanged at signed/GitHub-verified `0a3a9ceceeab497af614e07e80e91780c7f3be47`. Current signed main is `dfe8282a4d93af0ca1c495065ec82002352d4d86`; this Draft branch is not current-main-qualified. Preserve the existing carrier order: land/review #572, compose it into this same #565 lane, recreate unsigned #576/#577 on fresh signed history, then refresh existing #567/#568. Do not open a replacement TIN-2864 lane.

TIN-2658's ratified README/AGENTS keep-baseline decision now folds into TIN-2864's future versioned, digest-bound Plan/Execute contract as explicit one-shot `keep-current-local` decisions. Routing remains root-ID-only; canonical relative paths are digest-bound action selectors. Legacy `ResolveConflict` and Git-only `ResolveRegisteredRoot` remain disabled for ordinary files. This current 44-file source packet remains intentionally `SOURCE_ONLY_DIGESTLESS` and does not yet implement the production Plan/Execute API or mint live authority.

Any future implementation must reuse the strict local/state/Git/catalog/publication spine already carried here, absorb the newer TIN-3277/TIN-3278 state/conflict corrections in the ratified order, and preserve the no-delete, complete-truth, exact-digest, stable-lock, all-writer, and partial-failure boundaries. No source push, CI rerun, deployment, resolver, auth, or runtime action is authorized by this body rebind.