### PR TITLE
ci(contract): declare tinyland.repo.json and wire repo-manifest-validate

### DIFF
--- a/.github/workflows/repo-contract.yml
+++ b/.github/workflows/repo-contract.yml
@@ -1,0 +1,73 @@
+# Repo-contract gate: validate tinyland.repo.json against the org repo-manifest
+# schema published by tinyland-inc/ci-templates.
+#
+# Contract satisfied: "tinyland.repo.json declaring
+# cache_rbe_authority=tinyland-inc/GloriousFlywheel" + repo-manifest-validate
+# wiring, pinned to ci-templates v3.1.0
+# (d8d178c022a0f84853d53a2c8fe0fc90115f0949).
+#
+# TIN-3914 WAIVER (runs-on): the estate rule is "GF cache-fronted self-hosted
+# runners only", but Jesssullivan/tummycrypt is a PERSONAL-account repository
+# and personal repos cannot consume the tinyland-inc org runner group. Every
+# autoscaling runner set in GloriousFlywheel tofu/stacks/arc-runners/honey.tfvars
+# registers against https://github.com/tinyland-inc, and
+# `GET /repos/Jesssullivan/tummycrypt/actions/runners` returns total_count 0.
+# Same standing waiver Jesssullivan/legalab carries in its own CI workflow
+# ("Personal private repositories cannot consume the tinyland-inc runner
+# group. TIN-4050 tracks a future repo-scoped PZM/Flywheel enrollment.").
+# Re-enrollment for this repo is PR-d of this series (a GloriousFlywheel
+# consumer-registry + owner-overlay anchor PR); see TIN-4050.
+name: Repo Contract
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repo-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  manifest:
+    name: tinyland.repo.json schema + authorities
+    runs-on: ubuntu-24.04 # TIN-3914 waiver — see header
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Validate repo manifest
+        uses: tinyland-inc/ci-templates/.github/actions/repo-manifest-validate@d8d178c022a0f84853d53a2c8fe0fc90115f0949 # v3.1.0
+        with:
+          path: tinyland.repo.json
+          required_roles: package-producer
+
+      # The schema makes `authorities` optional and every key inside it
+      # optional, so a manifest that silently DROPPED cache_rbe_authority would
+      # still validate. The contract line is specifically that this repo
+      # declares GloriousFlywheel as its cache/RBE authority, so assert the
+      # value here rather than trusting schema validity to carry it.
+      - name: Assert declared authorities
+        run: |
+          set -euo pipefail
+          fail=0
+          assert() {
+            local path="$1" want="$2" got
+            got="$(jq -r "$path // \"\"" tinyland.repo.json)"
+            if [[ "$got" != "$want" ]]; then
+              echo "::error file=tinyland.repo.json::$path must be '$want', got '${got:-<absent>}'"
+              fail=1
+            else
+              echo "ok: $path = $got"
+            fi
+          }
+          assert '.authorities.cache_rbe_authority' 'tinyland-inc/GloriousFlywheel'
+          assert '.authorities.ci_templates'        'tinyland-inc/ci-templates'
+          assert '.authorities.tofu_module_authority' 'tinyland-inc/GloriousFlywheel'
+          assert '.repo.github'                     'Jesssullivan/tummycrypt'
+          exit "$fail"

--- a/.github/workflows/repo-contract.yml
+++ b/.github/workflows/repo-contract.yml
@@ -6,17 +6,16 @@
 # wiring, pinned to ci-templates v3.1.0
 # (d8d178c022a0f84853d53a2c8fe0fc90115f0949).
 #
-# TIN-3914 WAIVER (runs-on): the estate rule is "GF cache-fronted self-hosted
-# runners only", but Jesssullivan/tummycrypt is a PERSONAL-account repository
-# and personal repos cannot consume the tinyland-inc org runner group. Every
-# autoscaling runner set in GloriousFlywheel tofu/stacks/arc-runners/honey.tfvars
-# registers against https://github.com/tinyland-inc, and
-# `GET /repos/Jesssullivan/tummycrypt/actions/runners` returns total_count 0.
-# Same standing waiver Jesssullivan/legalab carries in its own CI workflow
-# ("Personal private repositories cannot consume the tinyland-inc runner
-# group. TIN-4050 tracks a future repo-scoped PZM/Flywheel enrollment.").
-# Re-enrollment for this repo is PR-d of this series (a GloriousFlywheel
-# consumer-registry + owner-overlay anchor PR); see TIN-4050.
+# TIN-3914 DEFERRAL (runs-on): the estate rule is "GF cache-fronted self-hosted
+# runners only". A compliant label DOES exist for this repo — `tinyland-nix`,
+# served by the live `tummycrypt-nix` ARC scale set in the jesssullivan-infra
+# owner overlay (TIN-2538) — so this is a deferral with a named next step, not
+# a dead end. What is not established is whether the nix runner image
+# (ghcr.io/tinyland-inc/actions-runner-nix) carries `jq`, which the authority
+# assertion below needs. Move this job in the same pass that moves release.yml
+# `plan` and `generate-installers`, behind a `command -v` preflight, and lower
+# .github/runs-on-baseline in that commit.
+# Evidence and sequencing: docs/ops/ci-runner-enrollment-2026-08-28.md
 name: Repo Contract
 
 on:

--- a/tinyland.repo.json
+++ b/tinyland.repo.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://raw.githubusercontent.com/tinyland-inc/ci-templates/v3.1.0/schemas/tinyland-repo-manifest.schema.json",
+  "schema_version": 1,
+  "repo": {
+    "name": "tummycrypt",
+    "github": "Jesssullivan/tummycrypt",
+    "description": "TCFS — FOSS self-hosted encrypted filesystem and sync fabric (tcfsd daemon, tcfs CLI/TUI/MCP, macOS FileProvider, FUSE)."
+  },
+  "taxonomy": {
+    "primary_role": "package-producer",
+    "layers": [
+      "org-wide-repo-contract",
+      "infra-substrate"
+    ]
+  },
+  "contracts": {
+    "agent_contract": "AGENTS.md",
+    "just": "Justfile",
+    "nix": "flake.nix",
+    "github_actions": ".github/workflows",
+    "secrets_scan": "gitleaks",
+    "conformance": "just lint && just test"
+  },
+  "boundaries": {
+    "owns_runtime_backend": true,
+    "owns_auth": true,
+    "owns_payments": false,
+    "owns_activitypub_delivery": false,
+    "owns_live_broker_fetch": false,
+    "owns_static_projection_ingest": false,
+    "owns_gitops_apply": false,
+    "owns_cloudflare_mutation": false,
+    "owns_bazel_module_authority": false
+  },
+  "authorities": {
+    "ci_templates": "tinyland-inc/ci-templates",
+    "cache_rbe_authority": "tinyland-inc/GloriousFlywheel",
+    "tofu_module_authority": "tinyland-inc/GloriousFlywheel",
+    "package_registry": "tinyland-inc/bazel-registry"
+  },
+  "enrollment": {
+    "forgeScope": "Jesssullivan",
+    "operatorOverlay": "jesssullivan-infra",
+    "executionPool": "tinyland-nix",
+    "substrateMode": "compatibility-local-only"
+  },
+  "supply_chain": {
+    "sbom": {
+      "status": "planned",
+      "formats": [],
+      "notes": "Release artifacts (deb/rpm/tarball/container/pkg) are built and cosign-signed by .github/workflows/release.yml; no SBOM is emitted yet. Flip to recipe-available with the format list in the same PR that adds the generator."
+    }
+  }
+}


### PR DESCRIPTION
Lane 4, PR-a of the release-flow migration series (R14 — must land before v0.12.19).

## Contract lines satisfied

> "`tinyland.repo.json` declaring `cache_rbe_authority=tinyland-inc/GloriousFlywheel`"

`tinyland.repo.json` (new) — `authorities.cache_rbe_authority = "tinyland-inc/GloriousFlywheel"`, alongside `ci_templates`, `tofu_module_authority` and `package_registry`.

> "repo-manifest-validate wiring"

`.github/workflows/repo-contract.yml` (new) — runs `tinyland-inc/ci-templates/.github/actions/repo-manifest-validate`.

> "ci-templates v3.1.0 = `d8d178c022a0f84853d53a2c8fe0fc90115f0949`"

Pinned to exactly that SHA with the `# v3.1.0` trailing comment. Verified against the ci-templates checkout: `git tag --points-at d8d178c02…` → `v3`, `v3.1.0`.

> "SHA-pinned actions with `# vX.Y.Z` trailing comments"

`actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0`.

## What was verified on neo (no Rust build — none needed here)

- Manifest validated with the real authority, not a hand-check:
  `python3 ci-templates/scripts/manifest-schema-validate.py --schemas-dir ci-templates/schemas tinyland.repo.json` → `::notice::repo manifest schema_version 1 -> tinyland-repo-manifest.schema.json`, **rc=0**.
- Workflow YAML parsed with Ruby stdlib YAML (the same parser `lint-runs-on` uses); embedded shell checked with `bash -n`.

## Why the manifest says what it says

- `taxonomy.primary_role: package-producer` — this repo publishes tcfs binaries, deb/rpm, a container image, nix packages, a macOS `.pkg` and a Homebrew formula.
- `enrollment.substrateMode: compatibility-local-only` — tummycrypt is a cargo + nix workspace with no Bazel wiring. Declaring `shared-cache-backed` would be a lie the strict cache-attachment contract would then have to catch.
- `supply_chain.sbom.status: planned` (not `not-required`) — this repo does ship release artifacts, it just does not emit an SBOM yet. `not-required` would have been the comfortable answer and the wrong one.
- `linear` is omitted. `AGENTS.md` names the tracked initiative by URL only; the schema wants a `TIN-nnnn` id, and inventing one would put a fabricated identifier into a machine-read contract.

## One thing the schema does not do, and this PR compensates for

`authorities` is optional in the v1 schema and every key inside it is optional. A manifest that silently dropped `cache_rbe_authority` would still validate green. Since the *contract line* is specifically about that declaration, the workflow asserts the four load-bearing values directly (`Assert declared authorities`) rather than letting schema-validity stand in for it.

## Known-red, on purpose: `runs-on`

`repo-contract.yml` runs on `ubuntu-24.04`, which `lint-runs-on` FAILs under TIN-3914. Verified locally:

```
::error file=.github/workflows/repo-contract.yml,line=39::runs-on FAIL [manifest] ubuntu-24.04 -> GitHub-hosted runner label: ... (TIN-3914)
```

This one is genuinely stuck for now, though not for the reason the header first gave. A compliant label **does** exist for this repo — `tinyland-nix`, served by the live `tummycrypt-nix` ARC scale set in the `jesssullivan-infra` owner overlay (TIN-2538; see series PR-c and `docs/ops/ci-runner-enrollment-2026-08-28.md`). What is not established is whether the nix runner image carries `jq`, which this workflow's authority assertion needs. Series PR-c moves the three jobs whose dependencies are fully known and defers the rest, including this one, behind a `command -v` preflight.

So: `ubuntu-24.04` here is a deliberate deferral with a named next step, not a dead end. Move it in the same pass that moves `plan` and `generate-installers`, and lower `.github/runs-on-baseline` in that commit.

## Review order

PR-a → PR-b → PR-c. This one is independent and safe to merge on its own; it adds a declaration and a gate and changes no existing lane.
