### PR TITLE
ci(contract): adopt lint-runs-on as a ratchet and close the runner_label enums

### DIFF
--- a/.github/runs-on-baseline
+++ b/.github/runs-on-baseline
@@ -15,13 +15,19 @@
 # landed both new gate workflows. Until PR-a merges this reads 26 and the gate
 # emits the "lower the baseline" warning, which is correct and not a failure.
 #
-# All FAILs are the same finding. TIN-3914 forbids GitHub-hosted labels, and
-# Jesssullivan/tummycrypt is a PERSONAL-account repository that cannot consume
-# the tinyland-inc org runner group: every autoscaling runner set in
-# GloriousFlywheel tofu/stacks/arc-runners/honey.tfvars registers against
-# https://github.com/tinyland-inc, and
-# GET /repos/Jesssullivan/tummycrypt/actions/runners returns total_count 0.
-# No compliant label is available to this repo today, so this number cannot
-# reach 0 from inside this repo. It reaches 0 in the PR that follows the
-# repo-scoped Flywheel enrollment (TIN-4050, series PR-d).
+# All FAILs are TIN-3914: GitHub-hosted labels, which the estate forbids.
+#
+# A compliant label DOES exist for this repo — `tinyland-nix`, served by the
+# live `tummycrypt-nix` ARC scale set in the jesssullivan-infra owner overlay
+# (TIN-2538) — so this number is reducible, not stuck. Series PR-c moves the
+# three pure-nix jobs and takes it to 22 (24 with both gate workflows present).
+#
+# It does not reach 0 soon, and not from inside a single PR:
+#   - release.yml build-binaries and create-release shell out to
+#     apt-get / dpkg / rpm / brew. Those are ports, not label swaps.
+#   - The four macOS jobs have NO destination. ARC is Linux-on-Kubernetes, no
+#     darwin capability class exists, and notarization needs real macOS.
+#
+# Whichever of series PR-b / PR-c lands second should lower this number.
+# Evidence and sequencing: docs/ops/ci-runner-enrollment-2026-08-28.md
 27

--- a/.github/runs-on-baseline
+++ b/.github/runs-on-baseline
@@ -1,0 +1,27 @@
+# lint-runs-on ratchet baseline for .github/workflows/runs-on-contract.yml.
+#
+# Number of FAIL findings ci-templates lint-runs-on reports across this repo's
+# workflows. The gate FAILS if the count goes UP; a DROP is only a warning
+# asking you to lower this number (good news should not turn CI red).
+#
+# Measured on neo 2026-08-28 against ci-templates v3.1.0
+# (d8d178c022a0f84853d53a2c8fe0fc90115f0949):
+#
+#   origin/main c782bb9 as-is ...................... 25 FAIL / 8 WARN / 15 files
+#   + this PR's runs-on-contract.yml ............... 26 FAIL / 8 WARN / 16 files
+#   + series PR-a's repo-contract.yml .............. 27 FAIL / 8 WARN / 17 files
+#
+# The declared baseline is 27: the count once the a -> b review order has
+# landed both new gate workflows. Until PR-a merges this reads 26 and the gate
+# emits the "lower the baseline" warning, which is correct and not a failure.
+#
+# All FAILs are the same finding. TIN-3914 forbids GitHub-hosted labels, and
+# Jesssullivan/tummycrypt is a PERSONAL-account repository that cannot consume
+# the tinyland-inc org runner group: every autoscaling runner set in
+# GloriousFlywheel tofu/stacks/arc-runners/honey.tfvars registers against
+# https://github.com/tinyland-inc, and
+# GET /repos/Jesssullivan/tummycrypt/actions/runners returns total_count 0.
+# No compliant label is available to this repo today, so this number cannot
+# reach 0 from inside this repo. It reaches 0 in the PR that follows the
+# repo-scoped Flywheel enrollment (TIN-4050, series PR-d).
+27

--- a/.github/workflows/homebrew-install-smoke.yml
+++ b/.github/workflows/homebrew-install-smoke.yml
@@ -31,9 +31,19 @@ on:
         required: true
         default: "0.12.13"
       runner_label:
