### PR TITLE
docs(design): TIN-1556 — record the D4 Q1 ruling (/tcfs/<root_id>) and the lifted fence

### DIFF
--- a/docs/design/stable-root-lifecycle-tin1556-2026-07-28.md
+++ b/docs/design/stable-root-lifecycle-tin1556-2026-07-28.md
@@ -155,12 +155,26 @@ The recorded escalation — **a uniform absolute prefix, identical on every
 host** — is adopted here as the binding convention for agent-session and
 roam-first roots:
 
-- A reserved conventional prefix (proposal: `/tcfs/<root_id>`, with
-  `~/tcfs/<root_id>` as the non-root-privilege fallback — **operator
-  question Q1**) at which the `RootBindingV1.local_root` is *identical on
-  every host*, so slug, registry key, and embedded cwd all match with zero
-  rewriting. In-place transcript rewriting stays rejected — it would break
-  the byte-exact convergence invariant roam enrollment depends on.
+- **Ruled 2026-07-29 (Q1):** the canonical identity remains `root_id` — no
+  path is ever the protocol (reaffirming TIN-2853). Host paths are
+  *platform projections* recorded in `RootBindingV1`. The default Unix
+  projection is `/tcfs/<root_id>`: a root-owned boundary directory with
+  user-owned children — exactly the ancestry shape the landed B0
+  validation already accepts — so slug, registry key, and embedded cwd
+  all match with zero rewriting on every host that carries the boundary.
+  `~/tcfs/<root_id>` is the documented fallback projection where root
+  provisioning is unavailable; FileProvider/CFAPI clients use their
+  mandated containers. In-place transcript rewriting stays rejected — it
+  would break the byte-exact convergence invariant roam enrollment
+  depends on.
+- Boundary provisioning is one line per platform (`tmpfiles.d` on Linux,
+  `synthetic.conf` on macOS — the `/nix` mechanism already proven on the
+  darwin fleet), rendered by lab and deploy-gated behind the live freeze.
+  An optional `~/tcfs → /tcfs` symlink is the same-OS compat bridge for
+  legacy embedded paths; legacy `~/tcfs` roots are grandfathered until
+  re-adopted through the D1 transaction. Cross-OS session healing is
+  expected to be a no-op for default-projection roots; a mapping layer
+  remains only for fallback-projection and mandated-container hosts.
 - Uniform-prefix bindings are a *convention on top of* the binding contract,
   not a change to it: hosts that cannot honor the prefix stay `UNBOUND` and
   fail closed.
@@ -227,21 +241,27 @@ defers the rest:
 | Cross-machine convergence, different local paths, no collisions | UNBOUND/binding model + D2 driver; proven by the B0c two-host test (and the uniform-prefix variant for agent roots) |
 | Rollback/removal documented and tested | D1 remove semantics |
 
-## Operator questions (blocking decisions, batched for one interview)
+## Operator rulings (2026-07-29 interview; asked as one batch)
 
-- **Q1 — uniform roam-root prefix:** `/tcfs/<root_id>` (needs a root-owned
-  directory created once per host) vs `~/tcfs/<root_id>` (no privilege, but
-  `~` differs across OSes so only the *suffix* is uniform — breaks the
-  full-path-slug healing for cross-OS pairs). A third option is a per-OS
-  synthetic mount point unified by the daemon. D4 recommends `/tcfs`.
-- **Q2 — remove retention window:** how long removed-root state caches are
-  retained before `--purge-state` is allowed (proposal: 30 days).
-- **Q3 — driver default posture:** should migrated roots default
-  `lifecycle_policy = "reconcile"` (units retired eagerly) or
-  `"inspect-only"` (operator flips each root after observing plan output)?
-  D2 recommends inspect-only defaults with explicit per-root promotion.
-- **Q4 — home profiles in B:** confirm inventory-and-shadow-only scope for
-  `home-*-v1`, with live home subtrees deferred to C.
+All four blocking questions are now ruled. The original question text is
+preserved in git history at the pre-ruling revision of this document.
+
+- **Q1 — uniform roam-root prefix: RULED — rootful.** Identity is
+  `root_id`; host paths are platform projections (see the amended D4 for
+  the full ruling text). The default Unix projection is `/tcfs/<root_id>`;
+  `~/tcfs/<root_id>` is the fallback projection; FileProvider/CFAPI use
+  mandated containers. The operator ratified erring toward the rootful,
+  filesystem-native pattern as the core product contract: mountpoints and
+  user-level implementation adjust underneath it with no further
+  consumer-facing decisions.
+- **Q2 — remove retention window: RULED — 7 days** of removed-root state
+  cache retention before `--purge-state` is allowed (tighter than the
+  30-day proposal).
+- **Q3 — driver default posture: RULED — `inspect-only` defaults** with
+  explicit per-root promotion after the operator observes each root's
+  plan output (D2 as recommended).
+- **Q4 — home profiles in B: RULED — inventory-and-shadow only** for
+  `home-*-v1`; live home subtrees stay deferred to C.
 
 ## Explicit non-goals of this ADR
 

