### PR TITLE
TIN-1417: tcfs device revoke operator UX + shared-master fleet migration runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ intent rather than the current supported/proven surface.
 
 ### Added
 
+- `tcfs device revoke` gained an operator-grade UX (TIN-1417): `--dry-run`
+  previews the resolved target, post-revoke roll-call impact, effective
+  `crypto.wrap_mode`, and propagation target without mutating anything;
+  `--sync-remote` publishes the revocation to the canonical signed fleet
+  registry in the same step (previously a separate `device enroll --sync-remote`
+  that was easy to forget, leaving a revocation no peer ever saw). A device may
+  now be addressed by name, full device id, or the 8-character id prefix printed
+  by `tcfs device list`, and an ambiguous selector is a hard error listing the
+  candidates instead of a silent first match. Revocation is applied by device id
+  when one exists, so a same-named ghost sibling is never collaterally revoked.
+- Operator runbook for migrating a shared-master fleet to per-device wrapping
+  (`docs/ops/shared-master-fleet-migration-runbook-2026-07-28.md`): per-step
+  commands, hard preconditions, verification, abort, and a status ledger for the
+  ratified `master -> dual -> roll-call -> per_device` sequence. Documents the
+  FileProvider backend-capability precondition the roll-call gate cannot see —
+  the `direct`/`uniffi` (iOS) backends only unwrap under the master key and fail
+  closed on a per-device v3 manifest, so they must be accounted for before any
+  contract flip. Doc-only: no fleet state and no config default changes.
 - Daemon-trusted stable-root routing for isolated conflict caches: clients can
   inspect a named root and run the bounded Git keep-both dry-run/execute flow
   without supplying a state path or storage prefix. Registered roots inherit
@@ -29,6 +47,18 @@ intent rather than the current supported/proven surface.
 
 ### Security
 
+- `tcfs device revoke` now confirms before mutating, and refuses to proceed on a
+  non-interactive stdin without `--yes`, because revocation is sticky
+  fleet-wide: the registry merge only ever flips `revoked` false to true and no
+  peer can reverse it. It also refuses by default to revoke the identity the
+  running host is itself enrolled as (`--allow-self` to override), and its
+  `--sync-remote` path reuses the same TIN-1417 B4 trust enforcement as enroll —
+  a signature-present-but-invalid remote registry is hard-rejected and an
+  unsigned legacy remote is refused unless `--accept-unsigned-remote` is passed,
+  so an attacker-injected recipient cannot be laundered into a signed registry.
+  The existing forward-secrecy warning is unchanged, and under
+  `crypto.wrap_mode = master` the command now states plainly that a revoke has
+  no cryptographic effect at all.
 - V1 inventory never reinterprets the legacy conflict-only root registry,
   creates a state-lock inode, repairs or recovers a cache, exposes an MCP tool,
   or grants reconcile/mutation authority. It filters unauthorized prefixes

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -549,10 +549,36 @@ enum DeviceAction {
     },
     /// List enrolled devices
     List,
-    /// Revoke a device by name
+    /// Revoke a device (by name, device id, or unique id prefix)
+    ///
+    /// Revocation is STICKY across the fleet: the registry merge only ever flips
+    /// `revoked` false -> true, so a peer can never resurrect a revoked device.
+    /// Treat this as a one-way operation and preview it with `--dry-run` first.
     Revoke {
-        /// Device name to revoke
-        name: String,
+        /// Device name, full device id, or an unambiguous device-id prefix
+        device: String,
+        /// Preview the effect (target, roll-call impact, propagation) and exit
+        /// without mutating any registry, local or remote
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip the interactive confirmation. Required for non-interactive use
+        /// (scripts, CI, ssh without a TTY).
+        #[arg(long, short = 'y')]
+        yes: bool,
+        /// Propagate the revocation to the canonical remote registry
+        /// (`{prefix}/tcfs-meta/devices.json`). Without this the revocation is
+        /// LOCAL ONLY and no peer will ever learn about it.
+        #[arg(long)]
+        sync_remote: bool,
+        /// TIN-1417 B4 migration escape hatch: explicitly accept and re-sign an
+        /// UNSIGNED (legacy) remote registry during `--sync-remote`. Same
+        /// laundering guard as `device enroll --accept-unsigned-remote`.
+        #[arg(long, requires = "sync_remote")]
+        accept_unsigned_remote: bool,
+        /// Allow revoking the identity this host itself is enrolled as. Without
+        /// this the command refuses, because it would strand this host.
+        #[arg(long)]
+        allow_self: bool,
     },
     /// Show this device's identity and status
     Status,
@@ -908,7 +934,27 @@ async fn main() -> Result<()> {
                 .await
             }
             DeviceAction::List => cmd_device_list(),
