### PR TITLE
docs(agents): re-baseline AGENTS.md for the neo/nix era

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,16 +58,20 @@ nix develop
 # Or let direnv load the committed .envrc once:
 direnv allow
 
-# Build / test / lint — cargo comes from the devShell or the pinned toolchain
+# Build / test / lint. On `neo` these run on `sting` or `honey`, never
+# locally — see "Machines that run this repo" below.
 cargo build --workspace
 cargo test --workspace
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets
 
-# Same lanes through the task runner
-task build
+# Related lanes through the task runner. The flags are NOT identical to the
+# cargo block or to CI: `task lint` adds `-D warnings` but omits
+# `--all-targets`, so it never compiles tests/benches/examples; CI clippy is
+# `--all-targets` without `-D warnings`. Green in one does not imply the other.
+task build         # cargo build --workspace
 task test          # cargo test --workspace
-task lint          # cargo clippy -D warnings + cargo fmt --check
+task lint          # cargo clippy --workspace -D warnings + cargo fmt --check
 
 # Local dev stack: 8 containers (3 SeaweedFS masters + volume + filer, NATS,
 # Prometheus, Grafana) via docker-compose. Linux host only — see below.
@@ -79,45 +83,74 @@ task dev
 ### Toolchain
 
 - **Rust**: edition 2021; workspace `rust-version = "1.93"`; pinned to
-  `1.93.0` by `rust-toolchain.toml`. `.envrc` fails loud when the active
-  `rustc` is below the minimum or does not match the pin.
+  `1.93.0` by `rust-toolchain.toml`. `.envrc` prints a loud direnv error when
+  the active `rustc` is below the minimum or does not match the pin — but
+  `log_error` does not abort the load, so the mismatched `rustc` stays on
+  `PATH`. Check `rustc --version` yourself; do not treat a successful direnv
+  load as proof.
 - **Invoke plain `cargo`.** It is expected to come from the pinned toolchain or
   the Nix devShell (`Justfile` header; `flake.nix` `shellHook`). Do not
   hardcode `~/.cargo/bin/cargo` — that path is only the rustup fallback
-  `.envrc` adds when `nix` is absent.
-- **Linker**: `mold` ships in the Nix devShell; outside Nix the default system
-  linker is used. Do not add a `mold` entry to `.cargo/config.toml`; opt in
-  per-shell with `RUSTFLAGS="-C link-arg=-fuse-ld=mold"`.
+  `.envrc` adds when `nix` is absent. Known drift: `Taskfile.yaml` `bench`
+  still hardcodes `~/.cargo/bin/cargo bench`, so `task bench` fails on a
+  Nix-only machine.
+- **Linker**: there is no `mold` in the Nix devShell or in any system
+  toolchain this repo assumes — `flake.nix` does not package it. The default
+  system linker is used everywhere. The `mold` comment at the top of
+  `.cargo/config.toml` is stale; do not act on it, and do not add a `mold`
+  entry to `.cargo/config.toml`.
 - **PATH ordering**: the devShell and `.envrc` both put `target/debug` and
   `target/release` ahead of installed packages, so a stale workspace build can
-  shadow the deployed `tcfs`/`tcfsd`. Smoke harnesses print the resolved binary
-  path — check it before believing a version string.
+  shadow the deployed `tcfs`/`tcfsd`. Separately, on `neo` an unmanaged
+  `v0.12.12` install currently shadows the managed build in the effective
+  interactive `PATH` (`docs/ops/current.md`, Fleet row; an attended cleanup is
+  queued). Smoke harnesses print the resolved binary path — check it before
+  believing a version string.
 
 ### Machines that run this repo
 
+Not exhaustive: acceptance and storage hosts are a separate pool, listed in
+[docs/ops/lab-host-acceptance-matrix.md](docs/ops/lab-host-acceptance-matrix.md).
+
 | Host | What it is | How agents use it |
 | --- | --- | --- |
