### PR TITLE
docs(ops): v0.12.18 release-exception ruling (scope ratified, cut deferred)

### DIFF
--- a/docs/ops/v0.12.18-release-exception-ruling-2026-07-28.md
+++ b/docs/ops/v0.12.18-release-exception-ruling-2026-07-28.md
@@ -1,0 +1,48 @@
+# Operator ruling: v0.12.18 release exception — scope ratified, cut deferred
+
+- **Date:** 2026-07-28
+- **Ruled by:** operator (Jess Sullivan), interview ruling
+- **Decision packet:** Linear TIN-2801 comment `36e4cba3` (2026-07-28)
+- **Governing procedure:**
+  [tin2856-credential-rotation-ceremony-2026-07-16.md](tin2856-credential-rotation-ceremony-2026-07-16.md)
+  Phase 0.2
+
+## Ruling
+
+The release-policy exception for a minimal signed `v0.12.18` maintenance
+release is **ratified in scope, with the tag cut deferred**. No branch, tag,
+or release artifact is created by this ruling.
+
+Ratified scope (binding when the cut is later executed):
+
+1. `v0.12.18` = tag `v0.12.17` (`88a2ecf3`) plus the single cherry-pick
+   `b89d4734` ("feat(cli): rotate-key --new-key-file exact-key input",
+   PR #558) plus release metadata only (workspace version bump, Cargo.lock
+   regeneration, CHANGELOG entry). Explicitly **not** derived from `main`
+   HEAD.
+2. Scope is the TCFS passphrase-rotation ceremony's `rotate-key` invocation
+   only. `v0.12.18` is not a fleet baseline bump; hosts are not mass-upgraded
+   to it.
+3. The signed binary is pinned by absolute path as `ROTATE_TCFS_BIN`;
+   `--version` must report `tcfs 0.12.18` exactly and release assets must
+   verify against `SHA256SUMS.txt` before any `[SECRET-GATE]` step.
+4. The build explicitly excludes the post-`v0.12.17` `storage.enforce_tls`
+   fix (TIN-2854); this is accepted for a single rotate-key run against the
+   existing endpoint and is not a production-TLS decision.
+5. Build happens only via hosted GitHub Actions `release.yml` (cosign
+   keyless, canonical-repo check); never a local compile.
+
+## Why the cut is deferred
+
+- Phase 0.4 fleet inventory is incomplete: 4 of 7 hosts have no recorded
+  executable/runtime evidence, and petting-zoo-mini's stopped daemon is a
+  live Phase 0.4 stop condition. The ceremony cannot proceed past inventory
+  regardless of the binary's existence.
+- TIN-2856's Linear "Done" (2026-07-22) covers containment/harness
+  acceptance only; the runbook remains DESIGNED-ONLY with no Phase 2
+  execution evidence, and parent TIN-2801 (with `LAB_DEPLOY_FREEZE`) remains
+  open.
+
+The tag cut is authorized to proceed, under the scope above, in the same
+attended window that closes the Phase 0.4 inventory gap — no further
+release-policy ruling is required at that point.


### PR DESCRIPTION
Records the 2026-07-28 operator interview ruling on the v0.12.18 release exception as the dated docs/ops note the decision packet (TIN-2801 comment 36e4cba3) called for — the packet noted no formal release-policy doc exists, so the ruling record is the policy artifact.

Scope ratified: v0.12.17 + single cherry-pick b89d4734 + metadata only; ceremony-scoped (not a fleet baseline); ROTATE_TCFS_BIN pinning + SHA256SUMS verification; TIN-2854 TLS exclusion accepted; hosted-CI build only. Cut deferred until the Phase 0.4 inventory gap (4/7 hosts unrecorded; petting-zoo-mini stop condition) closes in an attended window — at which point the cut proceeds under this scope with no further ruling.

Docs-only.