### PR TITLE
chore(ci): cap artifact retention at 7 days - account storage quota hit 2026-07-30

### DIFF
--- a/.github/workflows/container-runtime-smoke.yml
+++ b/.github/workflows/container-runtime-smoke.yml
@@ -111,3 +111,4 @@ jobs:
           name: container-runtime-smoke-${{ github.event.inputs.tag }}-${{ matrix.artifact_suffix }}
           path: ${{ env.LOG_DIR }}
           if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           name: tcfs-docs-pdf
           path: dist/docs/*.pdf
+          retention-days: 7
 
   deploy:
     name: Deploy to GitHub Pages
@@ -71,6 +72,8 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          retention-days: 1
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/homebrew-install-smoke.yml
+++ b/.github/workflows/homebrew-install-smoke.yml
@@ -126,3 +126,4 @@ jobs:
           name: homebrew-install-smoke-${{ github.event.inputs.binary_expected_version }}
           path: ${{ runner.temp }}/homebrew-install-smoke
           if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/macos-fileprovider-testing-mode-pkg.yml
+++ b/.github/workflows/macos-fileprovider-testing-mode-pkg.yml
@@ -475,6 +475,7 @@ jobs:
           name: fileprovider-testing-policy-${{ github.run_id }}
           path: ${{ runner.temp }}/tcfs-fileprovider-testing-policy
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: Archive FileProvider app
         shell: bash

--- a/.github/workflows/nix-profile-install-smoke.yml
+++ b/.github/workflows/nix-profile-install-smoke.yml
@@ -185,3 +185,4 @@ jobs:
           name: ${{ env.TCFS_NIX_SMOKE_ARTIFACT_NAME }}
           path: ${{ runner.temp }}/nix-profile-install-smoke
           if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/storage-large-restore-canary.yml
+++ b/.github/workflows/storage-large-restore-canary.yml
@@ -560,3 +560,4 @@ jobs:
           name: storage-large-restore-canary-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ env.EVIDENCE_DIR }}
           if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
## Summary

On 2026-07-30 the Jesssullivan account hit its GitHub Actions artifact-storage quota: QA lanes across the estate died on `CreateArtifact` until a manual sweep deleted 1073 old artifacts (~7.5 GB). This repo was the largest holder (~2.4 GB). Root cause: `actions/upload-artifact` steps without `retention-days` sit at the account default (90 days) and accumulate. This PR is the prevention half.

## Changes

- Capped at `retention-days: 7` (previously 90-day default), 6 steps:
  - `docs.yml` - PDF docs bundle
  - `homebrew-install-smoke.yml` - smoke logs
  - `nix-profile-install-smoke.yml` - smoke logs
  - `container-runtime-smoke.yml` - smoke logs
  - `storage-large-restore-canary.yml` - run evidence
  - `macos-fileprovider-testing-mode-pkg.yml` - testing-policy diagnostics
- `docs.yml` `upload-pages-artifact@v3` pinned to `retention-days: 1` (the action default, now explicit; the artifact is consumed immediately by `deploy-pages` in the same run)
- Left as-is on purpose: the deliberate 14-day windows in `storage-posture-canary.yml`, `linux-package-container-smoke.yml`, and `macos-fileprovider-pkg-notarization-proof.yml`; every other upload step already sat at 7.

No release or Pages output is affected: release artifacts already had 7-day caps and the Pages artifact is consumed at deploy time.

## Test plan

- [x] YAML validated for every touched workflow
- [ ] `task test` passes locally (n/a - workflow metadata only)
- [ ] `task lint` passes locally (n/a - workflow metadata only)

## Checklist

- [x] No secrets or credentials in diff
- [ ] Docs updated (n/a)
- [ ] CHANGELOG.md updated (n/a)