-| `neo` | macOS (Darwin) maintainer workstation, 8 GiB RAM | Orchestration, review, editing, and the release-adjacent `neo → honey` live lane. **No local compile/test/`task dev` here** — the estate build-placement ruling sends heavy toolchain work to a remote host, and an unbounded local build takes every session on the machine down with it. Login shell is `bash`. |
-| `honey` | Rocky Linux 10 control-plane voter; canonical Linux control point | High-volume push/pull, daemon and service checks, conflict and stress lanes, Linux-first operator truth. Login shell is **`fish`**, which has no `export VAR=VALUE`; use `env VAR=VALUE command` or wrap in `bash -c '...'`. |
-| `sting` | Rocky Linux 10.2 voter; headless remote-dev seat driven from `neo` | The dev seat for build/test work that must not run on `neo`. Login shell is POSIX `bash` with an interactive-only fish handoff, so a non-interactive SSH command lands in `bash`. |
+| `neo` | macOS (Darwin) maintainer workstation, resource-constrained | Orchestration, review, editing, and the release-adjacent `neo → honey` live lane. **No local compile/test/`task dev` here** — the estate build-placement ruling sends heavy toolchain work to a remote host, and an unbounded local build takes every session on the machine down with it. Login shell is `bash`, so agent and SSH commands land in bash; interactive terminals re-enter fish from emulator config, so `export VAR=VALUE` fails at a `neo` prompt too. |
+| `honey` | Rocky Linux 10; canonical Linux control point | High-volume push/pull, daemon and service checks, conflict and stress lanes, Linux-first operator truth. Login shell is **`fish`**, which has no `export VAR=VALUE`; use `env VAR=VALUE command` or wrap in `bash -c '...'`. |
+| `sting` | Rocky Linux 10.2; headless remote-dev seat driven from `neo` | The dev seat for build/test work that must not run on `neo` — under the bounded readmission below. Login shell is POSIX `bash` with an interactive-only fish handoff, so a non-interactive SSH command lands in `bash`. |
 
-Host facts and shell settings above are owned by `tinyland-inc/lab`
-(`AGENTS.md`, `inventory/host_vars/{macbook-neo,honey,sting}.yml`); that repo
-is authoritative if it disagrees with this table.
+Host facts, shell settings, and every hold state above are owned by
+`tinyland-inc/lab` (`AGENTS.md`, `inventory/host_vars/{macbook-neo,honey,sting}.yml`,
+`vars/fleet_switch_targets.json`); that repo is authoritative if it disagrees
+with this table.
 
 - **Rocky-specific (`honey`, `sting`)**: a rustup install lands in
   `~/.cargo/bin`, which is not on `PATH` by default. `.envrc`'s non-Nix
   fallback adds it. Inside `nix develop` the pinned toolchain leads and this
   does not apply.
-- **`sting` is a dev seat, not a TCFS target.** The lab-side continuity hold
-  readmitted interactive SSH, tmux, and dev work under `~/git`; the
-  `tcfs_runtime` role stays disabled. Build and test this repo there; do not
-  drive daemon, enrollment, or fleet operations against it.
+- **`sting` is under an open continuity hold.** The lab-side machine hold
+  (`STING_CONTINUITY_INCIDENT_2026-08-17`) is still active; `hold.active` is
+  `true` and the host stays out of every rendered switch scope. An attended
+  2026-08-22 operator ruling readmitted the **dev-seat role only** —
+  interactive SSH, tmux, and dev work under `~/git`. That readmission lifts no
+  other role. Before using `sting`, read `hold.roles` in lab's
+  `vars/fleet_switch_targets.json`. `sting` also carries production roles owned
+  by lab and outside this repo's scope, so unbounded resource use, reboots, and
+  any host-level change there are not this repo's call.
+- **`sting`'s `tcfs_runtime` role is held disabled** — `tcfsd` and
+  `tcfsd-health` are inactive and disabled/masked/not-found. Do not start a
+  daemon or drive enrollment there. That is narrower than "not a TCFS target":
+  `docs/ops/current.md` still queues `sting` for release/root-topology
+  convergence and for candidate/activation invariants, so fleet-coherence work
+  against it is sequenced, not forbidden — it just needs its own attended
+  readmission first.
 - **Acceptance hosts are a different question.** The host pool, lane order, and
   reset contract for real-host acceptance live in
   [docs/ops/lab-host-acceptance-matrix.md](docs/ops/lab-host-acceptance-matrix.md)
   and [docs/ops/neo-honey-acceptance.md](docs/ops/neo-honey-acceptance.md).
