### PR TITLE
fix(sync): canonicalize state-cache keys and merge duplicate entries (TIN-3278)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -392,6 +392,29 @@ enum Commands {
         state: Option<PathBuf>,
     },
 
+    /// Repair duplicate state-cache key namespaces (TIN-3278)
+    ///
+    /// One logical file can be tracked under two keys — the absolute
+    /// canonicalized path live reads/writes derive, plus a bare
+    /// prefix-relative key left by an older keying scheme — which
+    /// double-counts in raw scans such as `tcfs conflicts`. This is the only
+    /// verb that repairs that: it takes the state-cache lock and folds the
+    /// duplicate away. Dry run unless `--execute` is given.
+    #[command(name = "state-migrate-keys")]
+    StateMigrateKeys {
+        /// Apply the migration under the state-cache lock. Without this flag
+        /// nothing is written.
+        #[arg(long)]
+        execute: bool,
+        /// Emit machine-readable JSON instead of the human summary
+        #[arg(long)]
+        json: bool,
+        /// Path to the sync state cache JSON file (overrides config).
+        /// `.db` paths are normalized to their `.json` sibling.
+        #[arg(long, env = "TCFS_STATE_PATH")]
+        state: Option<PathBuf>,
+    },
+
     /// Manage the sync trash (staged deletes)
     ///
     /// When trash is enabled, deletion writes an immutable safety copy and
@@ -1079,6 +1102,11 @@ async fn main() -> Result<()> {
         Commands::Conflicts { json, root, state } => {
             cmd_conflicts(&config, json, root.as_deref(), state.as_deref()).await
         }
+        Commands::StateMigrateKeys {
+            execute,
+            json,
+            state,
+        } => cmd_state_migrate_keys(&config, execute, json, state.as_deref()).await,
     }
 }
 
@@ -9151,13 +9179,142 @@ fn conflict_age(detected_at: u64) -> String {
 /// `tcfs conflicts` — list recorded conflicts, grouped by repo for
 /// `.git`-internal paths. Named roots use the daemon-selected cache; the
 /// primary/legacy path stays an offline read.
+/// Tell the operator when the conflict list collapsed duplicate key-namespace
+/// rows, and how to repair the cache (TIN-3278).
+///
+/// Reporting deliberately does not repair: `tcfs conflicts` on the default
+/// primary holds no `StateFileLock`, so it must not write.
+fn report_duplicate_cache_keys(duplicate_cache_keys: &[String], state_path: &Path) {
+    if duplicate_cache_keys.is_empty() {
+        return;
+    }
+    println!(
+        "note: {} duplicate cache key(s) collapsed for reporting (TIN-3278); \
+         the count above is per logical file, matching the daemon's cycle count.",
+        duplicate_cache_keys.len()
+    );
+    for key in duplicate_cache_keys {
+        println!("  duplicate key: {key}");
+    }
+    println!(
+        "  repair (writes, takes the state lock): tcfs state-migrate-keys --state {} --execute",
+        state_path.display()
+    );
+}
+
+/// `tcfs state-migrate-keys` — explicit duplicate-key repair (TIN-3278).
+///
+/// Dry run by default. **Both** modes acquire the same `StateFileLock` every
+/// other state-cache writer uses, before `StateCache::open`. The dry run needs
+/// it too, and not for the migration (which it never calls): `open` itself can
+/// write, because it recovers a missing or corrupt primary from `.bak` and
+/// `Drop` flushes that recovery even for a nominally read-only command — the
+/// same hazard `lock_explicit_state_cache` documents. Taking the lock up front
+/// means this verb can never write unlocked in either mode, and a run that
+/// collides with a daemon cycle fails loudly instead of racing it.
+///
+/// `--execute` hands the guard to `StateCache::migrate_duplicate_keys_locked`,
+/// which verifies it is a lock for *this* cache and refuses otherwise. This is
+/// the only path that repairs duplicate key namespaces; `open` and
+/// `reload_from_disk` never do.
+async fn cmd_state_migrate_keys(
+    config: &tcfs_core::config::TcfsConfig,
+    execute: bool,
+    json: bool,
+    state_override: Option<&Path>,
+) -> Result<()> {
+    let state_path = resolve_state_path(config, state_override);
+
+    let render = |plan: &tcfs_sync::state::KeyMigrationPlan| {
+        if json {
+            let merges: Vec<serde_json::Value> = plan
+                .merges
+                .iter()
+                .map(|record| {
+                    serde_json::json!({
+                        "dropped_key": record.dropped_key,
+                        "kept_key": record.kept_key,
+                        "conflict_preserved": record.conflict_preserved,
+                    })
+                })
+                .collect();
+            let skipped: Vec<serde_json::Value> = plan
+                .skipped
+                .iter()
+                .map(|(key, reason)| {
+                    serde_json::json!({ "key": key, "reason": format!("{reason:?}") })
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "state_path": state_path.to_string_lossy(),
+                    "executed": execute,
+                    "merges": merges,
+                    "skipped": skipped,
+                }))
+                .unwrap_or_else(|_| "{}".to_string())
+            );
+            return;
+        }
+        println!("state cache: {}", state_path.display());
+        println!(
+            "{} ({} fold(s), {} left in place)",
+            if execute {
+                "applied"
+            } else {
+                "dry run — nothing written"
+            },
+            plan.merges.len(),
+            plan.skipped.len()
+        );
+        for record in &plan.merges {
+            println!(
+                "  fold {} -> {}{}",
+                record.dropped_key,
+                record.kept_key,
+                if record.conflict_preserved {
+                    " (conflict recurrence/clocks absorbed)"
+                } else {
+                    ""
+                }
+            );
+        }
+        for (key, reason) in &plan.skipped {
+            println!("  keep {key}: {reason:?}");
+        }
+        if !execute && !plan.merges.is_empty() {
+            println!("re-run with --execute to apply under the state-cache lock.");
+        }
+    };
+
+    // Held for both modes, and taken before `open` — see the note above.
+    let lock = tcfs_sync::state::StateFileLock::acquire(&state_path).with_context(|| {
+        format!(
+            "locking state cache for migration: {}",
+            state_path.display()
+        )
+    })?;
+    let mut cache = tcfs_sync::state::StateCache::open(&state_path)
+        .with_context(|| format!("opening state cache: {}", state_path.display()))?;
+
+    if !execute {
+        render(&cache.plan_duplicate_key_migration());
+        return Ok(());
+    }
+
+    let applied = cache.migrate_duplicate_keys_locked(&lock)?;
+    render(&applied);
+    Ok(())
+}
+
 async fn cmd_conflicts(
     config: &tcfs_core::config::TcfsConfig,
     json: bool,
     root_id: Option<&str>,
     state_override: Option<&Path>,
 ) -> Result<()> {
-    let (state_path, routed_local_root, routed_remote_prefix, items) =
+    let (state_path, routed_local_root, routed_remote_prefix, items, duplicate_cache_keys) =
         if let Some(root_id) = root_id {
             let mut client = connect_daemon(&config.daemon.socket).await?;
             let response = client
@@ -9201,23 +9358,35 @@ async fn cmd_conflicts(
                 Some(response.local_root),
                 Some(response.remote_prefix),
                 items,
+                Vec::new(),
             )
         } else {
             let state_path = resolve_state_path(config, state_override);
             let _state_lock = lock_explicit_state_cache(&state_path, state_override)?;
             let state = tcfs_sync::state::StateCache::open(&state_path)
                 .with_context(|| format!("opening state cache: {}", state_path.display()))?;
-            let items: Vec<(String, tcfs_sync::conflict::ConflictInfo)> = state
-                .conflicts()
-                .into_iter()
-                .filter_map(|(key, state)| {
-                    state
+            // TIN-3278: collapse duplicate key-namespace rows for the same
+            // logical file at *read* time. This is reporting only — it never
+            // mutates the cache, so a `tcfs conflicts` that holds no state-file
+            // lock (the default primary path: `lock_explicit_state_cache` takes
+            // the lock only for an explicit `--state`) still writes nothing.
+            // Repair is the separate, locked `tcfs state-migrate-keys` verb.
+            let report = state.conflicts_report();
+            let mut duplicate_keys: Vec<String> = report
+                .iter()
+                .flat_map(|row| row.shadowed_keys.iter().map(|key| (*key).to_string()))
+                .collect();
+            duplicate_keys.sort();
+            let items: Vec<(String, tcfs_sync::conflict::ConflictInfo)> = report
+                .iter()
+                .filter_map(|row| {
+                    row.state
                         .conflict
                         .as_ref()
-                        .map(|conflict| (key.to_string(), conflict.clone()))
+                        .map(|conflict| (row.cache_key.to_string(), conflict.clone()))
                 })
                 .collect();
-            (state_path, None, None, items)
+            (state_path, None, None, items, duplicate_keys)
         };
 
     let groups = group_conflicts(&items);
@@ -9257,6 +9426,11 @@ async fn cmd_conflicts(
                 "remote_prefix": routed_remote_prefix.as_deref(),
                 "state_path": state_path.to_string_lossy(),
                 "conflict_count": items.len(),
+                // TIN-3278: duplicate key-namespace rows collapsed for
+                // reporting. Present means the cache carries repairable debt;
+                // the count above is the per-logical-file count the reconciler
+                // acts on.
+                "duplicate_cache_keys": duplicate_cache_keys,
                 "groups": rendered,
             }))?
         );
@@ -9268,6 +9442,7 @@ async fn cmd_conflicts(
             println!("Root: {root_id}");
         }
         println!("No recorded conflicts.");
+        report_duplicate_cache_keys(&duplicate_cache_keys, &state_path);
         return Ok(());
     }
 
@@ -9286,6 +9461,7 @@ async fn cmd_conflicts(
         items.len(),
         groups.len()
     );
