### PR TITLE
ci(release): SHA-pin actions, fail loud on cache pushes, ONE nix cache, migrate the nix jobs to tinyland-nix

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,8 +1,25 @@
 # Nix CI with Attic binary cache push
 #
-# Builds all tcfs packages with Nix and pushes results to the
-# tinyland Attic binary cache. Consuming machines can then
-# `nix profile install` or `nix build` with near-instant cache hits.
+# Builds all tcfs packages with Nix and pushes results to the tinyland Attic
+# binary cache. Consuming machines can then `nix profile install` or `nix build`
+# with near-instant cache hits — this is the leg that keeps macbook-neo
+# SUBSTITUTING the aarch64-darwin closure instead of compiling it.
+#
+# ONE CACHE. This workflow used to publish to two: Attic and FlakeHub Cache.
+# Attic is the survivor, because it is the one the repo actually declares —
+# flake.nix `nixConfig` names the Attic substituter and nothing else, and all
+# four workflows already configure it. The FlakeHub leg was never proven here:
+# it was pinned to a moving `@main` ref, marked `continue-on-error: true`, and
+# it HUNG to the 6h runner ceiling twice with every build step skipped. Nothing
+# is lost by dropping it — the darwin Attic push below already covers the full
+# closure (cli, tui, mcp, tcfsd, tcfsd-app, staticlib), which is exactly what
+# neo needs to substitute.
+#
+# FAIL LOUD. Every cache step here used to degrade to a `::warning::` — missing
+# token, failed `attic use`, failed push. A green run that published nothing is
+# the worst outcome available: the damage is invisible until some machine
+# starts compiling from source days later. A push branch with no token, a
+# broken login, or a failed push now fails the job.
 #
 # Required secrets:
 #   ATTIC_TOKEN — obtained from `attic login tinyland <server> <token>`
@@ -16,20 +33,24 @@ on:
     branches: [main, dev]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
-  # Public Attic endpoint shared with flake.nix and other workflows.
+  # Public Attic endpoint shared with flake.nix and the other workflows.
   ATTIC_SERVER: https://nix-cache.tinyland.dev
   ATTIC_CACHE: main
+  ATTIC_PUBLIC_KEY: main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
 jobs:
   flake-check:
     name: Flake Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TIN-3914 waiver — see docs/ops/ci-runner-enrollment-2026-08-28.md
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           extra_nix_config: |
             extra-substituters = https://nix-cache.tinyland.dev/main
@@ -43,13 +64,13 @@ jobs:
 
   build-linux-x86_64:
     name: Build Linux x86_64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TIN-3914 waiver — see docs/ops/ci-runner-enrollment-2026-08-28.md
     needs: flake-check
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Bootstrap Nix CLI
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           extra_nix_config: |
             extra-substituters = https://nix-cache.tinyland.dev/main
@@ -59,19 +80,30 @@ jobs:
         run: |
           echo "ATTIC_SERVER=${ATTIC_SERVER}"
           echo "ATTIC_CACHE=${ATTIC_CACHE}"
-          echo "BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE:-unset}"
 
       - name: Configure Attic
+        id: attic
+        env:
+          # Token via env, not argv: an argv secret is readable from /proc and
+          # from any `ps` running in a concurrent step.
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
         run: |
+          set -euo pipefail
           nix profile install nixpkgs#attic-client
-          if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland "${{ env.ATTIC_SERVER }}" "${{ secrets.ATTIC_TOKEN }}"
-            attic use "${{ env.ATTIC_CACHE }}" || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> "$GITHUB_ENV"
-          else
-            echo "::warning::ATTIC_TOKEN not set, skipping cache push"
-            echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
+          if [ -z "${ATTIC_TOKEN}" ]; then
+            # A fork PR legitimately has no secrets. A push to main/dev with no
+            # token is a broken cache lane and must not pass quietly.
+            if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+              echo "::error::ATTIC_TOKEN is not set on a push to ${GITHUB_REF_NAME}. Nothing would reach ${ATTIC_SERVER}, and the fleet would fall back to compiling from source."
+              exit 1
+            fi
+            echo "::notice::ATTIC_TOKEN unavailable on this ${GITHUB_EVENT_NAME}; building without a cache push."
+            echo "push_enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          attic login tinyland "${ATTIC_SERVER}" "${ATTIC_TOKEN}"
+          attic use "${ATTIC_CACHE}"
+          echo "push_enabled=true" >> "$GITHUB_OUTPUT"
 
       - name: Build tcfsd
         run: nix build --accept-flake-config --fallback .#tcfsd
@@ -86,69 +118,60 @@ jobs:
         run: nix build --accept-flake-config --fallback .#tcfs-mcp
 
       - name: Push to Attic
-        if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
+        if: steps.attic.outputs.push_enabled == 'true' && github.event_name == 'push'
         run: |
+          set -euo pipefail
           for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
             nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
-            attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
+            attic push "${ATTIC_CACHE}" "result-${pkg}"
           done
 
   build-macos-aarch64:
     name: Build macOS aarch64
-    runs-on: macos-14
-    # Hard stop well under the 6h hosted-runner ceiling: a wedged job must fail
-    # loud with hours to spare, not silently eat the whole window (both prior
-    # runs of this job died at exactly 6h00m inside "Set up FlakeHub Cache").
+    runs-on: macos-14 # TIN-3914 waiver — see docs/ops/ci-runner-enrollment-2026-08-28.md
+    # Hard stop under the 6h hosted-runner ceiling: a wedged job must fail loud
+    # with hours to spare rather than silently eat the whole window. The two
+    # 6h00m deaths this bound was added for were both inside "Set up FlakeHub
+    # Cache", which is gone as of this commit; the bound stays because a cold
+    # darwin closure build is genuinely long and a wedge is still possible.
     timeout-minutes: 300
     needs: flake-check
-    # id-token: write is required for FlakeHub Cache OIDC push (below).
-    permissions:
-      contents: read
-      id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           extra_nix_config: |
             extra-substituters = https://nix-cache.tinyland.dev/main
             extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
-      # FlakeHub Cache is the canonical nix cache the fleet substitutes from
-      # (lab nix/home-manager/nix.nix: "Attic replaced by FlakeHub"; macbook-neo
-      # trusts cache.flakehub.com). This action sets up a post-build push hook so
-      # EVERY darwin store path built below is published to FlakeHub Cache — which
-      # is what lets neo `nix-switch` SUBSTITUTE the aarch64-darwin closure
-      # (incl. tcfsd) instead of ever compiling locally. Requires this repo to be
-      # enrolled in FlakeHub Cache; no-ops with a warning if not yet enrolled.
-      # continue-on-error alone is not enough: when un-enrolled this action can
-      # HANG rather than fail (observed twice: job cancelled at exactly the 6h
-      # ceiling with every build step still skipped) — timeout-minutes converts
-      # the hang into the warning this comment always assumed.
-      - name: Set up FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@main
-        timeout-minutes: 10
-        continue-on-error: true
-
       - name: Configure Attic
