### PR TITLE
fix(ci): restore fail-closed GloriousFlywheel authority (TIN-2538)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - tinyland-dind
+    - tinyland-nix

--- a/.github/actions/tcfs-public-read-nix-job/action.yml
+++ b/.github/actions/tcfs-public-read-nix-job/action.yml
@@ -1,0 +1,74 @@
+name: TCFS public-read Nix job
+description: Run a TCFS command with the public Tinyland Nix cache on sanctioned self-hosted compute
+
+inputs:
+  attic-enabled:
+    description: Require the public Attic substituter
+    required: true
+  attic-public-key:
+    description: Trusted public key for the public Attic cache
+    required: true
+  attic-public-read-only:
+    description: Require a read-only cache session
+    required: true
+  attic-public-read-site:
+    description: Audited TCFS workload identity
+    required: true
+  push-cache:
+    description: Cache publication must remain disabled
+    required: true
+  require-cache-push:
+    description: Cache publication must not be required
+    required: true
+  command:
+    description: Repository-owned command body to execute under the public-read environment
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate and run the TCFS public-read workload
+      shell: bash
+      env:
+        GF_COMMAND: ${{ inputs.command }}
+        GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ env.GF_EXPECTED_RUNNER_ENVIRONMENT }}
+        GF_INPUT_ATTIC_ENABLED: ${{ inputs.attic-enabled }}
+        GF_INPUT_ATTIC_PUBLIC_KEY: ${{ inputs.attic-public-key }}
+        GF_INPUT_ATTIC_PUBLIC_READ_ONLY: ${{ inputs.attic-public-read-only }}
+        GF_INPUT_ATTIC_PUBLIC_READ_SITE: ${{ inputs.attic-public-read-site }}
+        GF_INPUT_PUSH_CACHE: ${{ inputs.push-cache }}
+        GF_INPUT_REQUIRE_CACHE_PUSH: ${{ inputs.require-cache-push }}
+        ATTIC_TOKEN: ${{ env.ATTIC_TOKEN }}
+        ATTIC_SERVER: https://nix-cache.tinyland.dev
+        ATTIC_CACHE: main
+        ATTIC_PUBLIC_KEY: main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
+        ATTIC_PUBLIC_READ_SITE: ${{ inputs.attic-public-read-site }}
+        BAZEL_REMOTE_CACHE: https://bazel-cache.tinyland.dev
+        GF_BAZEL_SUBSTRATE_MODE: shared-cache-backed
+        NIX_USER_CONF_FILES: /dev/null
+        NETRC: /dev/null
+        NIX_CONFIG: |
+          extra-substituters = https://nix-cache.tinyland.dev/main
+          extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
+          netrc-file = /dev/null
+      run: |
+        set -euo pipefail
+        test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+        test "${GF_INPUT_ATTIC_ENABLED:-}" = true
+        test "${GF_INPUT_ATTIC_PUBLIC_KEY:-}" = "${ATTIC_PUBLIC_KEY}"
+        test "${GF_INPUT_ATTIC_PUBLIC_READ_ONLY:-}" = true
+        case "${GF_INPUT_ATTIC_PUBLIC_READ_SITE:-}" in
+          tcfs-linux-source|tcfs-windows-cross|tcfs-live-storage|tcfs-nix-linux) ;;
+          *)
+            echo "::error title=Unreviewed public-read site::${GF_INPUT_ATTIC_PUBLIC_READ_SITE:-<empty>}"
+            exit 1
+            ;;
+        esac
+        test "${GF_INPUT_PUSH_CACHE:-}" = false
+        test "${GF_INPUT_REQUIRE_CACHE_PUSH:-}" = false
+        test "${ATTIC_TOKEN:-}" = ""
+        test "${NIX_USER_CONF_FILES:-}" = /dev/null
+        test "${NETRC:-}" = /dev/null
+        test -n "${GF_COMMAND:-}"
+        command -v nix
+        bash -euo pipefail -c "${GF_COMMAND}"

--- a/.github/workflows/ci-live-storage.yml
+++ b/.github/workflows/ci-live-storage.yml
@@ -1,16 +1,11 @@
 name: CI Live Storage
 
-# TIN-1421: real-storage CI lane.
-#
-# Brings up SeaweedFS + NATS via the project's existing docker-compose stack
-# inside the job container, then runs `cargo test -p tcfs-e2e --test fleet_live`
-# with TCFS_E2E_LIVE=1. This is the single highest-leverage QA investment from
-# the 2026-05-18 audit: today PRs can land broken sync paths and ci.yml stays
-# green because the live-fleet tests are operator-only on neo/honey/yoga.
-#
-# The compose stack is a subset of `task dev` (masters + volume + filer + nats —
-# no prometheus/grafana since those aren't on the test path). Same images, same
-# config, so a green CI run carries the same authority as a green local run.
+# TIN-2538: live-storage proof is valid only on the shared GloriousFlywheel
+# DinD capability lane with immutable service images and the TIN-3127
+# public-read-only Nix front door. Public-only applies to Attic authentication:
+# the pinned helper may retain the repository-scoped contents:read GitHub token
+# for Nix source fetches. A missing personal-owner binding queues this job; it
+# never falls back to hosted execution.
 
 on:
   pull_request:
@@ -22,6 +17,8 @@ on:
       - "docker-compose.yml"
       - "config/**"
       - ".github/workflows/ci-live-storage.yml"
+      - "scripts/test-ci-authority-contract.py"
+      - "config/ci-authority-policy.json"
   push:
     branches: [main]
     paths:
@@ -32,63 +29,96 @@ on:
       - "docker-compose.yml"
       - "config/**"
       - ".github/workflows/ci-live-storage.yml"
+      - "scripts/test-ci-authority-contract.py"
+      - "config/ci-authority-policy.json"
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: ci-live-storage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: "1.93.0"
-  # Override defaults baked into fleet_live.rs (which point at tailnet MagicDNS)
+  ATTIC_TOKEN: ""
   TCFS_E2E_LIVE: "1"
   TCFS_S3_ENDPOINT: "http://127.0.0.1:8333"
-  # Explicit test-only opt-in for the job-local compose endpoint.
   TCFS_STORAGE_ALLOW_INSECURE_HTTP: "true"
   TCFS_S3_BUCKET: "tcfs"
   TCFS_NATS_URL: "nats://127.0.0.1:4222"
-  # Keep infra failures cheap in CI; the production default is 300s.
   TCFS_UPLOAD_CHUNK_TIMEOUT_SECS: "30"
   AWS_ACCESS_KEY_ID: "admin"
   AWS_SECRET_ACCESS_KEY: "admin"
 
 jobs:
   fleet-live:
-    name: fleet_live tests against compose-managed SeaweedFS + NATS
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
+    name: fleet_live on GloriousFlywheel DinD
+    runs-on: tinyland-dind
+    timeout-minutes: 35
 
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
-      - name: Cache cargo registry + target
-        uses: Swatinem/rust-cache@v2
+      - name: Verify exact checked out revision
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Require the preinstalled GF Nix runtime
+        run: command -v nix
+
+      - name: Attach GloriousFlywheel public-read-only DinD cache runtime
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
+        env:
+          GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          ATTIC_TOKEN: ""
         with:
-          shared-key: ci-live-storage-${{ runner.os }}
-          workspaces: ". -> target"
+          attic-enabled: "true"
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-read-only: "true"
+          attic-public-read-site: tcfs-live-storage
+          push-cache: "false"
+          require-cache-push: "false"
+          command: |
+            set -euo pipefail
+            test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+            test "${ATTIC_TOKEN:-}" = ""
+            test -n "${DOCKER_HOST:-}"
+            test -n "${ATTIC_SERVER:-}"
+            test "${ATTIC_CACHE:-}" = main
+            test -n "${ATTIC_PUBLIC_KEY:-}"
+            test -n "${BAZEL_REMOTE_CACHE:-}"
+            test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
+            test "${NIX_USER_CONF_FILES:-}" = /dev/null
+            test "${NETRC:-}" = /dev/null
+            test "$(nix config show netrc-file)" = /dev/null
+            nix config show extra-substituters |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+            docker version
+            docker info
 
-      - name: Write CI compose override
-        # Keep CI on the repo-managed dev stack, with narrow overrides for
-        # image-version realities that currently make a fresh runner fail
-        # before tcfs is under test:
-        #
-        # - SeaweedFS: the shared stack uses `-max=0` for the volume server.
-        #   Current SeaweedFS can then report "No writable volumes" for the
-        #   S3 bucket collection. Give the CI volume server room to create
-        #   collection volumes.
-        # - NATS: the shared stack passes `--max_payload 8MB`; current
-        #   nats:2.10-alpine rejects that CLI flag.
+      - name: Write immutable CI compose override
         run: |
           set -euo pipefail
           mkdir -p .github/compose-overrides
           cat > .github/compose-overrides/ci.yml <<'EOF'
           services:
+            seaweed-master-1:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+            seaweed-master-2:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+            seaweed-master-3:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
             seaweed-volume:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
               command: >
                 volume
                 -mserver=seaweed-master-1:9333,seaweed-master-2:9333,seaweed-master-3:9333
@@ -99,7 +129,10 @@ jobs:
                 -max=32
                 -ip=seaweed-volume
                 -ip.bind=0.0.0.0
+            seaweed-filer:
+              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
             nats:
+              image: nats:2.10.29-alpine3.22@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
               command: >
                 --name tcfs-nats
                 --jetstream
@@ -107,7 +140,7 @@ jobs:
                 --http_port 8222
           EOF
 
-      - name: Bring up compose-managed SeaweedFS + NATS
+      - name: Bring up compose-managed SeaweedFS and NATS
         run: |
           set -euo pipefail
           docker compose -f docker-compose.yml -f .github/compose-overrides/ci.yml up -d \
@@ -120,10 +153,6 @@ jobs:
         run: |
           set -euo pipefail
           for i in $(seq 1 60); do
-            # -s silent, -o discard body, -w just the http code. NO -f, since -f
-            # suppresses --write-out on HTTP error responses (SeaweedFS S3 returns
-            # 403 from `/` without credentials, which is the correct "service up"
-            # signal but would silence the code under -f).
             CODE="$(curl -s -m 5 -o /dev/null -w "%{http_code}" "${TCFS_S3_ENDPOINT}/" || echo "000")"
             case "$CODE" in
               200|301|302|307|403|404)
@@ -132,7 +161,8 @@ jobs:
                 ;;
             esac
             echo "waiting for SeaweedFS S3 (attempt $i/60, last code: $CODE)..."
-            sleep 2
+            sleep 2 &
+            wait $!
           done
           echo "::error::SeaweedFS S3 did not become reachable at ${TCFS_S3_ENDPOINT}" >&2
           docker compose logs seaweed-filer | tail -80 || true
@@ -148,52 +178,38 @@ jobs:
               exit 0
             fi
             echo "waiting for NATS ($i/30)..."
-            sleep 1
+            sleep 1 &
+            wait $!
           done
           echo "::error::NATS did not become healthy" >&2
           docker compose logs nats | tail -80 || true
           exit 1
 
-      - name: Create S3 bucket (if not auto-created)
+      - name: Create S3 bucket
         run: |
           set -euo pipefail
-          # SeaweedFS S3 auto-creates buckets on PUT for admin identities, but
-          # do an explicit create with awscli to surface auth/config issues
-          # before the cargo test step.
-          aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
-              s3api create-bucket --bucket "${TCFS_S3_BUCKET}" \
-              --region us-east-1 2>&1 \
+          nix develop --accept-flake-config .#default --command \
+            aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
+                s3api create-bucket --bucket "${TCFS_S3_BUCKET}" \
+                --region us-east-1 2>&1 \
             | tee /tmp/bucket-create.log || true
-          aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
-              s3api head-bucket --bucket "${TCFS_S3_BUCKET}"
-          echo "S3 bucket '${TCFS_S3_BUCKET}' reachable"
+          nix develop --accept-flake-config .#default --command \
+            aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
+                s3api head-bucket --bucket "${TCFS_S3_BUCKET}"
 
       - name: Run fleet_live tests
         run: |
-          set -euo pipefail
-          cargo test -p tcfs-e2e --test fleet_live -- --nocapture
-        env:
-          # Re-export so the test process sees env from `env:` above
-          # (cargo test inherits the workflow env; this is belt-and-suspenders).
-          TCFS_E2E_LIVE: "1"
+          nix develop --accept-flake-config .#default --command \
+            cargo test -p tcfs-e2e --test fleet_live --locked -- --nocapture
 
-      - name: Collect compose logs on failure
+      - name: Print compose logs on failure
         if: failure()
         run: |
-          mkdir -p /tmp/compose-logs
           for svc in seaweed-master-1 seaweed-master-2 seaweed-master-3 seaweed-volume seaweed-filer nats; do
-            docker compose logs "$svc" > "/tmp/compose-logs/${svc}.log" 2>&1 || true
+            echo "===== ${svc} ====="
+            docker compose logs --no-color "$svc" | tail -200 || true
           done
-
-      - name: Upload compose logs artifact
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: compose-logs-${{ github.run_id }}
-          path: /tmp/compose-logs/
-          retention-days: 7
 
       - name: Tear down compose stack
         if: always()
-        run: |
-          docker compose down -v --remove-orphans || true
+        run: docker compose down -v --remove-orphans || true

--- a/.github/workflows/ci-live-storage.yml
+++ b/.github/workflows/ci-live-storage.yml
@@ -55,6 +55,7 @@ env:
 jobs:
   fleet-live:
     name: fleet_live on GloriousFlywheel DinD
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: tinyland-dind
     timeout-minutes: 35
 
@@ -81,7 +82,7 @@ jobs:
           ATTIC_TOKEN: ""
         with:
           attic-enabled: "true"
-          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-key: "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
           attic-public-read-only: "true"
           attic-public-read-site: tcfs-live-storage
           push-cache: "false"
@@ -94,6 +95,7 @@ jobs:
             test -n "${ATTIC_SERVER:-}"
             test "${ATTIC_CACHE:-}" = main
             test -n "${ATTIC_PUBLIC_KEY:-}"
+            test "${ATTIC_PUBLIC_KEY:-}" = "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
             test -n "${BAZEL_REMOTE_CACHE:-}"
             test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
             test "${NIX_USER_CONF_FILES:-}" = /dev/null
@@ -104,102 +106,81 @@ jobs:
               grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
             docker version
             docker info
-
-      - name: Write immutable CI compose override
-        run: |
-          set -euo pipefail
-          mkdir -p .github/compose-overrides
-          cat > .github/compose-overrides/ci.yml <<'EOF'
-          services:
-            seaweed-master-1:
-              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
-            seaweed-master-2:
-              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
-            seaweed-master-3:
-              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
-            seaweed-volume:
-              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
-              command: >
-                volume
-                -mserver=seaweed-master-1:9333,seaweed-master-2:9333,seaweed-master-3:9333
-                -port=8080
-                -dir=/data
-                -dataCenter=dc1
-                -rack=dc1-rack1
-                -max=32
-                -ip=seaweed-volume
-                -ip.bind=0.0.0.0
-            seaweed-filer:
-              image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
-            nats:
-              image: nats:2.10.29-alpine3.22@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
-              command: >
-                --name tcfs-nats
-                --jetstream
-                --store_dir /data
-                --http_port 8222
-          EOF
-
-      - name: Bring up compose-managed SeaweedFS and NATS
-        run: |
-          set -euo pipefail
-          docker compose -f docker-compose.yml -f .github/compose-overrides/ci.yml up -d \
-            seaweed-master-1 seaweed-master-2 seaweed-master-3 \
-            seaweed-volume seaweed-filer \
-            nats
-
-      - name: Wait for SeaweedFS S3 endpoint
-        timeout-minutes: 3
-        run: |
-          set -euo pipefail
-          for i in $(seq 1 60); do
-            CODE="$(curl -s -m 5 -o /dev/null -w "%{http_code}" "${TCFS_S3_ENDPOINT}/" || echo "000")"
-            case "$CODE" in
-              200|301|302|307|403|404)
-                echo "SeaweedFS S3 ready (HTTP $CODE)"
-                exit 0
-                ;;
-            esac
-            echo "waiting for SeaweedFS S3 (attempt $i/60, last code: $CODE)..."
-            sleep 2 &
-            wait $!
-          done
-          echo "::error::SeaweedFS S3 did not become reachable at ${TCFS_S3_ENDPOINT}" >&2
-          docker compose logs seaweed-filer | tail -80 || true
-          exit 1
-
-      - name: Wait for NATS
-        timeout-minutes: 1
-        run: |
-          set -euo pipefail
-          for i in $(seq 1 30); do
-            if curl -sf "http://127.0.0.1:8222/healthz" >/dev/null; then
-              echo "NATS ready"
-              exit 0
-            fi
-            echo "waiting for NATS ($i/30)..."
-            sleep 1 &
-            wait $!
-          done
-          echo "::error::NATS did not become healthy" >&2
-          docker compose logs nats | tail -80 || true
-          exit 1
-
-      - name: Create S3 bucket
-        run: |
-          set -euo pipefail
-          nix develop --accept-flake-config .#default --command \
+            mkdir -p .github/compose-overrides
+            cat > .github/compose-overrides/ci.yml <<'EOF'
+            services:
+              seaweed-master-1:
+                image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+              seaweed-master-2:
+                image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+              seaweed-master-3:
+                image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+              seaweed-volume:
+                image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+                command: >
+                  volume
+                  -mserver=seaweed-master-1:9333,seaweed-master-2:9333,seaweed-master-3:9333
+                  -port=8080
+                  -dir=/data
+                  -dataCenter=dc1
+                  -rack=dc1-rack1
+                  -max=32
+                  -ip=seaweed-volume
+                  -ip.bind=0.0.0.0
+              seaweed-filer:
+                image: chrislusf/seaweedfs:4.40@sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602
+              nats:
+                image: nats:2.10.29-alpine3.22@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927
+                command: >
+                  --name tcfs-nats
+                  --jetstream
+                  --store_dir /data
+                  --http_port 8222
+            EOF
+            docker compose -f docker-compose.yml -f .github/compose-overrides/ci.yml up -d \
+              seaweed-master-1 seaweed-master-2 seaweed-master-3 \
+              seaweed-volume seaweed-filer \
+              nats
+            for i in $(seq 1 60); do
+              CODE="$(curl -s -m 5 -o /dev/null -w "%{http_code}" "${TCFS_S3_ENDPOINT}/" || echo "000")"
+              case "$CODE" in
+                200|301|302|307|403|404)
+                  echo "SeaweedFS S3 ready (HTTP $CODE)"
+                  break
+                  ;;
+              esac
+              if [ "$i" -eq 60 ]; then
+                echo "::error::SeaweedFS S3 did not become reachable at ${TCFS_S3_ENDPOINT}" >&2
+                docker compose logs seaweed-filer | tail -80 || true
+                exit 1
+              fi
+              echo "waiting for SeaweedFS S3 (attempt $i/60, last code: $CODE)..."
+              sleep 2 &
+              wait $!
+            done
+            for i in $(seq 1 30); do
+              if curl -sf "http://127.0.0.1:8222/healthz" >/dev/null; then
+                echo "NATS ready"
+                break
+              fi
+              if [ "$i" -eq 30 ]; then
+                echo "::error::NATS did not become healthy" >&2
+                docker compose logs nats | tail -80 || true
+                exit 1
+              fi
+              echo "waiting for NATS ($i/30)..."
+              sleep 1 &
+              wait $!
+            done
+            nix develop .#default --command \
             aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
                 s3api create-bucket --bucket "${TCFS_S3_BUCKET}" \
                 --region us-east-1 2>&1 \
-            | tee /tmp/bucket-create.log || true
-          nix develop --accept-flake-config .#default --command \
+              | tee /tmp/bucket-create.log || true
+            nix develop .#default --command \
             aws --endpoint-url "${TCFS_S3_ENDPOINT}" \
                 s3api head-bucket --bucket "${TCFS_S3_BUCKET}"
-
-      - name: Run fleet_live tests
-        run: |
-          nix develop --accept-flake-config .#default --command \
+            nix develop .#default --command \
             cargo test -p tcfs-e2e --test fleet_live --locked -- --nocapture
 
       - name: Print compose logs on failure

--- a/.github/workflows/ci-live-storage.yml
+++ b/.github/workflows/ci-live-storage.yml
@@ -1,11 +1,11 @@
 name: CI Live Storage
 
 # TIN-2538: live-storage proof is valid only on the shared GloriousFlywheel
-# DinD capability lane with immutable service images and the TIN-3127
-# public-read-only Nix front door. Public-only applies to Attic authentication:
-# the pinned helper may retain the repository-scoped contents:read GitHub token
-# for Nix source fetches. A missing personal-owner binding queues this job; it
-# never falls back to hosted execution.
+# DinD capability lane with immutable service images and the repository-local
+# TCFS public-read-only Nix front door. Public-only applies to Attic authentication.
+# The contents:read GitHub token boundary remains separately documented for Nix
+# source fetches. A missing personal-owner binding queues this job; it never
+# falls back to hosted execution.
 
 on:
   pull_request:
@@ -17,6 +17,7 @@ on:
       - "docker-compose.yml"
       - "config/**"
       - ".github/workflows/ci-live-storage.yml"
+      - ".github/actions/tcfs-public-read-nix-job/action.yml"
       - "scripts/test-ci-authority-contract.py"
       - "config/ci-authority-policy.json"
   push:
@@ -29,6 +30,7 @@ on:
       - "docker-compose.yml"
       - "config/**"
       - ".github/workflows/ci-live-storage.yml"
+      - ".github/actions/tcfs-public-read-nix-job/action.yml"
       - "scripts/test-ci-authority-contract.py"
       - "config/ci-authority-policy.json"
   workflow_dispatch:
@@ -75,8 +77,8 @@ jobs:
       - name: Require the preinstalled GF Nix runtime
         run: command -v nix
 
-      - name: Attach GloriousFlywheel public-read-only DinD cache runtime
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
+      - name: Attach the TCFS public-read DinD cache runtime on GloriousFlywheel
+        uses: ./.github/actions/tcfs-public-read-nix-job
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""
@@ -101,9 +103,12 @@ jobs:
             test "${NIX_USER_CONF_FILES:-}" = /dev/null
             test "${NETRC:-}" = /dev/null
             test "$(nix config show netrc-file)" = /dev/null
-            nix config show extra-substituters |
+            nix config show substituters |
               tr ' ' '\n' |
               grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+            nix config show trusted-public-keys |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_PUBLIC_KEY}"
             docker version
             docker info
             mkdir -p .github/compose-overrides

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   linux-source:
     name: Linux source authority (GloriousFlywheel)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: tinyland-nix
     timeout-minutes: 90
     steps:
@@ -49,9 +50,10 @@ jobs:
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
         with:
           attic-enabled: "true"
-          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-key: "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
           attic-public-read-only: "true"
           attic-public-read-site: tcfs-linux-source
           push-cache: "false"
@@ -63,6 +65,7 @@ jobs:
             test -n "${ATTIC_SERVER:-}"
             test "${ATTIC_CACHE:-}" = main
             test -n "${ATTIC_PUBLIC_KEY:-}"
+            test "${ATTIC_PUBLIC_KEY:-}" = "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
             test -n "${BAZEL_REMOTE_CACHE:-}"
             test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
             test "${NIX_USER_CONF_FILES:-}" = /dev/null
@@ -71,13 +74,8 @@ jobs:
             nix config show extra-substituters |
               tr ' ' '\n' |
               grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
-
-      - name: Build, lint, test, and scan in the repo toolchain
-        env:
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
-        run: |
-          # shellcheck disable=SC2016 # Expanded by the inner repo-toolchain shell.
-          nix develop --accept-flake-config .#default --command bash -euo pipefail -c '
+            # shellcheck disable=SC2016 # Expanded by the inner repo-toolchain shell.
+            nix develop .#default --command bash -euo pipefail -c '
             python3 scripts/test-ci-authority-contract.py
             cargo check --workspace --locked
             cargo fmt --all -- --check
@@ -99,10 +97,11 @@ jobs:
             else
               gitleaks git --config .gitleaks.toml --redact
             fi
