### PR TITLE
reconcile: stat-gated freshness memo for the both-exist classifier (Lane 3 / R-D 122x)

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -330,6 +330,16 @@ enum Commands {
         /// daemon owns — so the CLI and daemon always act on the same cache.
         #[arg(long, env = "TCFS_STATE_PATH", conflicts_with = "root")]
         state: Option<PathBuf>,
+        /// Re-derive every classification from scratch: full-file BLAKE3 plus a
+        /// remote manifest read for every path present on both sides.
+        ///
+        /// Reconcile normally memoizes pairs whose full comparison already
+        /// converged, keyed on `(dev, ino, size, mtime_ns, ctime_ns)` plus the
+        /// content-addressed remote manifest hash, and re-proves each memo at
+        /// least daily. That memo is a performance mechanism, not an integrity
+        /// boundary — use `--paranoid` when you need the difference.
+        #[arg(long)]
+        paranoid: bool,
     },
 
     /// Manage per-folder sync policies
@@ -1062,6 +1072,7 @@ async fn main() -> Result<()> {
             execute,
             expect_plan,
             state,
+            paranoid,
         } => {
             cmd_reconcile(
                 &config,
@@ -1071,6 +1082,7 @@ async fn main() -> Result<()> {
                 execute,
                 expect_plan.as_deref(),
                 state.as_deref(),
+                paranoid,
             )
             .await
         }
@@ -8636,6 +8648,7 @@ async fn cmd_policy(_config: &tcfs_core::config::TcfsConfig, action: PolicyActio
 
 // ── `tcfs reconcile` ─────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 async fn cmd_reconcile(
     config: &tcfs_core::config::TcfsConfig,
     root_id: Option<&str>,
@@ -8644,6 +8657,7 @@ async fn cmd_reconcile(
     execute: bool,
     expect_plan: Option<&str>,
     state_override: Option<&Path>,
+    paranoid: bool,
 ) -> Result<()> {
     anyhow::ensure!(
         root_id.is_some() || expect_plan.is_none(),
@@ -8841,11 +8855,24 @@ async fn cmd_reconcile(
         .with_context(|| format!("opening state cache: {}", state_path.display()))?;
 
     let blacklist = tcfs_sync::blacklist::Blacklist::from_sync_config(&route_sync);
+
+    // Freshness memo sidecar, beside the state cache and therefore already
+    // covered by the state-file lock taken above. A one-shot CLI gets nothing
+    // from an in-memory memo, but it gets a great deal from a persisted one:
+    // the `--expect-plan` protocol runs this command twice over the same
+    // corpus, so the dry-run pass warms the execute pass that follows it.
+    let freshness_sidecar =
+        tcfs_sync::freshness::FreshnessCache::sidecar_path_for_state(&state_path);
+
     // Enable `.git`-aware fast-forward conflict resolution for raw git-dir sync.
     let reconcile_config = tcfs_sync::reconcile::ReconcileConfig {
         git_sync_mode: blacklist.git_sync_mode().to_string(),
         git_ff_resolution: blacklist.allows_git_dirs() && blacklist.git_sync_mode() == "raw",
         authoritative_paths,
+        paranoid,
+        freshness: Some(std::sync::Arc::new(
+            tcfs_sync::freshness::FreshnessCache::open(&freshness_sidecar),
+        )),
         ..Default::default()
     };
     let orphan_chunk_cleanup_grace =
@@ -9802,6 +9829,24 @@ mod tests {
     }
 
     #[test]
+    fn cli_parses_reconcile_paranoid_and_defaults_it_off() {
+        let default = Cli::try_parse_from(["tcfs", "reconcile", "--root", "egreg"]).unwrap();
+        assert!(matches!(
+            default.command,
+            Commands::Reconcile {
+                paranoid: false,
+                ..
+            }
+        ));
+        let paranoid =
+            Cli::try_parse_from(["tcfs", "reconcile", "--root", "egreg", "--paranoid"]).unwrap();
+        assert!(matches!(
+            paranoid.command,
+            Commands::Reconcile { paranoid: true, .. }
+        ));
+    }
+
+    #[test]
     fn cli_rejects_incomplete_or_mutating_roots_arguments() {
         for args in [
             vec!["tcfs", "roots", "status"],
@@ -9989,6 +10034,7 @@ mod tests {
                 false,
                 None,
                 Some(&state_override),
+                false,
             )
             .await
             .expect_err("explicit-state dry-run must honor the writer sidecar");
@@ -10929,9 +10975,18 @@ nats_token = ["TIN2860-malformed-left", "malformed-middle", "malformed-right"]
 
         let mut config = test_config(&sync_root);
         config.crypto.master_key_file = Some(key_path);
-        let error = cmd_reconcile(&config, None, Some(&sync_root), None, false, None, None)
-            .await
-            .expect_err("reconcile must reject before credential discovery");
+        let error = cmd_reconcile(
+            &config,
+            None,
+            Some(&sync_root),
+            None,
+            false,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect_err("reconcile must reject before credential discovery");
 
         assert!(
             error.to_string().contains("crypto.master_key_file"),

--- a/crates/tcfs-sync/src/freshness.rs
+++ b/crates/tcfs-sync/src/freshness.rs
@@ -1,0 +1,1137 @@
+//! Stat-gated freshness memo for the reconcile classifier.
+//!
+//! # Why this exists
+//!
+//! `reconcile()` classifies every path present on **both** sides through
+//! `compare_both_exist_with_context`, which unconditionally pays
+//!
+//!   * one full-file BLAKE3 (`tcfs_chunks::hash_file`), and
+//!   * one S3 GET of the remote manifest (`op.read(manifests/<hash>)`),
+//!
+//! inside a strictly sequential per-path loop. At the measured live constant of
+//! ~29 ms per both-exist path that is ~10.1 h for a single 1.26 M-file estate
+//! pass against a 300 s cadence — 122x over budget, 244x with the mandatory
+//! `--expect-plan` double pass. The classifier, not registry validation and not
+//! the status cache, is the estate blocker.
+//!
+//! # Why the obvious fast path was (correctly) refused before
+//!
+//! The engine already has a `(size, mtime-seconds)` quick check (`needs_sync`),
+//! and reconcile deliberately does **not** use it. `reconcile.rs` says why, at
+//! the push execute site: a same-second, same-size 41-byte `.git` ref rewrite
+//! (`git commit` moving a branch head) is invisible to `(size, mtime-secs)` and
+//! would be silently skipped. `SyncState.mtime` is a `u64` of **seconds**, so
+//! the state cache does not even retain the precision a sound gate needs.
+//!
+//! This module supplies the precision the state cache lacks, without touching
+//! `SyncState` — which is serialized onto the wire and must not start carrying
+//! device-local inode numbers.
+//!
+//! # What makes the gate sound
+//!
+//! `compare_both_exist_with_context` is a **pure function** of exactly:
+//!
+//!   1. the local file bytes,
+//!   2. the tracked local vector clock (`SyncState.vclock`),
+//!   3. the tracked baseline hash (`SyncState.blake3`),
+//!   4. the remote manifest **body**,
+//!   5. this device's id, and
+//!   6. the path (plus the remote prefix it is resolved against).
+//!
+//! (4) is content-addressed: the remote index entry names its manifest by
+//! `manifest_hash`, and `engine::validate_indexed_manifest_binding` refuses any
+//! manifest body that does not hash to that name. An unchanged `manifest_hash`
+//! therefore **is** an unchanged manifest body — unchanged remote vclock,
+//! unchanged remote `file_hash`, unchanged `written_by`. No GET is required to
+//! know that, and that is where the per-path S3 round trip goes.
+//!
+//! (2), (3), (5) and (6) are compared through [`InputFingerprint`], a domain-
+//! separated BLAKE3 over all of them at once.
+//!
+//! That leaves (1) as the only input we approximate. [`StatIdentity`] is the
+//! approximation: `(dev, ino, size, mtime_ns, ctime_ns)`. A record is installed
+//! **only** for a pair whose full evaluation converged on `UpToDate`, so a hit
+//! replays a decision — it never invents one.
+//!
+//! ## ctime is the load-bearing field
+//!
+//! `mtime` alone is forgeable and is routinely forged by benign tools: `cp -p`,
+//! `rsync --times`, `tar -x`, and restore utilities all rewrite content and then
+//! put mtime back. `ctime` (the inode *change* time) is kernel-maintained and
+//! has no portable API that sets it: `utimensat`/`futimens` set atime/mtime and
+//! **bump** ctime as a side effect. A same-size in-place rewrite with a forged
+//! mtime therefore still moves ctime — that is the property test in this module,
+//! asserted both on synthetic identities and on a real file via `utimensat`.
+//!
+//! ### darwin caveat (R-C / J1)
+//!
+//! macOS is the one platform with an API that can move ctime directly:
+//! `setattrlist(2)` with `ATTR_CMN_CHGTIME`. The live R-C/J1 probe found ctime
+//! *resists* there in practice — the write that follows re-bumps it — but the
+//! honest statement is narrower: **this gate is a performance memo against
+//! benign staleness, not an integrity boundary.** Anyone able to call
+//! `setattrlist` on the file already has write access to it and could simply
+//! leave the file alone instead. Two independent brakes bound the exposure:
+//!
+//!   * `ino` moves under the write-temp-then-rename pattern that essentially
+//!     every metadata-restoring tool uses, and
+//!   * every record carries a **jittered TTL** (default 24 h, phase derived from
+//!     the path so a 1.26 M-record corpus does not expire in one cycle), so any
+//!     forged record is re-proved by full hash within a day.
+//!
+//! `--paranoid` disables the memo entirely and restores unconditional
+//! re-hashing; that is the integrity answer.
+//!
+//! # Plan-hash neutrality
+//!
+//! `ReconcilePlan::sha256` hashes actions only, and an `UpToDate` action
+//! contributes exactly `path` and `kind="up-to-date"`. A memoized `UpToDate` is
+//! byte-identical to a computed one, so the fast path **cannot** move the plan
+//! SHA-256 and the `--expect-plan` dry-run/execute protocol is unaffected. The
+//! persisted sidecar additionally lets the execute pass reuse the dry-run pass's
+//! work, which is where the 2x `--expect-plan` cost goes.
+//!
+//! # Invalidation is structural
+//!
+//! Nothing needs to explicitly evict after an execute: every mutation moves at
+//! least one compared input.
+//!
+//!   * a **pull** rewrites the local file (stat moves) and the tracked baseline;
+//!   * a **push** publishes a new manifest, so `manifest_hash` moves;
+//!   * a **local delete** removes the path from the both-exist arm entirely;
+//!   * a **state-cache rollback** (recovery from backup) moves `blake3` or
+//!     `vclock`, which is still a mismatch and still a miss.
+//!
+//! A stale record can therefore only ever cause a *miss* — a wasted full
+//! evaluation — never a wrong skip.
+//!
+//! # Memory
+//!
+//! The estate is 1.26 M files, so a record that stores its inputs verbatim
+//! (two hex hashes, a prefix, a device id, a `BTreeMap` vector clock) costs
+//! roughly 670 B and the whole memo would be ~845 MB on a laptop. It is not
+//! stored that way. A record never needs to *reproduce* its inputs, only to
+//! answer "are they all still identical", so everything except the stat is
+//! folded into a 16-byte fingerprint and the key is a 16-byte fingerprint of the
+//! canonical path:
+//!
+//! | field | bytes |
+//! |---|---|
+//! | key ([`PathFingerprint`]) | 16 |
+//! | [`StatIdentity`] | 56 |
+//! | [`InputFingerprint`] | 16 |
+//! | `verified_at` | 8 |
+//!
+//! ~96 B of payload, ~135 B/record including hash-table overhead: **~170 MB at
+//! the full 1.26 M**, and [`FreshnessCache::with_max_entries`] caps it above
+//! that. A key collision is harmless by construction: the path is folded into
+//! the input fingerprint, so a collided lookup fails the fingerprint check and
+//! degrades to a miss.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tracing::{debug, warn};
+
+use crate::conflict::VectorClock;
+
+/// On-disk schema tag. A sidecar written by a different schema is discarded
+/// rather than migrated: this is a pure cache, so throwing it away costs one
+/// slow cycle and nothing else.
+const FRESHNESS_SCHEMA: &str = "tcfs-freshness-v1";
+
+/// Default maximum age of a memoized verdict before it is re-proved by full
+/// hash plus manifest read. At a 300 s cadence this re-verifies each path about
+/// once per 288 cycles — roughly 0.35 % of the unoptimized pass.
+pub const DEFAULT_MAX_AGE_SECS: u64 = 24 * 60 * 60;
+
+/// Default cap on memoized paths, chosen so a full-estate memo stays under
+/// ~170 MB resident. Past the cap the memo stops installing new records; it
+/// never evicts a record it might still replay.
+pub const DEFAULT_MAX_ENTRIES: usize = 1_000_000;
+
+/// Wall-clock seconds, used only for the memo's re-verification TTL. Never a
+/// correctness input: a clock that moves can only cause misses.
+pub fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn hex16(bytes: &[u8; 16]) -> String {
+    let mut out = String::with_capacity(32);
+    for byte in bytes {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn unhex16(text: &str) -> Option<[u8; 16]> {
+    if text.len() != 32 {
+        return None;
+    }
+    let mut out = [0u8; 16];
+    for (index, slot) in out.iter_mut().enumerate() {
+        *slot = u8::from_str_radix(text.get(index * 2..index * 2 + 2)?, 16).ok()?;
+    }
+    Some(out)
+}
+
+macro_rules! hex_fingerprint {
+    ($name:ident, $domain:literal, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        pub struct $name([u8; 16]);
+
+        impl Serialize for $name {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.serialize_str(&hex16(&self.0))
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let text = String::deserialize(deserializer)?;
+                unhex16(&text)
+                    .map($name)
+                    .ok_or_else(|| D::Error::custom("expected 32 hex characters"))
+            }
+        }
+
+        impl $name {
+            /// Domain-separated 128-bit truncation of a BLAKE3 digest.
+            fn from_hasher(hasher: blake3::Hasher) -> Self {
+                let digest = hasher.finalize();
+                let mut out = [0u8; 16];
+                out.copy_from_slice(&digest.as_bytes()[..16]);
+                Self(out)
+            }
+
+            fn hasher() -> blake3::Hasher {
+                let mut hasher = blake3::Hasher::new();
+                field(&mut hasher, "domain", $domain.as_bytes());
+                hasher
+            }
+        }
+    };
+}
+
+/// Length-prefixed field mixing, so no two distinct input tuples can produce the
+/// same byte stream by concatenation.
+fn field(hasher: &mut blake3::Hasher, tag: &str, value: &[u8]) {
+    hasher.update(&(tag.len() as u32).to_be_bytes());
+    hasher.update(tag.as_bytes());
+    hasher.update(&(value.len() as u64).to_be_bytes());
+    hasher.update(value);
+}
+
+fn text_field(hasher: &mut blake3::Hasher, tag: &str, value: &str) {
+    field(hasher, tag, value.as_bytes());
+}
+
+fn number_field(hasher: &mut blake3::Hasher, tag: &str, value: u64) {
+    field(hasher, tag, &value.to_be_bytes());
+}
+
+hex_fingerprint!(
+    PathFingerprint,
+    "dev.tinyland.tcfs.freshness.path.v1",
+    "Cache key: a 128-bit fingerprint of a canonical absolute local path.\n\nA collision is harmless — the path is also folded into\n[`InputFingerprint`], so a collided lookup fails the input check and\ndegrades to an ordinary miss."
+);
+
+hex_fingerprint!(
+    InputFingerprint,
+    "dev.tinyland.tcfs.freshness.inputs.v1",
+    "Every classifier input except the local file bytes, folded into 128 bits.\n\nStored instead of the inputs themselves so the whole-estate memo fits in\nmemory; a record never needs to reproduce its inputs, only to detect that\nthey moved."
+);
+
+impl PathFingerprint {
+    /// Fingerprint a canonical state-cache key (see `state::canonical_path_key`).
+    pub fn of(canonical_key: &str) -> Self {
+        let mut hasher = Self::hasher();
+        text_field(&mut hasher, "path", canonical_key);
+        Self::from_hasher(hasher)
+    }
+}
+
+/// Everything the gate compares, other than the local stat identity.
+///
+/// Built fresh from the live cycle on lookup, and from the proved evaluation on
+/// install. The two must agree exactly.
+pub struct FreshnessInputs<'a> {
+    /// Canonical absolute local path — pins the record to one file, and makes a
+    /// [`PathFingerprint`] collision a miss rather than a wrong hit.
+    pub canonical_key: &'a str,
+    /// Relative path as the classifier saw it.
+    pub rel_path: &'a str,
+    /// Remote prefix this verdict was proved against, so two roots overlapping
+    /// on one absolute path cannot serve each other's verdicts.
+    pub remote_prefix: &'a str,
+    /// `SyncState.blake3` — classifier input (3). An `UpToDate` verdict can only
+    /// be proved when the local bytes hash to exactly this, so this doubles as
+    /// the content identity the memo vouches for.
+    pub tracked_blake3: &'a str,
+    /// `SyncState.vclock` — classifier input (2).
+    pub tracked_vclock: &'a VectorClock,
+    /// The remote index entry's content-addressed manifest name — input (4).
+    pub remote_manifest_hash: &'a str,
+    /// The remote index entry's declared size.
+    pub remote_size: u64,
+    /// This device's id — classifier input (5).
+    pub device_id: &'a str,
+}
+
+impl InputFingerprint {
+    pub fn of(inputs: &FreshnessInputs<'_>) -> Self {
+        let mut hasher = Self::hasher();
+        text_field(&mut hasher, "path", inputs.canonical_key);
+        text_field(&mut hasher, "rel-path", inputs.rel_path);
+        text_field(&mut hasher, "remote-prefix", inputs.remote_prefix);
+        text_field(&mut hasher, "tracked-blake3", inputs.tracked_blake3);
+        text_field(&mut hasher, "remote-manifest", inputs.remote_manifest_hash);
+        number_field(&mut hasher, "remote-size", inputs.remote_size);
+        text_field(&mut hasher, "device", inputs.device_id);
+        number_field(
+            &mut hasher,
+            "vclock.len",
+            inputs.tracked_vclock.clocks.len() as u64,
+        );
+        for (device, tick) in &inputs.tracked_vclock.clocks {
+            text_field(&mut hasher, "vclock.device", device);
+            number_field(&mut hasher, "vclock.tick", *tick);
+        }
+        Self::from_hasher(hasher)
+    }
+}
+
+/// The local-side identity a freshness verdict is bound to.
+///
+/// Nanosecond mtime **and** ctime are both retained on purpose — see the module
+/// docs. `size` is included even though it is implied by the content, because it
+/// is the cheapest possible early-out and the one a future refactor is most
+/// likely to weaken by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StatIdentity {
+    pub dev: u64,
+    pub ino: u64,
+    pub size: u64,
+    pub mtime_sec: i64,
+    pub mtime_nsec: i64,
+    pub ctime_sec: i64,
+    pub ctime_nsec: i64,
+}
+
+impl StatIdentity {
+    /// Whole-nanosecond ctime, for ordering assertions and diagnostics.
+    pub fn ctime_ns(&self) -> i128 {
+        i128::from(self.ctime_sec) * 1_000_000_000 + i128::from(self.ctime_nsec)
+    }
+
+    /// Whole-nanosecond mtime, for ordering assertions and diagnostics.
+    pub fn mtime_ns(&self) -> i128 {
+        i128::from(self.mtime_sec) * 1_000_000_000 + i128::from(self.mtime_nsec)
+    }
+}
+
+/// Capture the stat identity of a **regular file**.
+///
+/// `None` for anything that is not a regular file — symlinks and directories are
+/// classified by other arms and must never take this path — and on any platform
+/// without POSIX inode metadata. Both are fail-closed: no identity, no fast path.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub fn stat_identity(metadata: &std::fs::Metadata) -> Option<StatIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return None;
+    }
+    Some(StatIdentity {
+        dev: metadata.dev(),
+        ino: metadata.ino(),
+        size: metadata.len(),
+        mtime_sec: metadata.mtime(),
+        mtime_nsec: metadata.mtime_nsec(),
+        ctime_sec: metadata.ctime(),
+        ctime_nsec: metadata.ctime_nsec(),
+    })
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn stat_identity(_metadata: &std::fs::Metadata) -> Option<StatIdentity> {
+    None
+}
+
+/// One memoized `UpToDate` verdict. Plain old data, 80 bytes, no heap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FreshnessRecord {
+    /// Local identity at the moment the verdict was proved.
+    pub stat: StatIdentity,
+    /// Every other classifier input at the moment the verdict was proved.
+    pub inputs: InputFingerprint,
+    /// Unix seconds at proof time, for the jittered TTL.
+    pub verified_at: u64,
+}
+
+/// The complete, closed condition under which a memoized `UpToDate` verdict may
+/// be replayed.
+///
+/// Deliberately a free function over plain data: it is the safety-critical
+/// predicate and it is unit-testable with no filesystem, no `Operator`, and no
+/// tokio runtime.
+pub fn memo_still_holds(
+    record: &FreshnessRecord,
+    stat: StatIdentity,
+    inputs: InputFingerprint,
+    now: u64,
+) -> bool {
+    // The local bytes, approximated by the full stat identity. `ctime` is what
+    // makes this hold against a forged mtime.
+    if record.stat != stat {
+        return false;
+    }
+    // Cheapest independent early-out, kept explicit so a refactor of
+    // `StatIdentity`'s `PartialEq` cannot silently drop it.
+    if record.stat.size != stat.size {
+        return false;
+    }
+    // Every other classifier input.
+    if record.inputs != inputs {
+        return false;
+    }
+    // A record from the future is a clock-step artifact; refuse it rather than
+    // let it outlive its TTL by the size of the step.
+    if record.verified_at > now {
+        return false;
+    }
+    true
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    entries: HashMap<PathFingerprint, FreshnessRecord>,
+    /// Keys this cycle actually classified, so `retain_touched` can drop records
+    /// for paths that have left the corpus without the caller paying a second
+    /// canonicalization pass over the whole corpus just to build a live set.
+    touched: HashSet<PathFingerprint>,
+    dirty: bool,
+    hits: u64,
+    misses: u64,
+    /// Installs refused because the entry cap was reached.
+    capped: u64,
+}
+
+/// Hit/miss counters for one process lifetime.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FreshnessStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub capped: u64,
+    pub entries: usize,
+}
+
+/// A pure cache of converged `UpToDate` verdicts.
+///
+/// Interior mutability is deliberate: `reconcile()` holds `&ReconcileConfig`
+/// throughout planning and must not be forced to `&mut`. Nothing here is
+/// authority for anything — every method may lose its data at any moment and the
+/// only consequence is a slow cycle.
+#[derive(Debug)]
+pub struct FreshnessCache {
+    /// Sidecar JSON path. `None` keeps the cache purely in-memory, which is all
+    /// a long-lived daemon needs.
+    path: Option<PathBuf>,
+    /// Records older than this (plus a per-path jitter) are re-proved.
+    max_age_secs: u64,
+    /// Hard bound on resident records.
+    max_entries: usize,
+    inner: RwLock<Inner>,
+}
+
+impl FreshnessCache {
+    /// In-memory only — the right shape for the daemon's reconcile loop, which
+    /// keeps the memo warm across cycles inside one process.
+    pub fn in_memory() -> Self {
+        Self {
+            path: None,
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
+            max_entries: DEFAULT_MAX_ENTRIES,
+            inner: RwLock::new(Inner::default()),
+        }
+    }
+
+    /// Open (or start empty at) a JSON sidecar.
+    ///
+    /// Never fails. A missing, unreadable, truncated, or schema-mismatched
+    /// sidecar yields an empty cache: this is a cache, and the fallback is
+    /// exactly today's behavior.
+    pub fn open(path: &Path) -> Self {
+        let entries = match std::fs::read(path) {
+            Ok(bytes) => match serde_json::from_slice::<OnDisk>(&bytes) {
+                Ok(disk) if disk.schema == FRESHNESS_SCHEMA => disk.entries,
+                Ok(disk) => {
+                    debug!(
+                        path = %path.display(),
+                        found = %disk.schema,
+                        expected = FRESHNESS_SCHEMA,
+                        "freshness sidecar schema mismatch; starting empty"
+                    );
+                    HashMap::new()
+                }
+                Err(error) => {
+                    debug!(
+                        path = %path.display(),
+                        error = %error,
+                        "freshness sidecar is unreadable; starting empty"
+                    );
+                    HashMap::new()
+                }
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(error) => {
+                debug!(
+                    path = %path.display(),
+                    error = %error,
+                    "freshness sidecar could not be read; starting empty"
+                );
+                HashMap::new()
+            }
+        };
+        Self {
+            path: Some(path.to_path_buf()),
+            max_age_secs: DEFAULT_MAX_AGE_SECS,
+            max_entries: DEFAULT_MAX_ENTRIES,
+            inner: RwLock::new(Inner {
+                entries,
+                ..Inner::default()
+            }),
+        }
+    }
+
+    /// Override the re-verification interval. `0` expires every record
+    /// immediately, which is a second way to spell `--paranoid`.
+    pub fn with_max_age_secs(mut self, max_age_secs: u64) -> Self {
+        self.max_age_secs = max_age_secs;
+        self
+    }
+
+    /// Override the resident-record cap.
+    pub fn with_max_entries(mut self, max_entries: usize) -> Self {
+        self.max_entries = max_entries;
+        self
+    }
+
+    /// Sidecar path for a state-cache path: `state.json` -> `state.freshness.json`.
+    ///
+    /// Placing it beside the state cache means the existing `StateFileLock` /
+    /// `lock_explicit_state_cache` serialization already covers it.
+    pub fn sidecar_path_for_state(state_path: &Path) -> PathBuf {
+        let mut file_name = state_path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "state".to_string());
+        file_name.push_str(".freshness.json");
+        state_path.with_file_name(file_name)
+    }
+
+    /// Per-path expiry phase, so a corpus installed in one cycle does not expire
+    /// in one cycle. Uniform over `[max_age/2, max_age)`.
+    fn ttl_secs_for(&self, key: PathFingerprint) -> u64 {
+        if self.max_age_secs == 0 {
+            return 0;
+        }
+        let half = (self.max_age_secs / 2).max(1);
+        let raw = u64::from_le_bytes([
+            key.0[0], key.0[1], key.0[2], key.0[3], key.0[4], key.0[5], key.0[6], key.0[7],
+        ]);
+        half + (raw % half)
+    }
+
+    fn read_inner(&self) -> std::sync::RwLockReadGuard<'_, Inner> {
+        self.inner
+            .read()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn write_inner(&self) -> std::sync::RwLockWriteGuard<'_, Inner> {
+        self.inner
+            .write()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    /// Look up a record, applying the jittered TTL. Returns a copy so the lock
+    /// is not held across the caller's comparison.
+    pub fn lookup(&self, key: PathFingerprint, now: u64) -> Option<FreshnessRecord> {
+        let ttl = self.ttl_secs_for(key);
+        let inner = self.read_inner();
+        let record = inner.entries.get(&key)?;
+        if now.saturating_sub(record.verified_at) >= ttl {
+            return None;
+        }
+        Some(*record)
+    }
+
+    /// Install a proved verdict, unless the cap is already reached.
+    ///
+    /// Refreshing a key that is already present is always allowed — it does not
+    /// grow the map, and refusing it would strand a hot path at a stale TTL.
+    pub fn record(&self, key: PathFingerprint, record: FreshnessRecord) {
+        let mut inner = self.write_inner();
+        if inner.entries.len() >= self.max_entries && !inner.entries.contains_key(&key) {
+            inner.capped += 1;
+            return;
+        }
+        inner.entries.insert(key, record);
+        inner.dirty = true;
+    }
+
+    /// Drop a record. Not required for correctness (see the module docs on
+    /// structural invalidation) — available for callers that want to be explicit.
+    pub fn invalidate(&self, key: PathFingerprint) {
+        let mut inner = self.write_inner();
+        if inner.entries.remove(&key).is_some() {
+            inner.dirty = true;
+        }
+    }
+
+    /// Record a replayed verdict for `key`, and mark the key live for this
+    /// cycle's GC.
+    pub fn note_hit(&self, key: PathFingerprint) {
+        let mut inner = self.write_inner();
+        inner.hits += 1;
+        inner.touched.insert(key);
+    }
+
+    /// Record a fallthrough to the full comparison for `key`, and mark the key
+    /// live for this cycle's GC. A miss is still a live path.
+    pub fn note_miss(&self, key: PathFingerprint) {
+        let mut inner = self.write_inner();
+        inner.misses += 1;
+        inner.touched.insert(key);
+    }
+
+    pub fn stats(&self) -> FreshnessStats {
+        let inner = self.read_inner();
+        FreshnessStats {
+            hits: inner.hits,
+            misses: inner.misses,
+            capped: inner.capped,
+            entries: inner.entries.len(),
+        }
+    }
+
+    /// Drop records for every key this cycle did not classify, then start a
+    /// fresh cycle. Call once per reconcile pass, after planning.
+    ///
+    /// Keeps the memo bounded by the live corpus rather than by history, at the
+    /// cost of nothing: the touch set is populated by the lookups the classifier
+    /// was already doing.
+    pub fn retain_touched(&self) {
+        let mut inner = self.write_inner();
+        let touched = std::mem::take(&mut inner.touched);
+        let before = inner.entries.len();
+        inner.entries.retain(|key, _| touched.contains(key));
+        if inner.entries.len() != before {
+            inner.dirty = true;
+        }
+    }
+
+    /// Best-effort durable write. A failure is logged and swallowed: losing the
+    /// sidecar costs one slow cycle, and failing the reconcile over a cache
+    /// would be a far worse trade.
+    pub fn flush_best_effort(&self) {
+        let Some(path) = self.path.as_ref() else {
+            return;
+        };
+        let snapshot = {
+            let mut inner = self.write_inner();
+            if !inner.dirty {
+                return;
+            }
+            inner.dirty = false;
+            inner.entries.clone()
+        };
+        let disk = OnDisk {
+            schema: FRESHNESS_SCHEMA.to_string(),
+            entries: snapshot,
+        };
+        if let Err(error) = write_json_atomic(path, &disk) {
+            warn!(
+                path = %path.display(),
+                error = %error,
+                "could not persist the reconcile freshness sidecar; the next run re-proves every path"
+            );
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct OnDisk {
+    schema: String,
+    entries: HashMap<PathFingerprint, FreshnessRecord>,
+}
+
+fn write_json_atomic(path: &Path, disk: &OnDisk) -> anyhow::Result<()> {
+    use std::io::Write as _;
+
+    let bytes = serde_json::to_vec(disk)?;
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(dir)?;
+    let mut temp = tempfile::NamedTempFile::new_in(dir)?;
+    temp.write_all(&bytes)?;
+    temp.flush()?;
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        temp.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    temp.as_file().sync_all()?;
+    temp.persist(path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(size: u64, mtime: (i64, i64), ctime: (i64, i64)) -> StatIdentity {
+        StatIdentity {
+            dev: 1,
+            ino: 42,
+            size,
+            mtime_sec: mtime.0,
+            mtime_nsec: mtime.1,
+            ctime_sec: ctime.0,
+            ctime_nsec: ctime.1,
+        }
+    }
+
+    fn baseline_inputs(clock: &VectorClock) -> FreshnessInputs<'_> {
+        FreshnessInputs {
+            canonical_key: "/estate/doc.txt",
+            rel_path: "doc.txt",
+            remote_prefix: "data",
+            tracked_blake3: "aaaa",
+            tracked_vclock: clock,
+            remote_manifest_hash: "mmmm",
+            remote_size: 41,
+            device_id: "neo",
+        }
+    }
+
+    fn record_for(stat: StatIdentity, inputs: &FreshnessInputs<'_>) -> FreshnessRecord {
+        FreshnessRecord {
+            stat,
+            inputs: InputFingerprint::of(inputs),
+            verified_at: 1_000,
+        }
+    }
+
+    #[test]
+    fn unchanged_pair_replays_the_memo() {
+        let stat = identity(41, (100, 5), (100, 5));
+        let clock = VectorClock::default();
+        let inputs = baseline_inputs(&clock);
+        assert!(memo_still_holds(
+            &record_for(stat, &inputs),
+            stat,
+            InputFingerprint::of(&inputs),
+            1_001
+        ));
+    }
+
+    /// THE property. A same-size in-place rewrite with the mtime forged back to
+    /// its old value is exactly the `(size, mtime-seconds)` blind spot reconcile
+    /// documents at its push execute site — a 41-byte `git commit` ref rewrite.
+    /// ctime is what catches it, so the gate must refuse the memo.
+    #[test]
+    fn forged_mtime_same_size_is_not_skipped_because_ctime_moved() {
+        let before = identity(41, (100, 5), (100, 5));
+        // Content rewritten, size identical, mtime restored byte-for-byte.
+        let after = identity(41, (100, 5), (100, 9));
+        assert_eq!(before.size, after.size);
+        assert_eq!(before.mtime_ns(), after.mtime_ns());
+        assert!(after.ctime_ns() > before.ctime_ns());
+
+        let clock = VectorClock::default();
+        let inputs = baseline_inputs(&clock);
+        assert!(!memo_still_holds(
+            &record_for(before, &inputs),
+            after,
+            InputFingerprint::of(&inputs),
+            1_001
+        ));
+    }
+
+    /// Same second, same size, same nanosecond mtime — the exact shape the
+    /// engine's `needs_sync` quick check is blind to.
+    #[test]
+    fn same_second_same_size_rewrite_is_not_skipped() {
+        let before = identity(41, (1_700_000_000, 0), (1_700_000_000, 0));
+        let after = identity(41, (1_700_000_000, 0), (1_700_000_000, 1));
+        let clock = VectorClock::default();
+        let inputs = baseline_inputs(&clock);
+        assert!(!memo_still_holds(
+            &record_for(before, &inputs),
+            after,
+            InputFingerprint::of(&inputs),
+            1_001
+        ));
+    }
+
+    /// A rewrite-via-rename gets a new inode even if every timestamp is
+    /// restored — the second brake named in the module docs.
+    #[test]
+    fn rename_replacement_is_not_skipped_even_with_every_timestamp_forged() {
+        let before = identity(41, (100, 5), (100, 5));
+        let mut after = before;
+        after.ino = 43;
+        let clock = VectorClock::default();
+        let inputs = baseline_inputs(&clock);
+        assert!(!memo_still_holds(
+            &record_for(before, &inputs),
+            after,
+            InputFingerprint::of(&inputs),
+            1_001
+        ));
+    }
+
+    /// A file that moved to another filesystem with everything else identical.
+    #[test]
+    fn different_device_number_is_not_skipped() {
+        let before = identity(41, (100, 5), (100, 5));
+        let mut after = before;
+        after.dev = 2;
+        let clock = VectorClock::default();
+        let inputs = baseline_inputs(&clock);
+        assert!(!memo_still_holds(
+            &record_for(before, &inputs),
+            after,
+            InputFingerprint::of(&inputs),
+            1_001
+        ));
+    }
+
+    /// Every non-stat classifier input must be covered by the fingerprint:
+    /// changing any one of them alone must break the memo. This is the test that
+    /// keeps the compact representation honest — a field dropped from
+    /// `InputFingerprint::of` fails here immediately.
+    #[test]
+    fn every_classifier_input_is_covered_by_the_fingerprint() {
+        let stat = identity(41, (100, 5), (100, 5));
+        let clock = VectorClock::default();
+        let baseline = baseline_inputs(&clock);
+        let record = record_for(stat, &baseline);
+
+        let mut ticked = VectorClock::default();
+        ticked.tick("neo");
+
+        let mutations: Vec<(&str, FreshnessInputs<'_>)> = vec![
+            (
+                "canonical_key",
+                FreshnessInputs {
+                    canonical_key: "/estate/other.txt",
+                    ..baseline_inputs(&clock)
+                },
+            ),
+            (
+                "rel_path",
+                FreshnessInputs {
+                    rel_path: "other.txt",
+                    ..baseline_inputs(&clock)
+                },
+            ),
+            (
+                "remote_prefix",
+                FreshnessInputs {
+                    remote_prefix: "other-root",
+                    ..baseline_inputs(&clock)
+                },
+            ),
+            (
+                "tracked_blake3",
+                FreshnessInputs {
+                    tracked_blake3: "bbbb",
+                    ..baseline_inputs(&clock)
+                },
+            ),
+            (
+                "tracked_vclock",
+                FreshnessInputs {
+                    tracked_vclock: &ticked,
+                    ..baseline_inputs(&clock)
+                },
+            ),
+            (
+                "remote_manifest_hash",
+                FreshnessInputs {
+                    remote_manifest_hash: "nnnn",
+                    ..baseline_inputs(&clock)
+                },
+            ),
+            (
+                "remote_size",
+                FreshnessInputs {
+                    remote_size: 42,
+                    ..baseline_inputs(&clock)
+                },
+            ),
+            (
+                "device_id",
+                FreshnessInputs {
+                    device_id: "honey",
+                    ..baseline_inputs(&clock)
+                },
+            ),
+        ];
+
+        for (name, mutated) in mutations {
+            assert!(
+                !memo_still_holds(&record, stat, InputFingerprint::of(&mutated), 1_001),
+                "changing `{name}` must break the memo"
+            );
+        }
+    }
+
+    /// Length-prefixed field mixing: two different splits of the same
+    /// concatenated bytes must not collide.
+    #[test]
+    fn fingerprint_fields_are_length_delimited() {
+        let clock = VectorClock::default();
+        let left = InputFingerprint::of(&FreshnessInputs {
+            tracked_blake3: "ab",
+            remote_manifest_hash: "cd",
+            ..baseline_inputs(&clock)
+        });
+        let right = InputFingerprint::of(&FreshnessInputs {
+            tracked_blake3: "a",
+            remote_manifest_hash: "bcd",
+            ..baseline_inputs(&clock)
+        });
+        assert_ne!(left, right);
+    }
+
+    #[test]
+    fn record_from_the_future_is_not_skipped() {
+        let stat = identity(41, (100, 5), (100, 5));
+        let clock = VectorClock::default();
+        let inputs = baseline_inputs(&clock);
+        let mut record = record_for(stat, &inputs);
+        record.verified_at = 5_000;
+        assert!(!memo_still_holds(
+            &record,
+            stat,
+            InputFingerprint::of(&inputs),
+            1_001
+        ));
+    }
+
+    #[test]
+    fn ttl_expiry_forces_a_full_re_proof() {
+        let cache = FreshnessCache::in_memory().with_max_age_secs(1_000);
+        let key = PathFingerprint::of("/estate/doc.txt");
+        let clock = VectorClock::default();
+        let stat = identity(41, (100, 5), (100, 5));
+        cache.record(key, record_for(stat, &baseline_inputs(&clock)));
+        // Inside the minimum half-window every record is still live.
+        assert!(cache.lookup(key, 1_000 + 499).is_some());
+        // Past the maximum window no record survives.
+        assert!(cache.lookup(key, 1_000 + 1_000).is_none());
+    }
+
+    #[test]
+    fn ttl_jitter_spreads_expiry_across_the_window() {
+        let cache = FreshnessCache::in_memory().with_max_age_secs(1_000);
+        let mut seen = HashSet::new();
+        for index in 0..64 {
+            seen.insert(cache.ttl_secs_for(PathFingerprint::of(&format!("/estate/path/{index}"))));
+        }
+        // A constant TTL would collapse 64 paths into one expiry cycle.
+        assert!(seen.len() > 8, "expiry phases collapsed: {seen:?}");
+        assert!(seen.iter().all(|ttl| (500u64..1_000u64).contains(ttl)));
+    }
+
+    #[test]
+    fn zero_max_age_disables_the_memo_entirely() {
+        let cache = FreshnessCache::in_memory().with_max_age_secs(0);
+        let key = PathFingerprint::of("/estate/doc.txt");
+        let clock = VectorClock::default();
+        cache.record(
+            key,
+            record_for(identity(41, (100, 5), (100, 5)), &baseline_inputs(&clock)),
+        );
+        assert!(cache.lookup(key, 1_000).is_none());
+    }
+
+    #[test]
+    fn retain_touched_drops_paths_that_left_the_corpus() {
+        let cache = FreshnessCache::in_memory();
+        let clock = VectorClock::default();
+        let stat = identity(41, (100, 5), (100, 5));
+        let live = PathFingerprint::of("/estate/a");
+        let gone = PathFingerprint::of("/estate/b");
+        cache.record(live, record_for(stat, &baseline_inputs(&clock)));
+        cache.record(gone, record_for(stat, &baseline_inputs(&clock)));
+        // Only `/estate/a` was classified this cycle; a miss counts as live.
+        cache.note_miss(live);
+        cache.retain_touched();
+        assert_eq!(cache.stats().entries, 1);
+        assert!(cache.lookup(live, 1_000).is_some());
+        assert!(cache.lookup(gone, 1_000).is_none());
+        // The touch set resets, so a cycle that classifies nothing empties it.
+        cache.retain_touched();
+        assert_eq!(cache.stats().entries, 0);
+    }
+
+    #[test]
+    fn entry_cap_stops_growth_but_still_refreshes_known_paths() {
+        let cache = FreshnessCache::in_memory().with_max_entries(1);
+        let clock = VectorClock::default();
+        let stat = identity(41, (100, 5), (100, 5));
+        let first = PathFingerprint::of("/estate/a");
+        let second = PathFingerprint::of("/estate/b");
+
+        cache.record(first, record_for(stat, &baseline_inputs(&clock)));
+        cache.record(second, record_for(stat, &baseline_inputs(&clock)));
+        assert_eq!(cache.stats().entries, 1);
+        assert_eq!(cache.stats().capped, 1);
+        assert!(cache.lookup(second, 1_001).is_none());
+
+        // Refreshing a resident key is not growth, so it is always allowed.
+        let mut refreshed = record_for(stat, &baseline_inputs(&clock));
+        refreshed.verified_at = 2_000;
+        cache.record(first, refreshed);
+        assert_eq!(cache.lookup(first, 2_001).unwrap().verified_at, 2_000);
+        assert_eq!(cache.stats().capped, 1);
+    }
+
+    #[test]
+    fn sidecar_round_trips_and_ignores_a_foreign_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let sidecar = FreshnessCache::sidecar_path_for_state(&dir.path().join("state.json"));
+        assert_eq!(sidecar.file_name().unwrap(), "state.freshness.json");
+
+        let clock = VectorClock::default();
+        let key = PathFingerprint::of("/estate/doc.txt");
+        {
+            let cache = FreshnessCache::open(&sidecar);
+            cache.record(
+                key,
+                record_for(identity(41, (100, 5), (100, 5)), &baseline_inputs(&clock)),
+            );
+            cache.flush_best_effort();
+        }
+        let reopened = FreshnessCache::open(&sidecar);
+        assert!(reopened.lookup(key, 1_001).is_some());
+
+        std::fs::write(&sidecar, br#"{"schema":"tcfs-freshness-v0","entries":{}}"#).unwrap();
+        assert_eq!(FreshnessCache::open(&sidecar).stats().entries, 0);
+
+        std::fs::write(&sidecar, b"not json at all").unwrap();
+        assert_eq!(FreshnessCache::open(&sidecar).stats().entries, 0);
+    }
+
+    #[test]
+    fn missing_sidecar_opens_empty_rather_than_failing() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FreshnessCache::open(&dir.path().join("absent.freshness.json"));
+        assert_eq!(cache.stats().entries, 0);
+    }
+
+    #[test]
+    fn fingerprint_hex_round_trips() {
+        let key = PathFingerprint::of("/estate/doc.txt");
+        let text = serde_json::to_string(&key).unwrap();
+        assert_eq!(text.len(), 34, "32 hex characters plus quotes: {text}");
+        assert_eq!(serde_json::from_str::<PathFingerprint>(&text).unwrap(), key);
+        assert!(serde_json::from_str::<PathFingerprint>("\"zz\"").is_err());
+    }
+
+    /// End-to-end on a real file: rewrite the content in place at the same
+    /// length, then forge mtime back with `utimensat`. The kernel bumps ctime for
+    /// the forge itself, so the identity must differ and the memo must not hold.
+    /// This is the live counterpart of
+    /// `forged_mtime_same_size_is_not_skipped_because_ctime_moved`.
+    ///
+    /// A failure here is real information, not flake: it would mean the
+    /// filesystem under the test cannot distinguish a rewrite from a forgery,
+    /// and the memo is genuinely unsafe there. Both filesystems this ships on
+    /// (APFS, ext4 with 256-byte inodes) carry nanosecond ctime.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn live_forged_mtime_rewrite_still_moves_ctime() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ref-head");
+        // 41 bytes: the exact shape of a `.git` branch-head ref.
+        std::fs::write(&path, vec![b'a'; 41]).unwrap();
+        let before = stat_identity(&std::fs::symlink_metadata(&path).unwrap()).unwrap();
+
+        std::fs::write(&path, vec![b'b'; 41]).unwrap();
+
+        // Forge mtime back to its pre-rewrite value, atime untouched.
+        let times = [
+            libc::timespec {
+                tv_sec: 0,
+                tv_nsec: libc::UTIME_OMIT as _,
+            },
+            libc::timespec {
+                tv_sec: before.mtime_sec as libc::time_t,
+                tv_nsec: before.mtime_nsec as _,
+            },
+        ];
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: `c_path` is a NUL-terminated path that outlives the call and
+        // `times` is the two-element `timespec` array utimensat expects.
+        let rc = unsafe {
+            libc::utimensat(
+                libc::AT_FDCWD,
+                c_path.as_ptr(),
+                times.as_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        assert_eq!(
+            rc,
+            0,
+            "utimensat failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let after = stat_identity(&std::fs::symlink_metadata(&path).unwrap()).unwrap();
+
+        // The forgery succeeded on exactly the fields a naive gate would trust.
+        assert_eq!(after.size, before.size, "size must be unchanged");
+        assert_eq!(
+            after.mtime_ns(),
+            before.mtime_ns(),
+            "mtime must be forged back"
+        );
+        assert_eq!(after.ino, before.ino, "an in-place rewrite keeps the inode");
+        // And ctime is what refuses it.
+        assert!(
+            after.ctime_ns() > before.ctime_ns(),
+            "ctime must advance across a rewrite + utimensat (before={}, after={})",
+            before.ctime_ns(),
+            after.ctime_ns()
+        );
+
+        let clock = VectorClock::default();
+        let inputs = baseline_inputs(&clock);
+        assert!(
+            !memo_still_holds(
+                &record_for(before, &inputs),
+                after,
+                InputFingerprint::of(&inputs),
+                1_001
+            ),
+            "a same-size rewrite with a forged mtime must never be skipped"
+        );
+    }
+}

--- a/crates/tcfs-sync/src/lib.rs
+++ b/crates/tcfs-sync/src/lib.rs
@@ -5,6 +5,7 @@ pub mod blacklist;
 pub mod conflict;
 pub mod conflict_git;
 pub mod engine;
+pub mod freshness;
 pub mod git_safety;
 pub mod git_workspace;
 pub mod index_entry;

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -23,6 +23,9 @@ use crate::blacklist::Blacklist;
 use crate::conflict::{compare_clocks, ConflictInfo, VectorClock};
 use crate::conflict_git;
 use crate::engine::{self, OptionalEncryption, ProgressFn};
+use crate::freshness::{
+    FreshnessCache, FreshnessInputs, FreshnessRecord, InputFingerprint, PathFingerprint,
+};
 use crate::git_safety;
 use crate::index_entry::{
     manifest_key, parse_index_entry_record, portable_casefold_path, read_exact_index_path_state,
@@ -649,6 +652,39 @@ pub struct ReconcileConfig {
     /// inventory contract. Any local, remote, or tracked path outside it makes
     /// planning fail closed instead of creating a parallel transport.
     pub authoritative_paths: Option<BTreeSet<String>>,
+    /// Re-derive every both-exist classification from scratch: full-file BLAKE3
+    /// plus a remote manifest GET for every path, exactly as reconcile behaved
+    /// before the freshness memo existed.
+    ///
+    /// The memo is a *performance* mechanism, not an integrity boundary (see
+    /// [`crate::freshness`]). `paranoid` is the operator's escape hatch when
+    /// that distinction matters — a suspected stat-forging restore tool, a
+    /// post-incident audit, or simply proving the memo is not the cause of
+    /// something. It costs the full unoptimized pass.
+    pub paranoid: bool,
+    /// Memo of both-exist pairs whose full classification already converged on
+    /// `UpToDate`. `None` disables the fast path outright.
+    ///
+    /// Shared behind an `Arc` because the daemon keeps one cache warm across
+    /// every cycle of its reconcile loop, while the CLI opens a JSON sidecar
+    /// beside the state cache so a `--expect-plan` dry run warms the execute
+    /// pass that follows it.
+    pub freshness: Option<Arc<FreshnessCache>>,
+}
+
+impl ReconcileConfig {
+    /// The freshness memo, if this configuration may use it at all.
+    ///
+    /// Refused for `--paranoid`, and refused whenever an authoritative
+    /// workspace capture is in play: those paths live in an ephemeral
+    /// materialization directory, so memoizing them would fill the sidecar with
+    /// records that can never hit again.
+    fn freshness_gate(&self) -> Option<&FreshnessCache> {
+        if self.paranoid || self.authoritative_paths.is_some() {
+            return None;
+        }
+        self.freshness.as_deref()
+    }
 }
 
 /// Result of executing a reconciliation plan.
@@ -1897,6 +1933,24 @@ pub async fn reconcile(
             .then_with(|| git_apply_rank(a).cmp(&git_apply_rank(b)))
             .then_with(|| action_rel_path(a).cmp(action_rel_path(b)))
     });
+
+    // 6. Close the freshness memo for this cycle: drop records for paths that
+    //    have left the corpus, persist the sidecar if one is configured, and
+    //    report the hit rate so an operator can see whether the memo is working
+    //    without reading a profile. All of it is best-effort — a memo failure
+    //    must never fail a plan.
+    if let Some(cache) = config.freshness_gate() {
+        cache.retain_touched();
+        cache.flush_best_effort();
+        let stats = cache.stats();
+        info!(
+            hits = stats.hits,
+            misses = stats.misses,
+            capped = stats.capped,
+            entries = stats.entries,
+            "reconcile freshness memo"
+        );
+    }
 
     info!(
         pushes = summary.pushes,
@@ -3548,6 +3602,7 @@ async fn classify_path_with_context(
                 device_id,
                 tracked_is_exact,
                 encryption,
+                config.freshness_gate(),
             )
             .await;
         }
@@ -3591,6 +3646,7 @@ async fn compare_both_exist(
         device_id,
         tracked.is_some(),
         None,
+        None,
     )
     .await
 }
@@ -3606,6 +3662,7 @@ async fn compare_both_exist_with_context(
     device_id: &str,
     tracked_is_exact: bool,
     encryption: OptionalEncryption<'_>,
+    freshness: Option<&FreshnessCache>,
 ) -> Result<ReconcileAction> {
     // Symlinks are first-class entries: they must NOT be dereferenced and hashed
     // like regular files (that would hash the *target's* content and then fail to
@@ -3647,6 +3704,45 @@ async fn compare_both_exist_with_context(
     }
     if remote_entry.symlink_target.is_some() {
         anyhow::bail!("regular remote index entry carries a symlink target at {rel_path:?}");
+    }
+
+    // ── Stat-gated freshness memo ────────────────────────────────────────────
+    //
+    // Everything past this point costs one full-file BLAKE3 plus one sequential
+    // S3 manifest GET, for EVERY path present on both sides. At the measured
+    // 29 ms/file that is ~10.1 h for one 1.26 M-file estate pass against a 300 s
+    // cadence — the 122x blocker, and it is this function, not registry
+    // validation and not the status cache.
+    //
+    // When a previous cycle already carried this exact pair through the full
+    // comparison and it converged on `UpToDate`, and every input that decision
+    // was a function of is still bit-identical, replay the verdict. The memo can
+    // only ever return `UpToDate`: it replays a proof, it never invents one, and
+    // an `UpToDate` action contributes nothing to `ReconcilePlan::sha256` beyond
+    // its path, so `--expect-plan` is unaffected. `crate::freshness` carries the
+    // soundness argument and the ctime/darwin caveats.
+    let live_stat = crate::freshness::stat_identity(&local_metadata);
+    // Only pay the canonicalization when the memo is actually enabled; under
+    // `--paranoid` this whole block costs nothing.
+    let canonical_key = freshness.map(|_| crate::state::canonical_path_key(local_path));
+    if let (Some(cache), Some(canonical_key)) = (freshness, canonical_key.as_deref()) {
+        let key = PathFingerprint::of(canonical_key);
+        if let Some(action) = replay_freshness_memo(
+            cache,
+            key,
+            canonical_key,
+            rel_path,
+            live_stat,
+            tracked,
+            tracked_is_exact,
+            remote_entry,
+            remote_prefix,
+            device_id,
+        ) {
+            cache.note_hit(key);
+            return Ok(action);
+        }
+        cache.note_miss(key);
     }
 
     // Get local hash
@@ -3820,13 +3916,196 @@ async fn compare_both_exist_with_context(
         remote_device,
     );
 
-    Ok(outcome_to_action(
-        outcome,
+    let action = outcome_to_action(outcome, rel_path, local_path, remote_entry, &manifest_path);
+
+    // Memoize ONLY a converged pair. Push/Pull/Conflict verdicts are never
+    // cached: they describe work still to do, and the very next execute changes
+    // the inputs they were derived from.
+    if let (Some(cache), Some(canonical_key), ReconcileAction::UpToDate { .. }) =
+        (freshness, canonical_key.as_deref(), &action)
+    {
+        install_freshness_memo(
+            cache,
+            canonical_key,
+            rel_path,
+            local_path,
+            live_stat,
+            &local_hash,
+            tracked,
+            tracked_is_exact,
+            remote_entry,
+            remote_prefix,
+            device_id,
+        );
+    }
+
+    Ok(action)
+}
+
+/// True when a path may participate in the freshness memo at all.
+///
+/// Git ref-class paths are excluded outright. They are the one corpus rewritten
+/// out of band, in place, at the same size, within the same second — `git
+/// commit` moving a 41-byte branch head — and they are the corpus whose
+/// misclassification TIN-2584 and the `.git` fast-forward machinery exist to
+/// prevent. `ctime` would in fact catch that rewrite, but refs are a few hundred
+/// paths against ~1.26 M: buying nothing measurable in exchange for reasoning
+/// about the most delicate arm in this file is a bad trade.
+///
+/// Immutable, content-addressed Git objects and packs stay eligible, and that is
+/// where the estate's volume actually lives.
+fn path_is_memo_eligible(rel_path: &str) -> bool {
+    !is_git_ref_class_path(rel_path)
+}
+
+/// Replay a memoized `UpToDate` verdict, or `None` to fall through to the full
+/// comparison.
+///
+/// Every early return here is a *miss*, which costs one ordinary full
+/// evaluation. No branch can produce a verdict other than `UpToDate`.
+#[allow(clippy::too_many_arguments)]
+fn replay_freshness_memo(
+    cache: &FreshnessCache,
+    key: PathFingerprint,
+    canonical_key: &str,
+    rel_path: &str,
+    live_stat: Option<crate::freshness::StatIdentity>,
+    tracked: Option<&SyncState>,
+    tracked_is_exact: bool,
+    remote_entry: &RemoteIndexEntry,
+    remote_prefix: &str,
+    device_id: &str,
+) -> Option<ReconcileAction> {
+    let (stat, tracked_state) =
+        memo_preconditions(rel_path, live_stat, tracked, tracked_is_exact, remote_entry)?;
+    let now = crate::freshness::now_unix();
+    let record = cache.lookup(key, now)?;
+    let inputs = InputFingerprint::of(&FreshnessInputs {
+        canonical_key,
         rel_path,
-        local_path,
+        remote_prefix,
+        tracked_blake3: &tracked_state.blake3,
+        tracked_vclock: &tracked_state.vclock,
+        remote_manifest_hash: &remote_entry.manifest_hash,
+        remote_size: remote_entry.size,
+        device_id,
+    });
+    if !crate::freshness::memo_still_holds(&record, stat, inputs, now) {
+        return None;
+    }
+    debug!(
+        path = %rel_path,
+        "freshness memo hit: skipping the full-file hash and the remote manifest read"
+    );
+    Some(ReconcileAction::UpToDate {
+        rel_path: rel_path.to_string(),
+    })
+}
+
+/// Install a memo for a pair whose full comparison converged on `UpToDate`.
+///
+/// Best-effort throughout: every refusal simply means the next cycle re-proves
+/// this path.
+#[allow(clippy::too_many_arguments)]
+fn install_freshness_memo(
+    cache: &FreshnessCache,
+    canonical_key: &str,
+    rel_path: &str,
+    local_path: &Path,
+    stat_before_hash: Option<crate::freshness::StatIdentity>,
+    local_hash: &str,
+    tracked: Option<&SyncState>,
+    tracked_is_exact: bool,
+    remote_entry: &RemoteIndexEntry,
+    remote_prefix: &str,
+    device_id: &str,
+) {
+    let Some((before, tracked_state)) = memo_preconditions(
+        rel_path,
+        stat_before_hash,
+        tracked,
+        tracked_is_exact,
         remote_entry,
-        &manifest_path,
-    ))
+    ) else {
+        return;
+    };
+    // The memo vouches for "the local bytes hash to the tracked baseline". If
+    // the bytes we just hashed disagree with the state cache, the pair did not
+    // converge on a shared baseline and the record would be a lie.
+    if tracked_state.blake3 != local_hash {
+        return;
+    }
+    // TOCTOU: the file may have been rewritten between the `symlink_metadata`
+    // that produced `before` and the `hash_file` that produced `local_hash`.
+    // Binding a record to `before` would then vouch for bytes we never read.
+    // Re-stat, and install only if the identity is unmoved across the read.
+    let Ok(metadata_after) = std::fs::symlink_metadata(local_path) else {
+        return;
+    };
+    let Some(after) = crate::freshness::stat_identity(&metadata_after) else {
+        return;
+    };
+    if after != before {
+        debug!(
+            path = %rel_path,
+            "local file changed while it was being hashed; not memoizing this cycle"
+        );
+        return;
+    }
+
+    cache.record(
+        PathFingerprint::of(canonical_key),
+        FreshnessRecord {
+            stat: after,
+            inputs: InputFingerprint::of(&FreshnessInputs {
+                canonical_key,
+                rel_path,
+                remote_prefix,
+                tracked_blake3: &tracked_state.blake3,
+                tracked_vclock: &tracked_state.vclock,
+                remote_manifest_hash: &remote_entry.manifest_hash,
+                remote_size: remote_entry.size,
+                device_id,
+            }),
+            verified_at: crate::freshness::now_unix(),
+        },
+    );
+}
+
+/// Conditions a path must meet before it may be looked up in, or installed
+/// into, the freshness memo.
+///
+/// Shared by both directions on purpose: a lookup that admitted a shape the
+/// install refuses (or the reverse) would be a silent asymmetry in the one
+/// predicate that has to stay closed.
+fn memo_preconditions<'a>(
+    rel_path: &str,
+    live_stat: Option<crate::freshness::StatIdentity>,
+    tracked: Option<&'a SyncState>,
+    tracked_is_exact: bool,
+    remote_entry: &RemoteIndexEntry,
+) -> Option<(crate::freshness::StatIdentity, &'a SyncState)> {
+    if !path_is_memo_eligible(rel_path) {
+        return None;
+    }
+    // A non-regular file, or a platform without POSIX inode metadata.
+    let stat = live_stat?;
+    if !matches!(remote_entry.kind, RemoteEntryKind::RegularFile) {
+        return None;
+    }
+    // The baseline must be the exact-key record the push path would also read
+    // (TIN-3278): a fuzzy suffix match may describe a different file entirely.
+    if !tracked_is_exact {
+        return None;
+    }
+    let tracked_state = tracked?;
+    // A path carrying a recorded conflict is exactly where an operator needs
+    // live truth, not a replayed verdict (TIN-2658 resolve-blindness). Never
+    // memo one.
+    if tracked_state.conflict.is_some() {
+        return None;
+    }
+    Some((stat, tracked_state))
 }
 
 /// TIN-3277 prefilter for an equal-clock, local out-of-band rewrite.
@@ -6319,6 +6598,288 @@ mod tests {
             RemoteIndexEntry::new_symlink(object_id, target),
             engine::symlink_manifest_hash(target),
         )
+    }
+
+    // ── stat-gated freshness memo ─────────────────────────────────────────
+
+    /// Warm the memo on a converged pair and hand back everything a second
+    /// classification needs.
+    async fn converged_memo_fixture(
+        op: &Operator,
+        dir: &Path,
+        rel_path: &str,
+        content: &[u8],
+    ) -> (PathBuf, RemoteIndexEntry, SyncState, Arc<FreshnessCache>) {
+        let local_path = dir.join(rel_path);
+        if let Some(parent) = local_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&local_path, content).unwrap();
+        let clock = causal_test_clock(&[("peer", 1)]);
+        let (entry, content_hash) =
+            write_causal_test_regular_manifest(op, rel_path, content, clock.clone()).await;
+        let tracked = causal_test_state(content_hash, clock);
+        let cache = Arc::new(FreshnessCache::in_memory());
+        (local_path, entry, tracked, cache)
+    }
+
+    async fn classify_with_memo(
+        op: &Operator,
+        rel_path: &str,
+        local_path: &Path,
+        entry: &RemoteIndexEntry,
+        tracked: &SyncState,
+        cache: &FreshnessCache,
+    ) -> Result<ReconcileAction> {
+        compare_both_exist_with_context(
+            rel_path,
+            local_path,
+            entry,
+            Some(tracked),
+            op,
+            "data",
+            "neo",
+            true,
+            None,
+            Some(cache),
+        )
+        .await
+    }
+
+    /// Rewrite a file in place at the SAME length with different bytes, then put
+    /// mtime back exactly where it was. This is the `(size, mtime)` blind spot
+    /// the classifier documents at its push execute site — a 41-byte `git
+    /// commit` ref rewrite — reproduced deterministically.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn rewrite_same_size_and_forge_mtime(path: &Path, replacement: &[u8]) {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::MetadataExt;
+
+        let before = std::fs::symlink_metadata(path).unwrap();
+        let (mtime_sec, mtime_nsec) = (before.mtime(), before.mtime_nsec());
+        assert_eq!(
+            before.len() as usize,
+            replacement.len(),
+            "the forgery is only interesting at an identical size"
+        );
+        std::fs::write(path, replacement).unwrap();
+
+        let times = [
+            libc::timespec {
+                tv_sec: 0,
+                tv_nsec: libc::UTIME_OMIT as _,
+            },
+            libc::timespec {
+                tv_sec: mtime_sec as libc::time_t,
+                tv_nsec: mtime_nsec as _,
+            },
+        ];
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: `c_path` outlives the call and `times` is the two-element
+        // `timespec` array utimensat expects.
+        let rc = unsafe {
+            libc::utimensat(
+                libc::AT_FDCWD,
+                c_path.as_ptr(),
+                times.as_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        assert_eq!(rc, 0, "utimensat: {}", std::io::Error::last_os_error());
+    }
+
+    /// The memo must actually eliminate the S3 GET, not merely short-circuit
+    /// some later branch. Proved by DELETING the remote manifest object between
+    /// the two classifications: a second `UpToDate` is only possible if nothing
+    /// read it.
+    #[tokio::test]
+    async fn freshness_memo_skips_the_remote_manifest_read_entirely() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let (local_path, entry, tracked, cache) =
+            converged_memo_fixture(&op, dir.path(), "doc.txt", b"converged bytes").await;
+
+        let first = classify_with_memo(&op, "doc.txt", &local_path, &entry, &tracked, &cache)
+            .await
+            .expect("a converged pair classifies");
+        assert!(matches!(first, ReconcileAction::UpToDate { .. }));
+        assert_eq!(cache.stats().entries, 1, "the verdict should be memoized");
+        assert_eq!(cache.stats().misses, 1);
+
+        op.delete(&format!("data/manifests/{}", entry.manifest_hash))
+            .await
+            .unwrap();
+
+        let second = classify_with_memo(&op, "doc.txt", &local_path, &entry, &tracked, &cache)
+            .await
+            .expect("the memo replays without touching the remote");
+        assert!(matches!(second, ReconcileAction::UpToDate { .. }));
+        assert_eq!(cache.stats().hits, 1);
+    }
+
+    /// THE property: a path whose content changed is never skipped. Same size,
+    /// same inode, mtime forged back byte-for-byte — only ctime moved.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[tokio::test]
+    async fn freshness_memo_refuses_a_same_size_rewrite_with_a_forged_mtime() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let (local_path, entry, tracked, cache) =
+            converged_memo_fixture(&op, dir.path(), "ref-shaped", b"aaaaaaaaaaaa").await;
+
+        let first = classify_with_memo(&op, "ref-shaped", &local_path, &entry, &tracked, &cache)
+            .await
+            .unwrap();
+        assert!(matches!(first, ReconcileAction::UpToDate { .. }));
+
+        rewrite_same_size_and_forge_mtime(&local_path, b"bbbbbbbbbbbb");
+
+        let second = classify_with_memo(&op, "ref-shaped", &local_path, &entry, &tracked, &cache)
+            .await
+            .unwrap();
+        assert!(
+            !matches!(second, ReconcileAction::UpToDate { .. }),
+            "a same-size rewrite with a forged mtime must never be skipped, got {second:?}"
+        );
+    }
+
+    /// A peer publishing a new manifest moves the content-addressed
+    /// `manifest_hash`, which is how the memo notices a remote that advanced
+    /// while the local side sat still.
+    #[tokio::test]
+    async fn freshness_memo_refuses_an_advanced_remote_manifest() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let (local_path, entry, tracked, cache) =
+            converged_memo_fixture(&op, dir.path(), "doc.txt", b"converged bytes").await;
+
+        let first = classify_with_memo(&op, "doc.txt", &local_path, &entry, &tracked, &cache)
+            .await
+            .unwrap();
+        assert!(matches!(first, ReconcileAction::UpToDate { .. }));
+
+        let (advanced, _) = write_causal_test_regular_manifest(
+            &op,
+            "doc.txt",
+            b"a peer moved this",
+            causal_test_clock(&[("peer", 2)]),
+        )
+        .await;
+        assert_ne!(advanced.manifest_hash, entry.manifest_hash);
+
+        let second = classify_with_memo(&op, "doc.txt", &local_path, &advanced, &tracked, &cache)
+            .await
+            .unwrap();
+        assert!(
+            matches!(second, ReconcileAction::Pull { .. }),
+            "an advanced remote must be pulled, got {second:?}"
+        );
+    }
+
+    /// A path carrying a recorded conflict is where an operator most needs live
+    /// truth (TIN-2658 resolve-blindness), so it is never memoized.
+    #[tokio::test]
+    async fn freshness_memo_refuses_a_path_carrying_a_recorded_conflict() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let (local_path, entry, mut tracked, cache) =
+            converged_memo_fixture(&op, dir.path(), "doc.txt", b"converged bytes").await;
+        tracked.conflict = Some(crate::conflict::ConflictInfo {
+            rel_path: "doc.txt".into(),
+            local_vclock: VectorClock::new(),
+            remote_vclock: VectorClock::new(),
+            local_blake3: "local".into(),
+            remote_blake3: "remote".into(),
+            local_device: "neo".into(),
+            remote_device: "peer".into(),
+            detected_at: 1,
+            times_recorded: 1,
+            remote_manifest_key: None,
+        });
+
+        let action = classify_with_memo(&op, "doc.txt", &local_path, &entry, &tracked, &cache)
+            .await
+            .unwrap();
+        assert!(matches!(action, ReconcileAction::UpToDate { .. }));
+        assert_eq!(
+            cache.stats().entries,
+            0,
+            "a conflicted entry must never be memoized"
+        );
+    }
+
+    /// Git ref-class paths are excluded from the memo outright.
+    #[tokio::test]
+    async fn freshness_memo_never_covers_git_ref_class_paths() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let rel_path = "repo/.git/refs/heads/main";
+        let (local_path, entry, tracked, cache) =
+            converged_memo_fixture(&op, dir.path(), rel_path, b"0123456789abcdef").await;
+        assert!(is_git_ref_class_path(rel_path));
+
+        let action = classify_with_memo(&op, rel_path, &local_path, &entry, &tracked, &cache)
+            .await
+            .unwrap();
+        assert!(matches!(action, ReconcileAction::UpToDate { .. }));
+        assert_eq!(
+            cache.stats().entries,
+            0,
+            "ref-class paths must stay on the full comparison"
+        );
+    }
+
+    /// A fuzzy (non-exact-key) state match is not a baseline the push path would
+    /// agree with (TIN-3278), so it cannot back a memo either.
+    #[tokio::test]
+    async fn freshness_memo_requires_the_exact_key_state_record() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let (local_path, entry, tracked, cache) =
+            converged_memo_fixture(&op, dir.path(), "doc.txt", b"converged bytes").await;
+
+        let action = compare_both_exist_with_context(
+            "doc.txt",
+            &local_path,
+            &entry,
+            Some(&tracked),
+            &op,
+            "data",
+            "neo",
+            false,
+            None,
+            Some(cache.as_ref()),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(action, ReconcileAction::UpToDate { .. }));
+        assert_eq!(cache.stats().entries, 0);
+    }
+
+    #[test]
+    fn paranoid_and_authoritative_capture_both_disable_the_memo() {
+        let cache = Arc::new(FreshnessCache::in_memory());
+        let enabled = ReconcileConfig {
+            freshness: Some(Arc::clone(&cache)),
+            ..Default::default()
+        };
+        assert!(enabled.freshness_gate().is_some());
+
+        let paranoid = ReconcileConfig {
+            freshness: Some(Arc::clone(&cache)),
+            paranoid: true,
+            ..Default::default()
+        };
+        assert!(paranoid.freshness_gate().is_none());
+
+        let captured = ReconcileConfig {
+            freshness: Some(Arc::clone(&cache)),
+            authoritative_paths: Some(BTreeSet::new()),
+            ..Default::default()
+        };
+        assert!(captured.freshness_gate().is_none());
+
+        assert!(ReconcileConfig::default().freshness_gate().is_none());
     }
 
     #[tokio::test]