+        id: attic
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
         run: |
+          set -euo pipefail
           nix profile install nixpkgs#attic-client
-          if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland "${{ env.ATTIC_SERVER }}" "${{ secrets.ATTIC_TOKEN }}"
-            attic use "${{ env.ATTIC_CACHE }}" || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> "$GITHUB_ENV"
-          else
-            echo "::warning::ATTIC_TOKEN not set, skipping cache push"
-            echo "ATTIC_CONFIGURED=false" >> "$GITHUB_ENV"
+          if [ -z "${ATTIC_TOKEN}" ]; then
+            if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+              echo "::error::ATTIC_TOKEN is not set on a push to ${GITHUB_REF_NAME}. The aarch64-darwin closure would not be published, and macbook-neo would compile tcfsd locally (2026-07-04 incident)."
+              exit 1
+            fi
+            echo "::notice::ATTIC_TOKEN unavailable on this ${GITHUB_EVENT_NAME}; building without a cache push."
+            echo "push_enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          attic login tinyland "${ATTIC_SERVER}" "${ATTIC_TOKEN}"
+          attic use "${ATTIC_CACHE}"
+          echo "push_enabled=true" >> "$GITHUB_OUTPUT"
 
       # NOTE: the aarch64-darwin DAEMON closure (tcfsd/tcfsd-app/staticlib) was
-      # previously NOT built here — only cli/tui/mcp — so macbook-neo could not
+      # once NOT built here — only cli/tui/mcp — so macbook-neo could not
       # substitute a new tcfsd and silently fell back to a LOCAL compile
-      # (2026-07-04 incident: a full day of neo compilation). Build the full set
-      # here on the GitHub macos-14 runner (off-neo, off-PZM) so the whole
-      # darwin closure lands in the caches and neo only ever substitutes.
+      # (2026-07-04 incident: a full day of neo compilation). The full set is
+      # built here on the GitHub macos-14 runner (off-neo, off-PZM) so the whole
+      # darwin closure lands in the cache and neo only ever substitutes.
       - name: Build tcfs-cli (no FUSE on macOS)
         run: nix build --accept-flake-config --fallback .#tcfs-cli
 
@@ -168,9 +191,10 @@ jobs:
         run: nix build --accept-flake-config --fallback .#tcfs-file-provider-staticlib
 
       - name: Push to Attic
-        if: env.ATTIC_CONFIGURED == 'true' && github.event_name == 'push'
+        if: steps.attic.outputs.push_enabled == 'true' && github.event_name == 'push'
         run: |
+          set -euo pipefail
           for pkg in tcfs-cli tcfs-tui tcfs-mcp tcfsd tcfsd-app tcfs-file-provider-staticlib; do
             nix build --accept-flake-config --fallback ".#${pkg}" -o "result-${pkg}"
-            attic push "${{ env.ATTIC_CACHE }}" "result-${pkg}" || echo "::warning::Failed to push ${pkg} to Attic"
+            attic push "${ATTIC_CACHE}" "result-${pkg}"
           done

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -21,6 +21,13 @@
 # starts compiling from source days later. A push branch with no token, a
 # broken login, or a failed push now fails the job.
 #
+# RUNNERS. The two Linux jobs run on `tinyland-nix`, served to this repository
+# by the `tummycrypt-nix` ARC scale set in the jesssullivan-infra owner overlay
+# (TIN-2538). These are the estate's first-choice canary for that anchor: they
+# fire on every push and PR rather than only on a release tag, and the runner
+# image (ghcr.io/tinyland-inc/actions-runner-nix) is built for exactly this
+# workload. The macOS job has no self-hosted destination and stays hosted.
+#
 # Required secrets:
 #   ATTIC_TOKEN — obtained from `attic login tinyland <server> <token>`
 
@@ -45,7 +52,7 @@ env:
 jobs:
   flake-check:
     name: Flake Check
-    runs-on: ubuntu-latest # TIN-3914 waiver — see docs/ops/ci-runner-enrollment-2026-08-28.md
+    runs-on: tinyland-nix
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
@@ -64,7 +71,7 @@ jobs:
 
   build-linux-x86_64:
     name: Build Linux x86_64
-    runs-on: ubuntu-latest # TIN-3914 waiver — see docs/ops/ci-runner-enrollment-2026-08-28.md
+    runs-on: tinyland-nix
     needs: flake-check
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -128,7 +135,10 @@ jobs:
 
   build-macos-aarch64:
     name: Build macOS aarch64
-    runs-on: macos-14 # TIN-3914 waiver — see docs/ops/ci-runner-enrollment-2026-08-28.md
+    # No darwin capability class exists — ARC is Linux-on-Kubernetes — so this
+    # job stays hosted. TIN-3914 waiver; see
+    # docs/ops/ci-runner-enrollment-2026-08-28.md
+    runs-on: macos-14
     # Hard stop under the 6h hosted-runner ceiling: a wedged job must fail loud
     # with hours to spare rather than silently eat the whole window. The two
     # 6h00m deaths this bound was added for were both inside "Set up FlakeHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,19 @@
 #   - Homebrew formula
 #   - Container image (GHCR, linux/amd64 + linux/arm64/v8)
 #   - SHA256SUMS.txt
+#
+# RUNNERS — TIN-3914 waiver, deliberate and documented.
+# The estate rule is "GF cache-fronted self-hosted runners only", and every
+# `runs-on:` below violates it. There is no compliant alternative for this
+# repo: Jesssullivan/tummycrypt is a PERSONAL-account repository, every
+# autoscaling runner set in GloriousFlywheel tofu/stacks/arc-runners/
+# honey.tfvars registers against https://github.com/tinyland-inc, and
+# GET /repos/Jesssullivan/tummycrypt/actions/runners returns total_count 0.
+# There is also no self-hosted darwin capability class anywhere in the
+# taxonomy, so the macos-14 notarization/pkg jobs have no destination even
+# after enrollment. Do not "fix" these by pointing them at a label that does
+# not exist — that strands the release lane, it does not migrate it.
+# Full reasoning and the exit path: docs/ops/ci-runner-enrollment-2026-08-28.md
 
 name: Release
 
@@ -39,6 +52,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: tcfsd  # Prefixed with lowercase $REGISTRY/$GITHUB_REPOSITORY_OWNER in tags
   RUST_TOOLCHAIN: 1.93.0
+  # The one nix binary cache. Same names and values as nix-ci.yml and
+  # flake.nix nixConfig, stated here rather than inlined per step.
+  ATTIC_SERVER: https://nix-cache.tinyland.dev
+  ATTIC_CACHE: main
+  ATTIC_PUBLIC_KEY: main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
 permissions:
   contents: write