-          '
+            '
 
   windows-cross:
     name: Windows CFAPI cross-check (source-only)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: tinyland-nix
     timeout-minutes: 45
     steps:
@@ -128,7 +127,7 @@ jobs:
           ATTIC_TOKEN: ""
         with:
           attic-enabled: "true"
-          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-key: "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
           attic-public-read-only: "true"
           attic-public-read-site: tcfs-windows-cross
           push-cache: "false"
@@ -140,6 +139,7 @@ jobs:
             test -n "${ATTIC_SERVER:-}"
             test "${ATTIC_CACHE:-}" = main
             test -n "${ATTIC_PUBLIC_KEY:-}"
+            test "${ATTIC_PUBLIC_KEY:-}" = "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
             test -n "${BAZEL_REMOTE_CACHE:-}"
             test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
             test "${NIX_USER_CONF_FILES:-}" = /dev/null
@@ -148,10 +148,7 @@ jobs:
             nix config show extra-substituters |
               tr ' ' '\n' |
               grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
-
-      - name: Type-check the Windows CFAPI surface from sanctioned Linux compute
-        run: |
-          nix develop --accept-flake-config .#default --command \
+            nix develop .#default --command \
             cargo check -p tcfs-cloudfilter \
               --target x86_64-pc-windows-gnu \
               --all-targets \
@@ -159,10 +156,11 @@ jobs:
 
   darwin-authority-held:
     name: HELD - native Darwin and iOS authority
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: tinyland-nix
     timeout-minutes: 5
     steps:
       - name: Hold until the authorized GF Darwin worker is proved
         run: |
-          echo "::error title=Darwin authority held::TIN-2998 has not yet proved an authorized native Apple Silicon GF worker. Linux cross-compilation is not a substitute for FileProvider or iOS native proof."
+          echo "::error title=Darwin authority held::TIN-2998 commissioned the bounded GF Apple Silicon worker, but TIN-2538 has not yet bound and proved TCFS-specific native FileProvider or iOS execution on that sanctioned path. Linux cross-compilation is not a substitute."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,241 +3,166 @@ name: CI
 on:
   push:
     branches: [main, dev, "sid/**", "1-*"]
+  # Stacked PRs require the same exact-head authority as main-bound PRs.
   pull_request:
-    branches: [main, dev]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUST_TOOLCHAIN: 1.93.0
-  GITLEAKS_VERSION: 8.30.1
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
+  # TIN-3127 public-read-only applies to Attic authentication. The pinned
+  # helper may separately retain the contents:read GitHub token for Nix source
+  # fetches; checked-out PR code receives no Attic token or inherited netrc.
+  ATTIC_TOKEN: ""
 
 jobs:
-  check:
-    name: Build + Lint + Test
-    runs-on: ubuntu-latest
+  linux-source:
+    name: Linux source authority (GloriousFlywheel)
+    runs-on: tinyland-nix
+    timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-
-      - name: Free hosted runner disk
-        run: |
-          set -euo pipefail
-          df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
-          df -h /
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            build-essential \
-            protobuf-compiler \
-            libfuse3-dev \
-            pkg-config \
-            libssl-dev
-
-      - name: Verify Cargo.lock is consistent
-        run: cargo check --workspace --locked
-
-      - name: cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: FileProvider surface contract
-        run: bash scripts/test-fileprovider-surface-contract.sh
-
-      - name: cargo clippy
-        run: cargo clippy --workspace --all-targets
-
-      - name: cargo test
-        run: cargo test --workspace
-
-      - name: cargo test tcfs-sync (nats + crypto features)
-        run: cargo test -p tcfs-sync --features nats,crypto
-
-      - name: Feature-isolated consumer tests
-        run: |
-          cargo test -p tcfs-file-provider --no-default-features --features grpc --locked
-          cargo test -p tcfs-file-provider --no-default-features --features uniffi --locked
-          cargo test -p tcfs-dbus --features grpc --locked
-
-      - name: Wire-up integration tests (prove modules are connected)
-        run: |
-          cargo test -p tcfs-e2e --test blacklist_wireup -- --nocapture
-          cargo test -p tcfs-e2e --test reconcile_wireup -- --nocapture
-
-      - name: Trim incremental artifacts before final builds
-        run: |
-          set -euo pipefail
-          du -sh target || true
-          find target -type d -name incremental -prune -exec rm -rf {} +
-          du -sh target || true
-          df -h .
-
-      - name: Build workspace (default features)
-        run: cargo build --workspace
-
-      - name: Build tcfsd (k8s-worker feature)
-        run: cargo build -p tcfsd --features k8s-worker
-
-      - name: Build tcfs CLI (no FUSE — macOS/Windows compat)
-        run: cargo build -p tcfs-cli --no-default-features
-
-  cloudfilter-windows:
-    name: CloudFilter compile (Windows)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-
-      - name: Compile Windows CloudFilter targets
-        run: cargo check -p tcfs-cloudfilter --all-targets --locked
-
-  nix:
-    name: Nix Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.tinyland.dev/main
-            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
-
-      - name: Verify runner Nix toolchain
-        run: nix --version
-
-      - name: Nix flake check
-        run: nix flake check --accept-flake-config
-
-      - name: Verify devShell Rust version
-        run: |
-          VERSION="$(nix develop --accept-flake-config --command rustc --version)"
-          echo "$VERSION"
-          echo "$VERSION" | grep -q "1.93.0"
-
-      - name: Build tcfsd
-        run: nix build --accept-flake-config --fallback .#tcfsd
-
-      - name: Build tcfs-cli
-        run: nix build --accept-flake-config --fallback .#tcfs-cli
-
-      - name: Build tcfs-tui
-        run: nix build --accept-flake-config --fallback .#tcfs-tui
-
-      - name: Build tcfs-mcp
-        run: nix build --accept-flake-config --fallback .#tcfs-mcp
-
-  fileprovider-staticlib:
-    name: FileProvider staticlib (macOS)
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-
-      - name: Build staticlib
-        run: cargo build -p tcfs-file-provider --release
-
-      - name: Verify staticlib exists
-        run: |
-          test -f target/release/libtcfs_file_provider.a
-          echo "staticlib size: $(du -h target/release/libtcfs_file_provider.a | cut -f1)"
-
-      - name: Verify cbindgen header
-        run: |
-          HEADER=$(find target -name tcfs_file_provider.h | head -1)
-          test -n "$HEADER"
-          grep -q "tcfs_provider_new" "$HEADER"
-          grep -q "tcfs_provider_upload" "$HEADER"
-          grep -q "tcfs_provider_delete" "$HEADER"
-          echo "header: $HEADER"
-
-      - name: Check gRPC backend compiles
-        run: cargo check -p tcfs-file-provider --no-default-features --features grpc
-
-  ios-typecheck:
-    name: iOS FileProvider typecheck
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          targets: aarch64-apple-ios-sim
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-
-      - name: Build iOS staticlib + type-check Swift
-        run: bash swift/ios/Scripts/build-ios.sh --simulator
-
-  deny:
-    name: cargo-deny
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-bin: false
-      - name: Install cargo-deny build dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends build-essential
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
-      - name: cargo deny check
-        run: cargo deny check
-
-  secret-scan:
-    name: Secret Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Install gitleaks
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact checked out revision
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Require the preinstalled GF Nix runtime
+        run: command -v nix
+
+      - name: Attach GloriousFlywheel public-read-only cache runtime
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
+        env:
+          GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          ATTIC_TOKEN: ""
+        with:
+          attic-enabled: "true"
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-read-only: "true"
+          attic-public-read-site: tcfs-linux-source
+          push-cache: "false"
+          require-cache-push: "false"
+          command: |
+            set -euo pipefail
+            test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+            test "${ATTIC_TOKEN:-}" = ""
+            test -n "${ATTIC_SERVER:-}"
+            test "${ATTIC_CACHE:-}" = main
+            test -n "${ATTIC_PUBLIC_KEY:-}"
+            test -n "${BAZEL_REMOTE_CACHE:-}"
+            test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
+            test "${NIX_USER_CONF_FILES:-}" = /dev/null
+            test "${NETRC:-}" = /dev/null
+            test "$(nix config show netrc-file)" = /dev/null
+            nix config show extra-substituters |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+
+      - name: Build, lint, test, and scan in the repo toolchain
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
         run: |
-          curl --retry 5 --retry-all-errors --retry-delay 2 -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | sudo tar xz -C /usr/local/bin gitleaks
-      - name: Scan for secrets
+          # shellcheck disable=SC2016 # Expanded by the inner repo-toolchain shell.
+          nix develop --accept-flake-config .#default --command bash -euo pipefail -c '
+            python3 scripts/test-ci-authority-contract.py
+            cargo check --workspace --locked
+            cargo fmt --all -- --check
+            bash scripts/test-fileprovider-surface-contract.sh
+            cargo clippy --workspace --all-targets --locked -- -D warnings
+            cargo test --workspace --locked
+            cargo test -p tcfs-sync --features nats,crypto --locked
+            cargo test -p tcfs-file-provider --no-default-features --features grpc --locked
+            cargo test -p tcfs-file-provider --no-default-features --features uniffi --locked
+            cargo test -p tcfs-dbus --features grpc --locked
+            cargo test -p tcfs-e2e --test blacklist_wireup --locked -- --nocapture
+            cargo test -p tcfs-e2e --test reconcile_wireup --locked -- --nocapture
+            cargo build --workspace --locked
+            cargo build -p tcfsd --features k8s-worker --locked
+            cargo build -p tcfs-cli --no-default-features --locked
+            cargo deny check
+            if [ -n "$BASE_SHA" ]; then
+              gitleaks git --config .gitleaks.toml --redact --log-opts="$BASE_SHA..HEAD"
+            else
+              gitleaks git --config .gitleaks.toml --redact
+            fi
+          '
+
+  windows-cross:
+    name: Windows CFAPI cross-check (source-only)
+    runs-on: tinyland-nix
+    timeout-minutes: 45
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact checked out revision
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Require the preinstalled GF Nix runtime
+        run: command -v nix
+
+      - name: Attach GloriousFlywheel public-read-only cache runtime
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
+        env:
+          GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          ATTIC_TOKEN: ""
+        with:
+          attic-enabled: "true"
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-read-only: "true"
+          attic-public-read-site: tcfs-windows-cross
+          push-cache: "false"
+          require-cache-push: "false"
+          command: |
+            set -euo pipefail
+            test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+            test "${ATTIC_TOKEN:-}" = ""
+            test -n "${ATTIC_SERVER:-}"
+            test "${ATTIC_CACHE:-}" = main
+            test -n "${ATTIC_PUBLIC_KEY:-}"
+            test -n "${BAZEL_REMOTE_CACHE:-}"
+            test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
+            test "${NIX_USER_CONF_FILES:-}" = /dev/null
+            test "${NETRC:-}" = /dev/null
+            test "$(nix config show netrc-file)" = /dev/null
+            nix config show extra-substituters |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+
+      - name: Type-check the Windows CFAPI surface from sanctioned Linux compute
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            gitleaks detect --source . --config .gitleaks.toml --log-opts="${{ github.event.pull_request.base.sha }}..HEAD" --verbose
-          else
-            gitleaks detect --source . --config .gitleaks.toml --verbose
-          fi
+          nix develop --accept-flake-config .#default --command \
+            cargo check -p tcfs-cloudfilter \
+              --target x86_64-pc-windows-gnu \
+              --all-targets \
+              --locked
+
+  darwin-authority-held:
+    name: HELD - native Darwin and iOS authority
+    runs-on: tinyland-nix
+    timeout-minutes: 5
+    steps:
+      - name: Hold until the authorized GF Darwin worker is proved
+        run: |
+          echo "::error title=Darwin authority held::TIN-2998 has not yet proved an authorized native Apple Silicon GF worker. Linux cross-compilation is not a substitute for FileProvider or iOS native proof."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,10 @@ env:
   RUST_BACKTRACE: 1
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
-  # TIN-3127 public-read-only applies to Attic authentication. The pinned
-  # helper may separately retain the contents:read GitHub token for Nix source
-  # fetches; checked-out PR code receives no Attic token or inherited netrc.
+  # Public-read-only applies to Attic authentication. The repository-local
+  # TCFS bootstrap does not receive an Attic token or inherited netrc. The
+  # contents:read GitHub token boundary remains separately documented for Nix
+  # source fetches.
   ATTIC_TOKEN: ""
 
 jobs:
@@ -45,8 +46,8 @@ jobs:
       - name: Require the preinstalled GF Nix runtime
         run: command -v nix
 
-      - name: Attach GloriousFlywheel public-read-only cache runtime
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
+      - name: Attach the TCFS public-read cache runtime on GloriousFlywheel
+        uses: ./.github/actions/tcfs-public-read-nix-job
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""
@@ -71,9 +72,12 @@ jobs:
             test "${NIX_USER_CONF_FILES:-}" = /dev/null
             test "${NETRC:-}" = /dev/null
             test "$(nix config show netrc-file)" = /dev/null
-            nix config show extra-substituters |
+            nix config show substituters |
               tr ' ' '\n' |
               grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+            nix config show trusted-public-keys |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_PUBLIC_KEY}"
             # shellcheck disable=SC2016 # Expanded by the inner repo-toolchain shell.
             nix develop .#default --command bash -euo pipefail -c '
             python3 scripts/test-ci-authority-contract.py
@@ -120,8 +124,8 @@ jobs:
       - name: Require the preinstalled GF Nix runtime
         run: command -v nix
 
-      - name: Attach GloriousFlywheel public-read-only cache runtime
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
+      - name: Attach the TCFS public-read cache runtime on GloriousFlywheel
+        uses: ./.github/actions/tcfs-public-read-nix-job
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""
@@ -145,9 +149,12 @@ jobs:
             test "${NIX_USER_CONF_FILES:-}" = /dev/null
             test "${NETRC:-}" = /dev/null
             test "$(nix config show netrc-file)" = /dev/null
-            nix config show extra-substituters |
+            nix config show substituters |
               tr ' ' '\n' |
               grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+            nix config show trusted-public-keys |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_PUBLIC_KEY}"
             nix develop .#default --command \
             cargo check -p tcfs-cloudfilter \
               --target x86_64-pc-windows-gnu \

--- a/.github/workflows/container-runtime-smoke.yml
+++ b/.github/workflows/container-runtime-smoke.yml
@@ -29,6 +29,7 @@ concurrency:
 
 jobs:
   runtime-smoke:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Runtime smoke (${{ matrix.platform }})
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   check-links:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Check Links
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +33,7 @@ jobs:
           fail: true
 
   build-pdf:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Build PDFs
     runs-on: ubuntu-latest
     steps:
@@ -50,10 +52,10 @@ jobs:
           path: dist/docs/*.pdf
 
   deploy:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: [check-links]
-    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/homebrew-install-smoke.yml
+++ b/.github/workflows/homebrew-install-smoke.yml
@@ -44,6 +44,7 @@ concurrency:
 
 jobs:
   install-smoke:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Homebrew ${{ github.event.inputs.smoke_mode }} smoke
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 25

--- a/.github/workflows/linux-package-container-smoke.yml
+++ b/.github/workflows/linux-package-container-smoke.yml
@@ -46,7 +46,7 @@ concurrency:
 jobs:
   package-container-smoke:
     name: ${{ matrix.surface }}
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     strategy:

--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -70,7 +70,7 @@ permissions:
 jobs:
   package-postinstall:
     name: Linux package post-install smoke
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 30
     environment: ${{ github.event.inputs.smoke_environment }}

--- a/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
+++ b/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   notarized-pkg-proof:
     name: Build, notarize, staple, and assess .pkg
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 120
     steps:

--- a/.github/workflows/macos-fileprovider-testing-mode-pkg.yml
+++ b/.github/workflows/macos-fileprovider-testing-mode-pkg.yml
@@ -60,7 +60,7 @@ env:
 jobs:
   build-testing-mode-pkg:
     name: Build testing-mode .pkg
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -105,7 +105,7 @@ permissions:
 jobs:
   pkg-postinstall:
     name: macOS .pkg post-install smoke
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 40
     environment: ${{ github.event.inputs.smoke_environment }}

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   nix-linux:
     name: Nix Linux source authority (GloriousFlywheel)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: tinyland-nix
     timeout-minutes: 90
     steps:
@@ -50,7 +51,7 @@ jobs:
           ATTIC_TOKEN: ""
         with:
           attic-enabled: "true"
-          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-key: "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
           attic-public-read-only: "true"
           attic-public-read-site: tcfs-nix-linux
           push-cache: "false"
@@ -62,6 +63,7 @@ jobs:
             test -n "${ATTIC_SERVER:-}"
             test "${ATTIC_CACHE:-}" = main
             test -n "${ATTIC_PUBLIC_KEY:-}"
+            test "${ATTIC_PUBLIC_KEY:-}" = "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
             test -n "${BAZEL_REMOTE_CACHE:-}"
             test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
             test "${NIX_USER_CONF_FILES:-}" = /dev/null
@@ -70,17 +72,18 @@ jobs:
             nix config show extra-substituters |
               tr ' ' '\n' |
               grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
-            nix flake check --accept-flake-config
+            nix flake check
             for package in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
-              nix build --accept-flake-config --fallback ".#${package}"
+              nix build --fallback ".#${package}"
             done
 
   nix-darwin-authority-held:
     name: HELD - native aarch64-darwin Nix authority
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: tinyland-nix
     timeout-minutes: 5
     steps:
       - name: Hold until the authorized GF Darwin worker is proved
         run: |
-          echo "::error title=Darwin Nix authority held::TIN-2998 has not yet proved an authorized native Apple Silicon GF worker. Linux evaluation or cross-compilation cannot publish a Darwin closure."
+          echo "::error title=Darwin Nix authority held::TIN-2998 commissioned the bounded GF Apple Silicon worker, but TIN-2538 has not yet bound and proved TCFS-specific aarch64-darwin Nix execution on that sanctioned path. Linux evaluation or cross-compilation cannot publish a Darwin closure."
           exit 1

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,176 +1,86 @@
-# Nix CI with Attic binary cache push
-#
-# Builds all tcfs packages with Nix and pushes results to the
-# tinyland Attic binary cache. Consuming machines can then
-# `nix profile install` or `nix build` with near-instant cache hits.
-#
-# Required secrets:
-#   ATTIC_TOKEN — obtained from `attic login tinyland <server> <token>`
+# TIN-2538: Nix proof is cache-read-only on the shared GloriousFlywheel Nix
+# capability lane. Publication remains a separately authorized standing path.
 
 name: Nix CI
 
 on:
   push:
     branches: [main, dev]
+  # Stacked PRs require the same exact-head authority as main-bound PRs.
   pull_request:
-    branches: [main, dev]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+# TIN-3127 public-read-only applies to Attic authentication. The pinned helper
+# may separately retain the contents:read GitHub token for Nix source fetches.
 env:
-  # Public Attic endpoint shared with flake.nix and other workflows.
-  ATTIC_SERVER: https://nix-cache.tinyland.dev
-  ATTIC_CACHE: main
+  ATTIC_TOKEN: ""
+
+concurrency:
+  group: nix-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  flake-check:
-    name: Flake Check
-    runs-on: ubuntu-latest
+  nix-linux:
+    name: Nix Linux source authority (GloriousFlywheel)
+    runs-on: tinyland-nix
+    timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.tinyland.dev/main
-            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
-      - name: Verify runner Nix toolchain
-        run: nix --version
+      - name: Verify exact checked out revision
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
 
-      - name: Nix flake check
-        run: nix flake check --accept-flake-config
+      - name: Require the preinstalled GF Nix runtime
+        run: command -v nix
 
-  build-linux-x86_64:
-    name: Build Linux x86_64
-    runs-on: ubuntu-latest
-    needs: flake-check
+      - name: Check and build through the public-read-only GloriousFlywheel Nix front door
+        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
+        env:
+          GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          ATTIC_TOKEN: ""
+        with:
+          attic-enabled: "true"
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          attic-public-read-only: "true"
+          attic-public-read-site: tcfs-nix-linux
+          push-cache: "false"
+          require-cache-push: "false"
+          command: |
+            set -euo pipefail
+            test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted
+            test "${ATTIC_TOKEN:-}" = ""
+            test -n "${ATTIC_SERVER:-}"
+            test "${ATTIC_CACHE:-}" = main
+            test -n "${ATTIC_PUBLIC_KEY:-}"
+            test -n "${BAZEL_REMOTE_CACHE:-}"
+            test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed
+            test "${NIX_USER_CONF_FILES:-}" = /dev/null
+            test "${NETRC:-}" = /dev/null
+            test "$(nix config show netrc-file)" = /dev/null
+            nix config show extra-substituters |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+            nix flake check --accept-flake-config
+            for package in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
+              nix build --accept-flake-config --fallback ".#${package}"
+            done
+
+  nix-darwin-authority-held:
+    name: HELD - native aarch64-darwin Nix authority
+    runs-on: tinyland-nix
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
-
-      - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.tinyland.dev/main
-            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
-
-      - name: Verify runner cache endpoints
+      - name: Hold until the authorized GF Darwin worker is proved
         run: |
-          echo "ATTIC_SERVER=${ATTIC_SERVER}"
-          echo "ATTIC_CACHE=${ATTIC_CACHE}"
-          echo "BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:-unset}"
-
-      - name: Configure Attic
-        run: |
-          nix profile install nixpkgs#attic-client
-          if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland "${{ env.ATTIC_SERVER }}" "${{ secrets.ATTIC_TOKEN }}"
-            attic use "${{ env.ATTIC_CACHE }}" || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> "$GITHUB_ENV"
-          else
-            echo "::warning::ATTIC_TOKEN not set, skipping cache push"
-            echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
-          fi
-
-      - name: Build tcfsd
-        run: nix build --accept-flake-config --fallback .#tcfsd
-
-      - name: Build tcfs-cli
-        run: nix build --accept-flake-config --fallback .#tcfs-cli
-
-      - name: Build tcfs-tui
-        run: nix build --accept-flake-config --fallback .#tcfs-tui
-
-      - name: Build tcfs-mcp
-        run: nix build --accept-flake-config --fallback .#tcfs-mcp
-
-      - name: Push to Attic
-        if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
-        run: |
-          for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
-            nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
-            attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
-          done
-
-  build-macos-aarch64:
-    name: Build macOS aarch64
-    runs-on: macos-14
-    # Hard stop well under the 6h hosted-runner ceiling: a wedged job must fail
-    # loud with hours to spare, not silently eat the whole window (both prior
-    # runs of this job died at exactly 6h00m inside "Set up FlakeHub Cache").
-    timeout-minutes: 300
-    needs: flake-check
-    # id-token: write is required for FlakeHub Cache OIDC push (below).
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            extra-substituters = https://nix-cache.tinyland.dev/main
-            extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
-
-      # FlakeHub Cache is the canonical nix cache the fleet substitutes from
-      # (lab nix/home-manager/nix.nix: "Attic replaced by FlakeHub"; macbook-neo
-      # trusts cache.flakehub.com). This action sets up a post-build push hook so
-      # EVERY darwin store path built below is published to FlakeHub Cache — which
-      # is what lets neo `nix-switch` SUBSTITUTE the aarch64-darwin closure
-      # (incl. tcfsd) instead of ever compiling locally. Requires this repo to be
-      # enrolled in FlakeHub Cache; no-ops with a warning if not yet enrolled.
-      # continue-on-error alone is not enough: when un-enrolled this action can
-      # HANG rather than fail (observed twice: job cancelled at exactly the 6h
-      # ceiling with every build step still skipped) — timeout-minutes converts
-      # the hang into the warning this comment always assumed.
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@main
-        timeout-minutes: 10
-        continue-on-error: true
-
-      - name: Configure Attic
-        run: |
-          nix profile install nixpkgs#attic-client
-          if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland "${{ env.ATTIC_SERVER }}" "${{ secrets.ATTIC_TOKEN }}"
-            attic use "${{ env.ATTIC_CACHE }}" || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> "$GITHUB_ENV"
-          else
-            echo "::warning::ATTIC_TOKEN not set, skipping cache push"
-            echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
-          fi
-
-      # NOTE: the aarch64-darwin DAEMON closure (tcfsd/tcfsd-app/staticlib) was
-      # previously NOT built here — only cli/tui/mcp — so macbook-neo could not
-      # substitute a new tcfsd and silently fell back to a LOCAL compile
-      # (2026-07-04 incident: a full day of neo compilation). Build the full set
-      # here on the GitHub macos-14 runner (off-neo, off-PZM) so the whole
-      # darwin closure lands in the caches and neo only ever substitutes.
-      - name: Build tcfs-cli (no FUSE on macOS)
-        run: nix build --accept-flake-config --fallback .#tcfs-cli
-
-      - name: Build tcfs-tui
-        run: nix build --accept-flake-config --fallback .#tcfs-tui
-
-      - name: Build tcfs-mcp
-        run: nix build --accept-flake-config --fallback .#tcfs-mcp
-
-      - name: Build tcfsd (daemon)
-        run: nix build --accept-flake-config --fallback .#tcfsd
-
-      - name: Build tcfsd-app (FileProvider app bundle)
-        run: nix build --accept-flake-config --fallback .#tcfsd-app
-
-      - name: Build tcfs-file-provider-staticlib
-        run: nix build --accept-flake-config --fallback .#tcfs-file-provider-staticlib
-
-      - name: Push to Attic
-        if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
-        run: |
-          for pkg in tcfs-cli tcfs-tui tcfs-mcp tcfsd tcfsd-app tcfs-file-provider-staticlib; do
-            nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
-            attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
-          done
+          echo "::error title=Darwin Nix authority held::TIN-2998 has not yet proved an authorized native Apple Silicon GF worker. Linux evaluation or cross-compilation cannot publish a Darwin closure."
+          exit 1

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -13,8 +13,9 @@ on:
 permissions:
   contents: read
 
-# TIN-3127 public-read-only applies to Attic authentication. The pinned helper
-# may separately retain the contents:read GitHub token for Nix source fetches.
+# Public-read-only applies to Attic authentication. The repository-local TCFS
+# bootstrap receives no Attic token or inherited netrc.
+# The contents:read GitHub token boundary remains documented for Nix fetches.
 env:
   ATTIC_TOKEN: ""
 
@@ -44,8 +45,8 @@ jobs:
       - name: Require the preinstalled GF Nix runtime
         run: command -v nix
 
-      - name: Check and build through the public-read-only GloriousFlywheel Nix front door
-        uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@693574567f9b879486782f1fb7f432c54a2fe294
+      - name: Check and build through the TCFS public-read Nix front door on GloriousFlywheel
+        uses: ./.github/actions/tcfs-public-read-nix-job
         env:
           GF_EXPECTED_RUNNER_ENVIRONMENT: ${{ runner.environment }}
           ATTIC_TOKEN: ""
@@ -69,9 +70,12 @@ jobs:
             test "${NIX_USER_CONF_FILES:-}" = /dev/null
             test "${NETRC:-}" = /dev/null
             test "$(nix config show netrc-file)" = /dev/null
-            nix config show extra-substituters |
+            nix config show substituters |
               tr ' ' '\n' |
               grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"
+            nix config show trusted-public-keys |
+              tr ' ' '\n' |
+              grep -Fx -- "${ATTIC_PUBLIC_KEY}"
             nix flake check
             for package in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
               nix build --fallback ".#${package}"

--- a/.github/workflows/nix-profile-install-smoke.yml
+++ b/.github/workflows/nix-profile-install-smoke.yml
@@ -46,6 +46,7 @@ concurrency:
 
 jobs:
   profile-install-smoke:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Nix profile install smoke
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
   # ── Plan release ──────────────────────────────────────────────────────────
 
   plan:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Plan release
     runs-on: ubuntu-latest
     outputs:
@@ -106,6 +107,7 @@ jobs:
   # ── Build client binaries ─────────────────────────────────────────────────
 
   build-binaries:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: plan
@@ -466,6 +468,7 @@ jobs:
   # ── Build container image (k8s-worker) ────────────────────────────────────
 
   build-image:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Build container image
     runs-on: ubuntu-latest
     needs: plan
@@ -526,6 +529,7 @@ jobs:
   # ── Nix build + Attic cache push ─────────────────────────────────────────
 
   nix-build:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Nix Build + Attic Push
     runs-on: ubuntu-latest
     needs: plan
@@ -568,6 +572,7 @@ jobs:
   # ── Generate installer scripts ────────────────────────────────────────────
 
   generate-installers:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Generate installer scripts
     runs-on: ubuntu-latest
     needs: plan
@@ -663,6 +668,7 @@ jobs:
   # ── Build FileProvider extension (macOS) ──────────────────────────────────
 
   build-fileprovider:
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     name: Build FileProvider (macOS)
     runs-on: macos-14
     needs: plan
@@ -820,11 +826,7 @@ jobs:
     name: Build macOS installer (.pkg)
     runs-on: macos-14
     needs: [plan, build-binaries, build-fileprovider]
-    if: |
-      success() && (
-        startsWith(github.ref, 'refs/tags/v') ||
-        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
-      )
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -949,11 +951,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [plan, build-binaries, generate-installers, build-fileprovider, build-pkg]
-    if: |
-      success() && (
-        startsWith(github.ref, 'refs/tags/v') ||
-        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
-      )
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
 
     steps:
       - name: Download all artifacts
@@ -1084,11 +1082,7 @@ jobs:
     name: Update Homebrew formula
     runs-on: ubuntu-latest
     needs: [plan, create-release]
-    if: |
-      success() && (
-        startsWith(github.ref, 'refs/tags/v') ||
-        (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
-      )
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/storage-large-restore-canary.yml
+++ b/.github/workflows/storage-large-restore-canary.yml
@@ -109,7 +109,7 @@ permissions:
 jobs:
   large-restore:
     name: Large push + restore
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 180
     environment: ${{ github.event.inputs.smoke_environment }}

--- a/.github/workflows/storage-posture-canary.yml
+++ b/.github/workflows/storage-posture-canary.yml
@@ -49,7 +49,7 @@ permissions:
 jobs:
   storage-canary:
     name: Scoped storage canary
-    if: github.repository == 'Jesssullivan/tummycrypt'
+    if: ${{ github.repository == '__TIN_2538_DISABLED__' }}
     runs-on: ${{ github.event.inputs.runner_label }}
     timeout-minutes: 20
     environment: ${{ github.event.inputs.smoke_environment }}

--- a/Justfile
+++ b/Justfile
@@ -154,6 +154,10 @@ linux-package-container-workflow-test:
 storage-large-restore-workflow-test:
     @bash scripts/test-storage-large-restore-canary-workflow.sh
 
+# Fail-closed first-party CI runner/cache/action/image authority contract
+ci-authority-contract-test:
+    @python3 scripts/test-ci-authority-contract.py
+
 # Regression test the storage large restore SLO evaluator
 storage-large-restore-slo-test:
     @bash scripts/test-evaluate-storage-large-restore-slo.sh

--- a/config/ci-authority-policy.json
+++ b/config/ci-authority-policy.json
@@ -1,0 +1,133 @@
+{
+  "version": 1,
+  "issue": "TIN-2538",
+  "gloriousflywheel_revision": "693574567f9b879486782f1fb7f432c54a2fe294",
+  "checkout_revision": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+  "live_proof_hold": {
+    "issue": "TIN-3120",
+    "reason": "the Jess personal-owner listener and multi-capability binding are absent; GitHub-hosted capacity is never a fallback"
+  },
+  "credential_boundary": {
+    "attic": "public-read-only; ATTIC_TOKEN empty; inherited netrc disabled",
+    "github": "repository-scoped contents:read token may remain available to Nix source fetches",
+    "claim": "not globally credential-free"
+  },
+  "protected_proof": [
+    {
+      "path": ".github/workflows/ci.yml",
+      "jobs": {
+        "linux-source": "tinyland-nix",
+        "windows-cross": "tinyland-nix",
+        "darwin-authority-held": "tinyland-nix"
+      },
+      "held_jobs": {
+        "darwin-authority-held": "TIN-2998"
+      },
+      "pull_request_all_bases": true,
+      "front_door": "nix-job",
+      "topology_sha256": "ec523770d2806d967dfb64af00191c7f68bb6242fc2239c4e5bd626bd78acd49"
+    },
+    {
+      "path": ".github/workflows/ci-live-storage.yml",
+      "jobs": {
+        "fleet-live": "tinyland-dind"
+      },
+      "held_jobs": {},
+      "pull_request_all_bases": true,
+      "front_door": "nix-job",
+      "topology_sha256": "074e1789a31482a3a4abad5f06daf1919200be8be1712ba5898405cae0bf685a"
+    },
+    {
+      "path": ".github/workflows/nix-ci.yml",
+      "jobs": {
+        "nix-linux": "tinyland-nix",
+        "nix-darwin-authority-held": "tinyland-nix"
+      },
+      "held_jobs": {
+        "nix-darwin-authority-held": "TIN-2998"
+      },
+      "pull_request_all_bases": true,
+      "front_door": "nix-job",
+      "topology_sha256": "f9549d2e0f06e98b752e279f7777b6c7394faff6f760cb87fac5b638d0372e39"
+    }
+  ],
+  "disabled_legacy_workflows": [
+    {
+      "path": ".github/workflows/container-runtime-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "6553b96d17d0d0fe1398755915321a0dec6c6a819fda7345069b0844a88304a0"
+    },
+    {
+      "path": ".github/workflows/docs.yml",
+      "owner": "TIN-2538",
+      "triggers": ["push", "pull_request", "workflow_dispatch"],
+      "topology_sha256": "d6d955a2af4e130c5e275738169c7b64a571501cb013e239c4545fc5cc71106e"
+    },
+    {
+      "path": ".github/workflows/homebrew-install-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "ad242cd50c5404859d90e743cf1050d202c68bd9077f00f60e3faae07cec4bf6"
+    },
+    {
+      "path": ".github/workflows/linux-package-container-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["pull_request", "workflow_dispatch"],
+      "topology_sha256": "6fe6fc413c9e4e35e39de26c62d06bce965a0bf7d6ca30c5a1c4bf8f426289d5"
+    },
+    {
+      "path": ".github/workflows/linux-postinstall-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "686e918b85b24af7f26970378b1379dc6ded8f7f1e13c7fbde89969614a3e156"
+    },
+    {
+      "path": ".github/workflows/macos-fileprovider-pkg-notarization-proof.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "06e45748ac285d6d16d9011f10085609850e9d3cb4b5780625c5eb6f7fbceec3"
+    },
+    {
+      "path": ".github/workflows/macos-fileprovider-testing-mode-pkg.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "b57dbf2e61e2a320ec9209a90d47dabf1f3db12f46a9dbabbf5be472a2a3f901"
+    },
+    {
+      "path": ".github/workflows/macos-postinstall-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "ddce25f9c5f5b6265a7122b3ad38a04be29207073ce9d17711b9247d3102d947"
+    },
+    {
+      "path": ".github/workflows/nix-profile-install-smoke.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "a8cfae7d6a7f488cfd0b3aa81d55c5f4e3ca824d9dfdeb07a278ea8df3572d77"
+    },
+    {
+      "path": ".github/workflows/release.yml",
+      "owner": "TIN-2538",
+      "triggers": ["push", "workflow_dispatch"],
+      "topology_sha256": "3fbf7f2e159f084591e8841b0056a5ac2aef13a9f99fedf9ecce19c9b277acad"
+    },
+    {
+      "path": ".github/workflows/storage-large-restore-canary.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "05be76ed05cd025a1adaad7e94809905e8b9e2af52a08b854101585d17fe1326"
+    },
+    {
+      "path": ".github/workflows/storage-posture-canary.yml",
+      "owner": "TIN-2538",
+      "triggers": ["workflow_dispatch"],
+      "topology_sha256": "7e5bf0304a248e5783371a5607cc4c44f09bf749c2c797489b8ab87b319e92a1"
+    }
+  ],
+  "blocked_prerequisites": {
+    "multi_capability_personal_owner_binding": "TIN-3120",
+    "native_darwin_worker": "TIN-2998",
+    "native_windows_runtime_and_installer": "TIN-1569"
+  }
+}

--- a/config/ci-authority-policy.json
+++ b/config/ci-authority-policy.json
@@ -1,8 +1,13 @@
 {
-  "version": 2,
+  "version": 3,
   "issue": "TIN-2538",
-  "gloriousflywheel_revision": "693574567f9b879486782f1fb7f432c54a2fe294",
   "checkout_revision": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+  "public_read_front_door": {
+    "action_path": "./.github/actions/tcfs-public-read-nix-job",
+    "source_path": ".github/actions/tcfs-public-read-nix-job/action.yml",
+    "source_sha256": "8110be069476b984518dc6ff793592993d8a6e4a24b705389a83238a3aa43ed8",
+    "ownership": "TCFS-owned independently authored repository-local public-read bootstrap; not private GloriousFlywheel action source"
+  },
   "attic_public_read": {
     "public_key": "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=",
     "local_dev_substituter": "https://nix-cache.tinyland.dev/main"
@@ -28,12 +33,12 @@
         "darwin-authority-held": "TIN-2538"
       },
       "command_sha256": {
-        "linux-source": "546b4ac02cfa6ba83f9ee4a00e17151a735b4d97181278d9b8471fc8d2ed63a0",
-        "windows-cross": "0c86cd94cb1103feb1aed49db318ba6c6ebc245b76cd64ac19386e1e74dbd134"
+        "linux-source": "f9817905b7ac82e0d615eeac7a2577f22152842ed995ff71713245370d601b56",
+        "windows-cross": "33a806559d22a8377346e4f97826cce6b11cfca1308714446461d1a166e11397"
       },
       "pull_request_all_bases": true,
-      "front_door": "nix-job",
-      "topology_sha256": "ff30faa218f7a345fe235cd08db3b9241183251dcad43ee404dc4170f9d589eb"
+      "front_door": "./.github/actions/tcfs-public-read-nix-job",
+      "topology_sha256": "3b163bb61a99eba0a34d4bf42355628480b163f9a12553328d3bb9bf91aed845"
     },
     {
       "path": ".github/workflows/ci-live-storage.yml",
@@ -42,11 +47,11 @@
       },
       "held_jobs": {},
       "command_sha256": {
-        "fleet-live": "fe546799062e78d9e0be2917ed947fc1f1d8eb152823a7c9cebdfd873ed5acdf"
+        "fleet-live": "015ed2575332c03650e56303864e4e658a331408ba2e8c2002c67da7a6f62920"
       },
       "pull_request_all_bases": true,
-      "front_door": "nix-job",
-      "topology_sha256": "b84b88750d51728ad2c620b2354e758541cbf6c19c3019e8dfc69aff3c9bddea"
+      "front_door": "./.github/actions/tcfs-public-read-nix-job",
+      "topology_sha256": "9e568223faabd7fb46c3f806be186ef7cf83d64b45e078a65dc929f533d025eb"
     },
     {
       "path": ".github/workflows/nix-ci.yml",
@@ -58,11 +63,11 @@
         "nix-darwin-authority-held": "TIN-2538"
       },
       "command_sha256": {
-        "nix-linux": "9404929c63d5eb925b8421a4f12855bf290338b55982db628e0262d5e32f9d15"
+        "nix-linux": "101c965d971d08863ea5b4c66cfe48881c9c8726bdbe0c4900cf676d9976f990"
       },
       "pull_request_all_bases": true,
-      "front_door": "nix-job",
-      "topology_sha256": "14557f9d87699aaef03981652af0f97d002d26157e7a6ac4131d1ff35bed9062"
+      "front_door": "./.github/actions/tcfs-public-read-nix-job",
+      "topology_sha256": "86c17e246ddebb83dc8b433342ddfbb9fe0fc41d26ce67d42b4169c5d006d55a"
     }
   ],
   "disabled_legacy_workflows": [

--- a/config/ci-authority-policy.json
+++ b/config/ci-authority-policy.json
@@ -1,8 +1,12 @@
 {
-  "version": 1,
+  "version": 2,
   "issue": "TIN-2538",
   "gloriousflywheel_revision": "693574567f9b879486782f1fb7f432c54a2fe294",
   "checkout_revision": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+  "attic_public_read": {
+    "public_key": "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=",
+    "local_dev_substituter": "https://nix-cache.tinyland.dev/main"
+  },
   "live_proof_hold": {
     "issue": "TIN-3120",
     "reason": "the Jess personal-owner listener and multi-capability binding are absent; GitHub-hosted capacity is never a fallback"
@@ -21,11 +25,15 @@
         "darwin-authority-held": "tinyland-nix"
       },
       "held_jobs": {
-        "darwin-authority-held": "TIN-2998"
+        "darwin-authority-held": "TIN-2538"
+      },
+      "command_sha256": {
+        "linux-source": "546b4ac02cfa6ba83f9ee4a00e17151a735b4d97181278d9b8471fc8d2ed63a0",
+        "windows-cross": "0c86cd94cb1103feb1aed49db318ba6c6ebc245b76cd64ac19386e1e74dbd134"
       },
       "pull_request_all_bases": true,
       "front_door": "nix-job",
-      "topology_sha256": "ec523770d2806d967dfb64af00191c7f68bb6242fc2239c4e5bd626bd78acd49"
+      "topology_sha256": "ff30faa218f7a345fe235cd08db3b9241183251dcad43ee404dc4170f9d589eb"
     },
     {
       "path": ".github/workflows/ci-live-storage.yml",
@@ -33,9 +41,12 @@
         "fleet-live": "tinyland-dind"
       },
       "held_jobs": {},
+      "command_sha256": {
+        "fleet-live": "fe546799062e78d9e0be2917ed947fc1f1d8eb152823a7c9cebdfd873ed5acdf"
+      },
       "pull_request_all_bases": true,
       "front_door": "nix-job",
-      "topology_sha256": "074e1789a31482a3a4abad5f06daf1919200be8be1712ba5898405cae0bf685a"
+      "topology_sha256": "b84b88750d51728ad2c620b2354e758541cbf6c19c3019e8dfc69aff3c9bddea"
     },
     {
       "path": ".github/workflows/nix-ci.yml",
@@ -44,11 +55,14 @@
         "nix-darwin-authority-held": "tinyland-nix"
       },
       "held_jobs": {
-        "nix-darwin-authority-held": "TIN-2998"
+        "nix-darwin-authority-held": "TIN-2538"
+      },
+      "command_sha256": {
+        "nix-linux": "9404929c63d5eb925b8421a4f12855bf290338b55982db628e0262d5e32f9d15"
       },
       "pull_request_all_bases": true,
       "front_door": "nix-job",
-      "topology_sha256": "f9549d2e0f06e98b752e279f7777b6c7394faff6f760cb87fac5b638d0372e39"
+      "topology_sha256": "14557f9d87699aaef03981652af0f97d002d26157e7a6ac4131d1ff35bed9062"
     }
   ],
   "disabled_legacy_workflows": [
@@ -56,78 +70,259 @@
       "path": ".github/workflows/container-runtime-smoke.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "6553b96d17d0d0fe1398755915321a0dec6c6a819fda7345069b0844a88304a0"
+      "job_parity": {
+        "runtime-smoke": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2875",
+          "reason": "Cross-platform runtime smoke has no sanctioned GF replacement yet."
+        }
+      },
+      "topology_sha256": "49b9ac3a38fdeda16208976643744b80bea7f91b1dd339194ef1c68f4db0ad8c"
     },
     {
       "path": ".github/workflows/docs.yml",
       "owner": "TIN-2538",
       "triggers": ["push", "pull_request", "workflow_dispatch"],
-      "topology_sha256": "d6d955a2af4e130c5e275738169c7b64a571501cb013e239c4545fc5cc71106e"
+      "job_parity": {
+        "check-links": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2538",
+          "reason": "Link checking has not been migrated to a sanctioned GF proof job."
+        },
+        "build-pdf": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2538",
+          "reason": "PDF publication input has not been migrated to a sanctioned GF proof job."
+        },
+        "deploy": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2538",
+          "reason": "Pages deployment remains held until its source build runs only on sanctioned GF compute."
+        }
+      },
+      "topology_sha256": "b63e7ffdd43f3a8cf14e12fd2c36fea1f7985c8e71319acdc4bfd24ae1c6cbb2"
     },
     {
       "path": ".github/workflows/homebrew-install-smoke.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "ad242cd50c5404859d90e743cf1050d202c68bd9077f00f60e3faae07cec4bf6"
+      "job_parity": {
+        "install-smoke": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1425",
+          "reason": "Packaged first-run and upgrade smoke lacks a sanctioned GF replacement."
+        }
+      },
+      "topology_sha256": "13d38c818239eaed39f5728d1c7c65a06c56fabbba5753ce4a95b9e0bd1f99c8"
     },
     {
       "path": ".github/workflows/linux-package-container-smoke.yml",
       "owner": "TIN-2538",
       "triggers": ["pull_request", "workflow_dispatch"],
-      "topology_sha256": "6fe6fc413c9e4e35e39de26c62d06bce965a0bf7d6ca30c5a1c4bf8f426289d5"
+      "job_parity": {
+        "package-container-smoke": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1425",
+          "reason": "Linux package install and upgrade smoke lacks a sanctioned GF DinD replacement."
+        }
+      },
+      "topology_sha256": "563acb5906eadebf5ca49bf94866a98378b030bf0410304fb8cbc65f581fb5ba"
     },
     {
       "path": ".github/workflows/linux-postinstall-smoke.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "686e918b85b24af7f26970378b1379dc6ded8f7f1e13c7fbde89969614a3e156"
+      "job_parity": {
+        "package-postinstall": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1425",
+          "reason": "Linux post-install first-run smoke lacks a sanctioned GF replacement."
+        }
+      },
+      "topology_sha256": "1abc0b22ce7ae2f0ebac62938e77c1598b1c6b544c766d7bcec27ca53b733c0a"
     },
     {
       "path": ".github/workflows/macos-fileprovider-pkg-notarization-proof.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "06e45748ac285d6d16d9011f10085609850e9d3cb4b5780625c5eb6f7fbceec3"
+      "job_parity": {
+        "notarized-pkg-proof": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1547",
+          "reason": "Notarized FileProvider package proof is not bound to the commissioned GF Darwin path."
+        }
+      },
+      "topology_sha256": "7ce138d23843201e7352dccc2eb617df3088665bff8fef11d0f3f67fec84b6f0"
     },
     {
       "path": ".github/workflows/macos-fileprovider-testing-mode-pkg.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "b57dbf2e61e2a320ec9209a90d47dabf1f3db12f46a9dbabbf5be472a2a3f901"
+      "job_parity": {
+        "build-testing-mode-pkg": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1547",
+          "reason": "Testing-mode FileProvider package proof is not bound to the commissioned GF Darwin path."
+        }
+      },
+      "topology_sha256": "f97ea3e60ce478917feed49ce0306b045f1abc9a615b673f300b8579e192869f"
     },
     {
       "path": ".github/workflows/macos-postinstall-smoke.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "ddce25f9c5f5b6265a7122b3ad38a04be29207073ce9d17711b9247d3102d947"
+      "job_parity": {
+        "pkg-postinstall": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1547",
+          "reason": "Installed FileProvider post-install smoke is not bound to the commissioned GF Darwin path."
+        }
+      },
+      "topology_sha256": "02ba288edbfae893a16fd75646313b7928d3a86f5a3a0aedb840e620b534a6e6"
     },
     {
       "path": ".github/workflows/nix-profile-install-smoke.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "a8cfae7d6a7f488cfd0b3aa81d55c5f4e3ca824d9dfdeb07a278ea8df3572d77"
+      "job_parity": {
+        "profile-install-smoke": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1425",
+          "reason": "Nix profile first-run smoke lacks a sanctioned GF replacement."
+        }
+      },
+      "topology_sha256": "04e888b14cf5b2678f904a8d5e9b883ce2dc43bd90252425c3a1c2bc15aa657f"
     },
     {
       "path": ".github/workflows/release.yml",
       "owner": "TIN-2538",
       "triggers": ["push", "workflow_dispatch"],
-      "topology_sha256": "3fbf7f2e159f084591e8841b0056a5ac2aef13a9f99fedf9ecce19c9b277acad"
+      "job_parity": {
+        "plan": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2875",
+          "reason": "Release planning has not been migrated to a sanctioned GF proof job."
+        },
+        "build-binaries": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2875",
+          "reason": "Cross-platform release binaries lack complete sanctioned GF parity."
+        },
+        "build-image": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2875",
+          "reason": "Release image publication lacks a sanctioned GF replacement."
+        },
+        "nix-build": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2875",
+          "reason": "Release Nix builds lack complete sanctioned GF parity."
+        },
+        "generate-installers": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2875",
+          "reason": "Installer generation lacks complete sanctioned GF parity."
+        },
+        "build-fileprovider": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1547",
+          "reason": "FileProvider release build is not bound to the commissioned GF Darwin path."
+        },
+        "build-pkg": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1547",
+          "reason": "macOS package release build is not bound to the commissioned GF Darwin path."
+        },
+        "create-release": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2875",
+          "reason": "Release publication remains held until every required artifact has sanctioned GF proof."
+        },
+        "update-homebrew": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-2875",
+          "reason": "Homebrew publication remains held behind the sanctioned release contract."
+        }
+      },
+      "topology_sha256": "eb9cac3037e606705e74bc56c7a25d79ee63fce7a63e30d91b47aa9a9fc8aa36"
     },
     {
       "path": ".github/workflows/storage-large-restore-canary.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "05be76ed05cd025a1adaad7e94809905e8b9e2af52a08b854101585d17fe1326"
+      "job_parity": {
+        "large-restore": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1622",
+          "reason": "Large-restore storage proof lacks a sanctioned GF replacement."
+        }
+      },
+      "topology_sha256": "0a898072d133338bcd322427f9cf3b4c34e84a13169c625ba6aaa2aa25ae0960"
     },
     {
       "path": ".github/workflows/storage-posture-canary.yml",
       "owner": "TIN-2538",
       "triggers": ["workflow_dispatch"],
-      "topology_sha256": "7e5bf0304a248e5783371a5607cc4c44f09bf749c2c797489b8ab87b319e92a1"
+      "job_parity": {
+        "storage-canary": {
+          "disposition": "held",
+          "owner": "TIN-2538",
+          "replacement": null,
+          "blocked_by": "TIN-1546",
+          "reason": "Production storage posture proof lacks a sanctioned GF replacement."
+        }
+      },
+      "topology_sha256": "62f92270f57aba19e6790a54c55eccb62f32244108830dcc69de6eee90b5889c"
     }
   ],
   "blocked_prerequisites": {
     "multi_capability_personal_owner_binding": "TIN-3120",
-    "native_darwin_worker": "TIN-2998",
+    "native_darwin_tcfs_integration": "TIN-2538",
     "native_windows_runtime_and_installer": "TIN-1569"
+  },
+  "completed_provenance": {
+    "native_darwin_worker_commissioned": "TIN-2998"
   }
 }

--- a/config/ci-authority-policy.json
+++ b/config/ci-authority-policy.json
@@ -79,7 +79,7 @@
           "reason": "Cross-platform runtime smoke has no sanctioned GF replacement yet."
         }
       },
-      "topology_sha256": "49b9ac3a38fdeda16208976643744b80bea7f91b1dd339194ef1c68f4db0ad8c"
+      "topology_sha256": "5f133bcd5a4ede19fec6e52b2b9af3115df71c711b46ebe5e71f903b948fa446"
     },
     {
       "path": ".github/workflows/docs.yml",
@@ -108,7 +108,7 @@
           "reason": "Pages deployment remains held until its source build runs only on sanctioned GF compute."
         }
       },
-      "topology_sha256": "b63e7ffdd43f3a8cf14e12fd2c36fea1f7985c8e71319acdc4bfd24ae1c6cbb2"
+      "topology_sha256": "ff3dd13c4a3f6ef75b13aea4e90043b4adc1515879a53cf3c9e464ae81a1daf0"
     },
     {
       "path": ".github/workflows/homebrew-install-smoke.yml",
@@ -123,7 +123,7 @@
           "reason": "Packaged first-run and upgrade smoke lacks a sanctioned GF replacement."
         }
       },
-      "topology_sha256": "13d38c818239eaed39f5728d1c7c65a06c56fabbba5753ce4a95b9e0bd1f99c8"
+      "topology_sha256": "d7441f3a131f8f5907516881939237e3efbe182d278e0fb03b2342fd278ede8f"
     },
     {
       "path": ".github/workflows/linux-package-container-smoke.yml",
@@ -183,7 +183,7 @@
           "reason": "Testing-mode FileProvider package proof is not bound to the commissioned GF Darwin path."
         }
       },
-      "topology_sha256": "f97ea3e60ce478917feed49ce0306b045f1abc9a615b673f300b8579e192869f"
+      "topology_sha256": "c8b4af81019b2f2b255cadf82f08908dfaceb7e058ce2d6f9b7bde5ee62e698b"
     },
     {
       "path": ".github/workflows/macos-postinstall-smoke.yml",
@@ -213,7 +213,7 @@
           "reason": "Nix profile first-run smoke lacks a sanctioned GF replacement."
         }
       },
-      "topology_sha256": "04e888b14cf5b2678f904a8d5e9b883ce2dc43bd90252425c3a1c2bc15aa657f"
+      "topology_sha256": "eb64149ccacfb4a2e362bf8b39a54cb23f9898d616e56209796880f85b67aa09"
     },
     {
       "path": ".github/workflows/release.yml",
@@ -299,7 +299,7 @@
           "reason": "Large-restore storage proof lacks a sanctioned GF replacement."
         }
       },
-      "topology_sha256": "0a898072d133338bcd322427f9cf3b4c34e84a13169c625ba6aaa2aa25ae0960"
+      "topology_sha256": "ea511b32356ec29e05335be4875214fb19e53dae6b002b4075be780d2e62e102"
     },
     {
       "path": ".github/workflows/storage-posture-canary.yml",

--- a/crates/tcfs-cli/tests/cmd_unsync_state_ordering.rs
+++ b/crates/tcfs-cli/tests/cmd_unsync_state_ordering.rs
@@ -5,7 +5,6 @@
 //! reflects reality so the CLI never lies to the daemon about a file being
 //! `Synced` when the hydrated copy is gone (or the stub is half-written).
 
-use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
 
 use tcfs_sync::conflict::VectorClock;
@@ -41,26 +40,23 @@ async fn unsync_flips_status_before_destructive_ops() {
     // Seed state: file is Synced.
     seed_synced(&state_path, &original);
 
-    // Arrange a stub destination directory that cannot be written to so the
-    // destructive fs op fails AFTER the (correctly reordered) state flush.
-    let stub_dir = tmp.path().join("stubs_readonly");
-    std::fs::create_dir_all(&stub_dir).unwrap();
-    let mut perms = std::fs::metadata(&stub_dir).unwrap().permissions();
-    perms.set_mode(0o500);
-    std::fs::set_permissions(&stub_dir, perms).unwrap();
-
-    let stub_full = stub_dir.join("file.stub");
+    // Arrange a stub parent that is a regular file. Creating a child beneath
+    // it fails with ENOTDIR for every uid, unlike mode-bit denial, which root
+    // can bypass on sanctioned ARC runners. The failure still occurs only
+    // AFTER the (correctly reordered) state flush.
+    let stub_parent = tmp.path().join("stub_parent_file");
+    std::fs::write(&stub_parent, b"not a directory").unwrap();
+    let stub_full = stub_parent.join("file.stub");
 
     let result = tcfs_cli::commands::unsync::run_for_test(&original, &stub_full, &state_path).await;
 
-    // Restore permissions so TempDir cleanup can succeed regardless of outcome.
-    let mut restore = std::fs::metadata(&stub_dir).unwrap().permissions();
-    restore.set_mode(0o700);
-    std::fs::set_permissions(&stub_dir, restore).unwrap();
-
     assert!(
         result.is_err(),
-        "stub write into read-only dir should fail, got: {result:?}"
+        "stub write beneath a regular file should fail, got: {result:?}"
+    );
+    assert!(
+        original.exists(),
+        "stub write must fail before the original is removed"
     );
 
     // Invariant: persisted state must be NotSynced, not Synced, even though

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -2124,6 +2124,19 @@ fn split_explicit_git_dir(git_dir: &Path) -> Result<(PathBuf, Vec<std::ffi::OsSt
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
+fn is_protected_root_compatibility_alias(
+    path: &Path,
+    alias_uid: u32,
+    parent_uid: u32,
+    parent_mode: u32,
+) -> bool {
+    path.parent() == Some(Path::new("/"))
+        && alias_uid == 0
+        && parent_uid == 0
+        && parent_mode & 0o022 == 0
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn validate_explicit_repo_root_spelling(repo_root: &Path) -> Result<()> {
     use std::os::unix::fs::MetadataExt;
     use std::path::Component;
@@ -2170,9 +2183,17 @@ fn validate_explicit_repo_root_spelling(repo_root: &Path) -> Result<()> {
                 parent.display()
             )
         })?;
-        let protected_root_alias = metadata.uid() == 0
-            && parent_metadata.uid() == 0
-            && (parent_metadata.mode() & 0o022 == 0 || parent_metadata.mode() & 0o1000 != 0);
+        // Permit only an OS-managed compatibility alias directly below `/`
+        // (for example macOS `/var` -> `private/var`). A broader ownership
+        // predicate is unsafe under UID 0: any nested symlink created by that
+        // process is also root-owned and would otherwise redirect repository
+        // capture through an attacker-selected tree.
+        let protected_root_alias = is_protected_root_compatibility_alias(
+            &prefix,
+            metadata.uid(),
+            parent_metadata.uid(),
+            parent_metadata.mode(),
+        );
         if !protected_root_alias {
             anyhow::bail!(
                 "explicit Git repo root contains a mutable symlink component: {}",
@@ -8927,6 +8948,35 @@ mod tests {
             git_safety::local_ref_sha(&victim, "refs/heads/commondir-probe").is_none(),
             "commondir target refs must remain untouched"
         );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn protected_root_compatibility_alias_is_root_level_only() {
+        assert!(is_protected_root_compatibility_alias(
+            Path::new("/var"),
+            0,
+            0,
+            0o755,
+        ));
+        assert!(!is_protected_root_compatibility_alias(
+            Path::new("/tmp/tcfs/repo-alias"),
+            0,
+            0,
+            0o700,
+        ));
+        assert!(!is_protected_root_compatibility_alias(
+            Path::new("/var"),
+            501,
+            0,
+            0o755,
+        ));
+        assert!(!is_protected_root_compatibility_alias(
+            Path::new("/var"),
+            0,
+            0,
+            0o777,
+        ));
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/docs/ops/tin-2538-public-repo-ci-front-door-2026-08-15.md
+++ b/docs/ops/tin-2538-public-repo-ci-front-door-2026-08-15.md
@@ -1,0 +1,68 @@
+# TIN-2538 public-repository CI front door
+
+Date: 2026-08-15
+
+## Decision
+
+TCFS owns a small repository-local composite action for its public-read Nix
+bootstrap. The action runs only after the exact TCFS revision is checked out
+and verified, and only inside jobs assigned to literal sanctioned
+`tinyland-nix` or `tinyland-dind` runner classes.
+
+This action is independently authored TCFS source. It is not a copy, fork, or
+public representation of any private GloriousFlywheel action. GloriousFlywheel
+continues to own the runner, cache, and remote-execution substrate; TCFS owns
+the public repository's invocation and credential boundary.
+
+## Why the remote action reference was invalid
+
+Natural PR runs at `f3484c1bd0b0b030eb8f29f5afa3754cb901f1b1` were claimed by
+the sanctioned runner pools and then failed during action preparation with
+`Unable to resolve action tinyland-inc/gloriousflywheel, not found`.
+`Jesssullivan/tummycrypt` is a public user-owned repository, while the source
+action repository is private and organization-owned. GitHub permits private
+action sharing only to eligible private repositories under the documented
+owner, organization, or enterprise boundary; it does not provide that private
+action to this public cross-owner caller.
+
+GitHub explicitly supports composite actions stored in the calling repository
+and referenced by a relative path after checkout. That is the appropriate
+public front door here:
+
+- <https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action#creating-a-composite-action-within-the-same-repository>
+- <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository>
+
+## Closed contract
+
+The local action accepts only the existing audited command and six exact
+public-read inputs. It fails closed unless all of these are true:
+
+- GitHub reports a self-hosted runner environment.
+- The site is one of the four named TCFS workload identities.
+- `ATTIC_TOKEN` is empty and both cache-publication inputs are `false`.
+- `NIX_USER_CONF_FILES` and `NETRC` are `/dev/null`.
+- `NIX_CONFIG` adds only the public
+  `https://nix-cache.tinyland.dev/main` substituter, its committed public
+  verification key, and `netrc-file = /dev/null`.
+- Every productive command queries the canonical effective `substituters` and
+  `trusted-public-keys` settings and requires the exact endpoint and key.
+
+The Nix manual documents `NIX_CONFIG` as inline configuration applied after
+system and user configuration, and documents the public-key trust model for
+binary caches:
+
+- <https://nix.dev/manual/nix/latest/command-ref/conf-file#configuration-file>
+- <https://nix.dev/guides/recipes/add-binary-cache.html>
+
+The policy ledger binds the complete action source digest as well as every
+protected workflow topology and command body. Regression tests independently
+reject endpoint, public-key, netrc, token, publication, site, action-path, and
+hosted-runner drift.
+
+## Non-goals and holds
+
+This source repair does not publish cache objects, supply credentials, dispatch
+or rerun workflows, add hosted fallback, activate TCFS, or prove native Darwin
+or Windows runtime behavior. TIN-3120 listener/registration and capability
+binding remain separate. Durable exact-head CI must still be obtained through
+natural runs before this draft can be considered for promotion.

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,8 @@
           "aarch64-apple-darwin"
           "aarch64-apple-ios"
           "aarch64-apple-ios-sim"
+        ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+          "x86_64-pc-windows-gnu"
         ];
         rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = [ "rust-src" "rust-analyzer" "clippy" "rustfmt" ];
@@ -60,7 +62,7 @@
           filter = path: type:
             (protoFilter path type) || (craneLib.filterCargoSources path type);
         in pkgs.lib.cleanSourceWith {
-          src = craneLib.path ./.;
+          src = ./.;
           inherit filter;
         };
 
@@ -215,6 +217,7 @@
             cargo-watch
             cargo-deny
             cargo-audit
+            gitleaks
             shellcheck
             jq
 
@@ -237,13 +240,21 @@
             git
             just
             yq-go
-          ]);
+          ]) ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+            pkgs.pkgsCross.mingwW64.stdenv.cc
+          ];
           TCFS_RUST_TOOLCHAIN = rustVersion;
 
           shellHook = ''
             # Home Manager user profiles may carry an older rustc/cargo ahead
             # of Nix's shell paths. Keep the project-pinned toolchain first.
             export PATH="$PWD/target/debug:$PWD/target/release:${pkgs.lib.makeBinPath [ rustToolchain pkgs.go-task pkgs.just pkgs.shellcheck pkgs.jq.bin pkgs.awscli2 pkgs.s5cmd pkgs.minio-client ]}:$PATH"
+
+            if command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1; then
+              export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc
+              export CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc
+              export AR_x86_64_pc_windows_gnu=x86_64-w64-mingw32-ar
+            fi
 
             echo "tcfs devShell (tummycrypt monorepo)"
             echo "  rustc --version  # pinned toolchain should report ${rustVersion}"

--- a/scripts/test-ci-authority-contract.py
+++ b/scripts/test-ci-authority-contract.py
@@ -19,10 +19,15 @@ sys.dont_write_bytecode = True
 
 PENDING_GF_REVISION = "TIN_3127_SIGNED_MERGE_REVISION_PENDING"
 GF_ACTION_ROOT = "tinyland-inc/GloriousFlywheel/.github/actions/"
-PUBLIC_KEY_EXPRESSION = "${{ vars.ATTIC_PUBLIC_KEY || '' }}"
+ATTIC_PUBLIC_KEY = "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
+LOCAL_DEV_ATTIC_SUBSTITUTER = "https://nix-cache.tinyland.dev/main"
 EXPECTED_SHA_EXPRESSION = (
     "${{ github.event_name == 'pull_request' && "
     "github.event.pull_request.head.sha || github.sha }}"
+)
+SAME_REPOSITORY_OR_NON_PR_CONDITION = (
+    "${{ github.event_name != 'pull_request' || "
+    "github.event.pull_request.head.repo.full_name == github.repository }}"
 )
 DISABLED_JOB_CONDITION = "${{ github.repository == '__TIN_2538_DISABLED__' }}"
 HOSTED_RUNNER_PATTERN = re.compile(
@@ -52,6 +57,29 @@ PUBLIC_READ_SITES = {
     (".github/workflows/ci.yml", "windows-cross"): "tcfs-windows-cross",
     (".github/workflows/nix-ci.yml", "nix-linux"): "tcfs-nix-linux",
     (".github/workflows/ci-live-storage.yml", "fleet-live"): ("tcfs-live-storage"),
+}
+WORKLOAD_MARKERS = {
+    (".github/workflows/ci.yml", "linux-source"): (
+        "nix develop .#default --command bash -euo pipefail",
+        "cargo test --workspace --locked",
+        "cargo deny check",
+        "gitleaks git --config .gitleaks.toml --redact",
+    ),
+    (".github/workflows/ci.yml", "windows-cross"): (
+        "nix develop .#default --command",
+        "cargo check -p tcfs-cloudfilter",
+        "--target x86_64-pc-windows-gnu",
+    ),
+    (".github/workflows/ci-live-storage.yml", "fleet-live"): (
+        "docker compose -f docker-compose.yml",
+        "nix develop .#default --command",
+        "s3api head-bucket",
+        "cargo test -p tcfs-e2e --test fleet_live --locked",
+    ),
+    (".github/workflows/nix-ci.yml", "nix-linux"): (
+        "nix flake check",
+        'nix build --fallback ".#${package}"',
+    ),
 }
 LIVE_STORAGE_PATHS = [
     "crates/**",
@@ -103,7 +131,8 @@ def find_repo_root() -> Path:
 
 def load_policy(root: Path) -> dict[str, Any]:
     loaded = json.loads(
-        (root / "config/ci-authority-policy.json").read_text(encoding="utf-8")
+        (root / "config/ci-authority-policy.json").read_text(encoding="utf-8"),
+        object_pairs_hook=reject_duplicate_pairs,
     )
     if not isinstance(loaded, dict):
         raise ContractError("CI authority policy must be a JSON object")
@@ -173,23 +202,31 @@ def load_workflow(path: Path) -> tuple[dict[str, Any], str]:
     return document, source
 
 
-def scrub_topology(value: Any, *, key: str | None = None) -> Any:
-    if key in {"run", "command"}:
-        return "<script>"
-    if key == "uses" and isinstance(value, str) and value.startswith(GF_ACTION_ROOT):
-        return f"{value.rsplit('@', 1)[0]}@<GF_REVISION>"
+def semantic_topology(
+    value: Any,
+    *,
+    gf_revision: str,
+    key: str | None = None,
+) -> Any:
+    expected_nix_job = f"{GF_ACTION_ROOT}nix-job@{gf_revision}"
+    if key == "uses" and value == expected_nix_job:
+        return f"{GF_ACTION_ROOT}nix-job@<GF_REVISION>"
     if isinstance(value, dict):
         return {
-            item_key: scrub_topology(item_value, key=item_key)
+            item_key: semantic_topology(
+                item_value,
+                gf_revision=gf_revision,
+                key=item_key,
+            )
             for item_key, item_value in value.items()
         }
     if isinstance(value, list):
-        return [scrub_topology(item) for item in value]
+        return [semantic_topology(item, gf_revision=gf_revision) for item in value]
     return value
 
 
-def topology_sha256(document: dict[str, Any]) -> str:
-    topology = scrub_topology(document)
+def topology_sha256(document: dict[str, Any], *, gf_revision: str) -> str:
+    topology = semantic_topology(document, gf_revision=gf_revision)
     encoded = json.dumps(
         topology,
         ensure_ascii=False,
@@ -202,11 +239,13 @@ def topology_sha256(document: dict[str, Any]) -> str:
 def validate_topology(
     document: dict[str, Any],
     contract: dict[str, Any],
+    *,
+    gf_revision: str,
 ) -> None:
     expected = contract.get("topology_sha256")
     if not isinstance(expected, str) or re.fullmatch(r"[0-9a-f]{64}", expected) is None:
         raise ContractError(f"{contract['path']} lacks a reviewed topology digest")
-    actual = topology_sha256(document)
+    actual = topology_sha256(document, gf_revision=gf_revision)
     if actual != expected:
         raise ContractError(
             f"{contract['path']} workflow topology drifted "
@@ -340,6 +379,7 @@ def validate_public_read_tuple(
     *,
     checkout_revision: str,
     gf_revision: str,
+    expected_command_sha256: str,
 ) -> None:
     expected_action = f"{GF_ACTION_ROOT}nix-job@{gf_revision}"
     steps = workflow_steps(job_name, job)
@@ -399,16 +439,21 @@ def validate_public_read_tuple(
     action_with = action.get("with")
     if not isinstance(action_env, dict) or not isinstance(action_with, dict):
         raise ContractError(f"{job_name} GF action must define env and with mappings")
-    if action_env.get("ATTIC_TOKEN") != "":
-        raise ContractError(f"{job_name} must explicitly clear ATTIC_TOKEN")
-    if action_env.get("GF_EXPECTED_RUNNER_ENVIRONMENT") != (
-        "${{ runner.environment }}"
-    ):
-        raise ContractError(f"{job_name} must bind runner.environment explicitly")
+    expected_action_env = {
+        "GF_EXPECTED_RUNNER_ENVIRONMENT": "${{ runner.environment }}",
+        "ATTIC_TOKEN": "",
+    }
+    if (path, job_name) == (".github/workflows/ci.yml", "linux-source"):
+        expected_action_env["BASE_SHA"] = (
+            "${{ github.event_name == 'pull_request' && "
+            "github.event.pull_request.base.sha || '' }}"
+        )
+    if action_env != expected_action_env:
+        raise ContractError(f"{job_name} GF action environment drifted")
 
     exact_public_values = {
         "attic-enabled": "true",
-        "attic-public-key": PUBLIC_KEY_EXPRESSION,
+        "attic-public-key": ATTIC_PUBLIC_KEY,
         "attic-public-read-only": "true",
         "attic-public-read-site": expected_site,
         "push-cache": "false",
@@ -422,15 +467,20 @@ def validate_public_read_tuple(
     for forbidden in ("attic-server", "attic-cache"):
         if forbidden in action_with:
             raise ContractError(f"{job_name} must not override {forbidden}")
+    if set(action_with) != set(exact_public_values) | {"command"}:
+        raise ContractError(f"{job_name} GF action inputs drifted")
     command = action_with.get("command")
     if not isinstance(command, str) or not command:
         raise ContractError(f"{job_name} GF command is missing")
+    if hashlib.sha256(command.encode()).hexdigest() != expected_command_sha256:
+        raise ContractError(f"{job_name} GF command body drifted")
     for required in (
         'test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted',
         'test "${ATTIC_TOKEN:-}" = ""',
         'test -n "${ATTIC_SERVER:-}"',
         'test "${ATTIC_CACHE:-}" = main',
         'test -n "${ATTIC_PUBLIC_KEY:-}"',
+        f'test "${{ATTIC_PUBLIC_KEY:-}}" = "{ATTIC_PUBLIC_KEY}"',
         'test -n "${BAZEL_REMOTE_CACHE:-}"',
         'test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed',
         'test "${NIX_USER_CONF_FILES:-}" = /dev/null',
@@ -446,11 +496,31 @@ def validate_public_read_tuple(
             raise ContractError(
                 f"{job_name} public-read command contains {forbidden!r}"
             )
+    for marker in WORKLOAD_MARKERS[(path, job_name)]:
+        if marker not in command:
+            raise ContractError(f"{job_name} workload escaped the GF wrapper")
+
+    trailing_steps = steps[action_index + 1 :]
+    if path == ".github/workflows/ci-live-storage.yml":
+        trailing_shape = [(step.get("name"), step.get("if")) for step in trailing_steps]
+        if trailing_shape != [
+            ("Print compose logs on failure", "failure()"),
+            ("Tear down compose stack", "always()"),
+        ]:
+            raise ContractError(f"{job_name} has unaudited work after the GF wrapper")
+        for step in trailing_steps:
+            trailing_run = str(step.get("run", ""))
+            if re.search(r"\b(?:nix|cargo)\b", trailing_run):
+                raise ContractError(
+                    f"{job_name} has Nix-dependent work after the GF wrapper"
+                )
+    elif trailing_steps:
+        raise ContractError(f"{job_name} has work after the GF wrapper")
 
 
 def validate_held_job(job_name: str, job: dict[str, Any], issue: str) -> None:
-    if "if" in job or "uses" in job:
-        raise ContractError(f"{job_name} must be an unconditional held job")
+    if "uses" in job:
+        raise ContractError(f"{job_name} held job must not delegate")
     steps = workflow_steps(job_name, job)
     if len(steps) != 1:
         raise ContractError(f"{job_name} must contain one fail-closed step")
@@ -485,20 +555,37 @@ def validate_protected_workflow(
     contract: dict[str, Any],
     policy: dict[str, Any],
 ) -> None:
-    validate_topology(document, contract)
+    validate_topology(
+        document,
+        contract,
+        gf_revision=policy["gloriousflywheel_revision"],
+    )
     validate_protected_triggers(document, contract)
     validate_permissions(document)
     path = contract["path"]
     expected_jobs = contract["jobs"]
     held_jobs = contract["held_jobs"]
+    command_sha256 = contract.get("command_sha256")
     front_door = contract["front_door"]
     if not isinstance(path, str) or not isinstance(expected_jobs, dict):
         raise ContractError("protected policy entry has an invalid shape")
     if not isinstance(held_jobs, dict) or front_door != "nix-job":
         raise ContractError("protected workflows must use the nix-job front door")
+    productive_jobs = set(expected_jobs) - set(held_jobs)
+    if (
+        not isinstance(command_sha256, dict)
+        or set(command_sha256) != productive_jobs
+        or any(
+            not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None
+            for value in command_sha256.values()
+        )
+    ):
+        raise ContractError("protected GF command digest inventory drifted")
 
     if HOSTED_RUNNER_PATTERN.search(source):
         raise ContractError("GitHub-hosted runner label is forbidden")
+    if re.search(r"accept-flake-config", source, re.IGNORECASE):
+        raise ContractError("protected proof must not accept checked-in flake config")
     normalized = re.sub(r"\s+", "", source.lower())
     if "type=gha" in normalized:
         raise ContractError("GitHub cache provider is forbidden")
@@ -542,17 +629,22 @@ def validate_protected_workflow(
             raise ContractError(
                 f"{job_name} must use literal runner {expected_runner!r}"
             )
+        if job.get("if") != SAME_REPOSITORY_OR_NON_PR_CONDITION:
+            raise ContractError(
+                f"{job_name} must use the exact same-repository fork guard"
+            )
         if job_name in held_jobs:
             validate_held_job(job_name, job, held_jobs[job_name])
         else:
-            if "if" in job or "uses" in job:
-                raise ContractError(f"{job_name} must execute without a bypass")
+            if "uses" in job:
+                raise ContractError(f"{job_name} must not delegate")
             validate_public_read_tuple(
                 path,
                 job_name,
                 job,
                 checkout_revision=policy["checkout_revision"],
                 gf_revision=policy["gloriousflywheel_revision"],
+                expected_command_sha256=command_sha256[job_name],
             )
 
     validate_action_refs(
@@ -599,8 +691,11 @@ def validate_protected_workflow(
 def validate_disabled_workflow(
     document: dict[str, Any],
     contract: dict[str, Any],
+    *,
+    gf_revision: str,
+    protected_job_index: dict[tuple[str, str], str],
 ) -> None:
-    validate_topology(document, contract)
+    validate_topology(document, contract, gf_revision=gf_revision)
     expected_triggers = contract["triggers"]
     actual_triggers = workflow_triggers(document)
     if actual_triggers != expected_triggers:
@@ -609,11 +704,61 @@ def validate_disabled_workflow(
             f"(actual={actual_triggers}, expected={expected_triggers})"
         )
     jobs = workflow_jobs(document)
+    parity = contract.get("job_parity")
+    if not isinstance(parity, dict) or set(parity) != set(jobs):
+        raise ContractError("disabled workflow job parity inventory drifted")
     for job_name, job in jobs.items():
         if job.get("if") != DISABLED_JOB_CONDITION:
             raise ContractError(
                 f"disabled workflow job can allocate a runner: {job_name}"
             )
+        claim = parity[job_name]
+        expected_fields = {
+            "disposition",
+            "owner",
+            "replacement",
+            "blocked_by",
+            "reason",
+        }
+        if not isinstance(claim, dict) or set(claim) != expected_fields:
+            raise ContractError(f"{job_name} parity claim shape drifted")
+        if claim["owner"] != contract["owner"]:
+            raise ContractError(f"{job_name} parity owner drifted")
+        if not isinstance(claim["reason"], str) or not claim["reason"].strip():
+            raise ContractError(f"{job_name} parity reason is empty")
+
+        disposition = claim["disposition"]
+        replacement = claim["replacement"]
+        blocked_by = claim["blocked_by"]
+        if disposition == "held":
+            if (
+                replacement is not None
+                or not isinstance(blocked_by, str)
+                or re.fullmatch(r"TIN-[1-9][0-9]*", blocked_by) is None
+            ):
+                raise ContractError(f"{job_name} held parity claim is incomplete")
+        elif disposition == "retired":
+            if replacement is not None or blocked_by is not None:
+                raise ContractError(f"{job_name} retired parity claim drifted")
+        elif disposition == "migrated":
+            if blocked_by is not None or not isinstance(replacement, dict):
+                raise ContractError(f"{job_name} migrated parity claim is incomplete")
+            if set(replacement) != {"path", "job", "runner_class"}:
+                raise ContractError(f"{job_name} replacement shape drifted")
+            target = (replacement["path"], replacement["job"])
+            if protected_job_index.get(target) != replacement["runner_class"]:
+                raise ContractError(f"{job_name} replacement is not protected")
+        else:
+            raise ContractError(f"{job_name} has unknown parity disposition")
+
+
+def protected_job_index(policy: dict[str, Any]) -> dict[tuple[str, str], str]:
+    return {
+        (contract["path"], job_name): runner
+        for contract in policy["protected_proof"]
+        for job_name, runner in contract["jobs"].items()
+        if job_name not in contract["held_jobs"]
+    }
 
 
 def validate_inventory(root: Path, policy: dict[str, Any]) -> None:
@@ -642,7 +787,12 @@ def validate_inventory(root: Path, policy: dict[str, Any]) -> None:
                 "every disabled workflow must retain explicit issue ownership"
             )
         document, _ = load_workflow(root / entry["path"])
-        validate_disabled_workflow(document, entry)
+        validate_disabled_workflow(
+            document,
+            entry,
+            gf_revision=policy["gloriousflywheel_revision"],
+            protected_job_index=protected_job_index(policy),
+        )
 
 
 def validate_actionlint_labels(root: Path, policy: dict[str, Any]) -> None:
@@ -663,7 +813,41 @@ def validate_actionlint_labels(root: Path, policy: dict[str, Any]) -> None:
         )
 
 
+def validate_attic_public_read(root: Path, policy: dict[str, Any]) -> None:
+    expected_policy = {
+        "public_key": ATTIC_PUBLIC_KEY,
+        "local_dev_substituter": LOCAL_DEV_ATTIC_SUBSTITUTER,
+    }
+    if policy.get("attic_public_read") != expected_policy:
+        raise ContractError("Attic public-read policy drifted")
+
+    expected_block = (
+        "  nixConfig = {\n"
+        "    extra-substituters = [\n"
+        f'      "{LOCAL_DEV_ATTIC_SUBSTITUTER}"\n'
+        "    ];\n"
+        "    extra-trusted-public-keys = [\n"
+        f'      "{ATTIC_PUBLIC_KEY}"\n'
+        "    ];\n"
+        "  };"
+    )
+    source = (root / "flake.nix").read_text(encoding="utf-8")
+    if source.count(expected_block) != 1:
+        raise ContractError("flake.nix public Attic tuple drifted")
+    for token in (
+        "nixConfig = {",
+        "extra-substituters = [",
+        "extra-trusted-public-keys = [",
+        LOCAL_DEV_ATTIC_SUBSTITUTER,
+        ATTIC_PUBLIC_KEY,
+    ):
+        if source.count(token) != 1:
+            raise ContractError(f"flake.nix contains an ambiguous Attic token: {token}")
+
+
 def validate_current_tree(root: Path, policy: dict[str, Any]) -> None:
+    if policy.get("version") != 2 or policy.get("issue") != "TIN-2538":
+        raise ContractError("CI authority policy identity or version drifted")
     live_hold = policy.get("live_proof_hold")
     if (
         not isinstance(live_hold, dict)
@@ -672,8 +856,19 @@ def validate_current_tree(root: Path, policy: dict[str, Any]) -> None:
         not in str(live_hold.get("reason", ""))
     ):
         raise ContractError("TIN-3120 live-proof hold or no-fallback claim drifted")
+    if policy.get("blocked_prerequisites") != {
+        "multi_capability_personal_owner_binding": "TIN-3120",
+        "native_darwin_tcfs_integration": "TIN-2538",
+        "native_windows_runtime_and_installer": "TIN-1569",
+    }:
+        raise ContractError("CI authority prerequisite ledger drifted")
+    if policy.get("completed_provenance") != {
+        "native_darwin_worker_commissioned": "TIN-2998"
+    }:
+        raise ContractError("CI authority completed provenance drifted")
     validate_inventory(root, policy)
     validate_actionlint_labels(root, policy)
+    validate_attic_public_read(root, policy)
     for contract in policy["protected_proof"]:
         document, source = load_workflow(root / contract["path"])
         validate_protected_workflow(document, source, contract, policy)
@@ -771,7 +966,10 @@ class CiAuthorityContractTest(unittest.TestCase):
 
             for unsafe in unsafe_documents:
                 contract = copy.deepcopy(self.contracts[path])
-                contract["topology_sha256"] = topology_sha256(unsafe)
+                contract["topology_sha256"] = topology_sha256(
+                    unsafe,
+                    gf_revision=self.policy["gloriousflywheel_revision"],
+                )
                 with self.assertRaisesRegex(
                     ContractError,
                     "protected trigger contract drifted",
@@ -868,6 +1066,244 @@ class CiAuthorityContractTest(unittest.TestCase):
         for unsafe in variants:
             self.assert_protected_rejected(path, unsafe)
 
+    def test_protected_jobs_require_exact_same_repository_fork_guard(self) -> None:
+        for path in sorted(self.contracts):
+            document, source = load_workflow(self.root / path)
+            for job_name in sorted(document["jobs"]):
+                variants: list[dict[str, Any]] = []
+
+                missing = copy.deepcopy(document)
+                del missing["jobs"][job_name]["if"]
+                variants.append(missing)
+
+                negated = copy.deepcopy(document)
+                negated["jobs"][job_name]["if"] = (
+                    "${{ github.event_name != 'pull_request' || "
+                    "github.event.pull_request.head.repo.full_name != "
+                    "github.repository }}"
+                )
+                variants.append(negated)
+
+                unconditional = copy.deepcopy(document)
+                unconditional["jobs"][job_name]["if"] = "${{ always() }}"
+                variants.append(unconditional)
+
+                partial = copy.deepcopy(document)
+                partial["jobs"][job_name]["if"] = (
+                    "${{ github.event_name != 'pull_request' }}"
+                )
+                variants.append(partial)
+
+                for unsafe in variants:
+                    contract = copy.deepcopy(self.contracts[path])
+                    contract["topology_sha256"] = topology_sha256(
+                        unsafe,
+                        gf_revision=self.policy["gloriousflywheel_revision"],
+                    )
+                    with self.assertRaisesRegex(
+                        ContractError,
+                        "exact same-repository fork guard",
+                    ):
+                        validate_protected_workflow(
+                            unsafe,
+                            source,
+                            contract,
+                            self.policy,
+                        )
+
+    def test_semantic_topology_binds_bodies_order_and_non_gf_actions(self) -> None:
+        path = ".github/workflows/ci.yml"
+        document, _ = load_workflow(self.root / path)
+        contract = self.contracts[path]
+        gf_revision = self.policy["gloriousflywheel_revision"]
+        linux_steps = document["jobs"]["linux-source"]["steps"]
+        action = next(
+            step
+            for step in linux_steps
+            if str(step.get("uses", "")).startswith(GF_ACTION_ROOT)
+        )
+
+        body_drift = copy.deepcopy(document)
+        body_action = next(
+            step
+            for step in body_drift["jobs"]["linux-source"]["steps"]
+            if str(step.get("uses", "")).startswith(GF_ACTION_ROOT)
+        )
+        body_action["with"]["command"] += "\n# one-byte-authority-drift"
+
+        run_drift = copy.deepcopy(document)
+        run_drift["jobs"]["linux-source"]["steps"][1]["run"] += " "
+
+        order_drift = copy.deepcopy(document)
+        order_steps = order_drift["jobs"]["linux-source"]["steps"]
+        order_steps[0], order_steps[1] = order_steps[1], order_steps[0]
+
+        checkout_drift = copy.deepcopy(document)
+        checkout_drift["jobs"]["linux-source"]["steps"][0]["uses"] = (
+            "actions/checkout@" + "0" * 40
+        )
+
+        self.assertIn("command", action["with"])
+        for unsafe in (body_drift, run_drift, order_drift, checkout_drift):
+            with self.assertRaisesRegex(ContractError, "topology drifted"):
+                validate_topology(
+                    unsafe,
+                    contract,
+                    gf_revision=gf_revision,
+                )
+
+    def test_gf_revision_normalization_is_policy_bound(self) -> None:
+        path = ".github/workflows/ci.yml"
+        document, source = load_workflow(self.root / path)
+        current_revision = self.policy["gloriousflywheel_revision"]
+        next_revision = "1" * 40
+        changed = copy.deepcopy(document)
+        for job in changed["jobs"].values():
+            for step in job["steps"]:
+                if step.get("uses") == (f"{GF_ACTION_ROOT}nix-job@{current_revision}"):
+                    step["uses"] = f"{GF_ACTION_ROOT}nix-job@{next_revision}"
+
+        self.assertEqual(
+            topology_sha256(document, gf_revision=current_revision),
+            topology_sha256(changed, gf_revision=next_revision),
+        )
+        self.assertNotEqual(
+            topology_sha256(document, gf_revision=current_revision),
+            topology_sha256(changed, gf_revision=current_revision),
+        )
+
+        contract = copy.deepcopy(self.contracts[path])
+        contract["topology_sha256"] = topology_sha256(
+            changed,
+            gf_revision=current_revision,
+        )
+        with self.assertRaises(ContractError):
+            validate_protected_workflow(
+                changed,
+                source,
+                contract,
+                self.policy,
+            )
+
+    def test_accept_flake_config_variants_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        for token in (
+            "--accept-flake-config",
+            "--option accept-flake-config true",
+            "NIX_CONFIG='accept-flake-config = true'",
+        ):
+            with self.assertRaisesRegex(
+                ContractError,
+                "must not accept checked-in flake config",
+            ):
+                document, _ = load_workflow(self.root / path)
+                validate_protected_workflow(
+                    document,
+                    source + f"\n# {token}\n",
+                    self.contracts[path],
+                    self.policy,
+                )
+
+    def test_workload_cannot_escape_gf_wrapper(self) -> None:
+        path = ".github/workflows/ci.yml"
+        document, source = load_workflow(self.root / path)
+        gf_revision = self.policy["gloriousflywheel_revision"]
+
+        escaped = copy.deepcopy(document)
+        escaped["jobs"]["linux-source"]["steps"].append(
+            {
+                "name": "Escaped workload",
+                "run": "nix develop .#default --command cargo test",
+            }
+        )
+        escaped_contract = copy.deepcopy(self.contracts[path])
+        escaped_contract["topology_sha256"] = topology_sha256(
+            escaped,
+            gf_revision=gf_revision,
+        )
+        with self.assertRaisesRegex(ContractError, "work after the GF wrapper"):
+            validate_protected_workflow(
+                escaped,
+                source,
+                escaped_contract,
+                self.policy,
+            )
+
+        missing = copy.deepcopy(document)
+        missing_action = next(
+            step
+            for step in missing["jobs"]["linux-source"]["steps"]
+            if str(step.get("uses", "")).startswith(GF_ACTION_ROOT)
+        )
+        missing_action["with"]["command"] = missing_action["with"]["command"].replace(
+            "cargo deny check", "true", 1
+        )
+        missing_contract = copy.deepcopy(self.contracts[path])
+        missing_contract["topology_sha256"] = topology_sha256(
+            missing,
+            gf_revision=gf_revision,
+        )
+        missing_contract["command_sha256"]["linux-source"] = hashlib.sha256(
+            missing_action["with"]["command"].encode()
+        ).hexdigest()
+        with self.assertRaisesRegex(ContractError, "workload escaped"):
+            validate_protected_workflow(
+                missing,
+                source,
+                missing_contract,
+                self.policy,
+            )
+
+    def test_public_key_and_flake_tuple_are_exact(self) -> None:
+        path = ".github/workflows/ci.yml"
+        document, source = load_workflow(self.root / path)
+        changed = copy.deepcopy(document)
+        action = next(
+            step
+            for step in changed["jobs"]["linux-source"]["steps"]
+            if str(step.get("uses", "")).startswith(GF_ACTION_ROOT)
+        )
+        action["with"]["attic-public-key"] = "main:" + "A" * 44
+        contract = copy.deepcopy(self.contracts[path])
+        contract["topology_sha256"] = topology_sha256(
+            changed,
+            gf_revision=self.policy["gloriousflywheel_revision"],
+        )
+        with self.assertRaisesRegex(ContractError, "attic-public-key"):
+            validate_protected_workflow(
+                changed,
+                source,
+                contract,
+                self.policy,
+            )
+
+        changed_policy = copy.deepcopy(self.policy)
+        changed_policy["attic_public_read"]["public_key"] = "main:" + "A" * 44
+        with self.assertRaisesRegex(ContractError, "policy drifted"):
+            validate_attic_public_read(self.root, changed_policy)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = Path(temporary)
+            flake = (self.root / "flake.nix").read_text(encoding="utf-8")
+            (candidate / "flake.nix").write_text(
+                flake.replace(ATTIC_PUBLIC_KEY, "main:" + "A" * 44, 1),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ContractError, "tuple drifted"):
+                validate_attic_public_read(candidate, self.policy)
+
+    def test_policy_json_rejects_duplicate_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "config").mkdir()
+            (root / "config/ci-authority-policy.json").write_text(
+                '{"version": 2, "version": 2}',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ContractError, "duplicate mapping key"):
+                load_policy(root)
+
     def test_cache_and_action_authority_regressions_are_rejected(self) -> None:
         path = ".github/workflows/ci.yml"
         source = self.sources[path]
@@ -920,6 +1356,47 @@ class CiAuthorityContractTest(unittest.TestCase):
         with self.assertRaises(ContractError):
             validate_inventory(self.root, policy)
 
+    def test_disabled_job_parity_is_exact_and_fail_closed(self) -> None:
+        entry = self.policy["disabled_legacy_workflows"][0]
+        document, _ = load_workflow(self.root / entry["path"])
+        job_name = next(iter(document["jobs"]))
+        variants: list[dict[str, Any]] = []
+
+        missing = copy.deepcopy(entry)
+        del missing["job_parity"][job_name]
+        variants.append(missing)
+
+        unowned = copy.deepcopy(entry)
+        unowned["job_parity"][job_name]["owner"] = "TIN-1"
+        variants.append(unowned)
+
+        unblocked = copy.deepcopy(entry)
+        unblocked["job_parity"][job_name]["blocked_by"] = None
+        variants.append(unblocked)
+
+        held_as_replacement = copy.deepcopy(entry)
+        held_as_replacement["job_parity"][job_name] = {
+            "disposition": "migrated",
+            "owner": "TIN-2538",
+            "replacement": {
+                "path": ".github/workflows/ci.yml",
+                "job": "darwin-authority-held",
+                "runner_class": "tinyland-nix",
+            },
+            "blocked_by": None,
+            "reason": "Invalid migration to a held job.",
+        }
+        variants.append(held_as_replacement)
+
+        for unsafe in variants:
+            with self.assertRaises(ContractError):
+                validate_disabled_workflow(
+                    document,
+                    unsafe,
+                    gf_revision=self.policy["gloriousflywheel_revision"],
+                    protected_job_index=protected_job_index(self.policy),
+                )
+
     def test_disabled_workflow_cannot_reactivate_or_grow(self) -> None:
         entry = self.policy["disabled_legacy_workflows"][0]
         path = self.root / entry["path"]
@@ -945,7 +1422,12 @@ class CiAuthorityContractTest(unittest.TestCase):
                 candidate.write_text(unsafe, encoding="utf-8")
                 with self.assertRaises(ContractError):
                     document, _ = load_workflow(candidate)
-                    validate_disabled_workflow(document, entry)
+                    validate_disabled_workflow(
+                        document,
+                        entry,
+                        gf_revision=self.policy["gloriousflywheel_revision"],
+                        protected_job_index=protected_job_index(self.policy),
+                    )
 
 
 def print_topology(root: Path, policy: dict[str, Any]) -> None:
@@ -953,7 +1435,10 @@ def print_topology(root: Path, policy: dict[str, Any]) -> None:
     report = {}
     for entry in entries:
         document, _ = load_workflow(root / entry["path"])
-        report[entry["path"]] = topology_sha256(document)
+        report[entry["path"]] = topology_sha256(
+            document,
+            gf_revision=policy["gloriousflywheel_revision"],
+        )
     print(json.dumps(report, indent=2, sort_keys=True))
 
 

--- a/scripts/test-ci-authority-contract.py
+++ b/scripts/test-ci-authority-contract.py
@@ -1,0 +1,992 @@
+#!/usr/bin/env python3
+"""Fail-closed source contract for TCFS first-party CI authority."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Any
+import unittest
+
+sys.dont_write_bytecode = True
+
+PENDING_GF_REVISION = "TIN_3127_SIGNED_MERGE_REVISION_PENDING"
+GF_ACTION_ROOT = "tinyland-inc/GloriousFlywheel/.github/actions/"
+PUBLIC_KEY_EXPRESSION = "${{ vars.ATTIC_PUBLIC_KEY || '' }}"
+EXPECTED_SHA_EXPRESSION = (
+    "${{ github.event_name == 'pull_request' && "
+    "github.event.pull_request.head.sha || github.sha }}"
+)
+DISABLED_JOB_CONDITION = "${{ github.repository == '__TIN_2538_DISABLED__' }}"
+HOSTED_RUNNER_PATTERN = re.compile(
+    r"(?:ubuntu|macos|windows)-(?:latest|[0-9][A-Za-z0-9.-]*)",
+    re.IGNORECASE,
+)
+FORBIDDEN_CACHE_OR_BOOTSTRAP_TOKENS = (
+    "actions/cache",
+    "Swatinem/rust-cache",
+    "type=gha",
+    "ACTIONS_CACHE_URL",
+    "ACTIONS_RESULTS_URL",
+    "cachix/install-nix-action",
+    "DeterminateSystems/flakehub-cache-action",
+    "bazel-contrib/setup-bazel",
+)
+SEAWEED_IMAGE = (
+    "chrislusf/seaweedfs:4.40@"
+    "sha256:52194fba4fecd0083c842158b3a902ba6e04a63619b2b0efcd08007bdb6a4602"
+)
+NATS_IMAGE = (
+    "nats:2.10.29-alpine3.22@"
+    "sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927"
+)
+PUBLIC_READ_SITES = {
+    (".github/workflows/ci.yml", "linux-source"): "tcfs-linux-source",
+    (".github/workflows/ci.yml", "windows-cross"): "tcfs-windows-cross",
+    (".github/workflows/nix-ci.yml", "nix-linux"): "tcfs-nix-linux",
+    (".github/workflows/ci-live-storage.yml", "fleet-live"): ("tcfs-live-storage"),
+}
+LIVE_STORAGE_PATHS = [
+    "crates/**",
+    "tests/**",
+    "Cargo.toml",
+    "Cargo.lock",
+    "docker-compose.yml",
+    "config/**",
+    ".github/workflows/ci-live-storage.yml",
+    "scripts/test-ci-authority-contract.py",
+    "config/ci-authority-policy.json",
+]
+PROTECTED_TRIGGER_CONTRACTS: dict[str, dict[str, Any]] = {
+    ".github/workflows/ci.yml": {
+        "push": {"branches": ["main", "dev", "sid/**", "1-*"]},
+        "pull_request": None,
+    },
+    ".github/workflows/ci-live-storage.yml": {
+        "pull_request": {"paths": LIVE_STORAGE_PATHS},
+        "push": {
+            "branches": ["main"],
+            "paths": LIVE_STORAGE_PATHS,
+        },
+        "workflow_dispatch": None,
+    },
+    ".github/workflows/nix-ci.yml": {
+        "push": {"branches": ["main", "dev"]},
+        "pull_request": None,
+        "workflow_dispatch": None,
+    },
+}
+
+
+class ContractError(ValueError):
+    """The checked-in CI authority contract is unsafe or incomplete."""
+
+
+class PromotionHold(ContractError):
+    """The source shape is reviewable but cannot be promoted."""
+
+
+def find_repo_root() -> Path:
+    for candidate in [Path.cwd(), Path(__file__).resolve()]:
+        for parent in [candidate, *candidate.parents]:
+            if (parent / "config/ci-authority-policy.json").is_file():
+                return parent
+    raise ContractError("cannot locate repository root")
+
+
+def load_policy(root: Path) -> dict[str, Any]:
+    loaded = json.loads(
+        (root / "config/ci-authority-policy.json").read_text(encoding="utf-8")
+    )
+    if not isinstance(loaded, dict):
+        raise ContractError("CI authority policy must be a JSON object")
+    return loaded
+
+
+def reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    loaded: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in loaded:
+            raise ContractError(f"yq JSON contains a duplicate mapping key: {key!r}")
+        loaded[key] = value
+    return loaded
+
+
+def yq_json(path: Path, expression: str = ".") -> Any:
+    try:
+        completed = subprocess.run(
+            ["yq", "--output-format=json", "--no-colors", expression, str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ContractError("mikefarah yq v4 is required") from error
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or error.stdout.strip()
+        raise ContractError(f"{path} is not valid YAML: {detail}") from error
+
+    try:
+        return json.loads(
+            completed.stdout,
+            object_pairs_hook=reject_duplicate_pairs,
+        )
+    except json.JSONDecodeError as error:
+        raise ContractError(
+            f"{path} did not produce one strict JSON document: {error}"
+        ) from error
+
+
+def load_workflow(path: Path) -> tuple[dict[str, Any], str]:
+    source = path.read_text(encoding="utf-8")
+    document = yq_json(path)
+    if not isinstance(document, dict):
+        raise ContractError(f"{path} must contain one top-level mapping")
+
+    references = yq_json(
+        path,
+        ('[.. | select(anchor != "") | {"anchor": anchor, "path": path}]'),
+    )
+    if references:
+        raise ContractError(f"{path} must not use YAML anchors, aliases, or merges")
+
+    styled_keys = yq_json(
+        path,
+        (
+            '[.. | select(tag == "!!map") | to_entries | .[] | '
+            'select((.key | style) != "") | '
+            '{"key": (.key | tostring), "style": (.key | style)}]'
+        ),
+    )
+    if styled_keys:
+        raise ContractError(
+            f"{path} must use canonical unquoted mapping keys: {styled_keys!r}"
+        )
+
+    return document, source
+
+
+def scrub_topology(value: Any, *, key: str | None = None) -> Any:
+    if key in {"run", "command"}:
+        return "<script>"
+    if key == "uses" and isinstance(value, str) and value.startswith(GF_ACTION_ROOT):
+        return f"{value.rsplit('@', 1)[0]}@<GF_REVISION>"
+    if isinstance(value, dict):
+        return {
+            item_key: scrub_topology(item_value, key=item_key)
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list):
+        return [scrub_topology(item) for item in value]
+    return value
+
+
+def topology_sha256(document: dict[str, Any]) -> str:
+    topology = scrub_topology(document)
+    encoded = json.dumps(
+        topology,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_topology(
+    document: dict[str, Any],
+    contract: dict[str, Any],
+) -> None:
+    expected = contract.get("topology_sha256")
+    if not isinstance(expected, str) or re.fullmatch(r"[0-9a-f]{64}", expected) is None:
+        raise ContractError(f"{contract['path']} lacks a reviewed topology digest")
+    actual = topology_sha256(document)
+    if actual != expected:
+        raise ContractError(
+            f"{contract['path']} workflow topology drifted "
+            f"(actual={actual}, expected={expected})"
+        )
+
+
+def workflow_jobs(document: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict) or not jobs:
+        raise ContractError("workflow jobs must be a non-empty mapping")
+    for job_name, job in jobs.items():
+        if not isinstance(job_name, str) or not isinstance(job, dict):
+            raise ContractError("every workflow job must be a named mapping")
+    return jobs
+
+
+def workflow_steps(job_name: str, job: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = job.get("steps")
+    if not isinstance(steps, list) or not steps:
+        raise ContractError(f"{job_name} must contain a non-empty steps list")
+    for step in steps:
+        if not isinstance(step, dict):
+            raise ContractError(f"{job_name} contains a non-mapping step")
+    return steps
+
+
+def workflow_triggers(document: dict[str, Any]) -> list[str]:
+    triggers = document.get("on")
+    if not isinstance(triggers, dict) or not triggers:
+        raise ContractError("workflow on must be a non-empty mapping")
+    if not all(isinstance(trigger, str) for trigger in triggers):
+        raise ContractError("every workflow trigger must be a string key")
+    return list(triggers)
+
+
+def validate_protected_triggers(
+    document: dict[str, Any],
+    contract: dict[str, Any],
+) -> None:
+    path = contract.get("path")
+    if contract.get("pull_request_all_bases") is not True:
+        raise ContractError(f"{path} lacks the reviewed all-PR-base contract")
+
+    triggers = document.get("on")
+    expected = PROTECTED_TRIGGER_CONTRACTS.get(path)
+    if expected is None:
+        raise ContractError(f"{path} lacks a source-owned protected trigger contract")
+    if triggers != expected:
+        raise ContractError(
+            f"{path} protected trigger contract drifted "
+            f"(actual={triggers!r}, expected={expected!r})"
+        )
+
+
+def validate_permissions(document: dict[str, Any]) -> None:
+    if document.get("permissions") != {"contents": "read"}:
+        raise ContractError(
+            "protected workflow permissions must be exactly contents: read"
+        )
+
+
+def all_action_steps(
+    jobs: dict[str, dict[str, Any]],
+) -> list[tuple[str, dict[str, Any]]]:
+    found: list[tuple[str, dict[str, Any]]] = []
+    for job_name, job in jobs.items():
+        if "uses" in job:
+            raise ContractError(f"job-level reusable workflow is forbidden: {job_name}")
+        for step in workflow_steps(job_name, job):
+            if "uses" in step:
+                found.append((job_name, step))
+    return found
+
+
+def validate_action_refs(
+    jobs: dict[str, dict[str, Any]],
+    *,
+    checkout_revision: str,
+    gf_revision: str,
+    front_door: str,
+) -> None:
+    allowed = {
+        f"actions/checkout@{checkout_revision}",
+        f"{GF_ACTION_ROOT}{front_door}@{gf_revision}",
+    }
+    action_steps = all_action_steps(jobs)
+    if not action_steps:
+        raise ContractError("protected workflow must use reviewed actions")
+    for job_name, step in action_steps:
+        action_ref = step.get("uses")
+        if not isinstance(action_ref, str) or action_ref not in allowed:
+            raise ContractError(
+                f"{job_name} contains an unreviewed action reference: {action_ref!r}"
+            )
+        revision = action_ref.rsplit("@", 1)[-1]
+        if action_ref.startswith("actions/checkout@"):
+            if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+                raise ContractError("checkout action revision must be immutable")
+        elif (
+            revision != PENDING_GF_REVISION
+            and re.fullmatch(r"[0-9a-f]{40}", revision) is None
+        ):
+            raise ContractError("GloriousFlywheel action revision must be immutable")
+
+
+def unique_step(
+    job_name: str,
+    steps: list[dict[str, Any]],
+    *,
+    name: str | None = None,
+    uses: str | None = None,
+) -> tuple[int, dict[str, Any]]:
+    matches: list[tuple[int, dict[str, Any]]] = []
+    for index, step in enumerate(steps):
+        if name is not None and step.get("name") != name:
+            continue
+        if uses is not None and step.get("uses") != uses:
+            continue
+        matches.append((index, step))
+    if len(matches) != 1:
+        identity = name if name is not None else uses
+        raise ContractError(f"{job_name} must contain exactly one step {identity!r}")
+    return matches[0]
+
+
+def validate_public_read_tuple(
+    path: str,
+    job_name: str,
+    job: dict[str, Any],
+    *,
+    checkout_revision: str,
+    gf_revision: str,
+) -> None:
+    expected_action = f"{GF_ACTION_ROOT}nix-job@{gf_revision}"
+    steps = workflow_steps(job_name, job)
+    checkout_index, checkout = unique_step(
+        job_name,
+        steps,
+        uses=f"actions/checkout@{checkout_revision}",
+    )
+    action_index, action = unique_step(
+        job_name,
+        steps,
+        uses=expected_action,
+    )
+    nix_index, require_nix = unique_step(
+        job_name,
+        steps,
+        name="Require the preinstalled GF Nix runtime",
+    )
+    if not checkout_index < nix_index < action_index:
+        raise ContractError(
+            f"{job_name} must verify preinstalled Nix before entering GF"
+        )
+    if require_nix.get("run") != "command -v nix":
+        raise ContractError(f"{job_name} Nix preflight must fail closed")
+
+    checkout_with = checkout.get("with")
+    if not isinstance(checkout_with, dict):
+        raise ContractError(f"{job_name} checkout must define a with mapping")
+    if checkout_with != {
+        "fetch-depth": 0,
+        "ref": EXPECTED_SHA_EXPRESSION,
+        "persist-credentials": False,
+    }:
+        raise ContractError(f"{job_name} checkout authority tuple drifted")
+
+    unique_step(
+        job_name,
+        steps,
+        name="Verify exact checked out revision",
+    )
+    revision_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Verify exact checked out revision"
+    )
+    if revision_step.get("env") != {"EXPECTED_SHA": EXPECTED_SHA_EXPRESSION}:
+        raise ContractError(f"{job_name} revision identity drifted")
+    if 'test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"' not in str(
+        revision_step.get("run", "")
+    ):
+        raise ContractError(f"{job_name} does not verify the checked-out revision")
+
+    expected_site = PUBLIC_READ_SITES.get((path, job_name))
+    if expected_site is None:
+        raise ContractError(f"{path}:{job_name} has no reviewed public-read site")
+    action_env = action.get("env")
+    action_with = action.get("with")
+    if not isinstance(action_env, dict) or not isinstance(action_with, dict):
+        raise ContractError(f"{job_name} GF action must define env and with mappings")
+    if action_env.get("ATTIC_TOKEN") != "":
+        raise ContractError(f"{job_name} must explicitly clear ATTIC_TOKEN")
+    if action_env.get("GF_EXPECTED_RUNNER_ENVIRONMENT") != (
+        "${{ runner.environment }}"
+    ):
+        raise ContractError(f"{job_name} must bind runner.environment explicitly")
+
+    exact_public_values = {
+        "attic-enabled": "true",
+        "attic-public-key": PUBLIC_KEY_EXPRESSION,
+        "attic-public-read-only": "true",
+        "attic-public-read-site": expected_site,
+        "push-cache": "false",
+        "require-cache-push": "false",
+    }
+    for key, expected in exact_public_values.items():
+        if action_with.get(key) != expected:
+            raise ContractError(
+                f"{job_name} must set public-read input {key}: {expected!r}"
+            )
+    for forbidden in ("attic-server", "attic-cache"):
+        if forbidden in action_with:
+            raise ContractError(f"{job_name} must not override {forbidden}")
+    command = action_with.get("command")
+    if not isinstance(command, str) or not command:
+        raise ContractError(f"{job_name} GF command is missing")
+    for required in (
+        'test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted',
+        'test "${ATTIC_TOKEN:-}" = ""',
+        'test -n "${ATTIC_SERVER:-}"',
+        'test "${ATTIC_CACHE:-}" = main',
+        'test -n "${ATTIC_PUBLIC_KEY:-}"',
+        'test -n "${BAZEL_REMOTE_CACHE:-}"',
+        'test "${GF_BAZEL_SUBSTRATE_MODE:-}" = shared-cache-backed',
+        'test "${NIX_USER_CONF_FILES:-}" = /dev/null',
+        'test "${NETRC:-}" = /dev/null',
+        'test "$(nix config show netrc-file)" = /dev/null',
+        'grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"',
+    ):
+        if required not in command:
+            raise ContractError(f"{job_name} lacks public-read check: {required}")
+    lowered = command.lower()
+    for forbidden in ("attic login", "attic push", "secrets.attic_token", "type=gha"):
+        if forbidden in lowered:
+            raise ContractError(
+                f"{job_name} public-read command contains {forbidden!r}"
+            )
+
+
+def validate_held_job(job_name: str, job: dict[str, Any], issue: str) -> None:
+    if "if" in job or "uses" in job:
+        raise ContractError(f"{job_name} must be an unconditional held job")
+    steps = workflow_steps(job_name, job)
+    if len(steps) != 1:
+        raise ContractError(f"{job_name} must contain one fail-closed step")
+    step = steps[0]
+    name = step.get("name")
+    run = step.get("run")
+    if not isinstance(name, str) or not name.startswith("Hold until "):
+        raise ContractError(f"{job_name} held step name drifted")
+    if not isinstance(run, str) or issue not in run:
+        raise ContractError(f"{job_name} must name its prerequisite {issue}")
+    if not run.rstrip().endswith("exit 1"):
+        raise ContractError(f"{job_name} must end at fail-closed exit 1")
+    if re.search(r"(?m)^\s+exit 0\s*$|\|\|\s*true", run):
+        raise ContractError(f"{job_name} contains a success bypass")
+
+
+def validate_live_storage_images(source: str) -> None:
+    image_values = re.findall(r"(?m)^\s+image:\s*(\S+)\s*$", source)
+    expected = [SEAWEED_IMAGE] * 5 + [NATS_IMAGE]
+    if sorted(image_values) != sorted(expected):
+        raise ContractError(
+            "live-storage service images must match the reviewed digests"
+        )
+    for image in image_values:
+        if re.fullmatch(r"[^@\s]+@sha256:[0-9a-f]{64}", image) is None:
+            raise ContractError(f"live-storage image is not digest-pinned: {image}")
+
+
+def validate_protected_workflow(
+    document: dict[str, Any],
+    source: str,
+    contract: dict[str, Any],
+    policy: dict[str, Any],
+) -> None:
+    validate_topology(document, contract)
+    validate_protected_triggers(document, contract)
+    validate_permissions(document)
+    path = contract["path"]
+    expected_jobs = contract["jobs"]
+    held_jobs = contract["held_jobs"]
+    front_door = contract["front_door"]
+    if not isinstance(path, str) or not isinstance(expected_jobs, dict):
+        raise ContractError("protected policy entry has an invalid shape")
+    if not isinstance(held_jobs, dict) or front_door != "nix-job":
+        raise ContractError("protected workflows must use the nix-job front door")
+
+    if HOSTED_RUNNER_PATTERN.search(source):
+        raise ContractError("GitHub-hosted runner label is forbidden")
+    normalized = re.sub(r"\s+", "", source.lower())
+    if "type=gha" in normalized:
+        raise ContractError("GitHub cache provider is forbidden")
+    for token in FORBIDDEN_CACHE_OR_BOOTSTRAP_TOKENS:
+        if token.lower() in source.lower():
+            raise ContractError(f"forbidden cache/bootstrap path: {token}")
+
+    if document.get("env", {}).get("ATTIC_TOKEN") != "":
+        raise ContractError(
+            "protected workflow must clear ambient Attic credentials globally"
+        )
+    if policy.get("credential_boundary") != {
+        "attic": "public-read-only; ATTIC_TOKEN empty; inherited netrc disabled",
+        "github": (
+            "repository-scoped contents:read token may remain available to "
+            "Nix source fetches"
+        ),
+        "claim": "not globally credential-free",
+    }:
+        raise ContractError("credential claim boundary drifted")
+    for required_claim in (
+        "Attic authentication",
+        "contents:read GitHub token",
+    ):
+        if required_claim not in source:
+            raise ContractError(
+                f"protected workflow omits credential boundary: {required_claim}"
+            )
+
+    jobs = workflow_jobs(document)
+    if set(jobs) != set(expected_jobs):
+        raise ContractError(
+            "protected job inventory drifted "
+            f"(actual={sorted(jobs)}, expected={sorted(expected_jobs)})"
+        )
+    for job_name, expected_runner in expected_jobs.items():
+        job = jobs[job_name]
+        if job.get("runs-on") != expected_runner or not isinstance(
+            job.get("runs-on"), str
+        ):
+            raise ContractError(
+                f"{job_name} must use literal runner {expected_runner!r}"
+            )
+        if job_name in held_jobs:
+            validate_held_job(job_name, job, held_jobs[job_name])
+        else:
+            if "if" in job or "uses" in job:
+                raise ContractError(f"{job_name} must execute without a bypass")
+            validate_public_read_tuple(
+                path,
+                job_name,
+                job,
+                checkout_revision=policy["checkout_revision"],
+                gf_revision=policy["gloriousflywheel_revision"],
+            )
+
+    validate_action_refs(
+        jobs,
+        checkout_revision=policy["checkout_revision"],
+        gf_revision=policy["gloriousflywheel_revision"],
+        front_door=front_door,
+    )
+
+    conditions = [
+        step["if"]
+        for job_name, job in jobs.items()
+        for step in workflow_steps(job_name, job)
+        if "if" in step
+    ]
+    allowed_conditions = (
+        ["failure()", "always()"]
+        if path == ".github/workflows/ci-live-storage.yml"
+        else []
+    )
+    if conditions != allowed_conditions:
+        raise ContractError("protected proof contains an unaudited conditional")
+
+    if path == ".github/workflows/ci-live-storage.yml":
+        validate_live_storage_images(source)
+        live_command = next(
+            step["with"]["command"]
+            for step in workflow_steps("fleet-live", jobs["fleet-live"])
+            if step.get("uses", "").startswith(GF_ACTION_ROOT)
+        )
+        for required in (
+            'test -n "${DOCKER_HOST:-}"',
+            "docker version",
+            "docker info",
+        ):
+            if required not in live_command:
+                raise ContractError(f"live-storage lacks DinD check: {required}")
+    if path == ".github/workflows/ci.yml" and (
+        "--target x86_64-pc-windows-gnu" not in source
+    ):
+        raise ContractError("Windows source proof must use the reviewed cross target")
+
+
+def validate_disabled_workflow(
+    document: dict[str, Any],
+    contract: dict[str, Any],
+) -> None:
+    validate_topology(document, contract)
+    expected_triggers = contract["triggers"]
+    actual_triggers = workflow_triggers(document)
+    if actual_triggers != expected_triggers:
+        raise ContractError(
+            "disabled workflow trigger inventory drifted "
+            f"(actual={actual_triggers}, expected={expected_triggers})"
+        )
+    jobs = workflow_jobs(document)
+    for job_name, job in jobs.items():
+        if job.get("if") != DISABLED_JOB_CONDITION:
+            raise ContractError(
+                f"disabled workflow job can allocate a runner: {job_name}"
+            )
+
+
+def validate_inventory(root: Path, policy: dict[str, Any]) -> None:
+    protected = policy["protected_proof"]
+    disabled = policy["disabled_legacy_workflows"]
+    protected_paths = [entry["path"] for entry in protected]
+    disabled_paths = [entry["path"] for entry in disabled]
+    declared = protected_paths + disabled_paths
+    if len(declared) != len(set(declared)):
+        raise ContractError("workflow authority ledger has duplicate paths")
+    actual = sorted(
+        str(path.relative_to(root))
+        for path in (root / ".github/workflows").iterdir()
+        if path.suffix in {".yml", ".yaml"}
+    )
+    if sorted(declared) != actual:
+        raise ContractError(
+            "workflow authority ledger is not closed "
+            f"(undeclared={sorted(set(actual) - set(declared))}, "
+            f"missing={sorted(set(declared) - set(actual))})"
+        )
+
+    for entry in disabled:
+        if entry.get("owner") != policy["issue"]:
+            raise ContractError(
+                "every disabled workflow must retain explicit issue ownership"
+            )
+        document, _ = load_workflow(root / entry["path"])
+        validate_disabled_workflow(document, entry)
+
+
+def validate_actionlint_labels(root: Path, policy: dict[str, Any]) -> None:
+    expected = sorted(
+        {
+            runner
+            for contract in policy["protected_proof"]
+            for runner in contract["jobs"].values()
+        }
+    )
+    config = (root / ".github/actionlint.yaml").read_text(encoding="utf-8")
+    rendered = "self-hosted-runner:\n  labels:\n" + "".join(
+        f"    - {label}\n" for label in expected
+    )
+    if config != rendered:
+        raise ContractError(
+            "actionlint labels must exactly match protected capability lanes"
+        )
+
+
+def validate_current_tree(root: Path, policy: dict[str, Any]) -> None:
+    live_hold = policy.get("live_proof_hold")
+    if (
+        not isinstance(live_hold, dict)
+        or live_hold.get("issue") != "TIN-3120"
+        or "GitHub-hosted capacity is never a fallback"
+        not in str(live_hold.get("reason", ""))
+    ):
+        raise ContractError("TIN-3120 live-proof hold or no-fallback claim drifted")
+    validate_inventory(root, policy)
+    validate_actionlint_labels(root, policy)
+    for contract in policy["protected_proof"]:
+        document, source = load_workflow(root / contract["path"])
+        validate_protected_workflow(document, source, contract, policy)
+
+
+def validate_promotable_revision(policy: dict[str, Any]) -> None:
+    revision = policy.get("gloriousflywheel_revision")
+    hold = policy.get("promotion_hold")
+    if revision == PENDING_GF_REVISION:
+        if not isinstance(hold, dict) or hold.get("issue") != "TIN-3127":
+            raise ContractError("pending GF revision lacks its exact TIN-3127 hold")
+        raise PromotionHold(
+            "TIN-3127 signed merge revision is unavailable; "
+            "the protected workflows are intentionally non-promotable"
+        )
+    if not isinstance(revision, str) or re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        raise ContractError("GloriousFlywheel revision must be a full commit SHA")
+    if hold is not None:
+        raise ContractError("resolved GloriousFlywheel revision retains a stale hold")
+
+
+class CiAuthorityContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root = find_repo_root()
+        cls.policy = load_policy(cls.root)
+        cls.contracts = {
+            entry["path"]: entry for entry in cls.policy["protected_proof"]
+        }
+        cls.sources = {
+            path: (cls.root / path).read_text(encoding="utf-8")
+            for path in cls.contracts
+        }
+
+    def assert_protected_rejected(self, path: str, unsafe: str) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate = Path(temporary) / "workflow.yml"
+            candidate.write_text(unsafe, encoding="utf-8")
+            with self.assertRaises(ContractError):
+                document, source = load_workflow(candidate)
+                validate_protected_workflow(
+                    document,
+                    source,
+                    self.contracts[path],
+                    self.policy,
+                )
+
+    def test_current_tree_is_closed_and_fail_closed(self) -> None:
+        validate_current_tree(self.root, self.policy)
+
+    def test_revision_promotion_state_is_explicit(self) -> None:
+        if self.policy["gloriousflywheel_revision"] == PENDING_GF_REVISION:
+            with self.assertRaisesRegex(PromotionHold, "TIN-3127"):
+                validate_promotable_revision(self.policy)
+        else:
+            validate_promotable_revision(self.policy)
+
+    def test_quoted_job_and_trigger_keys_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        variants = [
+            source.replace("  linux-source:\n", '  "linux-source":\n', 1),
+            source.replace(
+                "  linux-source:\n",
+                '  "linux\\u002dsource":\n',
+                1,
+            ),
+            source.replace("  pull_request:\n", '  "pull_request":\n', 1),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_protected_trigger_contract_rejects_narrowing_and_expansion(self) -> None:
+        for path in sorted(self.contracts):
+            document, parsed_source = load_workflow(self.root / path)
+            pull_request_variants = [
+                {"branches": ["main"]},
+                {"branches-ignore": ["dev"]},
+                {"types": ["closed"]},
+                {"paths": ["README.md"]},
+                {"paths-ignore": ["**"]},
+            ]
+            unsafe_documents: list[dict[str, Any]] = []
+            for pull_request in pull_request_variants:
+                unsafe = copy.deepcopy(document)
+                unsafe["on"]["pull_request"] = pull_request
+                unsafe_documents.append(unsafe)
+            for trigger, value in (
+                ("pull_request_target", None),
+                ("schedule", [{"cron": "0 0 * * *"}]),
+            ):
+                unsafe = copy.deepcopy(document)
+                unsafe["on"][trigger] = value
+                unsafe_documents.append(unsafe)
+
+            for unsafe in unsafe_documents:
+                contract = copy.deepcopy(self.contracts[path])
+                contract["topology_sha256"] = topology_sha256(unsafe)
+                with self.assertRaisesRegex(
+                    ContractError,
+                    "protected trigger contract drifted",
+                ):
+                    validate_protected_workflow(
+                        unsafe,
+                        parsed_source,
+                        contract,
+                        self.policy,
+                    )
+
+    def test_escaped_uses_and_runs_on_keys_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        variants = [
+            source.replace(
+                "        uses:",
+                '        "u\\u0073es":',
+                1,
+            ),
+            source.replace(
+                "    runs-on:",
+                '    "r\\u0075ns-on":',
+                1,
+            ),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_alias_duplicate_and_extra_topology_is_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        variants = [
+            source.replace(
+                "    runs-on: tinyland-nix",
+                "    runs-on: &authority-lane tinyland-nix",
+                1,
+            ),
+            source.replace(
+                "  linux-source:\n",
+                "  linux-source: &linux-job\n",
+                1,
+            ).replace(
+                "  windows-cross:\n",
+                "  windows-cross:\n    <<: *linux-job\n",
+                1,
+            ),
+            source.replace(
+                "jobs:\n  linux-source:",
+                "jobs:\n  linux-source: {}\n  linux-source:",
+                1,
+            ),
+            source
+            + (
+                "\n  bypass:\n"
+                "    runs-on: tinyland-nix\n"
+                "    steps:\n"
+                "      - name: Bypass\n"
+                "        run: 'true'\n"
+            ),
+            source.replace(
+                "      - name: Verify exact checked out revision",
+                "      - name: Extra step\n"
+                "        run: 'true'\n\n"
+                "      - name: Verify exact checked out revision",
+                1,
+            ),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_dynamic_list_and_reusable_runners_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        variants = [
+            source.replace(
+                "runs-on: tinyland-nix",
+                "runs-on: ${{ vars.RUNNER || 'tinyland-nix' }}",
+                1,
+            ),
+            source.replace(
+                "runs-on: tinyland-nix",
+                "runs-on: [self-hosted, tinyland-nix]",
+                1,
+            ),
+            source.replace(
+                "    runs-on: tinyland-nix",
+                "    uses: example/repository/.github/workflows/ci.yml@main\n"
+                "    runs-on: tinyland-nix",
+                1,
+            ),
+            source.replace("runs-on: tinyland-nix", "runs-on: ubuntu-latest", 1),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_cache_and_action_authority_regressions_are_rejected(self) -> None:
+        path = ".github/workflows/ci.yml"
+        source = self.sources[path]
+        checkout = self.policy["checkout_revision"]
+        gf_revision = self.policy["gloriousflywheel_revision"]
+        variants = [
+            source + "\n# actions/cache@" + "0" * 40 + "\n",
+            source + "\n# cache-to: type=gha,mode=max\n",
+            source.replace(f"actions/checkout@{checkout}", "actions/checkout@main"),
+            source.replace(
+                f"{GF_ACTION_ROOT}nix-job@{gf_revision}",
+                f"{GF_ACTION_ROOT}nix-job@{'0' * 40}",
+                1,
+            ),
+            source.replace("persist-credentials: false", "persist-credentials: true"),
+            source.replace(
+                '          require-cache-push: "false"',
+                '          require-cache-push: "true"',
+                1,
+            ),
+            source.replace(
+                '          ATTIC_TOKEN: ""',
+                "          ATTIC_TOKEN: inherited",
+                1,
+            ),
+        ]
+        for unsafe in variants:
+            self.assert_protected_rejected(path, unsafe)
+
+    def test_held_platform_gate_cannot_turn_green(self) -> None:
+        path = ".github/workflows/ci.yml"
+        unsafe = self.sources[path].replace(
+            "          exit 1\n",
+            "          exit 0\n",
+            1,
+        )
+        self.assert_protected_rejected(path, unsafe)
+
+    def test_live_storage_image_tags_are_rejected(self) -> None:
+        path = ".github/workflows/ci-live-storage.yml"
+        unsafe = self.sources[path].replace(
+            SEAWEED_IMAGE,
+            "chrislusf/seaweedfs:latest",
+        )
+        self.assert_protected_rejected(path, unsafe)
+
+    def test_new_workflow_requires_ledger_classification(self) -> None:
+        policy = copy.deepcopy(self.policy)
+        policy["disabled_legacy_workflows"] = policy["disabled_legacy_workflows"][:-1]
+        with self.assertRaises(ContractError):
+            validate_inventory(self.root, policy)
+
+    def test_disabled_workflow_cannot_reactivate_or_grow(self) -> None:
+        entry = self.policy["disabled_legacy_workflows"][0]
+        path = self.root / entry["path"]
+        source = path.read_text(encoding="utf-8")
+        variants = [
+            source.replace(
+                f"if: {DISABLED_JOB_CONDITION}",
+                "if: ${{ github.repository == github.repository }}",
+                1,
+            ),
+            source
+            + (
+                "\n  extra-disabled:\n"
+                f"    if: {DISABLED_JOB_CONDITION}\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - run: 'true'\n"
+            ),
+        ]
+        for unsafe in variants:
+            with tempfile.TemporaryDirectory() as temporary:
+                candidate = Path(temporary) / "workflow.yml"
+                candidate.write_text(unsafe, encoding="utf-8")
+                with self.assertRaises(ContractError):
+                    document, _ = load_workflow(candidate)
+                    validate_disabled_workflow(document, entry)
+
+
+def print_topology(root: Path, policy: dict[str, Any]) -> None:
+    entries = policy["protected_proof"] + policy["disabled_legacy_workflows"]
+    report = {}
+    for entry in entries:
+        document, _ = load_workflow(root / entry["path"])
+        report[entry["path"]] = topology_sha256(document)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source-hold-ok",
+        action="store_true",
+        help="validate the source shape while retaining the explicit TIN-3127 hold",
+    )
+    parser.add_argument(
+        "--print-topology",
+        action="store_true",
+        help="print reviewed workflow topology digests",
+    )
+    args = parser.parse_args()
+    root = find_repo_root()
+    policy = load_policy(root)
+    if args.print_topology:
+        print_topology(root, policy)
+        return 0
+
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(CiAuthorityContractTest)
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    if not result.wasSuccessful():
+        return 1
+    try:
+        validate_promotable_revision(policy)
+    except PromotionHold as hold:
+        print(f"HOLD: {hold}", file=sys.stderr)
+        return 0 if args.source_hold_ok else 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-ci-authority-contract.py
+++ b/scripts/test-ci-authority-contract.py
@@ -17,10 +17,12 @@ import unittest
 
 sys.dont_write_bytecode = True
 
-PENDING_GF_REVISION = "TIN_3127_SIGNED_MERGE_REVISION_PENDING"
-GF_ACTION_ROOT = "tinyland-inc/GloriousFlywheel/.github/actions/"
+LOCAL_PUBLIC_READ_ACTION = "./.github/actions/tcfs-public-read-nix-job"
+LOCAL_PUBLIC_READ_ACTION_FILE = ".github/actions/tcfs-public-read-nix-job/action.yml"
 ATTIC_PUBLIC_KEY = "main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA="
+ATTIC_SERVER = "https://nix-cache.tinyland.dev"
 LOCAL_DEV_ATTIC_SUBSTITUTER = "https://nix-cache.tinyland.dev/main"
+BAZEL_REMOTE_CACHE = "https://bazel-cache.tinyland.dev"
 EXPECTED_SHA_EXPRESSION = (
     "${{ github.event_name == 'pull_request' && "
     "github.event.pull_request.head.sha || github.sha }}"
@@ -89,6 +91,7 @@ LIVE_STORAGE_PATHS = [
     "docker-compose.yml",
     "config/**",
     ".github/workflows/ci-live-storage.yml",
+    LOCAL_PUBLIC_READ_ACTION_FILE,
     "scripts/test-ci-authority-contract.py",
     "config/ci-authority-policy.json",
 ]
@@ -115,10 +118,6 @@ PROTECTED_TRIGGER_CONTRACTS: dict[str, dict[str, Any]] = {
 
 class ContractError(ValueError):
     """The checked-in CI authority contract is unsafe or incomplete."""
-
-
-class PromotionHold(ContractError):
-    """The source shape is reviewable but cannot be promoted."""
 
 
 def find_repo_root() -> Path:
@@ -202,33 +201,9 @@ def load_workflow(path: Path) -> tuple[dict[str, Any], str]:
     return document, source
 
 
-def semantic_topology(
-    value: Any,
-    *,
-    gf_revision: str,
-    key: str | None = None,
-) -> Any:
-    expected_nix_job = f"{GF_ACTION_ROOT}nix-job@{gf_revision}"
-    if key == "uses" and value == expected_nix_job:
-        return f"{GF_ACTION_ROOT}nix-job@<GF_REVISION>"
-    if isinstance(value, dict):
-        return {
-            item_key: semantic_topology(
-                item_value,
-                gf_revision=gf_revision,
-                key=item_key,
-            )
-            for item_key, item_value in value.items()
-        }
-    if isinstance(value, list):
-        return [semantic_topology(item, gf_revision=gf_revision) for item in value]
-    return value
-
-
-def topology_sha256(document: dict[str, Any], *, gf_revision: str) -> str:
-    topology = semantic_topology(document, gf_revision=gf_revision)
+def topology_sha256(document: dict[str, Any]) -> str:
     encoded = json.dumps(
-        topology,
+        document,
         ensure_ascii=False,
         separators=(",", ":"),
         sort_keys=True,
@@ -239,13 +214,11 @@ def topology_sha256(document: dict[str, Any], *, gf_revision: str) -> str:
 def validate_topology(
     document: dict[str, Any],
     contract: dict[str, Any],
-    *,
-    gf_revision: str,
 ) -> None:
     expected = contract.get("topology_sha256")
     if not isinstance(expected, str) or re.fullmatch(r"[0-9a-f]{64}", expected) is None:
         raise ContractError(f"{contract['path']} lacks a reviewed topology digest")
-    actual = topology_sha256(document, gf_revision=gf_revision)
+    actual = topology_sha256(document)
     if actual != expected:
         raise ContractError(
             f"{contract['path']} workflow topology drifted "
@@ -325,12 +298,11 @@ def validate_action_refs(
     jobs: dict[str, dict[str, Any]],
     *,
     checkout_revision: str,
-    gf_revision: str,
     front_door: str,
 ) -> None:
     allowed = {
         f"actions/checkout@{checkout_revision}",
-        f"{GF_ACTION_ROOT}{front_door}@{gf_revision}",
+        front_door,
     }
     action_steps = all_action_steps(jobs)
     if not action_steps:
@@ -341,15 +313,12 @@ def validate_action_refs(
             raise ContractError(
                 f"{job_name} contains an unreviewed action reference: {action_ref!r}"
             )
-        revision = action_ref.rsplit("@", 1)[-1]
         if action_ref.startswith("actions/checkout@"):
+            revision = action_ref.rsplit("@", 1)[-1]
             if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
                 raise ContractError("checkout action revision must be immutable")
-        elif (
-            revision != PENDING_GF_REVISION
-            and re.fullmatch(r"[0-9a-f]{40}", revision) is None
-        ):
-            raise ContractError("GloriousFlywheel action revision must be immutable")
+        elif action_ref != LOCAL_PUBLIC_READ_ACTION:
+            raise ContractError("public-read action must be repository-local")
 
 
 def unique_step(
@@ -378,10 +347,9 @@ def validate_public_read_tuple(
     job: dict[str, Any],
     *,
     checkout_revision: str,
-    gf_revision: str,
     expected_command_sha256: str,
 ) -> None:
-    expected_action = f"{GF_ACTION_ROOT}nix-job@{gf_revision}"
+    expected_action = LOCAL_PUBLIC_READ_ACTION
     steps = workflow_steps(job_name, job)
     checkout_index, checkout = unique_step(
         job_name,
@@ -400,7 +368,7 @@ def validate_public_read_tuple(
     )
     if not checkout_index < nix_index < action_index:
         raise ContractError(
-            f"{job_name} must verify preinstalled Nix before entering GF"
+            f"{job_name} must verify preinstalled Nix before the public-read action"
         )
     if require_nix.get("run") != "command -v nix":
         raise ContractError(f"{job_name} Nix preflight must fail closed")
@@ -438,7 +406,9 @@ def validate_public_read_tuple(
     action_env = action.get("env")
     action_with = action.get("with")
     if not isinstance(action_env, dict) or not isinstance(action_with, dict):
-        raise ContractError(f"{job_name} GF action must define env and with mappings")
+        raise ContractError(
+            f"{job_name} public-read action must define env and with mappings"
+        )
     expected_action_env = {
         "GF_EXPECTED_RUNNER_ENVIRONMENT": "${{ runner.environment }}",
         "ATTIC_TOKEN": "",
@@ -449,7 +419,7 @@ def validate_public_read_tuple(
             "github.event.pull_request.base.sha || '' }}"
         )
     if action_env != expected_action_env:
-        raise ContractError(f"{job_name} GF action environment drifted")
+        raise ContractError(f"{job_name} public-read action environment drifted")
 
     exact_public_values = {
         "attic-enabled": "true",
@@ -468,12 +438,12 @@ def validate_public_read_tuple(
         if forbidden in action_with:
             raise ContractError(f"{job_name} must not override {forbidden}")
     if set(action_with) != set(exact_public_values) | {"command"}:
-        raise ContractError(f"{job_name} GF action inputs drifted")
+        raise ContractError(f"{job_name} public-read action inputs drifted")
     command = action_with.get("command")
     if not isinstance(command, str) or not command:
-        raise ContractError(f"{job_name} GF command is missing")
+        raise ContractError(f"{job_name} public-read command is missing")
     if hashlib.sha256(command.encode()).hexdigest() != expected_command_sha256:
-        raise ContractError(f"{job_name} GF command body drifted")
+        raise ContractError(f"{job_name} public-read command body drifted")
     for required in (
         'test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted',
         'test "${ATTIC_TOKEN:-}" = ""',
@@ -486,7 +456,10 @@ def validate_public_read_tuple(
         'test "${NIX_USER_CONF_FILES:-}" = /dev/null',
         'test "${NETRC:-}" = /dev/null',
         'test "$(nix config show netrc-file)" = /dev/null',
+        "nix config show substituters |",
         'grep -Fx -- "${ATTIC_SERVER%/}/${ATTIC_CACHE}"',
+        "nix config show trusted-public-keys |",
+        'grep -Fx -- "${ATTIC_PUBLIC_KEY}"',
     ):
         if required not in command:
             raise ContractError(f"{job_name} lacks public-read check: {required}")
@@ -498,7 +471,7 @@ def validate_public_read_tuple(
             )
     for marker in WORKLOAD_MARKERS[(path, job_name)]:
         if marker not in command:
-            raise ContractError(f"{job_name} workload escaped the GF wrapper")
+            raise ContractError(f"{job_name} workload escaped the public-read wrapper")
 
     trailing_steps = steps[action_index + 1 :]
     if path == ".github/workflows/ci-live-storage.yml":
@@ -507,15 +480,17 @@ def validate_public_read_tuple(
             ("Print compose logs on failure", "failure()"),
             ("Tear down compose stack", "always()"),
         ]:
-            raise ContractError(f"{job_name} has unaudited work after the GF wrapper")
+            raise ContractError(
+                f"{job_name} has unaudited work after the public-read wrapper"
+            )
         for step in trailing_steps:
             trailing_run = str(step.get("run", ""))
             if re.search(r"\b(?:nix|cargo)\b", trailing_run):
                 raise ContractError(
-                    f"{job_name} has Nix-dependent work after the GF wrapper"
+                    f"{job_name} has Nix-dependent work after the public-read wrapper"
                 )
     elif trailing_steps:
-        raise ContractError(f"{job_name} has work after the GF wrapper")
+        raise ContractError(f"{job_name} has work after the public-read wrapper")
 
 
 def validate_held_job(job_name: str, job: dict[str, Any], issue: str) -> None:
@@ -555,11 +530,7 @@ def validate_protected_workflow(
     contract: dict[str, Any],
     policy: dict[str, Any],
 ) -> None:
-    validate_topology(
-        document,
-        contract,
-        gf_revision=policy["gloriousflywheel_revision"],
-    )
+    validate_topology(document, contract)
     validate_protected_triggers(document, contract)
     validate_permissions(document)
     path = contract["path"]
@@ -569,8 +540,10 @@ def validate_protected_workflow(
     front_door = contract["front_door"]
     if not isinstance(path, str) or not isinstance(expected_jobs, dict):
         raise ContractError("protected policy entry has an invalid shape")
-    if not isinstance(held_jobs, dict) or front_door != "nix-job":
-        raise ContractError("protected workflows must use the nix-job front door")
+    if not isinstance(held_jobs, dict) or front_door != LOCAL_PUBLIC_READ_ACTION:
+        raise ContractError(
+            "protected workflows must use the local public-read front door"
+        )
     productive_jobs = set(expected_jobs) - set(held_jobs)
     if (
         not isinstance(command_sha256, dict)
@@ -580,7 +553,7 @@ def validate_protected_workflow(
             for value in command_sha256.values()
         )
     ):
-        raise ContractError("protected GF command digest inventory drifted")
+        raise ContractError("protected public-read command digest inventory drifted")
 
     if HOSTED_RUNNER_PATTERN.search(source):
         raise ContractError("GitHub-hosted runner label is forbidden")
@@ -643,14 +616,12 @@ def validate_protected_workflow(
                 job_name,
                 job,
                 checkout_revision=policy["checkout_revision"],
-                gf_revision=policy["gloriousflywheel_revision"],
                 expected_command_sha256=command_sha256[job_name],
             )
 
     validate_action_refs(
         jobs,
         checkout_revision=policy["checkout_revision"],
-        gf_revision=policy["gloriousflywheel_revision"],
         front_door=front_door,
     )
 
@@ -673,7 +644,7 @@ def validate_protected_workflow(
         live_command = next(
             step["with"]["command"]
             for step in workflow_steps("fleet-live", jobs["fleet-live"])
-            if step.get("uses", "").startswith(GF_ACTION_ROOT)
+            if step.get("uses") == LOCAL_PUBLIC_READ_ACTION
         )
         for required in (
             'test -n "${DOCKER_HOST:-}"',
@@ -692,10 +663,9 @@ def validate_disabled_workflow(
     document: dict[str, Any],
     contract: dict[str, Any],
     *,
-    gf_revision: str,
     protected_job_index: dict[tuple[str, str], str],
 ) -> None:
-    validate_topology(document, contract, gf_revision=gf_revision)
+    validate_topology(document, contract)
     expected_triggers = contract["triggers"]
     actual_triggers = workflow_triggers(document)
     if actual_triggers != expected_triggers:
@@ -790,7 +760,6 @@ def validate_inventory(root: Path, policy: dict[str, Any]) -> None:
         validate_disabled_workflow(
             document,
             entry,
-            gf_revision=policy["gloriousflywheel_revision"],
             protected_job_index=protected_job_index(policy),
         )
 
@@ -845,8 +814,143 @@ def validate_attic_public_read(root: Path, policy: dict[str, Any]) -> None:
             raise ContractError(f"flake.nix contains an ambiguous Attic token: {token}")
 
 
+def validate_local_public_read_action(root: Path, policy: dict[str, Any]) -> None:
+    front_door = policy.get("public_read_front_door")
+    if not isinstance(front_door, dict) or set(front_door) != {
+        "action_path",
+        "source_path",
+        "source_sha256",
+        "ownership",
+    }:
+        raise ContractError("local public-read front-door policy drifted")
+    if front_door.get("action_path") != LOCAL_PUBLIC_READ_ACTION:
+        raise ContractError("local public-read action path drifted")
+    if front_door.get("source_path") != LOCAL_PUBLIC_READ_ACTION_FILE:
+        raise ContractError("local public-read action source path drifted")
+    if front_door.get("ownership") != (
+        "TCFS-owned independently authored repository-local public-read "
+        "bootstrap; not private GloriousFlywheel action source"
+    ):
+        raise ContractError("local public-read action ownership claim drifted")
+
+    source_path = root / LOCAL_PUBLIC_READ_ACTION_FILE
+    source = source_path.read_text(encoding="utf-8")
+    expected_digest = front_door.get("source_sha256")
+    if (
+        not isinstance(expected_digest, str)
+        or re.fullmatch(r"[0-9a-f]{64}", expected_digest) is None
+        or hashlib.sha256(source.encode()).hexdigest() != expected_digest
+    ):
+        raise ContractError("local public-read action source digest drifted")
+    if "tinyland-inc/gloriousflywheel" in source.lower():
+        raise ContractError(
+            "local public-read action must not reference private GF source"
+        )
+
+    document, _ = load_workflow(source_path)
+    if set(document) != {"name", "description", "inputs", "runs"}:
+        raise ContractError("local public-read action top-level shape drifted")
+    inputs = document.get("inputs")
+    expected_inputs = {
+        "attic-enabled",
+        "attic-public-key",
+        "attic-public-read-only",
+        "attic-public-read-site",
+        "push-cache",
+        "require-cache-push",
+        "command",
+    }
+    if not isinstance(inputs, dict) or set(inputs) != expected_inputs:
+        raise ContractError("local public-read action input inventory drifted")
+    for name, value in inputs.items():
+        if (
+            not isinstance(value, dict)
+            or set(value) != {"description", "required"}
+            or value.get("required") is not True
+            or not isinstance(value.get("description"), str)
+            or not value["description"].strip()
+        ):
+            raise ContractError(f"local public-read action input drifted: {name}")
+
+    runs = document.get("runs")
+    if not isinstance(runs, dict) or set(runs) != {"using", "steps"}:
+        raise ContractError("local public-read action runtime shape drifted")
+    steps = runs.get("steps")
+    if (
+        runs.get("using") != "composite"
+        or not isinstance(steps, list)
+        or len(steps) != 1
+    ):
+        raise ContractError("local public-read action must be one composite step")
+    step = steps[0]
+    if not isinstance(step, dict) or set(step) != {"name", "shell", "env", "run"}:
+        raise ContractError("local public-read action step shape drifted")
+    if step.get("shell") != "bash":
+        raise ContractError("local public-read action shell drifted")
+
+    expected_nix_config = (
+        f"extra-substituters = {LOCAL_DEV_ATTIC_SUBSTITUTER}\n"
+        f"extra-trusted-public-keys = {ATTIC_PUBLIC_KEY}\n"
+        "netrc-file = /dev/null\n"
+    )
+    expected_env = {
+        "GF_COMMAND": "${{ inputs.command }}",
+        "GF_EXPECTED_RUNNER_ENVIRONMENT": ("${{ env.GF_EXPECTED_RUNNER_ENVIRONMENT }}"),
+        "GF_INPUT_ATTIC_ENABLED": "${{ inputs.attic-enabled }}",
+        "GF_INPUT_ATTIC_PUBLIC_KEY": "${{ inputs.attic-public-key }}",
+        "GF_INPUT_ATTIC_PUBLIC_READ_ONLY": ("${{ inputs.attic-public-read-only }}"),
+        "GF_INPUT_ATTIC_PUBLIC_READ_SITE": "${{ inputs.attic-public-read-site }}",
+        "GF_INPUT_PUSH_CACHE": "${{ inputs.push-cache }}",
+        "GF_INPUT_REQUIRE_CACHE_PUSH": "${{ inputs.require-cache-push }}",
+        "ATTIC_TOKEN": "${{ env.ATTIC_TOKEN }}",
+        "ATTIC_SERVER": ATTIC_SERVER,
+        "ATTIC_CACHE": "main",
+        "ATTIC_PUBLIC_KEY": ATTIC_PUBLIC_KEY,
+        "ATTIC_PUBLIC_READ_SITE": "${{ inputs.attic-public-read-site }}",
+        "BAZEL_REMOTE_CACHE": BAZEL_REMOTE_CACHE,
+        "GF_BAZEL_SUBSTRATE_MODE": "shared-cache-backed",
+        "NIX_USER_CONF_FILES": "/dev/null",
+        "NETRC": "/dev/null",
+        "NIX_CONFIG": expected_nix_config,
+    }
+    if step.get("env") != expected_env:
+        raise ContractError("local public-read action environment drifted")
+
+    run = step.get("run")
+    if not isinstance(run, str):
+        raise ContractError("local public-read action command is missing")
+    for required in (
+        'test "${GF_EXPECTED_RUNNER_ENVIRONMENT:-}" = self-hosted',
+        'test "${GF_INPUT_ATTIC_ENABLED:-}" = true',
+        'test "${GF_INPUT_ATTIC_PUBLIC_KEY:-}" = "${ATTIC_PUBLIC_KEY}"',
+        'test "${GF_INPUT_ATTIC_PUBLIC_READ_ONLY:-}" = true',
+        "tcfs-linux-source|tcfs-windows-cross|tcfs-live-storage|tcfs-nix-linux",
+        'test "${GF_INPUT_PUSH_CACHE:-}" = false',
+        'test "${GF_INPUT_REQUIRE_CACHE_PUSH:-}" = false',
+        'test "${ATTIC_TOKEN:-}" = ""',
+        'test "${NIX_USER_CONF_FILES:-}" = /dev/null',
+        'test "${NETRC:-}" = /dev/null',
+        'bash -euo pipefail -c "${GF_COMMAND}"',
+    ):
+        if required not in run:
+            raise ContractError(f"local public-read action lacks guard: {required}")
+    lowered = run.lower()
+    for forbidden in (
+        "attic login",
+        "attic push",
+        "github_env",
+        "secrets.",
+        "push-cache=true",
+        "require-cache-push=true",
+    ):
+        if forbidden in lowered:
+            raise ContractError(
+                f"local public-read action contains forbidden capability: {forbidden}"
+            )
+
+
 def validate_current_tree(root: Path, policy: dict[str, Any]) -> None:
-    if policy.get("version") != 2 or policy.get("issue") != "TIN-2538":
+    if policy.get("version") != 3 or policy.get("issue") != "TIN-2538":
         raise ContractError("CI authority policy identity or version drifted")
     live_hold = policy.get("live_proof_hold")
     if (
@@ -869,25 +973,10 @@ def validate_current_tree(root: Path, policy: dict[str, Any]) -> None:
     validate_inventory(root, policy)
     validate_actionlint_labels(root, policy)
     validate_attic_public_read(root, policy)
+    validate_local_public_read_action(root, policy)
     for contract in policy["protected_proof"]:
         document, source = load_workflow(root / contract["path"])
         validate_protected_workflow(document, source, contract, policy)
-
-
-def validate_promotable_revision(policy: dict[str, Any]) -> None:
-    revision = policy.get("gloriousflywheel_revision")
-    hold = policy.get("promotion_hold")
-    if revision == PENDING_GF_REVISION:
-        if not isinstance(hold, dict) or hold.get("issue") != "TIN-3127":
-            raise ContractError("pending GF revision lacks its exact TIN-3127 hold")
-        raise PromotionHold(
-            "TIN-3127 signed merge revision is unavailable; "
-            "the protected workflows are intentionally non-promotable"
-        )
-    if not isinstance(revision, str) or re.fullmatch(r"[0-9a-f]{40}", revision) is None:
-        raise ContractError("GloriousFlywheel revision must be a full commit SHA")
-    if hold is not None:
-        raise ContractError("resolved GloriousFlywheel revision retains a stale hold")
 
 
 class CiAuthorityContractTest(unittest.TestCase):
@@ -916,15 +1005,88 @@ class CiAuthorityContractTest(unittest.TestCase):
                     self.policy,
                 )
 
+    def assert_local_action_rejected(
+        self,
+        old: str,
+        new: str,
+        message: str,
+    ) -> None:
+        source = (self.root / LOCAL_PUBLIC_READ_ACTION_FILE).read_text(encoding="utf-8")
+        self.assertIn(old, source)
+        unsafe = source.replace(old, new, 1)
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate_root = Path(temporary)
+            candidate = candidate_root / LOCAL_PUBLIC_READ_ACTION_FILE
+            candidate.parent.mkdir(parents=True)
+            candidate.write_text(unsafe, encoding="utf-8")
+            policy = copy.deepcopy(self.policy)
+            policy["public_read_front_door"]["source_sha256"] = hashlib.sha256(
+                unsafe.encode()
+            ).hexdigest()
+            with self.assertRaisesRegex(ContractError, message):
+                validate_local_public_read_action(candidate_root, policy)
+
     def test_current_tree_is_closed_and_fail_closed(self) -> None:
         validate_current_tree(self.root, self.policy)
 
-    def test_revision_promotion_state_is_explicit(self) -> None:
-        if self.policy["gloriousflywheel_revision"] == PENDING_GF_REVISION:
-            with self.assertRaisesRegex(PromotionHold, "TIN-3127"):
-                validate_promotable_revision(self.policy)
-        else:
-            validate_promotable_revision(self.policy)
+    def test_local_front_door_is_source_bound(self) -> None:
+        validate_local_public_read_action(self.root, self.policy)
+
+    def test_local_front_door_rejects_public_read_boundary_mutations(self) -> None:
+        mutations = [
+            (
+                "extra-substituters = https://nix-cache.tinyland.dev/main",
+                "extra-substituters = https://cache.invalid/main",
+                "environment drifted",
+            ),
+            (
+                f"extra-trusted-public-keys = {ATTIC_PUBLIC_KEY}",
+                "extra-trusted-public-keys = main:" + "A" * 44,
+                "environment drifted",
+            ),
+            (
+                "netrc-file = /dev/null",
+                "netrc-file = /home/runner/.netrc",
+                "environment drifted",
+            ),
+            (
+                "ATTIC_TOKEN: ${{ env.ATTIC_TOKEN }}",
+                "ATTIC_TOKEN: inherited",
+                "environment drifted",
+            ),
+            (
+                'test "${GF_INPUT_PUSH_CACHE:-}" = false',
+                'test "${GF_INPUT_PUSH_CACHE:-}" = true',
+                "lacks guard",
+            ),
+            (
+                "tcfs-linux-source|tcfs-windows-cross|tcfs-live-storage|tcfs-nix-linux",
+                "tcfs-linux-source|tcfs-windows-cross|tcfs-live-storage|unreviewed",
+                "lacks guard",
+            ),
+        ]
+        for old, new, message in mutations:
+            self.assert_local_action_rejected(old, new, message)
+
+    def test_local_front_door_rejects_write_and_credential_inputs(self) -> None:
+        self.assert_local_action_rejected(
+            "  command:\n",
+            "  attic-token:\n"
+            "    description: Forbidden cache credential\n"
+            "    required: true\n"
+            "  command:\n",
+            "input inventory drifted",
+        )
+
+        source = (self.root / LOCAL_PUBLIC_READ_ACTION_FILE).read_text(encoding="utf-8")
+        unsafe = source + "\n# digest drift\n"
+        with tempfile.TemporaryDirectory() as temporary:
+            candidate_root = Path(temporary)
+            candidate = candidate_root / LOCAL_PUBLIC_READ_ACTION_FILE
+            candidate.parent.mkdir(parents=True)
+            candidate.write_text(unsafe, encoding="utf-8")
+            with self.assertRaisesRegex(ContractError, "source digest drifted"):
+                validate_local_public_read_action(candidate_root, self.policy)
 
     def test_quoted_job_and_trigger_keys_are_rejected(self) -> None:
         path = ".github/workflows/ci.yml"
@@ -966,10 +1128,7 @@ class CiAuthorityContractTest(unittest.TestCase):
 
             for unsafe in unsafe_documents:
                 contract = copy.deepcopy(self.contracts[path])
-                contract["topology_sha256"] = topology_sha256(
-                    unsafe,
-                    gf_revision=self.policy["gloriousflywheel_revision"],
-                )
+                contract["topology_sha256"] = topology_sha256(unsafe)
                 with self.assertRaisesRegex(
                     ContractError,
                     "protected trigger contract drifted",
@@ -1096,10 +1255,7 @@ class CiAuthorityContractTest(unittest.TestCase):
 
                 for unsafe in variants:
                     contract = copy.deepcopy(self.contracts[path])
-                    contract["topology_sha256"] = topology_sha256(
-                        unsafe,
-                        gf_revision=self.policy["gloriousflywheel_revision"],
-                    )
+                    contract["topology_sha256"] = topology_sha256(unsafe)
                     with self.assertRaisesRegex(
                         ContractError,
                         "exact same-repository fork guard",
@@ -1111,23 +1267,20 @@ class CiAuthorityContractTest(unittest.TestCase):
                             self.policy,
                         )
 
-    def test_semantic_topology_binds_bodies_order_and_non_gf_actions(self) -> None:
+    def test_semantic_topology_binds_bodies_order_and_action_paths(self) -> None:
         path = ".github/workflows/ci.yml"
         document, _ = load_workflow(self.root / path)
         contract = self.contracts[path]
-        gf_revision = self.policy["gloriousflywheel_revision"]
         linux_steps = document["jobs"]["linux-source"]["steps"]
         action = next(
-            step
-            for step in linux_steps
-            if str(step.get("uses", "")).startswith(GF_ACTION_ROOT)
+            step for step in linux_steps if step.get("uses") == LOCAL_PUBLIC_READ_ACTION
         )
 
         body_drift = copy.deepcopy(document)
         body_action = next(
             step
             for step in body_drift["jobs"]["linux-source"]["steps"]
-            if str(step.get("uses", "")).startswith(GF_ACTION_ROOT)
+            if step.get("uses") == LOCAL_PUBLIC_READ_ACTION
         )
         body_action["with"]["command"] += "\n# one-byte-authority-drift"
 
@@ -1146,37 +1299,24 @@ class CiAuthorityContractTest(unittest.TestCase):
         self.assertIn("command", action["with"])
         for unsafe in (body_drift, run_drift, order_drift, checkout_drift):
             with self.assertRaisesRegex(ContractError, "topology drifted"):
-                validate_topology(
-                    unsafe,
-                    contract,
-                    gf_revision=gf_revision,
-                )
+                validate_topology(unsafe, contract)
 
-    def test_gf_revision_normalization_is_policy_bound(self) -> None:
+    def test_local_action_path_is_policy_bound(self) -> None:
         path = ".github/workflows/ci.yml"
         document, source = load_workflow(self.root / path)
-        current_revision = self.policy["gloriousflywheel_revision"]
-        next_revision = "1" * 40
         changed = copy.deepcopy(document)
         for job in changed["jobs"].values():
             for step in job["steps"]:
-                if step.get("uses") == (f"{GF_ACTION_ROOT}nix-job@{current_revision}"):
-                    step["uses"] = f"{GF_ACTION_ROOT}nix-job@{next_revision}"
+                if step.get("uses") == LOCAL_PUBLIC_READ_ACTION:
+                    step["uses"] = "./.github/actions/unreviewed"
 
-        self.assertEqual(
-            topology_sha256(document, gf_revision=current_revision),
-            topology_sha256(changed, gf_revision=next_revision),
-        )
         self.assertNotEqual(
-            topology_sha256(document, gf_revision=current_revision),
-            topology_sha256(changed, gf_revision=current_revision),
+            topology_sha256(document),
+            topology_sha256(changed),
         )
 
         contract = copy.deepcopy(self.contracts[path])
-        contract["topology_sha256"] = topology_sha256(
-            changed,
-            gf_revision=current_revision,
-        )
+        contract["topology_sha256"] = topology_sha256(changed)
         with self.assertRaises(ContractError):
             validate_protected_workflow(
                 changed,
@@ -1184,6 +1324,66 @@ class CiAuthorityContractTest(unittest.TestCase):
                 contract,
                 self.policy,
             )
+
+    def test_effective_nix_setting_proofs_use_canonical_names(self) -> None:
+        for path, contract in self.contracts.items():
+            document, source = load_workflow(self.root / path)
+            for job_name in contract["command_sha256"]:
+                changed = copy.deepcopy(document)
+                action = next(
+                    step
+                    for step in changed["jobs"][job_name]["steps"]
+                    if step.get("uses") == LOCAL_PUBLIC_READ_ACTION
+                )
+                command = action["with"]["command"]
+                self.assertIn("nix config show substituters |", command)
+                action["with"]["command"] = command.replace(
+                    "nix config show substituters |",
+                    "nix config show extra-substituters |",
+                    1,
+                )
+                changed_contract = copy.deepcopy(contract)
+                changed_contract["topology_sha256"] = topology_sha256(changed)
+                changed_contract["command_sha256"][job_name] = hashlib.sha256(
+                    action["with"]["command"].encode()
+                ).hexdigest()
+                with self.assertRaisesRegex(
+                    ContractError,
+                    "lacks public-read check: nix config show substituters",
+                ):
+                    validate_protected_workflow(
+                        changed,
+                        source,
+                        changed_contract,
+                        self.policy,
+                    )
+
+                missing_key = copy.deepcopy(document)
+                key_action = next(
+                    step
+                    for step in missing_key["jobs"][job_name]["steps"]
+                    if step.get("uses") == LOCAL_PUBLIC_READ_ACTION
+                )
+                key_action["with"]["command"] = key_action["with"]["command"].replace(
+                    "nix config show trusted-public-keys |",
+                    "nix config show substituters |",
+                    1,
+                )
+                key_contract = copy.deepcopy(contract)
+                key_contract["topology_sha256"] = topology_sha256(missing_key)
+                key_contract["command_sha256"][job_name] = hashlib.sha256(
+                    key_action["with"]["command"].encode()
+                ).hexdigest()
+                with self.assertRaisesRegex(
+                    ContractError,
+                    "lacks public-read check: nix config show trusted-public-keys",
+                ):
+                    validate_protected_workflow(
+                        missing_key,
+                        source,
+                        key_contract,
+                        self.policy,
+                    )
 
     def test_accept_flake_config_variants_are_rejected(self) -> None:
         path = ".github/workflows/ci.yml"
@@ -1205,10 +1405,9 @@ class CiAuthorityContractTest(unittest.TestCase):
                     self.policy,
                 )
 
-    def test_workload_cannot_escape_gf_wrapper(self) -> None:
+    def test_workload_cannot_escape_public_read_wrapper(self) -> None:
         path = ".github/workflows/ci.yml"
         document, source = load_workflow(self.root / path)
-        gf_revision = self.policy["gloriousflywheel_revision"]
 
         escaped = copy.deepcopy(document)
         escaped["jobs"]["linux-source"]["steps"].append(
@@ -1218,11 +1417,10 @@ class CiAuthorityContractTest(unittest.TestCase):
             }
         )
         escaped_contract = copy.deepcopy(self.contracts[path])
-        escaped_contract["topology_sha256"] = topology_sha256(
-            escaped,
-            gf_revision=gf_revision,
-        )
-        with self.assertRaisesRegex(ContractError, "work after the GF wrapper"):
+        escaped_contract["topology_sha256"] = topology_sha256(escaped)
+        with self.assertRaisesRegex(
+            ContractError, "work after the public-read wrapper"
+        ):
             validate_protected_workflow(
                 escaped,
                 source,
@@ -1234,16 +1432,13 @@ class CiAuthorityContractTest(unittest.TestCase):
         missing_action = next(
             step
             for step in missing["jobs"]["linux-source"]["steps"]
-            if str(step.get("uses", "")).startswith(GF_ACTION_ROOT)
+            if step.get("uses") == LOCAL_PUBLIC_READ_ACTION
         )
         missing_action["with"]["command"] = missing_action["with"]["command"].replace(
             "cargo deny check", "true", 1
         )
         missing_contract = copy.deepcopy(self.contracts[path])
-        missing_contract["topology_sha256"] = topology_sha256(
-            missing,
-            gf_revision=gf_revision,
-        )
+        missing_contract["topology_sha256"] = topology_sha256(missing)
         missing_contract["command_sha256"]["linux-source"] = hashlib.sha256(
             missing_action["with"]["command"].encode()
         ).hexdigest()
@@ -1262,14 +1457,11 @@ class CiAuthorityContractTest(unittest.TestCase):
         action = next(
             step
             for step in changed["jobs"]["linux-source"]["steps"]
-            if str(step.get("uses", "")).startswith(GF_ACTION_ROOT)
+            if step.get("uses") == LOCAL_PUBLIC_READ_ACTION
         )
         action["with"]["attic-public-key"] = "main:" + "A" * 44
         contract = copy.deepcopy(self.contracts[path])
-        contract["topology_sha256"] = topology_sha256(
-            changed,
-            gf_revision=self.policy["gloriousflywheel_revision"],
-        )
+        contract["topology_sha256"] = topology_sha256(changed)
         with self.assertRaisesRegex(ContractError, "attic-public-key"):
             validate_protected_workflow(
                 changed,
@@ -1308,14 +1500,13 @@ class CiAuthorityContractTest(unittest.TestCase):
         path = ".github/workflows/ci.yml"
         source = self.sources[path]
         checkout = self.policy["checkout_revision"]
-        gf_revision = self.policy["gloriousflywheel_revision"]
         variants = [
             source + "\n# actions/cache@" + "0" * 40 + "\n",
             source + "\n# cache-to: type=gha,mode=max\n",
             source.replace(f"actions/checkout@{checkout}", "actions/checkout@main"),
             source.replace(
-                f"{GF_ACTION_ROOT}nix-job@{gf_revision}",
-                f"{GF_ACTION_ROOT}nix-job@{'0' * 40}",
+                LOCAL_PUBLIC_READ_ACTION,
+                "tinyland-inc/GloriousFlywheel/.github/actions/nix-job@" + "0" * 40,
                 1,
             ),
             source.replace("persist-credentials: false", "persist-credentials: true"),
@@ -1393,7 +1584,6 @@ class CiAuthorityContractTest(unittest.TestCase):
                 validate_disabled_workflow(
                     document,
                     unsafe,
-                    gf_revision=self.policy["gloriousflywheel_revision"],
                     protected_job_index=protected_job_index(self.policy),
                 )
 
@@ -1425,7 +1615,6 @@ class CiAuthorityContractTest(unittest.TestCase):
                     validate_disabled_workflow(
                         document,
                         entry,
-                        gf_revision=self.policy["gloriousflywheel_revision"],
                         protected_job_index=protected_job_index(self.policy),
                     )
 
@@ -1435,10 +1624,7 @@ def print_topology(root: Path, policy: dict[str, Any]) -> None:
     report = {}
     for entry in entries:
         document, _ = load_workflow(root / entry["path"])
-        report[entry["path"]] = topology_sha256(
-            document,
-            gf_revision=policy["gloriousflywheel_revision"],
-        )
+        report[entry["path"]] = topology_sha256(document)
     print(json.dumps(report, indent=2, sort_keys=True))
 
 
@@ -1447,7 +1633,7 @@ def main() -> int:
     parser.add_argument(
         "--source-hold-ok",
         action="store_true",
-        help="validate the source shape while retaining the explicit TIN-3127 hold",
+        help="compatibility alias for source-only CI authority validation",
     )
     parser.add_argument(
         "--print-topology",
@@ -1465,11 +1651,6 @@ def main() -> int:
     result = unittest.TextTestRunner(verbosity=1).run(suite)
     if not result.wasSuccessful():
         return 1
-    try:
-        validate_promotable_revision(policy)
-    except PromotionHold as hold:
-        print(f"HOLD: {hold}", file=sys.stderr)
-        return 0 if args.source_hold_ok else 2
     return 0
 
 


### PR DESCRIPTION
## Summary

Restores TCFS CI to a source-owned, fail-closed GloriousFlywheel-only authority on exact base `dfe8282a4d93af0ca1c495065ec82002352d4d86`. This PR remains draft, source-only, digestless, and runtime-inert.

The repository-local public-read composite replaces the private cross-owner GF action that this public user-owned repository cannot consume. It keeps productive work on literal `tinyland-nix` and `tinyland-dind`, with no hosted fallback or copied private GF source.

## Current exact head

- signed head: `3d4de77933f2234d491dce1be2ac9e46e6fb4b10`
- parent: `292de66b5ef6d13b4d5c7cbf1231fc2e99e9de15`
- base: `dfe8282a4d93af0ca1c495065ec82002352d4d86`
- state: draft; auto-merge off

Two additive root-runner repairs sit above the reviewed 22-path authority packet:

- TIN-3799 replaces a mode-bit write-denial fixture with a regular-file parent, making the post-flush failure deterministic for every uid while proving the original file was not removed.
- TIN-3800 permits only root-level OS compatibility aliases such as macOS `/var`, and rejects nested root-owned repo aliases before Git capture, bundle, or ref side effects.

## Source evidence

- independent current-source review: P0=0/P1=0
- authority contract: 23/23
- TIN-3799 focused integration proof: 1/1
- `tcfs-sync` library suite: 441/441
- Cargo fmt and strict `tcfs-sync` clippy pass
- exact local action SHA-256: `8110be069476b984518dc6ff793592993d8a6e4a24b705389a83238a3aa43ed8`
- policy topology/action/command digests recomputed exact
- Actionlint, Bash syntax, Ruff, and diff hygiene pass
- complete authority manifest is unchanged by both one-file repairs

## Natural infrastructure findings

Prior sanctioned runs proved the public front door and then exposed three separate blockers:

- TIN-3798: the GF-owned `tummycrypt-dind` image lacks Docker Compose v2.
- TIN-545: exact-head evidence is cross-derivation and cross-runner: `rust-docs-1.93.0-x86_64-unknown-linux-gnu.drv` was killed by signal 9 on Linux job `94980810817` and Windows source-only job `94980810822`, while `tcfs-tui-0.12.17.drv` was killed on Nix job `94980811119`; no evidence-bound complete GF fix or quarantine exists yet.
- TIN-3800: UID 0 made the older nested root-alias assumption unsafe; this head contains the reviewed source repair.

None is GitHub billing or hosted capacity. Fresh runs `31871524701`, `31871524696`, and `31871524803` were created naturally for exact head `3d4de779…`; no rerun or dispatch occurred.

## Explicit holds

- Draft only; no merge or auto-merge.
- No hosted fallback, consumer-side Compose bootstrap, private GF source vendoring, or `type=gha`.
- TIN-3798, TIN-545, exact-head CI, and native Darwin authority remain open gates.
- Product order remains #572 authority, #565 product, fresh signed replacements for unsigned #576 and #577, then #567 and #568.
- No planner digest, TCFS runtime, apply or reconcile, deployment or activation, credential or environment mutation, local Nix or Bazel, or local cmux occurred.

Related to TIN-2538, TIN-3799, TIN-3800, TIN-3798, TIN-545.