-            DeviceAction::Revoke { name } => cmd_device_revoke(&config, &name),
+            DeviceAction::Revoke {
+                device,
+                dry_run,
+                yes,
+                sync_remote,
+                accept_unsigned_remote,
+                allow_self,
+            } => {
+                cmd_device_revoke(
+                    &config,
+                    &device,
+                    RevokeOptions {
+                        dry_run,
+                        yes,
+                        sync_remote,
+                        accept_unsigned_remote,
+                        allow_self,
+                    },
+                )
+                .await
+            }
             DeviceAction::Status => cmd_device_status(),
             DeviceAction::Invite { expiry_hours, qr } => {
                 cmd_device_invite(&config, expiry_hours, qr).await
@@ -5561,58 +5607,411 @@ fn cmd_device_list() -> Result<()> {
     println!("Enrolled devices ({}):", registry.devices.len());
     for device in &registry.devices {
         let status = if device.revoked { "REVOKED" } else { "active" };
-        let id_short = if device.device_id.len() > 8 {
-            &device.device_id[..8]
-        } else {
-            &device.device_id
-        };
         println!(
             "  {} [{}] id={} — enrolled {} — {}",
-            device.name, status, id_short, device.enrolled_at, device.public_key
+            device.name,
+            status,
+            short_device_id(&device.device_id),
+            device.enrolled_at,
+            device.public_key
         );
     }
 
     Ok(())
 }
 
+/// Abbreviated device id as printed by `tcfs device list` — the string an
+/// operator actually copies when they target a device.
+fn short_device_id(device_id: &str) -> &str {
+    if device_id.len() > 8 {
+        &device_id[..8]
+    } else {
+        device_id
+    }
+}
+
 // ── `tcfs device revoke` ─────────────────────────────────────────────────────
 
-fn cmd_device_revoke(config: &tcfs_core::config::TcfsConfig, name: &str) -> Result<()> {
+/// Operator-facing options for `tcfs device revoke` (TIN-1417).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct RevokeOptions {
+    dry_run: bool,
+    yes: bool,
+    sync_remote: bool,
+    accept_unsigned_remote: bool,
+    allow_self: bool,
+}
+
+/// Everything the operator needs to see BEFORE a revoke mutates anything.
+///
+/// Computed by [`plan_device_revoke`] against an unmutated registry so
+/// `--dry-run` and the real path print identical facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RevokePlan {
+    name: String,
+    device_id: String,
+    public_key: String,
+    /// The device is already revoked; applying is a no-op locally (still worth
+    /// running with `--sync-remote` to finish a half-propagated revocation).
+    already_revoked: bool,
+    /// This host is enrolled as the targeted device (same identity `tcfs device
+    /// status` reports), so revoking it would strand this host.
+    is_self: bool,
+    /// Active devices remaining after this revoke.
+    remaining_active: usize,
+    /// How many of those carry a real age recipient.
+    remaining_capable: usize,
+    /// Remaining active devices that would still block the `per_device`
+    /// contract flip (no real age recipient).
+    remaining_incapable: Vec<String>,
+}
+
+impl RevokePlan {
+    /// True when the post-revoke fleet satisfies the roll-call gate, i.e. the
+    /// `per_device` contract flip is not blocked by a missing recipient.
+    fn roll_call_ready_after(&self) -> bool {
+        self.remaining_active > 0
+            && self.remaining_capable == self.remaining_active
+            && self.remaining_incapable.is_empty()
+    }
+}
+
+/// Resolve an operator-supplied device selector to exactly one registry index.
+///
+/// Accepts, in priority order: an exact device NAME, an exact `device_id`, or an
+/// unambiguous `device_id` PREFIX of at least 4 chars (what `tcfs device list`
+/// prints). Names are not unique in a registry — duplicate/ghost entries are
+/// real (`docs/ops/ghost-device-revocation-safety-2026-07-02.md`) — so an
+/// ambiguous selector is a hard error listing the candidates rather than a
+/// silent first-match.
+fn resolve_device_selector(
+    registry: &tcfs_secrets::device::DeviceRegistry,
+    selector: &str,
+) -> Result<usize> {
+    let candidates = |matches: Vec<usize>| -> String {
+        matches
+            .iter()
+            .map(|&i| {
+                let d = &registry.devices[i];
+                format!("{} (id={})", d.name, short_device_id(&d.device_id))
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    let by_name: Vec<usize> = registry
+        .devices
+        .iter()
+        .enumerate()
+        .filter(|(_, d)| d.name == selector)
+        .map(|(i, _)| i)
+        .collect();
+    let name_matches = by_name.len();
+    match name_matches {
+        1 => return Ok(by_name[0]),
+        0 => {}
+        _ => anyhow::bail!(
+            "device name '{selector}' is ambiguous ({name_matches} entries: {}). Re-run with the \
+             device id shown by 'tcfs device list'.",
+            candidates(by_name)
+        ),
+    }
+
+    if let Some(i) = registry
+        .devices
+        .iter()
+        .position(|d| !d.device_id.is_empty() && d.device_id == selector)
+    {
+        return Ok(i);
+    }
+
+    if selector.len() >= 4 {
+        let by_prefix: Vec<usize> = registry
+            .devices
+            .iter()
+            .enumerate()
+            .filter(|(_, d)| !d.device_id.is_empty() && d.device_id.starts_with(selector))
+            .map(|(i, _)| i)
+            .collect();
+        let prefix_matches = by_prefix.len();
+        match prefix_matches {
+            1 => return Ok(by_prefix[0]),
+            0 => {}
+            _ => anyhow::bail!(
+                "device id prefix '{selector}' is ambiguous ({prefix_matches} matches: {}). \
+                 Use the full id.",
+                candidates(by_prefix)
+            ),
+        }
+    }
+
+    anyhow::bail!(
+        "no device matches '{selector}' (tried name, device id, and id prefix). \
+         Run 'tcfs device list' to see enrolled devices."
+    )
+}
+
+/// Build the [`RevokePlan`] for a selector without mutating anything.
+///
+/// `is_local` decides self-revocation: the caller passes a predicate that knows
+/// which registry entry this host is enrolled as.
+fn plan_device_revoke(
+    registry: &tcfs_secrets::device::DeviceRegistry,
+    selector: &str,
+    is_local: impl Fn(&tcfs_secrets::device::DeviceIdentity) -> bool,
+) -> Result<RevokePlan> {
+    let index = resolve_device_selector(registry, selector)?;
+    let target = &registry.devices[index];
+
+    let mut remaining_active = 0usize;
+    let mut remaining_capable = 0usize;
+    let mut remaining_incapable = Vec::new();
+    for (i, device) in registry.devices.iter().enumerate() {
+        if i == index || device.revoked {
+            continue;
+        }
+        remaining_active += 1;
+        if tcfs_secrets::device::is_real_age_public_key(&device.public_key) {
+            remaining_capable += 1;
+        } else {
+            remaining_incapable.push(device.name.clone());
+        }
+    }
+
+    Ok(RevokePlan {
+        name: target.name.clone(),
+        device_id: target.device_id.clone(),
+        public_key: target.public_key.clone(),
+        already_revoked: target.revoked,
+        is_self: is_local(target),
+        remaining_active,
+        remaining_capable,
+        remaining_incapable,
+    })
+}
+
+/// Print the plan. Identical output for `--dry-run` and the real path, so a
+/// preview is a faithful rehearsal.
+fn print_revoke_plan(
+    plan: &RevokePlan,
+    config: &tcfs_core::config::TcfsConfig,
+    opts: RevokeOptions,
+) {
+    println!("Revoke target:");
+    println!("  name:        {}", plan.name);
+    println!(
+        "  device_id:   {}",
+        if plan.device_id.is_empty() {
+            "(none — legacy entry, will be matched by name)".to_string()
+        } else {
+            plan.device_id.clone()
+        }
+    );
+    println!("  public_key:  {}", plan.public_key);
+    println!(
+        "  state:       {}",
+        if plan.already_revoked {
+            "ALREADY REVOKED"
+        } else {
+            "active"
+        }
+    );
+    if plan.is_self {
+        println!("  self:        YES — this host is enrolled as this device");
+    }
+
+    println!("Fleet after revoke:");
+    println!(
+        "  active devices:  {} ({} with a real age recipient)",
+        plan.remaining_active, plan.remaining_capable
+    );
+    if !plan.remaining_incapable.is_empty() {
+        println!(
+            "  roll-call blockers (no real age recipient): {}",
+            plan.remaining_incapable.join(", ")
+        );
+    }
+    println!(
+        "  per_device roll-call: {}",
+        if plan.roll_call_ready_after() {
+            "READY (contract flip is not blocked by recipient capability)"
+        } else if plan.remaining_active == 0 {
+            "NOT READY — zero active devices left; writers fall back to master-only"
+        } else {
+            "NOT READY — an active device lacks a real age recipient"
+        }
+    );
+
+    println!(
+        "  wrap_mode:       {:?} (revocation denies NEW content only under per_device)",
+        config.crypto.wrap_mode
+    );
+    let remote = format!(
+        "{}/tcfs-meta/devices.json",
+        config.storage.resolved_prefix().trim_end_matches('/')
+    );
+    println!(
+        "  propagation:     {}",
+        if opts.sync_remote {
+            format!("republish signed registry to {remote}")
+        } else {
+            "LOCAL ONLY (no remote publish; pass --sync-remote)".to_string()
+        }
+    );
+}
+
+/// Interactive confirmation. Revocation is sticky fleet-wide (the merge only
+/// flips `revoked` false -> true), so it gets a real prompt unless `--yes`.
+fn confirm_revoke(plan: &RevokePlan, yes: bool) -> Result<()> {
+    if yes {
+        return Ok(());
+    }
+    use std::io::{IsTerminal, Write};
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "refusing to revoke '{}' without confirmation on a non-interactive stdin. \
+             Re-run with --yes to confirm, or --dry-run to preview.",
+            plan.name
+        );
+    }
+    print!(
+        "Revoke '{}' (id={})? This is STICKY fleet-wide and cannot be undone by a peer. [y/N] ",
+        plan.name,
+        short_device_id(&plan.device_id)
+    );
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("reading confirmation from stdin")?;
+    if !matches!(line.trim(), "y" | "Y" | "yes" | "Yes" | "YES") {
+        anyhow::bail!("aborted: '{}' was NOT revoked", plan.name);
+    }
+    Ok(())
+}
+
+async fn cmd_device_revoke(
+    config: &tcfs_core::config::TcfsConfig,
+    selector: &str,
+    opts: RevokeOptions,
+) -> Result<()> {
     let registry_path = tcfs_secrets::device::default_registry_path();
     let mut registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path)?;
 
-    // Capture the public key for the forward-secrecy notice before mutating.
-    let recipient = registry.find(name).map(|d| d.public_key.clone());
+    // Self = the identity this host is ENROLLED as, i.e. exactly what
+    // `tcfs device status` reports. Deliberately NOT "any device whose secret
+    // half happens to sit in this registry directory": a host that minted
+    // throwaway identities locally (the FileProvider bring-up ghosts) holds
+    // their secrets too, and those must stay revocable without an override.
+    let hostname = tcfs_secrets::device::default_device_name();
+    let plan = plan_device_revoke(&registry, selector, |device| device.name == hostname)?;
 
-    if registry.revoke(name) {
+    print_revoke_plan(&plan, config, opts);
+
+    if plan.is_self && !opts.allow_self {
+        anyhow::bail!(
+            "refusing to revoke '{}': this host is enrolled as that device, so revoking it \
+             strands this host (it drops out of every recipient set built afterwards). \
+             Re-run with --allow-self if that is genuinely what you want.",
+            plan.name
+        );
+    }
+
+    if opts.dry_run {
+        println!();
+        println!("DRY RUN: nothing was changed (local registry and remote are untouched).");
+        return Ok(());
+    }
+
+    if plan.already_revoked {
+        println!();
+        println!(
+            "Device '{}' is already revoked locally; no local change needed.",
+            plan.name
+        );
+        if !opts.sync_remote {
+            println!(
+                "  If the fleet has not converged, re-run with --sync-remote to republish it."
+            );
+            return Ok(());
+        }
+    } else {
+        confirm_revoke(&plan, opts.yes)?;
+
         // TIN-1899: recipient-set REMOVAL is the DEFAULT, cheap, immediate action.
-        // `revoke()` drops the device from `active_devices()`, so every recipient
+        // Revoking drops the device from `active_devices()`, so every recipient
         // set built afterwards (CLI/daemon/FileProvider via load_verified) excludes
         // it: NO new content is wrapped to the revoked device. We re-sign so the
         // signed envelope records `revoked + revoked_at` and the removal is
         // trustworthy (TIN-1417 B4).
-        save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
-        println!("Revoked device: {name}");
-        println!("  Dropped from the recipient set (immediate): no NEW content will be wrapped to this device.");
-        if let Some(recipient) = recipient {
-            println!("  Removed age recipient: {recipient}");
-        }
-
-        // LOUD forward-secrecy warning: recipient-set removal alone does NOT
-        // re-key content the device could already read.
-        eprintln!();
-        eprintln!(
-            "  WARNING (forward secrecy): the revoked device RETAINS read access to content it \
-             already pulled AND to any content that has not yet been re-keyed (its old FileKey \
-             wraps and cached chunks are unchanged)."
+        //
+        // Revoke by ID whenever we have one: names are not unique, and the
+        // selector may well have been an id in the first place.
+        let revoked = if plan.device_id.is_empty() {
+            registry.revoke(&plan.name)
+        } else {
+            registry.revoke_by_id(&plan.device_id)
+        };
+        anyhow::ensure!(
+            revoked,
+            "device '{}' disappeared from the registry while revoking",
+            plan.name
         );
-        eprintln!(
-            "  To achieve forward secrecy, re-key the affected content (expensive):\n      \
-             tcfs key rotate <prefix> --rotate-keys\n  This generates fresh FileKeys, re-encrypts \
-             content under new addresses, and re-wraps ONLY to the current recipient set."
+        save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
+
+        println!();
+        println!(
+            "Revoked device: {} (id={})",
+            plan.name,
+            short_device_id(&plan.device_id)
+        );
+        println!("  Dropped from the recipient set (immediate): no NEW content will be wrapped to this device.");
+        println!("  Removed age recipient: {}", plan.public_key);
+        println!("  Registry: {}", registry_path.display());
+    }
+
+    if opts.sync_remote {
+        let remote = sync_registry_with_remote(
+            config,
+            &mut registry,
+            &registry_path,
+            opts.accept_unsigned_remote,
+        )
+        .await?;
+        println!("  Propagated: {remote}");
+        println!(
+            "  Converge peers with: tcfs device enroll --sync-remote  (revocation is sticky, \
+             so a stale peer cannot resurrect it)"
         );
     } else {
-        anyhow::bail!("Device '{name}' not found");
+        println!();
+        println!(
+            "  LOCAL ONLY: the canonical fleet registry has NOT been updated. No peer knows \
+             about this revocation yet."
+        );
+        println!("  Propagate with: tcfs device revoke {selector} --sync-remote --yes");
+    }
+
+    // LOUD forward-secrecy warning: recipient-set removal alone does NOT
+    // re-key content the device could already read.
+    eprintln!();
+    eprintln!(
+        "  WARNING (forward secrecy): the revoked device RETAINS read access to content it \
+         already pulled AND to any content that has not yet been re-keyed (its old FileKey \
+         wraps and cached chunks are unchanged)."
+    );
+    eprintln!(
+        "  To achieve forward secrecy, re-key the affected content (expensive):\n      \
+         tcfs key rotate <prefix> --rotate-keys\n  This generates fresh FileKeys, re-encrypts \
+         content under new addresses, and re-wraps ONLY to the current recipient set."
+    );
+    if config.crypto.wrap_mode == tcfs_core::config::WrapMode::Master {
+        eprintln!(
+            "  NOTE: crypto.wrap_mode = master, so this revocation has NO cryptographic effect \
+             today — every holder of the master key still decrypts everything. It is registry \
+             hygiene plus a roll-call precondition for the dual -> per_device migration \
+             (docs/ops/per-device-crypto-migration-2026-06-06.md)."
+        );
     }
 
     Ok(())
@@ -5675,48 +6074,13 @@ async fn cmd_device_enroll(
     save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
 
     if sync_remote {
-        let op = build_operator(config).await?;
-        let meta_prefix = config.storage.resolved_prefix();
-        // TIN-1417 B4: verify the remote registry before merging. The remote object
-        // store is the primary tamper surface, so a signature-PRESENT-but-invalid
-        // remote is hard-rejected by `load_remote_verified`. An UNSIGNED (legacy)
-        // remote verifies as `UnsignedLegacy` and its trust MUST be bound here: if
-        // we merged it and then re-signed the result with our real master, an
-        // attacker who stripped the signature and injected a recipient would have
-        // their entry LAUNDERED into a validly-signed registry. So we refuse to
-        // merge an unsigned remote unless the operator explicitly opts in with
-        // `--accept-unsigned-remote` (loud warning below).
-        let remote = match master_key_for_registry_signing(config) {
-            Some(mk) => {
-                let (remote, trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
-                    &op,
-                    meta_prefix,
-                    mk.as_bytes(),
-                )
-                .await?;
-                enforce_remote_merge_trust(trust, accept_unsigned_remote)?;
-                remote
-            }
-            None => {
-                // No master key available: we cannot verify the remote at all, and
-                // we will write the merged result UNSIGNED anyway (no laundering
-                // into a signed registry is possible). Preserve legacy behaviour.
-                tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?
-            }
-        };
-        merge_device_registry(&mut registry, &remote)?;
-        match master_key_for_registry_signing(config) {
-            Some(mk) => {
-                registry
-                    .sync_to_remote_signed(&op, meta_prefix, mk.as_bytes())
-                    .await?
-            }
-            None => {
-                tcfs_secrets::device::DeviceRegistry::sync_to_remote(&registry, &op, meta_prefix)
-                    .await?
-            }
-        }
-        save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
+        sync_registry_with_remote(
+            config,
+            &mut registry,
+            &registry_path,
+            accept_unsigned_remote,
+        )
+        .await?;
     }
 
     if enrolled_or_repaired {
@@ -5745,6 +6109,70 @@ async fn cmd_device_enroll(
     }
 
     Ok(())
+}
+
+/// Converge the local device registry with the canonical remote one and
+/// republish the signed result to `{prefix}/tcfs-meta/devices.json`.
+///
+/// Shared by `device enroll --sync-remote` and `device revoke --sync-remote` so
+/// both paths get identical trust handling: the remote is signature-verified
+/// before it is merged, an UNSIGNED (legacy) remote is refused unless the
+/// operator explicitly accepts it (see [`enforce_remote_merge_trust`]), and the
+/// merged result is re-signed with the master key when one is available.
+///
+/// Returns the remote object path that was published, for operator output.
+async fn sync_registry_with_remote(
+    config: &tcfs_core::config::TcfsConfig,
+    registry: &mut tcfs_secrets::device::DeviceRegistry,
+    registry_path: &Path,
+    accept_unsigned_remote: bool,
+) -> Result<String> {
+    let op = build_operator(config).await?;
+    let meta_prefix = config.storage.resolved_prefix();
+    // TIN-1417 B4: verify the remote registry before merging. The remote object
+    // store is the primary tamper surface, so a signature-PRESENT-but-invalid
+    // remote is hard-rejected by `load_remote_verified`. An UNSIGNED (legacy)
+    // remote verifies as `UnsignedLegacy` and its trust MUST be bound here: if
+    // we merged it and then re-signed the result with our real master, an
+    // attacker who stripped the signature and injected a recipient would have
+    // their entry LAUNDERED into a validly-signed registry. So we refuse to
+    // merge an unsigned remote unless the operator explicitly opts in with
+    // `--accept-unsigned-remote` (loud warning below).
+    let remote = match master_key_for_registry_signing(config) {
+        Some(mk) => {
+            let (remote, trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
+                &op,
+                meta_prefix,
+                mk.as_bytes(),
+            )
+            .await?;
+            enforce_remote_merge_trust(trust, accept_unsigned_remote)?;
+            remote
+        }
+        None => {
+            // No master key available: we cannot verify the remote at all, and
+            // we will write the merged result UNSIGNED anyway (no laundering
+            // into a signed registry is possible). Preserve legacy behaviour.
+            tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?
+        }
+    };
+    merge_device_registry(registry, &remote)?;
+    match master_key_for_registry_signing(config) {
+        Some(mk) => {
+            registry
+                .sync_to_remote_signed(&op, meta_prefix, mk.as_bytes())
+                .await?
+        }
+        None => {
+            tcfs_secrets::device::DeviceRegistry::sync_to_remote(registry, &op, meta_prefix).await?
+        }
+    }
+    save_registry_signed_or_warn(registry, registry_path, config)?;
+
+    Ok(format!(
+        "{}/tcfs-meta/devices.json",
+        meta_prefix.trim_end_matches('/')
+    ))
 }
 
 /// TIN-1417 B4 — close the unsigned-remote LAUNDERING bypass on the enroll
@@ -13200,5 +13628,272 @@ enabled = false
             !sentinel.exists(),
             "git_head_oneline must not execute the repository-configured gpg.program"
         );
+    }
+
+    // ── TIN-1417: `tcfs device revoke` operator UX ───────────────────────────
+
+    fn revoke_test_device(
+        name: &str,
+        device_id: &str,
+        public_key: &str,
+        revoked: bool,
+    ) -> tcfs_secrets::device::DeviceIdentity {
+        tcfs_secrets::device::DeviceIdentity {
+            name: name.to_string(),
+            device_id: device_id.to_string(),
+            public_key: public_key.to_string(),
+            signing_key_hash: String::new(),
+            description: None,
+            enrolled_at: 1000,
+            revoked,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
+            last_nats_seq: 0,
+        }
+    }
+
+    /// A syntactically real age recipient (bech32 `age1...`), so
+    /// `is_real_age_public_key` treats the device as per-device-capable.
+    fn revoke_test_recipient() -> String {
+        tcfs_secrets::device::generate_local_device_key().public_key
+    }
+
+    fn revoke_test_registry() -> tcfs_secrets::device::DeviceRegistry {
+        let mut registry = tcfs_secrets::device::DeviceRegistry::default();
+        registry.add(revoke_test_device(
+            "neo",
+            "aaaa1111-0000-0000-0000-000000000001",
+            &revoke_test_recipient(),
+            false,
+        ));
+        registry.add(revoke_test_device(
+            "honey",
+            "bbbb2222-0000-0000-0000-000000000002",
+            &revoke_test_recipient(),
+            false,
+        ));
+        registry
+    }
+
+    #[test]
+    fn cli_parses_device_revoke_flags() {
+        let parsed = Cli::try_parse_from([
+            "tcfs",
+            "device",
+            "revoke",
+            "d6d65d8d",
+            "--dry-run",
+            "--yes",
+            "--sync-remote",
+            "--accept-unsigned-remote",
+            "--allow-self",
+        ])
+        .expect("full revoke flag set must parse");
+        match parsed.command {
+            Commands::Device {
+                action:
+                    DeviceAction::Revoke {
+                        device,
+                        dry_run,
+                        yes,
+                        sync_remote,
+                        accept_unsigned_remote,
+                        allow_self,
+                    },
+            } => {
+                assert_eq!(device, "d6d65d8d");
+                assert!(dry_run && yes && sync_remote && accept_unsigned_remote && allow_self);
+            }
+            other => panic!("unexpected parse: {other:?}"),
+        }
+
+        // Bare form still works and defaults to the safe posture: no remote
+        // publish, no auto-confirm, no self-revocation.
+        let bare = Cli::try_parse_from(["tcfs", "device", "revoke", "old-phone"]).unwrap();
+        match bare.command {
+            Commands::Device {
+                action:
+                    DeviceAction::Revoke {
+                        device,
+                        dry_run,
+                        yes,
+                        sync_remote,
+                        accept_unsigned_remote,
+                        allow_self,
+                    },
+            } => {
+                assert_eq!(device, "old-phone");
+                assert!(!dry_run && !yes && !sync_remote && !accept_unsigned_remote && !allow_self);
+            }
+            other => panic!("unexpected parse: {other:?}"),
+        }
+    }
+
+    /// The unsigned-remote escape hatch must never be usable on its own: it only
+    /// means anything while merging a remote registry.
+    #[test]
+    fn cli_rejects_accept_unsigned_remote_without_sync_remote() {
+        assert!(Cli::try_parse_from([
+            "tcfs",
+            "device",
+            "revoke",
+            "old-phone",
+            "--accept-unsigned-remote",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn revoke_selector_resolves_name_id_and_prefix() {
+        let registry = revoke_test_registry();
+
+        assert_eq!(resolve_device_selector(&registry, "honey").unwrap(), 1);
+        assert_eq!(
+            resolve_device_selector(&registry, "bbbb2222-0000-0000-0000-000000000002").unwrap(),
+            1
+        );
+        // The 8-char form printed by `tcfs device list`.
+        assert_eq!(resolve_device_selector(&registry, "bbbb2222").unwrap(), 1);
+    }
+
+    #[test]
+    fn revoke_selector_rejects_unknown_short_and_ambiguous_input() {
+        let registry = revoke_test_registry();
+
+        let unknown = resolve_device_selector(&registry, "nope")
+            .unwrap_err()
+            .to_string();
+        assert!(unknown.contains("no device matches"), "{unknown}");
+
+        // Too short to be a prefix match; must not silently pick a device.
+        assert!(resolve_device_selector(&registry, "bb").is_err());
+
+        let mut ambiguous_prefix = revoke_test_registry();
+        ambiguous_prefix.add(revoke_test_device(
+            "honey-old",
+            "bbbb2222-0000-0000-0000-000000000099",
+            &revoke_test_recipient(),
+            false,
+        ));
+        let err = resolve_device_selector(&ambiguous_prefix, "bbbb2222")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ambiguous"), "{err}");
+
+        // Duplicate NAMES are real (ghost FileProvider identities); an ambiguous
+        // name must be an error, never a first-match.
+        let mut duplicate_names = tcfs_secrets::device::DeviceRegistry::default();
+        duplicate_names.add(revoke_test_device(
+            "local-fileprovider",
+            "d6d65d8d-0000-0000-0000-000000000001",
+            &revoke_test_recipient(),
+            false,
+        ));
+        duplicate_names.add(revoke_test_device(
+            "local-fileprovider",
+            "f1d980ab-0000-0000-0000-000000000002",
+            &revoke_test_recipient(),
+            false,
+        ));
+        let err = resolve_device_selector(&duplicate_names, "local-fileprovider")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ambiguous"), "{err}");
+        // ...but each is still addressable by id prefix.
+        assert_eq!(
+            resolve_device_selector(&duplicate_names, "f1d980ab").unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn revoke_plan_reports_roll_call_impact_and_self_target() {
+        let registry = revoke_test_registry();
+
+        let plan = plan_device_revoke(&registry, "honey", |d| d.name == "neo").unwrap();
+        assert_eq!(plan.name, "honey");
+        assert!(!plan.already_revoked);
+        assert!(!plan.is_self);
+        assert_eq!(plan.remaining_active, 1);
+        assert_eq!(plan.remaining_capable, 1);
+        assert!(plan.remaining_incapable.is_empty());
+        assert!(plan.roll_call_ready_after());
+
+        // Targeting the local host is flagged so the caller can refuse.
+        let self_plan = plan_device_revoke(&registry, "neo", |d| d.name == "neo").unwrap();
+        assert!(self_plan.is_self);
+    }
+
+    #[test]
+    fn revoke_plan_flags_remaining_roll_call_blocker() {
+        let mut registry = revoke_test_registry();
+        // A legacy placeholder entry: active but not per-device-capable.
+        registry.add(revoke_test_device(
+            "legacy-laptop",
+            "cccc3333-0000-0000-0000-000000000003",
+            "age1-device-deadbeef",
+            false,
+        ));
+
+        let plan = plan_device_revoke(&registry, "honey", |_| false).unwrap();
+        assert_eq!(plan.remaining_active, 2);
+        assert_eq!(plan.remaining_capable, 1);
+        assert_eq!(plan.remaining_incapable, vec!["legacy-laptop".to_string()]);
+        assert!(
+            !plan.roll_call_ready_after(),
+            "an active placeholder device must still block the per_device contract flip"
+        );
+
+        // Revoking the blocker itself is what makes the roll-call satisfiable.
+        let unblock = plan_device_revoke(&registry, "cccc3333", |_| false).unwrap();
+        assert_eq!(unblock.name, "legacy-laptop");
+        assert!(unblock.roll_call_ready_after());
+    }
+
+    /// Revoking the last active device leaves an empty recipient set; the plan
+    /// must say so rather than reporting a "ready" roll-call.
+    #[test]
+    fn revoke_plan_last_active_device_is_not_roll_call_ready() {
+        let mut registry = tcfs_secrets::device::DeviceRegistry::default();
+        registry.add(revoke_test_device(
+            "only",
+            "dddd4444-0000-0000-0000-000000000004",
+            &revoke_test_recipient(),
+            false,
+        ));
+
+        let plan = plan_device_revoke(&registry, "only", |_| false).unwrap();
+        assert_eq!(plan.remaining_active, 0);
+        assert!(!plan.roll_call_ready_after());
+    }
+
+    /// An already-revoked target resolves fine and is reported as a no-op, so
+    /// finishing a half-propagated revocation stays idempotent.
+    #[test]
+    fn revoke_plan_is_idempotent_for_already_revoked_device() {
+        let mut registry = revoke_test_registry();
+        assert!(registry.revoke_by_id("bbbb2222-0000-0000-0000-000000000002"));
+
+        let plan = plan_device_revoke(&registry, "honey", |_| false).unwrap();
+        assert!(plan.already_revoked);
+        assert_eq!(
+            plan.remaining_active, 1,
+            "already-revoked device is not counted twice"
+        );
+    }
+
+    /// `--yes` is required when stdin is not a TTY (cron, ssh, CI), so a script
+    /// can never silently consume an interactive prompt.
+    #[test]
+    fn confirm_revoke_requires_yes_when_non_interactive() {
+        let plan = plan_device_revoke(&revoke_test_registry(), "honey", |_| false).unwrap();
+        assert!(confirm_revoke(&plan, true).is_ok());
+
+        // Under `cargo test` stdin is not a terminal.
+        if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+            let err = confirm_revoke(&plan, false).unwrap_err().to_string();
+            assert!(err.contains("--yes"), "{err}");
+        }
     }
 }

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -435,6 +435,31 @@ impl DeviceRegistry {
         }
     }
 
+    /// Revoke a device by its UUID (`device_id`).
+    ///
+    /// Same semantics as [`DeviceRegistry::revoke`], but keyed on the stable
+    /// identifier instead of the display name. Names are NOT unique in a
+    /// registry (duplicate/ghost entries are real — see
+    /// `docs/ops/ghost-device-revocation-safety-2026-07-02.md`), so any operator
+    /// path that has already resolved an unambiguous device MUST revoke by id to
+    /// avoid revoking a same-named sibling. Returns `false` when no device
+    /// carries that id (including the empty-id legacy case, which callers must
+    /// handle by name).
+    pub fn revoke_by_id(&mut self, device_id: &str) -> bool {
+        if device_id.is_empty() {
+            return false;
+        }
+        if let Some(device) = self.devices.iter_mut().find(|d| d.device_id == device_id) {
+            device.revoked = true;
+            if device.revoked_at.is_none() {
+                device.revoked_at = Some(now_unix());
+            }
+            true
+        } else {
+            false
+        }
+    }
+
     /// Find a device by name
     pub fn find(&self, name: &str) -> Option<&DeviceIdentity> {
         self.devices.iter().find(|d| d.name == name)
@@ -734,6 +759,42 @@ mod tests {
         // revoke() stamps revoked_at (TIN-1417 B4).
         assert!(reg.find("old-phone").unwrap().revoked_at.is_some());
         assert!(!reg.revoke("nonexistent"));
+    }
+
+    /// TIN-1417: revoking by id must hit exactly the addressed device, even when
+    /// a same-named ghost sibling exists (the real neo registry shape).
+    #[test]
+    fn revoke_by_id_targets_exactly_one_duplicate_named_device() {
+        let device = |id: &str| DeviceIdentity {
+            name: "local-fileprovider".into(),
+            device_id: id.into(),
+            public_key: real_pubkey(),
+            signing_key_hash: String::new(),
+            description: None,
+            enrolled_at: 1000,
+            revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
+            last_nats_seq: 0,
+        };
+        let mut reg = DeviceRegistry::default();
+        reg.add(device("d6d65d8d"));
+        reg.add(device("f1d980ab"));
+
+        assert!(reg.revoke_by_id("f1d980ab"));
+        assert_eq!(reg.active_devices().count(), 1);
+        assert_eq!(
+            reg.active_devices().next().unwrap().device_id,
+            "d6d65d8d",
+            "revoke_by_id must not touch the same-named sibling"
+        );
+        assert!(reg.find_by_id("f1d980ab").unwrap().revoked_at.is_some());
+
+        // Unknown and empty ids are no-ops, never a name fallback.
+        assert!(!reg.revoke_by_id("ff818f17"));
+        assert!(!reg.revoke_by_id(""));
+        assert_eq!(reg.active_devices().count(), 1);
     }
 
     #[test]

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ development instruction source.
 ## Security and recovery
 
 - [Per-device crypto migration](ops/per-device-crypto-migration-2026-06-06.md)
+- [Shared-master fleet migration runbook](ops/shared-master-fleet-migration-runbook-2026-07-28.md)
 - [Per-device identity design](ops/per-device-crypto-identity-design-2026-05-18.md)
 - [Raw .git corruption analysis](ops/dotgit-as-files-conflict-corruption-2026-06-08.md)
 - [Ghost-device revocation safety](ops/ghost-device-revocation-safety-2026-07-02.md)

--- a/docs/ops/ghost-device-revocation-safety-2026-07-02.md
+++ b/docs/ops/ghost-device-revocation-safety-2026-07-02.md
@@ -24,9 +24,14 @@ FileProvider bring-up lanes and have no corresponding physical device.
 - `cmd_device_revoke` (`crates/tcfs-cli/src/main.rs:4275`): marks `revoked=true` +
   `revoked_at` in the **local** registry, re-signs the envelope
   (`save_registry_signed_or_warn`, TIN-1417 B4), prints a loud forward-secrecy warning.
-- It does **NOT** sync to the remote registry. Propagation is a separate step:
-  `tcfs device enroll --sync-remote` merges the verified remote and republishes the signed
-  merged registry to `<prefix>/tcfs-meta/devices.json` (`main.rs:4380–4414`).
+- It did **NOT** sync to the remote registry at the time of this analysis. Propagation was a
+  separate step: `tcfs device enroll --sync-remote` merges the verified remote and republishes
+  the signed merged registry to `<prefix>/tcfs-meta/devices.json` (`main.rs:4380–4414`).
+  **Superseded 2026-07-28 (TIN-1417):** `tcfs device revoke --sync-remote` now does the
+  revoke and the signed republish in one step, with the same B4 trust enforcement, and says
+  "LOCAL ONLY" loudly when the flag is absent. `--dry-run` previews the target and roll-call
+  impact first. See
+  [`shared-master-fleet-migration-runbook-2026-07-28.md`](shared-master-fleet-migration-runbook-2026-07-28.md).
 - Merge is **revocation-sticky**: `merge_device_entry` only ever flips `revoked`
   false→true (`if … && incoming.revoked`), so a peer whose copy still lists the ghosts as
   active cannot resurrect them; unsigned-remote laundering is refused

--- a/docs/ops/per-device-crypto-migration-2026-06-06.md
+++ b/docs/ops/per-device-crypto-migration-2026-06-06.md
@@ -18,6 +18,15 @@ below as the current per-device wrapping plan, but treat `tcfs key rotate
 <prefix>` as a rebuild gate, not an available operator remedy, until `TIN-2551`
 lands with fresh tests and review.
 
+2026-07-28 companion: the operator-facing execution surface for this plan — per
+step commands, hard preconditions, verification, abort, and a re-derivable status
+ledger of which steps have actually landed — now lives in
+[`shared-master-fleet-migration-runbook-2026-07-28.md`](shared-master-fleet-migration-runbook-2026-07-28.md).
+This document remains the authority for the SEQUENCING and its rationale; the
+runbook is the authority for how to execute a step. Fleet state at that date is
+unchanged: every host is still `wrap_mode = master` and the next action in the
+sequence is Step 3 (a disposable-prefix `dual` canary).
+
 Grounding: every primitive, phase, and revocation claim here derives from
 `docs/ops/per-device-crypto-identity-design-2026-05-18.md` (the "design doc"
 below). Where this plan adds operational structure not in the design doc — an

--- a/docs/ops/shared-master-fleet-migration-runbook-2026-07-28.md
+++ b/docs/ops/shared-master-fleet-migration-runbook-2026-07-28.md
@@ -1,0 +1,297 @@
+# Shared-master fleet -> per-device: operator runbook (TIN-1417)
+
+Status: operator runbook. Doc-only. **No config flips, no fleet mutation, and no
+ceremony occur from merging this document.** It is the executable companion to
+the ratified sequencing in
+[`per-device-crypto-migration-2026-06-06.md`](per-device-crypto-migration-2026-06-06.md)
+(the "plan doc"), which remains the authority for *why* the order is what it is.
+This runbook adds what the plan doc deliberately left out: the exact operator
+commands, the hard preconditions to check before each flip, what "green" looks
+like, and where the abort is.
+
+Date: 2026-07-28. Grounded in `origin/main` at the time of writing.
+
+Reading order: design recon
+([`per-device-crypto-identity-design-2026-05-18.md`](per-device-crypto-identity-design-2026-05-18.md))
+-> plan doc -> this runbook.
+
+## Who this is for
+
+An operator running a fleet that is still on the shared-master-key model
+(`crypto.wrap_mode = master`, the default) and wants to reach real per-device
+wrapping. Every host in the fleet holds the same master key today; that is the
+starting state this runbook assumes.
+
+## The one-paragraph version
+
+You cannot go straight to `per_device`. The only approved path is
+`master -> dual -> (green roll-call) -> per_device`, and the FileProvider read
+path must reach per-device parity **before** any host leaves `master`. `dual`
+adds per-device wraps without removing the master wrap, so it is reversible;
+`per_device` drops the master wrap and writes v3 manifests, so it strands anyone
+who cannot unwrap per-device. Revocation only denies *new* content — it is not
+retroactive, and it is not forward-secret without a separate, currently gated,
+rotation.
+
+## Status ledger (2026-07-28)
+
+Where each step of the plan doc stands. This is the first thing to re-verify
+before starting: do not trust this table, re-derive it.
+
+| Plan-doc step | Substance | State |
+|---|---|---|
+| 1 — FileProvider parity | FP-local `build_encryption_context` + fail-closed fence | Landed (`crates/tcfs-file-provider/src/device_ctx.rs`). See P1 below for the residual trap. |
+| 2 — dual-write through every caller + roll-call gate | `crypto.wrap_mode` tri-state, `DeviceRegistry::roll_call`, effective-mode downgrade | Landed (`crates/tcfs-core/src/config.rs`, `crates/tcfs-secrets/src/device.rs`). |
+| 3 — canary both directions incl. FP hydrate | live neo/honey canary on a disposable prefix | **NOT DONE.** No fleet host has left `wrap_mode = master`. |
+| 4 — sign `devices.json` | signed registry, unsigned-remote laundering refused | Landed AND executed on the live fleet 2026-07-09 (see `docs/release/evidence/ghost-device-revocation-2026-07-10T0107Z/`). |
+| 5 — `tcfs key rotate <prefix>` | the only forward-secrecy remedy | **GATED.** The WIP path was found revocation-defeating; rebuild tracked in `TIN-2551`. Treat as unavailable. |
+| 6 — keychain hardening | device secret halves out of `0600` files | Partial; file fallback is still the documented posture on headless Linux. |
+| 7 — contract to `per_device` | writers drop the master wrap, manifests bump to v3 | **NOT DONE**, and blocked by steps 3 and 5. |
+
+Consequence: the live fleet is at "code landed, mode still `master`". The next
+action in the sequence is Step 3 (a disposable-prefix `dual` canary), not
+anything involving `per_device`.
+
+## Hard preconditions
+
+These are pass/fail gates. Each one strands devices if skipped.
+
+### P1 — FileProvider backend capability (the armed trap)
+
+The historical trap was that the FileProvider direct read path built
+`EncryptionContext::new(master_key)` with no device identity, so the first
+per-device-only manifest to reach a hydrate would break it. That is closed for
+the **gRPC** backend: `crates/tcfs-file-provider/src/device_ctx.rs` mirrors the
+daemon's `build_encryption_context`, reads `crypto.wrap_mode`, applies the same
+roll-call downgrade, and requires a signature-verified registry before it will
+trust a recipient set. The macOS FileProvider extension ships with
+`--features grpc` (see `.github/workflows/release.yml`), so macOS is covered.
+
+What is **not** covered, and is the live precondition:
+
+- The `direct` and `uniffi` backends only implement master-key unwrapping. The
+  `uniffi` backend is the iOS client.
+- `ensure_master_decryptable` (`device_ctx.rs`, mirrored in
+  `uniffi_bridge.rs`) fences them: a manifest with non-empty `wrapped_file_keys`
+  and no master `encrypted_file_key` is refused with a loud error instead of
+  materializing raw ciphertext. This converts silent corruption into a hard
+  failure — it does **not** make those backends able to read per-device content.
+- Therefore: **any client on the `direct`/`uniffi` backend fails closed on a v3
+  per-device manifest.** Under `dual` it is fine (the master wrap is still
+  there). Under `per_device` it is locked out of every newly written file.
+
+Gate: before Step 7, enumerate every client that reads the affected prefixes and
+prove each one is on the gRPC backend (or accept, in writing, that it is being
+cut off). The roll-call gate does **not** catch this — it checks registry
+recipient capability, not which FileProvider backend a host is running.
+
+### P2 — Signed registry everywhere
+
+`per_device` makes recipient-set membership the sole gate on readability, so the
+registry must be tamper-evident before the contract flip. Verify no host reports
+an UNSIGNED registry, and that no path still needs `--accept-unsigned-remote`.
+
+```bash
+tcfs device enroll --sync-remote          # must succeed with NO unsigned warning
+ssh <peer> 'tcfs device enroll --sync-remote'
+```
+
+If a host still needs `--accept-unsigned-remote`, P2 is failed: re-sign from a
+master-key holder first, then re-verify. The escape hatch is scheduled for hard
+removal (`TIN-1900`, 2026-09-01).
+
+### P3 — Green roll-call
+
+Every active (non-revoked) device must carry a real `age1...` recipient. Ghost
+and placeholder entries block the flip permanently until revoked.
+
+```bash
+tcfs device list     # every 'active' row must show a real age1... public key
+```
+
+Anything showing `age1-device-<hash>` is a placeholder: repair it
+(`tcfs device enroll --repair-placeholder`) or revoke it (below). The code gate
+enforces this independently — if the roll-call is not green, a requested
+`per_device` is **downgraded to `dual`** with a loud warning rather than
+silently dropping the master wrap.
+
+### P4 — A working forward-secrecy remedy
+
+`tcfs key rotate <prefix>` is the only mechanism that re-keys content after a
+revocation, and it is currently gated on `TIN-2551`. Until it lands with fresh
+tests and review, a revocation on this fleet is "denies new content" only, with
+no available remedy for already-written content. Do not flip to `per_device`
+while telling anyone that revocation is forward-secret.
+
+## Device revocation (operator UX)
+
+Revocation is the fleet-hygiene operation that makes the roll-call satisfiable
+(P3) and the security operation the whole migration exists for. It is **sticky
+fleet-wide**: the registry merge only ever flips `revoked` false -> true, so a
+stale peer can never resurrect a revoked device, and there is no un-revoke.
+
+Preview first — a dry run mutates nothing, local or remote, and prints exactly
+what the real run will print:
+
+```bash
+tcfs device revoke local-fileprovider-data --dry-run
+```
+
+It reports the resolved target (name, id, recipient), whether the device is
+already revoked, whether it is *this* host, the post-revoke active/capable
+counts, the remaining roll-call blockers, the effective `wrap_mode`, and where
+propagation would publish.
+
+Apply and propagate in one step:
+
+```bash
+tcfs device revoke local-fileprovider-data --sync-remote
+```
+
+Then converge each peer:
+
+```bash
+ssh <peer> 'tcfs device enroll --sync-remote'
+tcfs device list && ssh <peer> 'tcfs device list'
+```
+
+Selector: name, full device id, or the 8-character id prefix that
+`tcfs device list` prints. Duplicate names are real (the May FileProvider
+bring-up lanes minted same-shaped ghost identities), so an ambiguous selector is
+a hard error listing the candidates — it never silently picks the first match.
+When an id is available the revoke is applied **by id**, so a same-named sibling
+is never collaterally revoked.
+
+Guardrails, and why each exists:
+
+| Flag / behavior | Why |
+|---|---|
+| interactive confirmation by default | revocation is sticky and cannot be undone by a peer |
+| `--yes` | required for non-interactive stdin (ssh, cron, CI) — a script can never silently consume the prompt |
+| `--dry-run` | rehearse the exact target and roll-call impact before mutating |
+| `--sync-remote` | without it the revocation is **LOCAL ONLY** and no peer ever learns about it; the command says so loudly |
+| `--accept-unsigned-remote` | same B4 laundering guard as enroll; refuses to merge-then-re-sign an unsigned remote unless explicitly accepted |
+| `--allow-self` | refuses by default to revoke the identity this host is enrolled as, because that strands this host |
+| forward-secrecy warning | recipient-set removal does not re-key what the device already holds |
+| `wrap_mode = master` note | under `master` a revoke has **no cryptographic effect** at all; it is registry hygiene plus a roll-call precondition |
+
+Idempotence: re-running against an already-revoked device is a no-op locally and
+still republishes with `--sync-remote`, which is how you finish a
+half-propagated revocation.
+
+## Sequence
+
+Steps map 1:1 onto the plan doc. Steps 1, 2, 4 have landed; they are listed for
+completeness and re-verification, not re-execution.
+
+### Step 3 — `dual` canary on a disposable prefix
+
+Preconditions: P1 (macOS FP on the gRPC backend), P2 (signed registry
+everywhere), and a prefix you are willing to throw away.
+
+1. Set `crypto.wrap_mode = dual` on the canary host only. Do **not** set it
+   fleet-wide, and do not touch the default in `config/`.
+2. Exercise, in both directions: push from the canary, pull on the canary, pull
+   on a peer left at `master`, and FileProvider hydrate/evict/rehydrate/mutate on
+   macOS. The FP leg is the one most likely to regress and the whole reason
+   Step 1 exists.
+3. Green means: every direction decrypts, and manifests written during the
+   canary are v2 carrying BOTH `encrypted_file_key` and `wrapped_file_keys`.
+
+Abort: set `crypto.wrap_mode = master`. Every manifest written during the canary
+is dual (v2, master wrap present) and stays readable by every device — nothing
+is stranded. This abort is complete and costs nothing.
+
+### Step 5 — rotation rebuild (blocking, not yours to skip)
+
+`per_device` without a working `tcfs key rotate` means a revocation has no
+remedy. Wait for `TIN-2551`. Re-prove it on a disposable scoped prefix — dry-run
+first for the projected bytes-to-rewrite, then execute — before it counts as
+satisfied.
+
+### Step 6 — keychain hardening
+
+Move device secret halves off the `0600` `device-<device_id>.age` fallback where
+the platform supports it. Headless Linux remains the known weak spot and stays
+on the file fallback; record that as an accepted residual risk rather than
+pretending it is closed.
+
+### Step 7 — contract to `per_device`
+
+Only after Steps 3, 5, 6 and P1–P4. Set `crypto.wrap_mode = per_device`. The
+roll-call code gate is the enforcement, not this document: if any active device
+lacks a real recipient, the daemon refuses to contract and stays on `dual` with
+a loud warning naming the blockers.
+
+Verify after the flip:
+
+- New manifests are v3 and carry `wrapped_file_keys` with **no**
+  `encrypted_file_key`.
+- Every active device can still read newly written content.
+- A revoked device cannot read content written after the revocation propagated.
+- macOS FileProvider hydrate still works on the per-device path.
+
+Abort: set `crypto.wrap_mode = dual` (or `master`). Writers resume dual-write
+immediately. **The abort is partial**: v3 manifests already written are not
+rewritten, so readers must still be able to unwrap them per-device — which is
+exactly what the green roll-call guaranteed before the flip. Blast radius is
+bounded to manifests written while `per_device` was on.
+
+## Verification checklist
+
+Run before each flip and bank the output.
+
+```bash
+tcfs device list                 # roll-call: every active row has a real age1... key
+tcfs device status               # this host's identity and revoked state
+tcfs config show                 # effective crypto.wrap_mode actually in force
+```
+
+Then, per flip: a push from the changed host, a pull on a peer, a pull on a host
+left one mode behind, and — on macOS — a FileProvider hydrate. A flip is not
+green until all four are.
+
+## Evidence
+
+Bank each step as a dated packet under
+`docs/release/evidence/per-device-<step>-<UTC>/` containing the verbatim command
+output for the checklist above plus the direction tests. The ghost-device
+revocation packet (`docs/release/evidence/ghost-device-revocation-2026-07-10T0107Z/`)
+is the shape to copy.
+
+## Honest claim boundary
+
+Unchanged from the plan doc, restated because it is the thing most likely to be
+overclaimed in a status update:
+
+- A revoked device **cannot** decrypt manifests written after the revocation
+  propagates AND after those files are next rewritten in `per_device` (v3) mode.
+- A revoked device **can** still decrypt anything it already pulled — it holds
+  those FileKeys forever — and anything still carrying a wrap it can open.
+- Content that is already-pulled, still carries a master wrap (any v2
+  master/dual manifest), or is not-yet-rekeyed stays decryptable until a
+  rebuilt-and-reviewed `tcfs key rotate <prefix>` re-chunks and rewraps it.
+- Under `crypto.wrap_mode = master` — the current fleet state — revocation has
+  **no cryptographic effect whatsoever**.
+
+Operator-facing phrasing: "Revoking a device stops it from reading newly written
+content. It does not retroactively lock the device out of content it already
+synced, and it does not lock it out of unchanged files until a reviewed
+`tcfs key rotate` has rotated that prefix."
+
+## Residual risks
+
+Inherited from the plan doc (manual forward secrecy, deferred NATS advisory leg,
+v3 manifest namespace sharing, AES-SIV filename determinism, headless-Linux
+keychain, invite authenticity, symlink restore). Added by this runbook:
+
+- **Backend capability is invisible to the roll-call.** The roll-call proves
+  registry recipient capability, not that a client's FileProvider backend can
+  perform a per-device unwrap. An iOS/`uniffi` client passes the roll-call and
+  still fails closed on v3. P1 is a manual gate with no code enforcement.
+- **Propagation window.** A revoke is only fleet-canonical after a signed
+  `--sync-remote` republish AND a merge on each peer. Half-propagated state is
+  harmless under `master` (no crypto effect) but must be closed before any
+  `dual` flip.
+- **No un-revoke.** Sticky merge is deliberate; a mistaken revocation is
+  repaired by enrolling a NEW identity, not by reversing the old one.


### PR DESCRIPTION
## Summary

Closes the two enumerated TIN-1417 remainders: the shared-master-fleet migration doc and the `tcfs device revoke` operator UX. No config defaults change, no `wrap_mode` flip, no device revoked, no ceremony — source + docs only.

`tcfs device revoke` was a one-shot local mutation: it marked the device revoked in the **local** registry only, with no preview, no confirmation, and no way to address a device other than by name. Propagation to the canonical signed fleet registry was a separate `tcfs device enroll --sync-remote` that was easy to forget, leaving a revocation no peer ever saw — exactly the residual risk called out in `docs/ops/ghost-device-revocation-safety-2026-07-02.md` ("It does NOT sync to the remote registry… half-propagated state").

## Changes

**CLI — `tcfs device revoke`**

- `--dry-run` prints the resolved target, whether it is already revoked, whether it is this host, the post-revoke active/capable counts and roll-call blockers, the effective `crypto.wrap_mode`, and the propagation target — mutating nothing, local or remote. Identical output to the real path, so a preview is a faithful rehearsal.
- `--sync-remote` (+ `--accept-unsigned-remote`) does the revoke and the signed republish in one step. The enroll path's merge/verify/publish block is extracted into `sync_registry_with_remote` and shared, so both commands get identical B4 trust enforcement and cannot drift: a signature-present-but-invalid remote is hard-rejected, and an unsigned legacy remote is refused unless explicitly accepted (no laundering an injected recipient into a signed registry).
- Selector accepts **name, full device id, or the 8-char id prefix** printed by `tcfs device list`. Names are not unique — the May FileProvider bring-up minted same-shaped ghost identities — so an ambiguous selector is a hard error listing candidates instead of a silent first-match. When an id exists the revoke is applied **by id** (new `DeviceRegistry::revoke_by_id`), so a same-named sibling is never collaterally revoked.
- Interactive confirmation by default; `--yes` required on non-interactive stdin (ssh/cron/CI). Revocation is sticky fleet-wide — the merge only flips `revoked` false→true — so there is no un-revoke and it deserves a real prompt.
- Refuses to revoke the identity this host is enrolled as unless `--allow-self`. "Self" is deliberately the hostname-enrolled entry only (what `tcfs device status` reports), **not** "any device whose secret half sits in this registry dir" — otherwise locally minted throwaway identities would need an override to clean up.
- Says `LOCAL ONLY` loudly when not propagating, and states plainly that under `wrap_mode = master` a revoke has **no cryptographic effect at all** (registry hygiene + a roll-call precondition, nothing more). The existing forward-secrecy warning is unchanged.
- Idempotent: re-running against an already-revoked device is a local no-op and still republishes with `--sync-remote`, which is how a half-propagated revocation gets finished.

**Docs**

- New `docs/ops/shared-master-fleet-migration-runbook-2026-07-28.md` — the operator-facing execution surface for the ratified `master -> dual -> roll-call -> per_device` sequence. Per-step commands, hard preconditions, verification, abort, evidence layout, and a re-derivable status ledger of what has actually landed (steps 1/2/4 landed; step 3 canary not done; step 5 rotation gated on TIN-2551; step 7 blocked). The existing `per-device-crypto-migration-2026-06-06.md` stays the authority for *sequencing rationale*; the runbook is the authority for *how to execute a step*.
- Documents the armed FileProvider precondition honestly: the historical `EncryptionContext::new(mk)`-only gap is closed for the **gRPC** backend (`device_ctx.rs`, which is what macOS ships), but the `direct`/`uniffi` (iOS) backends only unwrap under the master key and **fail closed** on a per-device v3 manifest. The roll-call gate checks registry recipient capability, not which backend a client runs — so P1 is a manual gate with no code enforcement, and that is stated as such.
- Plan doc + ghost-device analysis cross-linked and de-staled; `docs/index.md` and CHANGELOG updated.

## Test plan

- [x] `cargo fmt` clean (`rustfmt --check` on both touched files)
- [ ] `task test` — **CI**; neo never builds locally, so the workspace suite runs on CI for this branch
- [ ] `task lint` — CI
- [x] New unit tests added (they are the verification for the new logic):
  - `tcfs-secrets`: `revoke_by_id_targets_exactly_one_duplicate_named_device` — by-id revoke does not touch a same-named sibling; unknown/empty ids never fall back to a name match.
  - `tcfs-cli`: `cli_parses_device_revoke_flags`, `cli_rejects_accept_unsigned_remote_without_sync_remote` (the escape hatch is unusable without `--sync-remote`), `revoke_selector_resolves_name_id_and_prefix`, `revoke_selector_rejects_unknown_short_and_ambiguous_input` (duplicate names and ambiguous prefixes are errors; short prefixes never match), `revoke_plan_reports_roll_call_impact_and_self_target`, `revoke_plan_flags_remaining_roll_call_blocker` (a placeholder device still blocks the contract flip; revoking it is what makes the roll-call satisfiable), `revoke_plan_last_active_device_is_not_roll_call_ready`, `revoke_plan_is_idempotent_for_already_revoked_device`, `confirm_revoke_requires_yes_when_non_interactive`.

Not exercised live: no fleet command was run, no registry mutated, no device revoked.

## Checklist

- [x] Docs updated
- [x] CHANGELOG.md updated
- [x] No secrets or credentials in diff
- [x] No config-default changes and no flag flips (`crypto.wrap_mode` default remains `master`)

## Claim boundary

This does not close TIN-1417's behavior gates. The fleet is still `wrap_mode = master`; step 3 (disposable-prefix `dual` canary), step 5 (`tcfs key rotate` rebuild, TIN-2551) and step 7 (contract flip) are untouched and remain blocked. What this PR closes is the *documented migration path* and the *operator surface for revocation* — the two remaining unchecked items enumerated on the issue.