-  A dev seat is not an acceptance target.
+  A dev seat is not an acceptance target. That matrix's `sting` row still reads
+  "none yet / blocked on lab-side hardware stabilization"; it predates the
+  dev-seat ratification and correcting it is an operator call, not a
+  docs-hygiene one.
 - **Live-work freezes outrank convenience.** `docs/ops/current.md` records
   which live resolver, enrollment, deploy, and crypto ceremonies are frozen.
   Source review, tests, and landing continue during a freeze; new fleet claims
@@ -182,16 +215,33 @@ Prefer the `lazy:test-*` regression recipes when changing a harness script.
 
 ## CI
 
-- `ci.yml`: `check` (fmt, FileProvider surface contract, clippy, `cargo test`,
-  feature-isolated and wire-up tests, then workspace/`k8s-worker`/no-FUSE
-  builds), plus `cloudfilter-windows`, `nix`, `fileprovider-staticlib`,
-  `ios-typecheck`, `deny` (cargo-deny), and `secret-scan` (gitleaks).
+Always-on lanes (every PR):
+
+- `ci.yml`: `check` (`cargo check --workspace --locked` first — a dependency
+  edit that leaves `Cargo.lock` stale fails here before anything else — then
+  fmt, FileProvider surface contract, clippy, `cargo test`, feature-isolated
+  and wire-up tests, then workspace/`k8s-worker`/no-FUSE builds), plus
+  `cloudfilter-windows`, `nix`, `fileprovider-staticlib`, `ios-typecheck`,
+  `deny` (cargo-deny), and `secret-scan` (gitleaks).
 - `nix-ci.yml`: `flake-check`, `build-linux-x86_64`, `build-macos-aarch64`.
-- `docs.yml`: lychee link check, tectonic PDF build, GitHub Pages deploy. The
-  repo's only pre-commit hook is the same lychee check, so a broken relative
-  link in a Markdown edit fails locally and in CI.
-- `release.yml`: 9 jobs — plan, binaries, container image, nix build,
-  installers, FileProvider, `.pkg`, release creation, Homebrew update.
+- `docs.yml`: `check-links` (lychee), `build-pdf` (tectonic), `deploy` (GitHub
+  Pages). The repo's only pre-commit hook is the same lychee check, so a broken
+  relative link in a Markdown edit fails locally and in CI.
+
+Path-scoped lanes that also fire on a PR — check `.github/workflows/` rather
+than assuming the list above is complete:
+
+- `ci-live-storage.yml`: real-storage lane on `crates/**`, `tests/**`,
+  `Cargo.toml`, `Cargo.lock`, `docker-compose.yml`, `config/**`. It exists
+  because `ci.yml` can stay green while a sync path is broken, so a code PR
+  that passes `ci.yml` is not yet proven.
+- `linux-package-container-smoke.yml`: on `scripts/install-smoke.sh` and its
+  own workflow/test files.
+
+Release: `release.yml` has 9 jobs — `plan`, `build-binaries`, `build-image`,
+`nix-build`, `generate-installers`, `build-fileprovider`, `build-pkg`,
+`create-release`, `update-homebrew`. The remaining workflows are
+`workflow_dispatch`-only.
 
 ## Agent Coordination
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 ## Program context — where truth lives
 
-This file covers build/test/navigation only. For what is true and what ships
-next, read these in order (each owns a distinct layer; none is duplicated here):
+This file covers build/test/navigation and the machines that run them. For what
+is true and what ships next, read these in order (each owns a distinct layer;
+none is duplicated here):
 
 1. [docs/VISION.md](docs/VISION.md) — north star + the claim-tier legend.
 2. [docs/PRODUCT.md](docs/PRODUCT.md) — the accepted A→B→C delivery sequence,
@@ -14,43 +15,113 @@ next, read these in order (each owns a distinct layer; none is duplicated here):
 5. [docs/release/evidence/README.md](docs/release/evidence/README.md) —
    evidence corpus index.
 