+        # Closed enum (was free text). NOTE: `petting-zoo-mini` currently has
+        # ZERO runners registered for this repo
+        # (GET /repos/Jesssullivan/tummycrypt/actions/runners -> total_count 0),
+        # so selecting it queues rather than runs. Kept because a workflow here
+        # still defaults to it; see TIN-4050.
         description: "Runner label"
         required: true
         default: "macos-14"
+        type: choice
+        options:
+          - "macos-15"
+          - "macos-14"
+          - "petting-zoo-mini"
 
 permissions:
   contents: read

--- a/.github/workflows/linux-postinstall-smoke.yml
+++ b/.github/workflows/linux-postinstall-smoke.yml
@@ -38,10 +38,16 @@ on:
         default: "dist-linux-x86_64"
         type: string
       runner_label:
+        # Closed enum (was free text). Only runners this repo can actually
+        # acquire are listed; `tinyland-nix` joins this list when the
+        # repo-scoped Flywheel enrollment lands (TIN-4050, PR-d).
         description: "Runner label (default: ubuntu-24.04). Use a self-hosted Linux label for private endpoints."
         required: false
         default: "ubuntu-24.04"
-        type: string
+        type: choice
+        options:
+          - "ubuntu-24.04"
+          - "ubuntu-22.04"
       smoke_environment:
         description: "GitHub environment containing TCFS_SMOKE_* secrets"
         required: false

--- a/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
+++ b/.github/workflows/macos-fileprovider-pkg-notarization-proof.yml
@@ -4,10 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       runner_label:
+        # Closed enum (was free text). NOTE: `petting-zoo-mini` currently has
+        # ZERO runners registered for this repo
+        # (GET /repos/Jesssullivan/tummycrypt/actions/runners -> total_count 0),
+        # so selecting it queues rather than runs. Kept because a workflow here
+        # still defaults to it; see TIN-4050.
         description: "macOS runner label for the remote proof"
         required: true
         default: "macos-14"
-        type: string
+        type: choice
+        options:
+          - "macos-15"
+          - "macos-14"
+          - "petting-zoo-mini"
 
 permissions:
   contents: read

--- a/.github/workflows/macos-fileprovider-testing-mode-pkg.yml
+++ b/.github/workflows/macos-fileprovider-testing-mode-pkg.yml
@@ -9,10 +9,19 @@ on:
         default: "v0.12.12"
         type: string
       runner_label:
+        # Closed enum (was free text). NOTE: `petting-zoo-mini` currently has
+        # ZERO runners registered for this repo
+        # (GET /repos/Jesssullivan/tummycrypt/actions/runners -> total_count 0),
+        # so selecting it queues rather than runs. Kept because a workflow here
+        # still defaults to it; see TIN-4050.
         description: "Registered self-hosted Mac runner label"
         required: true
         default: "petting-zoo-mini"
-        type: string
+        type: choice
+        options:
+          - "macos-15"
+          - "macos-14"
+          - "petting-zoo-mini"
       signing_identity:
         description: "Apple/Mac development codesigning identity, or auto-development"
         required: false

--- a/.github/workflows/macos-postinstall-smoke.yml
+++ b/.github/workflows/macos-postinstall-smoke.yml
@@ -83,10 +83,19 @@ on:
         default: "dist-testing-mode-pkg"
         type: string
       runner_label:
+        # Closed enum (was free text). NOTE: `petting-zoo-mini` currently has
+        # ZERO runners registered for this repo
+        # (GET /repos/Jesssullivan/tummycrypt/actions/runners -> total_count 0),
+        # so selecting it queues rather than runs. Kept because a workflow here
+        # still defaults to it; see TIN-4050.
         description: "Runner label. Use petting-zoo-mini for FileProvider testing-mode."
         required: false
         default: "macos-15"
-        type: string
+        type: choice
+        options:
+          - "macos-15"
+          - "macos-14"
+          - "petting-zoo-mini"
       smoke_environment:
         description: "GitHub environment containing TCFS_SMOKE_* secrets"
         required: false

--- a/.github/workflows/nix-profile-install-smoke.yml
+++ b/.github/workflows/nix-profile-install-smoke.yml
@@ -17,10 +17,16 @@ on:
         default: "0.12.13"
         type: string
       runner_label:
+        # Closed enum (was free text). Only runners this repo can actually
+        # acquire are listed; `tinyland-nix` joins this list when the
+        # repo-scoped Flywheel enrollment lands (TIN-4050, PR-d).
         description: "Runner label"
         required: true
         default: "ubuntu-24.04"