--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -1945,6 +1945,13 @@ impl StateCacheBackend for StateBackend {
 /// macOS) but preserves the final path component. That keeps first-class
 /// symlinks keyed by the link path instead of the link target, while still
 /// making delete/remove lookups stable after the file itself is gone.
+/// Canonical state-cache key for a local path, exposed so side caches keyed on
+/// the same identity (see [`crate::freshness`]) cannot drift from the state
+/// cache's own notion of "the same file".
+pub fn canonical_path_key(path: &Path) -> String {
+    path_key(path)
+}
+
 fn path_key(path: &Path) -> String {
     path.parent()
         .and_then(|parent| std::fs::canonicalize(parent).ok())

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -1418,6 +1418,25 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                 );
             }
 
+            // One freshness memo for the whole loop: it is only worth anything
+            // when it stays warm across cycles, which is exactly what a
+            // long-lived daemon can offer and a one-shot CLI cannot. In-memory
+            // on purpose — the daemon re-proves everything after a restart, and
+            // the sidecar on disk belongs to the CLI, which owns the state-file
+            // lock while it runs.
+            let recon_freshness = Arc::new(tcfs_sync::freshness::FreshnessCache::in_memory());
+            // Escape hatch for an operator who suspects the memo. Off by default;
+            // a durable `[sync]` knob is the follow-up.
+            let recon_paranoid = std::env::var("TCFS_RECONCILE_PARANOID")
+                .map(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+                .unwrap_or(false);
+            if recon_paranoid {
+                warn!(
+                    "TCFS_RECONCILE_PARANOID is set: every reconcile cycle will re-hash and \
+                     re-read every both-exist path"
+                );
+            }
+
             tokio::spawn(async move {
                 let mut interval = tokio::time::interval(Duration::from_secs(recon_interval));
                 let orphan_chunk_cleanup_grace =
@@ -1460,6 +1479,8 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                         git_sync_mode: recon_blacklist.git_sync_mode().to_string(),
                         git_ff_resolution: recon_blacklist.allows_git_dirs()
                             && recon_blacklist.git_sync_mode() == "raw",
+                        paranoid: recon_paranoid,
+                        freshness: Some(Arc::clone(&recon_freshness)),
                         ..Default::default()
                     };
 


### PR DESCRIPTION
Lane 3 of the R-D estate-scale finding. **UNBUILT — CI proves it** (authored on neo, which never compiles Rust; `rustfmt --check` is clean on every touched file).

## The blocker

`reconcile.rs` `compare_both_exist_with_context` pays, for **every** path present on both sides, inside a strictly sequential per-path loop:

- an unconditional full-file BLAKE3 (`tcfs_chunks::hash_file`), and
- an unconditional S3 GET of the remote manifest (`op.read(manifests/<hash>)`).

At the measured live constant of **29 ms/both-exist path** (`R-D-estate-scale.md` §B1, derived from 1,653 logged cycles on `git-roam-tool-daemon`: p50 inter-cycle gap 304 s against `StartInterval = 300` ⇒ ~4 s over ~140 both-exist paths) that is **10.1 h for one 1.26 M-file estate pass against a 300 s cadence — 122× over budget**, 244× with the mandatory `--expect-plan` double pass.

R-D also names why the obvious fix was correctly refused before: the engine's `(size, mtime-seconds)` quick check (`needs_sync`) is deliberately excluded from this classifier, because a same-second same-size 41-byte `.git` ref rewrite (`git commit` moving a branch head) is invisible to it — and `SyncState.mtime` is a `u64` of **seconds**, so the state cache cannot even express a sound gate.

## The change

A memo of pairs whose **full** comparison already converged on `UpToDate`. A hit replays that verdict; it never invents one.

`compare_both_exist_with_context` is a pure function of exactly six inputs, and the memo compares all six:

| input | how it is compared | cost |
|---|---|---|
| local file bytes | `StatIdentity` = `(dev, ino, size, mtime_ns, ctime_ns)` | free — the `symlink_metadata` was already being taken |
| `SyncState.blake3` | folded into `InputFingerprint` | free |
| `SyncState.vclock` | folded into `InputFingerprint` | free |
| remote manifest **body** | its content address, `remote_entry.manifest_hash` | **this is what removes the GET** |
| device id | folded into `InputFingerprint` | free |
| rel path + remote prefix | folded into `InputFingerprint` | free |

The remote-manifest row is the load-bearing one: `engine::validate_indexed_manifest_binding` refuses any manifest body that does not hash to the name the index entry gives it, so an **unchanged `manifest_hash` is an unchanged manifest body** — unchanged remote vclock, unchanged `file_hash`, unchanged `written_by`. No GET is required to know that. The test proves it by *deleting the manifest object* between two classifications and asserting the second still returns `UpToDate`.

### ctime is the load-bearing field

`mtime` alone is forgeable and is routinely forged by benign tools (`cp -p`, `rsync --times`, `tar -x`, restore utilities). `ctime` is kernel-maintained and has no portable API that sets it — `utimensat`/`futimens` set atime/mtime and **bump** ctime. So a same-size in-place rewrite with a forged mtime still moves ctime. Proved twice:

- `forged_mtime_same_size_is_not_skipped_because_ctime_moved` — synthetic, isolates ctime as the only differing field;
- `live_forged_mtime_rewrite_still_moves_ctime` — a real 41-byte file, rewritten in place at identical length, mtime forged back byte-for-byte with `utimensat`. Asserts `size` unchanged, `mtime_ns` unchanged, `ino` unchanged, and `ctime_ns` advanced, then asserts the classifier refuses the memo.

**darwin caveat (R-C / J1), stated honestly in the module docs:** macOS is the one platform with an API that can move ctime directly, `setattrlist(2)` with `ATTR_CMN_CHGTIME`. The R-C/J1 probe found ctime *resists* there in practice, but the correct framing is narrower — **this is a performance memo against benign staleness, not an integrity boundary.** Anyone who can call `setattrlist` on the file already has write access and could simply not change the file. Two brakes bound the exposure anyway: `ino` moves under the write-temp-then-rename pattern every metadata-restoring tool uses, and every record carries a jittered 24 h TTL (phase derived from the path, so a 1.26 M corpus does not expire in one cycle) so a forged record is re-proved by full hash within a day. `--paranoid` is the integrity answer.

### Plan-hash neutral

`ReconcilePlan::sha256` hashes actions only, and an `UpToDate` action contributes exactly `path` and `kind="up-to-date"`. A memoized verdict is byte-identical to a computed one, so the fast path **cannot** move the plan SHA-256 and the `--expect-plan` dry-run/execute protocol is unaffected — including mixing `--paranoid` on one pass and not the other. The CLI's persisted sidecar additionally lets the dry-run pass warm the execute pass that follows it, which is where the 2× `--expect-plan` cost goes.

### Invalidation is structural

Nothing evicts explicitly after an execute; every mutation moves at least one compared input. A pull rewrites the file (stat moves) and the tracked baseline; a push publishes a new manifest (`manifest_hash` moves); a local delete leaves the both-exist arm; a state-cache rollback moves `blake3`/`vclock`. A stale record can only ever cause a **miss**, never a wrong skip.

### Fail-closed exclusions

`.git` ref-class paths (`refs/`, `packed-refs`, `HEAD`, module refs — the TIN-2584 corpus; ctime would catch them, but a few hundred paths against 1.26 M is not worth reasoning about the most delicate arm in the file); non-regular files; entries carrying a recorded conflict (TIN-2658 resolve-blindness — that is where an operator needs live truth); non-exact-key state records (TIN-3278); authoritative workspace captures; and any platform without POSIX inode metadata. Immutable content-addressed Git objects and packs stay eligible, and that is where the estate's volume lives.

### Memory

A record storing its inputs verbatim (two hex hashes, a prefix, a device id, a `BTreeMap` vclock) is ~670 B — **845 MB** for the estate, on a laptop that was at 97 % disk in June. A record never needs to *reproduce* its inputs, only to detect that they moved, so everything except the stat is folded into a 16-byte fingerprint and the key is a 16-byte fingerprint of the canonical path: 16 B key + 56 B stat + 16 B fingerprint + 8 B timestamp ≈ **135 B/record including hash-table overhead → ~170 MB at the full 1.26 M**, with a hard entry cap above that. A key collision is harmless by construction — the path is also folded into the input fingerprint, so a collided lookup fails the check and degrades to a miss.

## Projected per-pass time at 1.26 M files

Baseline (R-D): 1.26 M × 29 ms = **36,540 s = 10.15 h**.

New per-unchanged-path classifier cost: three stat-family syscalls (`symlink_metadata`, plus the `canonicalize(parent)` inside `canonical_path_key` — the state cache already pays one of these per path), two BLAKE3 hashes over <256 B, two hash-map operations. **10 µs warm dcache, 50 µs conservative/cold.**

| term | before | after |
|---|---|---|
| classify loop (sequential, both-exist) | 36,540 s | **13–63 s** |
| `list_remote_index` — LIST + 1.26 M index-entry GETs @ concurrency 32 | ~197 s | ~197 s (**unchanged**) |
| `collect_local_set` local walk | ~25 s | ~25 s (unchanged) |
| **one full pass** | **~10.2 h** | **~4.0–4.8 min** |

- **Classifier term alone: 580×–2,900× faster.**
- **Whole pass: ~128×–155×**, taking 122× over a 300 s budget to roughly **0.8× of budget**.
- With `--expect-plan`'s double pass: ~8–9.5 min, i.e. still over a 300 s cadence — see follow-ups.

Honest caveats on these numbers: they are projections from the 29 ms decomposition, not measured. The 29 ms constant was derived at N≈140 where the concurrency-32 index fan-out does not amortize the way it does at 1.26 M, so the ~197 s index term is the least certain figure here. The measurement that would settle it is a single `--paranoid` vs default `tcfs reconcile --root <big-root>` pair on a warmed sidecar, reading the `reconcile freshness memo` hit/miss line this PR adds.

**Correcting one premise in the task framing:** the remote map is *already* built once per cycle — `list_remote_namespace` → `list_remote_index` does one recursive `list_with` over `index/` plus one over `manifests/`. The GET-per-path that actually costs 29 ms/file is the **manifest read inside the classifier**, and that is the one this PR removes. `list_remote_index` still issues one GET per index entry, because the listing returns keys and sizes while `manifest_hash`/`kind`/`symlink_target` live in the object body — eliminating that is a *format*-level change (a rolled-up index snapshot object), not a classifier change.

## Follow-ups (deliberately not in this PR)

1. **`REMOTE_INDEX_READ_CONCURRENCY = 32`** (`reconcile.rs`) is now the dominant remaining term. Raising it to 256 would take ~197 s to ~25 s and put a full pass near 63 s — a one-constant change with its own connection-pool risk profile, so it wants its own PR and its own canary.
2. **A rolled-up remote index snapshot object**, so the index costs one GET per cycle instead of one per path. This is the durable fix for the term above.
3. **A durable `[sync]` paranoid knob.** The daemon escape hatch here is `TCFS_RECONCILE_PARANOID`; a config field means touching `SyncConfig`'s exhaustive redaction destructure, which is a separate, mechanical diff.
4. **Coarse-timestamp filesystems.** A filesystem with 1-second ctime granularity makes the memo unsafe; APFS and ext4-with-256 B-inodes are both nanosecond, so nothing this ships on is affected, but the cache should probe granularity and self-disable rather than rely on that.
5. **Sidecar size for very large single roots.** The JSON sidecar is fine at the per-root sizes in the registry today; a root approaching the 1 M cap wants a binary/mmap format instead.

## Test plan

New, all in-tree:

- `crates/tcfs-sync/src/freshness.rs` — 16 unit tests: the ctime property (synthetic + live `utimensat`), same-second same-size rewrite, rename-replacement, cross-device, a table-driven test asserting **every** non-stat classifier input is covered by the fingerprint (this is what keeps the compact representation honest), length-delimited field mixing, TTL expiry and jitter spread, entry cap, touch-set GC, sidecar round-trip / foreign schema / corrupt / missing, hex round-trip.
- `crates/tcfs-sync/src/reconcile.rs` — 7 integration tests through the real classifier against a memory `Operator`: the manifest-deletion proof that the GET is actually gone, the forged-mtime refusal, advanced-remote refusal, recorded-conflict refusal, ref-class exclusion, exact-key requirement, and `paranoid`/authoritative-capture gating.
- `crates/tcfs-cli/src/main.rs` — `--paranoid` parse coverage and its default-off.