+    report_duplicate_cache_keys(&duplicate_cache_keys, &state_path);
     for g in &groups {
         println!();
         match &g.repo_root {

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -277,6 +277,13 @@ fn sync_parent_directory(_path: &Path) -> Result<()> {
 #[derive(Debug)]
 pub struct StateFileLock {
     _file: std::fs::File,
+    /// The state cache this lock guards (not the `.lock` sibling).
+    ///
+    /// Carried so an API that *requires* a held lock can verify the caller
+    /// handed it a lock for the right cache instead of trusting that any lock
+    /// guard in scope is the relevant one — see
+    /// [`StateCache::migrate_duplicate_keys_locked`].
+    state_path: PathBuf,
 }
 
 /// Result of probing the existing writer lock without creating or modifying it.
@@ -306,6 +313,11 @@ impl Drop for StateFileLock {
 }
 
 impl StateFileLock {
+    /// The state cache this guard locks.
+    pub fn state_path(&self) -> &Path {
+        &self.state_path
+    }
+
     /// Stable sibling path used by every state-cache writer.
     pub fn lock_path(state_path: &Path) -> PathBuf {
         let mut path = state_path.as_os_str().to_os_string();
@@ -350,7 +362,10 @@ impl StateFileLock {
         validate_opened_state_file(&file, &lock_path)
             .with_context(|| format!("revalidating opened state lock: {}", lock_path.display()))?;
         match file.try_lock() {
-            Ok(()) => Ok(Self { _file: file }),
+            Ok(()) => Ok(Self {
+                _file: file,
+                state_path: state_path.to_path_buf(),
+            }),
             Err(std::fs::TryLockError::WouldBlock) => anyhow::bail!(
                 "state cache {} is locked by another process; retry after the current reconcile cycle (lock: {})",
                 state_path.display(),
@@ -399,7 +414,10 @@ impl StateFileLock {
             .with_context(|| format!("validating existing state lock: {}", lock_path.display()))?;
 
         match file.try_lock() {
-            Ok(()) => Ok(ExistingStateFileLock::Acquired(Self { _file: file })),
+            Ok(()) => Ok(ExistingStateFileLock::Acquired(Self {
+                _file: file,
+                state_path: state_path.to_path_buf(),
+            })),
             Err(std::fs::TryLockError::WouldBlock) => Ok(ExistingStateFileLock::Contended),
             Err(std::fs::TryLockError::Error(error)) => Err(error).with_context(|| {
                 format!("locking existing state cache via {}", lock_path.display())
@@ -697,6 +715,94 @@ pub struct StateCacheKeySnapshot {
     recovered_from_backup: bool,
 }
 
+/// One conflict row as it should be *reported* to an operator (TIN-3278).
+///
+/// Produced by [`StateCache::conflicts_report`]. `state` is borrowed straight
+/// out of the cache — nothing about it is merged or synthesized.
+#[derive(Debug, Clone)]
+pub struct ConflictReportRow<'a> {
+    /// The key that represents this logical file: the one live
+    /// `get`/`set`/`mark_conflict` derive whenever it is present in the cache.
+    pub cache_key: &'a str,
+    /// The entry recorded under [`ConflictReportRow::cache_key`], verbatim.
+    pub state: &'a SyncState,
+    /// Duplicate keys for the same logical file that this row stands in for.
+    /// Non-empty means the cache carries key-namespace debt an operator can
+    /// repair with the explicit migration; the rows themselves were suppressed
+    /// only for reporting.
+    pub shadowed_keys: Vec<&'a str>,
+}
+
+/// One duplicate-key fold performed by an explicit, lock-holding duplicate-key
+/// migration (TIN-3278).
+///
+/// The primary state cache historically accumulated entries for the same
+/// logical file under two key namespaces — an absolute canonicalized path
+/// (the form [`path_key`] always produces today) and a bare prefix-relative
+/// path left behind by an older keying scheme. The orphaned relative key is
+/// never touched by any live read/write path (`get`/`set`/`mark_conflict`
+/// all re-derive the canonical key via [`path_key`]), so once such an entry
+/// exists it lingers forever, double-counting in raw-entry scans like
+/// [`StateCache::conflicts`] (`tcfs conflicts`) even though the live
+/// reconciler only ever visits the canonical path.
+///
+/// A record is produced per fold, both by the dry-run planner
+/// ([`StateCache::plan_duplicate_key_migration`]) and by the apply step
+/// ([`StateCache::migrate_duplicate_keys_locked`]); it is purely an audit
+/// trail (`Debug`/`Clone`, no `Drop` side effects).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyMergeRecord {
+    /// The non-canonical (or otherwise duplicate) key whose entry was folded
+    /// away. Removed from the cache once the merge completes.
+    pub dropped_key: String,
+    /// The canonical key that survived the merge and now carries the
+    /// combined entry.
+    pub kept_key: String,
+    /// Set when the dropped side carried an active `conflict` record whose
+    /// monotone parts (`times_recorded`, vector clocks) were folded into the
+    /// surviving key's own conflict payload. The surviving key's payload
+    /// **values** are never replaced — see [`merge_duplicate_sync_states`].
+    pub conflict_preserved: bool,
+}
+
+/// Why an explicit duplicate-key migration declined to fold a key (TIN-3278).
+///
+/// Every skip leaves the cache exactly as it was, so a skipped key keeps
+/// double-counting in raw scans; [`StateCache::conflicts_report`] still
+/// collapses it for reporting. Skips are surfaced to the operator rather than
+/// silently guessed at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyMigrationSkipReason {
+    /// The orphan matched zero or 2+ independently-resolvable keys by rel-path
+    /// suffix, so there is no unambiguous target (the multi-root case).
+    NoUnambiguousTarget { resolvable_candidates: usize },
+    /// The surviving key carries no conflict and the duplicate does. Folding
+    /// would turn a cosmetic double-count into a live conflict on a currently
+    /// clean entry (and hand that entry's key to `conflict_git` /
+    /// git-routing consumers), so the duplicate is left in place instead.
+    WouldResurrectConflict { kept_key: String },
+    /// The duplicate's conflict payload is *newer* than the surviving key's,
+    /// contradicting the premise that the duplicate is frozen history. Rather
+    /// than choose between two live-looking records, leave both for an operator.
+    DuplicateConflictIsNewer { kept_key: String },
+}
+
+/// What an explicit duplicate-key migration did, or would do (TIN-3278).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct KeyMigrationPlan {
+    /// Folds performed (or, for a dry run, that would be performed).
+    pub merges: Vec<KeyMergeRecord>,
+    /// Duplicates deliberately left alone, with the reason.
+    pub skipped: Vec<(String, KeyMigrationSkipReason)>,
+}
+
+impl KeyMigrationPlan {
+    /// No duplicate key namespaces to repair and nothing declined.
+    pub fn is_empty(&self) -> bool {
+        self.merges.is_empty() && self.skipped.is_empty()
+    }
+}
+
 impl StateCache {
     /// Load or create a state cache at the given path.
     ///
@@ -768,6 +874,27 @@ impl StateCache {
             (HashMap::new(), 0, String::new(), false)
         };
 
+        // TIN-3278: `open` deliberately does NOT repair duplicate key
+        // namespaces. Duplicate-key repair mutates entry content (it deletes a
+        // key and merges two states), and this constructor cannot write:
+        //
+        // - `Drop` flushes whenever `dirty || recovered_from_backup`
+        //   (see `impl Drop for StateCache`), and the `recovered_from_backup`
+        //   leg fires even for a nominally read-only command — which is exactly
+        //   why `lock_explicit_state_cache` (tcfs-cli) exists and says so;
+        // - the CLI takes a cross-process `StateFileLock` only when a `--state`
+        //   override is supplied, so `tcfs conflicts` on the default primary
+        //   holds no lock at all;
+        // - the daemon's startup lock is `<data_dir>/daemon-instance.lock`
+        //   (tcfsd/src/daemon.rs), not this cache's `state.json.lock`.
+        //
+        // A content-mutating fold here would therefore be persisted by unlocked
+        // readers racing the daemon's atomic-rename flush. Repair is an
+        // explicit, lock-holding operation instead:
+        // [`StateCache::plan_duplicate_key_migration`] (pure) and
+        // [`StateCache::migrate_duplicate_keys_locked`] (requires the lock).
+        // Reporting surfaces collapse duplicates at read time with
+        // [`StateCache::conflicts_report`], which never mutates anything.
         Ok(StateCache {
             db_path: db_path.to_path_buf(),
             entries,
@@ -839,6 +966,12 @@ impl StateCache {
         if self.device_id.is_empty() && !device_id.is_empty() {
             self.device_id = device_id;
         }
+        // TIN-3278: no duplicate-key fold here either. The `or_insert` above is
+        // the whole "in-memory wins" contract; a fold would violate it, because
+        // merging a disk entry into a resident key can only be done by choosing
+        // between a disk value and an in-memory value. Duplicate repair is the
+        // explicit locked operation — see `open`'s note and
+        // [`StateCache::migrate_duplicate_keys_locked`].
         Ok(())
     }
 
@@ -936,6 +1069,232 @@ impl StateCache {
             .filter(|(_, s)| s.conflict.is_some())
             .map(|(k, v)| (k.as_str(), v))
             .collect()
+    }
+
+    /// Conflicts collapsed to one row per logical file, for **reporting only**
+    /// (TIN-3278).
+    ///
+    /// [`StateCache::conflicts`] is a raw entry scan, so a file tracked under
+    /// two key namespaces (an absolute canonicalized path — the form
+    /// [`path_key`] always produces on live `get`/`set`/`mark_conflict` — plus a
+    /// bare prefix-relative key left by an older keying scheme) is reported
+    /// twice, while the reconciler only ever visits the canonical key. That is
+    /// the whole user-visible TIN-3278 symptom: `tcfs conflicts` printing 9
+    /// where the daemon's per-cycle plan line reports `conflicts=8`.
+    ///
+    /// This collapses those rows **without touching the cache**: it takes
+    /// `&self`, returns borrowed [`SyncState`]s exactly as recorded, and does
+    /// not merge, graft, re-key, or delete anything. Duplicate repair is a
+    /// separate, explicitly invoked, lock-holding operation
+    /// ([`StateCache::migrate_duplicate_keys_locked`]).
+    ///
+    /// Collapse rules — deliberately conservative:
+    ///
+    /// - Rows whose keys resolve on disk to the *same* path (e.g. `/var/f` and
+    ///   `/private/var/f`, or a symlinked-parent duplicate) are one group. The
+    ///   representative is the row already stored under that resolved path when
+    ///   present; otherwise the highest `last_synced`, breaking ties on the key
+    ///   so output is deterministic.
+    /// - A row whose key cannot resolve at all (the live TIN-3278 orphan shape:
+    ///   `/secrets/.audit.log`, whose `/secrets` does not exist at the
+    ///   filesystem root) is attached to a resolvable row using the same
+    ///   rel-path-suffix convention [`StateCache::get_by_rel_path`] uses for
+    ///   cross-host lookups — but only when **exactly one** resolvable row
+    ///   matches. Zero or 2+ candidates leave the orphan as its own reported
+    ///   row rather than guess.
+    /// - A conflict that has no duplicate among the reported rows is **never**
+    ///   suppressed. In particular, an orphan conflict whose live counterpart is
+    ///   currently clean stays visible: it is real cache debt, and hiding it (or
+    ///   grafting it onto the clean entry) would be worse than double-counting.
+    ///
+    /// Cost: one `fs::canonicalize` attempt per *conflict* row (not per cache
+    /// entry), plus an O(orphan rows x groups) suffix scan over pre-normalized
+    /// strings. Conflict rows are the small minority of a cache.
+    pub fn conflicts_report(&self) -> Vec<ConflictReportRow<'_>> {
+        /// One logical-file group under construction.
+        struct Group<'a> {
+            representative: &'a str,
+            state: &'a SyncState,
+            shadowed: Vec<&'a str>,
+            /// Independently resolved on-disk form, or the literal key when the
+            /// key does not resolve at all.
+            identity: String,
+            normalized_identity: String,
+            resolvable: bool,
+        }
+
+        // Deterministic input order: `conflicts()` iterates a HashMap.
+        let mut rows: Vec<(&str, &SyncState)> = self.conflicts();
+        rows.sort_by(|left, right| left.0.cmp(right.0));
+
+        // Phase 1: group rows that resolve to the same on-disk path.
+        let mut groups: Vec<Group<'_>> = Vec::new();
+        for (cache_key, state) in rows {
+            let resolved = resolve_key_on_disk(cache_key);
+            let identity = resolved.clone().unwrap_or_else(|| cache_key.to_string());
+            match groups.iter().position(|group| group.identity == identity) {
+                Some(index) => {
+                    let group = &mut groups[index];
+                    // Prefer the row already stored under the resolved path —
+                    // that is the key live `get`/`set` derive. Otherwise the
+                    // most recently synced row, ties broken on key order so the
+                    // report is stable.
+                    let challenger_wins =
+                        match (group.representative == identity, cache_key == identity) {
+                            (true, false) => false,
+                            (false, true) => true,
+                            _ => {
+                                state.last_synced > group.state.last_synced
+                                    || (state.last_synced == group.state.last_synced
+                                        && cache_key < group.representative)
+                            }
+                        };
+                    if challenger_wins {
+                        group.shadowed.push(group.representative);
+                        group.representative = cache_key;
+                        group.state = state;
+                    } else {
+                        group.shadowed.push(cache_key);
+                    }
+                }
+                None => groups.push(Group {
+                    representative: cache_key,
+                    state,
+                    shadowed: Vec::new(),
+                    normalized_identity: crate::engine::normalize_rel_path_text(&identity),
+                    resolvable: resolved.is_some(),
+                    identity,
+                }),
+            }
+        }
+
+        // Phase 2: attach an unresolvable orphan to its resolvable counterpart,
+        // but only when exactly one candidate matches by rel-path suffix.
+        let mut fold_target: Vec<Option<usize>> = vec![None; groups.len()];
+        for index in 0..groups.len() {
+            if groups[index].resolvable {
+                continue;
+            }
+            let normalized_orphan = crate::engine::normalize_rel_path_text(
+                groups[index].representative.trim_start_matches('/'),
+            );
+            if normalized_orphan.is_empty() {
+                continue;
+            }
+            let suffix = format!("/{normalized_orphan}");
+            let mut candidates = (0..groups.len()).filter(|other| {
+                *other != index
+                    && groups[*other].resolvable
+                    && groups[*other].normalized_identity.ends_with(&suffix)
+            });
+            let Some(target) = candidates.next() else {
+                continue; // no resolvable counterpart — stays its own row
+            };
+            if candidates.next().is_some() {
+                continue; // ambiguous — stays its own row
+            }
+            fold_target[index] = Some(target);
+        }
+
+        // Phase 3: emit surviving groups, then attribute folded orphan keys.
+        let mut report: Vec<ConflictReportRow<'_>> = Vec::new();
+        let mut report_index: Vec<Option<usize>> = vec![None; groups.len()];
+        for (index, group) in groups.iter().enumerate() {
+            if fold_target[index].is_some() {
+                continue;
+            }
+            report_index[index] = Some(report.len());
+            report.push(ConflictReportRow {
+                cache_key: group.representative,
+                state: group.state,
+                shadowed_keys: group.shadowed.clone(),
+            });
+        }
+        for (index, target) in fold_target.iter().enumerate() {
+            let Some(target) = *target else { continue };
+            let Some(position) = report_index[target] else {
+                continue;
+            };
+            report[position]
+                .shadowed_keys
+                .push(groups[index].representative);
+            report[position]
+                .shadowed_keys
+                .extend(groups[index].shadowed.iter().copied());
+        }
+        for row in &mut report {
+            row.shadowed_keys.sort_unstable();
+            row.shadowed_keys.dedup();
+        }
+        report
+    }
+
+    /// What an explicit duplicate-key migration would do to this cache
+    /// (TIN-3278). Pure: mutates nothing, writes nothing, takes no lock.
+    ///
+    /// Backs the dry-run half of the operator verb. Clones the entry map to
+    /// simulate the fold, so the plan and the apply step below can never
+    /// disagree — they run the identical routine.
+    pub fn plan_duplicate_key_migration(&self) -> KeyMigrationPlan {
+        let mut simulated = self.entries.clone();
+        fold_duplicate_keys(&mut simulated)
+    }
+
+    /// Fold duplicate key-namespace entries and persist the result (TIN-3278).
+    ///
+    /// **This is the only duplicate-key repair path.** It is deliberately not
+    /// reachable from `open`/`reload_from_disk`, because those are entered by
+    /// readers that hold no cross-process lock yet still write on drop when
+    /// `recovered_from_backup` is set — see the note in
+    /// [`StateCache::open`]. Repair is therefore an operation an operator
+    /// invokes, under the lock every other state-cache writer uses.
+    ///
+    /// `lock` is a witness, not decoration: it must be a [`StateFileLock`] for
+    /// *this* cache's path, and mismatches fail closed instead of being
+    /// trusted. The fold dirties the cache and flushes it while the caller's
+    /// guard is still alive.
+    ///
+    /// The fold's own invariant (see [`merge_duplicate_sync_states`]): the
+    /// surviving key's entry is authoritative for every value-bearing field, so
+    /// the only observable effects are that a duplicate key disappears, vector
+    /// clocks gain components, and `times_recorded` rises.
+    pub fn migrate_duplicate_keys_locked(
+        &mut self,
+        lock: &StateFileLock,
+    ) -> Result<KeyMigrationPlan> {
+        anyhow::ensure!(
+            lock.state_path() == self.db_path,
+            "refusing duplicate-key migration: held state lock is for {} but this cache is {}",
+            lock.state_path().display(),
+            self.db_path.display()
+        );
+
+        let applied = fold_duplicate_keys(&mut self.entries);
+        for record in &applied.merges {
+            tracing::warn!(
+                dropped_key = %record.dropped_key,
+                kept_key = %record.kept_key,
+                conflict_preserved = record.conflict_preserved,
+                "state cache: folded duplicate key-namespace entry (TIN-3278, explicit locked migration)"
+            );
+        }
+        for (key, reason) in &applied.skipped {
+            tracing::warn!(
+                key = %key,
+                reason = ?reason,
+                "state cache: duplicate key-namespace entry left in place (TIN-3278)"
+            );
+        }
+        if !applied.merges.is_empty() {
+            self.dirty = true;
+            self.flush().with_context(|| {
+                format!(
+                    "persisting duplicate-key migration: {}",
+                    self.db_path.display()
+                )
+            })?;
+        }
+        Ok(applied)
     }
 
     /// Capture a bounded set of cache entries so callers can roll back
@@ -1580,6 +1939,345 @@ fn path_key(path: &Path) -> String {
         .unwrap_or_else(|| path.to_path_buf())
         .to_string_lossy()
         .into_owned()
+}
+
+/// Like [`path_key`], but returns `None` instead of falling back to the
+/// input string when the key cannot be independently resolved on disk.
+///
+/// `path_key`'s identity fallback exists so the live get/set/remove path
+/// always has *some* key to use, even for a file that does not exist yet.
+/// Migration needs the opposite: a way to tell "this key is already
+/// canonical" apart from "this key cannot be resolved at all" — the two
+/// look identical through `path_key`'s fallback, which is exactly how an
+/// orphaned bare-relative key (e.g. `/secrets/.audit.log`, whose parent
+/// `/secrets` does not exist at the filesystem root) round-trips unchanged
+/// and masquerades as canonical.
+fn resolve_key_on_disk(key: &str) -> Option<String> {
+    let path = Path::new(key);
+    path.parent()
+        .and_then(|parent| std::fs::canonicalize(parent).ok())
+        .map(|parent| parent.join(path.file_name().unwrap_or_default()))
+        .or_else(|| std::fs::canonicalize(path).ok())
+        .map(|resolved| resolved.to_string_lossy().into_owned())
+}
+
+/// Outcome of folding a duplicate entry into the entry at the surviving key.
+#[derive(Debug)]
+enum DuplicateFold {
+    /// The state to store at the surviving key, plus whether the folded-away
+    /// side carried a conflict whose monotone parts were absorbed.
+    Folded {
+        state: Box<SyncState>,
+        conflict_preserved: bool,
+    },
+    /// The surviving key carries no conflict and the duplicate does. Folding
+    /// would manufacture a live conflict on a clean entry.
+    RefusedWouldResurrectConflict,
+    /// The duplicate's conflict is newer than the surviving key's, contradicting
+    /// the "duplicate is frozen history" premise.
+    RefusedDuplicateConflictIsNewer,
+}
+
+/// Fold `duplicate` into `surviving` — the entry stored under the key that will
+/// remain in the cache — for two keys that name the same logical file.
+///
+/// **Fold invariant (the whole safety argument).** `surviving` is authoritative
+/// for every value-bearing field. The fold may only:
+///
+/// 1. raise vector-clock components (pointwise [`VectorClock::merge`]),
+/// 2. raise `conflict.times_recorded`,
+/// 3. cause the duplicate key to disappear.
+///
+/// It never changes `blake3`, `size`, `mtime`, `chunk_count`, `remote_path`,
+/// `device_id`, `status`, `conflict.rel_path`, `conflict.remote_manifest_key`,
+/// or any other conflict payload value on the surviving key, and never gives a
+/// key a conflict it did not already have. That is what makes the migration
+/// provably unable to widen the downstream consumers of those fields:
+/// `conflict_git::collect_repo_conflicts` bails a whole repo resolution when
+/// `remote_path`/`remote_manifest_key` fall outside the selected storage prefix,
+/// `tcfsd::grpc::validate_conflict_cache_route` fails a registered root closed
+/// on the same fields, and `tcfsd::grpc` routes git keep-both on
+/// `Path::new(cache_key).starts_with(git_dir)` over `conflicts()`. None of them
+/// can observe a value at a key that the key did not already carry.
+///
+/// It also means the merge is *not* symmetric, on purpose: the surviving key is
+/// the key live `get`/`set`/`mark_conflict` derive via [`path_key`], so its
+/// entry is the one a live sync cycle has been maintaining, while the duplicate
+/// is by construction a key no live path has touched since the keying scheme
+/// changed (the TIN-3278 evidence: `times_recorded` frozen at 1881 since
+/// 2026-07-07). Preferring the higher `last_synced` instead would let a stale
+/// side's frozen digest overwrite the live one on a wall-clock comparison.
+///
+/// **Vector clocks are joined, not picked.** `partial_cmp_vc` reads a missing
+/// component as `0`, so dropping a component makes a genuinely *concurrent*
+/// pair read as "the remote dominates" against a peer that has advanced on the
+/// dropped device — the engine then classifies `RemoteNewer` and silently
+/// overwrites that divergence instead of recording a conflict. A join only ever
+/// raises components to values one side actually observed. The join is strictly
+/// same-side: `local_vclock` with `local_vclock`, `remote_vclock` with
+/// `remote_vclock`, never crossed, which would destroy the divergence the
+/// record exists to describe.
+///
+/// **Refusals.** A conflict is never resurrected and never silently dropped: if
+/// only the duplicate carries a conflict, the fold is refused outright and the
+/// duplicate key stays (so no record is lost and no clean entry becomes
+/// conflicted). If the duplicate's conflict is newer than the surviving one's,
+/// the fold is refused as well, because the "duplicate is frozen" premise does
+/// not hold and an operator should look.
+fn merge_duplicate_sync_states(surviving: SyncState, duplicate: SyncState) -> DuplicateFold {
+    match (surviving.conflict.as_ref(), duplicate.conflict.as_ref()) {
+        (None, Some(_)) => return DuplicateFold::RefusedWouldResurrectConflict,
+        (Some(kept), Some(dropped)) if dropped.detected_at > kept.detected_at => {
+            return DuplicateFold::RefusedDuplicateConflictIsNewer;
+        }
+        _ => {}
+    }
+
+    let conflict_preserved = duplicate.conflict.is_some();
+    let mut merged = surviving;
+
+    // (1) causal history is a join, never a pick.
+    merged.vclock.merge(&duplicate.vclock);
+
+    // (2) monotone conflict fields only; every payload value stays as recorded
+    // on the surviving key.
+    if let (Some(kept), Some(dropped)) = (merged.conflict.as_mut(), duplicate.conflict) {
+        kept.times_recorded = kept.times_recorded.max(dropped.times_recorded);
+        kept.local_vclock.merge(&dropped.local_vclock);
+        kept.remote_vclock.merge(&dropped.remote_vclock);
+    }
+
+    DuplicateFold::Folded {
+        state: Box::new(merged),
+        conflict_preserved,
+    }
+}
+
+/// Fold duplicate key-namespace entries for the same logical file into a
+/// single canonical entry (TIN-3278).
+///
+/// **Never call this from `open`, `reload_from_disk`, or any other implicitly
+/// reached path.** It mutates entry content, and the only place in this
+/// codebase where that is safe is behind a held [`StateFileLock`] — see
+/// [`StateCache::migrate_duplicate_keys_locked`], the sole caller, and the
+/// rationale recorded in [`StateCache::open`]. Reporting surfaces use
+/// [`StateCache::conflicts_report`] instead, which collapses duplicates without
+/// mutating anything.
+///
+/// Two shapes of duplicate are handled, in separate passes over a sorted
+/// (deterministic) snapshot of the keys present at call time:
+///
+/// 1. **Stray-but-resolvable key**: [`resolve_key_on_disk`] succeeds and
+///    differs from the stored key. The entry is re-keyed to the resolved
+///    form — which is exactly the key live `get`/`set`/`remove` derive via
+///    [`path_key`] for that file, so the repair moves the entry onto the key
+///    the reconciler was always going to look under, and cannot invent a key
+///    outside the file's own real location (same `file_name`, canonicalized
+///    parent). If that key already has an entry, the two are folded via
+///    [`merge_duplicate_sync_states`].
+/// 2. **Orphaned relative key**: [`resolve_key_on_disk`] fails outright —
+///    the key's parent does not exist as an independent filesystem path.
+///    This is the live TIN-3278 shape: a bare `/secrets/.audit.log` key
+///    whose `/secrets` does not exist at the root. The orphan is matched
+///    against the other loaded keys using the exact suffix convention
+///    [`StateCache::get_by_rel_path`] already uses for cross-host lookups.
+///    Only an *unambiguous* single match (one independently-resolvable
+///    other key ending in `/<orphan>`) is folded; zero or multiple
+///    candidates leave the orphan untouched rather than guess at a target.
+///
+/// Never drops an entry outright: a key is removed only when its state has been
+/// folded into the surviving key, and [`merge_duplicate_sync_states`] refuses
+/// (leaving both keys in place) rather than resurrect or discard a conflict.
+/// Refusals are reported in [`KeyMigrationPlan::skipped`] so the operator sees
+/// what was declined and why.
+///
+/// **Precision about pass 1 and git routing.** [`merge_duplicate_sync_states`]
+/// cannot give an existing key a conflict it did not already carry, but a pass-1
+/// *pure* re-key (target key absent) does move an existing conflict onto a key
+/// the cache did not previously hold, which `tcfsd::grpc`'s
+/// `Path::new(cache_key).starts_with(git_dir)` test could then match. That is
+/// not widening: the destination is by construction the key [`path_key`]
+/// derives for the very same file (same `file_name`, canonicalized parent), so
+/// the entry lands exactly where a live `get`/`set`/`mark_conflict` was always
+/// going to look, and routing simply follows the live reconciler instead of
+/// diverging from it. The mismatch this repairs is the whole bug.
+///
+/// **Known boundary (multi-root)**: pass 2's ambiguity guard rejects an orphan
+/// with 0 or 2+ *resolvable* suffix candidates, which does not cover a host
+/// with two registered sync roots sharing a relative suffix where the file is
+/// materialized under only one of them — there the single resolvable candidate
+/// can be the wrong root's entry. Closing that needs root-scoped matching
+/// (state cache keys carry no root attribution today); until then the fold is
+/// deliberately limited to the unambiguous single-candidate case, and the fold
+/// invariant bounds the damage of a mistaken target to a raised clock component
+/// and a raised recurrence count.
+///
+/// **Case sensitivity**: matching is byte-exact, so an orphan differing from its
+/// live counterpart only by case is left in place on case-insensitive volumes
+/// (APFS/NTFS). Declining is the conservative outcome, and the report path still
+/// collapses nothing it cannot prove — such an orphan keeps double-counting.
+///
+/// **Cost**: exactly one `fs::canonicalize` attempt per key per call, computed
+/// up front and reused by both passes. Acceptable because this runs only when
+/// an operator asks for it, never on an `open`/reload hot path.
+fn fold_duplicate_keys(entries: &mut HashMap<String, SyncState>) -> KeyMigrationPlan {
+    let mut plan = KeyMigrationPlan::default();
+
+    let mut keys: Vec<String> = entries.keys().cloned().collect();
+    keys.sort();
+
+    // One resolution attempt per key, shared by both passes.
+    let resolved_by_key: HashMap<&str, Option<String>> = keys
+        .iter()
+        .map(|key| (key.as_str(), resolve_key_on_disk(key)))
+        .collect();
+    // Keys known to resolve independently on disk: valid fold targets for
+    // pass 2. Pass 1's re-keyed forms are resolvable by construction.
+    let mut resolvable: std::collections::HashSet<String> = resolved_by_key
+        .iter()
+        .filter(|(_, resolved)| resolved.is_some())
+        .map(|(key, _)| (*key).to_string())
+        .collect();
+
+    // Pass 1: keys that independently resolve to a real (possibly
+    // different) filesystem path — re-key or fold onto that form.
+    for key in &keys {
+        if !entries.contains_key(key) {
+            continue; // already folded away earlier in this pass
+        }
+        let Some(resolved) = resolved_by_key
+            .get(key.as_str())
+            .and_then(|resolved| resolved.clone())
+        else {
+            continue; // orphan candidate — handled in pass 2
+        };
+        if &resolved == key {
+            continue; // already canonical
+        }
+        match entries.get(&resolved) {
+            Some(surviving) => {
+                let Some(duplicate) = entries.get(key) else {
+                    continue;
+                };
+                match merge_duplicate_sync_states(surviving.clone(), duplicate.clone()) {
+                    DuplicateFold::Folded {
+                        state,
+                        conflict_preserved,
+                    } => {
+                        entries.remove(key);
+                        entries.insert(resolved.clone(), *state);
+                        resolvable.insert(resolved.clone());
+                        plan.merges.push(KeyMergeRecord {
+                            dropped_key: key.clone(),
+                            kept_key: resolved,
+                            conflict_preserved,
+                        });
+                    }
+                    DuplicateFold::RefusedWouldResurrectConflict => plan.skipped.push((
+                        key.clone(),
+                        KeyMigrationSkipReason::WouldResurrectConflict { kept_key: resolved },
+                    )),
+                    DuplicateFold::RefusedDuplicateConflictIsNewer => plan.skipped.push((
+                        key.clone(),
+                        KeyMigrationSkipReason::DuplicateConflictIsNewer { kept_key: resolved },
+                    )),
+                }
+            }
+            None => {
+                // Pure re-key onto the form `path_key` derives for this file.
+                let Some(entry) = entries.remove(key) else {
+                    continue;
+                };
+                let conflict_preserved = entry.conflict.is_some();
+                entries.insert(resolved.clone(), entry);
+                resolvable.insert(resolved.clone());
+                plan.merges.push(KeyMergeRecord {
+                    dropped_key: key.clone(),
+                    kept_key: resolved,
+                    conflict_preserved,
+                });
+            }
+        }
+    }
+
+    // Pass 2: orphans that cannot independently resolve at all — match by
+    // rel-path suffix against a key that can, same convention as
+    // `get_by_rel_path`. Ambiguous (0 or 2+) matches are left in place.
+    for key in &keys {
+        if !entries.contains_key(key) {
+            continue;
+        }
+        if resolved_by_key
+            .get(key.as_str())
+            .is_some_and(Option::is_some)
+        {
+            continue; // handled in pass 1, or already canonical
+        }
+        let normalized_orphan = crate::engine::normalize_rel_path_text(key.trim_start_matches('/'));
+        if normalized_orphan.is_empty() {
+            continue;
+        }
+        let suffix = format!("/{normalized_orphan}");
+
+        let mut candidates: Vec<String> = entries
+            .keys()
+            .filter(|candidate| {
+                candidate.as_str() != key.as_str()
+                    && resolvable.contains(candidate.as_str())
+                    && crate::engine::normalize_rel_path_text(candidate).ends_with(&suffix)
+            })
+            .cloned()
+            .collect();
+
+        if candidates.len() != 1 {
+            // Zero candidates is the ordinary case for an entry whose file is
+            // simply absent (an un-hydrated stub, a deleted tree): not a
+            // duplicate at all, so it is not reported as a skipped repair. Two
+            // or more is the multi-root ambiguity an operator should see.
+            if candidates.len() >= 2 {
+                plan.skipped.push((
+                    key.clone(),
+                    KeyMigrationSkipReason::NoUnambiguousTarget {
+                        resolvable_candidates: candidates.len(),
+                    },
+                ));
+            }
+            continue; // no unambiguous canonical target — leave the orphan in place
+        }
+        let canonical_key = candidates.remove(0);
+        let (Some(surviving), Some(duplicate)) = (entries.get(&canonical_key), entries.get(key))
+        else {
+            continue;
+        };
+        match merge_duplicate_sync_states(surviving.clone(), duplicate.clone()) {
+            DuplicateFold::Folded {
+                state,
+                conflict_preserved,
+            } => {
+                entries.remove(key);
+                entries.insert(canonical_key.clone(), *state);
+                plan.merges.push(KeyMergeRecord {
+                    dropped_key: key.clone(),
+                    kept_key: canonical_key,
+                    conflict_preserved,
+                });
+            }
+            DuplicateFold::RefusedWouldResurrectConflict => plan.skipped.push((
+                key.clone(),
+                KeyMigrationSkipReason::WouldResurrectConflict {
+                    kept_key: canonical_key,
+                },
+            )),
+            DuplicateFold::RefusedDuplicateConflictIsNewer => plan.skipped.push((
+                key.clone(),
+                KeyMigrationSkipReason::DuplicateConflictIsNewer {
+                    kept_key: canonical_key,
+                },
+            )),
+        }
+    }
+
+    plan
 }
 
 /// Create a SyncState from a just-uploaded file
@@ -3298,6 +3996,883 @@ mod tests {
                 .get(std::path::Path::new("/sync/foreign.txt"))
                 .is_none(),
             "foreign-prefix non-conflict entry still purged"
+        );
+    }
+
+    // ── TIN-3278: duplicate key namespaces ──────────────────────────────
+    //
+    // Round-3 architecture (option B): `open`/`reload_from_disk` never repair
+    // anything, reporting collapses duplicates read-only, and repair is an
+    // explicit operation that requires the state-file lock. The tests below are
+    // grouped in that order.
+
+    fn write_state_entries(state_path: &Path, entries: HashMap<String, SyncState>) {
+        let on_disk = StateCacheOnDisk {
+            last_nats_seq: 0,
+            device_id: String::new(),
+            entries,
+        };
+        write_private_state_file(
+            state_path,
+            serde_json::to_string(&on_disk).unwrap().as_bytes(),
+        );
+    }
+
+    fn sample_sync_state(last_synced: u64, device_id: &str) -> SyncState {
+        SyncState {
+            blake3: format!("hash-{last_synced}"),
+            size: 5,
+            mtime: last_synced,
+            chunk_count: 1,
+            remote_path: "data/manifests/sample".into(),
+            last_synced,
+            vclock: VectorClock::new(),
+            device_id: device_id.into(),
+            conflict: None,
+            status: FileSyncStatus::Synced,
+        }
+    }
+
+    fn sample_conflict(
+        rel_path: &str,
+        detected_at: u64,
+        times_recorded: u64,
+        remote_manifest_key: Option<&str>,
+    ) -> crate::conflict::ConflictInfo {
+        crate::conflict::ConflictInfo {
+            rel_path: rel_path.into(),
+            local_vclock: VectorClock::new(),
+            remote_vclock: VectorClock::new(),
+            local_blake3: "local".into(),
+            remote_blake3: "remote".into(),
+            local_device: "neo".into(),
+            remote_device: "yoga".into(),
+            detected_at,
+            times_recorded,
+            remote_manifest_key: remote_manifest_key.map(str::to_string),
+        }
+    }
+
+    fn conflicted(mut state: SyncState, conflict: crate::conflict::ConflictInfo) -> SyncState {
+        state.conflict = Some(conflict);
+        state.status = FileSyncStatus::Conflict;
+        state
+    }
+
+    /// Materialize `<dir>/secrets/.audit.log` and return
+    /// `(file path, canonical key, orphaned bare-relative key)` — the exact live
+    /// TIN-3278 shape, where `/secrets` does not exist at the filesystem root and
+    /// so the orphan can never independently canonicalize.
+    fn duplicate_key_fixture(dir: &Path) -> (PathBuf, String, String) {
+        let secrets_dir = dir.join("secrets");
+        std::fs::create_dir_all(&secrets_dir).unwrap();
+        let audit_log = secrets_dir.join(".audit.log");
+        std::fs::write(&audit_log, b"audit").unwrap();
+        let canonical_key = std::fs::canonicalize(&audit_log)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        (audit_log, canonical_key, "/secrets/.audit.log".to_string())
+    }
+
+    fn conflicted_key_set(cache: &StateCache) -> std::collections::BTreeSet<String> {
+        cache
+            .entries
+            .iter()
+            .filter(|(_, state)| state.conflict.is_some())
+            .map(|(key, _)| key.clone())
+            .collect()
+    }
+
+    // ── open / reload are inert ──────────────────────────────────────────
+
+    #[test]
+    fn tin3278_open_never_folds_or_rewrites_duplicate_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+
+        let state_path = dir.path().join("state.json");
+        let mut entries = HashMap::new();
+        entries.insert(canonical_key.clone(), sample_sync_state(2000, "neo"));
+        entries.insert(orphan_key.clone(), sample_sync_state(1000, "yoga"));
+        write_state_entries(&state_path, entries);
+        let before = std::fs::read(&state_path).unwrap();
+
+        {
+            let cache = StateCache::open(&state_path).unwrap();
+            assert_eq!(
+                cache.len(),
+                2,
+                "open must hand back exactly what is on disk: repair is not a load-time side effect"
+            );
+            assert!(
+                !cache.dirty,
+                "open must not dirty the cache — Drop flushes on dirty and readers hold no lock"
+            );
+            assert!(cache.entries.contains_key(&orphan_key));
+        } // drop → a dirty flush would fire here
+
+        assert_eq!(
+            before,
+            std::fs::read(&state_path).unwrap(),
+            "an unlocked reader must leave the primary state cache byte-identical"
+        );
+    }
+
+    #[test]
+    fn tin3278_bak_recovery_open_writes_back_unfolded_content() {
+        // The `recovered_from_backup` leg of `Drop`/`flush` writes even when
+        // nothing called `set` — `lock_explicit_state_cache` (tcfs-cli) exists
+        // because of it. That write must therefore never carry a content
+        // migration: this is the round-2 `.bak`-recovery variant, and it is what
+        // makes "no fold at open" a structural guarantee rather than a flag check.
+        let dir = tempfile::tempdir().unwrap();
+        let (_audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+
+        let state_path = dir.path().join("state.json");
+        let bak_path = state_path.with_extension("json.bak");
+        let mut entries = HashMap::new();
+        entries.insert(canonical_key.clone(), sample_sync_state(2000, "neo"));
+        entries.insert(orphan_key.clone(), sample_sync_state(1000, "yoga"));
+        write_state_entries(&bak_path, entries);
+        let backup_before = std::fs::read(&bak_path).unwrap();
+        // Content-corrupt primary + valid backup → recovery path.
+        write_private_state_file(&state_path, b"{ this is not json");
+
+        {
+            let cache = StateCache::open(&state_path).unwrap();
+            assert!(cache.recovered_from_backup, "recovery path must be taken");
+            assert_eq!(cache.len(), 2, "recovery must not fold either");
+        } // drop → recovery flush fires here, with no lock held
+
+        let (recovered, _, _) = StateCache::load_from_file(&state_path).unwrap();
+        assert_eq!(
+            recovered.len(),
+            2,
+            "the unlocked recovery flush must write back what it read, not a migrated map"
+        );
+        assert!(
+            recovered.contains_key(&orphan_key),
+            "the duplicate key must survive an unlocked recovery flush"
+        );
+        assert_eq!(
+            recovered.get(&canonical_key).unwrap().blake3,
+            "hash-2000",
+            "no entry may be merged by a recovery flush"
+        );
+        assert_eq!(
+            backup_before,
+            std::fs::read(&bak_path).unwrap(),
+            "the recovery source must be preserved verbatim"
+        );
+    }
+
+    #[test]
+    fn tin3278_reload_from_disk_keeps_in_memory_values() {
+        // `reload_from_disk` documents "in-memory wins". A fold on that path
+        // would break it: the disk side can carry a higher (wall-clock,
+        // skew-prone) `last_synced` than a freshly re-hashed in-memory entry.
+        let dir = tempfile::tempdir().unwrap();
+        let (audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+
+        let mut cache = StateCache::open(&state_path).unwrap();
+        let mut live = sample_sync_state(1000, "neo");
+        live.blake3 = "NEW".into();
+        cache.set(&audit_log, live);
+
+        // Another process's file: stale digest under the canonical key, plus the
+        // legacy duplicate, both with a *higher* last_synced.
+        let mut disk = HashMap::new();
+        let mut stale = sample_sync_state(5000, "neo");
+        stale.blake3 = "OLD".into();
+        disk.insert(canonical_key.clone(), stale.clone());
+        disk.insert(orphan_key.clone(), stale);
+        write_state_entries(&state_path, disk);
+
+        cache.reload_from_disk().unwrap();
+
+        assert_eq!(
+            cache.get(&audit_log).unwrap().blake3,
+            "NEW",
+            "reload must not let a disk value overwrite a live in-memory one"
+        );
+        assert_eq!(
+            cache
+                .entries
+                .get(&orphan_key)
+                .map(|state| state.blake3.as_str()),
+            Some("OLD"),
+            "the new disk-only key is inserted as-is, unfolded"
+        );
+        assert_eq!(cache.len(), 2);
+    }
+
+    // ── read-side reporting collapse ─────────────────────────────────────
+
+    #[test]
+    fn tin3278_conflicts_report_collapses_duplicate_rows_without_mutating() {
+        // The observed defect: `tcfs conflicts` reports 9, the daemon's cycle
+        // reports 8, because one logical file is tracked under two key
+        // namespaces and both carry a conflict record.
+        let dir = tempfile::tempdir().unwrap();
+        let (_audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+
+        let mut entries = HashMap::new();
+        entries.insert(
+            canonical_key.clone(),
+            conflicted(
+                sample_sync_state(2000, "neo"),
+                sample_conflict("secrets/.audit.log", 1900, 3, Some("data/manifests/live")),
+            ),
+        );
+        entries.insert(
+            orphan_key.clone(),
+            conflicted(
+                sample_sync_state(1000, "yoga"),
+                sample_conflict("secrets/.audit.log", 500, 1881, Some("legacy/manifests/x")),
+            ),
+        );
+        write_state_entries(&state_path, entries);
+        let before = std::fs::read(&state_path).unwrap();
+
+        let cache = StateCache::open(&state_path).unwrap();
+        assert_eq!(
+            cache.conflicts().len(),
+            2,
+            "the raw scan is unchanged — security/routing consumers keep seeing every key"
+        );
+
+        let report = cache.conflicts_report();
+        assert_eq!(report.len(), 1, "reporting collapses to one row per file");
+        assert_eq!(
+            report[0].cache_key, canonical_key,
+            "the representative is the key live get/set derive"
+        );
+        assert_eq!(report[0].shadowed_keys, vec![orphan_key.as_str()]);
+        // The reported state is the live entry, verbatim — no payload grafting.
+        let reported = report[0].state;
+        assert_eq!(reported.blake3, "hash-2000");
+        assert_eq!(reported.conflict.as_ref().unwrap().times_recorded, 3);
+        assert_eq!(
+            reported
+                .conflict
+                .as_ref()
+                .unwrap()
+                .remote_manifest_key
+                .as_deref(),
+            Some("data/manifests/live")
+        );
+        // And nothing moved in the cache or on disk.
+        assert_eq!(cache.len(), 2);
+        assert!(!cache.dirty);
+        drop(cache);
+        assert_eq!(before, std::fs::read(&state_path).unwrap());
+    }
+
+    #[test]
+    fn tin3278_conflicts_report_never_hides_a_lone_orphan_conflict() {
+        // Only the orphan carries a conflict; the live entry is clean. Reporting
+        // must neither suppress the record (it is real cache debt) nor graft it
+        // onto the clean entry (that is the round-2 conflict-resurrection defect).
+        let dir = tempfile::tempdir().unwrap();
+        let (audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+
+        let mut entries = HashMap::new();
+        entries.insert(canonical_key.clone(), sample_sync_state(2000, "neo"));
+        entries.insert(
+            orphan_key.clone(),
+            conflicted(
+                sample_sync_state(1000, "yoga"),
+                sample_conflict("secrets/.audit.log", 500, 1881, None),
+            ),
+        );
+        write_state_entries(&state_path, entries);
+
+        let cache = StateCache::open(&state_path).unwrap();
+        let report = cache.conflicts_report();
+        assert_eq!(report.len(), 1);
+        assert_eq!(
+            report[0].cache_key, orphan_key,
+            "a conflict with no duplicate row must stay visible under its own key"
+        );
+        assert!(report[0].shadowed_keys.is_empty());
+        let live = cache.get(&audit_log).unwrap();
+        assert_eq!(live.status, FileSyncStatus::Synced);
+        assert!(
+            live.conflict.is_none(),
+            "the clean live entry must not acquire a conflict from reporting"
+        );
+    }
+
+    #[test]
+    fn tin3278_conflicts_report_leaves_ambiguous_orphan_visible() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo_a = dir.path().join("repo-a").join("secrets");
+        let repo_b = dir.path().join("repo-b").join("secrets");
+        std::fs::create_dir_all(&repo_a).unwrap();
+        std::fs::create_dir_all(&repo_b).unwrap();
+        std::fs::write(repo_a.join(".audit.log"), b"a").unwrap();
+        std::fs::write(repo_b.join(".audit.log"), b"b").unwrap();
+        let key_a = std::fs::canonicalize(repo_a.join(".audit.log"))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let key_b = std::fs::canonicalize(repo_b.join(".audit.log"))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+
+        let state_path = dir.path().join("state.json");
+        let mut entries = HashMap::new();
+        let conflict = sample_conflict("secrets/.audit.log", 100, 1, None);
+        entries.insert(
+            key_a,
+            conflicted(sample_sync_state(10, "neo"), conflict.clone()),
+        );
+        entries.insert(
+            key_b,
+            conflicted(sample_sync_state(10, "neo"), conflict.clone()),
+        );
+        entries.insert(
+            "/secrets/.audit.log".to_string(),
+            conflicted(sample_sync_state(5, "yoga"), conflict),
+        );
+        write_state_entries(&state_path, entries);
+
+        let cache = StateCache::open(&state_path).unwrap();
+        assert_eq!(
+            cache.conflicts_report().len(),
+            3,
+            "an orphan matching two resolvable keys must not be attributed to either"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tin3278_conflicts_report_collapses_resolvable_alias_key() {
+        // The other duplicate shape: a key that *does* resolve, but to a
+        // different stored key (symlinked parent, /var vs /private/var).
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        std::fs::create_dir_all(&real_dir).unwrap();
+        std::fs::write(real_dir.join("f.txt"), b"x").unwrap();
+        std::os::unix::fs::symlink(&real_dir, dir.path().join("alias")).unwrap();
+
+        let canonical_key = std::fs::canonicalize(real_dir.join("f.txt"))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let alias_key = dir
+            .path()
+            .join("alias")
+            .join("f.txt")
+            .to_string_lossy()
+            .into_owned();
+
+        let state_path = dir.path().join("state.json");
+        let mut entries = HashMap::new();
+        let conflict = sample_conflict("f.txt", 100, 1, None);
+        entries.insert(
+            canonical_key.clone(),
+            conflicted(sample_sync_state(2000, "neo"), conflict.clone()),
+        );
+        entries.insert(
+            alias_key.clone(),
+            conflicted(sample_sync_state(1000, "yoga"), conflict),
+        );
+        write_state_entries(&state_path, entries);
+
+        let cache = StateCache::open(&state_path).unwrap();
+        let report = cache.conflicts_report();
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].cache_key, canonical_key);
+        assert_eq!(report[0].shadowed_keys, vec![alias_key.as_str()]);
+    }
+
+    // ── explicit locked repair ───────────────────────────────────────────
+
+    #[test]
+    fn tin3278_explicit_migration_requires_a_lock_for_this_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+        let mut entries = HashMap::new();
+        entries.insert(canonical_key, sample_sync_state(2000, "neo"));
+        entries.insert(orphan_key, sample_sync_state(1000, "yoga"));
+        write_state_entries(&state_path, entries);
+        let before = std::fs::read(&state_path).unwrap();
+
+        let other_state_path = dir.path().join("other.json");
+        let foreign_lock = StateFileLock::acquire(&other_state_path).unwrap();
+
+        let mut cache = StateCache::open(&state_path).unwrap();
+        let error = cache
+            .migrate_duplicate_keys_locked(&foreign_lock)
+            .expect_err("a lock for a different cache must not authorize this migration");
+        assert!(
+            error.to_string().contains("held state lock is for"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(cache.len(), 2, "a refused migration must change nothing");
+        assert!(!cache.dirty);
+        drop(cache);
+        assert_eq!(before, std::fs::read(&state_path).unwrap());
+    }
+
+    #[test]
+    fn tin3278_explicit_migration_dry_run_plan_does_not_mutate() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+        let mut entries = HashMap::new();
+        entries.insert(canonical_key.clone(), sample_sync_state(2000, "neo"));
+        entries.insert(orphan_key.clone(), sample_sync_state(1000, "yoga"));
+        write_state_entries(&state_path, entries);
+        let before = std::fs::read(&state_path).unwrap();
+
+        let cache = StateCache::open(&state_path).unwrap();
+        let plan = cache.plan_duplicate_key_migration();
+        assert_eq!(plan.merges.len(), 1);
+        assert_eq!(plan.merges[0].dropped_key, orphan_key);
+        assert_eq!(plan.merges[0].kept_key, canonical_key);
+        assert!(plan.skipped.is_empty());
+        assert_eq!(cache.len(), 2, "planning must not mutate the cache");
+        assert!(!cache.dirty);
+        drop(cache);
+        assert_eq!(before, std::fs::read(&state_path).unwrap());
+    }
+
+    #[test]
+    fn tin3278_explicit_migration_folds_and_persists_under_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let (audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+
+        let mut live = conflicted(
+            sample_sync_state(2000, "neo"),
+            sample_conflict("secrets/.audit.log", 1900, 3, Some("data/manifests/live")),
+        );
+        live.vclock.clocks.insert("neo".into(), 4);
+        let mut orphan = conflicted(
+            sample_sync_state(1000, "yoga"),
+            sample_conflict("secrets/.audit.log", 500, 1881, Some("legacy/manifests/x")),
+        );
+        orphan.vclock.clocks.insert("yoga".into(), 7);
+
+        let mut entries = HashMap::new();
+        entries.insert(canonical_key.clone(), live);
+        entries.insert(orphan_key.clone(), orphan);
+        write_state_entries(&state_path, entries);
+
+        let lock = StateFileLock::acquire(&state_path).unwrap();
+        let mut cache = StateCache::open(&state_path).unwrap();
+        let applied = cache.migrate_duplicate_keys_locked(&lock).unwrap();
+        assert_eq!(applied.merges.len(), 1);
+        assert!(applied.merges[0].conflict_preserved);
+        assert!(applied.skipped.is_empty());
+
+        let entry = cache.get(&audit_log).unwrap();
+        // Surviving key is authoritative for every value…
+        assert_eq!(entry.blake3, "hash-2000");
+        assert_eq!(entry.remote_path, "data/manifests/sample");
+        let conflict = entry.conflict.as_ref().unwrap();
+        assert_eq!(
+            conflict.remote_manifest_key.as_deref(),
+            Some("data/manifests/live"),
+            "the duplicate's legacy manifest key must never ride onto the live key"
+        );
+        // …except the two monotone fields.
+        assert_eq!(
+            conflict.times_recorded, 1881,
+            "recurrence count never regresses"
+        );
+        assert_eq!(entry.vclock.get("yoga"), 7, "clock components are joined");
+        assert_eq!(entry.vclock.get("neo"), 4);
+
+        // Durable, under the lock the caller still holds.
+        let raw = std::fs::read_to_string(&state_path).unwrap();
+        assert!(raw.contains(&canonical_key));
+        assert!(
+            !raw.contains("\"/secrets/.audit.log\""),
+            "the duplicate key must be gone from disk after an applied migration"
+        );
+        drop(lock);
+    }
+
+    #[test]
+    fn tin3278_explicit_migration_refuses_to_resurrect_a_stale_conflict() {
+        // Round-2 must-fix #1, eliminated rather than guarded: the live entry is
+        // clean, the duplicate carries a frozen conflict. Grafting it would make
+        // a cosmetic double-count into a real conflict on the key the
+        // reconciler, FileProvider badges, `conflict_git`, and daemon git
+        // routing all use. The fold refuses instead, and says so.
+        let dir = tempfile::tempdir().unwrap();
+        let (audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+
+        let mut entries = HashMap::new();
+        entries.insert(canonical_key.clone(), sample_sync_state(2000, "neo"));
+        entries.insert(
+            orphan_key.clone(),
+            conflicted(
+                sample_sync_state(1000, "yoga"),
+                sample_conflict("secrets/.audit.log", 500, 1881, Some("legacy/manifests/x")),
+            ),
+        );
+        write_state_entries(&state_path, entries);
+
+        let lock = StateFileLock::acquire(&state_path).unwrap();
+        let mut cache = StateCache::open(&state_path).unwrap();
+        let applied = cache.migrate_duplicate_keys_locked(&lock).unwrap();
+
+        assert!(applied.merges.is_empty(), "nothing may be folded here");
+        assert_eq!(
+            applied.skipped,
+            vec![(
+                orphan_key.clone(),
+                KeyMigrationSkipReason::WouldResurrectConflict {
+                    kept_key: canonical_key.clone(),
+                }
+            )]
+        );
+        let live = cache.get(&audit_log).unwrap();
+        assert_eq!(live.status, FileSyncStatus::Synced);
+        assert!(live.conflict.is_none(), "no conflict may be manufactured");
+        assert!(
+            cache.entries.contains_key(&orphan_key),
+            "the record is kept, not dropped — a refusal loses nothing"
+        );
+        assert!(!cache.dirty, "a refused fold must not dirty the cache");
+        drop(lock);
+    }
+
+    #[test]
+    fn tin3278_explicit_migration_refuses_when_duplicate_conflict_is_newer() {
+        // The fold's premise is that the duplicate key is frozen history. If its
+        // conflict is *newer* than the live one, the premise is wrong; refuse
+        // rather than pick between two live-looking records.
+        let dir = tempfile::tempdir().unwrap();
+        let (_audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+
+        let mut entries = HashMap::new();
+        entries.insert(
+            canonical_key.clone(),
+            conflicted(
+                sample_sync_state(2000, "neo"),
+                sample_conflict("secrets/.audit.log", 100, 2, None),
+            ),
+        );
+        entries.insert(
+            orphan_key.clone(),
+            conflicted(
+                sample_sync_state(1000, "yoga"),
+                sample_conflict("secrets/.audit.log", 999, 1881, None),
+            ),
+        );
+        write_state_entries(&state_path, entries);
+
+        let lock = StateFileLock::acquire(&state_path).unwrap();
+        let mut cache = StateCache::open(&state_path).unwrap();
+        let applied = cache.migrate_duplicate_keys_locked(&lock).unwrap();
+        assert!(applied.merges.is_empty());
+        assert_eq!(
+            applied.skipped,
+            vec![(
+                orphan_key,
+                KeyMigrationSkipReason::DuplicateConflictIsNewer {
+                    kept_key: canonical_key
+                }
+            )]
+        );
+        assert_eq!(cache.len(), 2);
+        drop(lock);
+    }
+
+    #[test]
+    fn tin3278_explicit_migration_reports_ambiguous_multi_root_orphan() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo_a = dir.path().join("repo-a").join("secrets");
+        let repo_b = dir.path().join("repo-b").join("secrets");
+        std::fs::create_dir_all(&repo_a).unwrap();
+        std::fs::create_dir_all(&repo_b).unwrap();
+        std::fs::write(repo_a.join(".audit.log"), b"a").unwrap();
+        std::fs::write(repo_b.join(".audit.log"), b"b").unwrap();
+        let key_a = std::fs::canonicalize(repo_a.join(".audit.log"))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let key_b = std::fs::canonicalize(repo_b.join(".audit.log"))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+
+        let state_path = dir.path().join("state.json");
+        let mut entries = HashMap::new();
+        entries.insert(key_a, sample_sync_state(10, "neo"));
+        entries.insert(key_b, sample_sync_state(10, "neo"));
+        entries.insert(
+            "/secrets/.audit.log".to_string(),
+            sample_sync_state(5, "yoga"),
+        );
+        write_state_entries(&state_path, entries);
+
+        let lock = StateFileLock::acquire(&state_path).unwrap();
+        let mut cache = StateCache::open(&state_path).unwrap();
+        let applied = cache.migrate_duplicate_keys_locked(&lock).unwrap();
+        assert!(applied.merges.is_empty());
+        assert_eq!(
+            applied.skipped,
+            vec![(
+                "/secrets/.audit.log".to_string(),
+                KeyMigrationSkipReason::NoUnambiguousTarget {
+                    resolvable_candidates: 2
+                }
+            )]
+        );
+        assert_eq!(cache.len(), 3);
+        drop(lock);
+    }
+
+    #[test]
+    fn tin3278_explicit_migration_cannot_widen_git_consumer_fields() {
+        // Round-2 must-fix #4, eliminated rather than tested-around. The two
+        // downstream consumers read `status`, `remote_path` and
+        // `conflict.remote_manifest_key` off `conflicts()` rows
+        // (`conflict_git::collect_repo_conflicts` bails a whole repo resolution
+        // on an out-of-prefix key; `tcfsd::grpc` routes git keep-both on
+        // `Path::new(cache_key).starts_with(git_dir)`). The fold cannot change
+        // any of those on a surviving key, and cannot give a key a conflict it
+        // did not already carry.
+        let dir = tempfile::tempdir().unwrap();
+        let repo_git = dir.path().join("repo").join(".git").join("refs/heads");
+        std::fs::create_dir_all(&repo_git).unwrap();
+        std::fs::write(repo_git.join("main"), b"sha").unwrap();
+        let live_git_key = std::fs::canonicalize(repo_git.join("main"))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let orphan_git_key = "/repo/.git/refs/heads/main".to_string();
+        let (_clean_file, clean_key, clean_orphan_key) = duplicate_key_fixture(dir.path());
+
+        let state_path = dir.path().join("state.json");
+        let mut entries = HashMap::new();
+        let mut live_git = conflicted(
+            sample_sync_state(1000, "neo"),
+            sample_conflict(
+                "repo/.git/refs/heads/main",
+                1900,
+                3,
+                Some("data/manifests/live-head"),
+            ),
+        );
+        live_git.remote_path = "data/index/repo/.git/refs/heads/main".into();
+        // Deliberately *higher* last_synced on the stale duplicate, with a
+        // legacy storage prefix in both address fields.
+        let mut orphan_git = conflicted(
+            sample_sync_state(5000, "yoga"),
+            sample_conflict(
+                "repo/.git/refs/heads/main",
+                500,
+                1881,
+                Some("legacy/manifests/orphan-head"),
+            ),
+        );
+        orphan_git.remote_path = "legacy/index/repo/.git/refs/heads/main".into();
+        entries.insert(live_git_key.clone(), live_git);
+        entries.insert(orphan_git_key.clone(), orphan_git);
+        // Second pair: clean live entry, conflicted duplicate (refusal case).
+        entries.insert(clean_key.clone(), sample_sync_state(2000, "neo"));
+        entries.insert(
+            clean_orphan_key.clone(),
+            conflicted(
+                sample_sync_state(1000, "yoga"),
+                sample_conflict("secrets/.audit.log", 500, 1881, Some("legacy/manifests/y")),
+            ),
+        );
+        write_state_entries(&state_path, entries);
+
+        let lock = StateFileLock::acquire(&state_path).unwrap();
+        let mut cache = StateCache::open(&state_path).unwrap();
+        let conflicted_before = conflicted_key_set(&cache);
+        let git_entry_before = cache.entries.get(&live_git_key).cloned().unwrap();
+
+        let applied = cache.migrate_duplicate_keys_locked(&lock).unwrap();
+        assert_eq!(applied.merges.len(), 1, "only the git pair may fold");
+        assert_eq!(applied.merges[0].dropped_key, orphan_git_key);
+
+        let conflicted_after = conflicted_key_set(&cache);
+        assert!(
+            conflicted_after.is_subset(&conflicted_before),
+            "no key may gain a conflict: before={conflicted_before:?} after={conflicted_after:?}"
+        );
+        let git_entry_after = cache.entries.get(&live_git_key).unwrap();
+        assert_eq!(git_entry_after.status, git_entry_before.status);
+        assert_eq!(git_entry_after.remote_path, git_entry_before.remote_path);
+        assert_eq!(git_entry_after.blake3, git_entry_before.blake3);
+        let conflict_after = git_entry_after.conflict.as_ref().unwrap();
+        let conflict_before = git_entry_before.conflict.as_ref().unwrap();
+        assert_eq!(
+            conflict_after.remote_manifest_key,
+            conflict_before.remote_manifest_key
+        );
+        assert_eq!(conflict_after.rel_path, conflict_before.rel_path);
+        assert_eq!(conflict_after.times_recorded, 1881, "monotone field rises");
+        // No key that *survived a fold* may carry a legacy-prefix address. The
+        // refused pair's orphan still does, and must: refusing means nothing
+        // about that entry changed, so its own legacy addresses stay under its
+        // own (non-live) key where no consumer has ever routed on them.
+        for record in &applied.merges {
+            let survivor = cache.entries.get(&record.kept_key).unwrap();
+            assert!(
+                !survivor.remote_path.starts_with("legacy/"),
+                "folded key {} took the duplicate's remote_path",
+                record.kept_key
+            );
+            assert!(
+                !survivor
+                    .conflict
+                    .as_ref()
+                    .and_then(|conflict| conflict.remote_manifest_key.as_deref())
+                    .is_some_and(|key| key.starts_with("legacy/")),
+                "folded key {} took the duplicate's remote_manifest_key",
+                record.kept_key
+            );
+        }
+        assert!(
+            cache
+                .entries
+                .get(&clean_orphan_key)
+                .and_then(|state| state.conflict.as_ref())
+                .and_then(|conflict| conflict.remote_manifest_key.as_deref())
+                == Some("legacy/manifests/y"),
+            "a refused fold must leave the duplicate entry exactly as it was"
+        );
+        drop(lock);
+    }
+
+    #[test]
+    fn tin3278_explicit_migration_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_audit_log, canonical_key, orphan_key) = duplicate_key_fixture(dir.path());
+        let state_path = dir.path().join("state.json");
+        let mut entries = HashMap::new();
+        entries.insert(canonical_key, sample_sync_state(2000, "neo"));
+        entries.insert(orphan_key, sample_sync_state(1000, "yoga"));
+        write_state_entries(&state_path, entries);
+
+        let lock = StateFileLock::acquire(&state_path).unwrap();
+        let mut cache = StateCache::open(&state_path).unwrap();
+        assert_eq!(
+            cache
+                .migrate_duplicate_keys_locked(&lock)
+                .unwrap()
+                .merges
+                .len(),
+            1
+        );
+        let second = cache.migrate_duplicate_keys_locked(&lock).unwrap();
+        assert!(
+            second.is_empty(),
+            "second pass has nothing to do: {second:?}"
+        );
+        drop(lock);
+
+        // And a fresh open of the migrated file plans no further work.
+        let reopened = StateCache::open(&state_path).unwrap();
+        assert_eq!(reopened.len(), 1);
+        assert!(reopened.plan_duplicate_key_migration().is_empty());
+    }
+
+    // ── fold semantics ───────────────────────────────────────────────────
+
+    fn fold_or_panic(surviving: SyncState, duplicate: SyncState) -> (SyncState, bool) {
+        match merge_duplicate_sync_states(surviving, duplicate) {
+            DuplicateFold::Folded {
+                state,
+                conflict_preserved,
+            } => (*state, conflict_preserved),
+            other => panic!("expected a fold, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tin3278_fold_joins_vector_clocks_instead_of_dropping_one_side() {
+        // The folded-away side is the *only* side carrying a `yoga` component.
+        let mut duplicate = sample_sync_state(1000, "yoga");
+        duplicate.vclock.clocks.insert("yoga".into(), 7);
+        let mut surviving = sample_sync_state(2000, "neo");
+        surviving.vclock.clocks.insert("neo".into(), 4);
+
+        let (merged, _) = fold_or_panic(surviving.clone(), duplicate.clone());
+        assert_eq!(
+            merged.vclock.get("yoga"),
+            7,
+            "a component only the folded side carried must survive"
+        );
+        assert_eq!(merged.vclock.get("neo"), 4);
+
+        // A peer that has advanced on `neo` but never saw our `yoga` history.
+        // Against the joined clock that is honestly Concurrent — a real
+        // conflict. Against the surviving-only clock the remote falsely
+        // *dominates* (the lost component reads as 0), so the engine classifies
+        // RemoteNewer and silently overwrites the yoga-side change.
+        let mut peer = VectorClock::new();
+        peer.clocks.insert("neo".into(), 5);
+        assert_eq!(merged.vclock.partial_cmp_vc(&peer), None);
+        assert_eq!(
+            surviving.vclock.partial_cmp_vc(&peer),
+            Some(std::cmp::Ordering::Less),
+            "pinning the hazard: dropping a clock lets the remote falsely dominate"
+        );
+
+        // The join is order-independent, unlike the deliberate live-side
+        // preference for value-bearing fields.
+        let (swapped, _) = fold_or_panic(duplicate, surviving);
+        assert_eq!(swapped.vclock, merged.vclock);
+    }
+
+    #[test]
+    fn tin3278_fold_joins_conflict_side_clocks_same_side_only() {
+        let mut older =
+            sample_conflict("secrets/.audit.log", 100, 1881, Some("legacy/manifests/x"));
+        older.remote_device = "yoga".into();
+        older.local_vclock.clocks.insert("yoga".into(), 2);
+        older.remote_vclock.clocks.insert("yoga".into(), 5);
+
+        let mut newer = sample_conflict("secrets/.audit.log", 900, 3, Some("data/manifests/live"));
+        newer.remote_device = "honey".into();
+        newer.local_vclock.clocks.insert("neo".into(), 3);
+        newer.remote_vclock.clocks.insert("neo".into(), 1);
+
+        // The surviving key carries the newer record; the duplicate is frozen.
+        let surviving = conflicted(sample_sync_state(2000, "neo"), newer);
+        let duplicate = conflicted(sample_sync_state(1000, "yoga"), older);
+
+        let (merged, preserved) = fold_or_panic(surviving, duplicate);
+        assert!(preserved);
+        let conflict = merged.conflict.expect("conflict payload must survive");
+
+        // Every payload value stays as recorded on the surviving key…
+        assert_eq!(conflict.remote_device, "honey");
+        assert_eq!(
+            conflict.remote_manifest_key.as_deref(),
+            Some("data/manifests/live")
+        );
+        // …times_recorded rises to the max…
+        assert_eq!(conflict.times_recorded, 1881);
+        // …and both sides' causal history is joined, same-side only.
+        assert_eq!(conflict.local_vclock.get("yoga"), 2);
+        assert_eq!(conflict.local_vclock.get("neo"), 3);
+        assert_eq!(conflict.remote_vclock.get("yoga"), 5);
+        assert_eq!(conflict.remote_vclock.get("neo"), 1);
+        assert_ne!(
+            conflict.remote_vclock.get("neo"),
+            3,
+            "a local-only observation must never surface as a remote one"
         );
     }
 }


### PR DESCRIPTION
## Current delivery hold — 2026-08-18

This is a dated design/source packet, not a landable exact-head authority. The current PR head is `fee22353df9bf116828c2ec371e380e7652978e9`: its sole commit is unsigned. Its merge base is `e7bfc1f01c3298c5ed6ad25254f6cc67d2a59213`; protected main is now `dfe8282a4d93af0ca1c495065ec82002352d4d86`, so the branch is 1 ahead / 1 behind and its historical checks are not final acceptance evidence.

After #572, #565, and the signed #576 replacement land, reconstruct this patch semantically in a fresh clean worktree on the exact then-current base, create signed non-force replacement history, obtain independent exact-tree review, and require fresh natural sanctioned GloriousFlywheel CI. Do not rerun the old head, apply the migration, touch live state, or treat the Sting test transcript below as current runtime authority. This PR remains Draft with auto-merge off.

## Round-3 design decision: **Option B — reporting collapses, only an explicit locked operation repairs**

Rounds 1 and 2 both implemented this as a duplicate-key **fold at load time**
(`StateCache::open` + `reload_from_disk`). Round 1 found two defects in that
shape; round 2 found four more. Every one of the six is a consequence of the
same decision — mutating cache content on a path that unlocked readers enter —
not of six independent mistakes. Two consecutive rounds of new holes in
implicit-write-at-open is the signal that the design is fighting the
codebase's lock/flush/reload discipline rather than using it.

So round 3 does not add a seventh guard. It removes the load-time fold
entirely and splits the problem along the line the codebase already draws:

| | |
| --- | --- |
| **Reporting** (`StateCache::conflicts_report`) | Collapses duplicate rows per logical file at **read** time. `&self`, borrowed `SyncState`s verbatim, no merge / graft / re-key / delete. Zero new write paths. |
| **Repair** (`StateCache::migrate_duplicate_keys_locked`) | The only thing that mutates. Requires a `StateFileLock` **for this cache**, invoked deliberately via `tcfs state-migrate-keys`. Because it is explicit and locked, it can afford the full recency / refusal guards. |

`open` and `reload_from_disk` are unchanged apart from comments recording why
they must not repair.

### Why the split is the fix and not just a relocation

The user-facing defect is a **reporting** defect: `tcfs conflicts` prints 9
where the daemon's per-cycle plan line reports `conflicts=8`. Nothing about
that symptom requires writing to the cache. Once reporting stops depending on
repair, repair stops needing to happen implicitly, and the two round-2 defect
classes that exist *only because* the fold ran implicitly disappear rather
than being guarded:

- there is no fold on the `recovered_from_backup` flush path, because there is
  no fold on `open` at all (round-2 #2);
- there is no fold on `reload_from_disk`, so the documented "in-memory wins"
  contract is untouched by this PR (round-2 #3).

The remaining two classes shrink to the explicit locked operation, where they
are handled by a **fold invariant** strong enough that they cannot occur:

> The **surviving key** — the key `path_key()` derives, the one a live sync
> cycle has been maintaining — is authoritative for every value-bearing field.
> The fold may only (1) join vector clocks pointwise, (2) raise
> `conflict.times_recorded`, (3) make the duplicate key disappear.

It never writes `blake3` / `size` / `mtime` / `chunk_count` / `remote_path` /
`device_id` / `status`, never writes any conflict payload value (including
`remote_manifest_key` and `rel_path`), and **never gives a key a conflict it
did not already carry**. Note what this replaces: v2 preferred the higher
`last_synced` side, which is wall-clock and skew-prone, and backfilled
`remote_manifest_key` across the fold. Both are gone.

Two refusals back it up, reported to the operator rather than guessed at:

- `WouldResurrectConflict` — the survivor is clean and the duplicate carries a
  conflict. **Refuse the fold entirely**; both keys stay. No record is lost and
  no clean entry becomes conflicted (round-2 #1). Stronger than the requested
  recency guard, which would still have grafted when `detected_at` was newer.
- `DuplicateConflictIsNewer` — the duplicate's conflict post-dates the
  survivor's, contradicting the "duplicate is frozen history" premise. Refuse;
  an operator should look.

### What Option A would and would not have bought

Honest accounting, since Option A (patch the fold against the round-2
six-point checklist) was the alternative:

| Round-2 class | Option A | Option B (this PR) |
| --- | --- | --- |
| 1 — conflict resurrection | guarded (recency check on the graft) | **eliminated** (fold refuses outright; nothing is ever grafted) |
| 2 — `.bak`-recovery unlocked write | guarded (skip fold when `recovered_from_backup`) | **eliminated** (no fold on `open`) |
| 3 — `reload_from_disk` contract break | guarded (exclude reload, or non-overwriting fold) | **eliminated** (no fold on reload) |
| 4 — git-consumer widening | argued + tested per consumer | **eliminated** (invariant: no key can gain those values or a conflict) |

Option A leaves four live guards on an implicit write path, each of which must
stay correct as the fold and its callers evolve, and each of which is a place a
round 4 can find a hole. Option B leaves one write path that a caller must ask
for by name and hold a lock to reach. Only Option B has a structural argument;
Option A has four behavioral ones.

Cost of B, stated plainly: the repair is no longer automatic. An operator has
to run `tcfs state-migrate-keys --execute`. That is the trade, and it is the
right one for a cache whose corruption mode is "an entry no live path touches."

---

## Round-2 findings → disposition

| # | Round-2 must-fix | Disposition |
| --- | --- | --- |
| 1 | Conflict resurrection: stale conflict grafted onto a live clean entry, no recency guard; the PR's own test locked the defect in | **ELIMINATED.** The fold refuses when only the duplicate carries a conflict (`WouldResurrectConflict`) and when the duplicate's conflict is newer (`DuplicateConflictIsNewer`). No graft path exists at any `detected_at`. The offending test is gone; `tin3278_explicit_migration_refuses_to_resurrect_a_stale_conflict` asserts the refusal, that both keys survive, and that the clean entry stays `Synced` |
| 2 | `recovered_from_backup` still makes unlocked readers flush the **migrated** fold; `dirty:false` does not help; the regression test never writes a `.bak` | **ELIMINATED.** No fold on `open`, so the recovery flush writes back what it read. `tin3278_bak_recovery_open_writes_back_unfolded_content` builds the real shape (corrupt primary + valid `.bak` + duplicate pair), asserts `recovered_from_backup`, drops the cache so the recovery flush fires unlocked, then re-loads and asserts the duplicate key survived and no entry merged. The vacuous `debug_assert` is deleted |
| 3 | `reload_from_disk` breaks its documented "in-memory wins" contract; orphan re-inserted every reload, fold overwrites live values on a wall-clock tiebreak | **ELIMINATED.** No fold on reload; `or_insert` is again the whole contract. `tin3278_reload_from_disk_keeps_in_memory_values` runs the exact scenario from the finding — in-memory `blake3=NEW`/`last_synced=1000` vs disk `blake3=OLD`/`last_synced=5000` — and asserts the live entry keeps `NEW` |
| 4 | Grafted legacy-prefix `remote_manifest_key` makes `collect_repo_conflicts` bail the whole repo resolution; also flips daemon git routing at `grpc.rs:4296` | **ELIMINATED.** No backfill, no `status` forcing. `tin3278_explicit_migration_cannot_widen_git_consumer_fields` builds a `.git`-internal pair whose stale duplicate carries a **higher** `last_synced` and legacy prefixes in *both* `remote_path` and `remote_manifest_key`, plus a clean/conflicted refusal pair, and asserts: the set of conflicted keys after the fold is a subset of the set before; the survivor's `status`, `remote_path`, `remote_manifest_key`, `rel_path`, `blake3` are byte-identical; `times_recorded` rose to 1881; no folded key carries a `legacy/` address; and the refused duplicate is untouched |
| 5 (non-blocking) | `conflicts_naming_unknown_devices` has zero callers; "defect 2 fixed" framing unearned | **DROPPED** from the PR — function and tests removed. The ghost-device reporting scan is not claimed here |
| — | Pass-2 cost: O(orphans × entries) with per-candidate `normalize_rel_path_text` on the `open`/reload path; one `canonicalize` syscall per key per CLI invocation | **ELIMINATED from the hot path.** `open` and `reload_from_disk` issue **zero** extra syscalls — the migration does not run there. The fold's cost is paid only when an operator invokes the verb. `conflicts_report` canonicalizes once per **conflict** row (the small minority of a cache), not per entry |
| — | Dead `normalized_candidate == normalized_orphan` branch | **REMOVED** |
| — | `tin3278_migration_is_idempotent_on_second_load` only passed via an artificial `set`+`flush` | **REPOINTED.** `tin3278_explicit_migration_is_idempotent` folds under lock, immediately re-runs the same locked migration and asserts the plan is empty, then reopens the persisted file and asserts `plan_duplicate_key_migration()` is empty. No injected write |
| — | Case-sensitivity on APFS unproven | **DOCUMENTED** as a declining case on `fold_duplicate_keys`; matching is byte-exact and an orphan differing only by case is left in place and keeps double-counting. Not silently claimed as fixed |
| — | Multi-root boundary wants its own ticket | **REPORTED, not silent.** 2+ resolvable candidates now surface as `KeyMigrationSkipReason::NoUnambiguousTarget` in the plan the operator reads before `--execute`; `tin3278_explicit_migration_reports_ambiguous_multi_root_orphan` covers it. Still a boundary — state-cache keys carry no root attribution |

---

## What changed, concretely

**`crates/tcfs-sync/src/state.rs`**

- `StateFileLock` carries the state-cache path it guards, exposed via
  `state_path()`. So an API that *requires* a held lock can verify the caller
  handed it a lock for the right cache instead of trusting that any guard in
  scope is the relevant one.
- `StateCache::conflicts_report() -> Vec<ConflictReportRow<'_>>` — read-only
  collapse. Rules, deliberately conservative:
  - rows whose keys resolve on disk to the same path are one group; the
    representative is the row already stored under the resolved path when
    present, else highest `last_synced`, ties broken on key order (deterministic
    output — `conflicts()` iterates a `HashMap`);
  - an unresolvable orphan attaches to a resolvable row by the same rel-path
    suffix convention `get_by_rel_path` already uses, and **only** on exactly
    one match; 0 or 2+ leave it as its own visible row;
  - **a conflict with no duplicate is never suppressed** — an orphan conflict
    whose live counterpart is clean stays visible. It is real cache debt, and
    hiding it is worse than double-counting.
- `plan_duplicate_key_migration()` — pure dry run; clones the map and runs the
  *identical* routine as the apply step, so plan and apply cannot disagree.
- `migrate_duplicate_keys_locked(&StateFileLock)` — the sole repair path;
  verifies the lock is for this cache, folds, dirties, flushes under the
  caller's still-live guard, returns the audit trail.
- `merge_duplicate_sync_states` returns a three-way `DuplicateFold`
  (`Folded` / `RefusedWouldResurrectConflict` / `RefusedDuplicateConflictIsNewer`)
  instead of always producing a merged state.
- Vector clocks are still **joined, not picked** (round-1 #1, unchanged and
  still correct): pointwise `VectorClock::merge` on the entry clock, and
  strictly same-side on the payload (`local`∨`local`, `remote`∨`remote`, never
  crossed). `partial_cmp_vc` reads an absent component as `0`, so dropping one
  makes a genuinely concurrent pair read as *remote* dominance → false
  `RemoteNewer` → silent overwrite. Two tests pin the direction.
- `conflicts_naming_unknown_devices` and its tests removed.

**`crates/tcfs-cli/src/main.rs`**

- `tcfs conflicts` (primary/legacy offline branch) reports from
  `conflicts_report()`. Same command, no lock taken, still writes nothing —
  it now prints the per-logical-file count that matches the daemon, names each
  shadowed duplicate key, and points at the repair verb. `--json` gains
  `duplicate_cache_keys`.
- `tcfs state-migrate-keys [--execute] [--json] [--state <path>]` — dry run by
  default. **Both** modes take the `StateFileLock` before `StateCache::open`,
  not just `--execute`: `open` itself can write, because it recovers a missing
  or corrupt primary from `.bak` and `Drop` flushes that recovery even for a
  nominally read-only command — the hazard `lock_explicit_state_cache`
  documents and round-2 #2 caught. Taking the lock up front means this verb can
  never write unlocked in either mode, and a run colliding with a daemon cycle
  fails loudly instead of racing it.

### Precision about pass-1 re-keying (stated so it isn't found later)

`merge_duplicate_sync_states` cannot give an *existing* key a conflict it did
not carry. A pass-1 **pure** re-key (destination key absent) does move an
existing conflict onto a key the cache did not previously hold, which
`grpc.rs`'s `Path::new(cache_key).starts_with(git_dir)` could then match. That
is not widening: the destination is by construction the key `path_key()`
derives for the very same file (same `file_name`, canonicalized parent), so the
entry lands exactly where a live `get`/`set`/`mark_conflict` was always going to
look. Routing follows the live reconciler instead of diverging from it — the
mismatch this repairs is the whole bug. Recorded on `fold_duplicate_keys`.

### Known boundary: the daemon's registered-root conflict list

Unchanged and out of scope. `tcfs conflicts --root <id>` is served by the
daemon's `conflict_records` (`tcfsd/src/grpc.rs`), which scans `conflicts()`
raw. That path is already prefix-validated per root by
`validate_conflict_cache_route`, and the observed 9-vs-8 divergence is on the
primary/legacy cache the offline branch reads — so wiring `conflicts_report()`
into the daemon is a separate change in a separate crate, deliberately not
bundled here.

---

## Tests — 17 TIN-3278 tests

Load-path guarantees (the ones round 2 asked for):
`tin3278_open_never_folds_or_rewrites_duplicate_keys` ·
`tin3278_bak_recovery_open_writes_back_unfolded_content` ·
`tin3278_reload_from_disk_keeps_in_memory_values`

Read-side collapse:
`tin3278_conflicts_report_collapses_duplicate_rows_without_mutating` ·
`tin3278_conflicts_report_never_hides_a_lone_orphan_conflict` ·
`tin3278_conflicts_report_leaves_ambiguous_orphan_visible` ·
`tin3278_conflicts_report_collapses_resolvable_alias_key`

Explicit locked migration:
`tin3278_explicit_migration_requires_a_lock_for_this_cache` ·
`tin3278_explicit_migration_dry_run_plan_does_not_mutate` ·
`tin3278_explicit_migration_folds_and_persists_under_lock` ·
`tin3278_explicit_migration_refuses_to_resurrect_a_stale_conflict` ·
`tin3278_explicit_migration_refuses_when_duplicate_conflict_is_newer` ·
`tin3278_explicit_migration_reports_ambiguous_multi_root_orphan` ·
`tin3278_explicit_migration_cannot_widen_git_consumer_fields` ·
`tin3278_explicit_migration_is_idempotent`

Fold semantics:
`tin3278_fold_joins_vector_clocks_instead_of_dropping_one_side` ·
`tin3278_fold_joins_conflict_side_clocks_same_side_only`

## Gates — sting, `/tmp/tin3278-wt4` @ `fee22353`, cargo 1.91.0 (worktree removed after)

| Gate | Result |
| --- | --- |
| `cargo fmt --all --check` | **PASS** (exit 0) — no diffs |
| `cargo test -p tcfs-sync` | **PASS** (exit 0) — 579 passed, 0 failed, 0 ignored |
| `cargo clippy -p tcfs-sync --all-targets -- -D warnings` | **PASS** (exit 0) — 0 warnings |
| `cargo clippy -p tcfs-cli --all-targets` | **PASS** — 0 diagnostics attributed to `crates/tcfs-cli` (see caveat) |

Caveat on the last row, stated because it is a weaker gate than the other
three: `-p tcfs-cli` **cannot** be resolved on sting at all — `async-notify
v0.3.4` requires rustc 1.92.0 and sting is on 1.91.1. Verified pre-existing:
the identical failure reproduces on a clean `origin/main` worktree, so it is
not introduced here. To typecheck the CLI change anyway it was built with a
**worktree-local** `cargo update async-notify --precise 0.3.2`; `Cargo.lock` is
**not** modified in this PR and the three primary gates above all ran against
the pristine lockfile *before* that pin. The only diagnostic in that build is a
pre-existing `clippy::only_used_in_recursion` warning in
`crates/tcfs-secrets/src/kdbx.rs`, untouched by this PR.

## Test plan

- [x] `cargo fmt --all --check` on sting
- [x] `cargo test -p tcfs-sync` on sting
- [x] `cargo clippy -p tcfs-sync --all-targets -- -D warnings` on sting
- [x] `cargo clippy -p tcfs-cli --all-targets` on sting (local dep pin; see caveat)
- [ ] Manual, on a **read-only copy** of neo's `state.json` (LAB_DEPLOY_FREEZE:
      copy only, no live state mutation): confirm `tcfs conflicts` collapses the
      `/secrets/.audit.log` duplicate and matches the daemon's cycle count, that
      the copy is byte-identical afterwards, and that `tcfs state-migrate-keys`
      dry-run plans exactly that one fold

## Coordination

- **#576 / TIN-3277** landed a `tracked_is_exact` guard in `reconcile.rs` that
  warns when a lookup resolves through a dup-key path. Still complementary:
  that guard reports, `tcfs state-migrate-keys` removes. Disjoint files
  (`reconcile.rs` vs `state.rs` + `tcfs-cli/main.rs`).
- **#565 / TIN-2864** (Codex-owned, not modified) touches an unrelated region of
  `state.rs` (bounded-read primitives near the top); no construct-level overlap.

Stays **DRAFT** pending the round-3 gate.