-        type: string
+        type: choice
+        options:
+          - "ubuntu-24.04"
+          - "ubuntu-22.04"
       require_storage_ok:
         description: "Require installed tcfs status to report storage [ok]"
         required: true

--- a/.github/workflows/runs-on-contract.yml
+++ b/.github/workflows/runs-on-contract.yml
@@ -4,14 +4,17 @@
 # (d8d178c022a0f84853d53a2c8fe0fc90115f0949).
 #
 # Why a ratchet and not a hard gate. A hard gate is red on day one: this repo
-# has 26 FAIL findings once this file is added, all of them the same TIN-3914 finding, and none of them
-# fixable from inside this repo (see .github/runs-on-baseline). A gate that is
-# permanently red teaches reviewers to ignore it. A ratchet is enforceable
-# today: existing debt is declared in one reviewable number, and any NEW hosted
-# `runs-on` — the drift this lint exists to stop — fails the PR.
+# has 26 FAIL findings once this file is added. Some are fixable — the pure-nix
+# jobs move to tinyland-nix in series PR-c — but the rest are not, in this PR
+# or any near one: release.yml build-binaries and create-release shell out to
+# apt-get/dpkg/rpm/brew, and the four macOS jobs have no self-hosted
+# destination at all (see .github/runs-on-baseline). A gate that is permanently
+# red teaches reviewers to ignore it. A ratchet is enforceable today: existing
+# debt is declared in one reviewable number, and any NEW hosted `runs-on` — the
+# drift this lint exists to stop — fails the PR.
 #
-# Flip to a hard gate (drop the ratchet, drop `continue-on-error`) in the same
-# PR that lands the repo-scoped Flywheel enrollment and takes the baseline to 0.
+# Flip to a hard gate (drop the ratchet, drop `continue-on-error`) if and when
+# the baseline reaches 0.
 name: runs-on Contract
 
 on:

--- a/.github/workflows/runs-on-contract.yml
+++ b/.github/workflows/runs-on-contract.yml
@@ -1,0 +1,95 @@
+# runs-on contract gate: adopt ci-templates `lint-runs-on` as a RATCHET.
+#
+# Contract satisfied: "lint-runs-on adoption", pinned to ci-templates v3.1.0
+# (d8d178c022a0f84853d53a2c8fe0fc90115f0949).
+#
+# Why a ratchet and not a hard gate. A hard gate is red on day one: this repo
+# has 26 FAIL findings once this file is added, all of them the same TIN-3914 finding, and none of them
+# fixable from inside this repo (see .github/runs-on-baseline). A gate that is
+# permanently red teaches reviewers to ignore it. A ratchet is enforceable
+# today: existing debt is declared in one reviewable number, and any NEW hosted
+# `runs-on` — the drift this lint exists to stop — fails the PR.
+#
+# Flip to a hard gate (drop the ratchet, drop `continue-on-error`) in the same
+# PR that lands the repo-scoped Flywheel enrollment and takes the baseline to 0.
+name: runs-on Contract
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runs-on-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint-runs-on ratchet
+    runs-on: ubuntu-24.04 # TIN-3914 waiver — counted in .github/runs-on-baseline
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      # The action exits non-zero whenever any FAIL exists, which is always
+      # true here. It writes violations_count to GITHUB_OUTPUT BEFORE exiting
+      # (ci-templates scripts/lint-runs-on.rb:700-701), so the count survives
+      # continue-on-error and the ratchet below is the real verdict.
+      - name: lint-runs-on
+        id: lint
+        continue-on-error: true
+        uses: tinyland-inc/ci-templates/.github/actions/lint-runs-on@d8d178c022a0f84853d53a2c8fe0fc90115f0949 # v3.1.0
+        with:
+          root: "."
+          workflows_glob: ".github/workflows/*.yml"
+
+      - name: Ratchet against committed baseline
+        env:
+          COUNT: ${{ steps.lint.outputs.violations_count }}
+        run: |
+          set -euo pipefail
+          baseline="$(grep -vE '^\s*(#|$)' .github/runs-on-baseline | head -1 | tr -d '[:space:]')"
+          count="${COUNT:-}"
+
+          # An empty count means the action never produced an output — a broken
+          # pin or a crashed linter, not a clean repo. Fail loud; do not read
+          # silence as zero violations.
+          if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+            echo "::error::lint-runs-on produced no violations_count (got '${count}'). The lint did not run; this is a gate failure, not a pass."
+            exit 1
+          fi
+          if ! [[ "$baseline" =~ ^[0-9]+$ ]]; then
+            echo "::error file=.github/runs-on-baseline::baseline is not an integer (got '${baseline}')"
+            exit 1
+          fi
+
+          {
+            echo "### lint-runs-on ratchet"
+            echo
+            echo "| | count |"
+            echo "|---|---|"
+            echo "| FAIL findings now | \`${count}\` |"
+            echo "| committed baseline | \`${baseline}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if (( count > baseline )); then
+            echo "::error::runs-on FAIL count rose ${baseline} -> ${count}. A new GitHub-hosted or repo-shaped runs-on was introduced (TIN-3914). Fix the label, or — if this is deliberate and operator-approved — raise .github/runs-on-baseline in the same commit and say why."
+            exit 1
+          fi
+
+          # A DROP is the outcome this gate exists to encourage. Warn so the
+          # baseline gets tightened, but do not turn a green PR red for it —
+          # that is how ratchets get deleted.
+          if (( count < baseline )); then
+            echo "::warning file=.github/runs-on-baseline::runs-on FAIL count DROPPED ${baseline} -> ${count}. Lower .github/runs-on-baseline to ${count} so the ratchet keeps its grip."
+            echo "_Dropped to \`${count}\` — lower the baseline._" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "runs-on FAIL count holds at ${count} (baseline ${baseline})."
+          echo "_Holding at \`${count}\`._" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/storage-large-restore-canary.yml
+++ b/.github/workflows/storage-large-restore-canary.yml
@@ -15,10 +15,16 @@ on:
   workflow_dispatch:
     inputs:
       runner_label:
+        # Closed enum (was free text). Only runners this repo can actually
+        # acquire are listed; `tinyland-nix` joins this list when the
+        # repo-scoped Flywheel enrollment lands (TIN-4050, PR-d).
         description: "Runner label. Hosted runners require public HTTPS storage."
         required: false
         default: "ubuntu-24.04"
-        type: string
+        type: choice
+        options:
+          - "ubuntu-24.04"
+          - "ubuntu-22.04"
       smoke_environment:
         description: "GitHub environment containing TCFS_SMOKE_* storage secrets"
         required: false

--- a/.github/workflows/storage-posture-canary.yml
+++ b/.github/workflows/storage-posture-canary.yml
@@ -13,10 +13,16 @@ on:
   workflow_dispatch:
     inputs:
       runner_label:
+        # Closed enum (was free text). Only runners this repo can actually
+        # acquire are listed; `tinyland-nix` joins this list when the
+        # repo-scoped Flywheel enrollment lands (TIN-4050, PR-d).
         description: "Runner label. Hosted runners require public HTTPS storage."
         required: false
         default: "ubuntu-24.04"
-        type: string
+        type: choice
+        options:
+          - "ubuntu-24.04"
+          - "ubuntu-22.04"
       smoke_environment:
         description: "GitHub environment containing TCFS_SMOKE_* storage secrets"
         required: false


### PR DESCRIPTION
Lane 4, PR-b of the release-flow migration series (R14 — must land before v0.12.19). Review after PR-a.

## Contract lines satisfied

> "lint-runs-on adoption"

`.github/workflows/runs-on-contract.yml` (new) runs `tinyland-inc/ci-templates/.github/actions/lint-runs-on@d8d178c022a0f84853d53a2c8fe0fc90115f0949 # v3.1.0`.

> "collapse the free-text `runner_label` inputs"

Eight of them — the map said six; the repo has eight. All converted from `type: string` (or no `type:` at all, in `homebrew-install-smoke.yml`) to `type: choice` with a closed `options` list. A `workflow_dispatch` can no longer type an arbitrary string straight into `runs-on:`.

| workflow | default (unchanged) | enum |
|---|---|---|
| `homebrew-install-smoke` | `macos-14` | macos-15, macos-14, petting-zoo-mini |
| `macos-fileprovider-pkg-notarization-proof` | `macos-14` | macos-15, macos-14, petting-zoo-mini |
| `macos-fileprovider-testing-mode-pkg` | `petting-zoo-mini` | macos-15, macos-14, petting-zoo-mini |
| `macos-postinstall-smoke` | `macos-15` | macos-15, macos-14, petting-zoo-mini |
| `linux-postinstall-smoke` | `ubuntu-24.04` | ubuntu-24.04, ubuntu-22.04 |
| `nix-profile-install-smoke` | `ubuntu-24.04` | ubuntu-24.04, ubuntu-22.04 |
| `storage-large-restore-canary` | `ubuntu-24.04` | ubuntu-24.04, ubuntu-22.04 |
| `storage-posture-canary` | `ubuntu-24.04` | ubuntu-24.04, ubuntu-22.04 |

## Why the gate is a ratchet and not a hard gate

Measured on neo against ci-templates v3.1.0:

```
origin/main c782bb9 as-is ......... 25 FAIL / 8 WARN / 15 workflow files
+ this PR's runs-on-contract.yml .. 26 FAIL / 8 WARN / 16 files
+ PR-a's repo-contract.yml ........ 27 FAIL / 8 WARN / 17 files
```

Every one of those FAILs is TIN-3914: `ubuntu-*` / `macos-*` / `windows-*` are hard FAILs, and this repo's workflows are entirely hosted today. Some are fixable — series PR-c moves three pure-nix jobs onto `tinyland-nix` and takes the count to 22 — but a large remainder is not, in this PR or any near one:

- `build-binaries` and `create-release` shell out to `apt-get` / `dpkg` / `rpm` / `brew`. Those are real ports, not label swaps.
- The four macOS jobs have **no destination at all**. ARC is Linux-on-Kubernetes, no darwin capability class exists, and notarization needs real macOS with Xcode.

So a hard gate would be red on day one and stay red for the foreseeable future, on conditions a reviewer of a given PR cannot clear — and a permanently red gate is one people learn to click past. The ratchet is enforceable *today*: the existing debt is one reviewable number in `.github/runs-on-baseline`, and the drift this lint exists to stop — someone adding a new hosted or repo-shaped `runs-on` — raises the count and fails the PR.

Flip it to a hard gate (drop the ratchet and `continue-on-error`) if and when the count reaches 0.

**Note on ordering with PR-c.** PR-c lowers the count to 22 (24 with both gate workflows present). Whichever of b/c lands second should carry the baseline update; until then the ratchet emits its "lower the baseline" *warning*, which is the designed behaviour and not a failure.

## Two failure modes the gate handles deliberately

- **Empty `violations_count` fails the gate.** The action exits non-zero whenever any FAIL exists, so `continue-on-error: true` is required to reach the ratchet at all — which means a *broken pin* or a *crashed linter* would also arrive here, with no output. Reading that silence as "zero violations" would turn the gate into decoration. It exits 1 instead. (The count is safe to rely on otherwise: `scripts/lint-runs-on.rb:700-701` writes `GITHUB_OUTPUT` before returning 1.)
- **A count DROP warns, it does not fail.** Lowering the number is the outcome this gate wants. Failing a green PR for good news is how ratchets get deleted. It warns and asks for the baseline to be tightened.

The baseline is declared as **27** — the count after the `a → b` review order lands both gate workflows. Until PR-a merges the gate reads 26 and emits that "lower the baseline" warning, which is correct behaviour, not a failure.

## Two things found while doing this, left visible rather than tidied away

- `macos-fileprovider-testing-mode-pkg.yml` **defaults** to `petting-zoo-mini`, which currently has zero runners registered for this repo. Dispatching it as-shipped queues rather than runs. It is kept in the enum (a `choice` default must be a member) with the fact recorded in the comment.
- `tinyland-nix` is deliberately **not** offered in the Linux enums. Listing a label this repo cannot acquire would just be a menu item that hangs.

## Verified on neo (no Rust build — none needed)

- `lint-runs-on.rb` run directly at all three tree states for the counts above.
- All 16 workflows parsed with Ruby stdlib YAML (the same parser the lint uses).
- Every `choice` input in the repo checked so its `default` is a member of its `options` — GitHub rejects the workflow otherwise.
- The ratchet shell checked with `bash -n`.

UNBUILT — CI proves it.