@@ -50,7 +68,7 @@ jobs:
 
   plan:
     name: Plan release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TIN-3914 waiver — see header
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -171,16 +189,21 @@ jobs:
           #   rpm: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # dtolnay/rust-toolchain publishes no semver release tag, so this pins
+        # the `stable` BRANCH head instead of a version. That is safe here only
+        # because both call sites pass `toolchain:` explicitly — with this
+        # action the ref selects the default toolchain, so pinning a SHA without
+        # an explicit toolchain would silently change which Rust gets installed.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch, 2026-08-05
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.target }}
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: ${{ matrix.target }}
           cache-bin: false
@@ -223,7 +246,7 @@ jobs:
 
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -453,7 +476,7 @@ jobs:
       # ── Upload artifacts ──────────────────────────────────────────────────
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist-${{ matrix.name }}
           path: |
@@ -467,30 +490,30 @@ jobs:
 
   build-image:
     name: Build container image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TIN-3914 waiver — see header
     needs: plan
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU for arm64 image builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push image
         id: build_image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Containerfile
@@ -507,7 +530,7 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Sign container image with Cosign (keyless)
         env:
@@ -527,52 +550,63 @@ jobs:
 
   nix-build:
     name: Nix Build + Attic Push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TIN-3914 waiver — see header
     needs: plan
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           extra_nix_config: |
             extra-substituters = https://nix-cache.tinyland.dev/main
             extra-trusted-public-keys = main:eaUydxuDu7xBoy5cCo3MdknYAkVyTIASQ7DGuwxa+XA=
 
+      # This job is named "Nix Build + Attic Push" and it runs only on a release
+      # tag. Every step below used to degrade to a ::warning:: — a missing
+      # token, a failed `attic use`, a failed push — so a release could go out
+      # green having published NOTHING to the cache that the fleet substitutes
+      # from. The failure that matters is invisible at the moment it happens and
+      # only surfaces later, as a machine compiling from source. Fail loud here.
       - name: Configure Attic
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
         run: |
+          set -euo pipefail
           nix profile install nixpkgs#attic-client
-          if [ -n "${{ secrets.ATTIC_TOKEN }}" ]; then
-            attic login tinyland https://nix-cache.tinyland.dev ${{ secrets.ATTIC_TOKEN }}
-            attic use main || echo "::warning::Failed to configure Attic substituter"
-            echo "ATTIC_CONFIGURED=true" >> $GITHUB_ENV
-          else
-            echo "::warning::ATTIC_TOKEN not set, skipping Attic push"
-            echo "ATTIC_CONFIGURED=false" >> $GITHUB_ENV
+          if [ -z "${ATTIC_TOKEN}" ]; then
+            echo "::error::ATTIC_TOKEN is not set. This is the release lane; a release that pushes nothing to ${ATTIC_SERVER} leaves the fleet compiling from source. Set the secret or remove this job deliberately."
+            exit 1
           fi
+          # Token passed via env, not argv: an argv secret is readable from
+          # /proc and from any `ps` in a concurrent step.
+          attic login tinyland "${ATTIC_SERVER}" "${ATTIC_TOKEN}"
+          attic use "${ATTIC_CACHE}"
 
       - name: Build all Nix packages
         run: |
+          set -euo pipefail
           for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
             echo "Building ${pkg}..."
-            nix build --accept-flake-config .#${pkg} -o result-${pkg}
+            nix build --accept-flake-config ".#${pkg}" -o "result-${pkg}"
           done
 
       - name: Push to Attic cache
-        if: env.ATTIC_CONFIGURED == 'true'
         run: |
+          set -euo pipefail
           for pkg in tcfsd tcfs-cli tcfs-tui tcfs-mcp; do
-            attic push main result-${pkg} || echo "::warning::Failed to push ${pkg}"
+            echo "Pushing ${pkg}..."
+            attic push "${ATTIC_CACHE}" "result-${pkg}"
           done
 
   # ── Generate installer scripts ────────────────────────────────────────────
 
   generate-installers:
     name: Generate installer scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TIN-3914 waiver — see header
     needs: plan
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Generate shell installer
         run: |
@@ -652,7 +686,7 @@ jobs:
           sed -i "s|__TAG__|${{ needs.plan.outputs.tag }}|g" install.ps1
 
       - name: Upload installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist-installers
           path: |
@@ -664,17 +698,17 @@ jobs:
 
   build-fileprovider:
     name: Build FileProvider (macOS)
-    runs-on: macos-14
+    runs-on: macos-14 # TIN-3914 waiver — see header
     needs: plan
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch, 2026-08-05
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-bin: false
 
@@ -801,7 +835,7 @@ jobs:
             "TCFSProvider-${VERSION}-macos-aarch64.zip"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist-fileprovider
           path: build/TCFSProvider-*.zip
@@ -818,7 +852,7 @@ jobs:
 
   build-pkg:
     name: Build macOS installer (.pkg)
