### PR TITLE
docs(claude): root CLAUDE.md imports AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+@AGENTS.md
+
+> `AGENTS.md` is the canonical agent context for this repo (imported above). `.claude/` is gitignored here, so a repo-side `.claude/CLAUDE.md` can never carry the contract — this root file does.


### PR DESCRIPTION
Claude Code never loads `AGENTS.md` on its own, and this repo gitignores `.claude/` wholesale — so the local `.claude/CLAUDE.md` that says *read AGENTS.md first* is neither tracked nor an import, and every tummycrypt session has started with zero repo contract (lab seat config census, 2026-08-28). Add a root `CLAUDE.md` whose first line is `@AGENTS.md`, mirroring lab's canonical file. Doc-only.