--- a/docs/design/stable-root-lifecycle-tin1556-2026-07-28.md
+++ b/docs/design/stable-root-lifecycle-tin1556-2026-07-28.md
@@ -152,36 +152,37 @@ Claude-style agent state keys sessions by absolute-path slug *and* by a
 literal-path registry (`~/.claude.json` `projects{}`), and 32–57% of
 in-transcript path references are embedded absolute paths no shim reaches.
 The recorded escalation — **a uniform absolute prefix, identical on every
-host** — is adopted here as the binding convention for agent-session and
-roam-first roots:
+host** — remains the candidate binding convention for agent-session and
+roam-first roots. The exact presentation prefix is still an open operator
+decision:
 
-- **Ruled 2026-07-29 (Q1):** the canonical identity remains `root_id` — no
-  path is ever the protocol (reaffirming TIN-2853). Host paths are
-  *platform projections* recorded in `RootBindingV1`. The default Unix
-  projection is `/tcfs/<root_id>`: a root-owned boundary directory with
-  user-owned children — exactly the ancestry shape the landed B0
-  validation already accepts — so slug, registry key, and embedded cwd
-  all match with zero rewriting on every host that carries the boundary.
-  `~/tcfs/<root_id>` is the documented fallback projection where root
-  provisioning is unavailable; FileProvider/CFAPI clients use their
-  mandated containers. In-place transcript rewriting stays rejected — it
-  would break the byte-exact convergence invariant roam enrollment
-  depends on.
-- Boundary provisioning is one line per platform (`tmpfiles.d` on Linux,
-  `synthetic.conf` on macOS — the `/nix` mechanism already proven on the
-  darwin fleet), rendered by lab and deploy-gated behind the live freeze.
-  An optional `~/tcfs → /tcfs` symlink is the same-OS compat bridge for
-  legacy embedded paths; legacy `~/tcfs` roots are grandfathered until
-  re-adopted through the D1 transaction. Cross-OS session healing is
-  expected to be a no-op for default-projection roots; a mapping layer
-  remains only for fallback-projection and mandated-container hosts.
-- Uniform-prefix bindings are a *convention on top of* the binding contract,
-  not a change to it: hosts that cannot honor the prefix stay `UNBOUND` and
-  fail closed.
-- This is the designed unlock for the R7 fence ("sting = sole writer, no
-  roam until TIN-2301/1556"): agent-session roam resumes only via roots
-  adopted under this convention, after TIN-2301's resume proof passes
-  against a uniform-prefix root.
+- The canonical identity remains `root_id`; no local path is part of the
+  fleet-stable root identity, remote namespace, authorization identity, or
+  mutation selector (reaffirming TIN-2853). Host paths remain host-local
+  protocol/read-surface data recorded in `RootBindingV1` and its
+  `binding_fingerprint`; existing `~/tcfs` bindings remain valid.
+- `/tcfs` is a credible opt-in Unix continuity projection for a canary, not
+  yet the default product contract. A multiuser rootful layout also needs a
+  stable principal namespace (for example,
+  `/tcfs/u/<principal>/<root_id>`); `/tcfs/<root_id>` alone is only a
+  possible single-principal shorthand.
+- FileProvider and CFAPI continue to use their platform-managed or
+  explicitly registered roots. In-place transcript rewriting stays
+  rejected because it would break the byte-exact convergence invariant
+  roam enrollment depends on.
+- A `~/tcfs → /tcfs` symlink does not by itself prove path identity:
+  canonicalization and process `getcwd` behavior can still expose the
+  backing path. A projection is path-identity-capable only after the
+  literal cwd observed by session registries, pickers, resumed dialogs, and
+  embedded records is proven.
+- If Q1 selects a uniform prefix, it remains a *convention on top of* the
+  binding contract, not a change to it: hosts that cannot honor the prefix
+  stay `UNBOUND` and fail closed.
+- Q1 is therefore still part of the R7 fence ("sting = sole writer, no roam
+  until TIN-2301/1556"). A uniform-prefix choice requires TIN-2301's resume
+  proof against that projection; a non-uniform rootless choice defers
+  cross-OS agent-session roaming until a separately approved healing
+  mechanism exists.
 
 ## Decision D5 — scale posture for 100+ roots
 
@@ -222,10 +223,11 @@ defers the rest:
    any `git-raw-v1` root on a fresh host** — adopt/reconcile on the origin
    host does not depend on it.
 3. Delivery order: **B0b** (plan-only driver + adopt dry-run inventory) →
-   **B0c** (execute + fleet-rendered registry rows) → uniform-prefix
-   agent-static adoption + TIN-2301 resume proof → repo adoption after the
-   TIN-2306 two-repo stop rule passes. Broad `~/git`/home claims stay out
-   until the C phase, per the standing claim boundary.
+   **B0c** (execute + fleet-rendered registry rows) → Q1 ruling →
+   selected-projection agent-static adoption + the applicable TIN-2301
+   resume proof → repo adoption after the TIN-2306 two-repo stop rule
+   passes. Broad `~/git`/home claims stay out until the C phase, per the
+   standing claim boundary.
 4. Everything above is source/tests/docs until the TIN-2856/TIN-2801 freeze
    clears; no step in this ADR authorizes a live ceremony.
 
@@ -241,19 +243,22 @@ defers the rest:
 | Cross-machine convergence, different local paths, no collisions | UNBOUND/binding model + D2 driver; proven by the B0c two-host test (and the uniform-prefix variant for agent roots) |
 | Rollback/removal documented and tested | D1 remove semantics |
 
-## Operator rulings (2026-07-29 interview; asked as one batch)
+## Operator rulings and remaining question (2026-07-29 interview)
 
-All four blocking questions are now ruled. The original question text is
-preserved in git history at the pre-ruling revision of this document.
+Q2–Q4 were ruled in the batched interview. Q1 was not: the operator
+immediately reopened the initial `~/tcfs/<root_id>` selection, called the
+rootful alternative a complex architectural question worth careful
+consideration, and did not make a final choice.
 
-- **Q1 — uniform roam-root prefix: RULED — rootful.** Identity is
-  `root_id`; host paths are platform projections (see the amended D4 for
-  the full ruling text). The default Unix projection is `/tcfs/<root_id>`;
-  `~/tcfs/<root_id>` is the fallback projection; FileProvider/CFAPI use
-  mandated containers. The operator ratified erring toward the rootful,
-  filesystem-native pattern as the core product contract: mountpoints and
-  user-level implementation adjust underneath it with no further
-  consumer-facing decisions.
+- **Q1 — uniform roam-root prefix: OPEN.** Decide among extending the
+  existing rootless `~/tcfs` deployment convention with a proposed
+  `<root_id>` layout, a provisioned rootful Unix projection, or
+  profile-selected support for both. Before promoting a rootful default,
+  prove root-relative state/cache identity and migration, multiuser
+  ownership and collision resistance, reboot recovery, rootless
+  refusal/fallback, and the literal cwd seen by Claude/Codex session
+  registries and resumed dialogs. Keep existing bindings and historical
+  session paths available during any dual-projection canary.
 - **Q2 — remove retention window: RULED — 7 days** of removed-root state
   cache retention before `--purge-state` is allowed (tighter than the
   30-day proposal).

--- a/docs/design/stable-root-lifecycle-tin1556-2026-07-28.md
+++ b/docs/design/stable-root-lifecycle-tin1556-2026-07-28.md
@@ -1,9 +1,14 @@
 # ADR: Stable root lifecycle and broad-directory ownership (TIN-1556, B phase)
 
-- **Date:** 2026-07-28
-- **Status:** Proposed design (design spike only — no implementation, no live
-  claim; TIN-2856/TIN-2801 freeze on live resolver/enrollment/deploy/crypto
-  ceremonies remains in force)
+- **Date:** 2026-07-28 (amended 2026-08-28)
+- **Status:** D4 **accepted** — its open question Q1 was ruled by the operator
+  on 2026-08-26. D1–D3 and D5 remain proposed design. The freeze this ADR was
+  originally written under no longer applies: TIN-2856 has been **Done since
+  2026-07-22** and must not be cited as an open fence, and on 2026-08-28 the
+  operator lifted the TIN-2801 deploy freeze **in full** (live TCFS work —
+  enrollment, per-root configs, resolver actions — and attended fleet
+  nix-switches may resume). D4 implementation is therefore **live work, not
+  source-only**.
 - **Scope:** the B-phase root lifecycle — adopt, remove, daemon-owned
   reconcile, profile behavior, uniform roam-root — built on the landed
   B0a contract
@@ -152,20 +157,28 @@ Claude-style agent state keys sessions by absolute-path slug *and* by a
 literal-path registry (`~/.claude.json` `projects{}`), and 32–57% of
 in-transcript path references are embedded absolute paths no shim reaches.
 The recorded escalation — **a uniform absolute prefix, identical on every
-host** — remains the candidate binding convention for agent-session and
-roam-first roots. The exact presentation prefix is still an open operator
-decision:
+host** — is the adopted binding convention for agent-session and roam-first
+roots. The presentation prefix was ruled by the operator on 2026-08-26:
+**`/tcfs/<root_id>`**, the ADR's primary design.
 
 - The canonical identity remains `root_id`; no local path is part of the
   fleet-stable root identity, remote namespace, authorization identity, or
   mutation selector (reaffirming TIN-2853). Host paths remain host-local
   protocol/read-surface data recorded in `RootBindingV1` and its
   `binding_fingerprint`; existing `~/tcfs` bindings remain valid.
-- `/tcfs` is a credible opt-in Unix continuity projection for a canary, not
-  yet the default product contract. A multiuser rootful layout also needs a
-  stable principal namespace (for example,
-  `/tcfs/u/<principal>/<root_id>`); `/tcfs/<root_id>` alone is only a
-  possible single-principal shorthand.
+- **`/tcfs/<root_id>` is the ruled projection.** It is provisioned as one
+  root-owned directory per host, created once at enrollment (a single sudo);
+  TCFS itself never needs privilege afterwards. Hosts that cannot honor the
+  prefix stay `UNBOUND` and fail closed rather than binding a divergent path.
+- Both alternatives were **rejected** in the same ruling: `~/tcfs/<root_id>`
+  because `~` differs across OSes, so only the suffix is uniform and
+  full-path-slug healing breaks for exactly the macOS↔Linux pairs that
+  matter; and a per-OS synthetic mount point unified by the daemon because it
+  defers the guarantee to mount tooling.
+- The layout is currently the single-principal form. A multiuser rootful
+  deployment still needs a stable principal namespace (for example
+  `/tcfs/u/<principal>/<root_id>`); that extension is a later decision and
+  does not reopen Q1.
 - FileProvider and CFAPI continue to use their platform-managed or
   explicitly registered roots. In-place transcript rewriting stays
   rejected because it would break the byte-exact convergence invariant
@@ -175,14 +188,16 @@ decision:
   backing path. A projection is path-identity-capable only after the
   literal cwd observed by session registries, pickers, resumed dialogs, and
   embedded records is proven.
-- If Q1 selects a uniform prefix, it remains a *convention on top of* the
-  binding contract, not a change to it: hosts that cannot honor the prefix
-  stay `UNBOUND` and fail closed.
-- Q1 is therefore still part of the R7 fence ("sting = sole writer, no roam
-  until TIN-2301/1556"). A uniform-prefix choice requires TIN-2301's resume
-  proof against that projection; a non-uniform rootless choice defers
-  cross-OS agent-session roaming until a separately approved healing
-  mechanism exists.
+- The uniform prefix is a *convention on top of* the binding contract, not a
+  change to it. `root_id` stays the identity; `/tcfs/<root_id>` is only the
+  host-local presentation the binding records.
+- R7 ("sting = sole writer, no roam until TIN-2301/1556") is a design gate
+  that **self-releases when D4 lands**, not a standing operating fence.
+  Landing D4 still requires TIN-2301's resume proof against the
+  `/tcfs/<root_id>` projection, and the proof obligations named above
+  (root-relative state/cache identity and migration, multiuser ownership and
+  collision resistance, reboot recovery, rootless refusal/fallback, and the
+  literal cwd observed by session registries and resumed dialogs).
 
 ## Decision D5 — scale posture for 100+ roots
 
@@ -223,42 +238,52 @@ defers the rest:
    any `git-raw-v1` root on a fresh host** — adopt/reconcile on the origin
    host does not depend on it.
 3. Delivery order: **B0b** (plan-only driver + adopt dry-run inventory) →
-   **B0c** (execute + fleet-rendered registry rows) → Q1 ruling →
-   selected-projection agent-static adoption + the applicable TIN-2301
-   resume proof → repo adoption after the TIN-2306 two-repo stop rule
-   passes. Broad `~/git`/home claims stay out until the C phase, per the
-   standing claim boundary.
-4. Everything above is source/tests/docs until the TIN-2856/TIN-2801 freeze
-   clears; no step in this ADR authorizes a live ceremony.
+   **B0c** (execute + fleet-rendered registry rows) → `/tcfs/<root_id>`
+   agent-static adoption + TIN-2301's resume proof against that projection →
+   repo adoption after the TIN-2306 two-repo stop rule passes. Broad
+   `~/git`/home claims stay out until the C phase, per the standing claim
+   boundary.
+4. **`~/.claude/projects` enrollment must not widen before D4 lands.**
+   Widening first produces documented silent non-convergence — disjoint slug
+   trees per OS. Companion ruling on that lane: Option M now (per-root `-c`
+   against canonical state) plus the D2 daemon-owned root driver from this
+   ADR.
+5. The TIN-2856/TIN-2801 freeze that gated the original draft is cleared
+   (see Status). D4 proceeds as live work; the remaining gates above (1, 2,
+   4, TIN-2306) are the real preconditions, not a blanket source-only fence.
 
 ## Acceptance mapping (TIN-1556)
 
 | Acceptance criterion | Where satisfied |
 |---|---|
-| Stable root IDs independent of host path | landed (B0a fingerprints); D4 adds the uniform-prefix convention on top |
+| Stable root IDs independent of host path | landed (B0a fingerprints); D4 adds the ruled `/tcfs/<root_id>` uniform-prefix convention on top |
 | Manifests/index rooted by `(root_id, relative_path)` | remote keys already live under `remote_prefix`; D5's NATS-subject schema design extends identity to events; ordinary-file resolution returns only once manifest identity is root-bound (B0b/B0c) |
 | `tcfs root adopt/list/status` CLI | D1 (adopt/remove) + landed `roots list/status` |
 | Adopt requires dry-run inventory, refuses dirty/ambiguous | D1 phase structure |
 | Ignore presets: project-tree, git-repo, macOS home, Linux home | D3 profile table |
-| Cross-machine convergence, different local paths, no collisions | UNBOUND/binding model + D2 driver; proven by the B0c two-host test (and the uniform-prefix variant for agent roots) |
+| Cross-machine convergence, different local paths, no collisions | UNBOUND/binding model + D2 driver; proven by the B0c two-host test (and the `/tcfs/<root_id>` variant for agent roots) |
 | Rollback/removal documented and tested | D1 remove semantics |
 
-## Operator rulings and remaining question (2026-07-29 interview)
+## Operator rulings (2026-07-29 interview; Q1 ruled 2026-08-26)
 
-Q2–Q4 were ruled in the batched interview. Q1 was not: the operator
-immediately reopened the initial `~/tcfs/<root_id>` selection, called the
-rootful alternative a complex architectural question worth careful
-consideration, and did not make a final choice.
+Q2–Q4 were ruled in the 2026-07-29 batched interview. Q1 was not: the
+operator immediately reopened the initial `~/tcfs/<root_id>` selection,
+called the rootful alternative a complex architectural question worth
+careful consideration, and deferred it. It was ruled separately on
+2026-08-26.
 
-- **Q1 — uniform roam-root prefix: OPEN.** Decide among extending the
-  existing rootless `~/tcfs` deployment convention with a proposed
-  `<root_id>` layout, a provisioned rootful Unix projection, or
-  profile-selected support for both. Before promoting a rootful default,
-  prove root-relative state/cache identity and migration, multiuser
-  ownership and collision resistance, reboot recovery, rootless
-  refusal/fallback, and the literal cwd seen by Claude/Codex session
-  registries and resumed dialogs. Keep existing bindings and historical
-  session paths available during any dual-projection canary.
+- **Q1 — uniform roam-root prefix: RULED (2026-08-26) — `/tcfs/<root_id>`,**
+  the ADR's primary design. One root-owned directory per host, created once
+  at enrollment (a single sudo); hosts that cannot honor the prefix stay
+  `UNBOUND` and fail closed. `~/tcfs/<root_id>` was rejected (breaks
+  full-path-slug healing for the macOS↔Linux pairs that matter) and a per-OS
+  synthetic mount point was rejected (defers the guarantee to mount tooling).
+  The proof obligations carried forward into D4 are unchanged: root-relative
+  state/cache identity and migration, multiuser ownership and collision
+  resistance, reboot recovery, rootless refusal/fallback, and the literal cwd
+  seen by Claude/Codex session registries and resumed dialogs. Existing
+  bindings and historical session paths stay available during any
+  dual-projection canary.
 - **Q2 — remove retention window: RULED — 7 days** of removed-root state
   cache retention before `--purge-state` is allowed (tighter than the
   30-day proposal).
@@ -269,6 +294,10 @@ consideration, and did not make a final choice.
   `home-*-v1`; live home subtrees stay deferred to C.
 
 ## Explicit non-goals of this ADR
+
+These are scope boundaries of the *design*, not a freeze — the 2026-08-28
+ruling lifted that (see Status). Each item below still needs its own
+authorization before it happens; this ADR just does not grant one.
 
 Live rollout of anything; TOTP/enrollment/crypto ceremonies; MCP or TUI
 root surfaces; per-root storage endpoints; subscription selective sync


### PR DESCRIPTION
Corrects the TIN-1556 ADR record for the 2026-07-29 batched interview, the
2026-08-26 Q1 ruling, and the 2026-08-28 fence correction.

- **Q1 — RULED (2026-08-26):** uniform absolute prefix `/tcfs/<root_id>`, the
  ADR's primary design. One root-owned directory per host, created once at
  enrollment (a single sudo); hosts that cannot honor the prefix stay
  `UNBOUND` and fail closed. `~/tcfs/<root_id>` rejected (only the suffix is
  uniform, so full-path-slug healing breaks for the macOS↔Linux pairs that
  matter); per-OS synthetic mount point rejected (defers the guarantee to
  mount tooling). The rootful proof obligations are carried forward into D4,
  not dropped.
- **Q2 — RULED:** 7-day removed-root state retention before `--purge-state`.
- **Q3 — RULED:** `inspect-only` driver defaults with explicit per-root promotion.
- **Q4 — RULED:** `home-*-v1` remains inventory-and-shadow-only in B.
- **Fence correction (2026-08-28):** the ADR's Status block cited a
  TIN-2856/TIN-2801 freeze. TIN-2856 has been **Done since 2026-07-22** and
  must not be cited as an open fence; on 2026-08-28 the operator lifted the
  TIN-2801 deploy freeze **in full** (live TCFS work and attended fleet
  nix-switches). **D4 implementation is live work, not source-only.** R7 is
  restated as a design gate that self-releases when D4 lands, not a standing
  operating fence.
- **New sequencing gate:** `~/.claude/projects` enrollment must not widen
  before D4 lands — widening first produces silent non-convergence (disjoint
  slug trees per OS).

Supersedes this PR's previous "Q1 stays open" framing, which was correct as of
2026-07-30 and is no longer.

Prior draft holds, dispositioned:

- *Source integrity* — discharged. Head `1b760b36daa5e3d0dc0fdcbcec6e585eface1a60`
  is signed and GitHub-verified (`verification.reason=valid`); the unsigned
  `b87ced49` that the 2026-07-30 fence comment named is no longer the head.
- *TIN-2538 hosted-runner CI authority* — acknowledged, non-blocking for this
  change. TIN-2538 is a GloriousFlywheel substrate program item (make GF the
  only proof substrate for this repo), not a defect in this docs-only ADR
  correction. Its repair carrier #572 has not landed, so tummycrypt `main`
  workflows still route to hosted labels; no hosted green is claimed as
  authority here. `docs/design/**` is not covered by any Rust/Nix proof lane.

Scope: one file, `docs/design/stable-root-lifecycle-tin1556-2026-07-28.md`.
Design-authority record only. It does not itself provision `/tcfs`, rewrite
transcripts, enroll a device, deploy, reconcile, or start a crypto ceremony —
each of those needs its own authorization.

Linear: TIN-1556
Related: TIN-2801, TIN-2856, TIN-2301, TIN-2306, TIN-2538