+Operational ladders an agent should read rather than re-derive:
+
+- **Gate ladder (G0–G6).**
+  [docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md](docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md)
+  owns the gate definitions and their dependency order (`G1 + G2 → G3 → G4`,
+  with `G5`/`G6` following). It is explicitly superseded for *live status* by
+  `docs/ops/current.md` — read it for sequencing, not for state.
+- **Repo-roam program.**
+  [docs/ops/repo-roam-test-plan-2026-06-08.md](docs/ops/repo-roam-test-plan-2026-06-08.md)
+  is the G5 dev-env zero-diff ladder over `neo`/`honey`;
+  [docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md](docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md)
+  is the "machine does not matter" acceptance plan.
+- **Per-device crypto is sequenced, not a config flip.**
+  [docs/ops/per-device-crypto-identity-design-2026-05-18.md](docs/ops/per-device-crypto-identity-design-2026-05-18.md)
+  is the design;
+  [docs/ops/per-device-crypto-migration-2026-06-06.md](docs/ops/per-device-crypto-migration-2026-06-06.md)
+  owns the expand/contract ordering and the tri-state `crypto.wrap_mode` gate
+  that replaces the shipped-but-never-flipped `crypto.per_device_wrapping`
+  bool; and
+  [docs/ops/shared-master-fleet-migration-runbook-2026-07-28.md](docs/ops/shared-master-fleet-migration-runbook-2026-07-28.md)
+  owns how to execute one step. Every host is still `wrap_mode = master`. Do
+  not flip a wrapping mode as a side effect of a code change, and treat
+  `tcfs key rotate <prefix>` as a rebuild gate rather than an available
+  operator remedy.
+
 Tracked work: Linear initiative "Tummycrypt — Daily Driver Track"
 (https://linear.app/tinyland/initiative/tummycrypt-daily-driver-track-95eeeb5e7493),
 umbrella "Cordillera - Tinyland Remote-Everything Program"
 (https://linear.app/tinyland/initiative/cordillera-tinyland-remote-everything-program-15f56b187c19).
 Sibling repos: tinyland-inc/rockies (OS adoption seed, TIN-2300),
-tinyland-inc/lab (fleet deploy/pins), Jesssullivan/prompts-enqueue
+tinyland-inc/lab (fleet deploy/pins, host inventory, and the estate's
+build-placement and host-hold rulings), Jesssullivan/prompts-enqueue
 (program ledger, prompts 47/60).
 
 ## Quick Start
 
 ```bash
-# Enter Nix devShell (recommended)
+# Enter the Nix devShell (recommended). Its shellHook puts the pinned
+# toolchain ahead of any Home Manager rustc/cargo already on PATH.
 nix develop
-# Or with direnv:
+# Or let direnv load the committed .envrc once:
 direnv allow
 
-# Build
-~/.cargo/bin/cargo build --workspace
+# Build / test / lint — cargo comes from the devShell or the pinned toolchain
+cargo build --workspace
+cargo test --workspace
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets
 
-# Test
-~/.cargo/bin/cargo test --workspace
+# Same lanes through the task runner
+task build
+task test          # cargo test --workspace
+task lint          # cargo clippy -D warnings + cargo fmt --check
 
-# Lint
-~/.cargo/bin/cargo fmt --all -- --check
-~/.cargo/bin/cargo clippy --workspace --all-targets
-
-# Start dev infrastructure (SeaweedFS + NATS + Prometheus + Grafana)
+# Local dev stack: 8 containers (3 SeaweedFS masters + volume + filer, NATS,
+# Prometheus, Grafana) via docker-compose. Linux host only — see below.
 task dev
 ```
 
 ## Environment Notes
 
-- **Shell**: fish (does NOT support `export VAR=VALUE`; use `env VAR=VALUE command`)
-- **Cargo**: Not in PATH on Rocky Linux — always use `~/.cargo/bin/cargo`
-- **Linker**: mold is NOT installed outside Nix; do not add to `.cargo/config.toml`
-- **Docker**: Do not run docker-compose on yoga (resource-constrained)
-- **Rust edition**: 2021 (Rust >= 1.93 required for workspace)
+### Toolchain
+
+- **Rust**: edition 2021; workspace `rust-version = "1.93"`; pinned to
+  `1.93.0` by `rust-toolchain.toml`. `.envrc` fails loud when the active
+  `rustc` is below the minimum or does not match the pin.
+- **Invoke plain `cargo`.** It is expected to come from the pinned toolchain or
+  the Nix devShell (`Justfile` header; `flake.nix` `shellHook`). Do not
+  hardcode `~/.cargo/bin/cargo` — that path is only the rustup fallback
+  `.envrc` adds when `nix` is absent.
+- **Linker**: `mold` ships in the Nix devShell; outside Nix the default system
+  linker is used. Do not add a `mold` entry to `.cargo/config.toml`; opt in
+  per-shell with `RUSTFLAGS="-C link-arg=-fuse-ld=mold"`.
+- **PATH ordering**: the devShell and `.envrc` both put `target/debug` and
+  `target/release` ahead of installed packages, so a stale workspace build can
+  shadow the deployed `tcfs`/`tcfsd`. Smoke harnesses print the resolved binary
+  path — check it before believing a version string.
+
+### Machines that run this repo
+
+| Host | What it is | How agents use it |
+| --- | --- | --- |
+| `neo` | macOS (Darwin) maintainer workstation, 8 GiB RAM | Orchestration, review, editing, and the release-adjacent `neo → honey` live lane. **No local compile/test/`task dev` here** — the estate build-placement ruling sends heavy toolchain work to a remote host, and an unbounded local build takes every session on the machine down with it. Login shell is `bash`. |
+| `honey` | Rocky Linux 10 control-plane voter; canonical Linux control point | High-volume push/pull, daemon and service checks, conflict and stress lanes, Linux-first operator truth. Login shell is **`fish`**, which has no `export VAR=VALUE`; use `env VAR=VALUE command` or wrap in `bash -c '...'`. |
+| `sting` | Rocky Linux 10.2 voter; headless remote-dev seat driven from `neo` | The dev seat for build/test work that must not run on `neo`. Login shell is POSIX `bash` with an interactive-only fish handoff, so a non-interactive SSH command lands in `bash`. |
+
+Host facts and shell settings above are owned by `tinyland-inc/lab`
+(`AGENTS.md`, `inventory/host_vars/{macbook-neo,honey,sting}.yml`); that repo
+is authoritative if it disagrees with this table.
+
+- **Rocky-specific (`honey`, `sting`)**: a rustup install lands in
+  `~/.cargo/bin`, which is not on `PATH` by default. `.envrc`'s non-Nix
+  fallback adds it. Inside `nix develop` the pinned toolchain leads and this
+  does not apply.
+- **`sting` is a dev seat, not a TCFS target.** The lab-side continuity hold
+  readmitted interactive SSH, tmux, and dev work under `~/git`; the
+  `tcfs_runtime` role stays disabled. Build and test this repo there; do not
+  drive daemon, enrollment, or fleet operations against it.
+- **Acceptance hosts are a different question.** The host pool, lane order, and
+  reset contract for real-host acceptance live in
+  [docs/ops/lab-host-acceptance-matrix.md](docs/ops/lab-host-acceptance-matrix.md)
+  and [docs/ops/neo-honey-acceptance.md](docs/ops/neo-honey-acceptance.md).
+  A dev seat is not an acceptance target.
+- **Live-work freezes outrank convenience.** `docs/ops/current.md` records
+  which live resolver, enrollment, deploy, and crypto ceremonies are frozen.
+  Source review, tests, and landing continue during a freeze; new fleet claims
+  do not.
 
 ## Workspace Crates (19 members)
 
@@ -89,24 +160,38 @@ task dev
 
 ```bash
 # All tests
-~/.cargo/bin/cargo test --workspace
+cargo test --workspace
 
 # Specific crate
-~/.cargo/bin/cargo test -p tcfs-sync
+cargo test -p tcfs-sync
+
+# Feature-gated lane CI also runs
+cargo test -p tcfs-sync --features nats,crypto
 
 # Property-based tests
-~/.cargo/bin/cargo test -p tcfs-sync -- conflict
-~/.cargo/bin/cargo test -p tcfs-sync --test multi_machine_sim
+cargo test -p tcfs-sync -- conflict
+cargo test -p tcfs-sync --test multi_machine_sim
 
 # With output
-~/.cargo/bin/cargo test -- --nocapture
+cargo test -- --nocapture
 ```
+
+Shell-harness and proof lanes are `task` recipes, not cargo tests — see
+`task --list` (for example `task lazy:check`, `task lazy:dev-env-fingerprint`).
+Prefer the `lazy:test-*` regression recipes when changing a harness script.
 
 ## CI
 
-- GitHub Actions: fmt, clippy, test, build, cargo-deny, security audit, nix build
-- Docs CI: lychee link check + tectonic PDF build + Jekyll GitHub Pages
-- Release: 9 build targets (5 platforms + container + nix + installers + plan)
+- `ci.yml`: `check` (fmt, FileProvider surface contract, clippy, `cargo test`,
+  feature-isolated and wire-up tests, then workspace/`k8s-worker`/no-FUSE
+  builds), plus `cloudfilter-windows`, `nix`, `fileprovider-staticlib`,
+  `ios-typecheck`, `deny` (cargo-deny), and `secret-scan` (gitleaks).
+- `nix-ci.yml`: `flake-check`, `build-linux-x86_64`, `build-macos-aarch64`.
+- `docs.yml`: lychee link check, tectonic PDF build, GitHub Pages deploy. The
+  repo's only pre-commit hook is the same lychee check, so a broken relative
+  link in a Markdown edit fails locally and in CI.
+- `release.yml`: 9 jobs — plan, binaries, container image, nix build,
+  installers, FileProvider, `.pkg`, release creation, Homebrew update.
 
 ## Agent Coordination
 
@@ -131,6 +216,10 @@ concurrently. Adapted from the GFTB multi-agent orchestration pattern
   clean head; each "fix round" cited a fresh adversarial pass but none
   re-ran a local build/test. Verify before stacking; don't self-certify onto
   someone else's lane.
+- **`README.md` and `AGENTS.md` are live roam fixtures.** `docs/ops/current.md`
+  tracks deliberate user-content conflicts on these two paths for the TIN-2658
+  production resolver gate. Editing them in a PR is fine; do not "resolve" the
+  live host-side divergence as a side effect of a docs change.
 - **Durable notes over scratchpad.** Findings that matter beyond the current
   session go in dated files under `docs/ops/` (the existing ~30-file
   convention), never only in an ephemeral scratchpad or chat context a


### PR DESCRIPTION
## Why

`AGENTS.md` still carried the retired yoga/Rocky-seat environment block. Every
line of it was either wrong for the machines that run this repo today, or right
but scoped to the wrong host.

Head `f60b125` applies the confirmed findings from the adversarial review of
`e1367ed`. The table below is the full claim ledger for the branch.

## What changed, and what grounds it

| Old claim | New claim | Grounding |
| --- | --- | --- |
| "Shell: fish (does NOT support `export`)" — unscoped | scoped per host: `honey` login shell is `fish`; `neo` and `sting` are `bash`, and **`neo`'s interactive terminals re-enter fish**, so the caveat still applies at a `neo` prompt | `lab` `inventory/host_vars/honey.yml:276`, `macbook-neo.yml:97-98`, `sting.yml:618-627` |
| "Cargo: Not in PATH on Rocky Linux — always use `~/.cargo/bin/cargo`" | invoke plain `cargo`; the rustup-fallback note is scoped to the Rocky hosts and to the non-Nix path only | `Justfile:3,5`, `flake.nix:244-246`, `.envrc:56-63` |
| "mold is NOT installed outside Nix" → (first draft) "mold ships in the devShell" | **`mold` is nowhere** — the default system linker is used everywhere; the `.cargo/config.toml` comment is stale | `flake.nix` has zero `mold` occurrences: `commonBuildInputs` at `:46-55` is `protobuf pkg-config openssl` (+ `fuse3 rocksdb` Linux / `apple-sdk` Darwin), devShell `buildInputs` at `:197-241` adds no linker. Only other repo hits are the stale comments at `.cargo/config.toml:3,5` |
| "Do not run docker-compose on yoga (resource-constrained)" | `task dev` (8 containers) is a Linux-host lane, not `neo` | `docker-compose.yml` (8 services + 1 network), `lab` `AGENTS.md:197-209` |
| — (absent) | `neo` / `honey` / `sting` role table, marked **not exhaustive** | `docs/ops/lab-host-acceptance-matrix.md:23-26`, `docs/ops/current.md:22` |
| — (absent) | `sting` is under an **open** continuity hold (`STING_CONTINUITY_INCIDENT_2026-08-17`); the 2026-08-22 attended ruling readmitted the **dev-seat role only** and lifts no other role | `lab` `vars/fleet_switch_targets.json:132-151` (`hold.active: true`, enumerated `dev_seat.permits`, and `:151` "Dev-seat readmission does NOT lift the machine hold"); `lab` `AGENTS.md:136-156`, `:164-166` |
| "`sting` is a dev seat, **not a TCFS target**" | only the **`tcfs_runtime` role** is held disabled; fleet-coherence work against `sting` is sequenced, not forbidden | `lab` `vars/fleet_switch_targets.json:184-187` (`tcfs_runtime.status: "disabled"`, `tcfsd`/`tcfsd-health` inactive) vs. `docs/ops/current.md:93` ("prove … invariants on honey, neo, and sting") and `:113` ("**Fleet coherence.** Bring sting to the selected release and root topology") |
| "`.envrc` **fails loud**" | `.envrc` prints a loud direnv error but **does not abort the load**; verify `rustc --version` yourself | `.envrc:77-86` uses `log_error` in every branch; `direnv stdlib:145-147` is `log_error() { "$direnv" log -error "$*" }` — stderr only, no `exit`, no non-zero return, and `.envrc` has no `set -e` |
| "CI: fmt, clippy, test, build, cargo-deny, security audit, nix build" | actual job names, split into **always-on** vs **path-scoped** lanes | `ci.yml:18,97,115,152,187,206,226`; `nix-ci.yml:25,44,96`; `docs.yml:22,34,53`; `release.yml:51,108,468,528,570,665,819,948,1083` |
| — (absent) | the two path-scoped workflows that **also fire on `pull_request`** | `ci-live-storage.yml:16-24` (`crates/**`, `tests/**`, `Cargo.toml`, `Cargo.lock`, `docker-compose.yml`, `config/**`; its own header at `:7-9` explains why a green `ci.yml` is not proof) and `linux-package-container-smoke.yml:10-15` |
| — (absent) | `ci.yml`'s first step is `cargo check --workspace --locked` — the usual way a dependency edit fails CI | `.github/workflows/ci.yml:51-52` |
| "Same lanes through the task runner" | **Related** lanes — the flags differ from each other and from CI | `Taskfile.yaml:36-40` `lint` is `cargo clippy --workspace -- -D warnings` (no `--all-targets`); `ci.yml:61` is `cargo clippy --workspace --all-targets` (no `-D warnings`) |
| — (absent) | known drift: `task bench` hardcodes the path this file forbids | `Taskfile.yaml:55-56` (`~/.cargo/bin/cargo bench`) |
| — (absent) | PATH-shadow warning now also names the **live** shadow | `.envrc:103-104` and `flake.nix:246` front-load `target/{debug,release}`; `docs/ops/current.md:22` "Neo's effective interactive PATH still selects `v0.12.12`", with the attended cleanup queued at `:87-90` |
| — (absent) | `.pre-commit-config.yaml` runs the same lychee check as docs CI | `.pre-commit-config.yaml:1-7` |

## Operational ladders in "where truth lives"

- **Gate ladder (G0–G6)** — `docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md:138-159`; critical path `G1 + G2 → G3 → G4` verified in that file's dependency-graph section. Superseded for *live status* by `docs/ops/current.md` per its own line 1 banner.
- **Repo-roam program** — `docs/ops/repo-roam-test-plan-2026-06-08.md`, `docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md`.
- **Per-device crypto is sequenced, not a flip** — `docs/ops/per-device-crypto-migration-2026-06-06.md:37-45` (tri-state `crypto.wrap_mode` replaces the shipped-but-never-flipped `crypto.per_device_wrapping` bool) and `:12-19` (`tcfs key rotate <prefix>` is a rebuild gate, not a remedy, per `TIN-2551`).

## Operator decision requested before merge

The first draft published facts sourced from the **private** `tinyland-inc/lab`
inventory into this **public** repo for the first time: that `honey` and `sting`
are control-plane/etcd voters of a production cluster, `neo`'s exact RAM, and
the existence of an open continuity incident on a named production host.
`git grep` over `origin/main` `*.md` (excluding evidence dumps) returns zero
prior hits for any of it. None of it is a credential, but it is irreversible
once merged, and quorum-member identification is the reconnaissance-useful half.

**Head `f60b125` removes the cluster-role and RAM specifics** and keeps only
what is already public in this repo (`Rocky Linux 10` appears at
`README.md:46,81`, `docs/BENCHMARKS.md:328`, `docs/PRODUCT.md:12,238`;
"`honey` cluster" at `docs/ops/onprem-authority-recovery.md:4,39`). The
operational caution the review asked for is preserved without topology: the doc
says `sting` carries production roles owned by lab and outside this repo's
scope, so unbounded resource use, reboots, and host-level changes there are not
this repo's call.

If you would rather publish the topology, say so and I will restore the fuller
table in a follow-up commit — that ratification belongs on this PR either way.

## Preserved unchanged

`## Program context — where truth lives`, `## Workspace Crates (19 members)`,
`## Key Patterns`, `## Testing`, and the whole `## Agent Coordination` block
(the `#534` lesson, DO-NOT-TOUCH lists, single merge authority, the roam-fixture
note, durable-notes precedence). Heading names are unchanged everywhere.
Confirmed nothing greps AGENTS.md by section: the only `AGENTS`-matching hits
under `.github`, `Justfile`, `Taskfile.yaml`, and `scripts/` are
`LAUNCHAGENTS` variables. All 13 relative links resolve. `.claude/CLAUDE.md` is
untracked and untouched.

## Not fixed here (scoped to AGENTS.md)

- `.cargo/config.toml:3,5` still carries the false `mold` comment. AGENTS.md now
  names it stale rather than repeating it. A one-line follow-up should delete it,
  or `mold` should be added to `flake.nix:197` — an actual toolchain decision.
- `Taskfile.yaml:55-56` still hardcodes `~/.cargo/bin/cargo bench`, so
  `task bench` fails on a Nix-only machine. Recorded as known drift in the doc.
- `.github/workflows/ci-live-storage.yml:9` still says the live-fleet tests are
  "operator-only on neo/honey/**yoga**" — the last yoga reference in an
  operator-facing surface. Remaining `yoga` hits are test fixtures only
  (`crates/tcfs-sync/tests/multi_machine_sim.rs`, `crates/tcfs-secrets/src/device.rs`).
- `README.md:52-56` still shows a `~/.cargo/bin/cargo` invocation. Left alone
  deliberately: it is a live roam fixture (below) and this PR is scoped to AGENTS.md.

## Roam-fixture note

`docs/ops/current.md:55,60,72` records `README.md` and `AGENTS.md` as the two
deliberate user-content conflict fixtures for the TIN-2658 production resolver
gate. Changing tracked `AGENTS.md` content is the normal path, but the residual
closeout still calls for adjudicating those two paths on the hosts. A note to
that effect is in `## Agent Coordination` so the next agent does not "resolve"
the live divergence as a side effect of a docs edit.

## Unverified

- Whether `sting` currently has the 1.93 toolchain installed outside Nix. The
  Rocky `~/.cargo/bin` note is written as a conditional about rustup layout and
  `.envrc` behaviour, not as a claim about installed state on that host.
- Whether `docs/ops/lab-host-acceptance-matrix.md:26` ("`sting`: none yet /
  blocked on lab-side hardware stabilization", April 2026) should now change.
  It is stale against the lab-side dev-seat ratification, but the hold is still
  open, so it is an operator call. The doc routes to it rather than restating it.
- No command in this branch was executed on `honey` or `sting`; every host claim
  is read from `lab`'s committed inventory at `7d0d455`, not from a live probe.