-    runs-on: macos-14
+    runs-on: macos-14 # TIN-3914 waiver — see header
     needs: [plan, build-binaries, build-fileprovider]
     if: |
       success() && (
@@ -826,16 +860,16 @@ jobs:
         (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v'))
       )
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Download macOS CLI binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-macos-aarch64
           path: cli-dist/
 
       - name: Download FileProvider app
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist-fileprovider
           path: fp-dist/
@@ -930,7 +964,7 @@ jobs:
             --require-stapled-ticket
 
       - name: Upload .pkg artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist-pkg
           path: "*.pkg"
@@ -947,7 +981,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TIN-3914 waiver — see header
     needs: [plan, build-binaries, generate-installers, build-fileprovider, build-pkg]
     if: |
       success() && (
@@ -957,7 +991,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist/
 
@@ -980,7 +1014,7 @@ jobs:
           sha256sum * > SHA256SUMS.txt
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Sign checksums with Cosign (keyless)
         run: |
@@ -992,7 +1026,7 @@ jobs:
           echo "Cosign signature created for SHA256SUMS.txt"
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           token: ${{ secrets.GH_RELEASE_TOKEN || github.token }}
           tag_name: ${{ needs.plan.outputs.tag }}
@@ -1082,7 +1116,7 @@ jobs:
 
   update-homebrew:
     name: Update Homebrew formula
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TIN-3914 waiver — see header
     needs: [plan, create-release]
     if: |
       success() && (
@@ -1091,7 +1125,7 @@ jobs:
       )
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Download release checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,21 @@
 #   - Container image (GHCR, linux/amd64 + linux/arm64/v8)
 #   - SHA256SUMS.txt
 #
-# RUNNERS — TIN-3914 waiver, deliberate and documented.
-# The estate rule is "GF cache-fronted self-hosted runners only", and every
-# `runs-on:` below violates it. There is no compliant alternative for this
-# repo: Jesssullivan/tummycrypt is a PERSONAL-account repository, every
-# autoscaling runner set in GloriousFlywheel tofu/stacks/arc-runners/
-# honey.tfvars registers against https://github.com/tinyland-inc, and
-# GET /repos/Jesssullivan/tummycrypt/actions/runners returns total_count 0.
-# There is also no self-hosted darwin capability class anywhere in the
-# taxonomy, so the macos-14 notarization/pkg jobs have no destination even
-# after enrollment. Do not "fix" these by pointing them at a label that does
-# not exist — that strands the release lane, it does not migrate it.
-# Full reasoning and the exit path: docs/ops/ci-runner-enrollment-2026-08-28.md
+# RUNNERS — partially migrated; the rest are a documented TIN-3914 waiver.
+# The correct labels for this repo are `tinyland-nix` and `tinyland-dind`,
+# served by the `tummycrypt-nix` / `tummycrypt-dind` ARC scale sets in the
+# jesssullivan-infra owner overlay (TIN-2538). `tummycrypt-*` is the scale-set
+# ANCHOR name, never a `runs-on` label — the taxonomy authority rejects
+# project-identity labels outright.
+#   MIGRATED: nix-build -> tinyland-nix.
+#   DEFERRED, with reasons, per job below: build-binaries and create-release
+#     apt-get/dpkg/rpm against Ubuntu; build-image needs qemu+buildx on dind;
+#     plan/generate-installers/update-homebrew depend on hosted-image tooling
+#     that the nix runner image is not known to carry.
+#   NO DESTINATION: the macos-14 jobs. ARC is Linux-on-Kubernetes and no darwin
+#     capability class exists, so notarization/pkg stay hosted indefinitely.
+# Sequencing and the evidence behind each call:
+# docs/ops/ci-runner-enrollment-2026-08-28.md
 
 name: Release
 
@@ -68,7 +71,7 @@ jobs:
 
   plan:
     name: Plan release
-    runs-on: ubuntu-latest # TIN-3914 waiver — see header
+    runs-on: ubuntu-latest # TIN-3914 waiver — deferred, see header
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -490,7 +493,7 @@ jobs:
 
   build-image:
     name: Build container image
-    runs-on: ubuntu-latest # TIN-3914 waiver — see header
+    runs-on: ubuntu-latest # TIN-3914 waiver — deferred, see header
     needs: plan
     timeout-minutes: 120
     steps:
@@ -550,7 +553,14 @@ jobs:
 
   nix-build:
     name: Nix Build + Attic Push
-    runs-on: ubuntu-latest # TIN-3914 waiver — see header
+    # MIGRATED (TIN-2538). tinyland-nix is served to this repository by the
+    # `tummycrypt-nix` ARC scale set in the jesssullivan-infra owner overlay
+    # (tofu/stacks/arc-runners/jesssullivan.tfvars), whose helm_release is live
+    # in tofu state as of the 2026-08-28T04:00Z apply. The runner image is
+    # ghcr.io/tinyland-inc/actions-runner-nix, so a job that does nothing but
+    # run `nix` is the right first job to move — and it is a LEAF (nothing
+    # `needs:` it), so a bad first run cannot take the release with it.
+    runs-on: tinyland-nix
     needs: plan
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -603,7 +613,7 @@ jobs:
 
   generate-installers:
     name: Generate installer scripts
-    runs-on: ubuntu-latest # TIN-3914 waiver — see header
+    runs-on: ubuntu-latest # TIN-3914 waiver — deferred, see header
     needs: plan
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -698,7 +708,7 @@ jobs:
 
   build-fileprovider:
     name: Build FileProvider (macOS)
-    runs-on: macos-14 # TIN-3914 waiver — see header
+    runs-on: macos-14 # TIN-3914 waiver — no darwin class exists, see header
     needs: plan
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -852,7 +862,7 @@ jobs:
 
   build-pkg:
     name: Build macOS installer (.pkg)
-    runs-on: macos-14 # TIN-3914 waiver — see header
+    runs-on: macos-14 # TIN-3914 waiver — no darwin class exists, see header
     needs: [plan, build-binaries, build-fileprovider]
     if: |
       success() && (
@@ -981,7 +991,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest # TIN-3914 waiver — see header
+    runs-on: ubuntu-latest # TIN-3914 waiver — deferred, see header
     needs: [plan, build-binaries, generate-installers, build-fileprovider, build-pkg]
     if: |
       success() && (
@@ -1116,7 +1126,7 @@ jobs:
 
   update-homebrew:
     name: Update Homebrew formula
-    runs-on: ubuntu-latest # TIN-3914 waiver — see header
+    runs-on: ubuntu-latest # TIN-3914 waiver — deferred, see header
     needs: [plan, create-release]
     if: |
       success() && (

--- a/docs/ops/ci-runner-enrollment-2026-08-28.md
+++ b/docs/ops/ci-runner-enrollment-2026-08-28.md
@@ -57,7 +57,7 @@ capability labels."*
 `runs-on: tinyland-nix`.
 
 **Liveness, not just declaration.** `jesssullivan-infra` run
-[33140300433](https://github.com/Jesssullivan/jesssullivan-infra/actions/runs/33140300433)
+`33140300433` (private repo — link elided for link-check)
 ("Deploy ARC Runners v2", success, 2026-08-28T03:55Z) logs at 04:00:11Z and
 04:00:29Z:
 

--- a/docs/ops/ci-runner-enrollment-2026-08-28.md
+++ b/docs/ops/ci-runner-enrollment-2026-08-28.md
@@ -1,0 +1,109 @@
+# CI runner enrollment: why `runs-on` was NOT migrated to a `tummycrypt-*` class
+
+Date: 2026-08-28. Measured on neo against `origin/main` c782bb9, ci-templates
+v3.1.0 (`d8d178c022a0f84853d53a2c8fe0fc90115f0949`), and
+GloriousFlywheel `main`.
+
+Lane 4 of the release-flow migration was specified as, among other things,
+"`release.yml` `runs-on` → `tummycrypt-*` class". That instruction is not
+executable as written, and executing it would break the release lane. This note
+records what was measured, so the next person does not re-derive it.
+
+## 1. There is no `tummycrypt-*` runner set
+
+`GloriousFlywheel tofu/stacks/arc-runners/honey.tfvars` defines seven runner
+sets. Every one carries a `tinyland-*` `runner_label`:
+
+| `runner_label` | line |
+|---|---|
+| `tinyland-nix-operator` | 836 |
+| `tinyland-nix-merge-gate` | 952 |
+| `tinyland-nix` | 1074 |
+| `tinyland-dind` | 1166 |
+| `tinyland-nix-heavy` | 1270 |
+| `tinyland-nix-kvm` | 1374 |
+| `tinyland-nix-gpu` | 1479 |
+
+There is no `tummycrypt` anywhere in the file.
+
+## 2. A `tummycrypt-*` label is forbidden by the taxonomy authority
+
+`GloriousFlywheel scripts/validate-arc-runner-taxonomy.py` — the authority for
+tinyland tfvars `runner_label` values — lists `tummycrypt` explicitly in
+`PROJECT_IDENTITY_TOKENS`, and rejects any label whose first token is not
+`tinyland` (`label_errors()`, lines 304-332).
+
+The Ruby port that `ci-templates lint-runs-on` uses
+(`scripts/runner_label_taxonomy.rb`) carries the same
+`PROJECT_IDENTITY_TOKENS` list, and its action description names the failure
+class directly: "FAILS known repo-shaped / project-identity self-hosted
+fossils (e.g. `dollhouse-farm-nix`, `jesssullivan-nix-heavy`)".
+
+The `tummycrypt-*` name in the delivery-stack map is best read as an ARS
+**anchor** name (`tfvars_anchor`), not a `runs-on` label. That distinction is
+already load-bearing elsewhere: in `GloriousFlywheel config/consumer-registry.json`,
+`Jesssullivan/bulkload` has `tfvars_anchor: bulkload-nix` but
+`runner_class: tinyland-nix`, and `Jesssullivan/bulkload/.github/workflows/ci.yml`
+line 20 reads `runs-on: tinyland-nix`.
+
+## 3. Even `tinyland-nix` is unreachable from this repo today
+
+Every runner set in `honey.tfvars` registers against
+`github_config_url = "https://github.com/tinyland-inc"` (line 32). GitHub
+organization runners serve repositories **in that organization**.
+`Jesssullivan/tummycrypt` is a personal-account repository.
+
+Measured:
+
+```
+GET /repos/Jesssullivan/tummycrypt/actions/runners
+  -> {"total_count":0,"runners":[]}
+```
+
+`Jesssullivan/legalab` has already hit this and committed the finding into its
+own CI workflow header: *"Personal private repositories cannot consume the
+tinyland-inc runner group. TIN-4050 tracks a future repo-scoped PZM/Flywheel
+enrollment."*
+
+Flipping any `runs-on:` in this repo to a `tinyland-*` label today would queue
+those jobs forever.
+
+## 4. The darwin jobs have no destination even after enrollment
+
+ARC runs on the honey Kubernetes cluster: Linux only. The taxonomy permits
+`macos`/`darwin` **suffixes** on a constructed label, but no such runner set
+exists. `release.yml`'s `build-fileprovider` and `build-pkg` jobs, and
+`nix-ci.yml`'s `build-macos-aarch64`, need real macOS with Xcode and
+notarization credentials. The only self-hosted Mac in the estate is
+`petting-zoo-mini`, which is itself a repo-shaped fossil label and currently has
+zero runners registered against this repository.
+
+So even a successful enrollment closes the Linux half only.
+
+## 5. What was done instead
+
+- `runs-on:` values are unchanged. Changing them to a nonexistent label strands
+  the release lane; it does not migrate it.
+- The waiver is written into the header of `release.yml` and `nix-ci.yml`, where
+  CI is actually read, rather than left as tribal knowledge.
+- `.github/workflows/runs-on-contract.yml` (series PR-b) adopts `lint-runs-on`
+  as a **ratchet** against `.github/runs-on-baseline`, so the existing debt is a
+  single reviewable number and any *new* hosted or repo-shaped `runs-on` fails
+  the PR.
+
+## 6. Exit path
+
+1. A GloriousFlywheel PR adding `Jesssullivan/tummycrypt` to
+   `config/consumer-registry.json` with `runner_class: tinyland-nix` and
+   `tfvars_anchor: tummycrypt-nix` — the bulkload shape. Drafted as series PR-d.
+2. The matching owner-overlay extra runner set (`jesssullivan-infra`), so a
+   runner actually registers against this repository. Verify with
+   `GET /repos/Jesssullivan/tummycrypt/actions/runners` returning a non-zero
+   `total_count` carrying the `tinyland-nix` label.
+3. Then, and only then, flip the Linux `runs-on:` values, lower
+   `.github/runs-on-baseline` in the same commit, and drop the waiver headers
+   for the jobs that moved.
+4. The darwin jobs stay on hosted runners until a darwin capability class
+   exists. Track separately; do not fold it into the Linux flip.
+
+Related: TIN-3914 (hosted-runner ruling), TIN-4050 (repo-scoped enrollment).

--- a/docs/ops/ci-runner-enrollment-2026-08-28.md
+++ b/docs/ops/ci-runner-enrollment-2026-08-28.md
@@ -1,109 +1,143 @@
-# CI runner enrollment: why `runs-on` was NOT migrated to a `tummycrypt-*` class
+# CI runner enrollment: `tummycrypt-*` is a scale-set anchor, not a `runs-on` label
 
 Date: 2026-08-28. Measured on neo against `origin/main` c782bb9, ci-templates
-v3.1.0 (`d8d178c022a0f84853d53a2c8fe0fc90115f0949`), and
-GloriousFlywheel `main`.
+v3.1.0 (`d8d178c022a0f84853d53a2c8fe0fc90115f0949`), GloriousFlywheel `main`,
+and `Jesssullivan/jesssullivan-infra` `HEAD`.
 
-Lane 4 of the release-flow migration was specified as, among other things,
-"`release.yml` `runs-on` → `tummycrypt-*` class". That instruction is not
-executable as written, and executing it would break the release lane. This note
-records what was measured, so the next person does not re-derive it.
+Lane 4 of the release-flow migration was specified as "`release.yml` `runs-on`
+→ `tummycrypt-*` class". Taken literally that is wrong and would strand every
+job. Taken as intended it is right, already provisioned, and partly executed by
+this PR. This note records the difference, because the first two hours of the
+investigation went to the wrong conclusion and the receipts are worth keeping.
 
-## 1. There is no `tummycrypt-*` runner set
-
-`GloriousFlywheel tofu/stacks/arc-runners/honey.tfvars` defines seven runner
-sets. Every one carries a `tinyland-*` `runner_label`:
-
-| `runner_label` | line |
-|---|---|
-| `tinyland-nix-operator` | 836 |
-| `tinyland-nix-merge-gate` | 952 |
-| `tinyland-nix` | 1074 |
-| `tinyland-dind` | 1166 |
-| `tinyland-nix-heavy` | 1270 |
-| `tinyland-nix-kvm` | 1374 |
-| `tinyland-nix-gpu` | 1479 |
-
-There is no `tummycrypt` anywhere in the file.
-
-## 2. A `tummycrypt-*` label is forbidden by the taxonomy authority
+## 1. `tummycrypt-*` cannot be a `runs-on` label
 
 `GloriousFlywheel scripts/validate-arc-runner-taxonomy.py` — the authority for
 tinyland tfvars `runner_label` values — lists `tummycrypt` explicitly in
-`PROJECT_IDENTITY_TOKENS`, and rejects any label whose first token is not
-`tinyland` (`label_errors()`, lines 304-332).
+`PROJECT_IDENTITY_TOKENS`, and its `label_errors()` (lines 304-332) rejects any
+label whose first token is not `tinyland`.
 
-The Ruby port that `ci-templates lint-runs-on` uses
-(`scripts/runner_label_taxonomy.rb`) carries the same
-`PROJECT_IDENTITY_TOKENS` list, and its action description names the failure
-class directly: "FAILS known repo-shaped / project-identity self-hosted
-fossils (e.g. `dollhouse-farm-nix`, `jesssullivan-nix-heavy`)".
+The Ruby port used by `ci-templates lint-runs-on`
+(`scripts/runner_label_taxonomy.rb`) carries the same list, and the action
+description names the class directly: it "FAILS known repo-shaped /
+project-identity self-hosted fossils (e.g. `dollhouse-farm-nix`,
+`jesssullivan-nix-heavy`)".
 
-The `tummycrypt-*` name in the delivery-stack map is best read as an ARS
-**anchor** name (`tfvars_anchor`), not a `runs-on` label. That distinction is
-already load-bearing elsewhere: in `GloriousFlywheel config/consumer-registry.json`,
+## 2. `tummycrypt-*` IS the scale-set anchor, and it is live
+
+`Jesssullivan/jesssullivan-infra`,
+`tofu/stacks/arc-runners/jesssullivan.tfvars`, `extra_runner_sets` (TIN-2538):
+
+```hcl
+tummycrypt-nix = {
+  github_config_url     = "https://github.com/Jesssullivan/tummycrypt"
+  runner_label          = "tinyland-nix"
+  runner_scale_set_name = "tummycrypt-nix"
+  max_runners           = 3
+  runner_image          = "ghcr.io/tinyland-inc/actions-runner-nix@sha256:1ccce66d…"
+  node_selector         = { "kubernetes.io/hostname" = "honey" }
+}
+
+tummycrypt-dind = {
+  github_config_url     = "https://github.com/Jesssullivan/tummycrypt"
+  runner_label          = "tinyland-dind"
+  runner_scale_set_name = "tummycrypt-dind"
+  max_runners           = 1
+}
+```
+
+The anchor's own comment states the reason it exists: *"Personal-account
+repositories cannot consume the tinyland-inc org-scoped scale sets directly, so
+these two registration identities expose only the shared workflow-facing
+capability labels."*
+
+**Anchor name ≠ label.** The same split is load-bearing across the estate:
 `Jesssullivan/bulkload` has `tfvars_anchor: bulkload-nix` but
-`runner_class: tinyland-nix`, and `Jesssullivan/bulkload/.github/workflows/ci.yml`
-line 20 reads `runs-on: tinyland-nix`.
+`runner_class: tinyland-nix`, and its `ci.yml` line 20 reads
+`runs-on: tinyland-nix`.
 
-## 3. Even `tinyland-nix` is unreachable from this repo today
+**Liveness, not just declaration.** `jesssullivan-infra` run
+[33140300433](https://github.com/Jesssullivan/jesssullivan-infra/actions/runs/33140300433)
+("Deploy ARC Runners v2", success, 2026-08-28T03:55Z) logs at 04:00:11Z and
+04:00:29Z:
 
-Every runner set in `honey.tfvars` registers against
-`github_config_url = "https://github.com/tinyland-inc"` (line 32). GitHub
-organization runners serve repositories **in that organization**.
-`Jesssullivan/tummycrypt` is a personal-account repository.
+```
+module.extra_runners["tummycrypt-dind"].helm_release.arc_runner: Refreshing state... [id=tummycrypt-dind]
+module.extra_runners["tummycrypt-nix"].helm_release.arc_runner: Refreshing state... [id=tummycrypt-nix]
+```
 
-Measured:
+Both Helm releases exist in tofu state. The lane is live today.
+
+## 3. The probe that nearly produced the wrong answer
 
 ```
 GET /repos/Jesssullivan/tummycrypt/actions/runners
   -> {"total_count":0,"runners":[]}
 ```
 
-`Jesssullivan/legalab` has already hit this and committed the finding into its
-own CI workflow header: *"Personal private repositories cannot consume the
-tinyland-inc runner group. TIN-4050 tracks a future repo-scoped PZM/Flywheel
-enrollment."*
+This does **not** mean "no runners". ARC scale sets with `min_runners = 0`
+register *ephemeral* runners that exist only while a job is assigned, so the
+idle steady state is an empty list. Read alone, this reading supports a
+confident and completely wrong conclusion that the repo has no enrollment.
+`GET /repos/Jesssullivan/bulkload/actions/runners` returns the same empty list,
+and bulkload has been running on `tinyland-nix` for months.
 
-Flipping any `runs-on:` in this repo to a `tinyland-*` label today would queue
-those jobs forever.
+**Use the tofu apply log as the liveness oracle, not the runners API.**
 
-## 4. The darwin jobs have no destination even after enrollment
+## 4. What moved, and what did not
 
-ARC runs on the honey Kubernetes cluster: Linux only. The taxonomy permits
-`macos`/`darwin` **suffixes** on a constructed label, but no such runner set
-exists. `release.yml`'s `build-fileprovider` and `build-pkg` jobs, and
-`nix-ci.yml`'s `build-macos-aarch64`, need real macOS with Xcode and
-notarization credentials. The only self-hosted Mac in the estate is
-`petting-zoo-mini`, which is itself a repo-shaped fossil label and currently has
-zero runners registered against this repository.
+Migrated to `tinyland-nix` in this PR:
 
-So even a successful enrollment closes the Linux half only.
+| workflow | job | why it was chosen first |
+|---|---|---|
+| `nix-ci.yml` | `flake-check` | pure `nix`; fires on every push and PR, so the anchor gets exercised immediately rather than only at release time |
+| `nix-ci.yml` | `build-linux-x86_64` | pure `nix`; the runner image is `actions-runner-nix` |
+| `release.yml` | `nix-build` | pure `nix`, and a LEAF — nothing `needs:` it, so a bad first run cannot take a release with it |
 
-## 5. What was done instead
+Deferred, with the specific blocker:
 
-- `runs-on:` values are unchanged. Changing them to a nonexistent label strands
-  the release lane; it does not migrate it.
-- The waiver is written into the header of `release.yml` and `nix-ci.yml`, where
-  CI is actually read, rather than left as tribal knowledge.
-- `.github/workflows/runs-on-contract.yml` (series PR-b) adopts `lint-runs-on`
-  as a **ratchet** against `.github/runs-on-baseline`, so the existing debt is a
-  single reviewable number and any *new* hosted or repo-shaped `runs-on` fails
-  the PR.
+| job | blocker |
+|---|---|
+| `release.yml` `build-binaries` | `sudo apt-get install` for fuse3/protobuf; the nix runner image is not Ubuntu |
+| `release.yml` `create-release` | `sudo dpkg -i` / `sudo rpm -i` / `brew` verification steps |
+| `release.yml` `build-image` | needs qemu + buildx; belongs on `tinyland-dind`, and multi-arch qemu inside dind is untested here |
+| `release.yml` `plan`, `generate-installers`, `update-homebrew` | depend on hosted-image tooling (`jq`, `gh`, `brew`) that the nix runner image is not known to carry |
 
-## 6. Exit path
+No destination at all:
 
-1. A GloriousFlywheel PR adding `Jesssullivan/tummycrypt` to
-   `config/consumer-registry.json` with `runner_class: tinyland-nix` and
-   `tfvars_anchor: tummycrypt-nix` — the bulkload shape. Drafted as series PR-d.
-2. The matching owner-overlay extra runner set (`jesssullivan-infra`), so a
-   runner actually registers against this repository. Verify with
-   `GET /repos/Jesssullivan/tummycrypt/actions/runners` returning a non-zero
-   `total_count` carrying the `tinyland-nix` label.
-3. Then, and only then, flip the Linux `runs-on:` values, lower
-   `.github/runs-on-baseline` in the same commit, and drop the waiver headers
-   for the jobs that moved.
-4. The darwin jobs stay on hosted runners until a darwin capability class
-   exists. Track separately; do not fold it into the Linux flip.
+- `release.yml` `build-fileprovider`, `build-pkg`; `nix-ci.yml`
+  `build-macos-aarch64`. ARC is Linux-on-Kubernetes. The taxonomy permits
+  `macos`/`darwin` **suffixes** on a constructed label, but no such scale set
+  exists, and these jobs need real macOS with Xcode and notarization
+  credentials. The only self-hosted Mac in the estate is `petting-zoo-mini`,
+  itself a repo-shaped fossil label. These stay hosted indefinitely; track
+  separately and do not fold them into the Linux flip.
 
-Related: TIN-3914 (hosted-runner ruling), TIN-4050 (repo-scoped enrollment).
+## 5. Sequencing for the rest
+
+1. Let the three migrated jobs run green on `tinyland-nix` at least once.
+2. Then move `plan`, `generate-installers`, `update-homebrew` one at a time,
+   each with a `command -v` preflight for the tools it assumes.
+3. `build-image` → `tinyland-dind` once qemu-in-dind is proven.
+4. `build-binaries` and `create-release` need their apt/dpkg/rpm steps replaced
+   with nix equivalents first. That is a real piece of work, not a label swap.
+5. Lower `.github/runs-on-baseline` in the same commit as each move.
+
+## 6. What this is NOT
+
+Not a GloriousFlywheel `config/consumer-registry.json` entry. That registry is
+for Bazel RBE / container-image-builder repos, and its validator
+(`scripts/validate-consumer-registry.py`) requires `build_targets` to be a
+non-empty list of Bazel labels beginning with `//`, and restricts
+`substrate_mode` to `{executor-backed, shared-cache-backed}`. tummycrypt has no
+Bazel wiring at all — no `MODULE.bazel`, `BUILD.bazel`, `WORKSPACE.bazel`,
+`.bazelrc` or `.bazelversion` anywhere in the tree — so any entry would have to
+invent targets, which is precisely the "internal honesty" the registry exists
+to enforce. GF's own `docs/build-system/enrollment.md` §6 says it outright:
+*"Runner provisioning is outside this registry."*
+
+Runner provisioning for this repo is the owner-overlay anchor in §2, and it is
+already done.
+
+Related: TIN-2538 (the anchors), TIN-3914 (hosted-runner ruling), TIN-4050
+(personal-repo enrollment).


### PR DESCRIPTION
Lane 4, PR-c of the release-flow migration series (R14 — must land before v0.12.19). Review after PR-b.

## Contract lines satisfied

> "SHA-pinned actions with `# vX.Y.Z` trailing comments"

All 27 `uses:` lines in `release.yml` and all 4 in `nix-ci.yml`.

> "snip the silent-fail cache pushes (release.yml:562-566, nix-ci.yml:112-133)"

Both, plus the three sibling silent failures in the same steps.

> "pick ONE nix cache"

Attic. The FlakeHub Cache leg is removed.

> "no direct `uses: tinyland-inc/GloriousFlywheel/...`"

Already true and unchanged — this repo has never had one.

## Pins are pins, not upgrades

Every SHA is the tip of the **current major**, resolved through the GitHub API from its tag. Nothing crosses a major boundary in a PR about supply chain — `actions/checkout` v7 and `download-artifact` v8 exist, and are deliberately not taken here.

| action | pinned | |
|---|---|---|
| `actions/checkout` | `fbc6f39…` | v5.1.0 |
| `actions/upload-artifact` | `ea165f8…` | v4.6.2 |
| `actions/download-artifact` | `d3f86a1…` | v4.3.0 |
| `Swatinem/rust-cache` | `6323deb…` | v2.9.2 |
| `arduino/setup-protoc` | `c65c819…` | v3.0.0 |
| `docker/login-action` | `c94ce9f…` | v3.7.0 |
| `docker/setup-qemu-action` | `c7c5346…` | v3.7.0 |
| `docker/setup-buildx-action` | `8d2750c…` | v3.12.0 |
| `docker/build-push-action` | `ca052bb…` | v5.4.0 |
| `sigstore/cosign-installer` | `7e8b541…` | v3.10.1 |
| `cachix/install-nix-action` | `13d8dd5…` | v31.11.1 |
| `softprops/action-gh-release` | `3bb1273…` | v2.6.2 |
| `dtolnay/rust-toolchain` | `4360b52…` | `stable` branch, 2026-08-05 |

**One trap worth naming.** `dtolnay/rust-toolchain` publishes no semver tag, so the last row pins a branch head. With that action the *ref* selects the default toolchain, so a naive SHA pin silently changes which Rust gets installed. It is safe here only because both call sites already pass `toolchain: ${{ env.RUST_TOOLCHAIN }}` explicitly. That's recorded inline above the pin, not left for the next person to rediscover.

## Fail loud

`release.yml:562-566` was:

```yaml
attic push main result-${pkg} || echo "::warning::Failed to push ${pkg}"
```

with two more `::warning::` degradations above it — a missing `ATTIC_TOKEN`, and a failed `attic use`. Together they meant **a release could go out fully green having published nothing to the cache the fleet substitutes from.** That failure is invisible at the moment it happens and only surfaces days later as a machine compiling from source. All three now fail the job.

`nix-ci.yml` gets the same treatment with one legitimate skip preserved: a **fork PR** has no secrets, so it emits a `::notice::` and builds without pushing. A **push to main/dev** with no token is an error, not a skip — that distinction is the whole difference between a tolerable skip and a silent one.

Also moved `ATTIC_TOKEN` from argv to `env:`. An argv secret is readable from `/proc` and from any `ps` in a concurrent step.

## ONE cache: Attic

Attic is the survivor because it is the cache the repo actually **declares** — `flake.nix` `nixConfig` names the Attic substituter and nothing else, and all four workflows configure it.

Nothing is lost by dropping FlakeHub: the darwin Attic push already covers the full closure (`tcfs-cli`, `tcfs-tui`, `tcfs-mcp`, `tcfsd`, `tcfsd-app`, `tcfs-file-provider-staticlib`) — exactly what neo needs in order to substitute rather than compile. The FlakeHub leg was never proven here: a moving `@main` ref (unpinnable, and a direct contradiction of the pinning contract above), `continue-on-error: true`, and two documented hangs to the 6h ceiling with every build step skipped. Removing it also drops the `id-token: write` permission it required.

## `runs-on`: three jobs migrated, the rest deferred with reasons

**I got this wrong on the first pass and corrected it in the second commit — please read the correction rather than the first commit's rationale.**

The lane called for `release.yml` `runs-on` → a `tummycrypt-*` class. Taken *literally* that is wrong: `GloriousFlywheel scripts/validate-arc-runner-taxonomy.py` lists `tummycrypt` in `PROJECT_IDENTITY_TOKENS` and rejects any label whose first token is not `tinyland`, and `lint-runs-on` calls this exact shape a "repo-shaped / project-identity self-hosted fossil".

Taken as **intended** it is right, and already provisioned. `tummycrypt-*` is the scale-set *anchor* name; the label is `tinyland-nix`. From `Jesssullivan/jesssullivan-infra`, `tofu/stacks/arc-runners/jesssullivan.tfvars` (TIN-2538):

```hcl
tummycrypt-nix = {
  github_config_url     = "https://github.com/Jesssullivan/tummycrypt"
  runner_label          = "tinyland-nix"
  runner_scale_set_name = "tummycrypt-nix"
  max_runners           = 3
}
```

…plus a `tummycrypt-dind` twin. Same split `Jesssullivan/bulkload` already uses (`tfvars_anchor: bulkload-nix`, `runs-on: tinyland-nix`).

**And it is live, not merely declared.** `jesssullivan-infra` run [33140300433](https://github.com/Jesssullivan/jesssullivan-infra/actions/runs/33140300433) ("Deploy ARC Runners v2", success, 2026-08-28T03:55Z) logs at 04:00Z:

```
module.extra_runners["tummycrypt-nix"].helm_release.arc_runner:  Refreshing state... [id=tummycrypt-nix]
module.extra_runners["tummycrypt-dind"].helm_release.arc_runner: Refreshing state... [id=tummycrypt-dind]
```

### The probe that produced the wrong answer

```
GET /repos/Jesssullivan/tummycrypt/actions/runners -> {"total_count":0,"runners":[]}
```

That is **not** "no runners". ARC scale sets with `min_runners = 0` register *ephemeral* runners that exist only while a job is assigned, so the idle steady state is an empty list. `Jesssullivan/bulkload` returns the same empty list and has been on `tinyland-nix` for months. Read alone it supports a confident, fully wrong conclusion. **Use the tofu apply log as the liveness oracle, not the runners API.** That is written down in the ops note so the next person does not repeat it.

### Migrated (lint-runs-on: 25 → 22 FAIL)

| workflow | job | why this one first |
|---|---|---|
| `nix-ci.yml` | `flake-check` | pure `nix`; fires on every push/PR, so the anchor gets exercised now rather than at the next release |
| `nix-ci.yml` | `build-linux-x86_64` | pure `nix`; runner image *is* `actions-runner-nix` |
| `release.yml` | `nix-build` | pure `nix`, and a **leaf** — nothing `needs:` it, so a bad first run cannot take a release with it |

### Deferred, each with its blocker

| job | blocker |
|---|---|
| `release.yml` `build-binaries` | `sudo apt-get install` for fuse3/protobuf; the nix runner image is not Ubuntu |
| `release.yml` `create-release` | `sudo dpkg -i` / `sudo rpm -i` / `brew` verification steps |
| `release.yml` `build-image` | qemu + buildx; belongs on `tinyland-dind`, and multi-arch qemu inside dind is untested here |
| `release.yml` `plan`, `generate-installers`, `update-homebrew` | assume hosted-image tooling (`jq`, `gh`, `brew`) the nix image is not known to carry |

Since I cannot build or run anything on neo, moving a job whose dependencies I have not confirmed would be exactly the "long run launched on unvalidated assumptions" failure. Three jobs I can reason about completely, with a leaf as the release-lane canary, is the honest size of this step.

### No destination at all

`release.yml` `build-fileprovider` / `build-pkg` and `nix-ci.yml` `build-macos-aarch64`. ARC is Linux-on-Kubernetes; no darwin capability class exists, and these need real macOS with Xcode and notarization credentials. They stay hosted indefinitely — track separately, do not fold into the Linux flip.

### Effect on PR-b

This drops the count below PR-b's committed baseline, so PR-b's ratchet emits its "lower the baseline to N" **warning** rather than failing. That is the designed behaviour. Whichever of b/c lands second should carry the baseline update.

## Not a GF consumer-registry entry, and why

Series PR-d was specified as a GloriousFlywheel `config/consumer-registry.json` entry. It cannot be written honestly: that validator requires `build_targets` to be a non-empty list of Bazel labels beginning with `//`, and `substrate_mode ∈ {executor-backed, shared-cache-backed}`. This repo has **no Bazel wiring at all** — no `MODULE.bazel`, `BUILD.bazel`, `WORKSPACE.bazel`, `.bazelrc`, `.bazelversion` anywhere in the tree. Any entry would have to invent targets, which is precisely the internal honesty that registry exists to enforce.

GF's own `docs/build-system/enrollment.md` §6 settles it: *"Runner provisioning is outside this registry."* Runner provisioning for this repo is the owner-overlay anchor above, and it is already done. PR-d is therefore a no-op, and this PR carries the finding instead.

## Verified on neo (no Rust build — none needed)

- Both workflows parsed with Ruby stdlib YAML.
- Every `uses:` line confirmed to carry a 40-hex SHA plus a version comment (`grep -v '@[0-9a-f]\{40\} #'` → empty).
- Every pinned SHA resolved through the GitHub API from its tag, not copied.
- Embedded shell checked with `bash -n`.
- `lint-runs-on` re-run to confirm this PR changes no `runs-on` verdict: 25 FAIL, unchanged.

UNBUILT — CI proves it.
