### PR TITLE
feat(bulkload): native resumable transport and state carry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +398,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +679,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1126,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1465,6 +1511,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1620,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -1951,6 +2021,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,10 +2087,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2034,6 +2129,29 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -2432,6 +2550,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2919,17 @@ dependencies = [
  "libz-sys",
  "lz4-sys",
  "zstd-sys",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3589,6 +3734,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4377,6 +4535,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5022,6 +5194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5145,6 +5326,39 @@ dependencies = [
  "webauthn-rs",
  "webauthn-rs-proto",
  "zstd",
+]
+
+[[package]]
+name = "tcfs-bulkload-agent"
+version = "0.12.17"
+dependencies = [
+ "blake3",
+ "crc32c",
+ "fastcdc",
+ "ignore",
+ "libc",
+ "postcard",
+ "rayon",
+ "rusqlite",
+ "serde",
+ "tcfs-bulkload-proto",
+]
+
+[[package]]
+name = "tcfs-bulkload-bench"
+version = "0.12.17"
+dependencies = [
+ "clap",
+ "tcfs-bulkload-agent",
+ "tcfs-bulkload-proto",
+]
+
+[[package]]
+name = "tcfs-bulkload-proto"
+version = "0.12.17"
+dependencies = [
+ "postcard",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5351,6 +5351,7 @@ dependencies = [
  "clap",
  "tcfs-bulkload-agent",
  "tcfs-bulkload-proto",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ members = [
     "crates/tcfs-file-provider",
     "crates/tcfs-dbus",
     "crates/tcfs-auth",
+    "crates/tcfs-bulkload-proto",
+    "crates/tcfs-bulkload-agent",
+    "crates/tcfs-bulkload-bench",
     "tests/e2e",
 ]
 
@@ -130,6 +133,14 @@ prometheus-client = { version = "0.24" }
 
 # Parallelism
 rayon = { version = "1" }
+
+# Bulkload rebuild (R32-R35): the agent half is held to a deliberately small
+# dependency set enforced by the tcfs-bulkload-agent dep-graph test.
+postcard = { version = "1", features = ["use-std"] }
+libc = { version = "0.2" }
+rusqlite = { version = "0.32", features = ["bundled"] }
+ignore = { version = "0.4" }
+crc32c = { version = "0.6" }
 
 # UUID
 uuid = { version = "1", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -39,12 +39,33 @@ Claims without a packet or named live canary remain unproven.
 - Root-targeted production conflict resolution for scheduled roam roots.
 - Two repositories completing the full bidirectional roam, unsync, rehydrate,
   divergence, restore, and second-cycle convergence loop.
-- Linked-worktree reconstruction, arbitrary agent sessions, or broad home and
-  dot-directory remotification.
+- Automatic linked-worktree reconstruction through the roaming daemon,
+  arbitrary agent sessions, or broad home and dot-directory remotification.
 - Per-device-only crypto, headless SSH-first enrollment, or a TLS-protected
   production S3 path.
 - Rocky 10 RPM/FUSE acceptance, Windows Explorer parity, iOS production use, or
   NFS client parity.
+
+## Native Bulkload migration tools
+
+This source tree also contains the explicit Rust migration adapter, separate
+from automatic TCFS roaming:
+
+```bash
+cargo build --release -p tcfs-bulkload-agent -p tcfs-bulkload-bench
+target/release/tcfs-bulkload-bench --help
+```
+
+The [agent command interface](crates/tcfs-bulkload-agent/src/main.rs) supports
+resumable transfers, Git capture/import and guarded worktree restoration.
+Use explicit source snapshots and private state/receipt directories; retain
+captures until acceptance. An imported bundle is not a restored workspace.
+Existing worktrees and provider databases are not replaceable copy targets.
+
+The benchmark compares real local native/rclone copies and resumes on a sealed
+corpus. It does not establish network performance or whole-estate completion.
+See [TIN-3692](https://linear.app/tinyland/issue/TIN-3692) for migration acceptance
+and the outstanding policy decisions.
 
 ## Develop
 
@@ -56,7 +77,7 @@ nix develop
 ~/.cargo/bin/cargo clippy --workspace --all-targets
 ```
 
-The repository contains 19 workspace crates. The protobuf source of truth is
+The workspace members are declared in [Cargo.toml](Cargo.toml). The protobuf source of truth is
 [`crates/tcfs-core/src/proto/tcfs.proto`](crates/tcfs-core/src/proto/tcfs.proto).
 See [`AGENTS.md`](AGENTS.md) before changing code or running fleet workflows.
 

--- a/crates/tcfs-bulkload-agent/Cargo.toml
+++ b/crates/tcfs-bulkload-agent/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "tcfs-bulkload-agent"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "tcfs bulkload agent: the thin darwin-side walker/hasher half"
+
+[[bin]]
+name = "tcfs-bulkload-agent"
+path = "src/main.rs"
+
+# R34 dependency wall. This list is closed: the `dep_graph` integration test
+# asserts that tokio, opendal, reqwest, ring and tonic are absent from
+# `cargo tree -p tcfs-bulkload-agent -e normal`. Adding an async runtime, an
+# object-store abstraction, an HTTP client or a TLS stack to the agent half is
+# a design change, not a dependency bump -- take it back to the plan first.
+[dependencies]
+tcfs-bulkload-proto = { path = "../tcfs-bulkload-proto" }
+rayon = { workspace = true }
+blake3 = { workspace = true }
+fastcdc = { workspace = true }
+serde = { workspace = true }
+postcard = { workspace = true }
+libc = { workspace = true }
+rusqlite = { workspace = true }
+ignore = { workspace = true }
+crc32c = { workspace = true }
+
+[lints.clippy]
+# R33 deny-panics wall. Refusals are Results, never panics.
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+unwrap_used = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+panic = "deny"

--- a/crates/tcfs-bulkload-agent/Cargo.toml
+++ b/crates/tcfs-bulkload-agent/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "tcfs bulkload agent: the thin darwin-side walker/hasher half"
+description = "Native resumable file transport, Git estate carry, and provider-state composition"
 
 [[bin]]
 name = "tcfs-bulkload-agent"

--- a/crates/tcfs-bulkload-agent/Cargo.toml
+++ b/crates/tcfs-bulkload-agent/Cargo.toml
@@ -23,7 +23,7 @@ fastcdc = { workspace = true }
 serde = { workspace = true }
 postcard = { workspace = true }
 libc = { workspace = true }
-rusqlite = { workspace = true }
+rusqlite = { workspace = true, features = ["backup"] }
 ignore = { workspace = true }
 crc32c = { workspace = true }
 

--- a/crates/tcfs-bulkload-agent/src/estate.rs
+++ b/crates/tcfs-bulkload-agent/src/estate.rs
@@ -35,6 +35,14 @@ struct Capture {
     identity: crate::freshness::StatIdentity,
 }
 
+// Separate sidecars preserve the existing Capture postcard wire layout.
+#[derive(Clone, Serialize, Deserialize)]
+struct Base {
+    bundle: String,
+    digest: [u8; 32],
+    identity: crate::freshness::StatIdentity,
+}
+
 #[derive(Debug)]
 pub struct Receipt {
     pub item: String,
@@ -213,7 +221,73 @@ fn hash_file(path: &Path) -> Result<[u8; 32]> {
     Ok(*hasher.finalize().as_bytes())
 }
 
-fn capture_item(item: &Item, state: &Path, corpus: &Path) -> Result<&'static str> {
+fn base_path(corpus: &Path, base: &Base) -> Result<PathBuf> {
+    if !filename(&base.bundle) {
+        return Err(BulkloadRefusal::PathEscapesRoot);
+    }
+    Ok(corpus.join(&base.bundle))
+}
+
+fn retained_base(corpus: &Path, base: &Base) -> Result<bool> {
+    let path = base_path(corpus, base)?;
+    Ok(path.try_exists()?
+        && base.identity
+            == crate::freshness::StatIdentity::from_metadata(&fs::symlink_metadata(path)?))
+}
+
+fn prepare_base(item: &Item, group: &str, state: &Path, corpus: &Path) -> Result<Base> {
+    let record = corpus.join(format!("shared-{group}.base"));
+    if record.try_exists()? {
+        let base: Base = read(&record)?;
+        if retained_base(corpus, &base)? {
+            return Ok(base);
+        }
+        // Do not replace a missing or changed prerequisite while older deltas
+        // still depend on it. Keep the missing custody visible.
+        return Err(BulkloadRefusal::ReceiptBindingInvalid);
+    }
+    let mut generation = 0u64;
+    let attempt = loop {
+        let attempt = state.join(format!("shared-{group}-{generation}"));
+        if !attempt.try_exists()? {
+            break attempt;
+        }
+        generation = generation
+            .checked_add(1)
+            .ok_or(BulkloadRefusal::FieldDomainViolation)?;
+    };
+    let bundle = git_carry::shared::export_base(&item.source, &attempt)?;
+    let digest = hash_file(&bundle)?;
+    let name = format!(
+        "shared-{}.bundle",
+        blake3::Hash::from_bytes(digest).to_hex()
+    );
+    let published = corpus.join(&name);
+    if published.try_exists()? {
+        if hash_file(&published)? != digest {
+            return Err(BulkloadRefusal::DigestMismatch);
+        }
+    } else {
+        fs::hard_link(&bundle, &published)?;
+    }
+    // Git's successful pack write is not a durability guarantee. Flush the
+    // payload before write() publishes and directory-syncs its dependency.
+    fs::File::open(&published)?.sync_all()?;
+    let base = Base {
+        bundle: name,
+        digest,
+        identity: crate::freshness::StatIdentity::from_metadata(&fs::symlink_metadata(published)?),
+    };
+    write(&record, &base)?;
+    Ok(base)
+}
+
+fn capture_item(
+    item: &Item,
+    state: &Path,
+    corpus: &Path,
+    base: Option<&Base>,
+) -> Result<&'static str> {
     let identity = id(item)?;
     let record = corpus.join(format!("{identity}.capture"));
     let key = git_carry::reusable_capture_key(&item.source)?;
@@ -226,8 +300,14 @@ fn capture_item(item: &Item, state: &Path, corpus: &Path) -> Result<&'static str
         if previous.key == key
             && bundle.try_exists()?
             && previous.identity
-                == crate::freshness::StatIdentity::from_metadata(&fs::symlink_metadata(bundle)?)
+                == crate::freshness::StatIdentity::from_metadata(&fs::symlink_metadata(&bundle)?)
         {
+            if git_carry::shared::requires_base(&bundle)? {
+                let bound: Base = read(&corpus.join(format!("{}.base", previous.bundle)))?;
+                if !retained_base(corpus, &bound)? {
+                    return Err(BulkloadRefusal::ReceiptBindingInvalid);
+                }
+            }
             return Ok("capture-reused-after-census");
         }
     }
@@ -245,7 +325,15 @@ fn capture_item(item: &Item, state: &Path, corpus: &Path) -> Result<&'static str
             .ok_or(BulkloadRefusal::FieldDomainViolation)?;
     };
     // Failed private attempts are retained, never silently overwritten.
-    let bundle = git_carry::export_repository(&item.source, &attempt)?;
+    let bundle = if let Some(base) = base {
+        git_carry::export_repository_with_prerequisite(
+            &item.source,
+            &attempt,
+            &base_path(corpus, base)?,
+        )?
+    } else {
+        git_carry::export_repository(&item.source, &attempt)?
+    };
     if key != git_carry::reusable_capture_key(&item.source)? {
         return Err(BulkloadRefusal::GitAuthorityChanged);
     }
@@ -262,7 +350,13 @@ fn capture_item(item: &Item, state: &Path, corpus: &Path) -> Result<&'static str
     } else {
         fs::hard_link(&bundle, &published)?;
     }
+    // Completion may survive a crash only after its bundle bytes are durable.
+    fs::File::open(&published)?.sync_all()?;
     let metadata = fs::symlink_metadata(&published)?;
+    if let Some(base) = base {
+        // Publish dependency custody before the unchanged completion codec.
+        write(&corpus.join(format!("{name}.base")), base)?;
+    }
     write(
         &record,
         &Capture {
@@ -321,6 +415,64 @@ fn emit(state: &Path, row: &Receipt, receipt: &impl Fn(&Receipt) -> Result<()>) 
     receipt(row)
 }
 
+#[derive(Default)]
+struct CaptureGroups {
+    items: std::collections::BTreeMap<String, String>,
+    bases: std::collections::BTreeMap<String, Mutex<Option<Base>>>,
+}
+
+fn capture_groups(plan: &Plan) -> Result<CaptureGroups> {
+    let mut candidates = std::collections::BTreeMap::<String, Vec<String>>::new();
+    for item in &plan.items {
+        // Invalid sources still run through the ordinary per-item refusal path
+        // so one bad item cannot suppress receipts for unrelated valid work.
+        let Ok(common) = git_carry::common_repository(&item.source) else {
+            continue;
+        };
+        let Ok(metadata) = fs::metadata(&common) else {
+            continue;
+        };
+        let bytes = postcard::to_allocvec(&(common, metadata.dev(), metadata.ino()))
+            .map_err(|_| BulkloadRefusal::FrameCodec)?;
+        candidates
+            .entry(blake3::hash(&bytes).to_hex().to_string())
+            .or_default()
+            .push(id(item)?);
+    }
+    let mut groups = CaptureGroups::default();
+    for (group, items) in candidates {
+        if items.len() > 1 {
+            for item in items {
+                groups.items.insert(item, group.clone());
+            }
+            groups.bases.insert(group, Mutex::new(None));
+        }
+    }
+    Ok(groups)
+}
+
+fn group_base(
+    item: &Item,
+    groups: &CaptureGroups,
+    state: &Path,
+    corpus: &Path,
+) -> Result<Option<Base>> {
+    let Some(group) = groups.items.get(&id(item)?) else {
+        return Ok(None);
+    };
+    let mut base = groups
+        .bases
+        .get(group)
+        .ok_or(BulkloadRefusal::GitAuthorityChanged)?
+        .lock()
+        .map_err(|_| BulkloadRefusal::GitAuthorityChanged)?;
+    if base.is_none() {
+        *base = Some(prepare_base(item, group, state, corpus)?);
+    }
+    // Drop the base-creation lock before the independent workspace capture.
+    Ok(base.clone())
+}
+
 /// Capture explicit items with at most two Git pack workers at a time.
 ///
 /// # Errors
@@ -337,15 +489,69 @@ pub fn capture(
     private_directory(corpus)?;
     let contents: Plan = read(plan)?;
     let _lock = exclusive(&state.join("estate.lock"))?;
+    let groups = capture_groups(&contents)?;
     execute(
         &contents,
         jobs,
-        &|item| capture_item(item, state, corpus),
+        &|item| {
+            let base = group_base(item, &groups, state, corpus)?;
+            capture_item(item, state, corpus, base.as_ref())
+        },
         &|row| emit(state, row, receipt),
     )
 }
 
-fn apply_item(item: &Item, corpus: &Path, state: &Path, source: &str) -> Result<&'static str> {
+type ImportedBases = Mutex<std::collections::BTreeSet<(PathBuf, [u8; 32])>>;
+
+fn import_base(
+    item: &Item,
+    captured: &Capture,
+    corpus: &Path,
+    source: &str,
+    imported: &ImportedBases,
+) -> Result<()> {
+    let bundle = corpus.join(&captured.bundle);
+    if !git_carry::shared::requires_base(&bundle)? {
+        return Ok(());
+    }
+    let base: Base = read(&corpus.join(format!("{}.base", captured.bundle)))?;
+    let path = base_path(corpus, &base)?;
+    // Existing shared repositories are the supported optimization. Creating a
+    // standalone destination needs a separate private preseed implementation.
+    if !item.repository.try_exists()?
+        || item
+            .workspace
+            .as_ref()
+            .is_some_and(|workspace| workspace == &item.repository)
+    {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    let key = (git_carry::common_repository(&item.repository)?, base.digest);
+    if imported
+        .lock()
+        .map_err(|_| BulkloadRefusal::GitAuthorityChanged)?
+        .contains(&key)
+    {
+        return Ok(());
+    }
+    if hash_file(&path)? != base.digest || git_carry::shared::requires_base(&path)? {
+        return Err(BulkloadRefusal::DigestMismatch);
+    }
+    git_carry::import_bundle(&item.repository, &path, source)?;
+    imported
+        .lock()
+        .map_err(|_| BulkloadRefusal::GitAuthorityChanged)?
+        .insert(key);
+    Ok(())
+}
+
+fn apply_item(
+    item: &Item,
+    corpus: &Path,
+    state: &Path,
+    source: &str,
+    imported: &ImportedBases,
+) -> Result<&'static str> {
     let identity = id(item)?;
     let captured: Capture = read(&corpus.join(format!("{identity}.capture")))?;
     if !filename(&captured.bundle) {
@@ -368,6 +574,7 @@ fn apply_item(item: &Item, corpus: &Path, state: &Path, source: &str) -> Result<
     if hash_file(&bundle)? != captured.digest {
         return Err(BulkloadRefusal::DigestMismatch);
     }
+    import_base(item, &captured, corpus, source, imported)?;
     let outcome = if let Some(workspace) = &item.workspace {
         if item.repository == *workspace {
             git_carry::restore_bundle(&bundle, workspace, source)?;
@@ -401,6 +608,7 @@ pub fn apply(
     let contents: Plan = read(plan)?;
     let mut locks = std::collections::BTreeMap::new();
     let mut groups = std::collections::BTreeMap::new();
+    let imported = ImportedBases::default();
     for item in &contents.items {
         let common = if item.repository.try_exists()? {
             git_carry::common_repository(&item.repository)?
@@ -423,7 +631,7 @@ pub fn apply(
             let _guard = lock
                 .lock()
                 .map_err(|_| BulkloadRefusal::GitAuthorityChanged)?;
-            apply_item(item, corpus, state, source)
+            apply_item(item, corpus, state, source, &imported)
         },
         &|row| emit(state, row, receipt),
     )
@@ -455,6 +663,78 @@ mod tests {
             .expect("git command")
             .status
             .success());
+    }
+
+    #[test]
+    fn shared_capture_keeps_completion_codec_and_requires_retained_base() {
+        let root = std::env::temp_dir().join(format!("tcfs-estate-shared-{}", std::process::id()));
+        fs::DirBuilder::new().mode(0o700).create(&root).unwrap();
+        let source = root.join("source");
+        fs::create_dir(&source).unwrap();
+        git(&source, &["init", "--template="]);
+        fs::write(source.join("file"), b"base").unwrap();
+        git(&source, &["add", "file"]);
+        git(&source, &["commit", "-m", "base"]);
+        let second = root.join("second");
+        git(
+            &source,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                second.to_str().unwrap(),
+                "HEAD",
+            ],
+        );
+        fs::write(source.join("file"), b"first dirty").unwrap();
+        fs::write(second.join("file"), b"second dirty").unwrap();
+        let repository = root.join("repository");
+        fs::create_dir(&repository).unwrap();
+        git(&repository, &["init", "--template="]);
+        let first_target = root.join("first-target");
+        let second_target = root.join("second-target");
+        let plan = root.join("plan");
+        add(&plan, &source, &repository, Some(&first_target)).unwrap();
+        add(&plan, &second, &repository, Some(&second_target)).unwrap();
+        let state = root.join("state");
+        let corpus = root.join("corpus");
+        capture(&plan, &state, &corpus, 2, &|_| Ok(())).unwrap();
+        let outcomes = Mutex::new(Vec::new());
+        capture(&plan, &state, &corpus, 2, &|row| {
+            outcomes.lock().unwrap().push(row.outcome);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            *outcomes.lock().unwrap(),
+            vec!["capture-reused-after-census"; 2]
+        );
+        let items = inspect(&plan).unwrap();
+        let mut dependencies = Vec::new();
+        for item in &items {
+            // Decode through the unchanged completion struct used by existing
+            // independent standalone captures and their live restore journals.
+            let record: Capture =
+                read(&corpus.join(format!("{}.capture", id(item).unwrap()))).unwrap();
+            let base: Base = read(&corpus.join(format!("{}.base", record.bundle))).unwrap();
+            dependencies.push(base.bundle);
+        }
+        assert_eq!(dependencies.first(), dependencies.last());
+        let base = corpus.join(dependencies.first().unwrap());
+        let held = root.join("held-base");
+        fs::rename(&base, &held).unwrap();
+        assert!(capture(&plan, &state, &corpus, 2, &|_| Ok(())).is_err());
+        let applied = root.join("applied");
+        assert!(apply(&plan, &corpus, &applied, "neo", 2, &|_| Ok(())).is_err());
+        assert!(!first_target.exists() && !second_target.exists());
+        fs::rename(&held, &base).unwrap();
+        apply(&plan, &corpus, &applied, "neo", 2, &|_| Ok(())).unwrap();
+        assert_eq!(fs::read(first_target.join("file")).unwrap(), b"first dirty");
+        assert_eq!(
+            fs::read(second_target.join("file")).unwrap(),
+            b"second dirty"
+        );
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/crates/tcfs-bulkload-agent/src/estate.rs
+++ b/crates/tcfs-bulkload-agent/src/estate.rs
@@ -1,0 +1,528 @@
+//! Explicit reviewed Git batches. Capture reuse still performs a metadata census.
+//!
+//! Ref custody and usable restored workspaces are separate outcomes. Completed
+//! restores are never replayed over subsequent operator edits.
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{git_carry, BulkloadRefusal, Result};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Item {
+    pub source: PathBuf,
+    pub repository: PathBuf,
+    pub workspace: Option<PathBuf>,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct Plan {
+    items: Vec<Item>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Capture {
+    key: [u8; 32],
+    bundle: String,
+    digest: [u8; 32],
+    identity: crate::freshness::StatIdentity,
+}
+
+#[derive(Debug)]
+pub struct Receipt {
+    pub item: String,
+    pub source: PathBuf,
+    pub outcome: &'static str,
+    pub reason: Option<String>,
+}
+
+/// Read the exact reviewed items without performing capture or apply.
+///
+/// # Errors
+/// Refuses malformed, oversized or symlinked plans.
+pub fn inspect(plan: &Path) -> Result<Vec<Item>> {
+    Ok(read::<Plan>(plan)?.items)
+}
+
+fn read<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    let mut bytes = Vec::new();
+    file.take(16 * 1024 * 1024 + 1).read_to_end(&mut bytes)?;
+    if bytes.len() > 16 * 1024 * 1024 {
+        return Err(BulkloadRefusal::FieldDomainViolation);
+    }
+    postcard::from_bytes(&bytes).map_err(|_| BulkloadRefusal::FrameCodec)
+}
+
+fn write<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let bytes = postcard::to_allocvec(value).map_err(|_| BulkloadRefusal::FrameCodec)?;
+    // All callers hold a plan or phase lock. Retain interrupted publications
+    // rather than overwrite their bytes or make them a permanent resume blocker.
+    let mut generation = 0u64;
+    let (temporary, mut file) = loop {
+        let temporary = path.with_extension(format!("pending-{generation}"));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)
+        {
+            Ok(file) => break (temporary, file),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                generation = generation
+                    .checked_add(1)
+                    .ok_or(BulkloadRefusal::FieldDomainViolation)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    };
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    fs::rename(&temporary, path)?;
+    fs::File::open(path.parent().ok_or(BulkloadRefusal::PathNotAbsolute)?)?.sync_all()?;
+    Ok(())
+}
+
+fn private_directory(path: &Path) -> Result<()> {
+    match fs::DirBuilder::new().mode(0o700).create(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = fs::symlink_metadata(path)?;
+            // SAFETY: geteuid has no preconditions or side effects.
+            if metadata.is_dir()
+                && metadata.mode().trailing_zeros() >= 6
+                && metadata.uid() == unsafe { libc::geteuid() }
+            {
+                Ok(())
+            } else {
+                Err(BulkloadRefusal::PathEscapesRoot)
+            }
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn filename(value: &str) -> bool {
+    let mut parts = Path::new(value).components();
+    matches!(parts.next(), Some(std::path::Component::Normal(_))) && parts.next().is_none()
+}
+
+fn id(item: &Item) -> Result<String> {
+    let bytes = postcard::to_allocvec(item).map_err(|_| BulkloadRefusal::FrameCodec)?;
+    Ok(blake3::hash(&bytes).to_hex().to_string())
+}
+
+/// Append one operator-selected source and destination. No inventory guesses.
+///
+/// # Errors
+/// Refuses invalid paths, conflicting workspace targets, locked or malformed plans.
+pub fn add(plan: &Path, source: &Path, repository: &Path, workspace: Option<&Path>) -> Result<()> {
+    add_batch(
+        plan,
+        &[Item {
+            source: source.to_owned(),
+            repository: repository.to_owned(),
+            workspace: workspace.map(Path::to_owned),
+        }],
+    )
+}
+
+/// Append a reviewed batch with one plan read/write and linear duplicate checks.
+///
+/// # Errors
+/// Refuses malformed paths or conflicting targets without publishing a partial plan.
+pub fn add_batch(plan: &Path, items: &[Item]) -> Result<()> {
+    if !plan.is_absolute() {
+        return Err(BulkloadRefusal::PathNotAbsolute);
+    }
+    let _lock = exclusive(&plan.with_extension("lock"))?;
+    let mut contents: Plan = if plan.try_exists()? {
+        read(plan)?
+    } else {
+        Plan::default()
+    };
+    let mut identities = std::collections::HashSet::new();
+    let mut targets = std::collections::HashSet::new();
+    for previous in &contents.items {
+        identities.insert(id(previous)?);
+        if let Some(target) = &previous.workspace {
+            targets.insert(target.clone());
+        }
+    }
+    for incoming in items {
+        let mut item = incoming.clone();
+        item.source = fs::canonicalize(&item.source)?;
+        if !item.repository.is_absolute()
+            || item.workspace.as_ref().is_some_and(|p| !p.is_absolute())
+        {
+            return Err(BulkloadRefusal::PathNotAbsolute);
+        }
+        if !identities.insert(id(&item)?) {
+            continue;
+        }
+        if let Some(target) = &item.workspace {
+            if !targets.insert(target.clone()) {
+                return Err(BulkloadRefusal::GitDestinationOccupied);
+            }
+        }
+        contents.items.push(item);
+    }
+    write(plan, &contents)
+}
+
+fn exclusive(path: &Path) -> Result<fs::File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    // SAFETY: the owned file descriptor remains open for the lock lifetime.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(file)
+}
+
+fn hash_file(path: &Path) -> Result<[u8; 32]> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = vec![0; 65536];
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(buffer.get(..count).ok_or(BulkloadRefusal::FrameCodec)?);
+    }
+    Ok(*hasher.finalize().as_bytes())
+}
+
+fn capture_item(item: &Item, state: &Path, corpus: &Path) -> Result<&'static str> {
+    let identity = id(item)?;
+    let record = corpus.join(format!("{identity}.capture"));
+    let key = git_carry::reusable_capture_key(&item.source)?;
+    if record.try_exists()? {
+        let previous: Capture = read(&record)?;
+        if !filename(&previous.bundle) {
+            return Err(BulkloadRefusal::PathEscapesRoot);
+        }
+        let bundle = corpus.join(&previous.bundle);
+        if previous.key == key
+            && bundle.try_exists()?
+            && previous.identity
+                == crate::freshness::StatIdentity::from_metadata(&fs::symlink_metadata(bundle)?)
+        {
+            return Ok("capture-reused-after-census");
+        }
+    }
+    let mut generation = 0u64;
+    let attempt = loop {
+        let candidate = state.join(format!(
+            "{identity}-{}-{generation}",
+            blake3::Hash::from_bytes(key).to_hex()
+        ));
+        if !candidate.try_exists()? {
+            break candidate;
+        }
+        generation = generation
+            .checked_add(1)
+            .ok_or(BulkloadRefusal::FieldDomainViolation)?;
+    };
+    // Failed private attempts are retained, never silently overwritten.
+    let bundle = git_carry::export_repository(&item.source, &attempt)?;
+    if key != git_carry::reusable_capture_key(&item.source)? {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    let digest = hash_file(&bundle)?;
+    let name = format!(
+        "{identity}-{}.bundle",
+        blake3::Hash::from_bytes(digest).to_hex()
+    );
+    let published = corpus.join(&name);
+    if published.try_exists()? {
+        if hash_file(&published)? != digest {
+            return Err(BulkloadRefusal::DigestMismatch);
+        }
+    } else {
+        fs::hard_link(&bundle, &published)?;
+    }
+    let metadata = fs::symlink_metadata(&published)?;
+    write(
+        &record,
+        &Capture {
+            key,
+            bundle: name,
+            digest,
+            identity: crate::freshness::StatIdentity::from_metadata(&metadata),
+        },
+    )?;
+    Ok("captured")
+}
+
+fn execute(
+    plan: &Plan,
+    jobs: usize,
+    operation: &(impl Fn(&Item) -> Result<&'static str> + Sync),
+    receipt: &(impl Fn(&Receipt) -> Result<()> + Sync),
+) -> Result<()> {
+    if !(1..=2).contains(&jobs) {
+        return Err(BulkloadRefusal::FieldDomainViolation);
+    }
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(jobs)
+        .build()
+        .map_err(|_| BulkloadRefusal::FieldDomainViolation)?;
+    let refused = std::sync::atomic::AtomicBool::new(false);
+    pool.install(|| {
+        plan.items.par_iter().try_for_each(|item| {
+            let (outcome, reason) = match operation(item) {
+                Ok(outcome) => (outcome, None),
+                Err(error) => {
+                    refused.store(true, std::sync::atomic::Ordering::Relaxed);
+                    ("refused", Some(error.to_string()))
+                }
+            };
+            receipt(&Receipt {
+                item: id(item)?,
+                source: item.source.clone(),
+                outcome,
+                reason,
+            })
+        })
+    })?;
+    if refused.load(std::sync::atomic::Ordering::Relaxed) {
+        Err(BulkloadRefusal::ContractSelfInconsistent)
+    } else {
+        Ok(())
+    }
+}
+
+fn emit(state: &Path, row: &Receipt, receipt: &impl Fn(&Receipt) -> Result<()>) -> Result<()> {
+    write(
+        &state.join(format!("{}.outcome", row.item)),
+        &(&row.source, row.outcome, &row.reason),
+    )?;
+    receipt(row)
+}
+
+/// Capture explicit items with at most two Git pack workers at a time.
+///
+/// # Errors
+/// Refuses insecure state directories, changing sources or failed captures; completed
+/// items remain durable and each failed item is reported independently.
+pub fn capture(
+    plan: &Path,
+    state: &Path,
+    corpus: &Path,
+    jobs: usize,
+    receipt: &(impl Fn(&Receipt) -> Result<()> + Sync),
+) -> Result<()> {
+    private_directory(state)?;
+    private_directory(corpus)?;
+    let contents: Plan = read(plan)?;
+    let _lock = exclusive(&state.join("estate.lock"))?;
+    execute(
+        &contents,
+        jobs,
+        &|item| capture_item(item, state, corpus),
+        &|row| emit(state, row, receipt),
+    )
+}
+
+fn apply_item(item: &Item, corpus: &Path, state: &Path, source: &str) -> Result<&'static str> {
+    let identity = id(item)?;
+    let captured: Capture = read(&corpus.join(format!("{identity}.capture")))?;
+    if !filename(&captured.bundle) {
+        return Err(BulkloadRefusal::PathEscapesRoot);
+    }
+    let journal = state.join(format!(
+        "{identity}-{}-{}.done",
+        blake3::hash(source.as_bytes()).to_hex(),
+        blake3::Hash::from_bytes(captured.digest).to_hex()
+    ));
+    if journal.try_exists()? {
+        let done: String = read(&journal)?;
+        return match done.as_str() {
+            "workspace-restored" => Ok("previous-workspace-restoration-not-revalidated"),
+            "refs-imported" => Ok("previous-ref-custody-not-workspace-parity"),
+            _ => Err(BulkloadRefusal::ReceiptBindingInvalid),
+        };
+    }
+    let bundle = corpus.join(&captured.bundle);
+    if hash_file(&bundle)? != captured.digest {
+        return Err(BulkloadRefusal::DigestMismatch);
+    }
+    let outcome = if let Some(workspace) = &item.workspace {
+        if item.repository == *workspace {
+            git_carry::restore_bundle(&bundle, workspace, source)?;
+        } else {
+            git_carry::restore_linked(&bundle, &item.repository, workspace, source)?;
+        }
+        "workspace-restored"
+    } else {
+        git_carry::import_bundle(&item.repository, &bundle, source)?;
+        "refs-imported"
+    };
+    write(&journal, &outcome.to_owned())?;
+    Ok(outcome)
+}
+
+/// Apply explicit restores only; common Git administration is serialized.
+///
+/// # Errors
+/// Refuses occupied restore targets, invalid bundles or conflicting Git authority.
+/// Previously completed work is retained without replaying over operator edits.
+pub fn apply(
+    plan: &Path,
+    corpus: &Path,
+    state: &Path,
+    source: &str,
+    jobs: usize,
+    receipt: &(impl Fn(&Receipt) -> Result<()> + Sync),
+) -> Result<()> {
+    private_directory(state)?;
+    let _lock = exclusive(&state.join("estate.lock"))?;
+    let contents: Plan = read(plan)?;
+    let mut locks = std::collections::BTreeMap::new();
+    let mut groups = std::collections::BTreeMap::new();
+    for item in &contents.items {
+        let common = if item.repository.try_exists()? {
+            git_carry::common_repository(&item.repository)?
+        } else {
+            item.repository.clone()
+        };
+        groups.insert(id(item)?, common.clone());
+        locks.entry(common).or_insert_with(|| Mutex::new(()));
+    }
+    execute(
+        &contents,
+        jobs,
+        &|item| {
+            let common = groups
+                .get(&id(item)?)
+                .ok_or(BulkloadRefusal::GitAuthorityChanged)?;
+            let lock = locks
+                .get(common)
+                .ok_or(BulkloadRefusal::GitAuthorityChanged)?;
+            let _guard = lock
+                .lock()
+                .map_err(|_| BulkloadRefusal::GitAuthorityChanged)?;
+            apply_item(item, corpus, state, source)
+        },
+        &|row| emit(state, row, receipt),
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    fn git(path: &Path, args: &[&str]) {
+        assert!(Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .args([
+                "-c",
+                "user.name=Bulkload test",
+                "-c",
+                "user.email=test@localhost",
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "core.hooksPath=/dev/null"
+            ])
+            .args(args)
+            .output()
+            .expect("git command")
+            .status
+            .success());
+    }
+
+    #[test]
+    fn explicit_batches_reuse_capture_preserve_edits_and_refuse_public_corpus() {
+        let root = std::env::temp_dir().join(format!("tcfs-estate-test-{}", std::process::id()));
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&root)
+            .expect("owned root");
+        let source = root.join("source");
+        fs::create_dir(&source).expect("source");
+        git(&source, &["init", "--template="]);
+        fs::write(source.join("file"), b"base").expect("base");
+        git(&source, &["add", "file"]);
+        git(&source, &["commit", "-m", "base"]);
+        fs::write(source.join("file"), b"dirty").expect("dirty");
+        let target = root.join("destination");
+        let plan = root.join("plan");
+        let interrupted = plan.with_extension("pending-0");
+        fs::write(&interrupted, b"retained interrupted plan").expect("simulate interrupted write");
+        add(&plan, &source, &target, Some(&target)).expect("plan");
+        assert_eq!(
+            fs::read(&interrupted).expect("retained"),
+            b"retained interrupted plan"
+        );
+        add(&plan, &source, &target, Some(&target)).expect("idempotent plan");
+        assert_eq!(read::<Plan>(&plan).expect("read plan").items.len(), 1);
+        let state = root.join("state");
+        let corpus = root.join("corpus");
+        capture(&plan, &state, &corpus, 2, &|_| Ok(())).expect("capture");
+        let outcomes = Mutex::new(Vec::new());
+        capture(&plan, &state, &corpus, 2, &|row| {
+            outcomes.lock().expect("lock").push(row.outcome);
+            Ok(())
+        })
+        .expect("reuse");
+        assert_eq!(
+            *outcomes.lock().expect("lock"),
+            vec!["capture-reused-after-census"]
+        );
+        let applied = root.join("applied");
+        apply(&plan, &corpus, &applied, "neo", 2, &|_| Ok(())).expect("restore");
+        assert_eq!(
+            fs::read(target.join("file")).expect("dirty restored"),
+            b"dirty"
+        );
+        fs::write(target.join("file"), b"operator edited").expect("active write");
+        apply(&plan, &corpus, &applied, "neo", 2, &|_| Ok(())).expect("do not replay");
+        assert_eq!(
+            fs::read(target.join("file")).expect("preserved"),
+            b"operator edited"
+        );
+        let invalid = root.join("not-a-repository");
+        fs::create_dir(&invalid).expect("invalid source");
+        add(&plan, &invalid, &target, None).expect("explicit failing item");
+        outcomes.lock().expect("lock").clear();
+        assert!(capture(&plan, &state, &corpus, 2, &|row| {
+            outcomes.lock().expect("lock").push(row.outcome);
+            Ok(())
+        })
+        .is_err());
+        let mut partial = outcomes.lock().expect("lock").clone();
+        partial.sort_unstable();
+        assert_eq!(partial, vec!["capture-reused-after-census", "refused"]);
+        fs::set_permissions(&corpus, fs::Permissions::from_mode(0o755)).expect("public corpus");
+        assert!(capture(&plan, &state, &corpus, 2, &|_| Ok(())).is_err());
+        assert!(!filename("/"));
+        assert!(!filename("../escape"));
+        fs::remove_dir_all(&root).expect("remove owned fixture");
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/estate.rs
+++ b/crates/tcfs-bulkload-agent/src/estate.rs
@@ -188,7 +188,19 @@ pub fn add_batch(plan: &Path, items: &[Item]) -> Result<()> {
     write(plan, &contents)
 }
 
-fn exclusive(path: &Path) -> Result<fs::File> {
+struct Exclusive(fs::File);
+
+impl Drop for Exclusive {
+    fn drop(&mut self) {
+        // A concurrent fork can briefly inherit the open file description until
+        // exec closes it. Explicit unlock ends our operation's ownership even
+        // while such a descriptor exists; closing only this fd is insufficient.
+        // SAFETY: this guard owns a live descriptor for the acquired flock.
+        unsafe { libc::flock(self.0.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+fn exclusive(path: &Path) -> Result<Exclusive> {
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -201,7 +213,7 @@ fn exclusive(path: &Path) -> Result<fs::File> {
     if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
         return Err(std::io::Error::last_os_error().into());
     }
-    Ok(file)
+    Ok(Exclusive(file))
 }
 
 fn hash_file(path: &Path) -> Result<[u8; 32]> {
@@ -735,6 +747,24 @@ mod tests {
             b"second dirty"
         );
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn completed_operation_unlocks_even_with_an_inherited_description() {
+        let root = std::env::temp_dir().join(format!("tcfs-estate-lock-{}", std::process::id()));
+        fs::DirBuilder::new().mode(0o700).create(&root).unwrap();
+        let path = root.join("estate.lock");
+        let owner = exclusive(&path).unwrap();
+        let inherited = owner.0.try_clone().unwrap();
+        assert!(exclusive(&path).is_err());
+        drop(owner);
+        let next = exclusive(&path).expect("completed owner explicitly unlocked");
+        drop(inherited);
+        assert!(exclusive(&path).is_err());
+        drop(next);
+        assert!(exclusive(&path).is_ok());
+        fs::remove_file(path).unwrap();
+        fs::remove_dir(root).unwrap();
     }
 
     #[test]

--- a/crates/tcfs-bulkload-agent/src/freshness.rs
+++ b/crates/tcfs-bulkload-agent/src/freshness.rs
@@ -142,7 +142,7 @@ impl FreshnessCache for MemoryCache {
     }
 }
 
-/// A cache persisted in SQLite.
+/// A cache persisted in `SQLite`.
 ///
 /// M1 ships the schema and the round-trip only; the M3 lane wires this to the
 /// on-disk agent state directory and adds the eviction policy.
@@ -170,7 +170,7 @@ impl SqliteCache {
     ///
     /// # Errors
     ///
-    /// Refuses if SQLite declines to open or to create the schema.
+    /// Refuses if `SQLite` declines to open or to create the schema.
     pub fn open_in_memory() -> Result<Self> {
         let conn =
             rusqlite::Connection::open_in_memory().map_err(|_| BulkloadRefusal::Io(None))?;
@@ -181,7 +181,7 @@ impl SqliteCache {
     ///
     /// # Errors
     ///
-    /// Refuses if SQLite declines to open the file or to create the schema.
+    /// Refuses if `SQLite` declines to open the file or to create the schema.
     pub fn open(path: &std::path::Path) -> Result<Self> {
         let conn = rusqlite::Connection::open(path).map_err(|_| BulkloadRefusal::Io(None))?;
         Self::from_connection(conn)
@@ -193,7 +193,7 @@ impl SqliteCache {
         Ok(Self { conn })
     }
 
-    /// SQLite stores signed 64-bit integers; nanosecond timestamps wider than
+    /// `SQLite` stores signed 64-bit integers; nanosecond timestamps wider than
     /// that are a value this schema cannot carry, not a rounding opportunity.
     fn narrow(value: i128) -> Result<i64> {
         i64::try_from(value).map_err(|_| BulkloadRefusal::SqliteUnsupportedValue)

--- a/crates/tcfs-bulkload-agent/src/freshness.rs
+++ b/crates/tcfs-bulkload-agent/src/freshness.rs
@@ -1,0 +1,312 @@
+//! The freshness-cache seam.
+//!
+//! The walker never names a concrete cache. It takes anything implementing
+//! [`FreshnessCache`], keyed on a [`StatIdentity`] -- the
+//! `(dev, ino, size, mtime_ns, ctime_ns)` tuple that decides whether a seat
+//! may be skipped on resume.
+//!
+//! Why a local trait: `tcfs-sync` grows its own `freshness.rs` (PR #586), but
+//! the agent half must not depend on `tcfs-sync` -- that crate pulls tokio and
+//! the whole sync stack straight through the R34 dependency wall. The trait
+//! keeps M3 unblocked: when #586 lands, an adapter in the *daemon* half
+//! implements this trait over it, and nothing in the agent changes.
+//!
+//! Both R25 headline metrics fall out of this seam. A cache that reports
+//! `Fresh` for a seat whose bytes did not change is what drives
+//! `bytes_reread_on_resume` to zero; a cache consulted once per seat is what
+//! drives `files_statted_twice` to zero.
+
+use std::collections::HashMap;
+
+use tcfs_bulkload_proto::{BulkloadRefusal, Result, RowSchema};
+
+/// The identity tuple a freshness decision is keyed on.
+///
+/// Deliberately *not* a content hash: the point of the cache is to avoid
+/// reading bytes at all. `ctime_ns` is carried alongside `mtime_ns` because
+/// mtime alone is forgeable by a restore tool and does not move when only
+/// ownership or mode changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StatIdentity {
+    /// Containing device id.
+    pub dev: u64,
+    /// Inode number.
+    pub ino: u64,
+    /// Apparent size in bytes.
+    pub size: u64,
+    /// Modification time, nanoseconds since the unix epoch.
+    pub mtime_ns: i128,
+    /// Inode change time, nanoseconds since the unix epoch.
+    pub ctime_ns: i128,
+}
+
+impl StatIdentity {
+    /// Read the identity a row asserts.
+    #[must_use]
+    pub const fn from_row(row: &RowSchema) -> Self {
+        Self {
+            dev: row.dev,
+            ino: row.ino,
+            size: row.size,
+            mtime_ns: row.mtime_ns,
+            ctime_ns: row.ctime_ns,
+        }
+    }
+}
+
+/// What the cache says about a seat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Freshness {
+    /// Seen before with this exact identity: the bytes need not be re-read.
+    Fresh,
+    /// Never seen, or seen with a different identity: the bytes must be read.
+    Stale,
+}
+
+/// A cache of previously observed [`StatIdentity`] values.
+///
+/// Implementations must be cheap enough to consult once per seat on a walk of
+/// millions of files, and must never panic: a cache that cannot answer refuses
+/// with a [`BulkloadRefusal`] and the walker treats the seat as
+/// [`Freshness::Stale`].
+pub trait FreshnessCache {
+    /// Ask whether `identity` has been seen before.
+    ///
+    /// # Errors
+    ///
+    /// Refuses if the backing store cannot be consulted.
+    fn lookup(&self, identity: &StatIdentity) -> Result<Freshness>;
+
+    /// Record `identity` as observed.
+    ///
+    /// # Errors
+    ///
+    /// Refuses if the backing store cannot be written.
+    fn record(&mut self, identity: &StatIdentity) -> Result<()>;
+}
+
+/// A cache that remembers nothing: every seat is [`Freshness::Stale`].
+///
+/// This is the M0 bench's cold-walk baseline -- the "always re-read everything"
+/// arm that `bytes_reread_on_resume` is measured against.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullCache;
+
+impl FreshnessCache for NullCache {
+    fn lookup(&self, _identity: &StatIdentity) -> Result<Freshness> {
+        Ok(Freshness::Stale)
+    }
+
+    fn record(&mut self, _identity: &StatIdentity) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// An in-memory cache. Useful for tests and single-shot runs.
+#[derive(Debug, Default, Clone)]
+pub struct MemoryCache {
+    seen: HashMap<(u64, u64), StatIdentity>,
+}
+
+impl MemoryCache {
+    /// An empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many distinct inodes this cache remembers.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    /// Whether this cache remembers nothing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+}
+
+impl FreshnessCache for MemoryCache {
+    fn lookup(&self, identity: &StatIdentity) -> Result<Freshness> {
+        match self.seen.get(&(identity.dev, identity.ino)) {
+            Some(prev) if prev == identity => Ok(Freshness::Fresh),
+            _ => Ok(Freshness::Stale),
+        }
+    }
+
+    fn record(&mut self, identity: &StatIdentity) -> Result<()> {
+        self.seen.insert((identity.dev, identity.ino), *identity);
+        Ok(())
+    }
+}
+
+/// A cache persisted in SQLite.
+///
+/// M1 ships the schema and the round-trip only; the M3 lane wires this to the
+/// on-disk agent state directory and adds the eviction policy.
+pub struct SqliteCache {
+    conn: rusqlite::Connection,
+}
+
+impl std::fmt::Debug for SqliteCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteCache").finish_non_exhaustive()
+    }
+}
+
+impl SqliteCache {
+    const SCHEMA: &'static str = "CREATE TABLE IF NOT EXISTS freshness (
+            dev       INTEGER NOT NULL,
+            ino       INTEGER NOT NULL,
+            size      INTEGER NOT NULL,
+            mtime_ns  INTEGER NOT NULL,
+            ctime_ns  INTEGER NOT NULL,
+            PRIMARY KEY (dev, ino)
+        ) WITHOUT ROWID";
+
+    /// Open an ephemeral in-memory cache.
+    ///
+    /// # Errors
+    ///
+    /// Refuses if SQLite declines to open or to create the schema.
+    pub fn open_in_memory() -> Result<Self> {
+        let conn =
+            rusqlite::Connection::open_in_memory().map_err(|_| BulkloadRefusal::Io(None))?;
+        Self::from_connection(conn)
+    }
+
+    /// Open a cache backed by `path`, creating it if absent.
+    ///
+    /// # Errors
+    ///
+    /// Refuses if SQLite declines to open the file or to create the schema.
+    pub fn open(path: &std::path::Path) -> Result<Self> {
+        let conn = rusqlite::Connection::open(path).map_err(|_| BulkloadRefusal::Io(None))?;
+        Self::from_connection(conn)
+    }
+
+    fn from_connection(conn: rusqlite::Connection) -> Result<Self> {
+        conn.execute_batch(Self::SCHEMA)
+            .map_err(|_| BulkloadRefusal::SqliteIntegrityCheckFailed)?;
+        Ok(Self { conn })
+    }
+
+    /// SQLite stores signed 64-bit integers; nanosecond timestamps wider than
+    /// that are a value this schema cannot carry, not a rounding opportunity.
+    fn narrow(value: i128) -> Result<i64> {
+        i64::try_from(value).map_err(|_| BulkloadRefusal::SqliteUnsupportedValue)
+    }
+}
+
+impl FreshnessCache for SqliteCache {
+    fn lookup(&self, identity: &StatIdentity) -> Result<Freshness> {
+        let dev = Self::narrow(i128::from(identity.dev))?;
+        let ino = Self::narrow(i128::from(identity.ino))?;
+        let found: std::result::Result<(i64, i64, i64), rusqlite::Error> = self.conn.query_row(
+            "SELECT size, mtime_ns, ctime_ns FROM freshness WHERE dev = ?1 AND ino = ?2",
+            (dev, ino),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        );
+        match found {
+            Ok((size, mtime_ns, ctime_ns)) => {
+                let same = u64::try_from(size).is_ok_and(|s| s == identity.size)
+                    && i128::from(mtime_ns) == identity.mtime_ns
+                    && i128::from(ctime_ns) == identity.ctime_ns;
+                Ok(if same {
+                    Freshness::Fresh
+                } else {
+                    Freshness::Stale
+                })
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(Freshness::Stale),
+            Err(_) => Err(BulkloadRefusal::SqliteIntegrityCheckFailed),
+        }
+    }
+
+    fn record(&mut self, identity: &StatIdentity) -> Result<()> {
+        let dev = Self::narrow(i128::from(identity.dev))?;
+        let ino = Self::narrow(i128::from(identity.ino))?;
+        let size = Self::narrow(i128::from(identity.size))?;
+        let mtime_ns = Self::narrow(identity.mtime_ns)?;
+        let ctime_ns = Self::narrow(identity.ctime_ns)?;
+        self.conn
+            .execute(
+                "INSERT INTO freshness (dev, ino, size, mtime_ns, ctime_ns)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(dev, ino) DO UPDATE SET
+                     size = excluded.size,
+                     mtime_ns = excluded.mtime_ns,
+                     ctime_ns = excluded.ctime_ns",
+                (dev, ino, size, mtime_ns, ctime_ns),
+            )
+            .map_err(|_| BulkloadRefusal::SqliteIntegrityCheckFailed)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use super::{Freshness, FreshnessCache, MemoryCache, NullCache, SqliteCache, StatIdentity};
+
+    fn identity() -> StatIdentity {
+        StatIdentity {
+            dev: 16_777_220,
+            ino: 42,
+            size: 4096,
+            mtime_ns: 1_756_000_000_000_000_000,
+            ctime_ns: 1_756_000_000_000_000_001,
+        }
+    }
+
+    fn exercises_contract<C: FreshnessCache>(mut cache: C, remembers: bool) {
+        let id = identity();
+        assert_eq!(cache.lookup(&id).unwrap(), Freshness::Stale);
+        cache.record(&id).unwrap();
+        let expected = if remembers {
+            Freshness::Fresh
+        } else {
+            Freshness::Stale
+        };
+        assert_eq!(cache.lookup(&id).unwrap(), expected);
+
+        // A seat whose mtime moved is stale even at the same (dev, ino).
+        let touched = StatIdentity {
+            mtime_ns: id.mtime_ns + 1,
+            ..id
+        };
+        assert_eq!(cache.lookup(&touched).unwrap(), Freshness::Stale);
+    }
+
+    #[test]
+    fn null_cache_never_remembers() {
+        exercises_contract(NullCache, false);
+    }
+
+    #[test]
+    fn memory_cache_remembers() {
+        exercises_contract(MemoryCache::new(), true);
+    }
+
+    #[test]
+    fn sqlite_cache_remembers() {
+        exercises_contract(SqliteCache::open_in_memory().unwrap(), true);
+    }
+
+    #[test]
+    fn sqlite_cache_updates_in_place() {
+        let mut cache = SqliteCache::open_in_memory().unwrap();
+        let id = identity();
+        cache.record(&id).unwrap();
+        let touched = StatIdentity {
+            mtime_ns: id.mtime_ns + 1,
+            ..id
+        };
+        cache.record(&touched).unwrap();
+        assert_eq!(cache.lookup(&touched).unwrap(), Freshness::Fresh);
+        assert_eq!(cache.lookup(&id).unwrap(), Freshness::Stale);
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/freshness.rs
+++ b/crates/tcfs-bulkload-agent/src/freshness.rs
@@ -41,6 +41,19 @@ pub struct StatIdentity {
 }
 
 impl StatIdentity {
+    /// Identity of an already opened file; does not resolve its path again.
+    #[must_use]
+    pub fn from_metadata(meta: &std::fs::Metadata) -> Self {
+        use std::os::unix::fs::MetadataExt as _;
+        Self {
+            dev: meta.dev(),
+            ino: meta.ino(),
+            size: meta.size(),
+            mtime_ns: i128::from(meta.mtime()) * 1_000_000_000 + i128::from(meta.mtime_nsec()),
+            ctime_ns: i128::from(meta.ctime()) * 1_000_000_000 + i128::from(meta.ctime_nsec()),
+        }
+    }
+
     /// Read the identity a row asserts.
     #[must_use]
     pub const fn from_row(row: &RowSchema) -> Self {
@@ -67,8 +80,8 @@ pub enum Freshness {
 ///
 /// Implementations must be cheap enough to consult once per seat on a walk of
 /// millions of files, and must never panic: a cache that cannot answer refuses
-/// with a [`BulkloadRefusal`] and the walker treats the seat as
-/// [`Freshness::Stale`].
+/// with a [`BulkloadRefusal`]. A failed store is surfaced rather than silently
+/// turning every previously completed read into a cold read.
 pub trait FreshnessCache {
     /// Ask whether `identity` has been seen before.
     ///
@@ -83,6 +96,23 @@ pub trait FreshnessCache {
     ///
     /// Refuses if the backing store cannot be written.
     fn record(&mut self, identity: &StatIdentity) -> Result<()>;
+
+    /// Return a digest only after a successful read of this exact identity.
+    /// Stat-only observations must never satisfy this lookup.
+    ///
+    /// # Errors
+    /// Refuses if the backing store cannot be read.
+    fn digest(&self, _identity: &StatIdentity) -> Result<Option<[u8; 32]>> {
+        Ok(None)
+    }
+
+    /// Atomically remember a completed, identity-checked content read.
+    ///
+    /// # Errors
+    /// Refuses if the backing store cannot persist the completion.
+    fn record_digest(&mut self, identity: &StatIdentity, _digest: &[u8; 32]) -> Result<()> {
+        self.record(identity)
+    }
 }
 
 /// A cache that remembers nothing: every seat is [`Freshness::Stale`].
@@ -106,6 +136,7 @@ impl FreshnessCache for NullCache {
 #[derive(Debug, Default, Clone)]
 pub struct MemoryCache {
     seen: HashMap<(u64, u64), StatIdentity>,
+    digests: HashMap<(u64, u64), (StatIdentity, [u8; 32])>,
 }
 
 impl MemoryCache {
@@ -129,6 +160,20 @@ impl MemoryCache {
 }
 
 impl FreshnessCache for MemoryCache {
+    fn digest(&self, identity: &StatIdentity) -> Result<Option<[u8; 32]>> {
+        Ok(self
+            .digests
+            .get(&(identity.dev, identity.ino))
+            .filter(|(previous, _)| previous == identity)
+            .map(|(_, digest)| *digest))
+    }
+
+    fn record_digest(&mut self, identity: &StatIdentity, digest: &[u8; 32]) -> Result<()> {
+        self.digests
+            .insert((identity.dev, identity.ino), (*identity, *digest));
+        self.record(identity)
+    }
+
     fn lookup(&self, identity: &StatIdentity) -> Result<Freshness> {
         match self.seen.get(&(identity.dev, identity.ino)) {
             Some(prev) if prev == identity => Ok(Freshness::Fresh),
@@ -164,6 +209,10 @@ impl SqliteCache {
             mtime_ns  INTEGER NOT NULL,
             ctime_ns  INTEGER NOT NULL,
             PRIMARY KEY (dev, ino)
+        ) WITHOUT ROWID;
+        CREATE TABLE IF NOT EXISTS hash_completion (
+            identity BLOB PRIMARY KEY NOT NULL,
+            digest BLOB NOT NULL CHECK(length(digest) = 32)
         ) WITHOUT ROWID";
 
     /// Open an ephemeral in-memory cache.
@@ -172,8 +221,7 @@ impl SqliteCache {
     ///
     /// Refuses if `SQLite` declines to open or to create the schema.
     pub fn open_in_memory() -> Result<Self> {
-        let conn =
-            rusqlite::Connection::open_in_memory().map_err(|_| BulkloadRefusal::Io(None))?;
+        let conn = rusqlite::Connection::open_in_memory().map_err(|_| BulkloadRefusal::Io(None))?;
         Self::from_connection(conn)
     }
 
@@ -201,6 +249,51 @@ impl SqliteCache {
 }
 
 impl FreshnessCache for SqliteCache {
+    fn digest(&self, identity: &StatIdentity) -> Result<Option<[u8; 32]>> {
+        use rusqlite::OptionalExtension as _;
+        let key = postcard::to_allocvec(&(
+            identity.dev,
+            identity.ino,
+            identity.size,
+            identity.mtime_ns,
+            identity.ctime_ns,
+        ))?;
+        let bytes: Option<Vec<u8>> = self
+            .conn
+            .query_row(
+                "SELECT digest FROM hash_completion WHERE identity = ?1",
+                [key],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|_| BulkloadRefusal::SqliteIntegrityCheckFailed)?;
+        bytes
+            .map(|value| {
+                value
+                    .try_into()
+                    .map_err(|_| BulkloadRefusal::SqliteUnsupportedValue)
+            })
+            .transpose()
+    }
+
+    fn record_digest(&mut self, identity: &StatIdentity, digest: &[u8; 32]) -> Result<()> {
+        let key = postcard::to_allocvec(&(
+            identity.dev,
+            identity.ino,
+            identity.size,
+            identity.mtime_ns,
+            identity.ctime_ns,
+        ))?;
+        self.conn
+            .execute(
+                "INSERT INTO hash_completion(identity, digest) VALUES (?1, ?2)
+             ON CONFLICT(identity) DO UPDATE SET digest = excluded.digest",
+                (key, digest.as_slice()),
+            )
+            .map_err(|_| BulkloadRefusal::SqliteIntegrityCheckFailed)?;
+        Ok(())
+    }
+
     fn lookup(&self, identity: &StatIdentity) -> Result<Freshness> {
         let dev = Self::narrow(i128::from(identity.dev))?;
         let ino = Self::narrow(i128::from(identity.ino))?;
@@ -308,5 +401,42 @@ mod tests {
         cache.record(&touched).unwrap();
         assert_eq!(cache.lookup(&touched).unwrap(), Freshness::Fresh);
         assert_eq!(cache.lookup(&id).unwrap(), Freshness::Stale);
+    }
+
+    #[test]
+    fn stat_observation_is_not_a_completed_content_read() {
+        let mut cache = SqliteCache::open_in_memory().unwrap();
+        let id = identity();
+        cache.record(&id).unwrap();
+        assert_eq!(cache.digest(&id).unwrap(), None);
+        cache.record_digest(&id, &[7; 32]).unwrap();
+        assert_eq!(cache.digest(&id).unwrap(), Some([7; 32]));
+        let changed = StatIdentity {
+            ctime_ns: id.ctime_ns + 1,
+            ..id
+        };
+        assert_eq!(cache.digest(&changed).unwrap(), None);
+    }
+
+    #[test]
+    fn sqlite_completion_survives_reopen_with_full_width_identity() {
+        let path = std::env::temp_dir().join(format!(
+            "tcfs-bulkload-completion-{}.sqlite",
+            std::process::id()
+        ));
+        let id = StatIdentity {
+            ino: u64::MAX,
+            mtime_ns: i128::MAX,
+            ..identity()
+        };
+        {
+            let mut cache = SqliteCache::open(&path).unwrap();
+            cache.record_digest(&id, &[9; 32]).unwrap();
+        }
+        {
+            let cache = SqliteCache::open(&path).unwrap();
+            assert_eq!(cache.digest(&id).unwrap(), Some([9; 32]));
+        }
+        std::fs::remove_file(path).unwrap();
     }
 }

--- a/crates/tcfs-bulkload-agent/src/freshness.rs
+++ b/crates/tcfs-bulkload-agent/src/freshness.rs
@@ -26,7 +26,7 @@ use tcfs_bulkload_proto::{BulkloadRefusal, Result, RowSchema};
 /// reading bytes at all. `ctime_ns` is carried alongside `mtime_ns` because
 /// mtime alone is forgeable by a restore tool and does not move when only
 /// ownership or mode changed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct StatIdentity {
     /// Containing device id.
     pub dev: u64,

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -480,6 +480,118 @@ pub fn restore_bundle(bundle: &Path, destination: &Path, source: &str) -> Result
     Ok(())
 }
 
+/// Restore into a new linked worktree without changing any existing checkout.
+///
+/// The source branch is reused only when its tip matches and Git permits a new
+/// attachment; otherwise a private carry branch is created. Existing common
+/// ignore policy must match the capture: it is never overwritten.
+///
+/// # Errors
+/// Refuses occupied destinations, differing common excludes, and invalid capture.
+/// Partially created worktrees are retained on failure for explicit recovery.
+pub fn restore_linked(
+    bundle: &Path,
+    repository: &Path,
+    destination: &Path,
+    source: &str,
+) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::PermissionsExt;
+    if destination.symlink_metadata().is_ok() {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    let parent = fs::canonicalize(
+        destination
+            .parent()
+            .ok_or(BulkloadRefusal::PathNotAbsolute)?,
+    )?;
+    let destination = parent.join(
+        destination
+            .file_name()
+            .ok_or(BulkloadRefusal::PathNotAbsolute)?,
+    );
+    let bundle = fs::canonicalize(bundle)?;
+    let repository = fs::canonicalize(repository)?;
+    import_bundle(&repository, &bundle, source)?;
+    let heads = text(git(&repository).args(["bundle", "list-heads"]).arg(&bundle))?;
+    let find = |suffix: &str| -> Result<String> {
+        heads
+            .lines()
+            .find_map(|line| {
+                line.split_once(' ')
+                    .filter(|(_, name)| *name == format!("refs/carry-export/{suffix}"))
+            })
+            .map(|(value, _)| value.to_owned())
+            .filter(|value| oid(value))
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)
+    };
+    let head = find("head")?;
+    let symbolic =
+        text(git(&repository).args(["show", &format!("{}:value", find("head-symbolic")?)]))?;
+    let exclude = output(git(&repository).args(["show", &format!("{}:value", find("exclude")?)]))?;
+    let exclude_path = text(git(&repository).args([
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "info/exclude",
+    ]))?;
+    let existing_exclude = match fs::read(&exclude_path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => return Err(error.into()),
+    };
+    if exclude != existing_exclude {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    let attached = text(git(&repository).args(["worktree", "list", "--porcelain"]))?;
+    let source_tip = text(git(&repository).args(["rev-parse", "--verify", &symbolic]));
+    let reuse = symbolic.starts_with("refs/heads/")
+        && source_tip.as_ref().is_ok_and(|value| value == &head)
+        && !attached
+            .lines()
+            .any(|line| line == format!("branch {symbolic}"));
+    let branch = if reuse {
+        symbolic
+            .strip_prefix("refs/heads/")
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?
+            .to_owned()
+    } else {
+        let digest = blake3::hash(destination.as_os_str().as_bytes()).to_hex();
+        format!("carry/{source}/{digest}")
+    };
+    let mut command = git(&repository);
+    command.args(["worktree", "add", "--no-checkout"]);
+    if !reuse {
+        command.args(["-b", &branch]);
+    }
+    command
+        .arg("--")
+        .arg(&destination)
+        .arg(if reuse { &branch } else { &head });
+    output(&mut command)?;
+    // --no-checkout has created administration only, not captured payload.
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o700))?;
+    if text(git(&destination).args(["rev-parse", "--verify", "HEAD"]))? != head {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    let entries = output(git(&destination).args(["ls-tree", "-r", "-z", &find("worktree")?]))?;
+    for entry in entries.split(|b| *b == 0).filter(|entry| !entry.is_empty()) {
+        restore_entry(&destination, entry)?;
+    }
+    output(git(&destination).args(["read-tree", &format!("{}^{{tree}}", find("staged")?)]))?;
+    let final_exclude = match fs::read(exclude_path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => return Err(error.into()),
+    };
+    if final_exclude != exclude
+        || text(git(&destination).args(["rev-parse", "--verify", "HEAD"]))? != head
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    Ok(())
+}
+
 fn restore_entry(destination: &Path, entry: &[u8]) -> Result<()> {
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
@@ -581,6 +693,7 @@ mod tests {
             output(git(repo).args(["config", "user.name", "Test"])).unwrap();
             output(git(repo).args(["config", "user.email", "test@localhost"])).unwrap();
             fs::write(repo.join("tracked"), b"base").unwrap();
+            fs::write(repo.join("deleted"), b"staged deletion").unwrap();
             output(git(repo).args(["add", "."])).unwrap();
             output(git(repo).args(["-c", "commit.gpgsign=false", "commit", "-m", "base"])).unwrap();
         }
@@ -589,6 +702,8 @@ mod tests {
             output(git(&source).args(["stash", "push"])).unwrap();
         }
         fs::write(source.join("tracked"), b"staged").unwrap();
+        fs::remove_file(source.join("deleted")).unwrap();
+        fs::write(source.join("binary"), [0, 1, 128]).unwrap();
         output(git(&source).args(["add", "."])).unwrap();
         fs::write(source.join("tracked"), b"unstaged").unwrap();
         fs::write(source.join("binary"), [0, 255, 128]).unwrap();
@@ -657,6 +772,15 @@ mod tests {
         );
         let restored = root.join("restored");
         restore_bundle(&bundle, &restored, "neo").unwrap();
+        let linked = root.join("linked");
+        restore_linked(&bundle, &dest, &linked, "neo").unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&linked).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
         for args in [
             vec![
                 "status",
@@ -673,7 +797,32 @@ mod tests {
                 output(git(&restored).args(&args)).unwrap(),
                 "{args:?}"
             );
+            if args.first() != Some(&"symbolic-ref") {
+                assert_eq!(
+                    output(git(&source).args(&args)).unwrap(),
+                    output(git(&linked).args(&args)).unwrap(),
+                    "linked {args:?}"
+                );
+            }
         }
+        assert!(linked.join(".git").is_file());
+        let common =
+            text(git(&linked).args(["rev-parse", "--path-format=absolute", "--git-common-dir"]))
+                .unwrap();
+        assert_eq!(
+            fs::canonicalize(common).unwrap(),
+            fs::canonicalize(dest.join(".git")).unwrap()
+        );
+        let admin = text(git(&linked).args(["rev-parse", "--absolute-git-dir"])).unwrap();
+        assert_eq!(
+            fs::read_to_string(Path::new(&admin).join("gitdir"))
+                .unwrap()
+                .trim(),
+            linked.join(".git").to_str().unwrap()
+        );
+        assert_eq!(dest_index, fs::read(dest.join(".git/index")).unwrap());
+        assert_eq!(dest_head, fs::read(dest.join(".git/HEAD")).unwrap());
+        assert!(restore_linked(&bundle, &dest, &linked, "neo").is_err());
         assert_eq!(fs::read(restored.join("binary")).unwrap(), [0, 255, 128]);
         assert!(restore_bundle(&bundle, &restored, "neo").is_err());
         fs::remove_dir_all(root).unwrap();

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -238,6 +238,278 @@ fn canonical_tail(tail: &str) -> bool {
     source_slug(source) && snapshot.len() == 64 && oid(snapshot) && !suffix.is_empty()
 }
 
+/// Canonical common repository used to serialize applies sharing Git storage.
+///
+/// # Errors
+/// Refuses unavailable or malformed Git administration.
+pub fn common_repository(repo: &Path) -> Result<PathBuf> {
+    let common = text(git(repo).args(["rev-parse", "--path-format=absolute", "--git-common-dir"]))?;
+    Ok(fs::canonicalize(common)?)
+}
+
+/// Identity of a reusable capture, including new transit refs and full census.
+///
+/// This reads Git metadata and filesystem metadata, not ordinary file contents.
+/// Callers must compare before/after keys and retain the successful bundle.
+/// It is not a filesystem journal, atomic snapshot, or a no-rewalk claim.
+///
+/// # Errors
+/// Refuses unsupported source indexes, filesystem seats or Git state.
+pub fn reusable_capture_key(repo: &Path) -> Result<[u8; 32]> {
+    use std::os::unix::ffi::OsStrExt;
+    let repo = fs::canonicalize(repo)?;
+    let common = common_repository(&repo)?;
+    let inventory = refs(&repo)?;
+    let head = text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?;
+    let symbolic = git(&repo).args(["symbolic-ref", "-q", "HEAD"]).output()?;
+    if !symbolic.status.success() && symbolic.status.code() != Some(1) {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    let (_, index) = source_index(&repo)?;
+    let exclude_path = text(git(&repo).args([
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "info/exclude",
+    ]))?;
+    let exclude = match fs::read(exclude_path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => return Err(error.into()),
+    };
+    let stash = if inventory.lines().any(|line| line.ends_with(" refs/stash")) {
+        output(git(&repo).args(["reflog", "show", "--format=%H", "refs/stash"]))?
+    } else {
+        Vec::new()
+    };
+    let rows =
+        postcard::to_allocvec(&filesystem_rows(&repo)?).map_err(|_| BulkloadRefusal::FrameCodec)?;
+    let mut hash = blake3::Hasher::new();
+    hash.update(b"tcfs-git-reusable-capture-v1\0");
+    for bytes in [
+        repo.as_os_str().as_bytes(),
+        common.as_os_str().as_bytes(),
+        inventory.as_bytes(),
+        head.as_bytes(),
+        &symbolic.stdout,
+        &index,
+        &exclude,
+        &stash,
+        &rows,
+    ] {
+        hash.update(
+            &u64::try_from(bytes.len())
+                .map_err(|_| BulkloadRefusal::BudgetExceeded)?
+                .to_le_bytes(),
+        );
+        hash.update(bytes);
+    }
+    for directory in [&repo, &common] {
+        let identity = crate::freshness::StatIdentity::from_metadata(&fs::metadata(directory)?);
+        for value in [i128::from(identity.dev), i128::from(identity.ino)] {
+            hash.update(&value.to_le_bytes());
+        }
+    }
+    Ok(*hash.finalize().as_bytes())
+}
+
+/// Reconstruct a missing index from a same-HEAD capture without touching payload.
+///
+/// Receipt must be new, outside the worktree, and on the index filesystem for
+/// atomic create-only publication. Existing indexes always refuse. This restores
+/// captured staging, not a claim that the destination's lost staging was known.
+///
+/// # Errors
+/// Refuses HEAD/admin changes, active Git operations, occupied index/receipt,
+/// unsupported capture/index state, or cross-filesystem atomic publication.
+pub fn repair_missing_index(
+    bundle: &Path,
+    repo: &Path,
+    source: &str,
+    receipt: &Path,
+) -> Result<()> {
+    repair_missing_index_inner(bundle, repo, source, receipt, |_| Ok(()))
+}
+
+fn repair_missing_index_inner(
+    bundle: &Path,
+    repo: &Path,
+    source: &str,
+    receipt: &Path,
+    before_publish: impl FnOnce(&Path) -> Result<()>,
+) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    let repo = fs::canonicalize(repo)?;
+    let bundle = fs::canonicalize(bundle)?;
+    let admin = PathBuf::from(text(git(&repo).args(["rev-parse", "--absolute-git-dir"]))?);
+    let index = PathBuf::from(text(git(&repo).args([
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "index",
+    ]))?);
+    require_missing(&index)?;
+    for name in [
+        "index.lock",
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "rebase-merge",
+        "rebase-apply",
+        "sequencer",
+    ] {
+        require_missing(&admin.join(name))?;
+    }
+    let head = text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?;
+    let heads = text(git(&repo).args(["bundle", "list-heads"]).arg(&bundle))?;
+    let find = |suffix: &str| -> Result<String> {
+        heads
+            .lines()
+            .find_map(|line| {
+                line.split_once(' ')
+                    .filter(|(_, name)| *name == format!("refs/carry-export/{suffix}"))
+            })
+            .map(|(value, _)| value.to_owned())
+            .filter(|value| oid(value))
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)
+    };
+    if find("head")? != head {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    let controls = admin_controls(&admin)?;
+    let admin_identity = crate::freshness::StatIdentity::from_metadata(&fs::metadata(&admin)?);
+    let receipt_parent =
+        fs::canonicalize(receipt.parent().ok_or(BulkloadRefusal::PathNotAbsolute)?)?;
+    let receipt = receipt_parent.join(
+        receipt
+            .file_name()
+            .ok_or(BulkloadRefusal::PathNotAbsolute)?,
+    );
+    if receipt.starts_with(&repo) || receipt.starts_with(&admin) {
+        return Err(BulkloadRefusal::PathEscapesRoot);
+    }
+    fs::DirBuilder::new().mode(0o700).create(&receipt)?;
+    fs::write(
+        receipt.join("original-administration.postcard"),
+        postcard::to_allocvec(&(head.clone(), true, &controls))
+            .map_err(|_| BulkloadRefusal::FrameCodec)?,
+    )?;
+    fs::File::open(receipt.join("original-administration.postcard"))?.sync_all()?;
+    fs::File::open(&receipt)?.sync_all()?;
+    fs::File::open(&receipt_parent)?.sync_all()?;
+    import_bundle(&repo, &bundle, source)?;
+    let staged_entries = output(git(&repo).args(["ls-tree", "-r", "-z", &find("staged")?]))?;
+    if staged_entries
+        .split(|b| *b == 0)
+        .any(|entry| entry.starts_with(b"160000 "))
+    {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    let private_index = receipt.join("captured.index");
+    output(
+        git(&repo)
+            .env("GIT_INDEX_FILE", &private_index)
+            .args(["read-tree", &format!("{}^{{tree}}", find("staged")?)]),
+    )?;
+    fs::set_permissions(&private_index, fs::Permissions::from_mode(0o600))?;
+    fs::File::open(&private_index)?.sync_all()?;
+    fs::File::open(&receipt)?.sync_all()?;
+    let reservation = IndexReservation::acquire(admin.join("index.lock"))?;
+    let current_identity = crate::freshness::StatIdentity::from_metadata(&fs::metadata(&admin)?);
+    if (admin_identity.dev, admin_identity.ino) != (current_identity.dev, current_identity.ino)
+        || controls != admin_controls(&admin)?
+        || text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))? != head
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    before_publish(&index)?;
+    if controls != admin_controls(&admin)?
+        || text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))? != head
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    fs::hard_link(&private_index, &index)?;
+    fs::File::open(&admin)?.sync_all()?;
+    if text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))? != head {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    reservation.release()
+}
+
+/// Cooperates with native Git's index lock. The held descriptor identifies the
+/// exact inode owned by this operation; a replaced/pre-existing lock is never
+/// removed. Error paths release only this reservation, never another writer's.
+struct IndexReservation {
+    path: PathBuf,
+    file: fs::File,
+    released: bool,
+}
+
+impl IndexReservation {
+    fn acquire(path: PathBuf) -> Result<Self> {
+        use std::os::unix::fs::OpenOptionsExt;
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)?;
+        Ok(Self {
+            path,
+            file,
+            released: false,
+        })
+    }
+
+    fn remove_owned(&self) -> Result<()> {
+        use std::os::unix::fs::MetadataExt;
+        let original = self.file.metadata()?;
+        let current = fs::symlink_metadata(&self.path)?;
+        if !current.is_file() || (original.dev(), original.ino()) != (current.dev(), current.ino())
+        {
+            return Err(BulkloadRefusal::GitAuthorityChanged);
+        }
+        fs::remove_file(&self.path)?;
+        fs::File::open(self.path.parent().ok_or(BulkloadRefusal::PathEscapesRoot)?)?.sync_all()?;
+        Ok(())
+    }
+
+    fn release(mut self) -> Result<()> {
+        self.remove_owned()?;
+        self.released = true;
+        Ok(())
+    }
+}
+
+impl Drop for IndexReservation {
+    fn drop(&mut self) {
+        if !self.released {
+            let _ = self.remove_owned();
+        }
+    }
+}
+
+fn require_missing(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+        Ok(_) => Err(BulkloadRefusal::GitDestinationOccupied),
+    }
+}
+
+fn admin_controls(admin: &Path) -> Result<Vec<(String, Option<Vec<u8>>)>> {
+    ["HEAD", "commondir", "gitdir", "config", "config.worktree"]
+        .into_iter()
+        .map(|name| {
+            let bytes = match fs::read(admin.join(name)) {
+                Ok(value) => Some(value),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => return Err(error.into()),
+            };
+            Ok((name.to_owned(), bytes))
+        })
+        .collect()
+}
+
 /// Export one worktree and all repository refs into a new, private directory.
 ///
 /// # Errors
@@ -855,6 +1127,15 @@ mod tests {
         }
         let original_a = text(git(&a).args(["rev-parse", "HEAD"])).unwrap();
         let original_b = text(git(&b).args(["rev-parse", "HEAD"])).unwrap();
+        assert_eq!(
+            common_repository(&a).unwrap(),
+            fs::canonicalize(a.join(".git")).unwrap()
+        );
+        let reusable = reusable_capture_key(&a).unwrap();
+        assert_eq!(reusable, reusable_capture_key(&a).unwrap());
+        fs::write(a.join("tracked"), b"dirty-a!").unwrap();
+        assert_ne!(reusable, reusable_capture_key(&a).unwrap());
+        fs::write(a.join("tracked"), b"source-a").unwrap();
         let mut stashes = Vec::new();
         for repo in [&a, &b] {
             fs::write(repo.join("tracked"), b"unique stash state").unwrap();
@@ -863,7 +1144,9 @@ mod tests {
         }
         // A legacy nested provenance name is kept, not silently discarded.
         let legacy = "refs/carry/sting/old/registry/carry-export/refs/carry/neo/old/heads/topic";
+        let before_ref = reusable_capture_key(&a).unwrap();
         set_ref(&a, legacy, &original_a).unwrap();
+        assert_ne!(before_ref, reusable_capture_key(&a).unwrap());
         let mut fixed = None;
         for round in 0..5 {
             let ab = export_repository(&a, &root.join(format!("a-{round}"))).unwrap();
@@ -1087,6 +1370,67 @@ mod tests {
         assert!(restore_linked(&bundle, &dest, &linked, "neo").is_err());
         assert_eq!(fs::read(restored.join("binary")).unwrap(), [0, 255, 128]);
         assert!(restore_bundle(&bundle, &restored, "neo").is_err());
+        fs::remove_file(restored.join(".git/index")).unwrap();
+        fs::write(restored.join("tracked"), b"destination-only pending change").unwrap();
+        repair_missing_index(&bundle, &restored, "neo", &root.join("repair")).unwrap();
+        assert_eq!(
+            fs::read(restored.join("tracked")).unwrap(),
+            b"destination-only pending change"
+        );
+        assert_eq!(
+            output(git(&source).args(["diff", "--cached", "--binary"])).unwrap(),
+            output(git(&restored).args(["diff", "--cached", "--binary"])).unwrap()
+        );
+        assert!(root
+            .join("repair/original-administration.postcard")
+            .is_file());
+        assert!(
+            repair_missing_index(&bundle, &restored, "neo", &root.join("repair-again")).is_err()
+        );
+        fs::remove_file(restored.join(".git/index")).unwrap();
+        fs::write(restored.join(".git/index.lock"), b"another Git writer").unwrap();
+        assert!(
+            repair_missing_index(&bundle, &restored, "neo", &root.join("repair-locked")).is_err()
+        );
+        assert_eq!(
+            fs::read(restored.join(".git/index.lock")).unwrap(),
+            b"another Git writer"
+        );
+        fs::remove_file(restored.join(".git/index.lock")).unwrap();
+        assert!(repair_missing_index_inner(
+            &bundle,
+            &restored,
+            "neo",
+            &root.join("repair-race"),
+            |index| {
+                assert!(restored.join(".git/index.lock").is_file());
+                assert!(output(git(&restored).args(["read-tree", "HEAD"])).is_err());
+                fs::write(index, b"concurrent index publication")?;
+                Ok(())
+            }
+        )
+        .is_err());
+        assert_eq!(
+            fs::read(restored.join(".git/index")).unwrap(),
+            b"concurrent index publication"
+        );
+        assert!(!restored.join(".git/index.lock").exists());
+        let lock_path = root.join("reservation.lock");
+        let reservation = IndexReservation::acquire(lock_path.clone()).unwrap();
+        fs::rename(&lock_path, root.join("reservation-original")).unwrap();
+        fs::write(&lock_path, b"replacement writer").unwrap();
+        drop(reservation);
+        assert_eq!(fs::read(lock_path).unwrap(), b"replacement writer");
+        fs::remove_file(dest.join(".git/index")).unwrap();
+        assert_eq!(
+            repair_missing_index(&bundle, &dest, "neo", &root.join("repair-wrong-head")),
+            Err(BulkloadRefusal::GitAuthorityChanged)
+        );
+        assert!(!dest.join(".git/index").exists());
+        assert_eq!(
+            fs::read(dest.join("tracked")).unwrap(),
+            b"destination divergence"
+        );
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -984,7 +984,7 @@ fn prepare_linked_attachment(
         Err(error) => return Err(error.into()),
     };
     if exclude != captured_exclude {
-        return Err(BulkloadRefusal::GitDestinationOccupied);
+        return Err(BulkloadRefusal::GitIgnorePolicyConflict);
     }
     let attached = text(git(repository).args(["worktree", "list", "--porcelain"]))?;
     let reuse = symbolic.starts_with("refs/heads/")
@@ -1055,7 +1055,10 @@ fn attachment_policy_matches(repository: &Path, private: &Path, heads: &str) -> 
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
         Err(error) => return Err(error.into()),
     };
-    Ok(expected == actual)
+    if expected != actual {
+        return Err(BulkloadRefusal::GitIgnorePolicyConflict);
+    }
+    Ok(true)
 }
 
 /// Attach captured source administration to an exactly matching payload only.
@@ -1113,8 +1116,10 @@ pub fn attach_matching_payload(
         "rev-parse",
         &format!("{}^{{tree}}", capture_revision(&heads, "worktree")?),
     ]))?;
+    // The raw reader checks each file's identity before and after its one byte
+    // pass. The outer census also rejects namespace or metadata changes; a
+    // second full byte pass does not make this an atomic snapshot.
     if capture_tree(&private, &destination, &comparison)? != expected_tree
-        || capture_tree(&private, &destination, &comparison)? != expected_tree
         || filesystem_rows(&destination)? != before
     {
         return Err(BulkloadRefusal::GitAuthorityChanged);
@@ -1298,7 +1303,7 @@ pub fn restore_linked(
         Err(error) => return Err(error.into()),
     };
     if exclude != existing_exclude {
-        return Err(BulkloadRefusal::GitDestinationOccupied);
+        return Err(BulkloadRefusal::GitIgnorePolicyConflict);
     }
     let attached = text(git(&repository).args(["worktree", "list", "--porcelain"]))?;
     let source_tip = text(git(&repository).args(["rev-parse", "--verify", &symbolic]));
@@ -1342,9 +1347,10 @@ pub fn restore_linked(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
         Err(error) => return Err(error.into()),
     };
-    if final_exclude != exclude
-        || text(git(&destination).args(["rev-parse", "--verify", "HEAD"]))? != head
-    {
+    if final_exclude != exclude {
+        return Err(BulkloadRefusal::GitIgnorePolicyConflict);
+    }
+    if text(git(&destination).args(["rev-parse", "--verify", "HEAD"]))? != head {
         return Err(BulkloadRefusal::GitAuthorityChanged);
     }
     Ok(())
@@ -1709,6 +1715,19 @@ mod tests {
         let restored = root.join("restored");
         restore_bundle(&bundle, &restored, "neo").unwrap();
         let linked = root.join("linked");
+        let exclude_path = dest.join(".git/info/exclude");
+        let original_exclude = fs::read(&exclude_path).unwrap_or_default();
+        fs::create_dir_all(dest.join(".git/info")).unwrap();
+        fs::write(&exclude_path, b"operator-local-policy\n").unwrap();
+        assert_eq!(
+            restore_linked(&bundle, &dest, &linked, "neo"),
+            Err(BulkloadRefusal::GitIgnorePolicyConflict)
+        );
+        assert!(!linked.exists());
+        assert_eq!(fs::read(&exclude_path).unwrap(), b"operator-local-policy\n");
+        assert_eq!(dest_index, fs::read(dest.join(".git/index")).unwrap());
+        assert_eq!(dest_head, fs::read(dest.join(".git/HEAD")).unwrap());
+        fs::write(&exclude_path, original_exclude).unwrap();
         restore_linked(&bundle, &dest, &linked, "neo").unwrap();
         {
             use std::os::unix::fs::PermissionsExt;

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -270,6 +270,8 @@ pub fn reusable_capture_key(repo: &Path) -> Result<[u8; 32]> {
     };
     let rows =
         postcard::to_allocvec(&filesystem_rows(&repo)?).map_err(|_| BulkloadRefusal::FrameCodec)?;
+    let configuration = postcard::to_allocvec(&source_configuration(&repo)?)
+        .map_err(|_| BulkloadRefusal::FrameCodec)?;
     let mut hash = blake3::Hasher::new();
     hash.update(b"tcfs-git-reusable-capture-v1\0");
     for bytes in [
@@ -282,6 +284,7 @@ pub fn reusable_capture_key(repo: &Path) -> Result<[u8; 32]> {
         &exclude,
         &stash,
         &rows,
+        &configuration,
     ] {
         hash.update(
             &u64::try_from(bytes.len())
@@ -534,6 +537,7 @@ fn export_repository_inner(
         return Err(BulkloadRefusal::GitAuthorityOutsideRoot);
     }
     let before_refs = refs(&repo)?;
+    let configuration = source_configuration(&repo)?;
     let seats = filesystem_rows(&repo)?;
     let head = text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?;
     let (index_path, before_index) = source_index(&repo)?;
@@ -554,6 +558,11 @@ fn export_repository_inner(
         Err(error) => return Err(error.into()),
     };
     metadata(&private, "exclude", &exclude)?;
+    metadata(
+        &private,
+        "configuration-v1",
+        &postcard::to_allocvec(&configuration).map_err(|_| BulkloadRefusal::FrameCodec)?,
+    )?;
     let index = capture.join("index");
     fs::write(&index, &before_index)?;
     let staged = text(snapshot_command(&private, &repo, &index).arg("write-tree"))?;
@@ -564,6 +573,7 @@ fn export_repository_inner(
     )?;
     let (tree, _) = raw_tree::capture(&private, &repo, &seats)?;
     if before_refs != refs(&repo)?
+        || configuration != source_configuration(&repo)?
         || before_index != fs::read(index_path)?
         || head != text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?
         || seats != filesystem_rows(&repo)?
@@ -840,14 +850,46 @@ pub fn import_bundle(repo: &Path, bundle: &Path, source: &str) -> Result<usize> 
             .arg(&bundle)
             .args(names.iter().map(|(_, name, _)| name)),
     )?;
-    for (value, _, target) in &names {
-        if let Ok(existing) = text(git(repo).args(["rev-parse", "--verify", target])) {
-            if existing != *value {
-                return Err(BulkloadRefusal::GitDestinationOccupied);
-            }
-        } else {
-            set_ref(repo, target, value)?;
+    let inventory = text(git(repo).args([
+        "for-each-ref",
+        "--format=%(objectname) %(refname)",
+        "refs/carry/v1/",
+    ]))?;
+    let mut existing = std::collections::BTreeMap::new();
+    for line in inventory.lines() {
+        let (value, name) = line
+            .split_once(' ')
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+        if !oid(value) || existing.insert(name, value).is_some() {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
         }
+    }
+    let mut desired = std::collections::BTreeMap::new();
+    for (value, _, target) in &names {
+        if target.contains('\0')
+            || desired
+                .insert(target.as_str(), value.as_str())
+                .is_some_and(|prior| prior != value.as_str())
+        {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+    }
+    let mut transaction = Vec::new();
+    for (target, value) in desired {
+        let operation = match existing.get(target) {
+            Some(prior) if *prior == value => "verify",
+            Some(_) => return Err(BulkloadRefusal::GitDestinationOccupied),
+            None => "create",
+        };
+        transaction.extend_from_slice(format!("{operation} {target}\0{value}\0").as_bytes());
+    }
+    // One atomic compare/create transaction, including unchanged refs: a
+    // concurrent update or deletion refuses instead of publishing a partial set.
+    if !transaction.is_empty() {
+        input(
+            git(repo).args(["update-ref", "--no-deref", "--stdin", "-z"]),
+            &transaction,
+        )?;
     }
     Ok(names.len())
 }
@@ -950,6 +992,137 @@ fn prepare_attachment(
             .arg(destination),
     )?;
     Ok((private, heads))
+}
+
+fn source_configuration(repo: &Path) -> Result<Vec<(String, Vec<u8>)>> {
+    let mut files = Vec::new();
+    for name in ["config", "config.worktree"] {
+        let path =
+            text(git(repo).args(["rev-parse", "--path-format=absolute", "--git-path", name]))?;
+        match fs::read(path) {
+            Ok(bytes) => files.push((name.to_owned(), bytes)),
+            Err(error)
+                if error.kind() == std::io::ErrorKind::NotFound && name == "config.worktree" => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(files)
+}
+
+fn safe_configuration_value(private: &Path, key: &str, value: &str) -> bool {
+    if value.contains(['\0', '\n', '\r']) {
+        return false;
+    }
+    if matches!(key, "core.filemode" | "core.ignorecase" | "core.symlinks") {
+        return matches!(value, "true" | "false");
+    }
+    if matches!(key, "user.name" | "user.email") {
+        return true;
+    }
+    if key == "push.default" {
+        return matches!(
+            value,
+            "nothing" | "current" | "upstream" | "simple" | "matching"
+        );
+    }
+    if key == "pull.ff" {
+        return matches!(value, "true" | "false" | "only");
+    }
+    if key == "pull.rebase" {
+        return matches!(value, "true" | "false" | "merges");
+    }
+    if let Some((prefix, field)) = key.rsplit_once('.') {
+        if prefix.starts_with("branch.") {
+            return match field {
+                "remote" | "pushremote" => matches!(value, "origin" | "."),
+                "merge" => {
+                    value.starts_with("refs/heads/")
+                        && git(private)
+                            .args(["check-ref-format", value])
+                            .output()
+                            .is_ok_and(|out| out.status.success())
+                }
+                "rebase" => matches!(value, "true" | "false" | "merges"),
+                _ => false,
+            };
+        }
+        if prefix == "remote.origin" && field == "fetch" {
+            return value == "+refs/heads/*:refs/remotes/origin/*";
+        }
+    }
+    false
+}
+
+fn activate_standalone_configuration(
+    private: &Path,
+    heads: &str,
+    receipt: &Path,
+    from: &Path,
+    to: &Path,
+) -> Result<()> {
+    if !from.is_absolute() || !to.is_absolute() {
+        return Err(BulkloadRefusal::PathNotAbsolute);
+    }
+    common_repository(to)?;
+    let from = from
+        .to_str()
+        .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+    let to = to.to_str().ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+    let files: Vec<(String, Vec<u8>)> = postcard::from_bytes(&output(git(private).args([
+        "show",
+        &format!("{}:value", capture_revision(heads, "configuration-v1")?),
+    ]))?)
+    .map_err(|_| BulkloadRefusal::FrameCodec)?;
+    let mut activated = Vec::new();
+    let mut preserved_only = Vec::new();
+    let mut origin_seen = false;
+    for (name, bytes) in files {
+        if !matches!(name.as_str(), "config" | "config.worktree") {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        let retained = receipt.join(format!("source-{name}"));
+        fs::write(&retained, bytes)?;
+        // Worktree-local configuration may be dormant unless the source enables
+        // its extension. Preserve it, but do not silently flatten its authority.
+        if name == "config.worktree" {
+            preserved_only.push("config.worktree (not activated)".to_owned());
+            continue;
+        }
+        let parsed = output(
+            git(private)
+                .args(["config", "--no-includes", "--null", "--list", "--file"])
+                .arg(&retained),
+        )?;
+        for entry in parsed.split(|b| *b == 0).filter(|entry| !entry.is_empty()) {
+            let entry =
+                std::str::from_utf8(entry).map_err(|_| BulkloadRefusal::GitInventoryMalformed)?;
+            let (key, value) = entry.split_once('\n').unwrap_or((entry, ""));
+            let value = if key == "remote.origin.url" {
+                if value != from {
+                    return Err(BulkloadRefusal::GitAuthorityChanged);
+                }
+                origin_seen = true;
+                to
+            } else if safe_configuration_value(private, key, value) {
+                value
+            } else {
+                preserved_only.push(key.to_owned());
+                continue;
+            };
+            output(git(private).args(["config", "--local", "--add", key, value]))?;
+            activated.push(key.to_owned());
+        }
+    }
+    if !origin_seen {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    // Keys, not potentially sensitive values, explain the deliberate policy boundary.
+    fs::write(
+        receipt.join("configuration-activation.postcard"),
+        postcard::to_allocvec(&(activated, preserved_only, from, to))
+            .map_err(|_| BulkloadRefusal::FrameCodec)?,
+    )?;
+    Ok(())
 }
 
 fn prepare_linked_attachment(
@@ -1079,12 +1252,48 @@ pub fn attach_matching_payload(
     source: &str,
     receipt: &Path,
 ) -> Result<()> {
-    use std::io::Write;
-    use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    attach_payload(bundle, Some(repository), None, destination, source, receipt)
+}
+
+/// Attach standalone administration with an explicit local-origin path mapping.
+///
+/// Complete source local configuration remains immutable capture data. Only
+/// safe declarative keys activate; hooks, helpers, includes, extensions and
+/// source worktree paths never activate. The activation receipt names omissions.
+/// The receipt directory becomes live Git administration and must be retained.
+///
+/// # Errors
+/// Refuses payload divergence, occupied .git, invalid mapping or unknown origin.
+pub fn attach_standalone_payload(
+    bundle: &Path,
+    destination: &Path,
+    source: &str,
+    receipt: &Path,
+    origin_from: &Path,
+    origin_to: &Path,
+) -> Result<()> {
+    attach_payload(
+        bundle,
+        None,
+        Some((origin_from, origin_to)),
+        destination,
+        source,
+        receipt,
+    )
+}
+
+fn attach_payload(
+    bundle: &Path,
+    repository: Option<&Path>,
+    mapping: Option<(&Path, &Path)>,
+    destination: &Path,
+    source: &str,
+    receipt: &Path,
+) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
     let destination = fs::canonicalize(destination)?;
-    let repository = fs::canonicalize(repository)?;
-    let common = common_repository(&repository)?;
+    let repository = repository.map(fs::canonicalize).transpose()?;
+    let common = repository.as_deref().map(common_repository).transpose()?;
     let receipt_parent =
         fs::canonicalize(receipt.parent().ok_or(BulkloadRefusal::PathNotAbsolute)?)?;
     let receipt = receipt_parent.join(
@@ -1130,35 +1339,25 @@ pub fn attach_matching_payload(
     )?;
     sync_private_tree(&receipt)?;
     fs::File::open(&receipt_parent)?.sync_all()?;
-    let admin = prepare_linked_attachment(
-        &repository,
-        &destination,
-        source,
-        &receipt,
-        &private,
-        &heads,
-    )?;
-    let pointer = receipt.join("git-pointer");
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(&pointer)?;
-    if admin.as_os_str().as_bytes().contains(&b'\n')
-        || admin.as_os_str().as_bytes().contains(&b'\r')
-    {
-        return Err(BulkloadRefusal::GitInventoryMalformed);
-    }
-    file.write_all(b"gitdir: ")?;
-    file.write_all(admin.as_os_str().as_bytes())?;
-    file.write_all(b"\n")?;
+    let admin = if let Some(repository) = &repository {
+        prepare_linked_attachment(repository, &destination, source, &receipt, &private, &heads)?
+    } else {
+        let (from, to) = mapping.ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+        activate_standalone_configuration(&private, &heads, &receipt, from, to)?;
+        private.clone()
+    };
+    let pointer = write_git_pointer(&receipt, &admin)?;
     sync_private_tree(&receipt)?;
     fs::File::open(&receipt_parent)?.sync_all()?;
     let current_root = fs::metadata(&destination)?;
     if root.dev() != current_root.dev()
         || root.ino() != current_root.ino()
         || filesystem_rows(&destination)? != before
-        || !attachment_policy_matches(&repository, &private, &heads)?
+        || repository
+            .as_deref()
+            .map(|repo| attachment_policy_matches(repo, &private, &heads))
+            .transpose()?
+            .is_some_and(|matches| !matches)
         || text(
             snapshot_command(&admin, &destination, &admin.join("index"))
                 .args(["rev-parse", "HEAD"]),
@@ -1170,15 +1369,41 @@ pub fn attach_matching_payload(
     fs::hard_link(pointer, destination.join(".git"))?;
     fs::File::open(&destination)?.sync_all()?;
     if filesystem_rows(&destination)? != before
-        || common_repository(&destination)? != common
-        || !attachment_policy_matches(&repository, &private, &heads)?
+        || &common_repository(&destination)? != common.as_ref().unwrap_or(&private)
+        || repository
+            .as_deref()
+            .map(|repo| attachment_policy_matches(repo, &private, &heads))
+            .transpose()?
+            .is_some_and(|matches| !matches)
         || text(git(&destination).args(["rev-parse", "HEAD"]))? != capture_revision(&heads, "head")?
     {
         return Err(BulkloadRefusal::GitAuthorityChanged);
     }
-    fs::remove_file(admin.join("locked"))?;
+    if repository.is_some() {
+        fs::remove_file(admin.join("locked"))?;
+    }
     fs::File::open(admin)?.sync_all()?;
     Ok(())
+}
+
+fn write_git_pointer(receipt: &Path, admin: &Path) -> Result<PathBuf> {
+    use std::io::Write;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::OpenOptionsExt;
+    let pointer = receipt.join("git-pointer");
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&pointer)?;
+    let path = admin.as_os_str().as_bytes();
+    if path.contains(&b'\n') || path.contains(&b'\r') {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    file.write_all(b"gitdir: ")?;
+    file.write_all(path)?;
+    file.write_all(b"\n")?;
+    Ok(pointer)
 }
 
 /// Restore staged and unstaged state into a newly created, standalone repository.
@@ -1444,6 +1669,77 @@ fn restore_entry(destination: &Path, entry: &[u8]) -> Result<()> {
 mod tests {
     use super::*;
     #[test]
+    fn standalone_attachment_maps_origin_and_retains_tracking_without_executable_config() {
+        let root = std::env::temp_dir().join(format!("bulkload-config-{}", std::process::id()));
+        fs::create_dir(&root).unwrap();
+        let source = root.join("source");
+        let upstream = root.join("upstream");
+        for repo in [&source, &upstream] {
+            fs::create_dir(repo).unwrap();
+            output(git(repo).args(["init", "--template="])).unwrap();
+        }
+        output(git(&source).args(["config", "user.name", "Test"])).unwrap();
+        output(git(&source).args(["config", "user.email", "test@localhost"])).unwrap();
+        fs::write(source.join("tracked"), b"base").unwrap();
+        output(git(&source).args(["add", "."])).unwrap();
+        output(git(&source).args(["-c", "commit.gpgsign=false", "commit", "-m", "base"])).unwrap();
+        let symbolic = text(git(&source).args(["symbolic-ref", "HEAD"])).unwrap();
+        let branch = symbolic.strip_prefix("refs/heads/").unwrap();
+        let from = Path::new("/Users/jess/git/legalab");
+        output(git(&source).args(["config", "remote.origin.url"]).arg(from)).unwrap();
+        output(git(&source).args([
+            "config",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/remotes/origin/*",
+        ]))
+        .unwrap();
+        output(git(&source).args(["config", &format!("branch.{branch}.remote"), "origin"]))
+            .unwrap();
+        output(git(&source).args(["config", &format!("branch.{branch}.merge"), &symbolic]))
+            .unwrap();
+        output(git(&source).args(["config", "credential.helper", "!unsafe-helper"])).unwrap();
+        output(git(&source).args(["config", "alias.unsafe", "!unsafe-command"])).unwrap();
+        fs::write(source.join("tracked"), b"staged").unwrap();
+        output(git(&source).args(["add", "."])).unwrap();
+        fs::write(source.join("tracked"), b"dirty").unwrap();
+        let bundle = export_repository(&source, &root.join("capture")).unwrap();
+        let payload = root.join("payload");
+        restore_bundle(&bundle, &payload, "neo").unwrap();
+        fs::rename(payload.join(".git"), root.join("original-git")).unwrap();
+        let before = filesystem_rows(&payload).unwrap();
+        let receipt = root.join("receipt");
+        attach_standalone_payload(&bundle, &payload, "neo", &receipt, from, &upstream).unwrap();
+        assert_eq!(before, filesystem_rows(&payload).unwrap());
+        assert_eq!(
+            text(git(&payload).args(["config", "remote.origin.url"])).unwrap(),
+            upstream.to_str().unwrap()
+        );
+        assert_eq!(
+            text(git(&payload).args(["config", &format!("branch.{branch}.remote")])).unwrap(),
+            "origin"
+        );
+        assert_eq!(
+            text(git(&payload).args(["config", &format!("branch.{branch}.merge")])).unwrap(),
+            symbolic
+        );
+        assert!(text(git(&payload).args(["config", "credential.helper"])).is_err());
+        assert!(text(git(&payload).args(["config", "alias.unsafe"])).is_err());
+        assert_eq!(
+            fs::read(source.join(".git/config")).unwrap(),
+            fs::read(receipt.join("source-config")).unwrap()
+        );
+        assert_eq!(
+            output(git(&source).args(["diff", "--cached", "--binary"])).unwrap(),
+            output(git(&payload).args(["diff", "--cached", "--binary"])).unwrap()
+        );
+        assert_eq!(
+            output(git(&source).args(["diff", "--binary"])).unwrap(),
+            output(git(&payload).args(["diff", "--binary"])).unwrap()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn exact_payload_attachment_preserves_bytes_inodes_and_captured_staging() {
         use std::os::unix::fs::MetadataExt;
         let root = std::env::temp_dir().join(format!("bulkload-attach-{}", std::process::id()));
@@ -1705,6 +2001,27 @@ mod tests {
             output(git(&dest).args(["show", &format!("{staged}:tracked")])).unwrap(),
             b"staged"
         );
+        let staged_oid = text(git(&dest).args(["rev-parse", staged])).unwrap();
+        let conflicting_oid = text(git(&dest).args(["rev-parse", "HEAD"])).unwrap();
+        output(git(&dest).args(["update-ref", staged, &conflicting_oid, &staged_oid])).unwrap();
+        let before_refusal = refs(&dest).unwrap();
+        assert_eq!(
+            import_bundle(&dest, &bundle, "neo"),
+            Err(BulkloadRefusal::GitDestinationOccupied)
+        );
+        assert_eq!(refs(&dest).unwrap(), before_refusal);
+        output(git(&dest).args(["update-ref", staged, &staged_oid, &conflicting_oid])).unwrap();
+        output(git(&dest).args(["update-ref", "-d", staged, &staged_oid])).unwrap();
+        let native_missing = "refs/heads/must-stay-absent";
+        output(git(&dest).args(["symbolic-ref", staged, native_missing])).unwrap();
+        assert!(import_bundle(&dest, &bundle, "neo").is_err());
+        assert!(text(git(&dest).args(["rev-parse", "--verify", native_missing])).is_err());
+        assert_eq!(
+            text(git(&dest).args(["symbolic-ref", staged])).unwrap(),
+            native_missing
+        );
+        output(git(&dest).args(["update-ref", "--no-deref", "-d", staged])).unwrap();
+        set_ref(&dest, staged, &staged_oid).unwrap();
         assert_eq!(
             carried
                 .lines()

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -192,7 +192,16 @@ fn capture_refs(repo: &Path, private: &Path, inventory: &str) -> Result<()> {
         let (value, name) = line
             .split_once(' ')
             .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
-        set_ref(private, &format!("refs/carry-export/{name}"), value)?;
+        // Older carry spellings remain fully recoverable, once. They are
+        // never discarded merely because provenance predates this schema.
+        let exported = name
+            .strip_prefix("refs/carry/v1/")
+            .filter(|tail| canonical_tail(tail))
+            .map_or_else(
+                || format!("refs/carry-export/{name}"),
+                |tail| format!("refs/carry-export/union/v1/{tail}"),
+            );
+        set_ref(private, &exported, value)?;
     }
     let stash = output(git(repo).args(["reflog", "show", "--format=%H", "refs/stash"]));
     if let Ok(stash) = stash {
@@ -211,6 +220,22 @@ fn capture_refs(repo: &Path, private: &Path, inventory: &str) -> Result<()> {
         return Err(BulkloadRefusal::GitInventoryMalformed);
     }
     Ok(())
+}
+
+fn source_slug(source: &str) -> bool {
+    !source.is_empty()
+        && source.len() <= 64
+        && source
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+fn canonical_tail(tail: &str) -> bool {
+    let mut parts = tail.splitn(3, '/');
+    let source = parts.next().unwrap_or_default();
+    let snapshot = parts.next().unwrap_or_default();
+    let suffix = parts.next().unwrap_or_default();
+    source_slug(source) && snapshot.len() == 64 && oid(snapshot) && !suffix.is_empty()
 }
 
 /// Export one worktree and all repository refs into a new, private directory.
@@ -475,39 +500,37 @@ fn prepare_private(repo: &Path, capture: &Path) -> Result<PathBuf> {
 }
 
 /// Import into a content-addressed source namespace, never native branches.
-/// Repeats are idempotent; differing captures remain separately reachable.
+///
+/// Snapshot identity includes native refs and capture metadata, not carried
+/// transit refs. Already canonical refs retain their original source and
+/// identity across bidirectional rounds, bounding growth by distinct captures.
 ///
 /// # Errors
 /// Refuses invalid source names, non-export bundle refs, collisions or invalid
 /// bundles. A failed fetch may leave unreachable objects, never changed HEAD.
 pub fn import_bundle(repo: &Path, bundle: &Path, source: &str) -> Result<usize> {
-    use std::io::Read;
-    if source.is_empty()
-        || source.len() > 64
-        || !source
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
-    {
+    if !source_slug(source) {
         return Err(BulkloadRefusal::GitInventoryMalformed);
     }
     let bundle = fs::canonicalize(bundle)?;
-    let mut file = fs::File::open(&bundle)?;
-    let mut hasher = blake3::Hasher::new();
-    let mut bytes = vec![0_u8; 65_536];
-    loop {
-        let count = file.read(&mut bytes)?;
-        if count == 0 {
-            break;
-        }
-        hasher.update(
-            bytes
-                .get(..count)
-                .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
-        );
-    }
-    let digest = hasher.finalize().to_hex();
     output(git(repo).args(["bundle", "verify"]).arg(&bundle))?;
     let heads = text(git(repo).args(["bundle", "list-heads"]).arg(&bundle))?;
+    let mut native: Vec<_> = heads
+        .lines()
+        .filter(|line| {
+            !line
+                .split_once(' ')
+                .is_some_and(|(_, name)| name.starts_with("refs/carry-export/union/v1/"))
+        })
+        .collect();
+    native.sort_unstable();
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"tcfs-git-native-snapshot-v1\0");
+    for line in native {
+        hasher.update(line.as_bytes());
+        hasher.update(b"\n");
+    }
+    let digest = hasher.finalize().to_hex();
     let mut names = Vec::new();
     for line in heads.lines() {
         let (value, name) = line
@@ -519,11 +542,15 @@ pub fn import_bundle(repo: &Path, bundle: &Path, source: &str) -> Result<usize> 
         if !oid(value) {
             return Err(BulkloadRefusal::GitInventoryMalformed);
         }
-        names.push((
-            value.to_owned(),
-            name.to_owned(),
-            format!("refs/carry/{source}/{digest}/{suffix}"),
-        ));
+        let target = if let Some(tail) = suffix.strip_prefix("union/v1/") {
+            if !canonical_tail(tail) {
+                return Err(BulkloadRefusal::GitInventoryMalformed);
+            }
+            format!("refs/carry/v1/{tail}")
+        } else {
+            format!("refs/carry/v1/{source}/{digest}/{suffix}")
+        };
+        names.push((value.to_owned(), name.to_owned(), target));
     }
     // Fetch objects only. Compare-and-create below cannot clobber a native ref.
     output(
@@ -811,6 +838,68 @@ fn restore_entry(destination: &Path, entry: &[u8]) -> Result<()> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    #[test]
+    fn bidirectional_union_reaches_fixed_point_without_provenance_wrapping() {
+        let root = std::env::temp_dir().join(format!("bulkload-git-union-{}", std::process::id()));
+        fs::create_dir(&root).unwrap();
+        let a = root.join("a");
+        let b = root.join("b");
+        for (repo, content) in [(&a, b"source-a"), (&b, b"source-b")] {
+            fs::create_dir(repo).unwrap();
+            output(git(repo).args(["init", "--template="])).unwrap();
+            output(git(repo).args(["config", "user.name", "Test"])).unwrap();
+            output(git(repo).args(["config", "user.email", "test@localhost"])).unwrap();
+            fs::write(repo.join("tracked"), content).unwrap();
+            output(git(repo).args(["add", "."])).unwrap();
+            output(git(repo).args(["-c", "commit.gpgsign=false", "commit", "-m", "base"])).unwrap();
+        }
+        let original_a = text(git(&a).args(["rev-parse", "HEAD"])).unwrap();
+        let original_b = text(git(&b).args(["rev-parse", "HEAD"])).unwrap();
+        let mut stashes = Vec::new();
+        for repo in [&a, &b] {
+            fs::write(repo.join("tracked"), b"unique stash state").unwrap();
+            output(git(repo).args(["stash", "push"])).unwrap();
+            stashes.push(text(git(repo).args(["rev-parse", "refs/stash"])).unwrap());
+        }
+        // A legacy nested provenance name is kept, not silently discarded.
+        let legacy = "refs/carry/sting/old/registry/carry-export/refs/carry/neo/old/heads/topic";
+        set_ref(&a, legacy, &original_a).unwrap();
+        let mut fixed = None;
+        for round in 0..5 {
+            let ab = export_repository(&a, &root.join(format!("a-{round}"))).unwrap();
+            import_bundle(&b, &ab, "neo").unwrap();
+            let ba = export_repository(&b, &root.join(format!("b-{round}"))).unwrap();
+            import_bundle(&a, &ba, "sting").unwrap();
+            let current = (refs(&a).unwrap(), refs(&b).unwrap());
+            if round == 1 {
+                fixed = Some(current.clone());
+            }
+            if round > 1 {
+                assert_eq!(fixed.as_ref(), Some(&current));
+            }
+        }
+        for repo in [&a, &b] {
+            let inventory = refs(repo).unwrap();
+            assert!(inventory
+                .lines()
+                .any(|line| line.starts_with(&original_a) && line.contains(legacy)));
+            assert!(inventory.lines().any(|line| line.starts_with(&original_b)));
+            for stash in &stashes {
+                assert!(inventory.lines().any(|line| line.starts_with(stash)));
+            }
+            assert!(!inventory.contains("/refs/carry/v1/"));
+        }
+        assert_eq!(
+            text(git(&a).args(["rev-parse", "HEAD"])).unwrap(),
+            original_a
+        );
+        assert_eq!(
+            text(git(&b).args(["rev-parse", "HEAD"])).unwrap(),
+            original_b
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     #[allow(clippy::too_many_lines)] // One end-to-end source/union/restore invariant.
     fn union_preserves_native_head_index_binary_and_stash_history() {

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -10,6 +10,7 @@ use std::process::{Command, Output};
 
 use crate::{BulkloadRefusal, Result};
 
+mod raw_tree;
 pub mod shared;
 
 fn git(repo: &Path) -> Command {
@@ -143,53 +144,18 @@ fn commit_tree(private: &Path, tree: &str, label: &str) -> Result<String> {
     )
 }
 
-// Git's normal add applies attributes (including EOL normalization). Archive
-// raw worktree bytes instead; the separate staged tree retains index semantics.
-fn capture_tree(private: &Path, repo: &Path, index: &Path) -> Result<String> {
-    use std::os::unix::ffi::OsStrExt;
-    output(snapshot_command(private, repo, index).args(["add", "--all", "--force", "--", "."]))?;
-    let entries =
-        output(snapshot_command(private, repo, index).args(["ls-files", "--stage", "-z"]))?;
-    for entry in entries.split(|b| *b == 0).filter(|entry| !entry.is_empty()) {
-        let tab = entry
-            .iter()
-            .position(|b| *b == b'\t')
-            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
-        let header = std::str::from_utf8(
-            entry
-                .get(..tab)
-                .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
-        )
-        .map_err(|_| BulkloadRefusal::GitInventoryMalformed)?;
-        let mode = header
-            .split_whitespace()
-            .next()
-            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
-        let path = std::ffi::OsStr::from_bytes(
-            entry
-                .get(tab + 1..)
-                .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
-        );
-        if mode == "160000" {
-            return Err(BulkloadRefusal::GitInventoryMalformed);
-        }
-        if matches!(mode, "100644" | "100755") {
-            let value = text(
-                snapshot_command(private, repo, index)
-                    .args(["hash-object", "-w", "--no-filters", "--"])
-                    .arg(path),
-            )?;
-            output(
-                snapshot_command(private, repo, index)
-                    .args(["update-index", "--add", "--cacheinfo", mode, &value])
-                    .arg(path),
-            )?;
-        }
+// Build a raw tree without running attributes/filters or starting Git per file.
+fn capture_tree(private: &Path, repo: &Path, _index: &Path) -> Result<String> {
+    let rows = filesystem_rows(repo)?;
+    let (tree, _) = raw_tree::capture(private, repo, &rows)?;
+    if rows != filesystem_rows(repo)? {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
     }
-    text(snapshot_command(private, repo, index).arg("write-tree"))
+    Ok(tree)
 }
 
 fn capture_refs(repo: &Path, private: &Path, inventory: &str) -> Result<()> {
+    let mut pending = std::collections::BTreeMap::new();
     for line in inventory.lines() {
         let (value, name) = line
             .split_once(' ')
@@ -203,23 +169,41 @@ fn capture_refs(repo: &Path, private: &Path, inventory: &str) -> Result<()> {
                 || format!("refs/carry-export/{name}"),
                 |tail| format!("refs/carry-export/union/v1/{tail}"),
             );
-        set_ref(private, &exported, value)?;
+        if !oid(value) || exported.as_bytes().contains(&0) {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        if pending.insert(exported, value.to_owned()).is_some() {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
     }
     let stash = output(git(repo).args(["reflog", "show", "--format=%H", "refs/stash"]));
     if let Ok(stash) = stash {
         let stash = String::from_utf8(stash).map_err(|_| BulkloadRefusal::GitInventoryMalformed)?;
         for value in stash.lines() {
-            let name = format!("refs/carry-export/stashes/{value}");
-            if !git(private)
-                .args(["show-ref", "--verify", "--quiet", &name])
-                .status()?
-                .success()
-            {
-                set_ref(private, &name, value)?;
+            if !oid(value) {
+                return Err(BulkloadRefusal::GitInventoryMalformed);
             }
+            let name = format!("refs/carry-export/stashes/{value}");
+            pending.entry(name).or_insert_with(|| value.to_owned());
         }
     } else if inventory.lines().any(|line| line.ends_with(" refs/stash")) {
         return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    // One create-only Git transaction instead of one process per ref. NUL
+    // framing preserves legal quote characters without command interpolation.
+    let mut commands = Vec::new();
+    for (name, value) in pending {
+        commands.extend_from_slice(b"create ");
+        commands.extend_from_slice(name.as_bytes());
+        commands.push(0);
+        commands.extend_from_slice(value.as_bytes());
+        commands.push(0);
+    }
+    if !commands.is_empty() {
+        input(
+            git(private).args(["update-ref", "--stdin", "-z"]),
+            &commands,
+        )?;
     }
     Ok(())
 }
@@ -578,9 +562,8 @@ fn export_repository_inner(
         "refs/carry-export/staged",
         &commit_tree(&private, &staged, "bulkload staged tree")?,
     )?;
-    let tree = capture_tree(&private, &repo, &index)?;
-    if tree != capture_tree(&private, &repo, &index)?
-        || before_refs != refs(&repo)?
+    let (tree, _) = raw_tree::capture(&private, &repo, &seats)?;
+    if before_refs != refs(&repo)?
         || before_index != fs::read(index_path)?
         || head != text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?
         || seats != filesystem_rows(&repo)?
@@ -1638,6 +1621,7 @@ mod tests {
             fs::write(source.join("tracked"), content).unwrap();
             output(git(&source).args(["stash", "push"])).unwrap();
         }
+        output(git(&source).args(["branch", "quote\"branch"])).unwrap();
         fs::write(source.join("tracked"), b"staged").unwrap();
         fs::remove_file(source.join("deleted")).unwrap();
         fs::write(source.join("binary"), [0, 1, 128]).unwrap();
@@ -1667,6 +1651,11 @@ mod tests {
         let dest_head = fs::read(dest.join(".git/HEAD")).unwrap();
         let native = refs(&dest).unwrap();
         let bundle = export_repository(&source, &root.join("capture")).unwrap();
+        assert!(
+            text(git(&source).args(["bundle", "list-heads"]).arg(&bundle))
+                .unwrap()
+                .contains("refs/carry-export/refs/heads/quote\"branch")
+        );
         let count = import_bundle(&dest, &bundle, "neo").unwrap();
         assert!(count >= 6);
         assert_eq!(count, import_bundle(&dest, &bundle, "neo").unwrap());

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -228,6 +228,7 @@ pub fn export_repository(repo: &Path, capture: &Path) -> Result<PathBuf> {
         return Err(BulkloadRefusal::GitAuthorityOutsideRoot);
     }
     let before_refs = refs(&repo)?;
+    let seats = filesystem_rows(&repo)?;
     let head = text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?;
     let (index_path, before_index) = source_index(&repo)?;
     let private = prepare_private(&repo, &capture)?;
@@ -260,6 +261,7 @@ pub fn export_repository(repo: &Path, capture: &Path) -> Result<PathBuf> {
         || before_refs != refs(&repo)?
         || before_index != fs::read(index_path)?
         || head != text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?
+        || seats != filesystem_rows(&repo)?
     {
         return Err(BulkloadRefusal::GitAuthorityChanged);
     }
@@ -272,6 +274,11 @@ pub fn export_repository(repo: &Path, capture: &Path) -> Result<PathBuf> {
             "bulkload worktree including untracked and ignored files",
         )?,
     )?;
+    metadata(
+        &private,
+        "filesystem-v1",
+        &postcard::to_allocvec(&seats).map_err(|_| BulkloadRefusal::FrameCodec)?,
+    )?;
     let bundle = capture.join("capture.bundle");
     output(
         git(&private)
@@ -281,6 +288,129 @@ pub fn export_repository(repo: &Path, capture: &Path) -> Result<PathBuf> {
     )?;
     output(git(&private).args(["bundle", "verify"]).arg(&bundle))?;
     Ok(bundle)
+}
+
+// Reuse the transport's typed filesystem seats instead of treating Git's
+// executable-bit-only tree modes as complete filesystem metadata. .git is
+// administration owned by Git-native capture; nested repositories refuse.
+fn filesystem_rows(root: &Path) -> Result<Vec<crate::RowSchema>> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
+    use tcfs_bulkload_proto::FileKind;
+    let mut pending = vec![root.to_path_buf()];
+    let mut rows = Vec::new();
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(&directory)? {
+            let entry = entry?;
+            if entry.file_name() == ".git" {
+                if directory == root {
+                    continue;
+                }
+                return Err(BulkloadRefusal::GitInventoryMalformed);
+            }
+            let path = entry.path();
+            let meta = fs::symlink_metadata(&path)?;
+            let identity = crate::freshness::StatIdentity::from_metadata(&meta);
+            let kind = if meta.is_dir() {
+                FileKind::Directory
+            } else if meta.is_file() {
+                FileKind::Regular
+            } else if meta.is_symlink() {
+                FileKind::Symlink
+            } else {
+                return Err(BulkloadRefusal::GitInventoryMalformed);
+            };
+            if kind == FileKind::Directory {
+                pending.push(path.clone());
+            }
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|_| BulkloadRefusal::PathEscapesRoot)?;
+            rows.push(crate::RowSchema {
+                rel_path: relative.as_os_str().as_bytes().to_vec(),
+                kind,
+                dev: identity.dev,
+                ino: identity.ino,
+                size: identity.size,
+                mtime_ns: identity.mtime_ns,
+                ctime_ns: identity.ctime_ns,
+                mode: meta.mode(),
+                nlink: meta.nlink(),
+                link_target: if kind == FileKind::Symlink {
+                    Some(fs::read_link(&path)?.as_os_str().as_bytes().to_vec())
+                } else {
+                    None
+                },
+                blake3: None,
+            });
+        }
+    }
+    rows.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+    Ok(rows)
+}
+
+fn restore_filesystem_rows(destination: &Path, revision: &str) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::PermissionsExt;
+    use tcfs_bulkload_proto::FileKind;
+    let bytes = output(git(destination).args(["show", &format!("{revision}:value")]))?;
+    let rows: Vec<crate::RowSchema> =
+        postcard::from_bytes(&bytes).map_err(|_| BulkloadRefusal::FrameCodec)?;
+    for row in &rows {
+        let path = safe_destination(
+            destination,
+            Path::new(std::ffi::OsStr::from_bytes(&row.rel_path)),
+        )?;
+        match row.kind {
+            FileKind::Directory => match fs::create_dir(&path) {
+                Ok(()) => (),
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::AlreadyExists
+                        && fs::symlink_metadata(&path)?.is_dir() => {}
+                Err(error) => return Err(error.into()),
+            },
+            FileKind::Regular if fs::symlink_metadata(&path)?.is_file() => {
+                fs::set_permissions(&path, fs::Permissions::from_mode(row.mode & 0o777))?;
+            }
+            FileKind::Symlink if fs::symlink_metadata(&path)?.is_symlink() => {
+                if row.link_target.as_deref() != Some(fs::read_link(&path)?.as_os_str().as_bytes())
+                {
+                    return Err(BulkloadRefusal::GitInventoryMalformed);
+                }
+            }
+            _ => return Err(BulkloadRefusal::GitInventoryMalformed),
+        }
+    }
+    // Parents become readonly only after all descendants have materialized.
+    for row in rows
+        .iter()
+        .rev()
+        .filter(|row| row.kind == FileKind::Directory)
+    {
+        let path = safe_destination(
+            destination,
+            Path::new(std::ffi::OsStr::from_bytes(&row.rel_path)),
+        )?;
+        fs::set_permissions(path, fs::Permissions::from_mode(row.mode & 0o777))?;
+    }
+    Ok(())
+}
+
+fn safe_destination(root: &Path, relative: &Path) -> Result<PathBuf> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Component;
+    if relative.as_os_str().is_empty() || relative.components().any(|part| !matches!(part, Component::Normal(name) if !name.as_bytes().eq_ignore_ascii_case(b".git"))) {
+        return Err(BulkloadRefusal::PathEscapesRoot);
+    }
+    let mut path = root.to_path_buf();
+    let mut components = relative.components().peekable();
+    while let Some(part) = components.next() {
+        path.push(part);
+        if components.peek().is_some() && !fs::symlink_metadata(&path)?.is_dir() {
+            return Err(BulkloadRefusal::PathEscapesRoot);
+        }
+    }
+    Ok(path)
 }
 
 fn source_index(repo: &Path) -> Result<(PathBuf, Vec<u8>)> {
@@ -476,6 +606,7 @@ pub fn restore_bundle(bundle: &Path, destination: &Path, source: &str) -> Result
     }
     let staged = find("staged")?;
     output(git(&destination).args(["read-tree", &format!("{staged}^{{tree}}")]))?;
+    restore_filesystem_rows(&destination, &find("filesystem-v1")?)?;
     fs::set_permissions(&destination, fs::Permissions::from_mode(0o700))?;
     Ok(())
 }
@@ -579,6 +710,7 @@ pub fn restore_linked(
         restore_entry(&destination, entry)?;
     }
     output(git(&destination).args(["read-tree", &format!("{}^{{tree}}", find("staged")?)]))?;
+    restore_filesystem_rows(&destination, &find("filesystem-v1")?)?;
     let final_exclude = match fs::read(exclude_path) {
         Ok(value) => value,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
@@ -711,6 +843,16 @@ mod tests {
         fs::write(source.join("raw.txt"), b"raw\r\nbytes\r\n").unwrap();
         fs::write(source.join(".gitignore"), b"ignored\n").unwrap();
         fs::write(source.join("ignored"), b"unique ignored bytes").unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(source.join("ignored"), fs::Permissions::from_mode(0o600)).unwrap();
+            fs::create_dir_all(source.join("empty/nested")).unwrap();
+            fs::set_permissions(source.join("empty"), fs::Permissions::from_mode(0o750)).unwrap();
+            fs::write(source.join("executable"), b"#!/bin/sh\nexit 0\n").unwrap();
+            fs::set_permissions(source.join("executable"), fs::Permissions::from_mode(0o700))
+                .unwrap();
+            std::os::unix::fs::symlink("ignored", source.join("symlink")).unwrap();
+        }
         fs::write(dest.join("tracked"), b"destination divergence").unwrap();
         output(git(&dest).args(["add", "."])).unwrap();
         output(git(&dest).args(["-c", "commit.gpgsign=false", "commit", "-m", "destination"]))
@@ -776,6 +918,37 @@ mod tests {
         restore_linked(&bundle, &dest, &linked, "neo").unwrap();
         {
             use std::os::unix::fs::PermissionsExt;
+            for target in [&restored, &linked] {
+                assert_eq!(
+                    fs::metadata(target.join("ignored"))
+                        .unwrap()
+                        .permissions()
+                        .mode()
+                        & 0o777,
+                    0o600
+                );
+                assert_eq!(
+                    fs::metadata(target.join("empty"))
+                        .unwrap()
+                        .permissions()
+                        .mode()
+                        & 0o777,
+                    0o750
+                );
+                assert_eq!(
+                    fs::metadata(target.join("executable"))
+                        .unwrap()
+                        .permissions()
+                        .mode()
+                        & 0o777,
+                    0o700
+                );
+                assert!(target.join("empty/nested").is_dir());
+                assert_eq!(
+                    fs::read_link(target.join("symlink")).unwrap(),
+                    PathBuf::from("ignored")
+                );
+            }
             assert_eq!(
                 fs::metadata(&linked).unwrap().permissions().mode() & 0o777,
                 0o700

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -10,6 +10,8 @@ use std::process::{Command, Output};
 
 use crate::{BulkloadRefusal, Result};
 
+pub mod shared;
+
 fn git(repo: &Path) -> Command {
     let mut command = Command::new("git");
     for key in [
@@ -517,6 +519,29 @@ fn admin_controls(admin: &Path) -> Result<Vec<(String, Option<Vec<u8>>)>> {
 /// populated submodules (which require their own capture). On refusal the
 /// private capture is retained for diagnosis; source state is never changed.
 pub fn export_repository(repo: &Path, capture: &Path) -> Result<PathBuf> {
+    export_repository_inner(repo, capture, None)
+}
+
+/// Export workspace state without repacking a shared base's commit closure.
+///
+/// The base must be transported and imported before this prerequisite bundle.
+/// Callers must bind both bundles' digests in their durable capture record.
+///
+/// # Errors
+/// Refuses invalid prerequisites or any state refused by standalone capture.
+pub fn export_repository_with_prerequisite(
+    repo: &Path,
+    capture: &Path,
+    base: &Path,
+) -> Result<PathBuf> {
+    export_repository_inner(repo, capture, Some(base))
+}
+
+fn export_repository_inner(
+    repo: &Path,
+    capture: &Path,
+    prerequisite: Option<&Path>,
+) -> Result<PathBuf> {
     use std::os::unix::fs::DirBuilderExt;
     let repo = fs::canonicalize(repo)?;
     fs::DirBuilder::new().mode(0o700).create(capture)?;
@@ -577,12 +602,7 @@ pub fn export_repository(repo: &Path, capture: &Path) -> Result<PathBuf> {
         &postcard::to_allocvec(&seats).map_err(|_| BulkloadRefusal::FrameCodec)?,
     )?;
     let bundle = capture.join("capture.bundle");
-    output(
-        git(&private)
-            .args(["bundle", "create"])
-            .arg(&bundle)
-            .arg("--all"),
-    )?;
+    shared::write_bundle(&private, &bundle, prerequisite)?;
     output(git(&private).args(["bundle", "verify"]).arg(&bundle))?;
     Ok(bundle)
 }
@@ -849,6 +869,330 @@ pub fn import_bundle(repo: &Path, bundle: &Path, source: &str) -> Result<usize> 
     Ok(names.len())
 }
 
+fn capture_revision(heads: &str, suffix: &str) -> Result<String> {
+    heads
+        .lines()
+        .find_map(|line| {
+            line.split_once(' ')
+                .filter(|(_, name)| *name == format!("refs/carry-export/{suffix}"))
+        })
+        .map(|(value, _)| value.to_owned())
+        .filter(|value| oid(value))
+        .ok_or(BulkloadRefusal::GitInventoryMalformed)
+}
+
+fn payload_shape_equal(a: &[crate::RowSchema], b: &[crate::RowSchema]) -> bool {
+    use tcfs_bulkload_proto::FileKind;
+    a.len() == b.len()
+        && a.iter().zip(b).all(|(a, b)| {
+            a.rel_path == b.rel_path
+                && a.kind == b.kind
+                && a.link_target == b.link_target
+                && (a.kind != FileKind::Regular || a.size == b.size)
+                && (a.kind == FileKind::Symlink || a.mode & 0o777 == b.mode & 0o777)
+        })
+}
+
+fn sync_private_tree(root: &Path) -> Result<()> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            sync_private_tree(&entry.path())?;
+        } else if entry.file_type()?.is_file() {
+            fs::File::open(entry.path())?.sync_all()?;
+        } else {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+    }
+    fs::File::open(root)?.sync_all()?;
+    Ok(())
+}
+
+fn prepare_attachment(
+    bundle: &Path,
+    destination: &Path,
+    source: &str,
+    receipt: &Path,
+) -> Result<(PathBuf, String)> {
+    use std::os::unix::fs::DirBuilderExt;
+    fs::DirBuilder::new().mode(0o700).create(receipt)?;
+    // Retain the actual input, not merely a pathname that may later disappear.
+    let retained = receipt.join("capture.bundle");
+    fs::copy(bundle, &retained)?;
+    let heads = text(git(receipt).args(["bundle", "list-heads"]).arg(&retained))?;
+    let head = capture_revision(&heads, "head")?;
+    let format = if head.len() == 40 { "sha1" } else { "sha256" };
+    let private = receipt.join("repository.git");
+    output(
+        git(receipt)
+            .args([
+                "init",
+                "--bare",
+                "--template=",
+                &format!("--object-format={format}"),
+            ])
+            .arg(&private),
+    )?;
+    import_bundle(&private, &retained, source)?;
+    let symbolic = text(git(&private).args([
+        "show",
+        &format!("{}:value", capture_revision(&heads, "head-symbolic")?),
+    ]))?;
+    if symbolic.is_empty() {
+        output(git(&private).args(["update-ref", "--no-deref", "HEAD", &head]))?;
+    } else {
+        if !symbolic.starts_with("refs/heads/") {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        output(git(&private).args(["check-ref-format", &symbolic]))?;
+        set_ref(&private, &symbolic, &head)?;
+        output(git(&private).args(["symbolic-ref", "HEAD", &symbolic]))?;
+    }
+    let exclude = output(git(&private).args([
+        "show",
+        &format!("{}:value", capture_revision(&heads, "exclude")?),
+    ]))?;
+    fs::create_dir_all(private.join("info"))?;
+    fs::write(private.join("info/exclude"), exclude)?;
+    output(
+        snapshot_command(&private, destination, &private.join("index")).args([
+            "read-tree",
+            &format!("{}^{{tree}}", capture_revision(&heads, "staged")?),
+        ]),
+    )?;
+    output(git(&private).args(["config", "core.bare", "false"]))?;
+    output(
+        git(&private)
+            .args(["config", "core.worktree"])
+            .arg(destination),
+    )?;
+    Ok((private, heads))
+}
+
+fn prepare_linked_attachment(
+    repository: &Path,
+    destination: &Path,
+    source: &str,
+    receipt: &Path,
+    private: &Path,
+    heads: &str,
+) -> Result<PathBuf> {
+    use std::os::unix::ffi::OsStrExt;
+    let retained = receipt.join("capture.bundle");
+    import_bundle(repository, &retained, source)?;
+    let head = capture_revision(heads, "head")?;
+    let symbolic = text(git(private).args([
+        "show",
+        &format!("{}:value", capture_revision(heads, "head-symbolic")?),
+    ]))?;
+    let captured_exclude = output(git(private).args([
+        "show",
+        &format!("{}:value", capture_revision(heads, "exclude")?),
+    ]))?;
+    let exclude_path = PathBuf::from(text(git(repository).args([
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "info/exclude",
+    ]))?);
+    let exclude = match fs::read(&exclude_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => return Err(error.into()),
+    };
+    if exclude != captured_exclude {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    let attached = text(git(repository).args(["worktree", "list", "--porcelain"]))?;
+    let reuse = symbolic.starts_with("refs/heads/")
+        && text(git(repository).args(["rev-parse", "--verify", &symbolic]))
+            .is_ok_and(|tip| tip == head)
+        && !attached
+            .lines()
+            .any(|line| line == format!("branch {symbolic}"));
+    let branch = if reuse {
+        symbolic
+            .strip_prefix("refs/heads/")
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?
+            .to_owned()
+    } else {
+        format!(
+            "carry/{source}/{}",
+            blake3::hash(destination.as_os_str().as_bytes()).to_hex()
+        )
+    };
+    let prepared = receipt.join("prepared-worktree");
+    let mut command = git(repository);
+    command.args(["worktree", "add", "--no-checkout"]);
+    if !reuse {
+        command.args(["-b", &branch]);
+    }
+    output(
+        command
+            .arg("--")
+            .arg(&prepared)
+            .arg(if reuse { &branch } else { &head }),
+    )?;
+    if text(git(&prepared).args(["rev-parse", "HEAD"]))? != head {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    output(git(&prepared).args([
+        "read-tree",
+        &format!("{}^{{tree}}", capture_revision(heads, "staged")?),
+    ]))?;
+    let admin = PathBuf::from(text(
+        git(&prepared).args(["rev-parse", "--absolute-git-dir"]),
+    )?);
+    let mut reverse = destination.join(".git").as_os_str().as_bytes().to_vec();
+    if reverse.contains(&b'\n') || reverse.contains(&b'\r') {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    reverse.push(b'\n');
+    fs::write(admin.join("gitdir"), reverse)?;
+    // Native administrative locking prevents prune before pointer publication.
+    fs::write(admin.join("locked"), b"bulkload attachment preparation\n")?;
+    sync_private_tree(&admin)?;
+    fs::File::open(admin.parent().ok_or(BulkloadRefusal::PathNotAbsolute)?)?.sync_all()?;
+    Ok(admin)
+}
+
+fn attachment_policy_matches(repository: &Path, private: &Path, heads: &str) -> Result<bool> {
+    let expected = output(git(private).args([
+        "show",
+        &format!("{}:value", capture_revision(heads, "exclude")?),
+    ]))?;
+    let path = text(git(repository).args([
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "info/exclude",
+    ]))?;
+    let actual = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(expected == actual)
+}
+
+/// Attach captured source administration to an exactly matching payload only.
+///
+/// Existing payload is never rewritten. New linked administration inherits the
+/// explicit common repository's configuration and restores captured source
+/// staging, not unknown old staging. Comparisons are
+/// optimistic full censuses, not an atomic snapshot of uncooperative writers.
+///
+/// # Errors
+/// Refuses existing .git, differing bytes/modes/empty directories, concurrent
+/// changes, unsupported seats, or a receipt inside the payload/on another device.
+/// Failed private preparations remain available for inspection.
+pub fn attach_matching_payload(
+    bundle: &Path,
+    repository: &Path,
+    destination: &Path,
+    source: &str,
+    receipt: &Path,
+) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    let destination = fs::canonicalize(destination)?;
+    let repository = fs::canonicalize(repository)?;
+    let common = common_repository(&repository)?;
+    let receipt_parent =
+        fs::canonicalize(receipt.parent().ok_or(BulkloadRefusal::PathNotAbsolute)?)?;
+    let receipt = receipt_parent.join(
+        receipt
+            .file_name()
+            .ok_or(BulkloadRefusal::PathNotAbsolute)?,
+    );
+    if receipt.starts_with(&destination) {
+        return Err(BulkloadRefusal::PathEscapesRoot);
+    }
+    require_missing(&destination.join(".git"))?;
+    let root = fs::metadata(&destination)?;
+    if !root.is_dir() || root.dev() != fs::metadata(&receipt_parent)?.dev() {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    let before = filesystem_rows(&destination)?;
+    let (private, heads) = prepare_attachment(bundle, &destination, source, &receipt)?;
+    let expected: Vec<crate::RowSchema> = postcard::from_bytes(&output(git(&private).args([
+        "show",
+        &format!("{}:value", capture_revision(&heads, "filesystem-v1")?),
+    ]))?)
+    .map_err(|_| BulkloadRefusal::FrameCodec)?;
+    if !payload_shape_equal(&before, &expected) {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    let comparison = receipt.join("comparison.index");
+    output(snapshot_command(&private, &destination, &comparison).args(["read-tree", "--empty"]))?;
+    let expected_tree = text(git(&private).args([
+        "rev-parse",
+        &format!("{}^{{tree}}", capture_revision(&heads, "worktree")?),
+    ]))?;
+    if capture_tree(&private, &destination, &comparison)? != expected_tree
+        || capture_tree(&private, &destination, &comparison)? != expected_tree
+        || filesystem_rows(&destination)? != before
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    fs::write(
+        receipt.join("original-payload-index-absent.postcard"),
+        postcard::to_allocvec(&before).map_err(|_| BulkloadRefusal::FrameCodec)?,
+    )?;
+    sync_private_tree(&receipt)?;
+    fs::File::open(&receipt_parent)?.sync_all()?;
+    let admin = prepare_linked_attachment(
+        &repository,
+        &destination,
+        source,
+        &receipt,
+        &private,
+        &heads,
+    )?;
+    let pointer = receipt.join("git-pointer");
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&pointer)?;
+    if admin.as_os_str().as_bytes().contains(&b'\n')
+        || admin.as_os_str().as_bytes().contains(&b'\r')
+    {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    file.write_all(b"gitdir: ")?;
+    file.write_all(admin.as_os_str().as_bytes())?;
+    file.write_all(b"\n")?;
+    sync_private_tree(&receipt)?;
+    fs::File::open(&receipt_parent)?.sync_all()?;
+    let current_root = fs::metadata(&destination)?;
+    if root.dev() != current_root.dev()
+        || root.ino() != current_root.ino()
+        || filesystem_rows(&destination)? != before
+        || !attachment_policy_matches(&repository, &private, &heads)?
+        || text(
+            snapshot_command(&admin, &destination, &admin.join("index"))
+                .args(["rev-parse", "HEAD"]),
+        )? != capture_revision(&heads, "head")?
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    // Atomic create-only publication cannot overwrite another writer's .git.
+    fs::hard_link(pointer, destination.join(".git"))?;
+    fs::File::open(&destination)?.sync_all()?;
+    if filesystem_rows(&destination)? != before
+        || common_repository(&destination)? != common
+        || !attachment_policy_matches(&repository, &private, &heads)?
+        || text(git(&destination).args(["rev-parse", "HEAD"]))? != capture_revision(&heads, "head")?
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    fs::remove_file(admin.join("locked"))?;
+    fs::File::open(admin)?.sync_all()?;
+    Ok(())
+}
+
 /// Restore staged and unstaged state into a newly created, standalone repository.
 ///
 /// Existing destinations are always refused, including empty directories.
@@ -1110,6 +1454,95 @@ fn restore_entry(destination: &Path, entry: &[u8]) -> Result<()> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    #[test]
+    fn exact_payload_attachment_preserves_bytes_inodes_and_captured_staging() {
+        use std::os::unix::fs::MetadataExt;
+        let root = std::env::temp_dir().join(format!("bulkload-attach-{}", std::process::id()));
+        fs::create_dir(&root).unwrap();
+        let source = root.join("source");
+        fs::create_dir(&source).unwrap();
+        output(git(&source).args(["init", "--template="])).unwrap();
+        output(git(&source).args(["config", "user.name", "Test"])).unwrap();
+        output(git(&source).args(["config", "user.email", "test@localhost"])).unwrap();
+        fs::write(source.join("tracked"), b"base\0binary").unwrap();
+        output(git(&source).args(["add", "."])).unwrap();
+        output(git(&source).args(["-c", "commit.gpgsign=false", "commit", "-m", "base"])).unwrap();
+        fs::write(source.join("tracked"), b"staged\0binary").unwrap();
+        output(git(&source).args(["add", "."])).unwrap();
+        fs::write(source.join("tracked"), b"unstaged\0binary").unwrap();
+        fs::write(source.join("untracked"), b"kept").unwrap();
+        fs::create_dir(source.join("empty")).unwrap();
+        let bundle = export_repository(&source, &root.join("capture")).unwrap();
+        let payload = root.join("payload");
+        restore_bundle(&bundle, &payload, "neo").unwrap();
+        fs::rename(payload.join(".git"), root.join("old-private-git")).unwrap();
+        let before = filesystem_rows(&payload).unwrap();
+        let inode = fs::metadata(payload.join("tracked")).unwrap().ino();
+        output(git(&source).args([
+            "config",
+            "remote.origin.url",
+            "ssh://example.test/estate.git",
+        ]))
+        .unwrap();
+        attach_matching_payload(&bundle, &source, &payload, "neo", &root.join("receipt")).unwrap();
+        assert_eq!(
+            common_repository(&source).unwrap(),
+            common_repository(&payload).unwrap()
+        );
+        assert_eq!(
+            text(git(&payload).args(["config", "remote.origin.url"])).unwrap(),
+            "ssh://example.test/estate.git"
+        );
+        assert!(text(git(&source).args(["worktree", "list", "--porcelain"]))
+            .unwrap()
+            .contains(payload.to_str().unwrap()));
+        assert_eq!(before, filesystem_rows(&payload).unwrap());
+        assert_eq!(inode, fs::metadata(payload.join("tracked")).unwrap().ino());
+        for args in [
+            vec!["status", "--porcelain"],
+            vec!["diff", "--cached", "--binary"],
+            vec!["diff", "--binary"],
+        ] {
+            assert_eq!(
+                output(git(&source).args(&args)).unwrap(),
+                output(git(&payload).args(&args)).unwrap()
+            );
+        }
+        assert!(attach_matching_payload(
+            &bundle,
+            &source,
+            &payload,
+            "neo",
+            &root.join("occupied-receipt")
+        )
+        .is_err());
+        let different = root.join("different");
+        restore_bundle(&bundle, &different, "neo").unwrap();
+        fs::rename(different.join(".git"), root.join("other-private-git")).unwrap();
+        fs::write(different.join("extra"), b"destination-only").unwrap();
+        assert!(attach_matching_payload(
+            &bundle,
+            &source,
+            &different,
+            "neo",
+            &root.join("different-receipt")
+        )
+        .is_err());
+        assert!(!different.join(".git").exists());
+        fs::remove_file(different.join("extra")).unwrap();
+        fs::write(different.join("tracked"), b"different\0bytes").unwrap();
+        assert!(attach_matching_payload(
+            &bundle,
+            &source,
+            &different,
+            "neo",
+            &root.join("bytes-receipt")
+        )
+        .is_err());
+        assert!(!different.join(".git").exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn bidirectional_union_reaches_fixed_point_without_provenance_wrapping() {
         let root = std::env::temp_dir().join(format!("bulkload-git-union-{}", std::process::id()));

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -10,6 +10,7 @@ use std::process::{Command, Output};
 
 use crate::{BulkloadRefusal, Result};
 
+mod batch_objects;
 mod raw_tree;
 pub mod registered;
 pub mod shared;
@@ -662,7 +663,7 @@ fn filesystem_rows(root: &Path) -> Result<Vec<crate::RowSchema>> {
 
 fn restore_filesystem_rows(destination: &Path, revision: &str) -> Result<()> {
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
     use tcfs_bulkload_proto::FileKind;
     let bytes = output(git(destination).args(["show", &format!("{revision}:value")]))?;
     let rows: Vec<crate::RowSchema> =
@@ -681,7 +682,16 @@ fn restore_filesystem_rows(destination: &Path, revision: &str) -> Result<()> {
                 Err(error) => return Err(error.into()),
             },
             FileKind::Regular if fs::symlink_metadata(&path)?.is_file() => {
-                fs::set_permissions(&path, fs::Permissions::from_mode(row.mode & 0o777))?;
+                // Open before applying a potentially unreadable captured mode.
+                let file = fs::OpenOptions::new()
+                    .read(true)
+                    .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+                    .open(&path)?;
+                if !file.metadata()?.is_file() {
+                    return Err(BulkloadRefusal::GitInventoryMalformed);
+                }
+                file.set_permissions(fs::Permissions::from_mode(row.mode & 0o777))?;
+                file.sync_all()?;
             }
             FileKind::Symlink if fs::symlink_metadata(&path)?.is_symlink() => {
                 if row.link_target.as_deref() != Some(fs::read_link(&path)?.as_os_str().as_bytes())
@@ -702,7 +712,28 @@ fn restore_filesystem_rows(destination: &Path, revision: &str) -> Result<()> {
             destination,
             Path::new(std::ffi::OsStr::from_bytes(&row.rel_path)),
         )?;
-        fs::set_permissions(path, fs::Permissions::from_mode(row.mode & 0o777))?;
+        // Flush descendants before their parent, retaining an open descriptor
+        // across modes such as 000 so durability does not require reopening it.
+        let directory = fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY)
+            .open(path)?;
+        directory.set_permissions(fs::Permissions::from_mode(row.mode & 0o777))?;
+        directory.sync_all()?;
+    }
+    // These flush payload entry creation, not the separate Git administration
+    // or receipt transactions, which retain their own durability boundaries.
+    for path in [
+        destination,
+        destination
+            .parent()
+            .ok_or(BulkloadRefusal::PathNotAbsolute)?,
+    ] {
+        fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY)
+            .open(path)?
+            .sync_all()?;
     }
     Ok(())
 }
@@ -1500,9 +1531,7 @@ pub fn restore_bundle_configured(
     fs::write(destination.join(".git/info/exclude"), exclude)?;
     let worktree = find("worktree")?;
     let entries = output(git(&destination).args(["ls-tree", "-r", "-z", &worktree]))?;
-    for entry in entries.split(|b| *b == 0).filter(|entry| !entry.is_empty()) {
-        restore_entry(&destination, entry)?;
-    }
+    restore_entries(&destination, &entries)?;
     let staged = find("staged")?;
     output(git(&destination).args(["read-tree", &format!("{staged}^{{tree}}")]))?;
     restore_filesystem_rows(&destination, &find("filesystem-v1")?)?;
@@ -1608,9 +1637,7 @@ pub fn restore_linked(
         return Err(BulkloadRefusal::GitAuthorityChanged);
     }
     let entries = output(git(&destination).args(["ls-tree", "-r", "-z", &find("worktree")?]))?;
-    for entry in entries.split(|b| *b == 0).filter(|entry| !entry.is_empty()) {
-        restore_entry(&destination, entry)?;
-    }
+    restore_entries(&destination, &entries)?;
     output(git(&destination).args(["read-tree", &format!("{}^{{tree}}", find("staged")?)]))?;
     restore_filesystem_rows(&destination, &find("filesystem-v1")?)?;
     let final_exclude = match fs::read(exclude_path) {
@@ -1627,11 +1654,25 @@ pub fn restore_linked(
     Ok(())
 }
 
-fn restore_entry(destination: &Path, entry: &[u8]) -> Result<()> {
+fn restore_entries(destination: &Path, entries: &[u8]) -> Result<()> {
+    let mut objects = batch_objects::BatchObjects::new(destination)?;
+    for entry in entries
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+    {
+        restore_entry(destination, entry, &mut objects)?;
+    }
+    objects.finish()
+}
+
+fn restore_entry(
+    destination: &Path,
+    entry: &[u8],
+    objects: &mut batch_objects::BatchObjects,
+) -> Result<()> {
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
     use std::path::Component;
-    use std::process::Stdio;
     let tab = entry
         .iter()
         .position(|b| *b == b'\t')
@@ -1653,6 +1694,9 @@ fn restore_entry(destination: &Path, entry: &[u8]) -> Result<()> {
         .next()
         .filter(|value| oid(value))
         .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+    if fields.next().is_some() {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
     let relative = Path::new(std::ffi::OsStr::from_bytes(
         entry
             .get(tab + 1..)
@@ -1682,22 +1726,17 @@ fn restore_entry(destination: &Path, entry: &[u8]) -> Result<()> {
     }
     match mode {
         "120000" => {
-            let target = output(git(destination).args(["cat-file", "blob", value]))?;
+            let mut target = Vec::new();
+            objects.copy_into(value, &mut target, Some(65_536))?;
             std::os::unix::fs::symlink(std::ffi::OsStr::from_bytes(&target), path)?;
         }
         "100644" | "100755" => {
-            let file = fs::OpenOptions::new()
+            let mut file = fs::OpenOptions::new()
                 .write(true)
                 .create_new(true)
                 .mode(0o600)
                 .open(&path)?;
-            let status = git(destination)
-                .args(["cat-file", "blob", value])
-                .stdout(Stdio::from(file.try_clone()?))
-                .status()?;
-            if !status.success() {
-                return Err(BulkloadRefusal::GitInventoryMalformed);
-            }
+            objects.copy_into(value, &mut file, None)?;
             file.set_permissions(fs::Permissions::from_mode(if mode == "100755" {
                 0o755
             } else {
@@ -2038,9 +2077,10 @@ mod tests {
         fs::write(source.join("ignored"), b"unique ignored bytes").unwrap();
         {
             use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(source.join("ignored"), fs::Permissions::from_mode(0o600)).unwrap();
+            // Restoration must flush final modes even when the result is readonly.
+            fs::set_permissions(source.join("ignored"), fs::Permissions::from_mode(0o400)).unwrap();
             fs::create_dir_all(source.join("empty/nested")).unwrap();
-            fs::set_permissions(source.join("empty"), fs::Permissions::from_mode(0o750)).unwrap();
+            fs::set_permissions(source.join("empty"), fs::Permissions::from_mode(0o500)).unwrap();
             fs::write(source.join("executable"), b"#!/bin/sh\nexit 0\n").unwrap();
             fs::set_permissions(source.join("executable"), fs::Permissions::from_mode(0o700))
                 .unwrap();
@@ -2157,7 +2197,7 @@ mod tests {
                         .permissions()
                         .mode()
                         & 0o777,
-                    0o600
+                    0o400
                 );
                 assert_eq!(
                     fs::metadata(target.join("empty"))
@@ -2165,7 +2205,7 @@ mod tests {
                         .permissions()
                         .mode()
                         & 0o777,
-                    0o750
+                    0o500
                 );
                 assert_eq!(
                     fs::metadata(target.join("executable"))
@@ -2291,6 +2331,11 @@ mod tests {
             fs::read(dest.join("tracked")).unwrap(),
             b"destination divergence"
         );
+        // Only the test-owned trees regain write permission for fixture cleanup.
+        for target in [&source, &restored, &linked] {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(target.join("empty"), fs::Permissions::from_mode(0o700)).unwrap();
+        }
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -11,6 +11,7 @@ use std::process::{Command, Output};
 use crate::{BulkloadRefusal, Result};
 
 mod raw_tree;
+pub mod registered;
 pub mod shared;
 
 fn git(repo: &Path) -> Command {
@@ -1057,17 +1058,21 @@ fn activate_standalone_configuration(
     private: &Path,
     heads: &str,
     receipt: &Path,
-    from: &Path,
-    to: &Path,
+    mapping: Option<(&Path, &Path)>,
 ) -> Result<()> {
-    if !from.is_absolute() || !to.is_absolute() {
-        return Err(BulkloadRefusal::PathNotAbsolute);
-    }
-    common_repository(to)?;
-    let from = from
-        .to_str()
-        .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
-    let to = to.to_str().ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+    let mapping = mapping
+        .map(|(from, to)| {
+            if !from.is_absolute() || !to.is_absolute() {
+                return Err(BulkloadRefusal::PathNotAbsolute);
+            }
+            common_repository(to)?;
+            Ok((
+                from.to_str()
+                    .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
+                to.to_str().ok_or(BulkloadRefusal::GitInventoryMalformed)?,
+            ))
+        })
+        .transpose()?;
     let files: Vec<(String, Vec<u8>)> = postcard::from_bytes(&output(git(private).args([
         "show",
         &format!("{}:value", capture_revision(heads, "configuration-v1")?),
@@ -1098,11 +1103,12 @@ fn activate_standalone_configuration(
                 std::str::from_utf8(entry).map_err(|_| BulkloadRefusal::GitInventoryMalformed)?;
             let (key, value) = entry.split_once('\n').unwrap_or((entry, ""));
             let value = if key == "remote.origin.url" {
-                if value != from {
-                    return Err(BulkloadRefusal::GitAuthorityChanged);
-                }
                 origin_seen = true;
-                to
+                match mapping {
+                    Some((from, to)) if value == from => to,
+                    None if safe_https_origin(value) => value,
+                    _ => return Err(BulkloadRefusal::GitAuthorityChanged),
+                }
             } else if safe_configuration_value(private, key, value) {
                 value
             } else {
@@ -1113,16 +1119,33 @@ fn activate_standalone_configuration(
             activated.push(key.to_owned());
         }
     }
-    if !origin_seen {
+    if mapping.is_some() && !origin_seen {
         return Err(BulkloadRefusal::GitInventoryMalformed);
     }
     // Keys, not potentially sensitive values, explain the deliberate policy boundary.
     fs::write(
         receipt.join("configuration-activation.postcard"),
-        postcard::to_allocvec(&(activated, preserved_only, from, to))
+        postcard::to_allocvec(&(activated, preserved_only, mapping))
             .map_err(|_| BulkloadRefusal::FrameCodec)?,
     )?;
     Ok(())
+}
+
+fn safe_https_origin(value: &str) -> bool {
+    let Some(address) = value.strip_prefix("https://") else {
+        return false;
+    };
+    let Some((host, path)) = address.split_once('/') else {
+        return false;
+    };
+    !host.is_empty()
+        && !path.is_empty()
+        && host
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b".-".contains(&b))
+        && path
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"/-._~%".contains(&b))
 }
 
 fn prepare_linked_attachment(
@@ -1343,7 +1366,7 @@ fn attach_payload(
         prepare_linked_attachment(repository, &destination, source, &receipt, &private, &heads)?
     } else {
         let (from, to) = mapping.ok_or(BulkloadRefusal::GitInventoryMalformed)?;
-        activate_standalone_configuration(&private, &heads, &receipt, from, to)?;
+        activate_standalone_configuration(&private, &heads, &receipt, Some((from, to)))?;
         private.clone()
     };
     let pointer = write_git_pointer(&receipt, &admin)?;
@@ -1415,6 +1438,25 @@ fn write_git_pointer(receipt: &Path, admin: &Path) -> Result<PathBuf> {
 /// Refuses malformed paths/modes, missing capture metadata, or an occupied target.
 /// Partial new destinations are retained, never cleaned by recursive deletion.
 pub fn restore_bundle(bundle: &Path, destination: &Path, source: &str) -> Result<()> {
+    restore_bundle_configured(bundle, destination, source, None)
+}
+
+/// Restore an absent standalone checkout with explicit local-origin mapping.
+///
+/// Without a mapping, a captured HTTPS origin is retained unchanged; no origin
+/// is invented when the source has none. Other origin schemes require a reviewed
+/// mapping. Configuration omissions remain named in .git/carry-config receipts.
+/// No network operation or captured executable configuration is activated.
+///
+/// # Errors
+/// Refuses old captures lacking configuration, unsafe/unmapped origins, occupied
+/// destinations, or any malformed filesystem/capture state.
+pub fn restore_bundle_configured(
+    bundle: &Path,
+    destination: &Path,
+    source: &str,
+    mapping: Option<(&Path, &Path)>,
+) -> Result<()> {
     use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
     let bundle = fs::canonicalize(bundle)?;
     fs::DirBuilder::new().mode(0o700).create(destination)?;
@@ -1437,6 +1479,7 @@ pub fn restore_bundle(bundle: &Path, destination: &Path, source: &str) -> Result
             .ok_or(BulkloadRefusal::GitInventoryMalformed)
     };
     let head = find("head")?;
+    find("configuration-v1")?;
     let format = if head.len() == 40 { "sha1" } else { "sha256" };
     output(git(&destination).args(["init", "--template=", &format!("--object-format={format}")]))?;
     import_bundle(&destination, &bundle, source)?;
@@ -1463,6 +1506,9 @@ pub fn restore_bundle(bundle: &Path, destination: &Path, source: &str) -> Result
     let staged = find("staged")?;
     output(git(&destination).args(["read-tree", &format!("{staged}^{{tree}}")]))?;
     restore_filesystem_rows(&destination, &find("filesystem-v1")?)?;
+    let config_receipt = destination.join(".git/carry-config");
+    fs::DirBuilder::new().mode(0o700).create(&config_receipt)?;
+    activate_standalone_configuration(&destination, &heads, &config_receipt, mapping)?;
     fs::set_permissions(&destination, fs::Permissions::from_mode(0o700))?;
     Ok(())
 }
@@ -1704,7 +1750,7 @@ mod tests {
         fs::write(source.join("tracked"), b"dirty").unwrap();
         let bundle = export_repository(&source, &root.join("capture")).unwrap();
         let payload = root.join("payload");
-        restore_bundle(&bundle, &payload, "neo").unwrap();
+        restore_bundle_configured(&bundle, &payload, "neo", Some((from, &upstream))).unwrap();
         fs::rename(payload.join(".git"), root.join("original-git")).unwrap();
         let before = filesystem_rows(&payload).unwrap();
         let receipt = root.join("receipt");
@@ -1736,7 +1782,63 @@ mod tests {
             output(git(&source).args(["diff", "--binary"])).unwrap(),
             output(git(&payload).args(["diff", "--binary"])).unwrap()
         );
+        assert_https_restore(&root, &source);
         fs::remove_dir_all(root).unwrap();
+    }
+
+    fn assert_https_restore(root: &Path, source: &Path) {
+        let origin =
+            "https://github.com/Medical-Massage-Specialists/medical-massage-specialists-infra.git";
+        output(git(source).args(["config", "remote.origin.url", origin])).unwrap();
+        let capture = root.join("https-capture");
+        let bundle = export_repository(source, &capture).unwrap();
+        let destination = root.join("https-restored");
+        restore_bundle(&bundle, &destination, "neo").unwrap();
+        assert_eq!(
+            text(git(&destination).args(["config", "remote.origin.url"])).unwrap(),
+            origin
+        );
+        assert_eq!(
+            text(git(&destination).args(["config", "remote.origin.fetch"])).unwrap(),
+            "+refs/heads/*:refs/remotes/origin/*"
+        );
+        let symbolic = text(git(source).args(["symbolic-ref", "HEAD"])).unwrap();
+        let branch = symbolic.strip_prefix("refs/heads/").unwrap();
+        assert_eq!(
+            text(git(&destination).args(["config", &format!("branch.{branch}.remote")])).unwrap(),
+            "origin"
+        );
+        assert_eq!(
+            text(git(&destination).args(["config", &format!("branch.{branch}.merge")])).unwrap(),
+            symbolic
+        );
+        assert!(text(git(&destination).args(["config", "credential.helper"])).is_err());
+        assert_eq!(
+            output(git(source).args(["status", "--porcelain"])).unwrap(),
+            output(git(&destination).args(["status", "--porcelain"])).unwrap()
+        );
+        for unsafe_origin in [
+            "ext::bad",
+            "https://user:secret@host/repo",
+            "https://host/repo?token=secret",
+            "/Users/jess/git/legalab",
+        ] {
+            assert!(!safe_https_origin(unsafe_origin));
+        }
+        let private = capture.join("repository.git");
+        output(git(&private).args(["update-ref", "-d", "refs/carry-export/configuration-v1"]))
+            .unwrap();
+        let old_bundle = capture.join("old-format.bundle");
+        output(
+            git(&private)
+                .args(["bundle", "create"])
+                .arg(&old_bundle)
+                .arg("--all"),
+        )
+        .unwrap();
+        let old_destination = root.join("old-format-refused");
+        assert!(restore_bundle(&old_bundle, &old_destination, "neo").is_err());
+        assert!(!old_destination.join(".git").exists());
     }
 
     #[test]

--- a/crates/tcfs-bulkload-agent/src/git_carry.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry.rs
@@ -1,0 +1,681 @@
+//! Git-native archival union. Native refs, HEAD, index and checkout are never written.
+//!
+//! Bundles preserve staged state separately from the worktree (including ignored
+//! files). Submodules must be captured separately; this is not Git administration
+//! reconstruction. Capture is optimistic, not an atomic filesystem snapshot.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use crate::{BulkloadRefusal, Result};
+
+fn git(repo: &Path) -> Command {
+    let mut command = Command::new("git");
+    for key in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_NAMESPACE",
+        "GIT_CONFIG_COUNT",
+        "GIT_CONFIG_PARAMETERS",
+    ] {
+        command.env_remove(key);
+    }
+    command
+        .args([
+            "--no-optional-locks",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "gc.auto=0",
+            "-c",
+            "pack.threads=2",
+            "-c",
+            "pack.windowMemory=64m",
+            "-C",
+        ])
+        .arg(repo);
+    command
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_NO_REPLACE_OBJECTS", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null");
+    command
+}
+
+fn output(command: &mut Command) -> Result<Vec<u8>> {
+    let Output { status, stdout, .. } = command.output()?;
+    if !status.success() {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    Ok(stdout)
+}
+
+fn text(command: &mut Command) -> Result<String> {
+    String::from_utf8(output(command)?)
+        .map(|s| s.trim_end().to_owned())
+        .map_err(|_| BulkloadRefusal::GitInventoryMalformed)
+}
+
+fn input(command: &mut Command, bytes: &[u8]) -> Result<Vec<u8>> {
+    use std::io::Write;
+    use std::process::Stdio;
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or(BulkloadRefusal::Io(None))?
+        .write_all(bytes)?;
+    let result = child.wait_with_output()?;
+    if !result.status.success() {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    Ok(result.stdout)
+}
+
+fn metadata(private: &Path, name: &str, bytes: &[u8]) -> Result<()> {
+    let value = input(git(private).args(["hash-object", "-w", "--stdin"]), bytes)?;
+    let value = std::str::from_utf8(&value)
+        .map_err(|_| BulkloadRefusal::GitInventoryMalformed)?
+        .trim();
+    let tree = input(
+        git(private).args(["mktree", "-z"]),
+        format!("100644 blob {value}\tvalue\0").as_bytes(),
+    )?;
+    let tree = std::str::from_utf8(&tree)
+        .map_err(|_| BulkloadRefusal::GitInventoryMalformed)?
+        .trim();
+    set_ref(
+        private,
+        &format!("refs/carry-export/{name}"),
+        &commit_tree(private, tree, name)?,
+    )
+}
+
+fn refs(repo: &Path) -> Result<String> {
+    text(git(repo).args(["for-each-ref", "--format=%(objectname) %(refname)"]))
+}
+
+fn oid(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn set_ref(repo: &Path, name: &str, value: &str) -> Result<()> {
+    if !oid(value) {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    output(git(repo).args(["update-ref", name, value, ""]))?;
+    Ok(())
+}
+
+fn snapshot_command(private: &Path, worktree: &Path, index: &Path) -> Command {
+    let mut command = git(worktree);
+    command
+        .env("GIT_DIR", private)
+        .env("GIT_WORK_TREE", worktree)
+        .env("GIT_INDEX_FILE", index);
+    command.args(["-c", "core.bare=false"]);
+    command
+}
+
+fn commit_tree(private: &Path, tree: &str, label: &str) -> Result<String> {
+    text(
+        git(private)
+            .env("GIT_AUTHOR_NAME", "Bulkload archival capture")
+            .env("GIT_AUTHOR_EMAIL", "bulkload@localhost")
+            .env("GIT_COMMITTER_NAME", "Bulkload archival capture")
+            .env("GIT_COMMITTER_EMAIL", "bulkload@localhost")
+            .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
+            .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
+            .args(["commit-tree", tree, "-m", label]),
+    )
+}
+
+// Git's normal add applies attributes (including EOL normalization). Archive
+// raw worktree bytes instead; the separate staged tree retains index semantics.
+fn capture_tree(private: &Path, repo: &Path, index: &Path) -> Result<String> {
+    use std::os::unix::ffi::OsStrExt;
+    output(snapshot_command(private, repo, index).args(["add", "--all", "--force", "--", "."]))?;
+    let entries =
+        output(snapshot_command(private, repo, index).args(["ls-files", "--stage", "-z"]))?;
+    for entry in entries.split(|b| *b == 0).filter(|entry| !entry.is_empty()) {
+        let tab = entry
+            .iter()
+            .position(|b| *b == b'\t')
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+        let header = std::str::from_utf8(
+            entry
+                .get(..tab)
+                .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
+        )
+        .map_err(|_| BulkloadRefusal::GitInventoryMalformed)?;
+        let mode = header
+            .split_whitespace()
+            .next()
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+        let path = std::ffi::OsStr::from_bytes(
+            entry
+                .get(tab + 1..)
+                .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
+        );
+        if mode == "160000" {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        if matches!(mode, "100644" | "100755") {
+            let value = text(
+                snapshot_command(private, repo, index)
+                    .args(["hash-object", "-w", "--no-filters", "--"])
+                    .arg(path),
+            )?;
+            output(
+                snapshot_command(private, repo, index)
+                    .args(["update-index", "--add", "--cacheinfo", mode, &value])
+                    .arg(path),
+            )?;
+        }
+    }
+    text(snapshot_command(private, repo, index).arg("write-tree"))
+}
+
+fn capture_refs(repo: &Path, private: &Path, inventory: &str) -> Result<()> {
+    for line in inventory.lines() {
+        let (value, name) = line
+            .split_once(' ')
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+        set_ref(private, &format!("refs/carry-export/{name}"), value)?;
+    }
+    let stash = output(git(repo).args(["reflog", "show", "--format=%H", "refs/stash"]));
+    if let Ok(stash) = stash {
+        let stash = String::from_utf8(stash).map_err(|_| BulkloadRefusal::GitInventoryMalformed)?;
+        for value in stash.lines() {
+            let name = format!("refs/carry-export/stashes/{value}");
+            if !git(private)
+                .args(["show-ref", "--verify", "--quiet", &name])
+                .status()?
+                .success()
+            {
+                set_ref(private, &name, value)?;
+            }
+        }
+    } else if inventory.lines().any(|line| line.ends_with(" refs/stash")) {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    Ok(())
+}
+
+/// Export one worktree and all repository refs into a new, private directory.
+///
+/// # Errors
+/// Refuses unsupported/unmerged indexes, changing refs/index/worktree, and
+/// populated submodules (which require their own capture). On refusal the
+/// private capture is retained for diagnosis; source state is never changed.
+pub fn export_repository(repo: &Path, capture: &Path) -> Result<PathBuf> {
+    use std::os::unix::fs::DirBuilderExt;
+    let repo = fs::canonicalize(repo)?;
+    fs::DirBuilder::new().mode(0o700).create(capture)?;
+    let capture = fs::canonicalize(capture)?;
+    if capture.starts_with(&repo) {
+        return Err(BulkloadRefusal::GitAuthorityOutsideRoot);
+    }
+    let before_refs = refs(&repo)?;
+    let head = text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?;
+    let (index_path, before_index) = source_index(&repo)?;
+    let private = prepare_private(&repo, &capture)?;
+    capture_refs(&repo, &private, &before_refs)?;
+    set_ref(&private, "refs/carry-export/head", &head)?;
+    let symbolic_head = text(git(&repo).args(["symbolic-ref", "-q", "HEAD"])).unwrap_or_default();
+    metadata(&private, "head-symbolic", symbolic_head.as_bytes())?;
+    let exclude_path = PathBuf::from(text(git(&repo).args([
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "info/exclude",
+    ]))?);
+    let exclude = match fs::read(exclude_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => return Err(error.into()),
+    };
+    metadata(&private, "exclude", &exclude)?;
+    let index = capture.join("index");
+    fs::write(&index, &before_index)?;
+    let staged = text(snapshot_command(&private, &repo, &index).arg("write-tree"))?;
+    set_ref(
+        &private,
+        "refs/carry-export/staged",
+        &commit_tree(&private, &staged, "bulkload staged tree")?,
+    )?;
+    let tree = capture_tree(&private, &repo, &index)?;
+    if tree != capture_tree(&private, &repo, &index)?
+        || before_refs != refs(&repo)?
+        || before_index != fs::read(index_path)?
+        || head != text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    set_ref(
+        &private,
+        "refs/carry-export/worktree",
+        &commit_tree(
+            &private,
+            &tree,
+            "bulkload worktree including untracked and ignored files",
+        )?,
+    )?;
+    let bundle = capture.join("capture.bundle");
+    output(
+        git(&private)
+            .args(["bundle", "create"])
+            .arg(&bundle)
+            .arg("--all"),
+    )?;
+    output(git(&private).args(["bundle", "verify"]).arg(&bundle))?;
+    Ok(bundle)
+}
+
+fn source_index(repo: &Path) -> Result<(PathBuf, Vec<u8>)> {
+    let index_path = PathBuf::from(text(git(repo).args([
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "index",
+    ]))?);
+    let before_index = fs::read(&index_path)?;
+    let flags = text(git(repo).args(["ls-files", "--debug"]))?;
+    if flags
+        .lines()
+        .filter_map(|line| line.split_once("\tflags: "))
+        .any(|(_, flags)| flags != "0")
+    {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    if !text(git(repo).args(["rev-parse", "--shared-index-path"]))?.is_empty() {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    let entries = output(git(repo).args(["ls-files", "--stage", "-z"]))?;
+    if entries
+        .split(|b| *b == 0)
+        .any(|entry| entry.starts_with(b"160000 "))
+    {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    Ok((index_path, before_index))
+}
+
+fn prepare_private(repo: &Path, capture: &Path) -> Result<PathBuf> {
+    let format = text(git(repo).args(["rev-parse", "--show-object-format"]))?;
+    if !matches!(format.as_str(), "sha1" | "sha256") {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    let private = capture.join("repository.git");
+    output(
+        git(capture)
+            .args([
+                "init",
+                "--bare",
+                "--template=",
+                &format!("--object-format={format}"),
+            ])
+            .arg(&private),
+    )?;
+    let objects = text(git(repo).args([
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-path",
+        "objects",
+    ]))?;
+    if objects.contains(['\n', '\r']) {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    fs::write(
+        private.join("objects/info/alternates"),
+        format!("{objects}\n"),
+    )?;
+    Ok(private)
+}
+
+/// Import into a content-addressed source namespace, never native branches.
+/// Repeats are idempotent; differing captures remain separately reachable.
+///
+/// # Errors
+/// Refuses invalid source names, non-export bundle refs, collisions or invalid
+/// bundles. A failed fetch may leave unreachable objects, never changed HEAD.
+pub fn import_bundle(repo: &Path, bundle: &Path, source: &str) -> Result<usize> {
+    use std::io::Read;
+    if source.is_empty()
+        || source.len() > 64
+        || !source
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    let bundle = fs::canonicalize(bundle)?;
+    let mut file = fs::File::open(&bundle)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut bytes = vec![0_u8; 65_536];
+    loop {
+        let count = file.read(&mut bytes)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(
+            bytes
+                .get(..count)
+                .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
+        );
+    }
+    let digest = hasher.finalize().to_hex();
+    output(git(repo).args(["bundle", "verify"]).arg(&bundle))?;
+    let heads = text(git(repo).args(["bundle", "list-heads"]).arg(&bundle))?;
+    let mut names = Vec::new();
+    for line in heads.lines() {
+        let (value, name) = line
+            .split_once(' ')
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+        let suffix = name
+            .strip_prefix("refs/carry-export/")
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+        if !oid(value) {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        names.push((
+            value.to_owned(),
+            name.to_owned(),
+            format!("refs/carry/{source}/{digest}/{suffix}"),
+        ));
+    }
+    // Fetch objects only. Compare-and-create below cannot clobber a native ref.
+    output(
+        git(repo)
+            .args([
+                "fetch",
+                "--no-write-fetch-head",
+                "--no-auto-maintenance",
+                "--no-tags",
+                "--no-recurse-submodules",
+            ])
+            .arg(&bundle)
+            .args(names.iter().map(|(_, name, _)| name)),
+    )?;
+    for (value, _, target) in &names {
+        if let Ok(existing) = text(git(repo).args(["rev-parse", "--verify", target])) {
+            if existing != *value {
+                return Err(BulkloadRefusal::GitDestinationOccupied);
+            }
+        } else {
+            set_ref(repo, target, value)?;
+        }
+    }
+    Ok(names.len())
+}
+
+/// Restore staged and unstaged state into a newly created, standalone repository.
+///
+/// Existing destinations are always refused, including empty directories.
+/// The source bundle remains the recovery carrier if restoration is interrupted.
+///
+/// # Errors
+/// Refuses malformed paths/modes, missing capture metadata, or an occupied target.
+/// Partial new destinations are retained, never cleaned by recursive deletion.
+pub fn restore_bundle(bundle: &Path, destination: &Path, source: &str) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    let bundle = fs::canonicalize(bundle)?;
+    fs::DirBuilder::new().mode(0o700).create(destination)?;
+    let destination = fs::canonicalize(destination)?;
+    // Read bundle headers without assuming the destination's object format.
+    let heads = text(
+        git(&destination)
+            .args(["bundle", "list-heads"])
+            .arg(&bundle),
+    )?;
+    let find = |suffix: &str| -> Result<String> {
+        heads
+            .lines()
+            .find_map(|line| {
+                line.split_once(' ')
+                    .filter(|(_, name)| *name == format!("refs/carry-export/{suffix}"))
+            })
+            .map(|(value, _)| value.to_owned())
+            .filter(|value| oid(value))
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)
+    };
+    let head = find("head")?;
+    let format = if head.len() == 40 { "sha1" } else { "sha256" };
+    output(git(&destination).args(["init", "--template=", &format!("--object-format={format}")]))?;
+    import_bundle(&destination, &bundle, source)?;
+    let symbolic =
+        text(git(&destination).args(["show", &format!("{}:value", find("head-symbolic")?)]))?;
+    if symbolic.is_empty() {
+        output(git(&destination).args(["update-ref", "--no-deref", "HEAD", &head]))?;
+    } else {
+        if !symbolic.starts_with("refs/heads/") {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        output(git(&destination).args(["check-ref-format", &symbolic]))?;
+        set_ref(&destination, &symbolic, &head)?;
+        output(git(&destination).args(["symbolic-ref", "HEAD", &symbolic]))?;
+    }
+    let exclude = output(git(&destination).args(["show", &format!("{}:value", find("exclude")?)]))?;
+    fs::create_dir_all(destination.join(".git/info"))?;
+    fs::write(destination.join(".git/info/exclude"), exclude)?;
+    let worktree = find("worktree")?;
+    let entries = output(git(&destination).args(["ls-tree", "-r", "-z", &worktree]))?;
+    for entry in entries.split(|b| *b == 0).filter(|entry| !entry.is_empty()) {
+        restore_entry(&destination, entry)?;
+    }
+    let staged = find("staged")?;
+    output(git(&destination).args(["read-tree", &format!("{staged}^{{tree}}")]))?;
+    fs::set_permissions(&destination, fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+fn restore_entry(destination: &Path, entry: &[u8]) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    use std::path::Component;
+    use std::process::Stdio;
+    let tab = entry
+        .iter()
+        .position(|b| *b == b'\t')
+        .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+    let header = std::str::from_utf8(
+        entry
+            .get(..tab)
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
+    )
+    .map_err(|_| BulkloadRefusal::GitInventoryMalformed)?;
+    let mut fields = header.split_whitespace();
+    let mode = fields
+        .next()
+        .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+    if fields.next() != Some("blob") {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    let value = fields
+        .next()
+        .filter(|value| oid(value))
+        .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+    let relative = Path::new(std::ffi::OsStr::from_bytes(
+        entry
+            .get(tab + 1..)
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?,
+    ));
+    if relative.components().any(|part| !matches!(part, Component::Normal(name) if !name.as_bytes().eq_ignore_ascii_case(b".git"))) {
+        return Err(BulkloadRefusal::PathEscapesRoot);
+    }
+    let path = destination.join(relative);
+    let parent = path.parent().ok_or(BulkloadRefusal::PathEscapesRoot)?;
+    let mut current = destination.to_path_buf();
+    for part in parent
+        .strip_prefix(destination)
+        .map_err(|_| BulkloadRefusal::PathEscapesRoot)?
+        .components()
+    {
+        current.push(part);
+        match fs::create_dir(&current) {
+            Ok(()) => (),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if !fs::symlink_metadata(&current)?.is_dir() {
+                    return Err(BulkloadRefusal::PathEscapesRoot);
+                }
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    match mode {
+        "120000" => {
+            let target = output(git(destination).args(["cat-file", "blob", value]))?;
+            std::os::unix::fs::symlink(std::ffi::OsStr::from_bytes(&target), path)?;
+        }
+        "100644" | "100755" => {
+            let file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&path)?;
+            let status = git(destination)
+                .args(["cat-file", "blob", value])
+                .stdout(Stdio::from(file.try_clone()?))
+                .status()?;
+            if !status.success() {
+                return Err(BulkloadRefusal::GitInventoryMalformed);
+            }
+            file.set_permissions(fs::Permissions::from_mode(if mode == "100755" {
+                0o755
+            } else {
+                0o644
+            }))?;
+            file.sync_all()?;
+        }
+        _ => return Err(BulkloadRefusal::GitInventoryMalformed),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    #[test]
+    #[allow(clippy::too_many_lines)] // One end-to-end source/union/restore invariant.
+    fn union_preserves_native_head_index_binary_and_stash_history() {
+        let root = std::env::temp_dir().join(format!("bulkload-git-carry-{}", std::process::id()));
+        fs::create_dir(&root).unwrap();
+        let source = root.join("source");
+        let dest = root.join("dest");
+        fs::create_dir(&source).unwrap();
+        fs::create_dir(&dest).unwrap();
+        for repo in [&source, &dest] {
+            output(git(repo).args(["init", "--template="])).unwrap();
+            output(git(repo).args(["config", "user.name", "Test"])).unwrap();
+            output(git(repo).args(["config", "user.email", "test@localhost"])).unwrap();
+            fs::write(repo.join("tracked"), b"base").unwrap();
+            output(git(repo).args(["add", "."])).unwrap();
+            output(git(repo).args(["-c", "commit.gpgsign=false", "commit", "-m", "base"])).unwrap();
+        }
+        for content in [b"stash-one", b"stash-two"] {
+            fs::write(source.join("tracked"), content).unwrap();
+            output(git(&source).args(["stash", "push"])).unwrap();
+        }
+        fs::write(source.join("tracked"), b"staged").unwrap();
+        output(git(&source).args(["add", "."])).unwrap();
+        fs::write(source.join("tracked"), b"unstaged").unwrap();
+        fs::write(source.join("binary"), [0, 255, 128]).unwrap();
+        fs::write(source.join(".gitattributes"), b"*.txt text eol=lf\n").unwrap();
+        fs::write(source.join("raw.txt"), b"raw\r\nbytes\r\n").unwrap();
+        fs::write(source.join(".gitignore"), b"ignored\n").unwrap();
+        fs::write(source.join("ignored"), b"unique ignored bytes").unwrap();
+        fs::write(dest.join("tracked"), b"destination divergence").unwrap();
+        output(git(&dest).args(["add", "."])).unwrap();
+        output(git(&dest).args(["-c", "commit.gpgsign=false", "commit", "-m", "destination"]))
+            .unwrap();
+        let index = fs::read(source.join(".git/index")).unwrap();
+        let dest_index = fs::read(dest.join(".git/index")).unwrap();
+        let dest_head = fs::read(dest.join(".git/HEAD")).unwrap();
+        let native = refs(&dest).unwrap();
+        let bundle = export_repository(&source, &root.join("capture")).unwrap();
+        let count = import_bundle(&dest, &bundle, "neo").unwrap();
+        assert!(count >= 6);
+        assert_eq!(count, import_bundle(&dest, &bundle, "neo").unwrap());
+        assert_eq!(index, fs::read(source.join(".git/index")).unwrap());
+        assert_eq!(dest_index, fs::read(dest.join(".git/index")).unwrap());
+        assert_eq!(dest_head, fs::read(dest.join(".git/HEAD")).unwrap());
+        assert_eq!(
+            fs::read(dest.join("tracked")).unwrap(),
+            b"destination divergence"
+        );
+        for line in native.lines() {
+            assert!(refs(&dest).unwrap().lines().any(|now| now == line));
+        }
+        let carried =
+            text(git(&dest).args(["for-each-ref", "--format=%(refname)", "refs/carry/"])).unwrap();
+        let worktree = carried
+            .lines()
+            .find(|line| line.ends_with("/worktree"))
+            .unwrap();
+        assert_eq!(
+            output(git(&dest).args(["show", &format!("{worktree}:binary")])).unwrap(),
+            [0, 255, 128]
+        );
+        assert_eq!(
+            output(git(&dest).args(["show", &format!("{worktree}:raw.txt")])).unwrap(),
+            b"raw\r\nbytes\r\n"
+        );
+        assert_eq!(
+            output(git(&dest).args(["show", &format!("{worktree}:ignored")])).unwrap(),
+            b"unique ignored bytes"
+        );
+        assert_eq!(
+            import_bundle(&dest, &bundle, "../native"),
+            Err(BulkloadRefusal::GitInventoryMalformed)
+        );
+        let staged = carried
+            .lines()
+            .find(|line| line.ends_with("/staged"))
+            .unwrap();
+        assert_eq!(
+            output(git(&dest).args(["show", &format!("{staged}:tracked")])).unwrap(),
+            b"staged"
+        );
+        assert_eq!(
+            carried
+                .lines()
+                .filter(|line| line.contains("/stashes/"))
+                .count(),
+            2
+        );
+        let restored = root.join("restored");
+        restore_bundle(&bundle, &restored, "neo").unwrap();
+        for args in [
+            vec![
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                "--ignored",
+            ],
+            vec!["diff", "--binary"],
+            vec!["diff", "--cached", "--binary"],
+            vec!["symbolic-ref", "HEAD"],
+        ] {
+            assert_eq!(
+                output(git(&source).args(&args)).unwrap(),
+                output(git(&restored).args(&args)).unwrap(),
+                "{args:?}"
+            );
+        }
+        assert_eq!(fs::read(restored.join("binary")).unwrap(), [0, 255, 128]);
+        assert!(restore_bundle(&bundle, &restored, "neo").is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/git_carry/batch_objects.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry/batch_objects.rs
@@ -1,0 +1,187 @@
+//! One bounded raw-object reader per restore; no filters or per-file subprocesses.
+
+use std::io::{BufReader, Read, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Stdio};
+
+use super::{git, oid};
+use crate::{BulkloadRefusal, Result};
+
+pub(super) struct BatchObjects {
+    child: Option<Child>,
+    input: Option<ChildStdin>,
+    output: Option<BufReader<ChildStdout>>,
+}
+
+impl BatchObjects {
+    pub(super) fn new(repository: &Path) -> Result<Self> {
+        let mut child = git(repository)
+            .args(["cat-file", "--batch"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+        let input = child.stdin.take();
+        let output = child.stdout.take().map(BufReader::new);
+        let reader = Self {
+            child: Some(child),
+            input,
+            output,
+        };
+        if reader.input.is_none() || reader.output.is_none() {
+            return Err(BulkloadRefusal::Io(None));
+        }
+        Ok(reader)
+    }
+
+    pub(super) fn copy_into(
+        &mut self,
+        value: &str,
+        target: &mut impl Write,
+        limit: Option<u64>,
+    ) -> Result<u64> {
+        if !oid(value) {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        let input = self.input.as_mut().ok_or(BulkloadRefusal::Io(None))?;
+        input.write_all(value.as_bytes())?;
+        input.write_all(b"\n")?;
+        input.flush()?;
+        let output = self.output.as_mut().ok_or(BulkloadRefusal::Io(None))?;
+        let length = read_header(output, value)?;
+        if limit.is_some_and(|limit| length > limit) {
+            return Err(BulkloadRefusal::BudgetExceeded);
+        }
+        read_body(output, target, length)?;
+        Ok(length)
+    }
+
+    pub(super) fn finish(mut self) -> Result<()> {
+        self.close()
+    }
+
+    fn close(&mut self) -> Result<()> {
+        // Closing stdin ends Git's request loop. Drain boundedly before wait so
+        // a partially consumed body cannot leave the child blocked on its pipe.
+        drop(self.input.take());
+        let drained = self
+            .output
+            .take()
+            .map(|mut output| std::io::copy(&mut output, &mut std::io::sink()))
+            .transpose();
+        let status = self.child.take().map(|mut child| child.wait()).transpose();
+        if drained?.is_some_and(|bytes| bytes != 0)
+            || status?.is_some_and(|status| !status.success())
+        {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for BatchObjects {
+    fn drop(&mut self) {
+        // Failure keeps caller-owned output for diagnosis. Never signal a child
+        // or any agent; close, drain and reap only the process we spawned.
+        let _ = self.close();
+    }
+}
+
+fn read_header(reader: &mut impl Read, expected: &str) -> Result<u64> {
+    let mut header = Vec::with_capacity(128);
+    loop {
+        let mut byte = [0];
+        reader.read_exact(&mut byte)?;
+        if byte == [b'\n'] {
+            break;
+        }
+        if header.len() == 127 {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        header.extend_from_slice(&byte);
+    }
+    let header =
+        std::str::from_utf8(&header).map_err(|_| BulkloadRefusal::GitInventoryMalformed)?;
+    let mut fields = header.split(' ');
+    if fields.next() != Some(expected) || fields.next() != Some("blob") {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    let size = fields
+        .next()
+        .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+    if size.is_empty() || !size.bytes().all(|byte| byte.is_ascii_digit()) || fields.next().is_some()
+    {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    size.parse()
+        .map_err(|_| BulkloadRefusal::GitInventoryMalformed)
+}
+
+fn read_body(reader: &mut impl Read, writer: &mut impl Write, length: u64) -> Result<()> {
+    if std::io::copy(&mut (&mut *reader).take(length), writer)? != length {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    let mut terminator = [0];
+    reader.read_exact(&mut terminator)?;
+    if terminator != [b'\n'] {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn framing_is_exact_and_bounded() {
+        let oid = "1234567890123456789012345678901234567890";
+        assert_eq!(
+            read_header(&mut format!("{oid} blob 4\n").as_bytes(), oid).unwrap(),
+            4
+        );
+        for header in [
+            format!("{oid} tree 4\n"),
+            format!("{oid} blob 4 extra\n"),
+            format!("{oid} blob +4\n"),
+            format!("{oid} missing\n"),
+            "x".repeat(129),
+            format!("{} blob 4\n", "a".repeat(40)),
+        ] {
+            assert!(read_header(&mut header.as_bytes(), oid).is_err());
+        }
+        assert!(read_body(&mut b"short".as_slice(), &mut Vec::new(), 9).is_err());
+        assert!(read_body(&mut b"data!".as_slice(), &mut Vec::new(), 4).is_err());
+        let mut bytes = Vec::new();
+        read_body(&mut b"a\0b\n\n".as_slice(), &mut bytes, 4).unwrap();
+        assert_eq!(bytes, b"a\0b\n");
+    }
+
+    #[test]
+    fn one_child_streams_large_binary_multiple_blobs_and_reaps_after_limit() {
+        let root = std::env::temp_dir().join(format!("bulkload-batch-{}", std::process::id()));
+        std::fs::create_dir(&root).unwrap();
+        super::super::output(git(&root).args(["init", "--bare", "--template="])).unwrap();
+        let binary: Vec<u8> = (0..200_000)
+            .map(|i| u8::try_from(i % 256).unwrap())
+            .collect();
+        let hash = super::super::input(git(&root).args(["hash-object", "-w", "--stdin"]), &binary)
+            .unwrap();
+        let value = std::str::from_utf8(&hash).unwrap().trim();
+        let mut reader = BatchObjects::new(&root).unwrap();
+        for _ in 0..3 {
+            let mut received = Vec::new();
+            assert_eq!(
+                reader.copy_into(value, &mut received, None).unwrap(),
+                200_000
+            );
+            assert_eq!(received, binary);
+        }
+        reader.finish().unwrap();
+        let mut refused = BatchObjects::new(&root).unwrap();
+        assert!(refused.copy_into(value, &mut Vec::new(), Some(16)).is_err());
+        drop(refused);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/git_carry/raw_tree.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry/raw_tree.rs
@@ -1,0 +1,222 @@
+//! Raw tree construction in one Git process, with one regular-file byte pass.
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+use std::process::Stdio;
+
+use super::{git, output, safe_destination, text};
+use crate::{BulkloadRefusal, Result, RowSchema};
+use tcfs_bulkload_proto::FileKind;
+
+// Git fast-import accepts C-quoted arbitrary byte paths. Quote every byte in
+// octal, including spaces, newlines, quotes, backslashes and non-UTF8 bytes.
+fn quoted(path: &[u8]) -> Vec<u8> {
+    let mut value = Vec::with_capacity(path.len().saturating_mul(4).saturating_add(2));
+    value.push(b'"');
+    for byte in path {
+        value.extend_from_slice(&[
+            b'\\',
+            b'0' + (byte >> 6),
+            b'0' + ((byte >> 3) & 7),
+            b'0' + (byte & 7),
+        ]);
+    }
+    value.push(b'"');
+    value
+}
+
+fn regular(writer: &mut impl Write, path: &Path, row: &RowSchema) -> Result<u64> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file()
+        || crate::freshness::StatIdentity::from_metadata(&metadata)
+            != crate::freshness::StatIdentity::from_row(row)
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    writeln!(writer, "data {}", row.size)?;
+    let copied = std::io::copy(&mut Read::by_ref(&mut file).take(row.size), writer)?;
+    if copied != row.size
+        || crate::freshness::StatIdentity::from_metadata(&file.metadata()?)
+            != crate::freshness::StatIdentity::from_row(row)
+        || crate::freshness::StatIdentity::from_metadata(&fs::symlink_metadata(path)?)
+            != crate::freshness::StatIdentity::from_row(row)
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    writer.write_all(b"\n")?;
+    Ok(copied)
+}
+
+fn stream(writer: &mut impl Write, repo: &Path, rows: &[RowSchema]) -> Result<u64> {
+    writer.write_all(
+        b"commit refs/bulkload-raw-tree\ncommitter Bulkload <bulkload@localhost> 946684800 +0000\ndata 0\n\ndeleteall\n",
+    )?;
+    let mut bytes_read = 0u64;
+    for row in rows {
+        let relative = Path::new(std::ffi::OsStr::from_bytes(&row.rel_path));
+        let path = safe_destination(repo, relative)?;
+        let mode = match row.kind {
+            FileKind::Directory => continue,
+            FileKind::Regular if row.mode & 0o100 != 0 => "100755",
+            FileKind::Regular => "100644",
+            FileKind::Symlink => "120000",
+            _ => return Err(BulkloadRefusal::GitInventoryMalformed),
+        };
+        write!(writer, "M {mode} inline ")?;
+        writer.write_all(&quoted(&row.rel_path))?;
+        writer.write_all(b"\n")?;
+        if row.kind == FileKind::Regular {
+            bytes_read = bytes_read
+                .checked_add(regular(writer, &path, row)?)
+                .ok_or(BulkloadRefusal::BudgetExceeded)?;
+        } else {
+            let target = row
+                .link_target
+                .as_deref()
+                .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+            writeln!(writer, "data {}", target.len())?;
+            writer.write_all(target)?;
+            writer.write_all(b"\n")?;
+        }
+    }
+    writer.write_all(b"\ndone\n")?;
+    Ok(bytes_read)
+}
+
+// The regular byte counter counts actual bytes streamed from source file
+// descriptors. Metadata censuses, symlink reads and Git repacking are separate.
+pub(super) fn capture(private: &Path, repo: &Path, rows: &[RowSchema]) -> Result<(String, u64)> {
+    if git(private)
+        .args(["show-ref", "--verify", "--quiet", "refs/bulkload-raw-tree"])
+        .status()?
+        .success()
+    {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    let mut child = git(private)
+        .args(["fast-import", "--quiet", "--done"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let mut stdin = child.stdin.take().ok_or(BulkloadRefusal::Io(None))?;
+    let result = stream(&mut stdin, repo, rows);
+    drop(stdin);
+    // Even on a source refusal close the stream and reap our child normally.
+    // No process is signaled, and a partial private capture remains diagnostic.
+    let status = child.wait()?;
+    let bytes_read = result?;
+    if !status.success() {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    #[allow(clippy::literal_string_with_formatting_args)] // Git revision syntax, not interpolation.
+    let tree = text(git(private).args(["rev-parse", "refs/bulkload-raw-tree^{tree}"]))?;
+    output(git(private).args(["update-ref", "-d", "refs/bulkload-raw-tree"]))?;
+    Ok((tree, bytes_read))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::{symlink, DirBuilderExt, PermissionsExt};
+
+    #[test]
+    fn one_raw_pass_preserves_paths_links_modes_and_never_runs_filters() {
+        let root = std::env::temp_dir().join(format!("tcfs-raw-tree-{}", std::process::id()));
+        fs::DirBuilder::new().mode(0o700).create(&root).unwrap();
+        let repo = root.join("source");
+        fs::create_dir(&repo).unwrap();
+        output(git(&repo).args(["init", "--template="])).unwrap();
+        output(git(&repo).args(["config", "filter.poison.clean", "false"])).unwrap();
+        output(git(&repo).args(["config", "filter.poison.required", "true"])).unwrap();
+        fs::write(
+            repo.join(".gitattributes"),
+            b"* filter=poison text eol=lf\n",
+        )
+        .unwrap();
+        fs::write(repo.join(".gitignore"), b"ignored\n").unwrap();
+        fs::write(repo.join("ignored"), b"\0private\r\nraw\xff").unwrap();
+        let unusual = "quote\" tab\t newline\n slash\\";
+        fs::write(repo.join(unusual), b"raw\r\n\0\xff").unwrap();
+        fs::set_permissions(repo.join(unusual), fs::Permissions::from_mode(0o750)).unwrap();
+        symlink("missing\nsymlink-target", repo.join("link")).unwrap();
+        let rows = super::super::filesystem_rows(&repo).unwrap();
+        let expected_bytes: u64 = rows
+            .iter()
+            .filter(|row| row.kind == FileKind::Regular)
+            .map(|row| row.size)
+            .sum();
+        let private = super::super::prepare_private(&repo, &root).unwrap();
+        let (tree, bytes_read) = capture(&private, &repo, &rows).unwrap();
+        assert_eq!(bytes_read, expected_bytes);
+        assert_eq!(
+            output(git(&private).args(["show", &format!("{tree}:{unusual}")])).unwrap(),
+            b"raw\r\n\0\xff"
+        );
+        assert_eq!(
+            output(git(&private).args(["show", &format!("{tree}:ignored")])).unwrap(),
+            b"\0private\r\nraw\xff"
+        );
+        assert_eq!(
+            output(git(&private).args(["show", &format!("{tree}:link")])).unwrap(),
+            b"missing\nsymlink-target"
+        );
+        assert!(
+            output(git(&private).args(["ls-tree", &tree, "--", unusual]))
+                .unwrap()
+                .starts_with(b"100755 blob ")
+        );
+        assert!(!repo.join(".git/index").exists());
+        assert_eq!(
+            quoted(&[b'\n', b'"', b'\\', 0xff]),
+            b"\"\\012\\042\\134\\377\""
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    struct MutatingWriter {
+        path: std::path::PathBuf,
+        changed: bool,
+    }
+
+    impl Write for MutatingWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if !self.changed {
+                fs::write(&self.path, b"changed while descriptor was open")?;
+                self.changed = true;
+            }
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn raw_pass_refuses_a_file_changed_after_open() {
+        let root = std::env::temp_dir().join(format!("tcfs-raw-mutation-{}", std::process::id()));
+        fs::DirBuilder::new().mode(0o700).create(&root).unwrap();
+        let path = root.join("file");
+        fs::write(&path, b"original bytes").unwrap();
+        let rows = super::super::filesystem_rows(&root).unwrap();
+        let row = rows.first().unwrap();
+        let mut writer = MutatingWriter {
+            path: path.clone(),
+            changed: false,
+        };
+        assert!(matches!(
+            regular(&mut writer, &path, row),
+            Err(BulkloadRefusal::GitAuthorityChanged)
+        ));
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/git_carry/registered.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry/registered.rs
@@ -1,0 +1,299 @@
+//! Restore missing payload without replacing retained linked administration.
+
+use super::{
+    attachment_policy_matches, capture_revision, common_repository, git, import_bundle, output,
+    require_missing, restore_entry, restore_filesystem_rows, snapshot_command, sync_private_tree,
+    text, write_git_pointer, IndexReservation,
+};
+use crate::{BulkloadRefusal, Result};
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+
+type Image = Vec<(PathBuf, u32, Vec<u8>)>;
+
+fn image(root: &Path) -> Result<Image> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut result = Vec::new();
+    let mut remaining = 64 * 1024 * 1024u64;
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path == root.join("index.lock") {
+                continue;
+            }
+            let metadata = fs::symlink_metadata(&path)?;
+            if metadata.is_dir() {
+                pending.push(path);
+            } else if metadata.is_file() {
+                let mut file = fs::OpenOptions::new()
+                    .read(true)
+                    .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+                    .open(&path)?;
+                let before = crate::freshness::StatIdentity::from_metadata(&metadata);
+                if crate::freshness::StatIdentity::from_metadata(&file.metadata()?) != before {
+                    return Err(BulkloadRefusal::GitAuthorityChanged);
+                }
+                let mut bytes = Vec::new();
+                Read::by_ref(&mut file)
+                    .take(remaining + 1)
+                    .read_to_end(&mut bytes)?;
+                remaining = remaining
+                    .checked_sub(bytes.len() as u64)
+                    .ok_or(BulkloadRefusal::BudgetExceeded)?;
+                if crate::freshness::StatIdentity::from_metadata(&file.metadata()?) != before
+                    || crate::freshness::StatIdentity::from_metadata(&fs::symlink_metadata(&path)?)
+                        != before
+                {
+                    return Err(BulkloadRefusal::GitAuthorityChanged);
+                }
+                result.push((
+                    path.strip_prefix(root)
+                        .map_err(|_| BulkloadRefusal::PathEscapesRoot)?
+                        .to_path_buf(),
+                    metadata.mode(),
+                    bytes,
+                ));
+            } else {
+                return Err(BulkloadRefusal::GitInventoryMalformed);
+            }
+        }
+    }
+    result.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(result)
+}
+
+fn authority(repository: &Path, admin: &Path, head: &str, staged: &str) -> Result<()> {
+    let index = admin.join("index");
+    if text(snapshot_command(admin, repository, &index).args(["rev-parse", "HEAD"]))? != head {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    if !snapshot_command(admin, repository, &index)
+        .args(["diff", "--cached", "--quiet", staged, "--"])
+        .status()?
+        .success()
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    Ok(())
+}
+
+fn complete(
+    receipt: &Path,
+    destination: &Path,
+    admin: &Path,
+    head: &str,
+    staged: &str,
+) -> Result<()> {
+    let path = receipt.join("completed.postcard");
+    fs::write(
+        &path,
+        postcard::to_allocvec(&(destination, admin, head, staged))
+            .map_err(|_| BulkloadRefusal::FrameCodec)?,
+    )?;
+    fs::File::open(path)?.sync_all()?;
+    fs::File::open(receipt)?.sync_all()?;
+    Ok(())
+}
+
+/// Reuse an exact retained registration, index and HEAD; create missing payload only.
+///
+/// # Errors
+/// Refuses occupied payload, differing retained staging/HEAD/policy, active Git
+/// operations, malformed administration or changed authority. Partial new payload
+/// and its receipt remain on refusal; existing administration is never replaced.
+#[allow(clippy::too_many_arguments)]
+pub fn restore(
+    bundle: &Path,
+    repository: &Path,
+    destination: &Path,
+    admin: &Path,
+    source: &str,
+    receipt: &Path,
+) -> Result<()> {
+    let repository = fs::canonicalize(repository)?;
+    let common = common_repository(&repository)?;
+    let admin = fs::canonicalize(admin)?;
+    if admin.parent() != Some(common.join("worktrees").as_path()) {
+        return Err(BulkloadRefusal::GitAuthorityOutsideRoot);
+    }
+    let parent = fs::canonicalize(
+        destination
+            .parent()
+            .ok_or(BulkloadRefusal::PathNotAbsolute)?,
+    )?;
+    let destination = parent.join(
+        destination
+            .file_name()
+            .ok_or(BulkloadRefusal::PathNotAbsolute)?,
+    );
+    require_missing(&destination)?;
+    if fs::read_to_string(admin.join("gitdir"))?.trim_end()
+        != destination
+            .join(".git")
+            .to_str()
+            .ok_or(BulkloadRefusal::PathNotPortable)?
+        || fs::canonicalize(admin.join(fs::read_to_string(admin.join("commondir"))?.trim_end()))?
+            != common
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    for marker in [
+        "index.lock",
+        "locked",
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "rebase-merge",
+        "rebase-apply",
+        "sequencer",
+    ] {
+        require_missing(&admin.join(marker))?;
+    }
+    let before = image(&admin)?;
+    let receipt_parent =
+        fs::canonicalize(receipt.parent().ok_or(BulkloadRefusal::PathNotAbsolute)?)?;
+    let receipt = receipt_parent.join(
+        receipt
+            .file_name()
+            .ok_or(BulkloadRefusal::PathNotAbsolute)?,
+    );
+    if receipt.starts_with(&admin) || receipt.starts_with(&destination) {
+        return Err(BulkloadRefusal::PathEscapesRoot);
+    }
+    fs::DirBuilder::new().mode(0o700).create(&receipt)?;
+    fs::write(
+        receipt.join("original-administration.postcard"),
+        postcard::to_allocvec(&before).map_err(|_| BulkloadRefusal::FrameCodec)?,
+    )?;
+    fs::copy(bundle, receipt.join("capture.bundle"))?;
+    sync_private_tree(&receipt)?;
+    fs::File::open(&receipt_parent)?.sync_all()?;
+    import_bundle(&repository, &receipt.join("capture.bundle"), source)?;
+    let heads = text(
+        git(&repository)
+            .args(["bundle", "list-heads"])
+            .arg(receipt.join("capture.bundle")),
+    )?;
+    let head = capture_revision(&heads, "head")?;
+    let staged = capture_revision(&heads, "staged")?;
+    authority(&repository, &admin, &head, &staged)?;
+    attachment_policy_matches(&repository, &repository, &heads)?;
+    let reservation = IndexReservation::acquire(admin.join("index.lock"))?;
+    if image(&admin)? != before {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    authority(&repository, &admin, &head, &staged)?;
+    fs::DirBuilder::new().mode(0o700).create(&destination)?;
+    let pointer = write_git_pointer(&receipt, &admin)?;
+    fs::File::open(&pointer)?.sync_all()?;
+    fs::hard_link(pointer, destination.join(".git"))?;
+    let entries = output(git(&repository).args([
+        "ls-tree",
+        "-r",
+        "-z",
+        &capture_revision(&heads, "worktree")?,
+    ]))?;
+    for entry in entries
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+    {
+        restore_entry(&destination, entry)?;
+    }
+    restore_filesystem_rows(&destination, &capture_revision(&heads, "filesystem-v1")?)?;
+    if image(&admin)? != before {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    authority(&repository, &admin, &head, &staged)?;
+    attachment_policy_matches(&repository, &repository, &heads)?;
+    fs::File::open(&destination)?.sync_all()?;
+    reservation.release()?;
+    complete(&receipt, &destination, &admin, &head, &staged)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::super::export_repository;
+    use super::*;
+
+    #[test]
+    fn retained_registration_restores_payload_without_replacing_staging() {
+        let root = std::env::temp_dir().join(format!("bulkload-registered-{}", std::process::id()));
+        fs::create_dir(&root).unwrap();
+        let repository = root.join("repository");
+        fs::create_dir(&repository).unwrap();
+        output(git(&repository).args(["init", "--template="])).unwrap();
+        output(git(&repository).args(["config", "user.name", "Test"])).unwrap();
+        output(git(&repository).args(["config", "user.email", "test@localhost"])).unwrap();
+        fs::write(repository.join("tracked"), b"base").unwrap();
+        output(git(&repository).args(["add", "."])).unwrap();
+        output(git(&repository).args(["-c", "commit.gpgsign=false", "commit", "-m", "base"]))
+            .unwrap();
+        let target = root.join("linked");
+        output(
+            git(&repository)
+                .args(["worktree", "add", "-b", "linked"])
+                .arg(&target),
+        )
+        .unwrap();
+        fs::write(target.join("tracked"), b"staged").unwrap();
+        output(git(&target).args(["add", "tracked"])).unwrap();
+        fs::write(target.join("tracked"), b"unstaged\0bytes").unwrap();
+        fs::create_dir(target.join("empty")).unwrap();
+        let bundle = export_repository(&target, &root.join("capture")).unwrap();
+        let admin =
+            PathBuf::from(text(git(&target).args(["rev-parse", "--absolute-git-dir"])).unwrap());
+        let before = image(&admin).unwrap();
+        let index = fs::read(admin.join("index")).unwrap();
+        fs::rename(&target, root.join("retained-original-payload")).unwrap();
+        output(
+            snapshot_command(&admin, &repository, &admin.join("index")).args(["read-tree", "HEAD"]),
+        )
+        .unwrap();
+        assert_eq!(
+            restore(
+                &bundle,
+                &repository,
+                &target,
+                &admin,
+                "neo",
+                &root.join("refused")
+            ),
+            Err(BulkloadRefusal::GitAuthorityChanged)
+        );
+        assert!(!target.exists());
+        fs::write(admin.join("index"), index).unwrap();
+        restore(
+            &bundle,
+            &repository,
+            &target,
+            &admin,
+            "neo",
+            &root.join("receipt"),
+        )
+        .unwrap();
+        assert_eq!(image(&admin).unwrap(), before);
+        assert_eq!(
+            fs::read(target.join("tracked")).unwrap(),
+            b"unstaged\0bytes"
+        );
+        assert!(target.join("empty").is_dir());
+        assert_eq!(
+            text(git(&target).args(["rev-parse", "--absolute-git-dir"])).unwrap(),
+            admin.to_str().unwrap()
+        );
+        assert!(restore(
+            &bundle,
+            &repository,
+            &target,
+            &admin,
+            "neo",
+            &root.join("occupied")
+        )
+        .is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/git_carry/registered.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry/registered.rs
@@ -2,7 +2,7 @@
 
 use super::{
     attachment_policy_matches, capture_revision, common_repository, git, import_bundle, output,
-    require_missing, restore_entry, restore_filesystem_rows, snapshot_command, sync_private_tree,
+    require_missing, restore_entries, restore_filesystem_rows, snapshot_command, sync_private_tree,
     text, write_git_pointer, IndexReservation,
 };
 use crate::{BulkloadRefusal, Result};
@@ -196,12 +196,7 @@ pub fn restore(
         "-z",
         &capture_revision(&heads, "worktree")?,
     ]))?;
-    for entry in entries
-        .split(|byte| *byte == 0)
-        .filter(|entry| !entry.is_empty())
-    {
-        restore_entry(&destination, entry)?;
-    }
+    restore_entries(&destination, &entries)?;
     restore_filesystem_rows(&destination, &capture_revision(&heads, "filesystem-v1")?)?;
     if image(&admin)? != before {
         return Err(BulkloadRefusal::GitAuthorityChanged);
@@ -210,6 +205,12 @@ pub fn restore(
     attachment_policy_matches(&repository, &repository, &heads)?;
     fs::File::open(&destination)?.sync_all()?;
     reservation.release()?;
+    // The completion receipt must not precede the new target directory entry.
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY)
+        .open(&parent)?
+        .sync_all()?;
     complete(&receipt, &destination, &admin, &head, &staged)
 }
 

--- a/crates/tcfs-bulkload-agent/src/git_carry/shared.rs
+++ b/crates/tcfs-bulkload-agent/src/git_carry/shared.rs
@@ -1,0 +1,308 @@
+//! One common Git closure plus workspace-specific prerequisite bundles.
+//!
+//! Shared bases are transport dependencies, not a replacement for each
+//! workspace's staged, dirty, ignored and filesystem metadata capture.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+
+use super::{capture_refs, git, input, oid, output, prepare_private, refs, set_ref, text};
+use crate::{BulkloadRefusal, Result};
+
+fn stash_history(repo: &Path, inventory: &str) -> Result<Vec<u8>> {
+    if inventory.lines().any(|line| line.ends_with(" refs/stash")) {
+        output(git(repo).args(["reflog", "show", "--format=%H", "refs/stash"]))
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+/// Capture refs, stash history and HEAD once without walking workspace payloads.
+///
+/// This optimistic snapshot does not freeze writers. Subsequent workspace
+/// captures may include new commits absent from this base; those travel in
+/// their delta. The caller owns digest binding, retention and import ordering.
+///
+/// # Errors
+/// Refuses changing refs/stashes/HEAD, invalid Git state or occupied capture paths.
+pub fn export_base(repo: &Path, capture: &Path) -> Result<PathBuf> {
+    let repo = fs::canonicalize(repo)?;
+    fs::DirBuilder::new().mode(0o700).create(capture)?;
+    let capture = fs::canonicalize(capture)?;
+    if capture.starts_with(&repo) {
+        return Err(BulkloadRefusal::GitAuthorityOutsideRoot);
+    }
+    let inventory = refs(&repo)?;
+    let stashes = stash_history(&repo, &inventory)?;
+    let head = text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?;
+    let private = prepare_private(&repo, &capture)?;
+    capture_refs(&repo, &private, &inventory)?;
+    set_ref(&private, "refs/carry-export/shared-base-head", &head)?;
+    let bundle = capture.join("base.bundle");
+    write_bundle(&private, &bundle, None)?;
+    if inventory != refs(&repo)?
+        || stashes != stash_history(&repo, &inventory)?
+        || head != text(git(&repo).args(["rev-parse", "--verify", "HEAD"]))?
+    {
+        return Err(BulkloadRefusal::GitAuthorityChanged);
+    }
+    output(git(&private).args(["bundle", "verify"]).arg(&bundle))?;
+    Ok(bundle)
+}
+
+fn prerequisite_commits(private: &Path, base: &Path) -> Result<BTreeSet<String>> {
+    output(git(private).args(["bundle", "verify"]).arg(base))?;
+    let heads = text(git(private).args(["bundle", "list-heads"]).arg(base))?;
+    let mut commits = BTreeSet::new();
+    for line in heads.lines() {
+        let (value, name) = line
+            .split_once(' ')
+            .ok_or(BulkloadRefusal::GitInventoryMalformed)?;
+        if !oid(value) || !name.starts_with("refs/carry-export/") {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        // A ref may legally point to a tree/blob. Only commits can be bundle
+        // prerequisites; non-commit objects remain in the workspace pack.
+        output(git(private).args(["cat-file", "-e", value]))?;
+        if let Ok(commit) =
+            text(git(private).args(["rev-parse", "--verify", &format!("{value}^{{commit}}")]))
+        {
+            if !oid(&commit) {
+                return Err(BulkloadRefusal::GitInventoryMalformed);
+            }
+            commits.insert(commit);
+        }
+    }
+    if commits.is_empty() {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    Ok(commits)
+}
+
+/// Whether a bundle declares prerequisite commits that require retained custody.
+///
+/// # Errors
+/// Refuses malformed or oversized bundle headers and unavailable files.
+pub fn requires_base(bundle: &Path) -> Result<bool> {
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(bundle)?;
+    let mut source = BufReader::new(file);
+    let mut consumed = 0usize;
+    let mut prerequisite = false;
+    loop {
+        let mut line = Vec::new();
+        let count = source
+            .by_ref()
+            .take(1024 * 1024)
+            .read_until(b'\n', &mut line)?;
+        if consumed == 0 && line != b"# v2 git bundle\n" && line != b"# v3 git bundle\n" {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        consumed = consumed
+            .checked_add(count)
+            .ok_or(BulkloadRefusal::BudgetExceeded)?;
+        if count == 0 || !line.ends_with(b"\n") || consumed > 16 * 1024 * 1024 {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        if line == b"\n" {
+            return Ok(prerequisite);
+        }
+        prerequisite |= line.starts_with(b"-");
+    }
+}
+
+pub(super) fn write_bundle(private: &Path, bundle: &Path, base: Option<&Path>) -> Result<()> {
+    let Some(base) = base else {
+        output(
+            git(private)
+                .args(["bundle", "create"])
+                .arg(bundle)
+                .arg("--all"),
+        )?;
+        return Ok(());
+    };
+    let commits = prerequisite_commits(private, base)?;
+    let exclusions = commits.iter().fold(String::new(), |mut result, value| {
+        result.push('^');
+        result.push_str(value);
+        result.push('\n');
+        result
+    });
+    input(
+        git(private)
+            .args(["bundle", "create"])
+            .arg(bundle)
+            .args(["--all", "--stdin"]),
+        exclusions.as_bytes(),
+    )?;
+
+    // Git omits excluded ref tips from bundle headers. Our HEAD may be exactly
+    // a base tip, and staged/worktree commits deliberately have no parents.
+    // Retain every advertised workspace ref and explicitly declare the base
+    // commits needed by their trees. The pack remains entirely Git-generated.
+    let mut source = BufReader::new(fs::File::open(bundle)?);
+    let mut header = Vec::new();
+    let mut consumed = 0usize;
+    loop {
+        let mut line = Vec::new();
+        let count = source
+            .by_ref()
+            .take(1024 * 1024)
+            .read_until(b'\n', &mut line)?;
+        consumed = consumed
+            .checked_add(count)
+            .ok_or(BulkloadRefusal::BudgetExceeded)?;
+        if count == 0 || !line.ends_with(b"\n") || consumed > 16 * 1024 * 1024 {
+            return Err(BulkloadRefusal::GitInventoryMalformed);
+        }
+        if line == b"\n" {
+            break;
+        }
+        if line.starts_with(b"# v") || line.starts_with(b"@") {
+            header.extend_from_slice(&line);
+        }
+    }
+    if !header.starts_with(b"# v2 git bundle\n") && !header.starts_with(b"# v3 git bundle\n") {
+        return Err(BulkloadRefusal::GitInventoryMalformed);
+    }
+    for value in commits {
+        writeln!(header, "-{value} shared base")?;
+    }
+    writeln!(header, "{}\n", refs(private)?)?;
+    let pending = bundle.with_extension("header-pending");
+    let mut target = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&pending)?;
+    target.write_all(&header)?;
+    std::io::copy(&mut source, &mut target)?;
+    target.sync_all()?;
+    fs::rename(&pending, bundle)?;
+    fs::File::open(bundle.parent().ok_or(BulkloadRefusal::PathNotAbsolute)?)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn run(repo: &Path, args: &[&str]) {
+        output(
+            git(repo)
+                .args([
+                    "-c",
+                    "user.name=Bulkload test",
+                    "-c",
+                    "user.email=bulkload@localhost",
+                    "-c",
+                    "commit.gpgsign=false",
+                ])
+                .args(args),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn shared_base_preserves_workspace_refs_and_requires_imported_history() {
+        let root = std::env::temp_dir().join(format!(
+            "tcfs-shared-git-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::DirBuilder::new().mode(0o700).create(&root).unwrap();
+        let source = root.join("source");
+        fs::create_dir(&source).unwrap();
+        run(&source, &["init", "--template="]);
+        let mut random = 1u32;
+        let history: Vec<u8> = (0..262_144)
+            .map(|_| {
+                random ^= random << 13;
+                random ^= random >> 17;
+                random ^= random << 5;
+                random.to_le_bytes().first().copied().unwrap()
+            })
+            .collect();
+        fs::write(source.join("history"), &history).unwrap();
+        fs::write(source.join("file"), b"base").unwrap();
+        run(&source, &["add", "."]);
+        run(&source, &["commit", "-m", "base"]);
+        let head = text(git(&source).args(["rev-parse", "HEAD"])).unwrap();
+        let base = export_base(&source, &root.join("base")).unwrap();
+        fs::write(source.join("file"), b"staged").unwrap();
+        run(&source, &["add", "file"]);
+        fs::write(source.join("file"), b"dirty").unwrap();
+        fs::write(source.join(".gitignore"), b"ignored\n").unwrap();
+        fs::write(source.join("ignored"), b"private ignored payload").unwrap();
+        let status = output(git(&source).args(["status", "--porcelain=v1", "-z"])).unwrap();
+        let delta =
+            super::super::export_repository_with_prerequisite(&source, &root.join("delta"), &base)
+                .unwrap();
+        let standalone =
+            super::super::export_repository(&source, &root.join("standalone")).unwrap();
+        assert!(fs::metadata(&delta).unwrap().len() < fs::metadata(&standalone).unwrap().len());
+        assert!(
+            text(git(&source).args(["bundle", "list-heads"]).arg(&delta))
+                .unwrap()
+                .lines()
+                .any(|line| line == format!("{head} refs/carry-export/head"))
+        );
+        assert_eq!(
+            status,
+            output(git(&source).args(["status", "--porcelain=v1", "-z"])).unwrap()
+        );
+        let destination = root.join("destination");
+        fs::create_dir(&destination).unwrap();
+        run(&destination, &["init", "--template="]);
+        assert!(super::super::import_bundle(&destination, &delta, "neo").is_err());
+        super::super::import_bundle(&destination, &base, "neo").unwrap();
+        let restored = root.join("restored");
+        super::super::restore_linked(&delta, &destination, &restored, "neo").unwrap();
+        assert_eq!(
+            head,
+            text(git(&restored).args(["rev-parse", "HEAD"])).unwrap()
+        );
+        assert_eq!(fs::read(restored.join("history")).unwrap(), history);
+        assert_eq!(fs::read(restored.join("file")).unwrap(), b"dirty");
+        assert_eq!(
+            output(git(&restored).args(["show", ":file"])).unwrap(),
+            b"staged"
+        );
+        assert_eq!(
+            fs::read(restored.join("ignored")).unwrap(),
+            b"private ignored payload"
+        );
+        let linked_source = root.join("linked-source");
+        output(
+            git(&source)
+                .args(["worktree", "add", "--detach"])
+                .arg(&linked_source)
+                .arg(&head),
+        )
+        .unwrap();
+        fs::write(linked_source.join("file"), b"other workspace").unwrap();
+        let second = super::super::export_repository_with_prerequisite(
+            &linked_source,
+            &root.join("second-delta"),
+            &base,
+        )
+        .unwrap();
+        let second_restored = root.join("second-restored");
+        super::super::restore_linked(&second, &destination, &second_restored, "neo").unwrap();
+        assert_eq!(
+            fs::read(second_restored.join("file")).unwrap(),
+            b"other workspace"
+        );
+        assert_eq!(fs::read(restored.join("file")).unwrap(), b"dirty");
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/hash.rs
+++ b/crates/tcfs-bulkload-agent/src/hash.rs
@@ -1,0 +1,158 @@
+//! Content hashing and chunking for the agent half.
+//!
+//! Files are opened with `O_NOFOLLOW | O_CLOEXEC`, mirroring the Python
+//! engine's open flags: a seat the walker classified as a regular file must
+//! still be a regular file when its bytes are read, or the read is refused
+//! rather than followed somewhere else.
+
+use std::ffi::CString;
+use std::fs::File;
+use std::io::Read;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::FromRawFd;
+use std::path::Path;
+
+use tcfs_bulkload_proto::{BulkloadRefusal, Result};
+
+/// Read buffer size. Large enough to keep blake3's SIMD lanes busy without
+/// putting a megabyte per rayon worker on the stack.
+const READ_CHUNK_BYTES: usize = 256 * 1024;
+
+/// fastcdc content-defined chunking parameters (min / avg / max bytes).
+pub const CDC_MIN_BYTES: u32 = 16 * 1024;
+/// See [`CDC_MIN_BYTES`].
+pub const CDC_AVG_BYTES: u32 = 64 * 1024;
+/// See [`CDC_MIN_BYTES`].
+pub const CDC_MAX_BYTES: u32 = 256 * 1024;
+
+/// Open `path` without following a terminal symlink.
+///
+/// # Errors
+///
+/// Refuses with [`BulkloadRefusal::PathNotPortable`] if the path contains an
+/// interior NUL, and [`BulkloadRefusal::Io`] carrying the errno otherwise. A
+/// path that became a symlink between `lstat` and open surfaces as `ELOOP`.
+pub fn open_nofollow(path: &Path) -> Result<File> {
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| BulkloadRefusal::PathNotPortable)?;
+    // SAFETY: `c_path` is a valid NUL-terminated C string that outlives the
+    // call, and the flag set contains no mode-bearing flag (no O_CREAT), so
+    // the two-argument form of `open` is correct.
+    let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return Err(BulkloadRefusal::from(std::io::Error::last_os_error()));
+    }
+    // SAFETY: `fd` is a fresh, open, owned descriptor that nothing else holds.
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+/// blake3 of the bytes of `path`, streamed.
+///
+/// # Errors
+///
+/// Refuses if the file cannot be opened without following a symlink, or if a
+/// read fails partway through.
+pub fn hash_file(path: &Path) -> Result<[u8; 32]> {
+    let mut file = open_nofollow(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = vec![0_u8; READ_CHUNK_BYTES];
+    loop {
+        let read = file.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        let filled = buf.get(..read).ok_or(BulkloadRefusal::Io(None))?;
+        hasher.update(filled);
+    }
+    Ok(*hasher.finalize().as_bytes())
+}
+
+/// blake3 of an in-memory buffer.
+#[must_use]
+pub fn hash_bytes(data: &[u8]) -> [u8; 32] {
+    *blake3::hash(data).as_bytes()
+}
+
+/// CRC32-C of an in-memory buffer.
+///
+/// Used as the cheap per-frame integrity check on the wire, where a full
+/// blake3 would dominate the cost of a small control record.
+#[must_use]
+pub fn checksum(data: &[u8]) -> u32 {
+    crc32c::crc32c(data)
+}
+
+/// Content-defined chunk boundaries over `data`, as `(offset, length)` pairs.
+///
+/// M1 exposes the boundaries only; the M2 lane turns these into the
+/// deduplicated transfer unit.
+#[must_use]
+pub fn chunk_boundaries(data: &[u8]) -> Vec<(usize, usize)> {
+    fastcdc::v2020::FastCDC::new(data, CDC_MIN_BYTES, CDC_AVG_BYTES, CDC_MAX_BYTES)
+        .map(|chunk| (chunk.offset, chunk.length))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use std::io::Write as _;
+
+    use super::{chunk_boundaries, checksum, hash_bytes, hash_file, open_nofollow, CDC_MIN_BYTES};
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("tcfs-bulkload-agent-test-{}-{name}", std::process::id()));
+        dir
+    }
+
+    #[test]
+    fn hashes_a_file_like_it_hashes_the_bytes() {
+        let path = scratch("hash");
+        let payload = b"tcfs bulkload M1";
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(payload).unwrap();
+        drop(file);
+
+        assert_eq!(hash_file(&path).unwrap(), hash_bytes(payload));
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn refuses_to_follow_a_symlink() {
+        let target = scratch("nofollow-target");
+        let link = scratch("nofollow-link");
+        std::fs::write(&target, b"payload").unwrap();
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let refused = open_nofollow(&link);
+        assert!(refused.is_err(), "O_NOFOLLOW must refuse a symlink");
+
+        std::fs::remove_file(&link).unwrap();
+        std::fs::remove_file(&target).unwrap();
+    }
+
+    #[test]
+    fn chunks_cover_the_input_exactly_once() {
+        let data: Vec<u8> = (0..(CDC_MIN_BYTES * 8))
+            .map(|i| u8::try_from(i % 251).unwrap_or(0))
+            .collect();
+        let chunks = chunk_boundaries(&data);
+        assert!(!chunks.is_empty());
+
+        let mut cursor = 0_usize;
+        for (offset, length) in &chunks {
+            assert_eq!(*offset, cursor, "chunks must be contiguous");
+            cursor += *length;
+        }
+        assert_eq!(cursor, data.len(), "chunks must cover the whole input");
+    }
+
+    #[test]
+    fn checksum_is_stable_and_content_sensitive() {
+        assert_eq!(checksum(b"abc"), checksum(b"abc"));
+        assert_ne!(checksum(b"abc"), checksum(b"abd"));
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/hash.rs
+++ b/crates/tcfs-bulkload-agent/src/hash.rs
@@ -14,6 +14,8 @@ use std::path::Path;
 
 use tcfs_bulkload_proto::{BulkloadRefusal, Result};
 
+use crate::freshness::StatIdentity;
+
 /// Read buffer size. Large enough to keep blake3's SIMD lanes busy without
 /// putting a megabyte per rayon worker on the stack.
 const READ_CHUNK_BYTES: usize = 256 * 1024;
@@ -33,12 +35,17 @@ pub const CDC_MAX_BYTES: u32 = 256 * 1024;
 /// interior NUL, and [`BulkloadRefusal::Io`] carrying the errno otherwise. A
 /// path that became a symlink between `lstat` and open surfaces as `ELOOP`.
 pub fn open_nofollow(path: &Path) -> Result<File> {
-    let c_path = CString::new(path.as_os_str().as_bytes())
-        .map_err(|_| BulkloadRefusal::PathNotPortable)?;
+    let c_path =
+        CString::new(path.as_os_str().as_bytes()).map_err(|_| BulkloadRefusal::PathNotPortable)?;
     // SAFETY: `c_path` is a valid NUL-terminated C string that outlives the
     // call, and the flag set contains no mode-bearing flag (no O_CREAT), so
     // the two-argument form of `open` is correct.
-    let fd = unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC) };
+    let fd = unsafe {
+        libc::open(
+            c_path.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+        )
+    };
     if fd < 0 {
         return Err(BulkloadRefusal::from(std::io::Error::last_os_error()));
     }
@@ -53,7 +60,51 @@ pub fn open_nofollow(path: &Path) -> Result<File> {
 /// Refuses if the file cannot be opened without following a symlink, or if a
 /// read fails partway through.
 pub fn hash_file(path: &Path) -> Result<[u8; 32]> {
-    let mut file = open_nofollow(path)?;
+    let file = open_nofollow(path)?;
+    let identity = StatIdentity::from_metadata(&file.metadata()?);
+    hash_open_file(file, &identity, &mut 0, &mut 0)
+}
+
+/// Hash only the regular file identified by the walk, checking the opened
+/// descriptor before and after reading. A concurrent writer leaves no completion.
+///
+/// # Errors
+/// Refuses on I/O failure, a non-regular replacement, or changed identity.
+pub fn hash_file_checked(path: &Path, expected: &StatIdentity) -> Result<[u8; 32]> {
+    hash_file_observed(path, expected).digest
+}
+
+/// Read accounting survives refusals, including a writer changing the file
+/// after some bytes have already been read.
+pub(crate) struct HashRead {
+    pub digest: Result<[u8; 32]>,
+    pub bytes_read: u64,
+    pub metadata_checks: u64,
+}
+
+pub(crate) fn hash_file_observed(path: &Path, expected: &StatIdentity) -> HashRead {
+    let mut bytes_read = 0;
+    let mut metadata_checks = 0;
+    let digest = open_nofollow(path)
+        .and_then(|file| hash_open_file(file, expected, &mut bytes_read, &mut metadata_checks));
+    HashRead {
+        digest,
+        bytes_read,
+        metadata_checks,
+    }
+}
+
+fn hash_open_file(
+    mut file: File,
+    expected: &StatIdentity,
+    bytes_read: &mut u64,
+    metadata_checks: &mut u64,
+) -> Result<[u8; 32]> {
+    *metadata_checks += 1;
+    let before = file.metadata()?;
+    if !before.is_file() || StatIdentity::from_metadata(&before) != *expected {
+        return Err(BulkloadRefusal::SourceChangedAfterSnapshot);
+    }
     let mut hasher = blake3::Hasher::new();
     let mut buf = vec![0_u8; READ_CHUNK_BYTES];
     loop {
@@ -61,8 +112,13 @@ pub fn hash_file(path: &Path) -> Result<[u8; 32]> {
         if read == 0 {
             break;
         }
+        *bytes_read = bytes_read.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
         let filled = buf.get(..read).ok_or(BulkloadRefusal::Io(None))?;
         hasher.update(filled);
+    }
+    *metadata_checks += 1;
+    if StatIdentity::from_metadata(&file.metadata()?) != *expected {
+        return Err(BulkloadRefusal::SourceChangedAfterSnapshot);
     }
     Ok(*hasher.finalize().as_bytes())
 }
@@ -99,11 +155,14 @@ mod tests {
 
     use std::io::Write as _;
 
-    use super::{chunk_boundaries, checksum, hash_bytes, hash_file, open_nofollow, CDC_MIN_BYTES};
+    use super::{checksum, chunk_boundaries, hash_bytes, hash_file, open_nofollow, CDC_MIN_BYTES};
 
     fn scratch(name: &str) -> std::path::PathBuf {
         let mut dir = std::env::temp_dir();
-        dir.push(format!("tcfs-bulkload-agent-test-{}-{name}", std::process::id()));
+        dir.push(format!(
+            "tcfs-bulkload-agent-test-{}-{name}",
+            std::process::id()
+        ));
         dir
     }
 
@@ -154,5 +213,19 @@ mod tests {
     fn checksum_is_stable_and_content_sensitive() {
         assert_eq!(checksum(b"abc"), checksum(b"abc"));
         assert_ne!(checksum(b"abc"), checksum(b"abd"));
+    }
+
+    #[test]
+    fn changed_identity_cannot_produce_a_completion_digest() {
+        let path = scratch("changed");
+        std::fs::write(&path, b"before").unwrap();
+        let identity =
+            crate::freshness::StatIdentity::from_metadata(&std::fs::metadata(&path).unwrap());
+        std::fs::write(&path, b"after and larger").unwrap();
+        assert_eq!(
+            super::hash_file_checked(&path, &identity),
+            Err(tcfs_bulkload_proto::BulkloadRefusal::SourceChangedAfterSnapshot)
+        );
+        std::fs::remove_file(path).unwrap();
     }
 }

--- a/crates/tcfs-bulkload-agent/src/lib.rs
+++ b/crates/tcfs-bulkload-agent/src/lib.rs
@@ -1,0 +1,21 @@
+//! The tcfs bulkload agent: the thin darwin-side half of the rebuild.
+//!
+//! # Scope (plan workstream G, R32-R35)
+//!
+//! The agent walks a corpus, stats and optionally hashes each seat, and emits
+//! [`tcfs_bulkload_proto::Frame`]s. It does not talk to object storage, does
+//! not speak HTTP or gRPC, and has no async runtime -- see the dependency wall
+//! in `Cargo.toml` and the `dep_graph` integration test that enforces it.
+//!
+//! # Freshness
+//!
+//! The walker is written against the local [`freshness::FreshnessCache`]
+//! trait rather than any concrete cache. PR #586 lands a `freshness.rs` in
+//! `tcfs-sync`; the trait here keeps M3 unblocked either way and lets the M0
+//! bench swap in a null cache.
+
+pub mod freshness;
+pub mod hash;
+pub mod walk;
+
+pub use tcfs_bulkload_proto::{BulkloadRefusal, Frame, FrameKind, Result, RowSchema};

--- a/crates/tcfs-bulkload-agent/src/lib.rs
+++ b/crates/tcfs-bulkload-agent/src/lib.rs
@@ -1,9 +1,12 @@
-//! The tcfs bulkload agent: the thin darwin-side half of the rebuild.
+//! Native ordinary-file transport and offline provider composition on Unix.
 //!
 //! # Scope (plan workstream G, R32-R35)
 //!
-//! The agent walks a corpus, stats and optionally hashes each seat, and emits
-//! [`tcfs_bulkload_proto::Frame`]s. It does not talk to object storage, does
+//! The agent walks a corpus, transfers verified chunks in bounded frames,
+//! preserves divergent destinations, and composes retained `SQLite` candidates.
+//! It still enumerates the source on each run; resumable content completion is
+//! not a no-rewalk guarantee. Ordinary-file transfer does not provide Git-native
+//! divergent union or raw live `SQLite` copying. It does not talk to object storage, does
 //! not speak HTTP or gRPC, and has no async runtime -- see the dependency wall
 //! in `Cargo.toml` and the `dep_graph` integration test that enforces it.
 //!
@@ -16,7 +19,10 @@
 
 pub mod freshness;
 pub mod hash;
+pub mod materialize;
 pub mod provider_sqlite;
+pub mod transfer;
+pub mod transfer_store;
 pub mod walk;
 
 pub use tcfs_bulkload_proto::{BulkloadRefusal, Frame, FrameKind, Result, RowSchema};

--- a/crates/tcfs-bulkload-agent/src/lib.rs
+++ b/crates/tcfs-bulkload-agent/src/lib.rs
@@ -17,6 +17,7 @@
 //! `tcfs-sync`; the trait here keeps M3 unblocked either way and lets the M0
 //! bench swap in a null cache.
 
+pub mod estate;
 pub mod freshness;
 pub mod git_carry;
 pub mod hash;

--- a/crates/tcfs-bulkload-agent/src/lib.rs
+++ b/crates/tcfs-bulkload-agent/src/lib.rs
@@ -18,6 +18,7 @@
 //! bench swap in a null cache.
 
 pub mod freshness;
+pub mod git_carry;
 pub mod hash;
 pub mod materialize;
 pub mod provider_sqlite;

--- a/crates/tcfs-bulkload-agent/src/lib.rs
+++ b/crates/tcfs-bulkload-agent/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod freshness;
 pub mod hash;
+pub mod provider_sqlite;
 pub mod walk;
 
 pub use tcfs_bulkload_proto::{BulkloadRefusal, Frame, FrameKind, Result, RowSchema};

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -6,7 +6,7 @@
 //! subcommand.
 
 use std::io::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use tcfs_bulkload_agent::freshness::{Freshness, FreshnessCache as _, MemoryCache, StatIdentity};
@@ -30,13 +30,14 @@ fn main() -> ExitCode {
     let mut args = std::env::args().skip(1);
     let outcome = match args.next().as_deref() {
         Some("selftest") => selftest(),
-        Some("walk") => match args.next() {
-            Some(path) => walk_command(PathBuf::from(path)),
-            None => {
+        Some("walk") => {
+            if let Some(path) = args.next() {
+                walk_command(Path::new(&path))
+            } else {
                 eprintln!("tcfs-bulkload-agent: walk requires a PATH\n\n{USAGE}");
                 return ExitCode::from(2);
             }
-        },
+        }
         Some("help" | "--help" | "-h") => {
             println!("{USAGE}");
             return ExitCode::SUCCESS;
@@ -111,8 +112,8 @@ fn selftest() -> Result<()> {
     Ok(())
 }
 
-fn walk_command(root: PathBuf) -> Result<()> {
-    let root = std::fs::canonicalize(&root)?;
+fn walk_command(root: &Path) -> Result<()> {
+    let root = std::fs::canonicalize(root)?;
     let mut cache = MemoryCache::new();
     let options = WalkOptions {
         hash_policy: HashPolicy::Never,

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -1,0 +1,177 @@
+//! `tcfs-bulkload-agent` -- the thin darwin-side bulkload half.
+//!
+//! Argument parsing is hand-rolled on purpose. `clap` is not on the R34
+//! dependency allowlist for the agent, and a binary whose whole point is a
+//! closed dependency graph should not grow a parser crate to read one
+//! subcommand.
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use tcfs_bulkload_agent::freshness::{Freshness, FreshnessCache as _, MemoryCache, StatIdentity};
+use tcfs_bulkload_agent::hash;
+use tcfs_bulkload_agent::walk::{self, HashPolicy, WalkOptions};
+use tcfs_bulkload_proto::{BulkloadRefusal, FileKind, Frame, FrameKind, Result, RowSchema};
+
+const USAGE: &str = "\
+tcfs-bulkload-agent -- tcfs bulkload agent (M1 skeleton)
+
+USAGE:
+    tcfs-bulkload-agent <SUBCOMMAND>
+
+SUBCOMMANDS:
+    selftest    Hash a temporary file and round-trip a postcard frame
+    walk PATH   Stat-walk PATH and print the row and refusal counts
+    help        Print this message
+";
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let outcome = match args.next().as_deref() {
+        Some("selftest") => selftest(),
+        Some("walk") => match args.next() {
+            Some(path) => walk_command(PathBuf::from(path)),
+            None => {
+                eprintln!("tcfs-bulkload-agent: walk requires a PATH\n\n{USAGE}");
+                return ExitCode::from(2);
+            }
+        },
+        Some("help" | "--help" | "-h") => {
+            println!("{USAGE}");
+            return ExitCode::SUCCESS;
+        }
+        Some(other) => {
+            eprintln!("tcfs-bulkload-agent: unknown subcommand {other:?}\n\n{USAGE}");
+            return ExitCode::from(2);
+        }
+        None => {
+            eprintln!("{USAGE}");
+            return ExitCode::from(2);
+        }
+    };
+
+    match outcome {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(refusal) => {
+            eprintln!("tcfs-bulkload-agent: refused: {refusal}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Exercise the pieces M1 actually ships: hash a real file off disk, put its
+/// row in a frame, encode it with postcard, decode it back, and prove the
+/// round trip is exact.
+fn selftest() -> Result<()> {
+    println!("tcfs-bulkload-agent selftest");
+
+    let path = scratch_path("selftest");
+    let payload = b"tcfs bulkload M1 selftest payload";
+    write_scratch(&path, payload)?;
+
+    let digest = hash::hash_file(&path);
+    let meta = std::fs::metadata(&path);
+    let cleanup = std::fs::remove_file(&path);
+
+    let digest = digest?;
+    let meta = meta?;
+    cleanup?;
+
+    if digest != hash::hash_bytes(payload) {
+        return Err(BulkloadRefusal::DigestMismatch);
+    }
+    println!("  hashed        {} bytes", payload.len());
+    println!("  blake3        {}", hex(&digest));
+    println!("  crc32c        {:08x}", hash::checksum(payload));
+    println!("  cdc chunks    {}", hash::chunk_boundaries(payload).len());
+
+    let row = row_for(payload.len(), &meta, digest);
+    let identity = StatIdentity::from_row(&row);
+    let mut cache = MemoryCache::new();
+    if cache.lookup(&identity)? != Freshness::Stale {
+        return Err(BulkloadRefusal::ContractSelfInconsistent);
+    }
+    cache.record(&identity)?;
+    if cache.lookup(&identity)? != Freshness::Fresh {
+        return Err(BulkloadRefusal::ContractSelfInconsistent);
+    }
+    println!("  freshness     stale -> record -> fresh (ok)");
+
+    let frame = Frame::new(FrameKind::Row(row));
+    let encoded = frame.encode()?;
+    let (decoded, consumed) = Frame::decode(&encoded)?;
+    if decoded != frame || consumed != encoded.len() {
+        return Err(BulkloadRefusal::FrameCodec);
+    }
+    println!("  frame bytes   {}", encoded.len());
+    println!("  frame decoded {decoded:?}");
+    println!("  round trip    exact (ok)");
+    println!("selftest: ok");
+    Ok(())
+}
+
+fn walk_command(root: PathBuf) -> Result<()> {
+    let root = std::fs::canonicalize(&root)?;
+    let mut cache = MemoryCache::new();
+    let options = WalkOptions {
+        hash_policy: HashPolicy::Never,
+        ..WalkOptions::new(root)
+    };
+    let outcome = walk::walk(&options, &mut cache)?;
+    println!("rows                     {}", outcome.rows.len());
+    println!("refusals                 {}", outcome.refusals.len());
+    println!("seats_seen               {}", outcome.stats.seats_seen);
+    println!("bytes_seen               {}", outcome.stats.bytes_seen);
+    println!("fresh_skipped            {}", outcome.stats.fresh_skipped);
+    println!(
+        "bytes_reread_on_resume   {}",
+        outcome.stats.bytes_reread_on_resume
+    );
+    println!(
+        "files_statted_twice      {}",
+        outcome.stats.files_statted_twice
+    );
+    Ok(())
+}
+
+fn row_for(len: usize, meta: &std::fs::Metadata, digest: [u8; 32]) -> RowSchema {
+    use std::os::unix::fs::MetadataExt as _;
+    RowSchema {
+        rel_path: b"selftest".to_vec(),
+        kind: FileKind::Regular,
+        dev: meta.dev(),
+        ino: meta.ino(),
+        size: u64::try_from(len).unwrap_or(u64::MAX),
+        mtime_ns: i128::from(meta.mtime()) * 1_000_000_000 + i128::from(meta.mtime_nsec()),
+        ctime_ns: i128::from(meta.ctime()) * 1_000_000_000 + i128::from(meta.ctime_nsec()),
+        mode: meta.mode(),
+        nlink: meta.nlink(),
+        link_target: None,
+        blake3: Some(digest),
+    }
+}
+
+fn scratch_path(name: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "tcfs-bulkload-agent-{name}-{}",
+        std::process::id()
+    ));
+    path
+}
+
+fn write_scratch(path: &std::path::Path, payload: &[u8]) -> Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    file.write_all(payload)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::new(), |mut acc, byte| {
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    })
+}

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -50,6 +50,8 @@ SUBCOMMANDS:
                 Create a missing same-HEAD staged index only; never rewrite payload
     git-attach-matching-payload BUNDLE REPOSITORY DESTINATION SOURCE NEW_RECEIPT
                 Attach exact matching payload using existing common Git administration
+    git-attach-standalone-payload BUNDLE DESTINATION SOURCE NEW_RECEIPT ORIGIN_FROM ORIGIN_TO
+                Attach exact payload with retained config and explicit local origin mapping
     snapshot SOURCE OUTPUT [MAX_STEPS]
                 Capture live SQLite through its online backup API
     compose BASE INCOMING OUTPUT SOURCE_ID [MAX_STEPS]
@@ -97,6 +99,9 @@ fn main() -> ExitCode {
         Some("hydrate-state") => hydrate_command(&args.collect::<Vec<_>>()),
         Some("git-repair-missing-index") => repair_index_command(&args.collect::<Vec<_>>()),
         Some("git-attach-matching-payload") => attach_payload_command(&args.collect::<Vec<_>>()),
+        Some("git-attach-standalone-payload") => {
+            attach_standalone_command(&args.collect::<Vec<_>>())
+        }
         Some(
             name @ ("estate-add" | "estate-add-batch" | "estate-show" | "estate-capture"
             | "estate-apply"),
@@ -245,6 +250,31 @@ fn repair_index_command(args: &[std::ffi::OsString]) -> Result<()> {
         .ok_or(BulkloadRefusal::PathNotPortable)?;
     tcfs_bulkload_agent::git_carry::repair_missing_index(path(0)?, path(1)?, source, path(3)?)?;
     println!("missing index repaired; payload parity not asserted");
+    Ok(())
+}
+
+fn attach_standalone_command(args: &[std::ffi::OsString]) -> Result<()> {
+    if args.len() != 6 {
+        return Err(BulkloadRefusal::RequiredFieldMissing);
+    }
+    let path = |i| {
+        args.get(i)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    let source = args
+        .get(2)
+        .and_then(|value| value.to_str())
+        .ok_or(BulkloadRefusal::PathNotPortable)?;
+    tcfs_bulkload_agent::git_carry::attach_standalone_payload(
+        path(0)?,
+        path(1)?,
+        source,
+        path(3)?,
+        path(4)?,
+        path(5)?,
+    )?;
+    println!("standalone payload attached; config retained, selected origin mapping activated");
     Ok(())
 }
 

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -44,6 +44,8 @@ SUBCOMMANDS:
                 Compose Codex state with retained rollout path mapping
     hydrate-state SNAPSHOT SOURCE_HOME DEST_HOME MAX_BYTES JOBS [GZIP ZSTD]
                 Add missing raw rollouts from retained compressed files; never replace
+    apply-state-candidate LIVE BASE CANDIDATE MAX_ROWS
+                Explicit external live-state import; requires operator authorization
     help        Print this message
 
 BOUNDARIES:
@@ -79,6 +81,7 @@ fn main() -> ExitCode {
             &args.collect::<Vec<_>>(),
         ),
         Some("hydrate-state") => hydrate_command(&args.collect::<Vec<_>>()),
+        Some("apply-state-candidate") => apply_state_command(&args.collect::<Vec<_>>()),
         Some("serve") => tcfs_bulkload_agent::transfer::serve(
             &mut std::io::stdin().lock(),
             &mut std::io::stdout().lock(),
@@ -205,6 +208,39 @@ fn native_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
         }
         _ => Err(BulkloadRefusal::RequiredFieldMissing),
     }
+}
+
+fn apply_state_command(args: &[std::ffi::OsString]) -> Result<()> {
+    if args.len() != 4 {
+        return Err(BulkloadRefusal::RequiredFieldMissing);
+    }
+    let path = |index: usize| {
+        args.get(index)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    let max_rows = args
+        .get(3)
+        .and_then(|value| value.to_str())
+        .ok_or(BulkloadRefusal::FieldDomainViolation)?
+        .parse()
+        .map_err(|_| BulkloadRefusal::FieldDomainViolation)?;
+    tcfs_bulkload_agent::provider_sqlite::online::apply_state_candidate(
+        path(0)?,
+        path(1)?,
+        path(2)?,
+        max_rows,
+        &|receipt| {
+            let mut output = std::io::stdout().lock();
+            writeln!(
+                output,
+                "table={} inserted={} corrected={} conflicts={}",
+                receipt.table, receipt.inserted, receipt.corrected, receipt.conflicts
+            )?;
+            output.flush()?;
+            Ok(())
+        },
+    )
 }
 
 fn hydrate_command(args: &[std::ffi::OsString]) -> Result<()> {

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -1,13 +1,13 @@
-//! `tcfs-bulkload-agent` -- the thin darwin-side bulkload half.
+//! Native ordinary-file transport and offline provider composition on Unix.
 //!
 //! Argument parsing is hand-rolled on purpose. `clap` is not on the R34
 //! dependency allowlist for the agent, and a binary whose whole point is a
 //! closed dependency graph should not grow a parser crate to read one
-//! subcommand.
+//! subcommands.
 
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::ExitCode;
+use std::process::{Command, ExitCode, Stdio};
 
 use tcfs_bulkload_agent::freshness::{Freshness, FreshnessCache as _, MemoryCache, StatIdentity};
 use tcfs_bulkload_agent::hash;
@@ -15,7 +15,7 @@ use tcfs_bulkload_agent::walk::{self, HashPolicy, WalkOptions};
 use tcfs_bulkload_proto::{BulkloadRefusal, FileKind, Frame, FrameKind, Result, RowSchema};
 
 const USAGE: &str = "\
-tcfs-bulkload-agent -- tcfs bulkload agent (M1 skeleton)
+tcfs-bulkload-agent -- ordinary-file transport and offline SQLite composition
 
 USAGE:
     tcfs-bulkload-agent <SUBCOMMAND>
@@ -23,12 +23,31 @@ USAGE:
 SUBCOMMANDS:
     selftest    Hash a temporary file and round-trip a postcard frame
     walk PATH   Stat-walk PATH and print the row and refusal counts
+    copy SOURCE DEST SOURCE_STATE DEST_STATE
+                Native local copy with private resumable chunk stores
+    pull HOST SOURCE DEST SOURCE_STATE DEST_STATE
+                Native SSH pull; remote tcfs-bulkload-agent must be installed
+    serve       Serve one framed request on stdin/stdout (for SSH)
+    snapshot SOURCE OUTPUT [MAX_STEPS]
+                Capture live SQLite through its online backup API
+    compose BASE INCOMING OUTPUT SOURCE_ID [MAX_STEPS]
+                Compose retained SQLite snapshots into a private candidate
+    compose-state BASE INCOMING OUTPUT SOURCE_ID SOURCE_HOME DEST_HOME [MAX_STEPS]
+                Compose Codex state with retained rollout path mapping
     help        Print this message
+
+BOUNDARIES:
+    copy/pull preserve divergent destinations and refuse live SQLite files.
+    They enumerate the source each run; completed content is resumable.
+    File manifests are bounded to 8 MiB; oversized manifests refuse.
+    Git-native divergent union is not supplied by copy/pull.
+    compose commands write offline candidates, never install live databases.
 ";
 
 fn main() -> ExitCode {
-    let mut args = std::env::args().skip(1);
-    let outcome = match args.next().as_deref() {
+    let mut args = std::env::args_os().skip(1);
+    let command = args.next();
+    let outcome = match command.as_ref().and_then(|value| value.to_str()) {
         Some("selftest") => selftest(),
         Some("walk") => {
             if let Some(path) = args.next() {
@@ -38,6 +57,17 @@ fn main() -> ExitCode {
                 return ExitCode::from(2);
             }
         }
+        Some("copy" | "pull" | "snapshot" | "compose" | "compose-state") => native_command(
+            command
+                .as_ref()
+                .and_then(|value| value.to_str())
+                .unwrap_or(""),
+            &args.collect::<Vec<_>>(),
+        ),
+        Some("serve") => tcfs_bulkload_agent::transfer::serve(
+            &mut std::io::stdin().lock(),
+            &mut std::io::stdout().lock(),
+        ),
         Some("help" | "--help" | "-h") => {
             println!("{USAGE}");
             return ExitCode::SUCCESS;
@@ -58,6 +88,132 @@ fn main() -> ExitCode {
             eprintln!("tcfs-bulkload-agent: refused: {refusal}");
             ExitCode::FAILURE
         }
+    }
+}
+
+fn native_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
+    let path = |index: usize| {
+        args.get(index)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    match command {
+        "copy" if args.len() == 4 => {
+            let stats =
+                tcfs_bulkload_agent::transfer::copy(path(0)?, path(1)?, path(2)?, path(3)?)?;
+            report_transfer(&stats)
+        }
+        "pull" if args.len() == 5 => {
+            let host = args.first().ok_or(BulkloadRefusal::RequiredFieldMissing)?;
+            let mut child = Command::new("ssh")
+                .args(["-T", "-oBatchMode=yes", "-oConnectTimeout=15", "--"])
+                .arg(host)
+                .args(["tcfs-bulkload-agent", "serve"])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn()?;
+            let result = {
+                let mut output = child.stdin.take().ok_or(BulkloadRefusal::Io(None))?;
+                let mut input = child.stdout.take().ok_or(BulkloadRefusal::Io(None))?;
+                tcfs_bulkload_agent::transfer::receive(
+                    &mut input,
+                    &mut output,
+                    path(1)?,
+                    path(3)?,
+                    path(2)?,
+                    path(4)?,
+                )
+            };
+            let exit_status = child.wait()?;
+            let stats = result?;
+            if !exit_status.success() {
+                return Err(BulkloadRefusal::Io(None));
+            }
+            report_transfer(&stats)
+        }
+        "snapshot" if (2..=3).contains(&args.len()) => {
+            tcfs_bulkload_agent::provider_sqlite::snapshot(
+                path(0)?,
+                path(1)?,
+                steps(args.get(2))?,
+            )?;
+            println!("snapshot complete");
+            Ok(())
+        }
+        "compose" if (4..=5).contains(&args.len()) => {
+            let source_id = args
+                .get(3)
+                .and_then(|value| value.to_str())
+                .ok_or(BulkloadRefusal::PathNotPortable)?;
+            let stats = tcfs_bulkload_agent::provider_sqlite::compose_snapshots(
+                path(0)?,
+                path(1)?,
+                path(2)?,
+                source_id,
+                steps(args.get(4))?,
+            )?;
+            println!(
+                "inserted={} equivalent={} preserved={} unresolved={} paths_corrected={} unavailable_rollouts={}",
+                stats.inserted, stats.equivalent, stats.preserved, stats.unresolved,
+                stats.paths_corrected, stats.unavailable_rollouts
+            );
+            Ok(())
+        }
+        "compose-state" if (6..=7).contains(&args.len()) => {
+            let source_id = args
+                .get(3)
+                .and_then(|value| value.to_str())
+                .ok_or(BulkloadRefusal::PathNotPortable)?;
+            let mapping = tcfs_bulkload_agent::provider_sqlite::PathMapping {
+                source_home: path(4)?,
+                destination_home: path(5)?,
+            };
+            let stats = tcfs_bulkload_agent::provider_sqlite::compose_state_snapshots(
+                path(0)?,
+                path(1)?,
+                path(2)?,
+                source_id,
+                steps(args.get(6))?,
+                &mapping,
+            )?;
+            println!(
+                "inserted={} equivalent={} preserved={} unresolved={} paths_corrected={} unavailable_rollouts={}",
+                stats.inserted, stats.equivalent, stats.preserved, stats.unresolved,
+                stats.paths_corrected, stats.unavailable_rollouts
+            );
+            Ok(())
+        }
+        _ => Err(BulkloadRefusal::RequiredFieldMissing),
+    }
+}
+
+fn steps(value: Option<&std::ffi::OsString>) -> Result<u32> {
+    value.map_or(Ok(1_000_000), |value| {
+        value
+            .to_str()
+            .ok_or(BulkloadRefusal::FieldDomainViolation)?
+            .parse()
+            .map_err(|_| BulkloadRefusal::FieldDomainViolation)
+    })
+}
+
+fn report_transfer(stats: &tcfs_bulkload_agent::transfer::TransferStats) -> Result<()> {
+    println!(
+        "completed={} reused={} bytes_received={} source_bytes_read={} refusals={}",
+        stats.completed,
+        stats.reused,
+        stats.bytes_received,
+        stats.source_bytes_read,
+        stats.refusals.len()
+    );
+    for (path, code) in &stats.refusals {
+        eprintln!("refused {}: {code}", path.escape_ascii());
+    }
+    if stats.refusals.is_empty() {
+        Ok(())
+    } else {
+        Err(BulkloadRefusal::ContractSelfInconsistent)
     }
 }
 
@@ -155,10 +311,7 @@ fn row_for(len: usize, meta: &std::fs::Metadata, digest: [u8; 32]) -> RowSchema 
 
 fn scratch_path(name: &str) -> PathBuf {
     let mut path = std::env::temp_dir();
-    path.push(format!(
-        "tcfs-bulkload-agent-{name}-{}",
-        std::process::id()
-    ));
+    path.push(format!("tcfs-bulkload-agent-{name}-{}", std::process::id()));
     path
 }
 

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -52,6 +52,8 @@ SUBCOMMANDS:
                 Attach exact matching payload using existing common Git administration
     git-attach-standalone-payload BUNDLE DESTINATION SOURCE NEW_RECEIPT ORIGIN_FROM ORIGIN_TO
                 Attach exact payload with retained config and explicit local origin mapping
+    git-restore-registered-payload BUNDLE REPOSITORY DESTINATION ADMIN SOURCE NEW_RECEIPT
+                Restore absent payload only, preserving matching retained registration/index
     snapshot SOURCE OUTPUT [MAX_STEPS]
                 Capture live SQLite through its online backup API
     compose BASE INCOMING OUTPUT SOURCE_ID [MAX_STEPS]
@@ -98,6 +100,7 @@ fn main() -> ExitCode {
         ),
         Some("hydrate-state") => hydrate_command(&args.collect::<Vec<_>>()),
         Some("git-repair-missing-index") => repair_index_command(&args.collect::<Vec<_>>()),
+        Some("git-restore-registered-payload") => registered_command(&args.collect::<Vec<_>>()),
         Some("git-attach-matching-payload") => attach_payload_command(&args.collect::<Vec<_>>()),
         Some("git-attach-standalone-payload") => {
             attach_standalone_command(&args.collect::<Vec<_>>())
@@ -253,6 +256,30 @@ fn repair_index_command(args: &[std::ffi::OsString]) -> Result<()> {
     Ok(())
 }
 
+fn registered_command(args: &[std::ffi::OsString]) -> Result<()> {
+    if args.len() != 6 {
+        return Err(BulkloadRefusal::RequiredFieldMissing);
+    }
+    let path = |i| {
+        args.get(i)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    let source = args
+        .get(4)
+        .and_then(|arg| arg.to_str())
+        .ok_or(BulkloadRefusal::PathNotPortable)?;
+    tcfs_bulkload_agent::git_carry::registered::restore(
+        path(0)?,
+        path(1)?,
+        path(2)?,
+        path(3)?,
+        source,
+        path(5)?,
+    )?;
+    println!("registered payload restored; original administration and staging preserved");
+    Ok(())
+}
 fn attach_standalone_command(args: &[std::ffi::OsString]) -> Result<()> {
     if args.len() != 6 {
         return Err(BulkloadRefusal::RequiredFieldMissing);

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -25,7 +25,7 @@ SUBCOMMANDS:
     walk PATH   Stat-walk PATH and print the row and refusal counts
     copy SOURCE DEST SOURCE_STATE DEST_STATE
                 Native local copy with private resumable chunk stores
-    pull HOST SOURCE DEST SOURCE_STATE DEST_STATE [REMOTE_EXECUTABLE]
+    pull HOST SOURCE DEST SOURCE_STATE DEST_STATE [REMOTE_EXECUTABLE [SSH_CONFIG]]
                 Native SSH pull; remote tcfs-bulkload-agent must be installed
     serve       Serve one framed request on stdin/stdout (for SSH)
     git-export REPO NEW_CAPTURE_DIR
@@ -34,12 +34,16 @@ SUBCOMMANDS:
                 Preserve bundle refs in a content-addressed carry namespace
     git-restore BUNDLE ABSENT_DEST SOURCE
                 Restore captured staged/unstaged work into a new repository
+    git-restore-linked BUNDLE REPOSITORY ABSENT_DEST SOURCE
+                Restore captured work into a new linked worktree without switching others
     snapshot SOURCE OUTPUT [MAX_STEPS]
                 Capture live SQLite through its online backup API
     compose BASE INCOMING OUTPUT SOURCE_ID [MAX_STEPS]
                 Compose retained SQLite snapshots into a private candidate
     compose-state BASE INCOMING OUTPUT SOURCE_ID SOURCE_HOME DEST_HOME [MAX_STEPS]
                 Compose Codex state with retained rollout path mapping
+    hydrate-state SNAPSHOT SOURCE_HOME DEST_HOME MAX_BYTES JOBS [GZIP ZSTD]
+                Add missing raw rollouts from retained compressed files; never replace
     help        Print this message
 
 BOUNDARIES:
@@ -66,7 +70,7 @@ fn main() -> ExitCode {
         }
         Some(
             "copy" | "pull" | "snapshot" | "compose" | "compose-state" | "git-export"
-            | "git-import" | "git-restore",
+            | "git-import" | "git-restore" | "git-restore-linked",
         ) => native_command(
             command
                 .as_ref()
@@ -74,6 +78,7 @@ fn main() -> ExitCode {
                 .unwrap_or(""),
             &args.collect::<Vec<_>>(),
         ),
+        Some("hydrate-state") => hydrate_command(&args.collect::<Vec<_>>()),
         Some("serve") => tcfs_bulkload_agent::transfer::serve(
             &mut std::io::stdin().lock(),
             &mut std::io::stdout().lock(),
@@ -107,6 +112,15 @@ fn native_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
             .map(Path::new)
             .ok_or(BulkloadRefusal::RequiredFieldMissing)
     };
+    if command == "git-restore-linked" && args.len() == 4 {
+        let source = args
+            .get(3)
+            .and_then(|value| value.to_str())
+            .ok_or(BulkloadRefusal::PathNotPortable)?;
+        tcfs_bulkload_agent::git_carry::restore_linked(path(0)?, path(1)?, path(2)?, source)?;
+        println!("linked restoration complete");
+        return Ok(());
+    }
     match command {
         "git-restore" if args.len() == 3 => {
             let source = args
@@ -136,7 +150,7 @@ fn native_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
                 tcfs_bulkload_agent::transfer::copy(path(0)?, path(1)?, path(2)?, path(3)?)?;
             report_transfer(&stats)
         }
-        "pull" if (5..=6).contains(&args.len()) => pull_command(args),
+        "pull" if (5..=7).contains(&args.len()) => pull_command(args),
         "snapshot" if (2..=3).contains(&args.len()) => {
             tcfs_bulkload_agent::provider_sqlite::snapshot(
                 path(0)?,
@@ -193,6 +207,61 @@ fn native_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
     }
 }
 
+fn hydrate_command(args: &[std::ffi::OsString]) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+    if args.len() != 5 && args.len() != 7 {
+        return Err(BulkloadRefusal::RequiredFieldMissing);
+    }
+    let path = |index: usize| {
+        args.get(index)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    let number = |index: usize| -> Result<u64> {
+        args.get(index)
+            .and_then(|value| value.to_str())
+            .ok_or(BulkloadRefusal::FieldDomainViolation)?
+            .parse()
+            .map_err(|_| BulkloadRefusal::FieldDomainViolation)
+    };
+    let mapping = tcfs_bulkload_agent::provider_sqlite::PathMapping {
+        source_home: path(1)?,
+        destination_home: path(2)?,
+    };
+    let gzip = args
+        .get(5)
+        .map_or_else(|| Path::new("/usr/bin/gzip"), Path::new);
+    let zstd = args
+        .get(6)
+        .map_or_else(|| Path::new("/usr/bin/zstd"), Path::new);
+    let receipt = |report: &tcfs_bulkload_agent::provider_sqlite::hydrate::Hydrated| -> Result<()> {
+        let mut output = std::io::stdout().lock();
+        writeln!(
+            output,
+            "published={} bytes={} blake3={} source_identity={:?} path={} source={}",
+            report.published,
+            report.bytes,
+            report.blake3,
+            report.source_identity,
+            report.path.as_os_str().as_bytes().escape_ascii(),
+            report.source.as_os_str().as_bytes().escape_ascii()
+        )?;
+        output.flush()?;
+        Ok(())
+    };
+    let reports = tcfs_bulkload_agent::provider_sqlite::hydrate::hydrate_state(
+        path(0)?,
+        &mapping,
+        number(3)?,
+        usize::try_from(number(4)?).map_err(|_| BulkloadRefusal::BudgetExceeded)?,
+        gzip,
+        zstd,
+        &receipt,
+    )?;
+    println!("hydrated_files={}", reports.len());
+    Ok(())
+}
+
 fn pull_command(args: &[std::ffi::OsString]) -> Result<()> {
     let path = |index: usize| {
         args.get(index)
@@ -214,8 +283,16 @@ fn pull_command(args: &[std::ffi::OsString]) -> Result<()> {
             value
         }
     };
-    let mut child = Command::new("ssh")
-        .args(["-T", "-oBatchMode=yes", "-oConnectTimeout=15", "--"])
+    let mut ssh = Command::new("ssh");
+    ssh.args(["-T", "-oBatchMode=yes", "-oConnectTimeout=15"]);
+    if let Some(config) = args.get(6) {
+        if !Path::new(config).is_absolute() {
+            return Err(BulkloadRefusal::PathNotAbsolute);
+        }
+        ssh.arg("-F").arg(config);
+    }
+    let mut child = ssh
+        .arg("--")
         .arg(host)
         .args([remote, "serve"])
         .stdin(Stdio::piped())

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -25,9 +25,15 @@ SUBCOMMANDS:
     walk PATH   Stat-walk PATH and print the row and refusal counts
     copy SOURCE DEST SOURCE_STATE DEST_STATE
                 Native local copy with private resumable chunk stores
-    pull HOST SOURCE DEST SOURCE_STATE DEST_STATE
+    pull HOST SOURCE DEST SOURCE_STATE DEST_STATE [REMOTE_EXECUTABLE]
                 Native SSH pull; remote tcfs-bulkload-agent must be installed
     serve       Serve one framed request on stdin/stdout (for SSH)
+    git-export REPO NEW_CAPTURE_DIR
+                Archive refs/stashes and staged/worktree trees in a bundle
+    git-import REPO BUNDLE SOURCE
+                Preserve bundle refs in a content-addressed carry namespace
+    git-restore BUNDLE ABSENT_DEST SOURCE
+                Restore captured staged/unstaged work into a new repository
     snapshot SOURCE OUTPUT [MAX_STEPS]
                 Capture live SQLite through its online backup API
     compose BASE INCOMING OUTPUT SOURCE_ID [MAX_STEPS]
@@ -37,9 +43,10 @@ SUBCOMMANDS:
     help        Print this message
 
 BOUNDARIES:
+    copy/pull require an existing destination directory.
     copy/pull preserve divergent destinations and refuse live SQLite files.
     They enumerate the source each run; completed content is resumable.
-    File manifests are bounded to 8 MiB; oversized manifests refuse.
+    File manifests allow 131072 chunks and frames at most 8 MiB; oversized files refuse.
     Git-native divergent union is not supplied by copy/pull.
     compose commands write offline candidates, never install live databases.
 ";
@@ -57,7 +64,10 @@ fn main() -> ExitCode {
                 return ExitCode::from(2);
             }
         }
-        Some("copy" | "pull" | "snapshot" | "compose" | "compose-state") => native_command(
+        Some(
+            "copy" | "pull" | "snapshot" | "compose" | "compose-state" | "git-export"
+            | "git-import" | "git-restore",
+        ) => native_command(
             command
                 .as_ref()
                 .and_then(|value| value.to_str())
@@ -98,40 +108,35 @@ fn native_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
             .ok_or(BulkloadRefusal::RequiredFieldMissing)
     };
     match command {
+        "git-restore" if args.len() == 3 => {
+            let source = args
+                .get(2)
+                .and_then(|value| value.to_str())
+                .ok_or(BulkloadRefusal::PathNotPortable)?;
+            tcfs_bulkload_agent::git_carry::restore_bundle(path(0)?, path(1)?, source)?;
+            println!("{}", path(1)?.display());
+            Ok(())
+        }
+        "git-export" if args.len() == 2 => {
+            let bundle = tcfs_bulkload_agent::git_carry::export_repository(path(0)?, path(1)?)?;
+            println!("{}", bundle.display());
+            Ok(())
+        }
+        "git-import" if args.len() == 3 => {
+            let source = args
+                .get(2)
+                .and_then(|value| value.to_str())
+                .ok_or(BulkloadRefusal::PathNotPortable)?;
+            let count = tcfs_bulkload_agent::git_carry::import_bundle(path(0)?, path(1)?, source)?;
+            println!("{count}");
+            Ok(())
+        }
         "copy" if args.len() == 4 => {
             let stats =
                 tcfs_bulkload_agent::transfer::copy(path(0)?, path(1)?, path(2)?, path(3)?)?;
             report_transfer(&stats)
         }
-        "pull" if args.len() == 5 => {
-            let host = args.first().ok_or(BulkloadRefusal::RequiredFieldMissing)?;
-            let mut child = Command::new("ssh")
-                .args(["-T", "-oBatchMode=yes", "-oConnectTimeout=15", "--"])
-                .arg(host)
-                .args(["tcfs-bulkload-agent", "serve"])
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::inherit())
-                .spawn()?;
-            let result = {
-                let mut output = child.stdin.take().ok_or(BulkloadRefusal::Io(None))?;
-                let mut input = child.stdout.take().ok_or(BulkloadRefusal::Io(None))?;
-                tcfs_bulkload_agent::transfer::receive(
-                    &mut input,
-                    &mut output,
-                    path(1)?,
-                    path(3)?,
-                    path(2)?,
-                    path(4)?,
-                )
-            };
-            let exit_status = child.wait()?;
-            let stats = result?;
-            if !exit_status.success() {
-                return Err(BulkloadRefusal::Io(None));
-            }
-            report_transfer(&stats)
-        }
+        "pull" if (5..=6).contains(&args.len()) => pull_command(args),
         "snapshot" if (2..=3).contains(&args.len()) => {
             tcfs_bulkload_agent::provider_sqlite::snapshot(
                 path(0)?,
@@ -186,6 +191,55 @@ fn native_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
         }
         _ => Err(BulkloadRefusal::RequiredFieldMissing),
     }
+}
+
+fn pull_command(args: &[std::ffi::OsString]) -> Result<()> {
+    let path = |index: usize| {
+        args.get(index)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    let host = args.first().ok_or(BulkloadRefusal::RequiredFieldMissing)?;
+    let remote = match args.get(5) {
+        None => "tcfs-bulkload-agent",
+        Some(value) => {
+            let value = value.to_str().ok_or(BulkloadRefusal::PathNotPortable)?;
+            if !Path::new(value).is_absolute()
+                || !value
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"/_-.".contains(&b))
+            {
+                return Err(BulkloadRefusal::PathNotPortable);
+            }
+            value
+        }
+    };
+    let mut child = Command::new("ssh")
+        .args(["-T", "-oBatchMode=yes", "-oConnectTimeout=15", "--"])
+        .arg(host)
+        .args([remote, "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+    let result = {
+        let mut output = child.stdin.take().ok_or(BulkloadRefusal::Io(None))?;
+        let mut input = child.stdout.take().ok_or(BulkloadRefusal::Io(None))?;
+        tcfs_bulkload_agent::transfer::receive(
+            &mut input,
+            &mut output,
+            path(1)?,
+            path(3)?,
+            path(2)?,
+            path(4)?,
+        )
+    };
+    let exit_status = child.wait()?;
+    let stats = result?;
+    if !exit_status.success() {
+        return Err(BulkloadRefusal::Io(None));
+    }
+    report_transfer(&stats)
 }
 
 fn steps(value: Option<&std::ffi::OsString>) -> Result<u32> {

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -48,6 +48,8 @@ SUBCOMMANDS:
                 Restore captured work into a new linked worktree without switching others
     git-repair-missing-index BUNDLE REPOSITORY SOURCE NEW_RECEIPT
                 Create a missing same-HEAD staged index only; never rewrite payload
+    git-attach-matching-payload BUNDLE REPOSITORY DESTINATION SOURCE NEW_RECEIPT
+                Attach exact matching payload using existing common Git administration
     snapshot SOURCE OUTPUT [MAX_STEPS]
                 Capture live SQLite through its online backup API
     compose BASE INCOMING OUTPUT SOURCE_ID [MAX_STEPS]
@@ -94,6 +96,7 @@ fn main() -> ExitCode {
         ),
         Some("hydrate-state") => hydrate_command(&args.collect::<Vec<_>>()),
         Some("git-repair-missing-index") => repair_index_command(&args.collect::<Vec<_>>()),
+        Some("git-attach-matching-payload") => attach_payload_command(&args.collect::<Vec<_>>()),
         Some(
             name @ ("estate-add" | "estate-add-batch" | "estate-show" | "estate-capture"
             | "estate-apply"),
@@ -242,6 +245,30 @@ fn repair_index_command(args: &[std::ffi::OsString]) -> Result<()> {
         .ok_or(BulkloadRefusal::PathNotPortable)?;
     tcfs_bulkload_agent::git_carry::repair_missing_index(path(0)?, path(1)?, source, path(3)?)?;
     println!("missing index repaired; payload parity not asserted");
+    Ok(())
+}
+
+fn attach_payload_command(args: &[std::ffi::OsString]) -> Result<()> {
+    if args.len() != 5 {
+        return Err(BulkloadRefusal::RequiredFieldMissing);
+    }
+    let path = |i| {
+        args.get(i)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    let source = args
+        .get(3)
+        .and_then(|value| value.to_str())
+        .ok_or(BulkloadRefusal::PathNotPortable)?;
+    tcfs_bulkload_agent::git_carry::attach_matching_payload(
+        path(0)?,
+        path(1)?,
+        path(2)?,
+        source,
+        path(4)?,
+    )?;
+    println!("matching payload attached; existing common Git administration preserved");
     Ok(())
 }
 

--- a/crates/tcfs-bulkload-agent/src/main.rs
+++ b/crates/tcfs-bulkload-agent/src/main.rs
@@ -30,12 +30,24 @@ SUBCOMMANDS:
     serve       Serve one framed request on stdin/stdout (for SSH)
     git-export REPO NEW_CAPTURE_DIR
                 Archive refs/stashes and staged/worktree trees in a bundle
+    estate-add PLAN SOURCE_REPO DEST_REPO [ABSENT_WORKSPACE]
+                Append an explicit reviewed item; no automatic worktree proliferation
+    estate-show PLAN
+                Print the exact selected sources, repositories and restore targets
+    estate-add-batch PLAN SOURCE DEST WORKSPACE_OR_DASH [SOURCE DEST WORKSPACE_OR_DASH ...]
+                Append selected items in one linear plan update
+    estate-capture PLAN PRIVATE_STATE CORPUS JOBS
+                Capture reviewed Git items with successful capture reuse (jobs 1 or 2)
+    estate-apply PLAN CORPUS PRIVATE_STATE SOURCE JOBS
+                Import refs and restore only explicitly selected absent workspaces
     git-import REPO BUNDLE SOURCE
                 Preserve bundle refs in a content-addressed carry namespace
     git-restore BUNDLE ABSENT_DEST SOURCE
                 Restore captured staged/unstaged work into a new repository
     git-restore-linked BUNDLE REPOSITORY ABSENT_DEST SOURCE
                 Restore captured work into a new linked worktree without switching others
+    git-repair-missing-index BUNDLE REPOSITORY SOURCE NEW_RECEIPT
+                Create a missing same-HEAD staged index only; never rewrite payload
     snapshot SOURCE OUTPUT [MAX_STEPS]
                 Capture live SQLite through its online backup API
     compose BASE INCOMING OUTPUT SOURCE_ID [MAX_STEPS]
@@ -81,6 +93,11 @@ fn main() -> ExitCode {
             &args.collect::<Vec<_>>(),
         ),
         Some("hydrate-state") => hydrate_command(&args.collect::<Vec<_>>()),
+        Some("git-repair-missing-index") => repair_index_command(&args.collect::<Vec<_>>()),
+        Some(
+            name @ ("estate-add" | "estate-add-batch" | "estate-show" | "estate-capture"
+            | "estate-apply"),
+        ) => estate_command(name, &args.collect::<Vec<_>>()),
         Some("apply-state-candidate") => apply_state_command(&args.collect::<Vec<_>>()),
         Some("serve") => tcfs_bulkload_agent::transfer::serve(
             &mut std::io::stdin().lock(),
@@ -205,6 +222,98 @@ fn native_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
                 stats.paths_corrected, stats.unavailable_rollouts
             );
             Ok(())
+        }
+        _ => Err(BulkloadRefusal::RequiredFieldMissing),
+    }
+}
+
+fn repair_index_command(args: &[std::ffi::OsString]) -> Result<()> {
+    if args.len() != 4 {
+        return Err(BulkloadRefusal::RequiredFieldMissing);
+    }
+    let path = |i| {
+        args.get(i)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    let source = args
+        .get(2)
+        .and_then(|value| value.to_str())
+        .ok_or(BulkloadRefusal::PathNotPortable)?;
+    tcfs_bulkload_agent::git_carry::repair_missing_index(path(0)?, path(1)?, source, path(3)?)?;
+    println!("missing index repaired; payload parity not asserted");
+    Ok(())
+}
+
+// Escaped paths are intentional: receipts must not permit embedded newlines.
+#[allow(clippy::unnecessary_debug_formatting)]
+fn estate_command(command: &str, args: &[std::ffi::OsString]) -> Result<()> {
+    use tcfs_bulkload_agent::estate;
+    let path = |i| {
+        args.get(i)
+            .map(Path::new)
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)
+    };
+    let jobs = || {
+        args.last()
+            .and_then(|arg| arg.to_str())
+            .ok_or(BulkloadRefusal::FieldDomainViolation)?
+            .parse::<usize>()
+            .map_err(|_| BulkloadRefusal::FieldDomainViolation)
+    };
+    let receipt = |row: &estate::Receipt| {
+        let mut output = std::io::stdout().lock();
+        writeln!(
+            output,
+            "item={} source={:?} outcome={} reason={:?}",
+            row.item, row.source, row.outcome, row.reason
+        )?;
+        output.flush()?;
+        Ok(())
+    };
+    match command {
+        "estate-show" if args.len() == 1 => {
+            for item in estate::inspect(path(0)?)? {
+                println!("{item:?}");
+            }
+            Ok(())
+        }
+        "estate-add" if (3..=4).contains(&args.len()) => {
+            estate::add(path(0)?, path(1)?, path(2)?, args.get(3).map(Path::new))
+        }
+        "estate-add-batch" if args.len() >= 4 && (args.len() - 1).is_multiple_of(3) => {
+            let mut items = Vec::new();
+            for group in args
+                .get(1..)
+                .ok_or(BulkloadRefusal::RequiredFieldMissing)?
+                .chunks_exact(3)
+            {
+                let source = group
+                    .first()
+                    .map(PathBuf::from)
+                    .ok_or(BulkloadRefusal::RequiredFieldMissing)?;
+                let repository = group
+                    .get(1)
+                    .map(PathBuf::from)
+                    .ok_or(BulkloadRefusal::RequiredFieldMissing)?;
+                let workspace = group.get(2).filter(|p| *p != "-").map(PathBuf::from);
+                items.push(estate::Item {
+                    source,
+                    repository,
+                    workspace,
+                });
+            }
+            estate::add_batch(path(0)?, &items)
+        }
+        "estate-capture" if args.len() == 4 => {
+            estate::capture(path(0)?, path(1)?, path(2)?, jobs()?, &receipt)
+        }
+        "estate-apply" if args.len() == 5 => {
+            let source = args
+                .get(3)
+                .and_then(|arg| arg.to_str())
+                .ok_or(BulkloadRefusal::FieldDomainViolation)?;
+            estate::apply(path(0)?, path(1)?, path(2)?, source, jobs()?, &receipt)
         }
         _ => Err(BulkloadRefusal::RequiredFieldMissing),
     }

--- a/crates/tcfs-bulkload-agent/src/materialize.rs
+++ b/crates/tcfs-bulkload-agent/src/materialize.rs
@@ -1,0 +1,343 @@
+//! Descriptor-relative, no-clobber output publication.
+
+use std::ffi::CString;
+use std::fs::{File, Permissions};
+use std::io::{Read as _, Seek as _, Write as _};
+use std::os::fd::{AsRawFd as _, FromRawFd as _};
+use std::os::unix::ffi::OsStrExt as _;
+use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::freshness::StatIdentity;
+use crate::transfer_store::{Manifest, Store};
+use crate::{BulkloadRefusal, Result, RowSchema};
+
+static NEXT_FILE: AtomicU64 = AtomicU64::new(0);
+
+/// An opened destination root; descendants never traverse symlinks.
+pub struct Destination {
+    root: File,
+    path: PathBuf,
+    directories: Vec<PendingDirectory>,
+}
+
+struct PendingDirectory {
+    path: Vec<u8>,
+    mode: u32,
+    dev: u64,
+    ino: u64,
+    key: Vec<u8>,
+}
+
+impl Destination {
+    /// Open an existing destination directory without following its final link.
+    ///
+    /// # Errors
+    /// Refuses a missing root or symlink root.
+    pub fn open(path: &Path) -> Result<Self> {
+        let root = open_dir(libc::AT_FDCWD, &cstring(path.as_os_str().as_bytes())?)?;
+        Ok(Self {
+            root,
+            path: std::fs::canonicalize(path)?,
+            directories: Vec::new(),
+        })
+    }
+
+    /// Canonical destination root for completion-store namespacing.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Identity of an existing regular output. No symlink is followed.
+    ///
+    /// # Errors
+    /// Refuses a conflicting node or unsafe ancestor.
+    pub fn identity(&self, row: &RowSchema) -> Result<Option<StatIdentity>> {
+        let (parent, leaf) = self.parent(&row.rel_path)?;
+        match open_regular(&parent, &leaf) {
+            Ok(file) => Ok(Some(StatIdentity::from_metadata(&file.metadata()?))),
+            Err(BulkloadRefusal::Io(Some(libc::ENOENT))) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Create a directory, retaining an existing directory's metadata.
+    ///
+    /// # Errors
+    /// Refuses non-directory conflicts and divergent existing modes.
+    pub fn directory(&mut self, row: &RowSchema, store: &Store, authority: &[u8]) -> Result<()> {
+        let (parent, leaf) = self.parent(&row.rel_path)?;
+        let key = postcard::to_stdvec(&(authority, &row.rel_path))?;
+        let mode = row.mode & 0o7777;
+        // SAFETY: both descriptors and the NUL-terminated leaf remain valid.
+        let created = unsafe { libc::mkdirat(parent.as_raw_fd(), leaf.as_ptr(), 0o700) };
+        if created == 0 {
+            let metadata = open_dir(parent.as_raw_fd(), &leaf)?.metadata()?;
+            store.pending_directory(&key, metadata.dev(), metadata.ino(), mode, true)?;
+            self.directories.push(PendingDirectory {
+                path: row.rel_path.clone(),
+                mode,
+                dev: metadata.dev(),
+                ino: metadata.ino(),
+                key,
+            });
+            parent.sync_all()?;
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::AlreadyExists {
+            return Err(error.into());
+        }
+        let existing = open_dir(parent.as_raw_fd(), &leaf)?;
+        let metadata = existing.metadata()?;
+        if store.pending_directory(&key, metadata.dev(), metadata.ino(), mode, false)? {
+            self.directories.push(PendingDirectory {
+                path: row.rel_path.clone(),
+                mode,
+                dev: metadata.dev(),
+                ino: metadata.ino(),
+                key,
+            });
+        } else if metadata.mode() & 0o7777 != mode {
+            return Err(BulkloadRefusal::GitDestinationOccupied);
+        }
+        Ok(())
+    }
+
+    /// Apply final modes to directories this invocation created, deepest first.
+    ///
+    /// # Errors
+    /// Refuses changed/removed directories and failed durable metadata writes.
+    pub fn finish_directories(&self, store: &Store) -> Result<()> {
+        for pending in self.directories.iter().rev() {
+            let (parent, leaf) = self.parent(&pending.path)?;
+            let directory = open_dir(parent.as_raw_fd(), &leaf)?;
+            let metadata = directory.metadata()?;
+            if metadata.dev() != pending.dev || metadata.ino() != pending.ino {
+                return Err(BulkloadRefusal::GitDestinationOccupied);
+            }
+            directory.set_permissions(Permissions::from_mode(pending.mode))?;
+            directory.sync_all()?;
+            store.complete_directory(&pending.key)?;
+        }
+        Ok(())
+    }
+
+    /// Preserve the literal target of a source symlink, without following it.
+    ///
+    /// # Errors
+    /// Refuses a different existing target or any unsafe ancestor.
+    pub fn symlink(&self, row: &RowSchema) -> Result<()> {
+        let (parent, leaf) = self.parent(&row.rel_path)?;
+        let target = row
+            .link_target
+            .as_ref()
+            .ok_or(BulkloadRefusal::RequiredFieldMissing)?;
+        let target_c = cstring(target)?;
+        // SAFETY: descriptor and both NUL-terminated strings remain valid.
+        let result =
+            unsafe { libc::symlinkat(target_c.as_ptr(), parent.as_raw_fd(), leaf.as_ptr()) };
+        if result == 0 {
+            parent.sync_all()?;
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::AlreadyExists {
+            return Err(error.into());
+        }
+        let mut bytes = vec![0_u8; target.len().saturating_add(1)];
+        // SAFETY: bytes is writable for its full length; strings/descriptors valid.
+        let read = unsafe {
+            libc::readlinkat(
+                parent.as_raw_fd(),
+                leaf.as_ptr(),
+                bytes.as_mut_ptr().cast(),
+                bytes.len(),
+            )
+        };
+        if usize::try_from(read).ok() != Some(target.len())
+            || bytes.get(..target.len()) != Some(target.as_slice())
+        {
+            return Err(BulkloadRefusal::GitDestinationOccupied);
+        }
+        Ok(())
+    }
+
+    /// Verify chunks and publish a complete file with link-at no-replace semantics.
+    ///
+    /// # Errors
+    /// Refuses corrupt/missing chunks, size/digest mismatches or destination divergence.
+    pub fn file(
+        &self,
+        row: &RowSchema,
+        manifest: &Manifest,
+        store: &Store,
+    ) -> Result<StatIdentity> {
+        let (parent, leaf) = self.parent(&row.rel_path)?;
+        match open_regular(&parent, &leaf) {
+            Ok(file) => return verify_existing(file, row, manifest),
+            Err(BulkloadRefusal::Io(Some(libc::ENOENT))) => (),
+            Err(error) => return Err(error),
+        }
+        let temporary = cstring(
+            format!(
+                ".bulkload-{}-{}",
+                std::process::id(),
+                NEXT_FILE.fetch_add(1, Ordering::Relaxed)
+            )
+            .as_bytes(),
+        )?;
+        // SAFETY: parent descriptor and path are valid; mode accompanies O_CREAT.
+        let fd = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                temporary.as_ptr(),
+                libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+                0o600,
+            )
+        };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        // SAFETY: fd is a newly-created uniquely owned descriptor.
+        let mut file = unsafe { File::from_raw_fd(fd) };
+        let result = write_chunks(&mut file, row, manifest, store).and_then(|()| {
+            // SAFETY: all descriptors/paths valid; linkat never replaces an existing leaf.
+            let linked = unsafe {
+                libc::linkat(
+                    parent.as_raw_fd(),
+                    temporary.as_ptr(),
+                    parent.as_raw_fd(),
+                    leaf.as_ptr(),
+                    0,
+                )
+            };
+            if linked != 0 {
+                return Err(std::io::Error::last_os_error().into());
+            }
+            parent.sync_all()?;
+            Ok(())
+        });
+        // SAFETY: remove only the unique temporary name created above.
+        let removed = unsafe { libc::unlinkat(parent.as_raw_fd(), temporary.as_ptr(), 0) };
+        if removed != 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        result?;
+        verify_existing(file, row, manifest)
+    }
+
+    fn parent(&self, path: &[u8]) -> Result<(File, CString)> {
+        let mut parts = path.split(|byte| *byte == b'/').peekable();
+        let mut directory = self.root.try_clone()?;
+        while let Some(part) = parts.next() {
+            if part.is_empty() || part == b"." || part == b".." {
+                return Err(BulkloadRefusal::PathEscapesRoot);
+            }
+            let component = cstring(part)?;
+            if parts.peek().is_none() {
+                return Ok((directory, component));
+            }
+            directory = open_dir(directory.as_raw_fd(), &component)?;
+        }
+        Err(BulkloadRefusal::PathEscapesRoot)
+    }
+}
+
+fn write_chunks(
+    file: &mut File,
+    row: &RowSchema,
+    manifest: &Manifest,
+    store: &Store,
+) -> Result<()> {
+    let mut hasher = blake3::Hasher::new();
+    let mut size = 0_u64;
+    for chunk in &manifest.chunks {
+        let data = store
+            .chunk(&chunk.digest)?
+            .ok_or(BulkloadRefusal::SealedObjectMissing)?;
+        if data.len() as u64 != chunk.size {
+            return Err(BulkloadRefusal::DigestMismatch);
+        }
+        size = size
+            .checked_add(chunk.size)
+            .ok_or(BulkloadRefusal::BudgetExceeded)?;
+        if size > row.size {
+            return Err(BulkloadRefusal::DigestMismatch);
+        }
+        hasher.update(&data);
+        file.write_all(&data)?;
+    }
+    if size != row.size || *hasher.finalize().as_bytes() != manifest.digest {
+        return Err(BulkloadRefusal::DigestMismatch);
+    }
+    file.set_permissions(Permissions::from_mode(row.mode & 0o7777))?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn verify_existing(mut file: File, row: &RowSchema, manifest: &Manifest) -> Result<StatIdentity> {
+    file.rewind()?;
+    let before = file.metadata()?;
+    if before.len() != row.size || before.mode() & 0o7777 != row.mode & 0o7777 {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    let identity = StatIdentity::from_metadata(&before);
+    let mut buffer = vec![0; 256 * 1024];
+    let mut hasher = blake3::Hasher::new();
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(buffer.get(..read).ok_or(BulkloadRefusal::Io(None))?);
+    }
+    if *hasher.finalize().as_bytes() != manifest.digest
+        || StatIdentity::from_metadata(&file.metadata()?) != identity
+    {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    Ok(identity)
+}
+
+fn open_dir(parent: i32, name: &CString) -> Result<File> {
+    // SAFETY: name is NUL-terminated; successful descriptor is uniquely owned.
+    let fd = unsafe {
+        libc::openat(
+            parent,
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    // SAFETY: fd is a newly opened descriptor.
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+fn open_regular(parent: &File, name: &CString) -> Result<File> {
+    // SAFETY: parent and name are valid; no create flag needs a mode argument.
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    // SAFETY: fd is uniquely owned.
+    let file = unsafe { File::from_raw_fd(fd) };
+    if !file.metadata()?.is_file() {
+        return Err(BulkloadRefusal::GitDestinationOccupied);
+    }
+    Ok(file)
+}
+
+fn cstring(bytes: &[u8]) -> Result<CString> {
+    CString::new(bytes).map_err(|_| BulkloadRefusal::PathNotPortable)
+}

--- a/crates/tcfs-bulkload-agent/src/provider_sqlite.rs
+++ b/crates/tcfs-bulkload-agent/src/provider_sqlite.rs
@@ -13,6 +13,30 @@ use rusqlite::{Connection, OpenFlags};
 
 use crate::{BulkloadRefusal, Result};
 
+pub mod hydrate;
+
+fn mapped_path(path: &Path, mapping: &PathMapping<'_>) -> std::path::PathBuf {
+    if mapping.source_home == Path::new("/Users/jess") {
+        if let Ok(relative) = path.strip_prefix("/Volumes/TinylandState/tinyland-state/codex") {
+            return mapping.destination_home.join(".codex").join(relative);
+        }
+    }
+    path.strip_prefix(mapping.source_home).map_or_else(
+        |_| path.to_path_buf(),
+        |relative| mapping.destination_home.join(relative),
+    )
+}
+
+fn mapped_rollout_path(path: &Path, mapping: &PathMapping<'_>) -> std::path::PathBuf {
+    let mapped = mapped_path(path, mapping);
+    match mapped.to_str() {
+        Some(value) if value.ends_with(".jsonl.gz") || value.ends_with(".jsonl.zst") => {
+            mapped.with_extension("")
+        }
+        _ => mapped,
+    }
+}
+
 /// Capture a standalone database in an existing private directory.
 ///
 /// `max_steps` bounds retries and total backup steps, including restarts caused
@@ -302,7 +326,7 @@ fn correct_base_paths(
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(sql_refusal)?;
         let needs_mapping = [rollout,cwd].iter().any(|index| {
-            matches!(values.get(*index), Some(Value::Text(path)) if Path::new(path).starts_with(mapping.source_home))
+            matches!(values.get(*index), Some(Value::Text(path)) if (if *index == rollout {mapped_rollout_path(Path::new(path), mapping)} else {mapped_path(Path::new(path), mapping)}) != Path::new(path))
         });
         if !needs_mapping {
             continue;
@@ -502,10 +526,11 @@ fn mapped_values(
             {
                 return Ok(None);
             }
-            let mapped = path.strip_prefix(mapping.source_home).map_or_else(
-                |_| path.to_path_buf(),
-                |relative| mapping.destination_home.join(relative),
-            );
+            let mapped = if column.0 == "rollout_path" {
+                mapped_rollout_path(path, mapping)
+            } else {
+                mapped_path(path, mapping)
+            };
             if column.0 == "rollout_path" && !mapped.is_file() {
                 return Ok(None);
             }

--- a/crates/tcfs-bulkload-agent/src/provider_sqlite.rs
+++ b/crates/tcfs-bulkload-agent/src/provider_sqlite.rs
@@ -14,6 +14,7 @@ use rusqlite::{Connection, OpenFlags};
 use crate::{BulkloadRefusal, Result};
 
 pub mod hydrate;
+pub mod online;
 
 fn mapped_path(path: &Path, mapping: &PathMapping<'_>) -> std::path::PathBuf {
     if mapping.source_home == Path::new("/Users/jess") {

--- a/crates/tcfs-bulkload-agent/src/provider_sqlite.rs
+++ b/crates/tcfs-bulkload-agent/src/provider_sqlite.rs
@@ -1,6 +1,6 @@
 //! Standalone provider snapshots using `SQLite`'s online backup API.
 //!
-//! This module never installs a snapshot over a live database or merges rows.
+//! This module never installs a snapshot over a live database.
 //! All tables, including unknown tables and recovery orphans, are preserved.
 
 use std::fs::{self, OpenOptions};
@@ -100,10 +100,750 @@ pub fn snapshot(source: &Path, output: &Path, max_steps: u32) -> Result<()> {
     Ok(())
 }
 
+/// Accounting for an offline candidate. Preserved rows require explicit
+/// resolution before any future installation; they are never silently dropped.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Composition {
+    /// Rows inserted in native provider tables.
+    pub inserted: u64,
+    /// Rows already equal, or already imported from this immutable source.
+    pub equivalent: u64,
+    /// Divergent, recovery, or unsupported rows retained with typed values.
+    pub preserved: u64,
+    /// All unresolved provenance rows in the candidate, including earlier runs.
+    pub unresolved: u64,
+    /// Existing candidate threads whose typed home paths were corrected.
+    pub paths_corrected: u64,
+    /// Existing source-prefix threads whose mapped rollout is unavailable.
+    pub unavailable_rollouts: u64,
+}
+
+/// Compose retained snapshots into a new offline candidate.
+///
+/// Supports matching Codex history schemas and log schemas. History key or
+/// secondary-index collisions preserve the incoming row separately. Log IDs
+/// are host-local: incoming IDs are remapped and their original typed rows
+/// retained with provenance. This intentionally does not deduplicate log
+/// events across different sources. Recovery and unknown tables are retained
+/// as typed rows, not interpreted or installed as provider state.
+///
+/// `source_id` must identify immutable snapshot bytes (prefer their digest).
+/// Reusing it for different bytes is invalid. Neither input may change during
+/// composition. No provider process needs to pause for this offline operation.
+/// A returned candidate is never permission to replace a live database.
+///
+/// # Errors
+/// Refuses invalid source IDs, `SQLite` errors, and invalid candidate integrity.
+/// Failure leaves an incomplete private candidate, with both inputs untouched.
+pub fn compose_snapshots(
+    base: &Path,
+    incoming: &Path,
+    output: &Path,
+    source_id: &str,
+    max_steps: u32,
+) -> Result<Composition> {
+    compose(base, incoming, output, source_id, max_steps, None)
+}
+
+/// Typed home-path translation for importing missing provider threads.
+pub struct PathMapping<'a> {
+    /// Source home prefix, e.g. `/Users/jess`.
+    pub source_home: &'a Path,
+    /// Destination home prefix, e.g. `/home/jess`.
+    pub destination_home: &'a Path,
+}
+
+/// Compose missing Codex state rows with existing destination rollout files.
+///
+/// Imports compatible project/section dependencies before missing threads.
+/// Path fields alone are translated. Missing rollout files, divergent keys,
+/// and newer source-only columns stay in typed provenance; no control or
+/// enrollment table is activated and no target schema migration is invented.
+///
+/// # Errors
+/// Uses the same offline/private-output refusals as [`compose_snapshots`].
+pub fn compose_state_snapshots(
+    base: &Path,
+    incoming: &Path,
+    output: &Path,
+    source_id: &str,
+    max_steps: u32,
+    mapping: &PathMapping<'_>,
+) -> Result<Composition> {
+    if !mapping.source_home.is_absolute() || !mapping.destination_home.is_absolute() {
+        return Err(BulkloadRefusal::PathNotPortable);
+    }
+    compose(base, incoming, output, source_id, max_steps, Some(mapping))
+}
+
+fn compose(
+    base: &Path,
+    incoming: &Path,
+    output: &Path,
+    source_id: &str,
+    max_steps: u32,
+    mapping: Option<&PathMapping<'_>>,
+) -> Result<Composition> {
+    if source_id.is_empty() {
+        return Err(BulkloadRefusal::SqliteUnsupportedValue);
+    }
+    snapshot(base, output, max_steps)?;
+    let source = Connection::open_with_flags(incoming, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(sql_refusal)?;
+    source.busy_timeout(Duration::ZERO).map_err(sql_refusal)?;
+    source.execute_batch("BEGIN").map_err(sql_refusal)?;
+    let mut destination = Connection::open(output).map_err(sql_refusal)?;
+    destination
+        .busy_timeout(Duration::ZERO)
+        .map_err(sql_refusal)?;
+    destination
+        .execute_batch("PRAGMA foreign_keys=ON")
+        .map_err(sql_refusal)?;
+    let transaction = destination.transaction().map_err(sql_refusal)?;
+    transaction
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS bulkload_provider_rows (
+        source_id TEXT NOT NULL, table_name TEXT NOT NULL,
+        ordinal INTEGER NOT NULL, columns_blob BLOB NOT NULL,
+        row_blob BLOB NOT NULL, disposition TEXT NOT NULL,
+        native_id INTEGER, PRIMARY KEY(source_id,table_name,ordinal))",
+        )
+        .map_err(sql_refusal)?;
+    let mut tables = source
+        .prepare("SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name")
+        .map_err(sql_refusal)?
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(sql_refusal)?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(sql_refusal)?;
+    let mut summary = Composition::default();
+    if let Some(mapping) = mapping {
+        correct_base_paths(base, &transaction, mapping, &mut summary)?;
+    }
+    tables.sort_by_key(|table| match table.as_str() {
+        "projects" | "thread_sections" => 0,
+        "threads" => 1,
+        _ => 2,
+    });
+    for table in tables {
+        compose_table(
+            &source,
+            &transaction,
+            &table,
+            source_id,
+            mapping,
+            &mut summary,
+        )?;
+    }
+    let foreign_key_errors: i64 = transaction
+        .query_row("SELECT count(*) FROM pragma_foreign_key_check", [], |row| {
+            row.get(0)
+        })
+        .map_err(sql_refusal)?;
+    if foreign_key_errors != 0 {
+        return Err(BulkloadRefusal::SqliteIntegrityCheckFailed);
+    }
+    summary.unresolved = transaction
+        .query_row(
+            "SELECT count(*) FROM bulkload_provider_rows WHERE disposition IN ('conflict','unsupported','source-columns','base-path-unavailable')",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(sql_refusal)?;
+    transaction.commit().map_err(sql_refusal)?;
+    let integrity: String = destination
+        .query_row("PRAGMA quick_check", [], |row| row.get(0))
+        .map_err(sql_refusal)?;
+    if integrity != "ok" {
+        return Err(BulkloadRefusal::SqliteIntegrityCheckFailed);
+    }
+    fs::File::open(output)?.sync_all()?;
+    Ok(summary)
+}
+
+fn sql_refusal(_: rusqlite::Error) -> BulkloadRefusal {
+    BulkloadRefusal::SqliteUnsupportedValue
+}
+
+fn correct_base_paths(
+    base: &Path,
+    destination: &Connection,
+    mapping: &PathMapping<'_>,
+    summary: &mut Composition,
+) -> Result<()> {
+    use rusqlite::{params, types::Value};
+    let source =
+        Connection::open_with_flags(base, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(sql_refusal)?;
+    let schema = columns(&source, "threads")?;
+    if schema.is_empty() {
+        return Ok(());
+    }
+    if !native_insert_is_safe(destination, "threads", &schema)? {
+        return Err(BulkloadRefusal::SqliteUnsupportedValue);
+    }
+    let index = |name: &str| {
+        schema
+            .iter()
+            .position(|column| column.0 == name)
+            .ok_or(BulkloadRefusal::SqliteUnsupportedValue)
+    };
+    let id = index("id")?;
+    let rollout = index("rollout_path")?;
+    let cwd = index("cwd")?;
+    let columns_blob =
+        postcard::to_stdvec(&schema).map_err(|_| BulkloadRefusal::SqliteUnsupportedValue)?;
+    let mut statement = source
+        .prepare("SELECT * FROM threads")
+        .map_err(sql_refusal)?;
+    let mut rows = statement.query([]).map_err(sql_refusal)?;
+    while let Some(row) = rows.next().map_err(sql_refusal)? {
+        let values = (0..schema.len())
+            .map(|column| row.get::<_, Value>(column))
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(sql_refusal)?;
+        let needs_mapping = [rollout,cwd].iter().any(|index| {
+            matches!(values.get(*index), Some(Value::Text(path)) if Path::new(path).starts_with(mapping.source_home))
+        });
+        if !needs_mapping {
+            continue;
+        }
+        let encoded = encode_row(&values);
+        let provenance = format!("base-path:{}", blake3::hash(&encoded).to_hex());
+        let disposition = if let Some(mapped) =
+            mapped_values("threads", &schema, &schema, &values, Some(mapping))?
+        {
+            let updated = destination.prepare_cached("UPDATE threads SET rollout_path=?1,cwd=?2 WHERE id IS ?3 AND rollout_path IS ?4 AND cwd IS ?5")
+                .map_err(sql_refusal)?.execute(params![
+                    mapped.get(rollout), mapped.get(cwd), values.get(id), values.get(rollout), values.get(cwd)
+                ]).map_err(sql_refusal)?;
+            if updated != 1 {
+                return Err(BulkloadRefusal::SqliteStateChanged);
+            }
+            summary.paths_corrected += 1;
+            "base-path-corrected"
+        } else {
+            summary.unavailable_rollouts += 1;
+            "base-path-unavailable"
+        };
+        destination.prepare_cached("INSERT INTO bulkload_provider_rows VALUES (?1,'threads',0,?2,?3,?4,NULL) ON CONFLICT(source_id,table_name,ordinal) DO UPDATE SET disposition=excluded.disposition WHERE columns_blob=excluded.columns_blob AND row_blob=excluded.row_blob")
+            .map_err(sql_refusal)?.execute(params![provenance,columns_blob,encoded,disposition]).map_err(sql_refusal)?;
+    }
+    Ok(())
+}
+
+fn identifier(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+fn columns(connection: &Connection, table: &str) -> Result<Vec<(String, String, i64, i64)>> {
+    connection
+        .prepare(&format!("PRAGMA table_info({})", identifier(table)))
+        .map_err(sql_refusal)?
+        .query_map([], |row| {
+            Ok((row.get(1)?, row.get(2)?, row.get(3)?, row.get(5)?))
+        })
+        .map_err(sql_refusal)?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(sql_refusal)
+}
+
+// Typed provenance format: repeated tag/u64-LE-length/payload values. Tags
+// 0..4 are NULL, i64-LE, f64 bits-LE, UTF-8 text, and opaque blob respectively.
+// The columns_blob stores postcard (name, declared type, not-null, PK ordinal)
+// tuples in exactly the same order. Even identical recovery rows keep distinct
+// source ordinals; no DISTINCT/set reduction discards their multiplicity.
+fn encode_row(values: &[rusqlite::types::Value]) -> Vec<u8> {
+    use rusqlite::types::Value;
+    let mut encoded = Vec::new();
+    for value in values {
+        let (tag, bytes) = match value {
+            Value::Null => (0, Vec::new()),
+            Value::Integer(value) => (1, value.to_le_bytes().to_vec()),
+            Value::Real(value) => (2, value.to_bits().to_le_bytes().to_vec()),
+            Value::Text(value) => (3, value.as_bytes().to_vec()),
+            Value::Blob(value) => (4, value.clone()),
+        };
+        encoded.push(tag);
+        encoded.extend_from_slice(&u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_le_bytes());
+        encoded.extend_from_slice(&bytes);
+    }
+    encoded
+}
+
+fn compose_table(
+    source: &Connection,
+    destination: &Connection,
+    table: &str,
+    source_id: &str,
+    mapping: Option<&PathMapping<'_>>,
+    summary: &mut Composition,
+) -> Result<()> {
+    use rusqlite::{params, OptionalExtension as _};
+    let schema = columns(source, table)?;
+    let target_schema = columns(destination, table)?;
+    let history = matches!(
+        table,
+        "thread_turns"
+            | "thread_items"
+            | "thread_history_projection_state"
+            | "thread_realtime_items"
+            | "logs"
+    ) && schema == target_schema;
+    let state = mapping.is_some()
+        && matches!(
+            table,
+            "projects"
+                | "thread_sections"
+                | "project_roots"
+                | "threads"
+                | "thread_dynamic_tools"
+                | "thread_artifacts"
+                | "thread_spawn_edges"
+        )
+        && !target_schema.is_empty()
+        && target_schema.iter().all(|column| schema.contains(column));
+    let native = (history || state) && native_insert_is_safe(destination, table, &target_schema)?;
+    let names: Vec<_> = target_schema
+        .iter()
+        .map(|column| identifier(&column.0))
+        .collect();
+    let columns_blob =
+        postcard::to_stdvec(&schema).map_err(|_| BulkloadRefusal::SqliteUnsupportedValue)?;
+    let mut select = source
+        .prepare(&format!("SELECT * FROM {}", identifier(table)))
+        .map_err(sql_refusal)?;
+    let count = select.column_count();
+    let mut rows = select.query([]).map_err(sql_refusal)?;
+    let mut ordinal = 0_i64;
+    while let Some(row) = rows.next().map_err(sql_refusal)? {
+        ordinal = ordinal
+            .checked_add(1)
+            .ok_or(BulkloadRefusal::BudgetExceeded)?;
+        let values = (0..count)
+            .map(|index| row.get::<_, rusqlite::types::Value>(index))
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(sql_refusal)?;
+        let encoded = encode_row(&values);
+        let previous: Option<Vec<u8>> = destination.prepare_cached(
+            "SELECT row_blob FROM bulkload_provider_rows WHERE source_id=?1 AND table_name=?2 AND ordinal=?3"
+        ).map_err(sql_refusal)?.query_row(
+            params![source_id, table, ordinal], |row| row.get(0)
+        ).optional().map_err(sql_refusal)?;
+        if let Some(previous) = previous {
+            if previous != encoded {
+                return Err(BulkloadRefusal::SqliteStateChanged);
+            }
+            summary.equivalent += 1;
+            continue;
+        }
+        let mapped = mapped_values(table, &schema, &target_schema, &values, mapping)?;
+        let (disposition, native_id) = if native && mapped.is_some() {
+            let mapped = mapped.ok_or(BulkloadRefusal::SqliteUnsupportedValue)?;
+            let (disposition, native_id) =
+                insert_provider_row(destination, table, &names, &mapped, summary)?;
+            (
+                if schema != target_schema && disposition != "conflict" {
+                    "source-columns"
+                } else {
+                    disposition
+                },
+                native_id,
+            )
+        } else {
+            summary.preserved += 1;
+            ("unsupported", None)
+        };
+        destination
+            .prepare_cached("INSERT INTO bulkload_provider_rows VALUES (?1,?2,?3,?4,?5,?6,?7)")
+            .map_err(sql_refusal)?
+            .execute(params![
+                source_id,
+                table,
+                ordinal,
+                columns_blob,
+                encoded,
+                disposition,
+                native_id
+            ])
+            .map_err(sql_refusal)?;
+    }
+    Ok(())
+}
+
+fn mapped_values(
+    table: &str,
+    schema: &[(String, String, i64, i64)],
+    target: &[(String, String, i64, i64)],
+    values: &[rusqlite::types::Value],
+    mapping: Option<&PathMapping<'_>>,
+) -> Result<Option<Vec<rusqlite::types::Value>>> {
+    use rusqlite::types::Value;
+    let mut selected = Vec::new();
+    for column in target {
+        let Some(index) = schema.iter().position(|source| source.0 == column.0) else {
+            return Ok(None);
+        };
+        let mut value = values
+            .get(index)
+            .ok_or(BulkloadRefusal::SqliteUnsupportedValue)?
+            .clone();
+        if let Some(mapping) = mapping.filter(|_| {
+            (table == "threads" && matches!(column.0.as_str(), "rollout_path" | "cwd"))
+                || (table == "project_roots" && column.0 == "path")
+        }) {
+            let Value::Text(path) = &value else {
+                return Ok(None);
+            };
+            let path = Path::new(path);
+            if !path.is_absolute()
+                || path
+                    .components()
+                    .any(|part| part == std::path::Component::ParentDir)
+            {
+                return Ok(None);
+            }
+            let mapped = path.strip_prefix(mapping.source_home).map_or_else(
+                |_| path.to_path_buf(),
+                |relative| mapping.destination_home.join(relative),
+            );
+            if column.0 == "rollout_path" && !mapped.is_file() {
+                return Ok(None);
+            }
+            value = Value::Text(
+                mapped
+                    .to_str()
+                    .ok_or(BulkloadRefusal::PathNotPortable)?
+                    .to_owned(),
+            );
+        }
+        selected.push(value);
+    }
+    Ok(Some(selected))
+}
+
+fn native_insert_is_safe(
+    destination: &Connection,
+    table: &str,
+    schema: &[(String, String, i64, i64)],
+) -> Result<bool> {
+    let mut statement = destination
+        .prepare("SELECT name,sql FROM sqlite_schema WHERE type='trigger' AND tbl_name=?1")
+        .map_err(sql_refusal)?;
+    let triggers = statement
+        .query_map([table], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(sql_refusal)?;
+    for trigger in triggers {
+        let (name, sql) = trigger.map_err(sql_refusal)?;
+        let sql = sql.split_whitespace().collect::<Vec<_>>().join(" ");
+        // Exact known provider DDL, allowing formatting whitespace only.
+        // This DELETE-only trigger cannot fire during INSERT OR IGNORE.
+        // Unknown INSERT triggers could rewrite/delete retained base rows.
+        let known_delete = table == "thread_history_projection_state"
+            && name == "thread_realtime_items_projection_cleanup"
+            && sql
+                == "CREATE TRIGGER thread_realtime_items_projection_cleanup AFTER DELETE ON thread_history_projection_state BEGIN DELETE FROM thread_realtime_items WHERE thread_id = OLD.thread_id; END";
+        if !(known_delete || table == "threads" && known_thread_trigger(&name, &sql)) {
+            return Ok(false);
+        }
+    }
+    if table != "logs" {
+        return Ok(true);
+    }
+    let rowid_column = schema.first().is_some_and(|column| {
+        column.0 == "id" && column.1.eq_ignore_ascii_case("INTEGER") && column.3 == 1
+    }) && schema.iter().skip(1).all(|column| column.3 == 0);
+    let pk_indexes: i64 = destination
+        .query_row(
+            "SELECT count(*) FROM pragma_index_list(?1) WHERE origin='pk'",
+            [table],
+            |row| row.get(0),
+        )
+        .map_err(sql_refusal)?;
+    // INTEGER PRIMARY KEY DESC and WITHOUT ROWID tables have a PK index;
+    // neither gives the required NULL -> fresh rowid allocation semantics.
+    Ok(rowid_column && pk_indexes == 0)
+}
+
+fn known_thread_trigger(name: &str, sql: &str) -> bool {
+    // Observed provider DDL only. Each INSERT-trigger update targets NEW.id;
+    // UPDATE triggers do not change any other thread. Unknown bodies refuse.
+    const TRIGGERS: &[(&str, &str)] = &[
+        ("threads_created_at_ms_after_insert", "CREATE TRIGGER threads_created_at_ms_after_insert AFTER INSERT ON threads WHEN NEW.created_at_ms IS NULL BEGIN UPDATE threads SET created_at_ms = NEW.created_at * 1000 WHERE id = NEW.id; END"),
+        ("threads_updated_at_ms_after_insert", "CREATE TRIGGER threads_updated_at_ms_after_insert AFTER INSERT ON threads WHEN NEW.updated_at_ms IS NULL BEGIN UPDATE threads SET updated_at_ms = NEW.updated_at * 1000 WHERE id = NEW.id; END"),
+        ("threads_created_at_ms_after_update", "CREATE TRIGGER threads_created_at_ms_after_update AFTER UPDATE OF created_at ON threads WHEN NEW.created_at != OLD.created_at AND NEW.created_at_ms IS OLD.created_at_ms BEGIN UPDATE threads SET created_at_ms = NEW.created_at * 1000 WHERE id = NEW.id; END"),
+        ("threads_updated_at_ms_after_update", "CREATE TRIGGER threads_updated_at_ms_after_update AFTER UPDATE OF updated_at ON threads WHEN NEW.updated_at != OLD.updated_at AND NEW.updated_at_ms IS OLD.updated_at_ms BEGIN UPDATE threads SET updated_at_ms = NEW.updated_at * 1000 WHERE id = NEW.id; END"),
+        ("threads_recency_at_after_insert", "CREATE TRIGGER threads_recency_at_after_insert AFTER INSERT ON threads WHEN NEW.recency_at_ms = 0 BEGIN UPDATE threads SET recency_at = NEW.updated_at, recency_at_ms = COALESCE(NEW.updated_at_ms, NEW.updated_at * 1000) WHERE id = NEW.id; END"),
+    ];
+    TRIGGERS
+        .iter()
+        .any(|known| known.0 == name && known.1 == sql)
+}
+
+fn insert_provider_row(
+    destination: &Connection,
+    table: &str,
+    names: &[String],
+    values: &[rusqlite::types::Value],
+    summary: &mut Composition,
+) -> Result<(&'static str, Option<i64>)> {
+    use rusqlite::params_from_iter;
+    let mut insert_values = values.to_vec();
+    if table == "logs" {
+        if names.first().map(String::as_str) != Some("\"id\"") {
+            return Err(BulkloadRefusal::SqliteUnsupportedValue);
+        }
+        *insert_values
+            .first_mut()
+            .ok_or(BulkloadRefusal::SqliteUnsupportedValue)? = rusqlite::types::Value::Null;
+    } else {
+        let predicate = names
+            .iter()
+            .map(|name| format!("{name} IS ?"))
+            .collect::<Vec<_>>()
+            .join(" AND ");
+        let exists: bool = destination
+            .prepare_cached(&format!(
+                "SELECT EXISTS(SELECT 1 FROM {} WHERE {predicate})",
+                identifier(table)
+            ))
+            .map_err(sql_refusal)?
+            .query_row(params_from_iter(values), |row| row.get(0))
+            .map_err(sql_refusal)?;
+        if exists {
+            summary.equivalent += 1;
+            return Ok(("equivalent", None));
+        }
+    }
+    let placeholders = vec!["?"; names.len()].join(",");
+    let inserted = destination
+        .prepare_cached(&format!(
+            "INSERT OR IGNORE INTO {} ({}) VALUES ({placeholders})",
+            identifier(table),
+            names.join(",")
+        ))
+        .map_err(sql_refusal)?
+        .execute(params_from_iter(&insert_values));
+    let inserted = match inserted {
+        Ok(count) => count,
+        Err(rusqlite::Error::SqliteFailure(error, _))
+            if error.code == rusqlite::ErrorCode::ConstraintViolation =>
+        {
+            0
+        }
+        Err(error) => return Err(sql_refusal(error)),
+    };
+    if inserted == 1 {
+        summary.inserted += 1;
+        Ok((
+            "inserted",
+            (table == "logs").then(|| destination.last_insert_rowid()),
+        ))
+    } else {
+        summary.preserved += 1;
+        Ok(("conflict", None))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[test]
+    fn state_import_maps_existing_rollouts_and_keeps_missing_rows_private(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = std::env::temp_dir().join(format!("tcfs-provider-state-{}", std::process::id()));
+        fs::create_dir(&dir)?;
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))?;
+        let seat = dir.join("seat");
+        fs::create_dir(&seat)?;
+        fs::write(seat.join("session.jsonl"), b"{}\n")?;
+        let base = dir.join("base.sqlite");
+        let incoming = dir.join("incoming.sqlite");
+        let output = dir.join("candidate.sqlite");
+        let left = Connection::open(&base)?;
+        let right = Connection::open(&incoming)?;
+        for connection in [&left, &right] {
+            connection.execute_batch("CREATE TABLE projects(id TEXT PRIMARY KEY, name TEXT); CREATE TABLE threads(id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, cwd TEXT NOT NULL, project_id TEXT REFERENCES projects(id));")?;
+        }
+        left.execute_batch("INSERT INTO threads VALUES('stale','/source/home/session.jsonl','/source/home/git/existing',NULL);")?;
+        left.execute(
+            "INSERT INTO threads VALUES('native',?1,'/native/work',NULL)",
+            [seat.join("session.jsonl").to_string_lossy().as_ref()],
+        )?;
+        right.execute_batch("ALTER TABLE threads ADD COLUMN originator TEXT; INSERT INTO projects VALUES('project','source project'); INSERT INTO threads VALUES('ready','/source/home/session.jsonl','/source/home/git/lab','project','kept'); INSERT INTO threads VALUES('missing','/source/home/absent.jsonl','/source/home/git/lab','project','kept too');")?;
+        let result = compose_state_snapshots(
+            &base,
+            &incoming,
+            &output,
+            "source",
+            100,
+            &PathMapping {
+                source_home: Path::new("/source/home"),
+                destination_home: &seat,
+            },
+        );
+        assert!(matches!(
+            result,
+            Ok(Composition {
+                inserted: 2,
+                preserved: 1,
+                unresolved: 2,
+                paths_corrected: 1,
+                ..
+            })
+        ));
+        let candidate = Connection::open_with_flags(&output, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let path: String = candidate.query_row(
+            "SELECT rollout_path FROM threads WHERE id='ready'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(Path::new(&path), seat.join("session.jsonl"));
+        let corrected: String = candidate.query_row(
+            "SELECT rollout_path FROM threads WHERE id='stale' AND project_id IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(Path::new(&corrected), seat.join("session.jsonl"));
+        let native_cwd: String =
+            candidate.query_row("SELECT cwd FROM threads WHERE id='native'", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(native_cwd, "/native/work");
+        let missing: i64 = candidate.query_row(
+            "SELECT count(*) FROM threads WHERE id='missing'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(missing, 0);
+        let preserved: i64 = candidate.query_row(
+            "SELECT count(*) FROM bulkload_provider_rows WHERE table_name='threads'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(preserved, 3);
+        drop(candidate);
+        drop(left);
+        drop(right);
+        for file in [base, incoming, output, seat.join("session.jsonl")] {
+            fs::remove_file(file)?;
+        }
+        fs::remove_dir(seat)?;
+        fs::remove_dir(dir)?;
+        Ok(())
+    }
+
+    #[test]
+    fn native_insert_refuses_triggers_and_non_rowid_log_keys(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE logs(id INTEGER PRIMARY KEY, body TEXT); CREATE TRIGGER danger BEFORE INSERT ON logs BEGIN DELETE FROM logs; END;")?;
+        let schema = vec![
+            ("id".into(), "INTEGER".into(), 0, 1),
+            ("body".into(), "TEXT".into(), 0, 0),
+        ];
+        assert!(matches!(
+            native_insert_is_safe(&db, "logs", &schema),
+            Ok(false)
+        ));
+        db.execute_batch("DROP TRIGGER danger;")?;
+        assert!(matches!(
+            native_insert_is_safe(&db, "logs", &schema),
+            Ok(true)
+        ));
+        db.execute_batch(
+            "DROP TABLE logs; CREATE TABLE logs(id INTEGER PRIMARY KEY DESC, body TEXT);",
+        )?;
+        assert!(matches!(
+            native_insert_is_safe(&db, "logs", &schema),
+            Ok(false)
+        ));
+        db.execute_batch(
+            "DROP TABLE logs; CREATE TABLE logs(id INTEGER PRIMARY KEY, body TEXT) WITHOUT ROWID;",
+        )?;
+        assert!(matches!(
+            native_insert_is_safe(&db, "logs", &schema),
+            Ok(false)
+        ));
+        db.execute_batch("CREATE TABLE thread_history_projection_state(thread_id TEXT PRIMARY KEY); CREATE TABLE thread_realtime_items(thread_id TEXT); CREATE TRIGGER thread_realtime_items_projection_cleanup AFTER DELETE ON thread_history_projection_state BEGIN DELETE FROM thread_realtime_items WHERE thread_id = OLD.thread_id; END;")?;
+        assert!(matches!(
+            native_insert_is_safe(&db, "thread_history_projection_state", &[]),
+            Ok(true)
+        ));
+        db.execute_batch("DROP TRIGGER thread_realtime_items_projection_cleanup; CREATE TRIGGER thread_realtime_items_projection_cleanup AFTER INSERT ON thread_history_projection_state BEGIN DELETE FROM thread_realtime_items WHERE thread_id = NEW.thread_id; END;")?;
+        assert!(matches!(
+            native_insert_is_safe(&db, "thread_history_projection_state", &[]),
+            Ok(false)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn offline_union_preserves_collisions_and_remaps_log_ids(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = std::env::temp_dir().join(format!("tcfs-provider-union-{}", std::process::id()));
+        fs::create_dir(&dir)?;
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))?;
+        let base = dir.join("base.sqlite");
+        let incoming = dir.join("incoming.sqlite");
+        let output = dir.join("candidate.sqlite");
+        let repeated = dir.join("repeated.sqlite");
+        let left = Connection::open(&base)?;
+        let right = Connection::open(&incoming)?;
+        for connection in [&left, &right] {
+            connection.execute_batch("CREATE TABLE thread_items(thread_id TEXT, item_id TEXT, payload BLOB, PRIMARY KEY(thread_id,item_id)); CREATE TABLE logs(id INTEGER PRIMARY KEY AUTOINCREMENT, body TEXT);")?;
+        }
+        left.execute_batch("INSERT INTO thread_items VALUES('thread','item',x'01'); INSERT INTO logs VALUES(1,'sting');")?;
+        right.execute_batch("INSERT INTO thread_items VALUES('thread','item',x'02'); INSERT INTO thread_items VALUES('thread','new',x'03'); INSERT INTO logs VALUES(1,'neo'); CREATE TABLE lost_and_found(value BLOB); INSERT INTO lost_and_found VALUES(x'ff'),(x'ff');")?;
+        let first = compose_snapshots(&base, &incoming, &output, "neo-snapshot", 100);
+        assert!(first.is_ok());
+        let candidate = Connection::open_with_flags(&output, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let logs: i64 = candidate.query_row("SELECT count(*) FROM logs", [], |row| row.get(0))?;
+        assert_eq!(logs, 2);
+        let original: Vec<u8> = candidate.query_row(
+            "SELECT payload FROM thread_items WHERE item_id='item'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(original, vec![1]);
+        let conflicts: i64 = candidate.query_row(
+            "SELECT count(*) FROM bulkload_provider_rows WHERE disposition='conflict'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(conflicts, 1);
+        let orphans: i64 = candidate.query_row(
+            "SELECT count(*) FROM bulkload_provider_rows WHERE table_name='lost_and_found'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(orphans, 2);
+        let rerun = compose_snapshots(&output, &incoming, &repeated, "neo-snapshot", 100);
+        assert!(matches!(
+            rerun,
+            Ok(Composition {
+                inserted: 0,
+                preserved: 0,
+                unresolved: 4,
+                ..
+            })
+        ));
+        let again = Connection::open_with_flags(&repeated, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let logs_again: i64 = again.query_row("SELECT count(*) FROM logs", [], |row| row.get(0))?;
+        assert_eq!(logs_again, 2);
+        drop(again);
+        drop(candidate);
+        drop(left);
+        drop(right);
+        for file in [base, incoming, output, repeated] {
+            fs::remove_file(file)?;
+        }
+        fs::remove_dir(dir)?;
+        Ok(())
+    }
 
     #[test]
     fn captures_live_wal_and_orphans_without_overwriting(

--- a/crates/tcfs-bulkload-agent/src/provider_sqlite.rs
+++ b/crates/tcfs-bulkload-agent/src/provider_sqlite.rs
@@ -1,0 +1,151 @@
+//! Standalone provider snapshots using `SQLite`'s online backup API.
+//!
+//! This module never installs a snapshot over a live database or merges rows.
+//! All tables, including unknown tables and recovery orphans, are preserved.
+
+use std::fs::{self, OpenOptions};
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+use std::path::Path;
+use std::time::Duration;
+
+use rusqlite::backup::{Backup, StepResult};
+use rusqlite::{Connection, OpenFlags};
+
+use crate::{BulkloadRefusal, Result};
+
+/// Capture a standalone database in an existing private directory.
+///
+/// `max_steps` bounds retries and total backup steps, including restarts caused
+/// by concurrent writers. Each step copies at most 128 pages; lock contention
+/// returns immediately. The caller may retry with a *new* output path.
+///
+/// The source is opened read-only using normal WAL-aware `SQLite` access, never
+/// immutable mode. The output must not exist. On failure an incomplete private
+/// output may remain; only a successful return authorizes its use as a snapshot.
+/// Neither failure nor success removes source data.
+///
+/// # Errors
+/// Refuses non-private output directories, existing outputs, exhausted step
+/// budgets, `SQLite` errors, and failed database or foreign-key integrity checks.
+pub fn snapshot(source: &Path, output: &Path, max_steps: u32) -> Result<()> {
+    if max_steps == 0 {
+        return Err(BulkloadRefusal::BudgetExceeded);
+    }
+    let parent = output.parent().ok_or(BulkloadRefusal::Io(None))?;
+    let metadata = fs::metadata(parent).map_err(|_| BulkloadRefusal::Io(None))?;
+    if !metadata.is_dir() || metadata.permissions().mode() & 0o077 != 0 {
+        return Err(BulkloadRefusal::Io(None));
+    }
+    let source = Connection::open_with_flags(source, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    source
+        .busy_timeout(Duration::ZERO)
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(output)
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    let mut destination = Connection::open_with_flags(output, OpenFlags::SQLITE_OPEN_READ_WRITE)
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    destination
+        .busy_timeout(Duration::ZERO)
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    {
+        let backup =
+            Backup::new(&source, &mut destination).map_err(|_| BulkloadRefusal::Io(None))?;
+        let mut complete = false;
+        for _ in 0..max_steps {
+            match backup.step(128).map_err(|_| BulkloadRefusal::Io(None))? {
+                StepResult::Done => {
+                    complete = true;
+                    break;
+                }
+                StepResult::More => {}
+                // Do not spin or sleep while another process holds a lock.
+                _ => return Err(BulkloadRefusal::SqliteStateChanged),
+            }
+        }
+        if !complete {
+            return Err(BulkloadRefusal::BudgetExceeded);
+        }
+    }
+    // A WAL source must produce one portable database, without relying on
+    // destination sidecars. Changing the mode affects only the new snapshot.
+    let mode: String = destination
+        .query_row("PRAGMA journal_mode=DELETE", [], |row| row.get(0))
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    if mode != "delete" {
+        return Err(BulkloadRefusal::SqliteStateChanged);
+    }
+    let check: String = destination
+        .query_row("PRAGMA quick_check", [], |row| row.get(0))
+        .map_err(|_| BulkloadRefusal::SqliteIntegrityCheckFailed)?;
+    if check != "ok" {
+        return Err(BulkloadRefusal::SqliteIntegrityCheckFailed);
+    }
+    let mut statement = destination
+        .prepare("PRAGMA foreign_key_check")
+        .map_err(|_| BulkloadRefusal::SqliteIntegrityCheckFailed)?;
+    if statement
+        .query([])
+        .and_then(|mut rows| rows.next().map(|row| row.is_some()))
+        .map_err(|_| BulkloadRefusal::SqliteIntegrityCheckFailed)?
+    {
+        return Err(BulkloadRefusal::SqliteIntegrityCheckFailed);
+    }
+    file.sync_all().map_err(|_| BulkloadRefusal::Io(None))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[test]
+    fn captures_live_wal_and_orphans_without_overwriting(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "tcfs-provider-snapshot-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&dir)?;
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))?;
+        let source_path = dir.join("source.sqlite");
+        let output = dir.join("snapshot.sqlite");
+        let source = Connection::open(&source_path)?;
+        source.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE lost_and_found(payload BLOB); INSERT INTO lost_and_found VALUES (x'010203');")?;
+        assert!(snapshot(&source_path, &output, 0).is_err());
+        assert!(!output.exists());
+        assert!(snapshot(&source_path, &output, 100).is_ok());
+        assert_eq!(fs::metadata(&output)?.permissions().mode() & 0o777, 0o600);
+        let captured = Connection::open_with_flags(&output, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let value: Vec<u8> =
+            captured.query_row("SELECT payload FROM lost_and_found", [], |row| row.get(0))?;
+        assert_eq!(value, vec![1, 2, 3]);
+        source.execute("INSERT INTO lost_and_found VALUES (x'04')", [])?;
+        assert!(snapshot(&source_path, &output, 100).is_err());
+        let count: i64 =
+            captured.query_row("SELECT count(*) FROM lost_and_found", [], |row| row.get(0))?;
+        assert_eq!(count, 1);
+        assert!(!dir.join("snapshot.sqlite-wal").exists());
+        source.execute_batch("PRAGMA foreign_keys=OFF; CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(parent_id INTEGER REFERENCES parent(id)); INSERT INTO child VALUES(88);")?;
+        let invalid = dir.join("invalid.sqlite");
+        assert!(matches!(
+            snapshot(&source_path, &invalid, 100),
+            Err(BulkloadRefusal::SqliteIntegrityCheckFailed)
+        ));
+        drop(captured);
+        drop(source);
+        fs::remove_file(output)?;
+        fs::remove_file(invalid)?;
+        fs::remove_file(source_path)?;
+        fs::remove_dir(dir)?;
+        Ok(())
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/provider_sqlite/hydrate.rs
+++ b/crates/tcfs-bulkload-agent/src/provider_sqlite/hydrate.rs
@@ -1,0 +1,320 @@
+//! Bounded, additive hydration of retained compressed provider rollouts.
+use std::fs::{self, OpenOptions};
+use std::io::{Read as _, Write as _};
+use std::os::fd::AsRawFd as _;
+use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rayon::prelude::*;
+use rusqlite::{Connection, OpenFlags};
+
+use super::{mapped_rollout_path, sql_refusal, PathMapping};
+use crate::{BulkloadRefusal, Result};
+
+/// Per-file receipt. The compressed original is never removed.
+#[derive(Debug)]
+pub struct Hydrated {
+    pub path: std::path::PathBuf,
+    pub source: std::path::PathBuf,
+    pub source_identity: (u64, u64, u64, i64, i64, i64, i64),
+    pub bytes: u64,
+    pub blake3: String,
+    pub published: bool,
+}
+
+/// Hydrate only absent raw rollouts named by a retained database snapshot.
+///
+/// Caller must choose `max_bytes` below available filesystem space with a reserve.
+/// The shared actual-output budget is enforced before every write. Existing files
+/// and symlinks are never replaced. Native decompressors validate their checksums.
+/// Errors leave already published complete files in place for an idempotent retry.
+/// # Errors
+/// Refuses invalid limits, changed inputs, decompressor errors and budget exhaustion.
+#[allow(clippy::too_many_arguments)] // Explicit native tools and receipt sink are caller-owned.
+pub fn hydrate_state(
+    snapshot: &Path,
+    mapping: &PathMapping<'_>,
+    max_bytes: u64,
+    jobs: usize,
+    gzip: &Path,
+    zstd: &Path,
+    receipt: &(impl Fn(&Hydrated) -> Result<()> + Sync),
+) -> Result<Vec<Hydrated>> {
+    if max_bytes == 0 || jobs == 0 || jobs > 4 {
+        return Err(BulkloadRefusal::BudgetExceeded);
+    }
+    let connection = Connection::open_with_flags(snapshot, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(sql_refusal)?;
+    let mut statement = connection
+        .prepare("SELECT DISTINCT rollout_path FROM threads ORDER BY rollout_path")
+        .map_err(sql_refusal)?;
+    let paths = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(sql_refusal)?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(sql_refusal)?;
+    let budget = AtomicU64::new(max_bytes);
+    let sequence = AtomicU64::new(0);
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(jobs)
+        .build()
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    pool.install(|| {
+        paths
+            .par_iter()
+            .filter_map(|path| {
+                let raw = mapped_rollout_path(Path::new(path), mapping);
+                if raw
+                    .components()
+                    .any(|p| p == std::path::Component::ParentDir)
+                {
+                    return Some(Err(BulkloadRefusal::PathNotPortable));
+                }
+                // Unsupported historical roots remain unresolved in composition, not hydrated.
+                if !raw.starts_with(mapping.destination_home) {
+                    return None;
+                }
+                if fs::symlink_metadata(&raw).is_ok() {
+                    return None;
+                }
+                let source =
+                    [("gz", gzip), ("zst", zstd)]
+                        .into_iter()
+                        .find_map(|(extension, program)| {
+                            let source = std::path::PathBuf::from(format!(
+                                "{}.{}",
+                                raw.display(),
+                                extension
+                            ));
+                            source.is_file().then_some((source, program))
+                        });
+                source.map(|(source, program)| {
+                    let hydrated = hydrate_one(
+                        &source,
+                        &raw,
+                        program,
+                        &budget,
+                        sequence.fetch_add(1, Ordering::Relaxed),
+                        100 * 1024 * 1024 * 1024,
+                    )?;
+                    receipt(&hydrated)?;
+                    Ok(hydrated)
+                })
+            })
+            .collect()
+    })
+}
+
+fn hydrate_one(
+    source: &Path,
+    raw: &Path,
+    program: &Path,
+    budget: &AtomicU64,
+    sequence: u64,
+    reserve: u64,
+) -> Result<Hydrated> {
+    let identity = |m: &fs::Metadata| {
+        (
+            m.dev(),
+            m.ino(),
+            m.len(),
+            m.mtime(),
+            m.mtime_nsec(),
+            m.ctime(),
+            m.ctime_nsec(),
+        )
+    };
+    let before = fs::metadata(source).map_err(|_| BulkloadRefusal::Io(None))?;
+    let temporary = raw.with_extension(format!(
+        "bulkload-hydrate-{}-{sequence}",
+        std::process::id()
+    ));
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&temporary)
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    let result = (|| {
+        let mut child = Command::new(program)
+            .args(["-dc", "--"])
+            .arg(source)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| BulkloadRefusal::Io(None))?;
+        let mut input = child.stdout.take().ok_or(BulkloadRefusal::Io(None))?;
+        let mut hash = blake3::Hasher::new();
+        let mut bytes = 0u64;
+        let mut buffer = vec![0u8; 65536];
+        let streamed: Result<()> = (|| {
+            loop {
+                if bytes % (64 * 1024 * 1024) < 65536 {
+                    reserve_space(&output, reserve)?;
+                }
+                let count = input
+                    .read(&mut buffer)
+                    .map_err(|_| BulkloadRefusal::Io(None))?;
+                if count == 0 {
+                    break;
+                }
+                budget
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                        remaining.checked_sub(count as u64)
+                    })
+                    .map_err(|_| BulkloadRefusal::BudgetExceeded)?;
+                let data = buffer.get(..count).ok_or(BulkloadRefusal::BudgetExceeded)?;
+                output
+                    .write_all(data)
+                    .map_err(|_| BulkloadRefusal::Io(None))?;
+                hash.update(data);
+                bytes += count as u64;
+            }
+            Ok(())
+        })();
+        drop(input);
+        let status = child.wait().map_err(|_| BulkloadRefusal::Io(None))?;
+        streamed?;
+        if !status.success()
+            || identity(&before)
+                != identity(&fs::metadata(source).map_err(|_| BulkloadRefusal::Io(None))?)
+        {
+            return Err(BulkloadRefusal::SqliteStateChanged);
+        }
+        output.sync_all().map_err(|_| BulkloadRefusal::Io(None))?;
+        let published = match fs::hard_link(&temporary, raw) {
+            Ok(()) => true,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => false,
+            Err(_) => return Err(BulkloadRefusal::Io(None)),
+        };
+        if published {
+            fs::File::open(raw.parent().ok_or(BulkloadRefusal::Io(None))?)
+                .and_then(|parent| parent.sync_all())
+                .map_err(|_| BulkloadRefusal::Io(None))?;
+        }
+        Ok(Hydrated {
+            path: raw.to_path_buf(),
+            source: source.to_path_buf(),
+            source_identity: identity(&before),
+            bytes,
+            blake3: hash.finalize().to_hex().to_string(),
+            published,
+        })
+    })();
+    drop(output);
+    fs::remove_file(&temporary).map_err(|_| BulkloadRefusal::Io(None))?;
+    result
+}
+
+fn reserve_space(file: &fs::File, reserve: u64) -> Result<()> {
+    let mut metadata = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    // SAFETY: descriptor remains open and metadata points to writable storage.
+    if unsafe { libc::fstatvfs(file.as_raw_fd(), metadata.as_mut_ptr()) } != 0 {
+        return Err(BulkloadRefusal::Io(None));
+    }
+    // SAFETY: successful fstatvfs initialized the structure.
+    let metadata = unsafe { metadata.assume_init() };
+    let available = u128::from(metadata.f_bavail) * u128::from(metadata.f_frsize);
+    if available < (u128::from(reserve) + 4 * 64 * 1024 * 1024) {
+        return Err(BulkloadRefusal::BudgetExceeded);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::super::mapped_path;
+    use super::*;
+
+    #[test]
+    fn mapping_alias_is_typed() {
+        let mapping = PathMapping {
+            source_home: Path::new("/Users/jess"),
+            destination_home: Path::new("/home/jess"),
+        };
+        assert_eq!(
+            mapped_rollout_path(
+                Path::new("/Users/jess/.codex/sessions/x.jsonl.gz"),
+                &mapping
+            ),
+            Path::new("/home/jess/.codex/sessions/x.jsonl")
+        );
+        assert_eq!(
+            mapped_path(
+                Path::new("/Volumes/TinylandState/tinyland-state/codex/sessions/x.jsonl"),
+                &mapping
+            ),
+            Path::new("/home/jess/.codex/sessions/x.jsonl")
+        );
+        assert_eq!(
+            mapped_path(
+                Path::new("/Volumes/TinylandState/tinyland-state/codex-other/x"),
+                &mapping
+            ),
+            Path::new("/Volumes/TinylandState/tinyland-state/codex-other/x")
+        );
+    }
+
+    #[test]
+    fn native_hydration_preserves_collision_and_refuses_budget() {
+        let directory =
+            std::env::temp_dir().join(format!("tcfs-hydrate-test-{}", std::process::id()));
+        fs::create_dir(&directory).expect("owned test directory");
+        let source = directory.join("original.gz");
+        let compressed = Command::new("gzip")
+            .arg("-c")
+            .stdin(Stdio::null())
+            .output()
+            .expect("native gzip");
+        assert!(compressed.status.success());
+        fs::write(&source, &compressed.stdout).expect("compressed input");
+        let raw = directory.join("raw.jsonl");
+        fs::write(&raw, b"active destination").expect("destination");
+        let receipt = hydrate_one(
+            &source,
+            &raw,
+            Path::new("/usr/bin/gzip"),
+            &AtomicU64::new(1024),
+            0,
+            0,
+        )
+        .expect("no-clobber");
+        assert!(!receipt.published);
+        assert_eq!(fs::read(&raw).expect("raw"), b"active destination");
+        let original = directory.join("payload");
+        fs::write(&original, b"nonempty").expect("source");
+        let compressed = Command::new("gzip")
+            .arg("-c")
+            .arg(&original)
+            .output()
+            .expect("gzip");
+        fs::write(&source, compressed.stdout).expect("compressed");
+        let absent = directory.join("absent.jsonl");
+        assert!(hydrate_one(
+            &source,
+            &absent,
+            Path::new("/usr/bin/gzip"),
+            &AtomicU64::new(1),
+            1,
+            0
+        )
+        .is_err());
+        assert!(!absent.exists());
+        fs::write(&source, b"invalid gzip").expect("corrupt fixture");
+        assert!(hydrate_one(
+            &source,
+            &absent,
+            Path::new("/usr/bin/gzip"),
+            &AtomicU64::new(1024),
+            2,
+            0
+        )
+        .is_err());
+        assert!(!absent.exists());
+        fs::remove_dir_all(&directory).expect("remove exact owned test directory");
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/provider_sqlite/online.rs
+++ b/crates/tcfs-bulkload-agent/src/provider_sqlite/online.rs
@@ -1,0 +1,501 @@
+//! Optional external bulkload import; this is not a provider-supported API.
+//!
+//! Only a reviewed immutable candidate is accepted. No schema, migration or
+//! control-table changes are made. Callers must retain both input snapshots.
+use std::os::unix::fs::MetadataExt as _;
+use std::path::Path;
+use std::time::Duration;
+
+use rusqlite::types::Value;
+use rusqlite::{params_from_iter, Connection, OpenFlags, TransactionBehavior};
+
+use super::{columns, encode_row, identifier, native_insert_is_safe, sql_refusal};
+use crate::{BulkloadRefusal, Result};
+
+/// One bounded unit committed without changing any unrelated live row.
+#[derive(Debug)]
+pub struct Applied {
+    pub table: String,
+    pub inserted: usize,
+    pub corrected: usize,
+    pub conflicts: usize,
+}
+
+/// Apply only new rows and guarded path corrections from an offline candidate.
+///
+/// Each row gets its own immediate transaction with zero busy timeout. Existing
+/// unequal live rows win. Changed schema/migration authority stops the operation.
+/// Receipts are emitted after each commit, so a later refusal cannot hide earlier
+/// committed units. A failed receipt must be reconciled from retained snapshots.
+/// A private sibling `*.bulkload-import.sqlite` journal durably records insertion
+/// intents before live commits. Never remove it to retry: an absent attempted ID
+/// is a conflict, including ambiguous crashes and later operator deletions.
+/// # Errors
+/// Refuses schema drift, unknown triggers, absent files, busy writers and budgets.
+pub fn apply_state_candidate(
+    live: &Path,
+    base: &Path,
+    candidate: &Path,
+    max_rows: usize,
+    receipt: &impl Fn(&Applied) -> Result<()>,
+) -> Result<()> {
+    if max_rows == 0 || live == base || live == candidate {
+        return Err(BulkloadRefusal::BudgetExceeded);
+    }
+    let identity = |path: &Path| {
+        std::fs::metadata(path)
+            .map(|metadata| (metadata.dev(), metadata.ino()))
+            .map_err(|_| BulkloadRefusal::Io(None))
+    };
+    if identity(live)? == identity(base)? || identity(live)? == identity(candidate)? {
+        return Err(BulkloadRefusal::SqliteStateChanged);
+    }
+    let base = retained_input(base)?;
+    let candidate = retained_input(candidate)?;
+    let expected_authority = authority(&base)?;
+    let mut destination = Connection::open_with_flags(live, OpenFlags::SQLITE_OPEN_READ_WRITE)
+        .map_err(sql_refusal)?;
+    let journal = intent_journal(live)?;
+    destination
+        .busy_timeout(Duration::ZERO)
+        .map_err(sql_refusal)?;
+    destination
+        .execute_batch("PRAGMA foreign_keys=ON; PRAGMA recursive_triggers=ON;")
+        .map_err(sql_refusal)?;
+    let mut units = 0usize;
+    for table in [
+        "projects",
+        "thread_sections",
+        "project_roots",
+        "threads",
+        "thread_dynamic_tools",
+        "thread_artifacts",
+        "thread_spawn_edges",
+    ] {
+        let schema = columns(&base, table)?;
+        if schema != columns(&candidate, table)? {
+            return Err(BulkloadRefusal::SqliteStateChanged);
+        }
+        if schema.is_empty() {
+            continue;
+        }
+        let keys: Vec<_> = schema
+            .iter()
+            .enumerate()
+            .filter(|(_, column)| column.3 > 0)
+            .map(|(index, _)| index)
+            .collect();
+        if keys.is_empty() {
+            return Err(BulkloadRefusal::SqliteUnsupportedValue);
+        }
+        let query = format!("SELECT * FROM {}", identifier(table));
+        let mut statement = candidate.prepare(&query).map_err(sql_refusal)?;
+        let mut rows = statement.query([]).map_err(sql_refusal)?;
+        while let Some(row) = rows.next().map_err(sql_refusal)? {
+            let values = (0..schema.len())
+                .map(|index| row.get::<_, Value>(index))
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(sql_refusal)?;
+            let predicate = keys
+                .iter()
+                .filter_map(|index| schema.get(*index))
+                .map(|column| format!("{} IS ?", identifier(&column.0)))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            let lookup = format!("SELECT * FROM {} WHERE {predicate}", identifier(table));
+            let key_values: Vec<_> = keys.iter().filter_map(|index| values.get(*index)).collect();
+            let original = lookup_row(&base, &lookup, &key_values, schema.len())?;
+            if original.as_ref() == Some(&values) {
+                continue;
+            }
+            units += 1;
+            if units > max_rows {
+                return Err(BulkloadRefusal::BudgetExceeded);
+            }
+            if table == "threads" {
+                let rollout = schema
+                    .iter()
+                    .position(|column| column.0 == "rollout_path")
+                    .ok_or(BulkloadRefusal::SqliteUnsupportedValue)?;
+                if !matches!(values.get(rollout),Some(Value::Text(path)) if Path::new(path).is_absolute() && Path::new(path).is_file() && Path::new(path).extension()==Some(std::ffi::OsStr::new("jsonl")))
+                {
+                    return Err(BulkloadRefusal::SqliteStateChanged);
+                }
+            }
+            let unit = Unit {
+                table,
+                schema: &schema,
+                values: &values,
+                original,
+                keys: &key_values,
+                predicate: &predicate,
+                lookup: &lookup,
+            };
+            let applied = apply_unit(&mut destination, &journal, &expected_authority, &unit)?;
+            receipt(&applied)?;
+        }
+    }
+    Ok(())
+}
+
+fn retained_input(path: &Path) -> Result<Connection> {
+    let connection =
+        Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(sql_refusal)?;
+    connection.execute_batch("BEGIN").map_err(sql_refusal)?;
+    Ok(connection)
+}
+
+struct Unit<'a> {
+    table: &'a str,
+    schema: &'a [(String, String, i64, i64)],
+    values: &'a [Value],
+    original: Option<Vec<Value>>,
+    keys: &'a [&'a Value],
+    predicate: &'a str,
+    lookup: &'a str,
+}
+
+fn apply_unit(
+    destination: &mut Connection,
+    journal: &Connection,
+    expected: &[u8],
+    unit: &Unit<'_>,
+) -> Result<Applied> {
+    let transaction = destination
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sql_refusal)?;
+    if authority(&transaction)? != expected
+        || !native_insert_is_safe(&transaction, unit.table, unit.schema)?
+    {
+        return Err(BulkloadRefusal::SqliteStateChanged);
+    }
+    let current = lookup_row(&transaction, unit.lookup, unit.keys, unit.schema.len())?;
+    let mut applied = Applied {
+        table: unit.table.to_owned(),
+        inserted: 0,
+        corrected: 0,
+        conflicts: 0,
+    };
+    // Remember all observed base-absent identities, including rows another
+    // writer already supplied. Later deletion must not enable resurrection.
+    let fresh_intent = if unit.original.is_none() {
+        let key_blob = encode_row(
+            &unit
+                .keys
+                .iter()
+                .map(|value| (*value).clone())
+                .collect::<Vec<_>>(),
+        );
+        journal
+            .execute(
+                "INSERT OR IGNORE INTO attempts(table_name,key_blob) VALUES(?1,?2)",
+                rusqlite::params![unit.table, key_blob],
+            )
+            .map_err(sql_refusal)?
+            != 0
+    } else {
+        false
+    };
+    match (unit.original.as_ref(), current) {
+        (None, None) => {
+            if fresh_intent {
+                let sql = format!(
+                    "INSERT OR IGNORE INTO {} VALUES ({})",
+                    identifier(unit.table),
+                    vec!["?"; unit.schema.len()].join(",")
+                );
+                match transaction.execute(&sql, params_from_iter(unit.values)) {
+                    Ok(count) => {
+                        applied.inserted = count;
+                        applied.conflicts = usize::from(count == 0);
+                    }
+                    Err(rusqlite::Error::SqliteFailure(error, _))
+                        if error.code == rusqlite::ErrorCode::ConstraintViolation =>
+                    {
+                        applied.conflicts = 1;
+                    }
+                    Err(error) => return Err(sql_refusal(error)),
+                }
+            } else {
+                applied.conflicts = 1;
+            }
+        }
+        (Some(original), Some(current)) if unit.table == "threads" => {
+            (applied.corrected, applied.conflicts) = correct_paths(
+                &transaction,
+                unit.schema,
+                unit.predicate,
+                unit.keys,
+                original,
+                &current,
+                unit.values,
+            )?;
+        }
+        (_, Some(current)) if current == unit.values => {}
+        _ => applied.conflicts = 1,
+    }
+    transaction.commit().map_err(sql_refusal)?;
+    Ok(applied)
+}
+
+fn intent_journal(live: &Path) -> Result<Connection> {
+    use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+    let path = std::fs::canonicalize(live)
+        .map_err(|_| BulkloadRefusal::Io(None))?
+        .with_extension("bulkload-import.sqlite");
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+    {
+        Ok(file) => file.sync_all().map_err(|_| BulkloadRefusal::Io(None))?,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata =
+                std::fs::symlink_metadata(&path).map_err(|_| BulkloadRefusal::Io(None))?;
+            if !metadata.is_file() || metadata.permissions().mode() & 0o077 != 0 {
+                return Err(BulkloadRefusal::Io(None));
+            }
+        }
+        Err(_) => return Err(BulkloadRefusal::Io(None)),
+    }
+    let connection = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_WRITE)
+        .map_err(sql_refusal)?;
+    connection
+        .busy_timeout(Duration::ZERO)
+        .map_err(sql_refusal)?;
+    connection.execute_batch("PRAGMA synchronous=FULL; PRAGMA journal_mode=DELETE; CREATE TABLE IF NOT EXISTS attempts(table_name TEXT NOT NULL,key_blob BLOB NOT NULL,PRIMARY KEY(table_name,key_blob));").map_err(sql_refusal)?;
+    std::fs::File::open(path.parent().ok_or(BulkloadRefusal::Io(None))?)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| BulkloadRefusal::Io(None))?;
+    Ok(connection)
+}
+
+fn correct_paths(
+    connection: &Connection,
+    schema: &[(String, String, i64, i64)],
+    predicate: &str,
+    keys: &[&Value],
+    original: &[Value],
+    current: &[Value],
+    values: &[Value],
+) -> Result<(usize, usize)> {
+    let indices: Vec<_> = schema
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| matches!(column.0.as_str(), "rollout_path" | "cwd"))
+        .map(|(index, _)| index)
+        .collect();
+    if indices.len() != 2
+        || original
+            .iter()
+            .zip(values)
+            .enumerate()
+            .any(|(index, (old, new))| !indices.contains(&index) && old != new)
+    {
+        return Err(BulkloadRefusal::SqliteStateChanged);
+    }
+    if indices
+        .iter()
+        .all(|index| current.get(*index) == values.get(*index))
+    {
+        return Ok((0, 0));
+    }
+    if !indices
+        .iter()
+        .all(|index| current.get(*index) == original.get(*index))
+    {
+        return Ok((0, 1));
+    }
+    let assignments = indices
+        .iter()
+        .filter_map(|index| schema.get(*index))
+        .map(|column| format!("{}=?", identifier(&column.0)))
+        .collect::<Vec<_>>()
+        .join(",");
+    let guards = indices
+        .iter()
+        .filter_map(|index| schema.get(*index))
+        .map(|column| format!("{} IS ?", identifier(&column.0)))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    let mut parameters: Vec<_> = indices
+        .iter()
+        .filter_map(|index| values.get(*index))
+        .collect();
+    parameters.extend(keys.iter().copied());
+    parameters.extend(indices.iter().filter_map(|index| original.get(*index)));
+    let changed = connection
+        .execute(
+            &format!("UPDATE threads SET {assignments} WHERE {predicate} AND {guards}"),
+            params_from_iter(parameters),
+        )
+        .map_err(sql_refusal)?;
+    Ok((changed, usize::from(changed == 0)))
+}
+
+fn lookup_row(
+    connection: &Connection,
+    sql: &str,
+    keys: &[&Value],
+    count: usize,
+) -> Result<Option<Vec<Value>>> {
+    let mut statement = connection.prepare(sql).map_err(sql_refusal)?;
+    let mut rows = statement
+        .query(params_from_iter(keys))
+        .map_err(sql_refusal)?;
+    rows.next()
+        .map_err(sql_refusal)?
+        .map(|row| {
+            (0..count)
+                .map(|index| row.get(index))
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(sql_refusal)
+        })
+        .transpose()
+}
+
+fn authority(connection: &Connection) -> Result<Vec<u8>> {
+    let mut result = Vec::new();
+    for sql in ["SELECT type,name,tbl_name,sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY type,name", "SELECT * FROM _sqlx_migrations ORDER BY version", "PRAGMA user_version", "PRAGMA application_id"] {
+        let mut statement=connection.prepare(sql).map_err(sql_refusal)?;
+        let count=statement.column_count();
+        let mut rows=statement.query([]).map_err(sql_refusal)?;
+        while let Some(row)=rows.next().map_err(sql_refusal)? {
+            let values=(0..count).map(|index|row.get(index)).collect::<std::result::Result<Vec<Value>,_>>().map_err(sql_refusal)?;
+            let encoded=encode_row(&values);
+            result.extend_from_slice(&(encoded.len() as u64).to_le_bytes()); result.extend(encoded);
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    #[test]
+    #[allow(clippy::too_many_lines)] // One shared lifecycle proves lock, retry and deletion semantics.
+    fn busy_writer_refuses_readers_continue_and_live_fields_win() {
+        let dir = std::env::temp_dir().join(format!("tcfs-online-test-{}", std::process::id()));
+        std::fs::create_dir(&dir).expect("owned directory");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).expect("private");
+        let live = dir.join("live.sqlite");
+        let base = dir.join("base.sqlite");
+        let candidate = dir.join("candidate.sqlite");
+        let raw = dir.join("thread.jsonl");
+        std::fs::write(&raw, b"{}\n").expect("raw");
+        let writer = Connection::open(&live).expect("live");
+        writer.execute_batch("PRAGMA journal_mode=WAL; CREATE TABLE _sqlx_migrations(version INTEGER PRIMARY KEY,checksum BLOB); CREATE TABLE projects(id TEXT PRIMARY KEY); CREATE TABLE thread_sections(id TEXT PRIMARY KEY); CREATE TABLE project_roots(id TEXT PRIMARY KEY); CREATE TABLE threads(id TEXT PRIMARY KEY,rollout_path TEXT,cwd TEXT,title TEXT); INSERT INTO threads VALUES('old','/old/path','/old/cwd','original');").expect("schema");
+        super::super::snapshot(&live, &base, 100).expect("base");
+        super::super::snapshot(&base, &candidate, 100).expect("candidate");
+        let proposed = Connection::open(&candidate).expect("candidate");
+        proposed
+            .execute(
+                "UPDATE threads SET rollout_path=?1,cwd='/seat'",
+                [raw.to_str().expect("path")],
+            )
+            .expect("path correction");
+        proposed
+            .execute(
+                "INSERT INTO threads VALUES('new',?1,'/seat','new')",
+                [raw.to_str().expect("path")],
+            )
+            .expect("new row");
+        writer
+            .execute_batch("BEGIN IMMEDIATE; UPDATE threads SET title='active writer';")
+            .expect("active writer");
+        assert!(apply_state_candidate(&live, &base, &candidate, 100, &|_| Ok(())).is_err());
+        writer
+            .execute_batch("COMMIT")
+            .expect("writer finishes naturally");
+        let reader = Connection::open(&live).expect("reader");
+        reader.execute_batch("BEGIN").expect("reader snapshot");
+        assert_eq!(
+            reader
+                .query_row("SELECT count(*) FROM threads", [], |row| row
+                    .get::<_, u64>(0))
+                .expect("count"),
+            1
+        );
+        apply_state_candidate(&live, &base, &candidate, 100, &|_| Ok(()))
+            .expect("online import alongside reader");
+        assert_eq!(
+            reader
+                .query_row("SELECT count(*) FROM threads", [], |row| row
+                    .get::<_, u64>(0))
+                .expect("reader retains snapshot"),
+            1
+        );
+        assert_eq!(
+            writer
+                .query_row("SELECT title FROM threads WHERE id='old'", [], |row| row
+                    .get::<_, String>(
+                    0
+                ))
+                .expect("title"),
+            "active writer"
+        );
+        assert_eq!(
+            writer
+                .query_row("SELECT count(*) FROM threads", [], |row| row
+                    .get::<_, u64>(0))
+                .expect("new count"),
+            2
+        );
+        apply_state_candidate(&live, &base, &candidate, 100, &|_| Ok(()))
+            .expect("idempotent retry");
+        writer
+            .execute("DELETE FROM threads WHERE id='new'", [])
+            .expect("operator deletion");
+        apply_state_candidate(&live, &base, &candidate, 100, &|_| Ok(()))
+            .expect("retry retains deletion");
+        assert_eq!(
+            writer
+                .query_row("SELECT count(*) FROM threads WHERE id='new'", [], |row| row
+                    .get::<_, u64>(0))
+                .expect("not resurrected"),
+            0
+        );
+        proposed
+            .execute(
+                "INSERT INTO threads VALUES('independent',?1,'/seat','independent')",
+                [raw.to_str().expect("path")],
+            )
+            .expect("candidate independent row");
+        writer
+            .execute(
+                "INSERT INTO threads VALUES('independent',?1,'/seat','independent')",
+                [raw.to_str().expect("path")],
+            )
+            .expect("provider independent row");
+        apply_state_candidate(&live, &base, &candidate, 100, &|_| Ok(()))
+            .expect("observe independent row");
+        writer
+            .execute("DELETE FROM threads WHERE id='independent'", [])
+            .expect("operator deletes independent row");
+        apply_state_candidate(&live, &base, &candidate, 100, &|_| Ok(()))
+            .expect("retry preserves independent deletion");
+        assert_eq!(
+            writer
+                .query_row(
+                    "SELECT count(*) FROM threads WHERE id='independent'",
+                    [],
+                    |row| row.get::<_, u64>(0)
+                )
+                .expect("not resurrected"),
+            0
+        );
+        reader.execute_batch("COMMIT").expect("reader done");
+        writer
+            .execute_batch("ALTER TABLE threads ADD COLUMN extra TEXT;")
+            .expect("schema drift");
+        assert!(apply_state_candidate(&live, &base, &candidate, 100, &|_| Ok(())).is_err());
+        drop(reader);
+        drop(writer);
+        drop(proposed);
+        std::fs::remove_dir_all(&dir).expect("remove exact owned test directory");
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/transfer.rs
+++ b/crates/tcfs-bulkload-agent/src/transfer.rs
@@ -22,7 +22,7 @@ use tcfs_bulkload_proto::FileKind;
 
 use crate::freshness::{NullCache, StatIdentity};
 use crate::materialize::Destination;
-use crate::transfer_store::{row_key, Manifest, Store};
+use crate::transfer_store::{row_key, Manifest, Store, PERSIST_BATCH};
 use crate::walk::{walk, WalkOptions};
 use crate::{BulkloadRefusal, Frame, FrameKind, Result, RowSchema};
 
@@ -465,17 +465,25 @@ fn receive_chunks<R: Read, W: Write>(
             digests: missing.clone(),
         },
     )?;
+    let mut pending = Vec::with_capacity(PERSIST_BATCH);
     for expected in missing {
         match read_frame(input)?.kind {
             FrameKind::Chunk { digest, data } if digest == expected => {
+                if data.len() > crate::hash::CDC_MAX_BYTES as usize {
+                    return Err(BulkloadRefusal::DigestMismatch);
+                }
                 stats.bytes_received = stats.bytes_received.saturating_add(data.len() as u64);
-                store.put_chunk(&digest, &data)?;
+                pending.push((digest, data));
+                if pending.len() == PERSIST_BATCH {
+                    store.put_chunks(&pending)?;
+                    pending.clear();
+                }
             }
             FrameKind::Refusal { .. } => return Err(BulkloadRefusal::SealedObjectMissing),
             _ => return Err(BulkloadRefusal::FrameCodec),
         }
     }
-    Ok(())
+    store.put_chunks(&pending)
 }
 
 fn capture(
@@ -530,6 +538,7 @@ fn capture(
     }
     let mut hasher = blake3::Hasher::new();
     let mut chunks = Vec::new();
+    let mut pending = Vec::with_capacity(PERSIST_BATCH);
     for chunk in fastcdc::v2020::StreamCDC::new(
         prefix.as_slice().chain(reader),
         crate::hash::CDC_MIN_BYTES,
@@ -542,12 +551,17 @@ fn capture(
         }
         hasher.update(&chunk.data);
         let digest = crate::hash::hash_bytes(&chunk.data);
-        store.put_chunk(&digest, &chunk.data)?;
         chunks.push(ChunkSpec {
             digest,
             size: chunk.data.len() as u64,
         });
+        pending.push((digest, chunk.data));
+        if pending.len() == PERSIST_BATCH {
+            store.put_chunks(&pending)?;
+            pending.clear();
+        }
     }
+    store.put_chunks(&pending)?;
     if StatIdentity::from_metadata(&file.metadata()?) != expected {
         return Err(BulkloadRefusal::SourceChangedAfterSnapshot);
     }
@@ -735,6 +749,32 @@ mod tests {
                 std::fs::read(corpus.base.join("destination").join(relative)).unwrap()
             );
         }
+    }
+
+    #[test]
+    fn chunk_batches_round_trip_and_resume_large_file() {
+        let corpus = Corpus::new();
+        let mut seed = 1_u32;
+        let bytes: Vec<u8> = (0..=(PERSIST_BATCH * crate::hash::CDC_MAX_BYTES as usize))
+            .map(|_| {
+                seed ^= seed << 13;
+                seed ^= seed >> 17;
+                seed ^= seed << 5;
+                seed.to_le_bytes().first().copied().unwrap()
+            })
+            .collect();
+        std::fs::write(corpus.base.join("source/large"), &bytes).unwrap();
+        let first = corpus.run().unwrap();
+        assert!(first.refusals.is_empty());
+        assert_eq!(first.source_bytes_read, bytes.len() as u64);
+        assert_eq!(
+            std::fs::read(corpus.base.join("destination/large")).unwrap(),
+            bytes
+        );
+        let resumed = corpus.run().unwrap();
+        assert!(resumed.refusals.is_empty());
+        assert_eq!(resumed.source_bytes_read, 0);
+        assert_eq!(resumed.bytes_received, 0);
     }
 
     #[test]

--- a/crates/tcfs-bulkload-agent/src/transfer.rs
+++ b/crates/tcfs-bulkload-agent/src/transfer.rs
@@ -646,6 +646,98 @@ mod tests {
     }
 
     #[test]
+    fn interrupted_transport_resumes_completed_captures_without_source_reads() {
+        struct Interrupted<W> {
+            output: W,
+            remaining: usize,
+        }
+        impl<W: Write> Write for Interrupted<W> {
+            fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+                if self.remaining == 0 {
+                    return Err(std::io::ErrorKind::BrokenPipe.into());
+                }
+                let count = self
+                    .output
+                    .write(data.get(..data.len().min(self.remaining)).unwrap())?;
+                self.remaining -= count;
+                Ok(count)
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                self.output.flush()
+            }
+        }
+        let corpus = Corpus::new();
+        for index in 0_u64..3 {
+            let mut state = index + 1;
+            let bytes: Vec<u8> = (0..524_288)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1);
+                    u8::try_from(state >> 56).unwrap()
+                })
+                .collect();
+            std::fs::write(
+                corpus.base.join("source").join(format!("file-{index}")),
+                bytes,
+            )
+            .unwrap();
+        }
+        let (sender, mut receiver) = std::os::unix::net::UnixStream::pair().unwrap();
+        for stream in [&sender, &receiver] {
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(20)))
+                .unwrap();
+            stream
+                .set_write_timeout(Some(std::time::Duration::from_secs(20)))
+                .unwrap();
+        }
+        std::thread::scope(|scope| {
+            let producer = scope.spawn(move || {
+                let mut input = sender.try_clone().unwrap();
+                serve(
+                    &mut input,
+                    &mut Interrupted {
+                        output: sender,
+                        remaining: 700_000,
+                    },
+                )
+            });
+            let mut output = receiver.try_clone().unwrap();
+            let outcome = receive(
+                &mut receiver,
+                &mut output,
+                &corpus.base.join("source"),
+                &corpus.base.join("source-state"),
+                &corpus.base.join("destination"),
+                &corpus.base.join("destination-state"),
+            );
+            drop(output);
+            drop(receiver);
+            assert!(producer.join().unwrap().is_err());
+            assert!(outcome.is_err());
+        });
+        assert_eq!(
+            std::fs::read_dir(corpus.base.join("destination"))
+                .unwrap()
+                .count(),
+            1
+        );
+        let resumed = corpus.run().unwrap();
+        assert!(resumed.refusals.is_empty());
+        assert_eq!(resumed.reused, 1);
+        assert_eq!(resumed.completed, 2);
+        assert_eq!(resumed.source_bytes_read, 0);
+        for index in 0..3 {
+            let relative = format!("file-{index}");
+            assert_eq!(
+                std::fs::read(corpus.base.join("source").join(&relative)).unwrap(),
+                std::fs::read(corpus.base.join("destination").join(relative)).unwrap()
+            );
+        }
+    }
+
+    #[test]
     fn parallel_batches_resume_and_continue_after_a_refused_file() {
         let corpus = Corpus::new();
         let bytes = vec![71_u8; 65_536];

--- a/crates/tcfs-bulkload-agent/src/transfer.rs
+++ b/crates/tcfs-bulkload-agent/src/transfer.rs
@@ -9,6 +9,13 @@ use std::io::{Read, Write};
 use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
 use std::os::unix::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+const BATCH_ROWS: usize = 32;
+const CAPTURE_WORKERS: usize = 4;
+// At most four queued plus four in-flight manifests (5 MiB each), with
+// CDC buffers bounded separately. The existing full census remains O(N).
+const MAX_MANIFEST_CHUNKS: usize = 131_072;
 
 use tcfs_bulkload_proto::frame::{ChunkSpec, LENGTH_PREFIX_BYTES, MAX_FRAME_BYTES};
 use tcfs_bulkload_proto::FileKind;
@@ -22,7 +29,7 @@ use crate::{BulkloadRefusal, Frame, FrameKind, Result, RowSchema};
 /// Receiver accounting; any refusal means the requested carry is incomplete.
 #[derive(Debug, Default)]
 pub struct TransferStats {
-    /// Newly materialized or independently verified files and links.
+    /// Newly materialized or independently verified regular files.
     pub completed: u64,
     /// Outputs skipped using a previously persisted completion.
     pub reused: u64,
@@ -124,33 +131,28 @@ pub fn serve<R: Read, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
     }
     let mut source_bytes_read = 0;
     let mut rows = 0;
-    for row in census.rows {
-        rows += 1;
-        write_frame(output, FrameKind::Row(row.clone()))?;
-        let FrameKind::WantFile { needed } = read_frame(input)?.kind else {
+    for batch in census.rows.chunks(BATCH_ROWS) {
+        rows += batch.len() as u64;
+        write_frame(
+            output,
+            FrameKind::TransferBatch {
+                rows: batch.to_vec(),
+            },
+        )?;
+        let FrameKind::WantFiles { needed } = read_frame(input)?.kind else {
             return Err(BulkloadRefusal::FrameCodec);
         };
-        if !needed {
-            continue;
-        }
-        if row.kind != FileKind::Regular {
+        if needed.len() != batch.len() {
             return Err(BulkloadRefusal::FrameCodec);
         }
-        let captured = capture(&root, &authority, &row, &store, &mut source_bytes_read);
-        let manifest = match captured {
-            Ok(manifest) => manifest,
-            Err(refusal) => {
-                write_frame(
-                    output,
-                    FrameKind::Refusal {
-                        code: refusal.code().to_owned(),
-                        rel_path: row.rel_path,
-                    },
-                )?;
-                continue;
-            }
-        };
-        send_content(input, output, &manifest, &store, &row)?;
+        if batch
+            .iter()
+            .zip(&needed)
+            .any(|(row, needed)| *needed && row.kind != FileKind::Regular)
+        {
+            return Err(BulkloadRefusal::FrameCodec);
+        }
+        source_bytes_read += send_batch(input, output, &root, &authority, &store, batch, &needed)?;
     }
     write_frame(
         output,
@@ -159,6 +161,74 @@ pub fn serve<R: Read, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
             source_bytes_read,
         },
     )
+}
+
+fn send_batch<R: Read, W: Write>(
+    input: &mut R,
+    output: &mut W,
+    root: &Path,
+    authority: &[u8],
+    store: &Store,
+    batch: &[RowSchema],
+    needed: &[bool],
+) -> Result<u64> {
+    let next = AtomicUsize::new(0);
+    let state = store.root();
+    std::thread::scope(|scope| -> Result<u64> {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(CAPTURE_WORKERS);
+        for _ in 0..CAPTURE_WORKERS.min(needed.iter().filter(|value| **value).count()) {
+            let sender = sender.clone();
+            let next = &next;
+            std::thread::Builder::new().spawn_scoped(scope, move || {
+                let opened = Store::open(state);
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(row) = batch.get(index) else { break };
+                    if !needed.get(index).copied().unwrap_or(false) {
+                        continue;
+                    }
+                    let mut bytes = 0;
+                    let captured = opened
+                        .as_ref()
+                        .map_or(Err(BulkloadRefusal::Io(None)), |store| {
+                            capture(root, authority, row, store, &mut bytes)
+                        });
+                    if sender.send((index, bytes, captured)).is_err() {
+                        break;
+                    }
+                }
+            })?;
+        }
+        drop(sender);
+        let mut bytes_read = 0_u64;
+        let mut completed = 0;
+        for (index, bytes, captured) in receiver {
+            bytes_read = bytes_read.saturating_add(bytes);
+            completed += 1;
+            let row = batch.get(index).ok_or(BulkloadRefusal::FrameCodec)?;
+            write_frame(
+                output,
+                FrameKind::FileContent {
+                    index: u32::try_from(index).map_err(|_| BulkloadRefusal::FrameCodec)?,
+                },
+            )?;
+            match captured {
+                Ok(manifest) => send_content(input, output, &manifest, store, row)?,
+                Err(refusal) => write_frame(
+                    output,
+                    FrameKind::Refusal {
+                        code: refusal.code().to_owned(),
+                        rel_path: row.rel_path.clone(),
+                    },
+                )?,
+            }
+        }
+        if completed != needed.iter().filter(|value| **value).count() {
+            return Err(BulkloadRefusal::Io(None));
+        }
+        write_frame(output, FrameKind::BatchDone)?;
+        Ok(bytes_read)
+    })
 }
 
 fn send_content<R: Read, W: Write>(
@@ -243,17 +313,45 @@ pub fn receive<R: Read, W: Write>(
     let mut rows = 0;
     loop {
         match read_frame(input)?.kind {
-            FrameKind::Row(row) => {
-                rows += 1;
-                receive_row(
-                    input,
+            FrameKind::TransferBatch { rows: batch } => {
+                if batch.is_empty() || batch.len() > BATCH_ROWS {
+                    return Err(BulkloadRefusal::BudgetExceeded);
+                }
+                rows += batch.len() as u64;
+                let mut needed = batch
+                    .iter()
+                    .map(|row| prepare_row(&mut target, &store, &output_authority, row, &mut stats))
+                    .collect::<Result<Vec<_>>>()?;
+                write_frame(
                     output,
-                    &mut target,
-                    &store,
-                    &output_authority,
-                    &row,
-                    &mut stats,
+                    FrameKind::WantFiles {
+                        needed: needed.clone(),
+                    },
                 )?;
+                loop {
+                    match read_frame(input)?.kind {
+                        FrameKind::FileContent { index } => {
+                            let index = index as usize;
+                            let requested =
+                                needed.get_mut(index).ok_or(BulkloadRefusal::FrameCodec)?;
+                            if !*requested {
+                                return Err(BulkloadRefusal::FrameCodec);
+                            }
+                            *requested = false;
+                            receive_content(
+                                input,
+                                output,
+                                &target,
+                                &store,
+                                &output_authority,
+                                batch.get(index).ok_or(BulkloadRefusal::FrameCodec)?,
+                                &mut stats,
+                            )?;
+                        }
+                        FrameKind::BatchDone if needed.iter().all(|value| !*value) => break,
+                        _ => return Err(BulkloadRefusal::FrameCodec),
+                    }
+                }
             }
             FrameKind::Refusal { code, rel_path } => stats.refusals.push((rel_path, code)),
             FrameKind::TransferDone {
@@ -271,15 +369,13 @@ pub fn receive<R: Read, W: Write>(
     }
 }
 
-fn receive_row<R: Read, W: Write>(
-    input: &mut R,
-    output: &mut W,
+fn prepare_row(
     target: &mut Destination,
     store: &Store,
     authority: &[u8],
     row: &RowSchema,
     stats: &mut TransferStats,
-) -> Result<()> {
+) -> Result<bool> {
     let key = row_key(authority, row)?;
     let preparation = match row.kind {
         FileKind::Directory => target.directory(row, store, authority).map(|()| false),
@@ -304,12 +400,23 @@ fn receive_row<R: Read, W: Write>(
             false
         }
     };
-    write_frame(output, FrameKind::WantFile { needed })?;
-    if !needed {
-        return Ok(());
-    }
+    Ok(needed)
+}
+
+fn receive_content<R: Read, W: Write>(
+    input: &mut R,
+    output: &mut W,
+    target: &Destination,
+    store: &Store,
+    authority: &[u8],
+    row: &RowSchema,
+    stats: &mut TransferStats,
+) -> Result<()> {
+    let key = row_key(authority, row)?;
     let manifest = match read_frame(input)?.kind {
-        FrameKind::Manifest { digest, chunks } => Manifest { digest, chunks },
+        FrameKind::Manifest { digest, chunks } if chunks.len() <= MAX_MANIFEST_CHUNKS => {
+            Manifest { digest, chunks }
+        }
         FrameKind::Refusal { code, rel_path } => {
             stats.refusals.push((rel_path, code));
             return Ok(());
@@ -378,8 +485,14 @@ fn capture(
     store: &Store,
     bytes_read: &mut u64,
 ) -> Result<Manifest> {
+    if row.size > (MAX_MANIFEST_CHUNKS as u64) * u64::from(crate::hash::CDC_MAX_BYTES) {
+        return Err(BulkloadRefusal::BudgetExceeded);
+    }
     let key = row_key(authority, row)?;
     if let Some(manifest) = store.capture(&key)? {
+        if manifest.chunks.len() > MAX_MANIFEST_CHUNKS {
+            return Err(BulkloadRefusal::BudgetExceeded);
+        }
         let available =
             manifest
                 .chunks
@@ -424,6 +537,9 @@ fn capture(
         crate::hash::CDC_MAX_BYTES,
     ) {
         let chunk = chunk.map_err(|_| BulkloadRefusal::Io(None))?;
+        if chunks.len() >= MAX_MANIFEST_CHUNKS {
+            return Err(BulkloadRefusal::BudgetExceeded);
+        }
         hasher.update(&chunk.data);
         let digest = crate::hash::hash_bytes(&chunk.data);
         store.put_chunk(&digest, &chunk.data)?;
@@ -527,6 +643,46 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.base);
         }
+    }
+
+    #[test]
+    fn parallel_batches_resume_and_continue_after_a_refused_file() {
+        let corpus = Corpus::new();
+        let bytes = vec![71_u8; 65_536];
+        for index in 0..70 {
+            std::fs::write(
+                corpus.base.join("source").join(format!("file-{index:03}")),
+                &bytes,
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            corpus.base.join("source/file-035.db"),
+            b"SQLite format 3\0refused",
+        )
+        .unwrap();
+        let first = corpus.run().unwrap();
+        assert_eq!(first.completed, 70);
+        assert_eq!(first.refusals.len(), 1);
+        assert_eq!(first.source_bytes_read, 70 * 65_536 + 16);
+        assert_eq!(first.bytes_received, 65_536);
+        for index in 0..70 {
+            assert_eq!(
+                std::fs::read(
+                    corpus
+                        .base
+                        .join("destination")
+                        .join(format!("file-{index:03}"))
+                )
+                .unwrap(),
+                bytes
+            );
+        }
+        let second = corpus.run().unwrap();
+        assert_eq!(second.reused, 70);
+        assert_eq!(second.refusals.len(), 1);
+        assert_eq!(second.source_bytes_read, 16);
+        assert_eq!(second.bytes_received, 0);
     }
 
     #[test]

--- a/crates/tcfs-bulkload-agent/src/transfer.rs
+++ b/crates/tcfs-bulkload-agent/src/transfer.rs
@@ -1,0 +1,654 @@
+//! Native resumable transfer over framed bidirectional stdio.
+//!
+//! Only missing chunks cross the wire. Source reads are retained in a private
+//! content store; destination completion binds both source and output identity.
+//! Enumeration still walks the tree. This is not a no-rewalk performance claim.
+
+use std::collections::HashSet;
+use std::io::{Read, Write};
+use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::os::unix::fs::MetadataExt as _;
+use std::path::{Path, PathBuf};
+
+use tcfs_bulkload_proto::frame::{ChunkSpec, LENGTH_PREFIX_BYTES, MAX_FRAME_BYTES};
+use tcfs_bulkload_proto::FileKind;
+
+use crate::freshness::{NullCache, StatIdentity};
+use crate::materialize::Destination;
+use crate::transfer_store::{row_key, Manifest, Store};
+use crate::walk::{walk, WalkOptions};
+use crate::{BulkloadRefusal, Frame, FrameKind, Result, RowSchema};
+
+/// Receiver accounting; any refusal means the requested carry is incomplete.
+#[derive(Debug, Default)]
+pub struct TransferStats {
+    /// Newly materialized or independently verified files and links.
+    pub completed: u64,
+    /// Outputs skipped using a previously persisted completion.
+    pub reused: u64,
+    /// Content bytes received across the transport.
+    pub bytes_received: u64,
+    /// Actual source file bytes read while preparing missing captures.
+    pub source_bytes_read: u64,
+    /// Relative paths and refusal codes. Contents and credentials are never logged.
+    pub refusals: Vec<(Vec<u8>, String)>,
+}
+
+/// Run the same framed protocol locally over a bounded Unix stream pair.
+///
+/// # Errors
+/// Refuses overlapping roots, malformed data and transport or source failures.
+pub fn copy(
+    source: &Path,
+    destination: &Path,
+    source_state: &Path,
+    destination_state: &Path,
+) -> Result<TransferStats> {
+    let source_root = std::fs::canonicalize(source)?;
+    let destination_root = std::fs::canonicalize(destination)?;
+    if source_root.starts_with(&destination_root) || destination_root.starts_with(&source_root) {
+        return Err(BulkloadRefusal::SnapshotRootsOverlap);
+    }
+    let (mut sender, mut receiver) = std::os::unix::net::UnixStream::pair()?;
+    #[cfg(test)]
+    for stream in [&sender, &receiver] {
+        stream.set_read_timeout(Some(std::time::Duration::from_secs(20)))?;
+        stream.set_write_timeout(Some(std::time::Duration::from_secs(20)))?;
+    }
+    std::thread::scope(|scope| -> Result<TransferStats> {
+        let producer = std::thread::Builder::new().spawn_scoped(scope, move || {
+            let mut input = sender.try_clone()?;
+            serve(&mut input, &mut sender)
+        })?;
+        let result = {
+            let mut output = receiver.try_clone()?;
+            receive(
+                &mut receiver,
+                &mut output,
+                source,
+                source_state,
+                destination,
+                destination_state,
+            )
+        };
+        drop(receiver);
+        producer.join().map_err(|_| BulkloadRefusal::Io(None))??;
+        result
+    })
+}
+
+/// Serve one transfer request from a caller-authenticated stdio transport.
+///
+/// # Errors
+/// Refuses malformed frames, unsafe state roots, source failures and broken I/O.
+pub fn serve<R: Read, W: Write>(input: &mut R, output: &mut W) -> Result<()> {
+    let FrameKind::TransferOpen { root, state } = read_frame(input)?.kind else {
+        return Err(BulkloadRefusal::FrameCodec);
+    };
+    let root = std::fs::canonicalize(path(root))?;
+    let store = Store::open(&path(state))?;
+    if store.root().starts_with(&root) || root.starts_with(store.root()) {
+        return Err(BulkloadRefusal::SnapshotRootsOverlap);
+    }
+    let meta = std::fs::metadata(&root)?;
+    let authority = postcard::to_stdvec(&(
+        store.authority()?,
+        root.as_os_str().as_bytes(),
+        meta.dev(),
+        meta.ino(),
+    ))?;
+    write_frame(
+        output,
+        FrameKind::TransferStart {
+            authority: authority.clone(),
+        },
+    )?;
+    let mut census = walk(
+        &WalkOptions {
+            cross_device: true,
+            ..WalkOptions::new(root.clone())
+        },
+        &mut NullCache,
+    )?;
+    census
+        .rows
+        .sort_by(|left, right| left.rel_path.cmp(&right.rel_path));
+    for refused in census.refusals {
+        write_frame(
+            output,
+            FrameKind::Refusal {
+                code: refused.refusal.code().to_owned(),
+                rel_path: refused.rel_path,
+            },
+        )?;
+    }
+    let mut source_bytes_read = 0;
+    let mut rows = 0;
+    for row in census.rows {
+        rows += 1;
+        write_frame(output, FrameKind::Row(row.clone()))?;
+        let FrameKind::WantFile { needed } = read_frame(input)?.kind else {
+            return Err(BulkloadRefusal::FrameCodec);
+        };
+        if !needed {
+            continue;
+        }
+        if row.kind != FileKind::Regular {
+            return Err(BulkloadRefusal::FrameCodec);
+        }
+        let captured = capture(&root, &authority, &row, &store, &mut source_bytes_read);
+        let manifest = match captured {
+            Ok(manifest) => manifest,
+            Err(refusal) => {
+                write_frame(
+                    output,
+                    FrameKind::Refusal {
+                        code: refusal.code().to_owned(),
+                        rel_path: row.rel_path,
+                    },
+                )?;
+                continue;
+            }
+        };
+        send_content(input, output, &manifest, &store, &row)?;
+    }
+    write_frame(
+        output,
+        FrameKind::TransferDone {
+            rows,
+            source_bytes_read,
+        },
+    )
+}
+
+fn send_content<R: Read, W: Write>(
+    input: &mut R,
+    output: &mut W,
+    manifest: &Manifest,
+    store: &Store,
+    row: &RowSchema,
+) -> Result<()> {
+    write_frame(
+        output,
+        FrameKind::Manifest {
+            digest: manifest.digest,
+            chunks: manifest.chunks.clone(),
+        },
+    )?;
+    let FrameKind::WantChunks { digests } = read_frame(input)?.kind else {
+        return Err(BulkloadRefusal::FrameCodec);
+    };
+    let permitted: HashSet<_> = manifest.chunks.iter().map(|chunk| chunk.digest).collect();
+    let mut requested = HashSet::new();
+    for digest in digests {
+        if !permitted.contains(&digest) || !requested.insert(digest) {
+            return Err(BulkloadRefusal::FrameCodec);
+        }
+        match store.chunk(&digest) {
+            Ok(Some(data)) => write_frame(output, FrameKind::Chunk { digest, data })?,
+            result => {
+                let refusal = result.err().unwrap_or(BulkloadRefusal::SealedObjectMissing);
+                write_frame(
+                    output,
+                    FrameKind::Refusal {
+                        code: refusal.code().to_owned(),
+                        rel_path: row.rel_path.clone(),
+                    },
+                )?;
+                break;
+            }
+        }
+    }
+    if !matches!(read_frame(input)?.kind, FrameKind::Applied { .. }) {
+        return Err(BulkloadRefusal::FrameCodec);
+    }
+    Ok(())
+}
+
+/// Receive an ordinary-file carry without replacing divergent outputs.
+///
+/// # Errors
+/// Refuses protocol errors and unsafe roots. Per-path conflicts remain in stats.
+pub fn receive<R: Read, W: Write>(
+    input: &mut R,
+    output: &mut W,
+    source: &Path,
+    source_state: &Path,
+    destination: &Path,
+    destination_state: &Path,
+) -> Result<TransferStats> {
+    let store = Store::open(destination_state)?;
+    let mut target = Destination::open(destination)?;
+    if store.root().starts_with(target.path()) || target.path().starts_with(store.root()) {
+        return Err(BulkloadRefusal::SnapshotRootsOverlap);
+    }
+    write_frame(
+        output,
+        FrameKind::TransferOpen {
+            root: source.as_os_str().as_bytes().to_vec(),
+            state: source_state.as_os_str().as_bytes().to_vec(),
+        },
+    )?;
+    let FrameKind::TransferStart { authority } = read_frame(input)?.kind else {
+        return Err(BulkloadRefusal::FrameCodec);
+    };
+    let target_meta = std::fs::metadata(target.path())?;
+    let output_authority = postcard::to_stdvec(&(
+        authority,
+        target.path().as_os_str().as_bytes(),
+        target_meta.dev(),
+        target_meta.ino(),
+    ))?;
+    let mut stats = TransferStats::default();
+    let mut rows = 0;
+    loop {
+        match read_frame(input)?.kind {
+            FrameKind::Row(row) => {
+                rows += 1;
+                receive_row(
+                    input,
+                    output,
+                    &mut target,
+                    &store,
+                    &output_authority,
+                    &row,
+                    &mut stats,
+                )?;
+            }
+            FrameKind::Refusal { code, rel_path } => stats.refusals.push((rel_path, code)),
+            FrameKind::TransferDone {
+                rows: sent,
+                source_bytes_read,
+            } if sent == rows => {
+                stats.source_bytes_read = source_bytes_read;
+                if stats.refusals.is_empty() {
+                    target.finish_directories(&store)?;
+                }
+                return Ok(stats);
+            }
+            _ => return Err(BulkloadRefusal::FrameCodec),
+        }
+    }
+}
+
+fn receive_row<R: Read, W: Write>(
+    input: &mut R,
+    output: &mut W,
+    target: &mut Destination,
+    store: &Store,
+    authority: &[u8],
+    row: &RowSchema,
+    stats: &mut TransferStats,
+) -> Result<()> {
+    let key = row_key(authority, row)?;
+    let preparation = match row.kind {
+        FileKind::Directory => target.directory(row, store, authority).map(|()| false),
+        FileKind::Symlink => target.symlink(row).map(|()| false),
+        FileKind::Regular => target.identity(row).and_then(|identity| {
+            if let Some(identity) = identity {
+                if store.output_matches(&key, &identity)? {
+                    stats.reused += 1;
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }),
+        _ => Err(BulkloadRefusal::FieldDomainViolation),
+    };
+    let needed = match preparation {
+        Ok(needed) => needed,
+        Err(refusal) => {
+            stats
+                .refusals
+                .push((row.rel_path.clone(), refusal.code().to_owned()));
+            false
+        }
+    };
+    write_frame(output, FrameKind::WantFile { needed })?;
+    if !needed {
+        return Ok(());
+    }
+    let manifest = match read_frame(input)?.kind {
+        FrameKind::Manifest { digest, chunks } => Manifest { digest, chunks },
+        FrameKind::Refusal { code, rel_path } => {
+            stats.refusals.push((rel_path, code));
+            return Ok(());
+        }
+        _ => return Err(BulkloadRefusal::FrameCodec),
+    };
+    let received = receive_chunks(input, output, &manifest, store, stats);
+    let applied = received
+        .and_then(|()| target.file(row, &manifest, store))
+        .and_then(|identity| store.record_output(&key, &identity));
+    write_frame(
+        output,
+        FrameKind::Applied {
+            success: applied.is_ok(),
+        },
+    )?;
+    match applied {
+        Ok(()) => stats.completed += 1,
+        Err(refusal) => stats
+            .refusals
+            .push((row.rel_path.clone(), refusal.code().to_owned())),
+    }
+    Ok(())
+}
+
+fn receive_chunks<R: Read, W: Write>(
+    input: &mut R,
+    output: &mut W,
+    manifest: &Manifest,
+    store: &Store,
+    stats: &mut TransferStats,
+) -> Result<()> {
+    let mut missing = Vec::new();
+    let mut seen = HashSet::new();
+    for chunk in &manifest.chunks {
+        if chunk.size > u64::from(crate::hash::CDC_MAX_BYTES) {
+            return Err(BulkloadRefusal::BudgetExceeded);
+        }
+        if seen.insert(chunk.digest) && store.chunk(&chunk.digest)?.is_none() {
+            missing.push(chunk.digest);
+        }
+    }
+    write_frame(
+        output,
+        FrameKind::WantChunks {
+            digests: missing.clone(),
+        },
+    )?;
+    for expected in missing {
+        match read_frame(input)?.kind {
+            FrameKind::Chunk { digest, data } if digest == expected => {
+                stats.bytes_received = stats.bytes_received.saturating_add(data.len() as u64);
+                store.put_chunk(&digest, &data)?;
+            }
+            FrameKind::Refusal { .. } => return Err(BulkloadRefusal::SealedObjectMissing),
+            _ => return Err(BulkloadRefusal::FrameCodec),
+        }
+    }
+    Ok(())
+}
+
+fn capture(
+    root: &Path,
+    authority: &[u8],
+    row: &RowSchema,
+    store: &Store,
+    bytes_read: &mut u64,
+) -> Result<Manifest> {
+    let key = row_key(authority, row)?;
+    if let Some(manifest) = store.capture(&key)? {
+        let available =
+            manifest
+                .chunks
+                .iter()
+                .try_fold(true, |available, chunk| -> Result<bool> {
+                    Ok(available && store.chunk(&chunk.digest)?.is_some())
+                })?;
+        if available {
+            return Ok(manifest);
+        }
+    }
+    if row.rel_path.ends_with(b"-wal")
+        || row.rel_path.ends_with(b"-shm")
+        || row.rel_path.ends_with(b"-journal")
+    {
+        return Err(BulkloadRefusal::SqliteStateChanged);
+    }
+    let file_path = root.join(path(row.rel_path.clone()));
+    let mut file = crate::hash::open_nofollow(&file_path)?;
+    let expected = StatIdentity::from_row(row);
+    if StatIdentity::from_metadata(&file.metadata()?) != expected {
+        return Err(BulkloadRefusal::SourceChangedAfterSnapshot);
+    }
+    let mut prefix = Vec::new();
+    let mut reader = CountReader {
+        input: &mut file,
+        count: bytes_read,
+    };
+    (&mut reader).take(16).read_to_end(&mut prefix)?;
+    if prefix.starts_with(b"SQLite format 3\0")
+        || prefix.starts_with(&[0x37, 0x7f, 0x06, 0x82])
+        || prefix.starts_with(&[0x37, 0x7f, 0x06, 0x83])
+    {
+        return Err(BulkloadRefusal::SqliteStateChanged);
+    }
+    let mut hasher = blake3::Hasher::new();
+    let mut chunks = Vec::new();
+    for chunk in fastcdc::v2020::StreamCDC::new(
+        prefix.as_slice().chain(reader),
+        crate::hash::CDC_MIN_BYTES,
+        crate::hash::CDC_AVG_BYTES,
+        crate::hash::CDC_MAX_BYTES,
+    ) {
+        let chunk = chunk.map_err(|_| BulkloadRefusal::Io(None))?;
+        hasher.update(&chunk.data);
+        let digest = crate::hash::hash_bytes(&chunk.data);
+        store.put_chunk(&digest, &chunk.data)?;
+        chunks.push(ChunkSpec {
+            digest,
+            size: chunk.data.len() as u64,
+        });
+    }
+    if StatIdentity::from_metadata(&file.metadata()?) != expected {
+        return Err(BulkloadRefusal::SourceChangedAfterSnapshot);
+    }
+    let manifest = Manifest {
+        digest: *hasher.finalize().as_bytes(),
+        chunks,
+    };
+    store.record_capture(&key, &manifest)?;
+    Ok(manifest)
+}
+
+struct CountReader<'a, R> {
+    input: R,
+    count: &'a mut u64,
+}
+impl<R: Read> Read for CountReader<'_, R> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let count = self.input.read(buffer)?;
+        *self.count = self.count.saturating_add(count as u64);
+        Ok(count)
+    }
+}
+
+/// Read one bounded frame without searching for delimiters.
+///
+/// # Errors
+/// Refuses truncated/oversized/invalid frames and incompatible protocol versions.
+pub fn read_frame<R: Read>(input: &mut R) -> Result<Frame> {
+    let mut header = [0_u8; LENGTH_PREFIX_BYTES];
+    input.read_exact(&mut header)?;
+    let length = u32::from_be_bytes(header) as usize;
+    if length > MAX_FRAME_BYTES {
+        return Err(BulkloadRefusal::BudgetExceeded);
+    }
+    let mut bytes = header.to_vec();
+    bytes.resize(LENGTH_PREFIX_BYTES + length, 0);
+    input.read_exact(
+        bytes
+            .get_mut(LENGTH_PREFIX_BYTES..)
+            .ok_or(BulkloadRefusal::FrameCodec)?,
+    )?;
+    Ok(Frame::decode(&bytes)?.0)
+}
+
+/// Write one bounded frame and flush the request/reply boundary.
+///
+/// # Errors
+/// Refuses oversized messages and broken transports.
+pub fn write_frame<W: Write>(output: &mut W, kind: FrameKind) -> Result<()> {
+    output.write_all(&Frame::new(kind).encode()?)?;
+    output.flush()?;
+    Ok(())
+}
+
+fn path(bytes: Vec<u8>) -> PathBuf {
+    std::ffi::OsString::from_vec(bytes).into()
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+    use super::*;
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+
+    struct Corpus {
+        base: PathBuf,
+    }
+    impl Corpus {
+        fn new() -> Self {
+            let base = std::env::temp_dir().join(format!(
+                "tcfs-native-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir(&base).unwrap();
+            for path in ["source", "destination"] {
+                std::fs::create_dir(base.join(path)).unwrap();
+            }
+            Self { base }
+        }
+        fn run(&self) -> Result<TransferStats> {
+            copy(
+                &self.base.join("source"),
+                &self.base.join("destination"),
+                &self.base.join("source-state"),
+                &self.base.join("destination-state"),
+            )
+        }
+    }
+    impl Drop for Corpus {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.base);
+        }
+    }
+
+    #[test]
+    fn round_trip_resumes_without_source_reads_and_preserves_divergence() {
+        let corpus = Corpus::new();
+        let source = corpus.base.join("source");
+        let destination = corpus.base.join("destination");
+        std::fs::create_dir(source.join("nested")).unwrap();
+        let bytes: Vec<u8> = (0..800_000)
+            .map(|value| u8::try_from(value % 251).unwrap())
+            .collect();
+        std::fs::write(source.join("nested/data"), &bytes).unwrap();
+        std::fs::write(source.join(".credential"), b"account-file").unwrap();
+        std::fs::set_permissions(
+            source.join(".credential"),
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink("../elsewhere", source.join("link")).unwrap();
+        let first = corpus.run().unwrap();
+        assert!(first.refusals.is_empty(), "{:?}", first.refusals);
+        assert_eq!(
+            std::fs::read(destination.join("nested/data")).unwrap(),
+            bytes
+        );
+        assert_eq!(
+            std::fs::read_link(destination.join("link")).unwrap(),
+            Path::new("../elsewhere")
+        );
+        assert_eq!(
+            std::fs::metadata(destination.join(".credential"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let second = corpus.run().unwrap();
+        assert_eq!(second.reused, 2);
+        assert_eq!(second.source_bytes_read, 0);
+        assert_eq!(second.bytes_received, 0);
+        std::fs::set_permissions(
+            destination.join("nested"),
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        let metadata_conflict = corpus.run().unwrap();
+        assert_eq!(metadata_conflict.refusals.len(), 1);
+        assert_eq!(
+            std::fs::metadata(destination.join("nested"))
+                .unwrap()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        std::fs::set_permissions(
+            destination.join("nested"),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+        std::fs::write(destination.join(".credential"), b"sting-unique").unwrap();
+        let third = corpus.run().unwrap();
+        assert_eq!(third.refusals.len(), 1);
+        assert_eq!(
+            std::fs::read(destination.join(".credential")).unwrap(),
+            b"sting-unique"
+        );
+        assert_eq!(
+            std::fs::read(source.join(".credential")).unwrap(),
+            b"account-file"
+        );
+    }
+
+    #[test]
+    fn sqlite_headers_and_destination_symlinks_are_not_raw_copied() {
+        let corpus = Corpus::new();
+        let source = corpus.base.join("source");
+        let destination = corpus.base.join("destination");
+        std::fs::write(source.join("credentials.db"), b"SQLite format 3\0opaque").unwrap();
+        std::fs::create_dir(source.join("nested")).unwrap();
+        std::fs::write(source.join("nested/secret"), b"secret").unwrap();
+        let outside = corpus.base.join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, destination.join("nested")).unwrap();
+        let result = corpus.run().unwrap();
+        assert_eq!(result.refusals.len(), 3);
+        assert!(!destination.join("credentials.db").exists());
+        assert!(!outside.join("secret").exists());
+    }
+
+    #[test]
+    fn interrupted_directory_mode_finalization_resumes_only_its_owned_inode() {
+        let corpus = Corpus::new();
+        let source = corpus.base.join("source");
+        let destination = corpus.base.join("destination");
+        std::fs::create_dir(source.join("nested")).unwrap();
+        let mut row = walk(&WalkOptions::new(source), &mut NullCache)
+            .unwrap()
+            .rows
+            .remove(0);
+        row.mode = 0o40_555;
+        let store = Store::open(&corpus.base.join("destination-state")).unwrap();
+        {
+            let mut first = Destination::open(&destination).unwrap();
+            first.directory(&row, &store, b"authority").unwrap();
+            assert_eq!(
+                std::fs::metadata(destination.join("nested"))
+                    .unwrap()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+        }
+        let mut resumed = Destination::open(&destination).unwrap();
+        resumed.directory(&row, &store, b"authority").unwrap();
+        resumed.finish_directories(&store).unwrap();
+        assert_eq!(
+            std::fs::metadata(destination.join("nested"))
+                .unwrap()
+                .mode()
+                & 0o777,
+            0o555
+        );
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/transfer_store.rs
+++ b/crates/tcfs-bulkload-agent/src/transfer_store.rs
@@ -1,0 +1,336 @@
+//! Private, durable chunk storage and completion records for native transfers.
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read as _, Write as _};
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rusqlite::OptionalExtension as _;
+use serde::{Deserialize, Serialize};
+use tcfs_bulkload_proto::frame::ChunkSpec;
+
+use crate::freshness::StatIdentity;
+use crate::{BulkloadRefusal, Result, RowSchema};
+
+static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+/// Completed content capture; chunks retain file order, including repetitions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    /// Digest of the complete file.
+    pub digest: [u8; 32],
+    /// Content-defined chunks in order.
+    pub chunks: Vec<ChunkSpec>,
+}
+
+/// A private, source-bound transfer state directory.
+pub struct Store {
+    root: PathBuf,
+    conn: rusqlite::Connection,
+}
+
+impl Store {
+    /// Open or create a private transfer store outside the carried roots.
+    ///
+    /// # Errors
+    /// Refuses symlinks, non-private directories and database failures.
+    pub fn open(root: &Path) -> Result<Self> {
+        private_dir(root)?;
+        private_dir(&root.join("chunks"))?;
+        let db = root.join("transfer.sqlite");
+        if let Ok(meta) = fs::symlink_metadata(&db) {
+            if !meta.is_file() || meta.permissions().mode() & 0o077 != 0 {
+                return Err(BulkloadRefusal::PathEscapesRoot);
+            }
+        } else {
+            OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&db)?;
+        }
+        let conn = rusqlite::Connection::open(db).map_err(sqlite_error)?;
+        conn.busy_timeout(std::time::Duration::from_secs(5))
+            .map_err(sqlite_error)?;
+        conn.execute_batch(
+            "PRAGMA synchronous=FULL;
+            CREATE TABLE IF NOT EXISTS captures (key BLOB PRIMARY KEY, manifest BLOB NOT NULL);
+            CREATE TABLE IF NOT EXISTS outputs (key BLOB PRIMARY KEY, identity BLOB NOT NULL);
+            CREATE TABLE IF NOT EXISTS directories (key BLOB PRIMARY KEY, identity BLOB NOT NULL);
+            CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value BLOB NOT NULL);",
+        )
+        .map_err(sqlite_error)?;
+        Ok(Self {
+            root: fs::canonicalize(root)?,
+            conn,
+        })
+    }
+
+    /// Canonical state root, used to reject recursive self-capture.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// A persistent source-store identifier prevents cross-host inode collisions.
+    ///
+    /// # Errors
+    /// Refuses unavailable OS randomness or malformed persistent authority.
+    pub fn authority(&self) -> Result<[u8; 32]> {
+        let found: Option<Vec<u8>> = self
+            .conn
+            .query_row(
+                "SELECT value FROM settings WHERE key='authority'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(sqlite_error)?;
+        if let Some(bytes) = found {
+            return bytes
+                .try_into()
+                .map_err(|_| BulkloadRefusal::SchemaMismatch);
+        }
+        let mut random = [0_u8; 32];
+        fs::File::open("/dev/urandom")?.read_exact(&mut random)?;
+        self.conn
+            .execute(
+                "INSERT OR IGNORE INTO settings VALUES ('authority', ?1)",
+                [random.as_slice()],
+            )
+            .map_err(sqlite_error)?;
+        let bytes: Vec<u8> = self
+            .conn
+            .query_row(
+                "SELECT value FROM settings WHERE key='authority'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(sqlite_error)?;
+        bytes
+            .try_into()
+            .map_err(|_| BulkloadRefusal::SchemaMismatch)
+    }
+
+    /// Retrieve a capture without reopening source content.
+    ///
+    /// # Errors
+    /// Refuses malformed records or database errors.
+    pub fn capture(&self, key: &[u8]) -> Result<Option<Manifest>> {
+        let bytes: Option<Vec<u8>> = self
+            .conn
+            .query_row(
+                "SELECT manifest FROM captures WHERE key = ?1",
+                [key],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(sqlite_error)?;
+        bytes
+            .map(|value| postcard::from_bytes(&value).map_err(Into::into))
+            .transpose()
+    }
+
+    /// Commit only a completed identity-checked capture.
+    ///
+    /// # Errors
+    /// Refuses serialization or database failures.
+    pub fn record_capture(&self, key: &[u8], value: &Manifest) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO captures VALUES (?1, ?2)
+            ON CONFLICT(key) DO UPDATE SET manifest=excluded.manifest",
+                (key, postcard::to_stdvec(value)?),
+            )
+            .map_err(sqlite_error)?;
+        Ok(())
+    }
+
+    /// Whether a current output is the same object recorded on successful apply.
+    ///
+    /// # Errors
+    /// Refuses database failures.
+    pub fn output_matches(&self, key: &[u8], identity: &StatIdentity) -> Result<bool> {
+        let found: Option<Vec<u8>> = self
+            .conn
+            .query_row(
+                "SELECT identity FROM outputs WHERE key = ?1",
+                [key],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(sqlite_error)?;
+        Ok(found == Some(identity_bytes(identity)?))
+    }
+
+    /// Record output completion after fsync and publication.
+    ///
+    /// # Errors
+    /// Refuses database failures.
+    pub fn record_output(&self, key: &[u8], identity: &StatIdentity) -> Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO outputs VALUES (?1, ?2)
+            ON CONFLICT(key) DO UPDATE SET identity=excluded.identity",
+                (key, identity_bytes(identity)?),
+            )
+            .map_err(sqlite_error)?;
+        Ok(())
+    }
+
+    /// Remember an unfinished directory by inode and its intended mode.
+    ///
+    /// # Errors
+    /// Refuses persistence failures.
+    pub fn pending_directory(
+        &self,
+        key: &[u8],
+        dev: u64,
+        ino: u64,
+        mode: u32,
+        record: bool,
+    ) -> Result<bool> {
+        let identity = postcard::to_stdvec(&(dev, ino, mode))?;
+        if record {
+            self.conn
+                .execute(
+                    "INSERT INTO directories VALUES (?1, ?2)
+                ON CONFLICT(key) DO UPDATE SET identity=excluded.identity",
+                    (key, &identity),
+                )
+                .map_err(sqlite_error)?;
+            return Ok(true);
+        }
+        let found: Option<Vec<u8>> = self
+            .conn
+            .query_row(
+                "SELECT identity FROM directories WHERE key = ?1",
+                [key],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(sqlite_error)?;
+        Ok(found == Some(identity))
+    }
+
+    /// Retire pending ownership after directory metadata is durable.
+    ///
+    /// # Errors
+    /// Refuses persistence failures.
+    pub fn complete_directory(&self, key: &[u8]) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM directories WHERE key = ?1", [key])
+            .map_err(sqlite_error)?;
+        Ok(())
+    }
+
+    /// Read and authenticate a stored chunk. Missing or corrupt chunks are misses.
+    ///
+    /// # Errors
+    /// Refuses unexpected filesystem failures.
+    pub fn chunk(&self, digest: &[u8; 32]) -> Result<Option<Vec<u8>>> {
+        let path = self.root.join("chunks").join(hex(digest));
+        let file = match crate::hash::open_nofollow(&path) {
+            Ok(file) => file,
+            Err(BulkloadRefusal::Io(Some(libc::ENOENT))) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let meta = file.metadata()?;
+        if !meta.is_file() || meta.len() > u64::from(crate::hash::CDC_MAX_BYTES) {
+            return Err(BulkloadRefusal::DigestMismatch);
+        }
+        let mut data = Vec::new();
+        file.take(u64::from(crate::hash::CDC_MAX_BYTES) + 1)
+            .read_to_end(&mut data)?;
+        if crate::hash::hash_bytes(&data) != *digest {
+            return Err(BulkloadRefusal::DigestMismatch);
+        }
+        Ok(Some(data))
+    }
+
+    /// Publish an authenticated chunk atomically without replacing existing data.
+    ///
+    /// # Errors
+    /// Refuses a digest mismatch or failed durable publication.
+    pub fn put_chunk(&self, digest: &[u8; 32], data: &[u8]) -> Result<()> {
+        if data.len() > crate::hash::CDC_MAX_BYTES as usize
+            || crate::hash::hash_bytes(data) != *digest
+        {
+            return Err(BulkloadRefusal::DigestMismatch);
+        }
+        if self.chunk(digest)?.is_some() {
+            return Ok(());
+        }
+        let chunks = self.root.join("chunks");
+        let staging = chunks.join(format!(
+            ".part-{}-{}",
+            std::process::id(),
+            NEXT_TEMP.fetch_add(1, Ordering::Relaxed)
+        ));
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&staging)?;
+        let result = (|| -> Result<()> {
+            file.write_all(data)?;
+            file.sync_all()?;
+            let target = chunks.join(hex(digest));
+            match fs::hard_link(&staging, &target) {
+                Ok(()) => (),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    self.chunk(digest)?.ok_or(BulkloadRefusal::DigestMismatch)?;
+                }
+                Err(error) => return Err(error.into()),
+            }
+            Ok(())
+        })();
+        fs::remove_file(staging)?;
+        fs::File::open(chunks)?.sync_all()?;
+        result
+    }
+}
+
+/// Bind a row to its source root identity and destination namespace.
+///
+/// # Errors
+/// Refuses serialization failure.
+pub fn row_key(authority: &[u8], row: &RowSchema) -> Result<Vec<u8>> {
+    Ok(postcard::to_stdvec(&(authority, row))?)
+}
+
+fn identity_bytes(identity: &StatIdentity) -> Result<Vec<u8>> {
+    Ok(postcard::to_stdvec(&(
+        identity.dev,
+        identity.ino,
+        identity.size,
+        identity.mtime_ns,
+        identity.ctime_ns,
+    ))?)
+}
+
+fn private_dir(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.is_dir() && meta.permissions().mode().trailing_zeros() >= 6 => Ok(()),
+        Ok(_) => Err(BulkloadRefusal::PathEscapesRoot),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            use std::os::unix::fs::DirBuilderExt as _;
+            fs::DirBuilder::new().mode(0o700).create(path)?;
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn hex(digest: &[u8; 32]) -> String {
+    use std::fmt::Write as _;
+    digest.iter().fold(String::new(), |mut value, byte| {
+        let _ = write!(value, "{byte:02x}");
+        value
+    })
+}
+
+fn sqlite_error(_: rusqlite::Error) -> BulkloadRefusal {
+    BulkloadRefusal::SqliteIntegrityCheckFailed
+}

--- a/crates/tcfs-bulkload-agent/src/transfer_store.rs
+++ b/crates/tcfs-bulkload-agent/src/transfer_store.rs
@@ -22,6 +22,10 @@ static FILE_SYNC_NS: AtomicU64 = AtomicU64::new(0);
 static DIR_SYNCS: AtomicU64 = AtomicU64::new(0);
 static DIR_SYNC_NS: AtomicU64 = AtomicU64::new(0);
 
+/// Maximum buffered chunks per producer (at most 2 MiB of chunk payload).
+pub(crate) const PERSIST_BATCH: usize = 8;
+const PERSIST_WORKERS: usize = 2;
+
 /// Process-local chunk persistence instrumentation.
 ///
 /// Durations sum worker time,
@@ -306,7 +310,11 @@ impl Store {
     /// # Errors
     /// Refuses unexpected filesystem failures.
     pub fn chunk(&self, digest: &[u8; 32]) -> Result<Option<Vec<u8>>> {
-        let path = self.root.join("chunks").join(hex(digest));
+        Self::chunk_at(&self.root, digest)
+    }
+
+    fn chunk_at(root: &Path, digest: &[u8; 32]) -> Result<Option<Vec<u8>>> {
+        let path = root.join("chunks").join(hex(digest));
         let file = match crate::hash::open_nofollow(&path) {
             Ok(file) => file,
             Err(BulkloadRefusal::Io(Some(libc::ENOENT))) => return Ok(None),
@@ -330,6 +338,19 @@ impl Store {
     /// # Errors
     /// Refuses a digest mismatch or failed durable publication.
     pub fn put_chunk(&self, digest: &[u8; 32], data: &[u8]) -> Result<()> {
+        Self::put_chunk_at(&self.root, digest, data)
+    }
+
+    /// Persist a bounded batch; every worker is joined before returning, including
+    /// on refusal. Each chunk retains its own file and directory durability fence.
+    pub(crate) fn put_chunks(&self, chunks: &[([u8; 32], Vec<u8>)]) -> Result<()> {
+        let root = self.root.as_path();
+        persist_batch_with(chunks, &|digest, data| {
+            Self::put_chunk_at(root, digest, data)
+        })
+    }
+
+    fn put_chunk_at(root: &Path, digest: &[u8; 32], data: &[u8]) -> Result<()> {
         PUT_CALLS.fetch_add(1, Ordering::Relaxed);
         let _timer = PutTimer(Instant::now());
         if data.len() > crate::hash::CDC_MAX_BYTES as usize
@@ -337,10 +358,17 @@ impl Store {
         {
             return Err(BulkloadRefusal::DigestMismatch);
         }
-        if self.chunk(digest)?.is_some() {
+        if Self::chunk_at(root, digest)?.is_some() {
+            // A concurrent publisher may have linked the already-synced inode
+            // but not yet synced its directory. Fence that link before reuse.
+            timed_sync(
+                &fs::File::open(root.join("chunks"))?,
+                &DIR_SYNCS,
+                &DIR_SYNC_NS,
+            )?;
             return Ok(());
         }
-        let chunks = self.root.join("chunks");
+        let chunks = root.join("chunks");
         let staging = chunks.join(format!(
             ".part-{}-{}",
             std::process::id(),
@@ -358,7 +386,7 @@ impl Store {
             match fs::hard_link(&staging, &target) {
                 Ok(()) => (),
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    self.chunk(digest)?.ok_or(BulkloadRefusal::DigestMismatch)?;
+                    Self::chunk_at(root, digest)?.ok_or(BulkloadRefusal::DigestMismatch)?;
                 }
                 Err(error) => return Err(error.into()),
             }
@@ -368,6 +396,47 @@ impl Store {
         timed_sync(&fs::File::open(chunks)?, &DIR_SYNCS, &DIR_SYNC_NS)?;
         result
     }
+}
+
+fn persist_batch_with<F>(chunks: &[([u8; 32], Vec<u8>)], persist: &F) -> Result<()>
+where
+    F: Fn(&[u8; 32], &[u8]) -> Result<()> + Sync,
+{
+    if chunks.len() > PERSIST_BATCH {
+        return Err(BulkloadRefusal::BudgetExceeded);
+    }
+    if chunks
+        .iter()
+        .any(|(_, data)| data.len() > crate::hash::CDC_MAX_BYTES as usize)
+    {
+        return Err(BulkloadRefusal::DigestMismatch);
+    }
+    if chunks.is_empty() {
+        return Ok(());
+    }
+    std::thread::scope(|scope| {
+        let mut workers = Vec::new();
+        for group in chunks.chunks(chunks.len().div_ceil(PERSIST_WORKERS)) {
+            workers.push(std::thread::Builder::new().spawn_scoped(scope, move || {
+                for (digest, data) in group {
+                    persist(digest, data)?;
+                }
+                Ok(())
+            })?);
+        }
+        let mut outcome = Ok(());
+        for worker in workers {
+            let result = worker
+                .join()
+                .map_err(|_| BulkloadRefusal::Io(None))
+                .and_then(|result| result);
+            // Join even after an earlier refusal; no background writes escape.
+            if outcome.is_ok() {
+                outcome = result;
+            }
+        }
+        outcome
+    })
 }
 
 /// Bind a row to its source root identity and destination namespace.
@@ -411,4 +480,54 @@ fn hex(digest: &[u8; 32]) -> String {
 
 fn sqlite_error(_: rusqlite::Error) -> BulkloadRefusal {
     BulkloadRefusal::SqliteIntegrityCheckFailed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    #[test]
+    fn batch_joins_success_and_refusal_before_returning() -> Result<()> {
+        let chunks = vec![([0; 32], vec![0]), ([1; 32], vec![1])];
+        let finished = AtomicUsize::new(0);
+        persist_batch_with(&chunks, &|_, _| {
+            finished.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })?;
+        assert_eq!(finished.load(Ordering::SeqCst), 2);
+        finished.store(0, Ordering::SeqCst);
+        let failed = persist_batch_with(&chunks, &|digest, _| {
+            if digest.first() == Some(&0) {
+                return Err(BulkloadRefusal::DigestMismatch);
+            }
+            finished.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        });
+        assert_eq!(failed, Err(BulkloadRefusal::DigestMismatch));
+        // The second worker finishes even if the first worker failed first.
+        assert_eq!(finished.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn oversized_batch_refuses_before_any_write() {
+        let chunks = vec![([0; 32], Vec::new()); PERSIST_BATCH + 1];
+        let calls = AtomicUsize::new(0);
+        let result = persist_batch_with(&chunks, &|_, _| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        });
+        assert_eq!(result, Err(BulkloadRefusal::BudgetExceeded));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        let oversized = vec![([0; 32], vec![0; crate::hash::CDC_MAX_BYTES as usize + 1])];
+        assert_eq!(
+            persist_batch_with(&oversized, &|_, _| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }),
+            Err(BulkloadRefusal::DigestMismatch)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
 }

--- a/crates/tcfs-bulkload-agent/src/transfer_store.rs
+++ b/crates/tcfs-bulkload-agent/src/transfer_store.rs
@@ -5,6 +5,7 @@ use std::io::{Read as _, Write as _};
 use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use rusqlite::OptionalExtension as _;
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,81 @@ use crate::freshness::StatIdentity;
 use crate::{BulkloadRefusal, Result, RowSchema};
 
 static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+static PUT_CALLS: AtomicU64 = AtomicU64::new(0);
+static PUT_NS: AtomicU64 = AtomicU64::new(0);
+static FILE_SYNCS: AtomicU64 = AtomicU64::new(0);
+static FILE_SYNC_NS: AtomicU64 = AtomicU64::new(0);
+static DIR_SYNCS: AtomicU64 = AtomicU64::new(0);
+static DIR_SYNC_NS: AtomicU64 = AtomicU64::new(0);
+
+/// Process-local chunk persistence instrumentation.
+///
+/// Durations sum worker time,
+/// including failed operations, and must not be interpreted as wall-time shares.
+/// Concurrent independent transfers in the same process also contribute.
+#[derive(Clone, Copy, Debug)]
+pub struct ChunkTiming {
+    /// Calls to `put_chunk`, including already-present content.
+    pub put_calls: u64,
+    /// Aggregate worker nanoseconds inside `put_chunk`.
+    pub put_ns: u64,
+    /// Attempted chunk-file syncs.
+    pub file_syncs: u64,
+    /// Aggregate chunk-file sync worker nanoseconds.
+    pub file_sync_ns: u64,
+    /// Attempted chunk-directory syncs.
+    pub dir_syncs: u64,
+    /// Aggregate chunk-directory sync worker nanoseconds.
+    pub dir_sync_ns: u64,
+}
+
+impl ChunkTiming {
+    /// Snapshot counters without resetting other callers' observations.
+    #[must_use]
+    pub fn snapshot() -> Self {
+        Self {
+            put_calls: PUT_CALLS.load(Ordering::Relaxed),
+            put_ns: PUT_NS.load(Ordering::Relaxed),
+            file_syncs: FILE_SYNCS.load(Ordering::Relaxed),
+            file_sync_ns: FILE_SYNC_NS.load(Ordering::Relaxed),
+            dir_syncs: DIR_SYNCS.load(Ordering::Relaxed),
+            dir_sync_ns: DIR_SYNC_NS.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Difference from a prior snapshot after the observed operation has joined.
+    #[must_use]
+    pub const fn since(self, before: Self) -> Self {
+        Self {
+            put_calls: self.put_calls.saturating_sub(before.put_calls),
+            put_ns: self.put_ns.saturating_sub(before.put_ns),
+            file_syncs: self.file_syncs.saturating_sub(before.file_syncs),
+            file_sync_ns: self.file_sync_ns.saturating_sub(before.file_sync_ns),
+            dir_syncs: self.dir_syncs.saturating_sub(before.dir_syncs),
+            dir_sync_ns: self.dir_sync_ns.saturating_sub(before.dir_sync_ns),
+        }
+    }
+}
+
+struct PutTimer(Instant);
+
+impl Drop for PutTimer {
+    fn drop(&mut self) {
+        PUT_NS.fetch_add(nanos(self.0), Ordering::Relaxed);
+    }
+}
+
+fn nanos(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+fn timed_sync(file: &fs::File, count: &AtomicU64, time: &AtomicU64) -> std::io::Result<()> {
+    count.fetch_add(1, Ordering::Relaxed);
+    let started = Instant::now();
+    let result = file.sync_all();
+    time.fetch_add(nanos(started), Ordering::Relaxed);
+    result
+}
 
 /// Completed content capture; chunks retain file order, including repetitions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -254,6 +330,8 @@ impl Store {
     /// # Errors
     /// Refuses a digest mismatch or failed durable publication.
     pub fn put_chunk(&self, digest: &[u8; 32], data: &[u8]) -> Result<()> {
+        PUT_CALLS.fetch_add(1, Ordering::Relaxed);
+        let _timer = PutTimer(Instant::now());
         if data.len() > crate::hash::CDC_MAX_BYTES as usize
             || crate::hash::hash_bytes(data) != *digest
         {
@@ -275,7 +353,7 @@ impl Store {
             .open(&staging)?;
         let result = (|| -> Result<()> {
             file.write_all(data)?;
-            file.sync_all()?;
+            timed_sync(&file, &FILE_SYNCS, &FILE_SYNC_NS)?;
             let target = chunks.join(hex(digest));
             match fs::hard_link(&staging, &target) {
                 Ok(()) => (),
@@ -287,7 +365,7 @@ impl Store {
             Ok(())
         })();
         fs::remove_file(staging)?;
-        fs::File::open(chunks)?.sync_all()?;
+        timed_sync(&fs::File::open(chunks)?, &DIR_SYNCS, &DIR_SYNC_NS)?;
         result
     }
 }

--- a/crates/tcfs-bulkload-agent/src/walk.rs
+++ b/crates/tcfs-bulkload-agent/src/walk.rs
@@ -46,7 +46,7 @@ pub struct WalkOptions {
 impl WalkOptions {
     /// A stat-only walk of `root`, staying on one device.
     #[must_use]
-    pub fn new(root: PathBuf) -> Self {
+    pub const fn new(root: PathBuf) -> Self {
         Self {
             root,
             hash_policy: HashPolicy::Never,
@@ -125,10 +125,7 @@ pub fn walk<C: FreshnessCache>(options: &WalkOptions, cache: &mut C) -> Result<W
         .build();
 
     for entry in walker {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(_) => continue,
-        };
+        let Ok(entry) = entry else { continue };
         let path = entry.path();
         if path == options.root {
             continue;

--- a/crates/tcfs-bulkload-agent/src/walk.rs
+++ b/crates/tcfs-bulkload-agent/src/walk.rs
@@ -1,0 +1,388 @@
+//! The corpus walker.
+//!
+//! One pass over a corpus root producing one [`RowSchema`] per seat. Two
+//! properties matter and both are measured, not asserted:
+//!
+//! * **Each seat is statted once.** The walker consults the
+//!   [`FreshnessCache`] with the identity it already has; it never re-stats to
+//!   answer the cache. `files_statted_twice` counts violations.
+//! * **Fresh seats are not re-read.** A seat the cache calls
+//!   [`Freshness::Fresh`] contributes zero bytes to `bytes_reread_on_resume`.
+//!
+//! Refusals are forward-progressing: an unreadable or unportable seat is
+//! recorded and the walk continues, matching the Python engine's
+//! "every refusal is silent and forward-progressing" contract.
+
+use std::path::{Path, PathBuf};
+
+use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use tcfs_bulkload_proto::{BulkloadRefusal, FileKind, Result, RowSchema};
+
+use crate::freshness::{Freshness, FreshnessCache, StatIdentity};
+use crate::hash;
+
+/// How the walker should treat file contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashPolicy {
+    /// Stat only. The fastest arm of the M0 bench.
+    Never,
+    /// Hash every regular file the cache calls stale.
+    StaleOnly,
+    /// Hash every regular file regardless of freshness. The cold baseline.
+    Always,
+}
+
+/// Walker configuration.
+#[derive(Debug, Clone)]
+pub struct WalkOptions {
+    /// Corpus root. Must be absolute.
+    pub root: PathBuf,
+    /// Whether and when to hash file contents.
+    pub hash_policy: HashPolicy,
+    /// Whether to descend into other filesystems.
+    pub cross_device: bool,
+}
+
+impl WalkOptions {
+    /// A stat-only walk of `root`, staying on one device.
+    #[must_use]
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            hash_policy: HashPolicy::Never,
+            cross_device: false,
+        }
+    }
+}
+
+/// A seat the walker declined, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefusedSeat {
+    /// Path relative to the corpus root, as raw OS bytes.
+    pub rel_path: Vec<u8>,
+    /// Why the seat was declined.
+    pub refusal: BulkloadRefusal,
+}
+
+/// Counters for one walk.
+///
+/// The first two fields are the R25 headline metrics; the M0 bench prints them
+/// as its own columns. M1 wires the accounting; the numbers only become
+/// meaningful once the M2 resume path exists.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct WalkStats {
+    /// Seats visited.
+    pub seats_seen: u64,
+    /// Apparent bytes across all regular-file seats.
+    pub bytes_seen: u64,
+    /// Seats the cache called [`Freshness::Fresh`].
+    pub fresh_skipped: u64,
+    /// Bytes read again despite the cache calling the seat fresh.
+    ///
+    /// R25 headline metric. The product bar is zero.
+    pub bytes_reread_on_resume: u64,
+    /// Seats statted more than once in a single pass.
+    ///
+    /// R25 headline metric. The product bar is zero.
+    pub files_statted_twice: u64,
+}
+
+/// The result of one walk.
+#[derive(Debug, Default, Clone)]
+pub struct WalkOutcome {
+    /// One row per accepted seat.
+    pub rows: Vec<RowSchema>,
+    /// One entry per declined seat.
+    pub refusals: Vec<RefusedSeat>,
+    /// Counters for the pass.
+    pub stats: WalkStats,
+}
+
+/// Walk `options.root`, consulting and updating `cache`.
+///
+/// # Errors
+///
+/// Refuses with [`BulkloadRefusal::PathNotAbsolute`] if the root is relative,
+/// and [`BulkloadRefusal::Io`] if the root itself cannot be statted. Per-seat
+/// problems are recorded in [`WalkOutcome::refusals`], not returned.
+pub fn walk<C: FreshnessCache>(options: &WalkOptions, cache: &mut C) -> Result<WalkOutcome> {
+    if !options.root.is_absolute() {
+        return Err(BulkloadRefusal::PathNotAbsolute);
+    }
+    let root_meta = std::fs::metadata(&options.root)?;
+    let root_dev = device_of(&root_meta);
+
+    let mut outcome = WalkOutcome::default();
+    let mut to_hash: Vec<(usize, PathBuf)> = Vec::new();
+
+    let walker = ignore::WalkBuilder::new(&options.root)
+        // Bulkload copies a corpus, not a source tree: gitignore, hidden-file
+        // and parent-ignore filtering would silently drop payload.
+        .standard_filters(false)
+        .hidden(false)
+        .follow_links(false)
+        .same_file_system(!options.cross_device)
+        .build();
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        if path == options.root {
+            continue;
+        }
+        let rel_path = match relative_bytes(&options.root, path) {
+            Ok(bytes) => bytes,
+            Err(refusal) => {
+                outcome.refusals.push(RefusedSeat {
+                    rel_path: os_bytes(path.as_os_str()),
+                    refusal,
+                });
+                continue;
+            }
+        };
+
+        let Ok(meta) = entry.metadata() else {
+            outcome.refusals.push(RefusedSeat {
+                rel_path,
+                refusal: BulkloadRefusal::Io(None),
+            });
+            continue;
+        };
+        if !options.cross_device && device_of(&meta) != root_dev {
+            continue;
+        }
+
+        let mut row = row_from_metadata(rel_path, &meta);
+        if row.kind == FileKind::Symlink {
+            row.link_target = std::fs::read_link(path)
+                .ok()
+                .map(|target| os_bytes(target.as_os_str()));
+        }
+
+        outcome.stats.seats_seen += 1;
+        if row.kind == FileKind::Regular {
+            outcome.stats.bytes_seen = outcome.stats.bytes_seen.saturating_add(row.size);
+        }
+
+        // One stat, one cache consultation. The identity comes from the row we
+        // already built -- re-statting here is exactly the bug
+        // `files_statted_twice` exists to catch.
+        let identity = StatIdentity::from_row(&row);
+        let freshness = cache.lookup(&identity).unwrap_or(Freshness::Stale);
+        if freshness == Freshness::Fresh {
+            outcome.stats.fresh_skipped += 1;
+        }
+        cache.record(&identity)?;
+
+        let wants_hash = row.kind == FileKind::Regular
+            && match options.hash_policy {
+                HashPolicy::Never => false,
+                HashPolicy::StaleOnly => freshness == Freshness::Stale,
+                HashPolicy::Always => true,
+            };
+        if wants_hash {
+            if freshness == Freshness::Fresh {
+                // Re-reading a seat the cache vouched for. Counted, never hidden.
+                outcome.stats.bytes_reread_on_resume = outcome
+                    .stats
+                    .bytes_reread_on_resume
+                    .saturating_add(row.size);
+            }
+            to_hash.push((outcome.rows.len(), path.to_path_buf()));
+        }
+        outcome.rows.push(row);
+    }
+
+    let hashed: Vec<(usize, Result<[u8; 32]>)> = to_hash
+        .par_iter()
+        .map(|(index, path)| (*index, hash::hash_file(path)))
+        .collect();
+    for (index, digest) in hashed {
+        match digest {
+            Ok(bytes) => {
+                if let Some(row) = outcome.rows.get_mut(index) {
+                    row.blake3 = Some(bytes);
+                }
+            }
+            Err(refusal) => {
+                let rel_path = outcome
+                    .rows
+                    .get(index)
+                    .map(|row| row.rel_path.clone())
+                    .unwrap_or_default();
+                outcome.refusals.push(RefusedSeat { rel_path, refusal });
+            }
+        }
+    }
+
+    Ok(outcome)
+}
+
+fn device_of(meta: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt as _;
+    meta.dev()
+}
+
+fn os_bytes(value: &std::ffi::OsStr) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt as _;
+    value.as_bytes().to_vec()
+}
+
+fn relative_bytes(root: &Path, path: &Path) -> std::result::Result<Vec<u8>, BulkloadRefusal> {
+    path.strip_prefix(root)
+        .map(|rel| os_bytes(rel.as_os_str()))
+        .map_err(|_| BulkloadRefusal::PathEscapesRoot)
+}
+
+fn row_from_metadata(rel_path: Vec<u8>, meta: &std::fs::Metadata) -> RowSchema {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let kind = if meta.is_file() {
+        FileKind::Regular
+    } else if meta.is_dir() {
+        FileKind::Directory
+    } else if meta.is_symlink() {
+        FileKind::Symlink
+    } else {
+        FileKind::Other
+    };
+
+    RowSchema {
+        rel_path,
+        kind,
+        dev: meta.dev(),
+        ino: meta.ino(),
+        size: meta.size(),
+        mtime_ns: nanos(meta.mtime(), meta.mtime_nsec()),
+        ctime_ns: nanos(meta.ctime(), meta.ctime_nsec()),
+        mode: meta.mode(),
+        nlink: meta.nlink(),
+        link_target: None,
+        blake3: None,
+    }
+}
+
+fn nanos(seconds: i64, nanoseconds: i64) -> i128 {
+    i128::from(seconds) * 1_000_000_000 + i128::from(nanoseconds)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use std::path::PathBuf;
+
+    use tcfs_bulkload_proto::FileKind;
+
+    use super::{walk, HashPolicy, WalkOptions};
+    use crate::freshness::MemoryCache;
+
+    struct Corpus {
+        root: PathBuf,
+    }
+
+    impl Corpus {
+        fn new(name: &str) -> Self {
+            let mut root = std::env::temp_dir();
+            root.push(format!("tcfs-bulkload-walk-{}-{name}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&root);
+            std::fs::create_dir_all(root.join("nested")).unwrap();
+            std::fs::write(root.join("a.txt"), b"alpha").unwrap();
+            std::fs::write(root.join("nested/b.txt"), b"bravo!").unwrap();
+            Self { root }
+        }
+    }
+
+    impl Drop for Corpus {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn refuses_a_relative_root() {
+        let mut cache = MemoryCache::new();
+        let options = WalkOptions::new(PathBuf::from("relative/path"));
+        assert!(walk(&options, &mut cache).is_err());
+    }
+
+    #[test]
+    fn walks_every_seat_once() {
+        let corpus = Corpus::new("once");
+        let mut cache = MemoryCache::new();
+        let outcome = walk(&WalkOptions::new(corpus.root.clone()), &mut cache).unwrap();
+
+        // two files plus one directory
+        assert_eq!(outcome.stats.seats_seen, 3);
+        assert_eq!(outcome.stats.bytes_seen, 11);
+        assert_eq!(outcome.stats.files_statted_twice, 0);
+        assert_eq!(outcome.stats.bytes_reread_on_resume, 0);
+        assert!(outcome.refusals.is_empty());
+
+        let files = outcome
+            .rows
+            .iter()
+            .filter(|row| row.kind == FileKind::Regular)
+            .count();
+        assert_eq!(files, 2);
+        assert!(outcome.rows.iter().all(|row| row.blake3.is_none()));
+    }
+
+    #[test]
+    fn hashes_regular_files_when_asked() {
+        let corpus = Corpus::new("hash");
+        let mut cache = MemoryCache::new();
+        let options = WalkOptions {
+            hash_policy: HashPolicy::Always,
+            ..WalkOptions::new(corpus.root.clone())
+        };
+        let outcome = walk(&options, &mut cache).unwrap();
+
+        let hashed = outcome
+            .rows
+            .iter()
+            .filter(|row| row.blake3.is_some())
+            .count();
+        assert_eq!(hashed, 2);
+        assert!(outcome.refusals.is_empty());
+    }
+
+    #[test]
+    fn a_warm_stale_only_walk_rereads_nothing() {
+        let corpus = Corpus::new("resume");
+        let mut cache = MemoryCache::new();
+        let options = WalkOptions {
+            hash_policy: HashPolicy::StaleOnly,
+            ..WalkOptions::new(corpus.root.clone())
+        };
+
+        let cold = walk(&options, &mut cache).unwrap();
+        assert_eq!(cold.stats.fresh_skipped, 0);
+        assert_eq!(cold.stats.bytes_reread_on_resume, 0);
+
+        let warm = walk(&options, &mut cache).unwrap();
+        assert_eq!(warm.stats.fresh_skipped, warm.stats.seats_seen);
+        // R25 headline bar: a resume that changed nothing re-reads nothing.
+        assert_eq!(warm.stats.bytes_reread_on_resume, 0);
+        assert_eq!(warm.stats.files_statted_twice, 0);
+        assert!(warm.rows.iter().all(|row| row.blake3.is_none()));
+    }
+
+    #[test]
+    fn an_always_hash_walk_over_a_warm_cache_counts_the_rereads() {
+        let corpus = Corpus::new("reread");
+        let mut cache = MemoryCache::new();
+        let stat_only = WalkOptions::new(corpus.root.clone());
+        walk(&stat_only, &mut cache).unwrap();
+
+        let always = WalkOptions {
+            hash_policy: HashPolicy::Always,
+            ..stat_only
+        };
+        let warm = walk(&always, &mut cache).unwrap();
+        assert_eq!(warm.stats.bytes_reread_on_resume, 11);
+    }
+}

--- a/crates/tcfs-bulkload-agent/src/walk.rs
+++ b/crates/tcfs-bulkload-agent/src/walk.rs
@@ -3,9 +3,9 @@
 //! One pass over a corpus root producing one [`RowSchema`] per seat. Two
 //! properties matter and both are measured, not asserted:
 //!
-//! * **Each seat is statted once.** The walker consults the
-//!   [`FreshnessCache`] with the identity it already has; it never re-stats to
-//!   answer the cache. `files_statted_twice` counts violations.
+//! * Cache lookup uses the walk's metadata. A stale content read additionally
+//!   checks the opened descriptor before and after hashing to detect writers.
+//!   `files_statted_twice` counts these seats; warm resumes need no such checks.
 //! * **Fresh seats are not re-read.** A seat the cache calls
 //!   [`Freshness::Fresh`] contributes zero bytes to `bytes_reread_on_resume`.
 //!
@@ -75,15 +75,16 @@ pub struct WalkStats {
     pub seats_seen: u64,
     /// Apparent bytes across all regular-file seats.
     pub bytes_seen: u64,
+    /// Actual bytes read by hash workers, including reads later refused.
+    pub bytes_read: u64,
     /// Seats the cache called [`Freshness::Fresh`].
     pub fresh_skipped: u64,
     /// Bytes read again despite the cache calling the seat fresh.
     ///
     /// R25 headline metric. The product bar is zero.
     pub bytes_reread_on_resume: u64,
-    /// Seats statted more than once in a single pass.
-    ///
-    /// R25 headline metric. The product bar is zero.
+    /// Seats with actual descriptor metadata calls beyond the census stat.
+    /// Warm resumes should keep this at zero.
     pub files_statted_twice: u64,
 }
 
@@ -113,7 +114,7 @@ pub fn walk<C: FreshnessCache>(options: &WalkOptions, cache: &mut C) -> Result<W
     let root_dev = device_of(&root_meta);
 
     let mut outcome = WalkOutcome::default();
-    let mut to_hash: Vec<(usize, PathBuf)> = Vec::new();
+    let mut to_hash: Vec<(usize, PathBuf, StatIdentity, bool)> = Vec::new();
 
     let walker = ignore::WalkBuilder::new(&options.root)
         // Bulkload copies a corpus, not a source tree: gitignore, hidden-file
@@ -125,7 +126,15 @@ pub fn walk<C: FreshnessCache>(options: &WalkOptions, cache: &mut C) -> Result<W
         .build();
 
     for entry in walker {
-        let Ok(entry) = entry else { continue };
+        let Ok(entry) = entry else {
+            // An empty relative path marks an incomplete root traversal;
+            // never report a successful census after an enumeration error.
+            outcome.refusals.push(RefusedSeat {
+                rel_path: Vec::new(),
+                refusal: BulkloadRefusal::Io(None),
+            });
+            continue;
+        };
         let path = entry.path();
         if path == options.root {
             continue;
@@ -164,15 +173,28 @@ pub fn walk<C: FreshnessCache>(options: &WalkOptions, cache: &mut C) -> Result<W
             outcome.stats.bytes_seen = outcome.stats.bytes_seen.saturating_add(row.size);
         }
 
-        // One stat, one cache consultation. The identity comes from the row we
-        // already built -- re-statting here is exactly the bug
-        // `files_statted_twice` exists to catch.
+        // Cache lookup uses the metadata already in the row. Only an actual
+        // content read needs descriptor checks for concurrent source changes.
         let identity = StatIdentity::from_row(&row);
-        let freshness = cache.lookup(&identity).unwrap_or(Freshness::Stale);
+        let requires_digest =
+            row.kind == FileKind::Regular && options.hash_policy != HashPolicy::Never;
+        let cached_digest = if requires_digest {
+            cache.digest(&identity)?
+        } else {
+            None
+        };
+        let freshness = if requires_digest {
+            if cached_digest.is_some() {
+                Freshness::Fresh
+            } else {
+                Freshness::Stale
+            }
+        } else {
+            cache.lookup(&identity)?
+        };
         if freshness == Freshness::Fresh {
             outcome.stats.fresh_skipped += 1;
         }
-        cache.record(&identity)?;
 
         let wants_hash = row.kind == FileKind::Regular
             && match options.hash_policy {
@@ -181,41 +203,87 @@ pub fn walk<C: FreshnessCache>(options: &WalkOptions, cache: &mut C) -> Result<W
                 HashPolicy::Always => true,
             };
         if wants_hash {
-            if freshness == Freshness::Fresh {
-                // Re-reading a seat the cache vouched for. Counted, never hidden.
-                outcome.stats.bytes_reread_on_resume = outcome
-                    .stats
-                    .bytes_reread_on_resume
-                    .saturating_add(row.size);
-            }
-            to_hash.push((outcome.rows.len(), path.to_path_buf()));
+            to_hash.push((
+                outcome.rows.len(),
+                path.to_path_buf(),
+                identity,
+                freshness == Freshness::Fresh,
+            ));
+        } else if requires_digest {
+            row.blake3 = cached_digest;
+        } else {
+            cache.record(&identity)?;
         }
         outcome.rows.push(row);
     }
 
-    let hashed: Vec<(usize, Result<[u8; 32]>)> = to_hash
-        .par_iter()
-        .map(|(index, path)| (*index, hash::hash_file(path)))
-        .collect();
-    for (index, digest) in hashed {
-        match digest {
-            Ok(bytes) => {
-                if let Some(row) = outcome.rows.get_mut(index) {
-                    row.blake3 = Some(bytes);
-                }
-            }
-            Err(refusal) => {
-                let rel_path = outcome
-                    .rows
-                    .get(index)
-                    .map(|row| row.rel_path.clone())
-                    .unwrap_or_default();
-                outcome.refusals.push(RefusedSeat { rel_path, refusal });
+    complete_hashes(&mut outcome, &to_hash, cache)?;
+    Ok(outcome)
+}
+
+fn complete_hashes<C: FreshnessCache>(
+    outcome: &mut WalkOutcome,
+    to_hash: &[(usize, PathBuf, StatIdentity, bool)],
+    cache: &mut C,
+) -> Result<()> {
+    // Bounded handoff: workers never accumulate an O(N) result vector. The
+    // owning thread commits each successful read while other workers continue.
+    let (sender, receiver) = std::sync::mpsc::sync_channel(rayon::current_num_threads());
+    std::thread::scope(|scope| -> Result<()> {
+        let producer = std::thread::Builder::new().spawn_scoped(scope, move || {
+            let _ = to_hash
+                .par_iter()
+                .try_for_each(|(index, path, identity, reread)| {
+                    let read = hash::hash_file_observed(path, identity);
+                    sender.send((*index, *reread, read)).map_err(|_| ())
+                });
+        })?;
+        let mut result = Ok(());
+        for (index, reread, read) in &receiver {
+            if let Err(refusal) = finish_read(outcome, cache, index, reread, read) {
+                result = Err(refusal);
+                break;
             }
         }
-    }
+        // A failed cache write must unblock senders before joining them.
+        drop(receiver);
+        producer.join().map_err(|_| BulkloadRefusal::Io(None))?;
+        result
+    })
+}
 
-    Ok(outcome)
+fn finish_read<C: FreshnessCache>(
+    outcome: &mut WalkOutcome,
+    cache: &mut C,
+    index: usize,
+    reread: bool,
+    read: hash::HashRead,
+) -> Result<()> {
+    outcome.stats.bytes_read = outcome.stats.bytes_read.saturating_add(read.bytes_read);
+    if reread {
+        outcome.stats.bytes_reread_on_resume = outcome
+            .stats
+            .bytes_reread_on_resume
+            .saturating_add(read.bytes_read);
+    }
+    if read.metadata_checks > 0 {
+        outcome.stats.files_statted_twice += 1;
+    }
+    let row = outcome
+        .rows
+        .get_mut(index)
+        .ok_or(BulkloadRefusal::ContractSelfInconsistent)?;
+    match read.digest {
+        Ok(bytes) => {
+            cache.record_digest(&StatIdentity::from_row(row), &bytes)?;
+            row.blake3 = Some(bytes);
+        }
+        Err(refusal) => outcome.refusals.push(RefusedSeat {
+            rel_path: row.rel_path.clone(),
+            refusal,
+        }),
+    }
+    Ok(())
 }
 
 fn device_of(meta: &std::fs::Metadata) -> u64 {
@@ -359,27 +427,87 @@ mod tests {
         let cold = walk(&options, &mut cache).unwrap();
         assert_eq!(cold.stats.fresh_skipped, 0);
         assert_eq!(cold.stats.bytes_reread_on_resume, 0);
+        assert_eq!(cold.stats.bytes_read, 11);
+        assert_eq!(cold.stats.files_statted_twice, 2);
 
         let warm = walk(&options, &mut cache).unwrap();
         assert_eq!(warm.stats.fresh_skipped, warm.stats.seats_seen);
         // R25 headline bar: a resume that changed nothing re-reads nothing.
         assert_eq!(warm.stats.bytes_reread_on_resume, 0);
+        assert_eq!(warm.stats.bytes_read, 0);
         assert_eq!(warm.stats.files_statted_twice, 0);
-        assert!(warm.rows.iter().all(|row| row.blake3.is_none()));
+        assert_eq!(cold.rows, warm.rows);
     }
 
     #[test]
     fn an_always_hash_walk_over_a_warm_cache_counts_the_rereads() {
         let corpus = Corpus::new("reread");
         let mut cache = MemoryCache::new();
-        let stat_only = WalkOptions::new(corpus.root.clone());
-        walk(&stat_only, &mut cache).unwrap();
-
         let always = WalkOptions {
             hash_policy: HashPolicy::Always,
-            ..stat_only
+            ..WalkOptions::new(corpus.root.clone())
         };
+        walk(&always, &mut cache).unwrap();
         let warm = walk(&always, &mut cache).unwrap();
         assert_eq!(warm.stats.bytes_reread_on_resume, 11);
+    }
+
+    #[test]
+    fn stat_only_census_does_not_poison_content_resume() {
+        let corpus = Corpus::new("stat-then-hash");
+        let mut cache = MemoryCache::new();
+        walk(&WalkOptions::new(corpus.root.clone()), &mut cache).unwrap();
+        let options = WalkOptions {
+            hash_policy: HashPolicy::StaleOnly,
+            ..WalkOptions::new(corpus.root.clone())
+        };
+        let hashed = walk(&options, &mut cache).unwrap();
+        assert_eq!(
+            hashed
+                .rows
+                .iter()
+                .filter(|row| row.blake3.is_some())
+                .count(),
+            2
+        );
+        assert_eq!(hashed.stats.bytes_reread_on_resume, 0);
+    }
+
+    #[test]
+    fn refused_hash_never_records_completion() {
+        use crate::freshness::{FreshnessCache, StatIdentity};
+        use tcfs_bulkload_proto::Result;
+        struct RemovedDuringLookup {
+            path: PathBuf,
+        }
+        impl FreshnessCache for RemovedDuringLookup {
+            fn lookup(&self, _: &StatIdentity) -> Result<crate::freshness::Freshness> {
+                Ok(crate::freshness::Freshness::Stale)
+            }
+            fn record(&mut self, _: &StatIdentity) -> Result<()> {
+                Ok(())
+            }
+            fn digest(&self, _: &StatIdentity) -> Result<Option<[u8; 32]>> {
+                let _ = std::fs::remove_file(&self.path);
+                Ok(None)
+            }
+            fn record_digest(&mut self, _: &StatIdentity, _: &[u8; 32]) -> Result<()> {
+                panic!("failed hash must not become a completion")
+            }
+        }
+        let corpus = Corpus::new("hash-failure");
+        std::fs::remove_file(corpus.root.join("nested/b.txt")).unwrap();
+        let mut cache = RemovedDuringLookup {
+            path: corpus.root.join("a.txt"),
+        };
+        let options = WalkOptions {
+            hash_policy: HashPolicy::StaleOnly,
+            ..WalkOptions::new(corpus.root.clone())
+        };
+        let result = walk(&options, &mut cache).unwrap();
+        assert_eq!(result.refusals.len(), 1);
+        assert_eq!(result.stats.bytes_read, 0);
+        assert_eq!(result.stats.files_statted_twice, 0);
+        assert!(result.rows.iter().all(|row| row.blake3.is_none()));
     }
 }

--- a/crates/tcfs-bulkload-agent/tests/dep_graph.rs
+++ b/crates/tcfs-bulkload-agent/tests/dep_graph.rs
@@ -1,0 +1,120 @@
+//! M1 acceptance gate: the agent's dependency wall (R34).
+//!
+//! The agent half is the thin darwin-side process. It must not acquire an
+//! async runtime, an object-store abstraction, an HTTP client, a TLS stack, or
+//! a gRPC stack -- not directly and not transitively through a well-meaning
+//! shared crate. This test shells out to `cargo tree` and reads the real
+//! resolved graph rather than trusting the manifest, because the hazard is
+//! precisely the dependency nobody wrote down.
+//!
+//! If this test fails, the fix is to remove the dependency, not to widen the
+//! list.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::process::Command;
+
+/// Crates that must never appear in the agent's normal dependency graph.
+///
+/// A match is exact on the package name, or on the name plus a `-` (so
+/// `tokio-util` is caught alongside `tokio`, while `unicode-normalization`
+/// is not mistaken for `ring`).
+const FORBIDDEN: &[&str] = &["tokio", "opendal", "reqwest", "ring", "tonic"];
+
+fn is_forbidden(name: &str) -> Option<&'static str> {
+    FORBIDDEN.iter().copied().find(|forbidden| {
+        name == *forbidden || name.starts_with(&format!("{forbidden}-"))
+    })
+}
+
+/// Pull the package name out of one `cargo tree` line.
+///
+/// Lines look like `│   ├── serde v1.0.210` or `└── tokio v1.40.0 (*)`.
+fn package_name(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start_matches(|c: char| {
+        matches!(c, '│' | '├' | '└' | '─' | ' ' | '|' | '`' | '-' | '+')
+    });
+    let name = trimmed.split_whitespace().next()?;
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+#[test]
+fn agent_dependency_graph_has_no_forbidden_crates() {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+    let output = Command::new(&cargo)
+        .args([
+            "tree",
+            "-p",
+            "tcfs-bulkload-agent",
+            "-e",
+            "normal",
+            "--prefix",
+            "none",
+            "--no-dedupe",
+        ])
+        .current_dir(manifest_dir)
+        .output()
+        .expect("failed to run `cargo tree`; the dep-graph wall cannot be checked");
+
+    assert!(
+        output.status.success(),
+        "`cargo tree` failed ({}):\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut packages = 0_usize;
+    let mut violations: Vec<String> = Vec::new();
+
+    for line in stdout.lines() {
+        let Some(name) = package_name(line) else {
+            continue;
+        };
+        packages += 1;
+        if let Some(forbidden) = is_forbidden(name) {
+            violations.push(format!("{name} (matches forbidden `{forbidden}`)"));
+        }
+    }
+
+    assert!(
+        packages > 1,
+        "`cargo tree` produced no packages; the wall was not actually checked:\n{stdout}"
+    );
+
+    violations.sort_unstable();
+    violations.dedup();
+    assert!(
+        violations.is_empty(),
+        "tcfs-bulkload-agent must not depend on {FORBIDDEN:?}, but its graph contains:\n  {}\n\n\
+         full tree:\n{stdout}",
+        violations.join("\n  ")
+    );
+}
+
+/// Guard the parser itself: a matcher that silently matched nothing would make
+/// the wall above pass unconditionally.
+#[test]
+fn forbidden_matcher_is_neither_too_broad_nor_too_narrow() {
+    assert_eq!(is_forbidden("tokio"), Some("tokio"));
+    assert_eq!(is_forbidden("tokio-util"), Some("tokio"));
+    assert_eq!(is_forbidden("ring"), Some("ring"));
+    assert_eq!(is_forbidden("tonic-prost"), Some("tonic"));
+
+    assert_eq!(is_forbidden("unicode-normalization"), None);
+    assert_eq!(is_forbidden("blake3"), None);
+    assert_eq!(is_forbidden("ignore"), None);
+    assert_eq!(is_forbidden("rusqlite"), None);
+    assert_eq!(is_forbidden("stringprep"), None);
+
+    assert_eq!(package_name("├── serde v1.0.210"), Some("serde"));
+    assert_eq!(package_name("│   └── tokio v1.40.0 (*)"), Some("tokio"));
+    assert_eq!(package_name("tcfs-bulkload-agent v0.12.14"), Some("tcfs-bulkload-agent"));
+    assert_eq!(package_name("   "), None);
+}

--- a/crates/tcfs-bulkload-agent/tests/dep_graph.rs
+++ b/crates/tcfs-bulkload-agent/tests/dep_graph.rs
@@ -22,9 +22,10 @@ use std::process::Command;
 const FORBIDDEN: &[&str] = &["tokio", "opendal", "reqwest", "ring", "tonic"];
 
 fn is_forbidden(name: &str) -> Option<&'static str> {
-    FORBIDDEN.iter().copied().find(|forbidden| {
-        name == *forbidden || name.starts_with(&format!("{forbidden}-"))
-    })
+    FORBIDDEN
+        .iter()
+        .copied()
+        .find(|forbidden| name == *forbidden || name.starts_with(&format!("{forbidden}-")))
 }
 
 /// Pull the package name out of one `cargo tree` line.
@@ -115,6 +116,9 @@ fn forbidden_matcher_is_neither_too_broad_nor_too_narrow() {
 
     assert_eq!(package_name("├── serde v1.0.210"), Some("serde"));
     assert_eq!(package_name("│   └── tokio v1.40.0 (*)"), Some("tokio"));
-    assert_eq!(package_name("tcfs-bulkload-agent v0.12.14"), Some("tcfs-bulkload-agent"));
+    assert_eq!(
+        package_name("tcfs-bulkload-agent v0.12.14"),
+        Some("tcfs-bulkload-agent")
+    );
     assert_eq!(package_name("   "), None);
 }

--- a/crates/tcfs-bulkload-bench/Cargo.toml
+++ b/crates/tcfs-bulkload-bench/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tcfs-bulkload-bench"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "tcfs bulkload M0 real-corpus A/B harness"
+publish = false
+
+[[bin]]
+name = "tcfs-bulkload-bench"
+path = "src/main.rs"
+
+[dependencies]
+tcfs-bulkload-agent = { path = "../tcfs-bulkload-agent" }
+tcfs-bulkload-proto = { path = "../tcfs-bulkload-proto" }
+clap = { workspace = true }
+
+[lints.clippy]
+# R33 deny-panics wall. Refusals are Results, never panics.
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+unwrap_used = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+panic = "deny"

--- a/crates/tcfs-bulkload-bench/Cargo.toml
+++ b/crates/tcfs-bulkload-bench/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "tcfs bulkload M0 real-corpus A/B harness"
+description = "tcfs bulkload real local copy/resume comparison with rclone"
 publish = false
 
 [[bin]]
@@ -15,6 +15,9 @@ path = "src/main.rs"
 tcfs-bulkload-agent = { path = "../tcfs-bulkload-agent" }
 tcfs-bulkload-proto = { path = "../tcfs-bulkload-proto" }
 clap = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lints.clippy]
 # R33 deny-panics wall. Refusals are Results, never panics.

--- a/crates/tcfs-bulkload-bench/src/main.rs
+++ b/crates/tcfs-bulkload-bench/src/main.rs
@@ -1,0 +1,293 @@
+//! `tcfs-bulkload-bench` -- the M0 real-corpus A/B harness.
+//!
+//! This is deliberately **not** a criterion benchmark. The thing being
+//! measured is a one-shot walk of a real corpus of millions of files on real
+//! storage; criterion's model -- warm up, then run the same tiny operation
+//! thousands of times against a hot page cache -- measures the opposite of
+//! what R25 cares about. So: N reps, median and spread, and the headline
+//! metrics printed as first-class columns.
+//!
+//! # Status (M0)
+//!
+//! The harness is a skeleton. It compiles, it runs, and its shape is the shape
+//! the real numbers will land in. It is not yet meaningful:
+//!
+//! * The `agent` arm runs the real walker but against a
+//!   [`NullCache`](tcfs_bulkload_agent::freshness::NullCache), so there is no
+//!   resume to measure yet.
+//! * `bytes_reread_on_resume` and `files_statted_twice` are wired through from
+//!   the walker for the agent arm and stubbed at `0` for the baseline arm --
+//!   see the TODOs below.
+//!
+//! # Usage
+//!
+//! ```text
+//! tcfs-bulkload-bench --corpus-root /path/to/corpus --reps 3
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use tcfs_bulkload_agent::freshness::NullCache;
+use tcfs_bulkload_agent::walk::{self, HashPolicy, WalkOptions};
+use tcfs_bulkload_proto::BulkloadRefusal;
+
+/// The M0 real-corpus A/B harness.
+#[derive(Debug, Parser)]
+#[command(name = "tcfs-bulkload-bench", version, about, long_about = None)]
+struct Cli {
+    /// Corpus root to walk. Must be an absolute path to an existing directory.
+    #[arg(long, value_name = "PATH")]
+    corpus_root: PathBuf,
+
+    /// Repetitions per arm. The reported figure is the median.
+    #[arg(long, default_value_t = 3, value_name = "N")]
+    reps: usize,
+
+    /// Run only the named arm ("baseline" or "agent"). Default: both.
+    #[arg(long, value_name = "ARM")]
+    only: Option<String>,
+}
+
+/// One arm's result for one repetition.
+#[derive(Debug, Clone, Copy)]
+struct Rep {
+    elapsed: Duration,
+    files: u64,
+    bytes: u64,
+    bytes_reread_on_resume: u64,
+    files_statted_twice: u64,
+}
+
+/// One arm's aggregate across reps.
+#[derive(Debug)]
+struct ArmSummary {
+    name: &'static str,
+    reps: usize,
+    median_ms: f64,
+    spread_ms: f64,
+    files: u64,
+    bytes: u64,
+    bytes_reread_on_resume: u64,
+    files_statted_twice: u64,
+}
+
+fn main() -> std::process::ExitCode {
+    let cli = Cli::parse();
+    match run(&cli) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(refusal) => {
+            eprintln!("tcfs-bulkload-bench: refused: {refusal}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(cli: &Cli) -> Result<(), BulkloadRefusal> {
+    if !cli.corpus_root.is_absolute() {
+        return Err(BulkloadRefusal::PathNotAbsolute);
+    }
+    if !cli.corpus_root.is_dir() {
+        return Err(BulkloadRefusal::SnapshotCustodyUnavailable);
+    }
+    if cli.reps == 0 {
+        return Err(BulkloadRefusal::FieldDomainViolation);
+    }
+
+    let wanted = cli.only.as_deref();
+    let mut summaries = Vec::new();
+
+    if matches!(wanted, None | Some("baseline")) {
+        summaries.push(measure("baseline", cli.reps, || {
+            baseline_walk(&cli.corpus_root)
+        })?);
+    }
+    if matches!(wanted, None | Some("agent")) {
+        summaries.push(measure("agent", cli.reps, || agent_walk(&cli.corpus_root))?);
+    }
+    if summaries.is_empty() {
+        return Err(BulkloadRefusal::FieldDomainViolation);
+    }
+
+    println!("corpus_root: {}", cli.corpus_root.display());
+    println!("reps:        {}\n", cli.reps);
+    print_table(&summaries);
+    println!(
+        "\nNOTE (M0): this harness is a skeleton. The agent arm runs against a null\n\
+         freshness cache, so no resume is exercised yet and the two headline columns\n\
+         are not yet meaningful. See the M2 resume lane."
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// arms
+// ---------------------------------------------------------------------------
+
+/// The `rclone check`-style arm: a plain recursive stat walk with no cache and
+/// no parallelism. This is the bar the agent has to beat.
+fn baseline_walk(root: &Path) -> Result<Rep, BulkloadRefusal> {
+    let started = Instant::now();
+    let mut files = 0_u64;
+    let mut bytes = 0_u64;
+    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
+            if meta.is_dir() {
+                stack.push(entry.path());
+            } else if meta.is_file() {
+                files += 1;
+                bytes = bytes.saturating_add(meta.len());
+            }
+        }
+    }
+
+    Ok(Rep {
+        elapsed: started.elapsed(),
+        files,
+        bytes,
+        // TODO(M2): a resume-aware baseline re-reads everything by
+        // construction; wire this to the real re-read accounting once the
+        // resume path exists so the two arms are comparable.
+        bytes_reread_on_resume: 0,
+        // TODO(M2): count the baseline's second stat per seat (read_dir
+        // metadata plus the transfer-time stat) once the transfer half lands.
+        files_statted_twice: 0,
+    })
+}
+
+/// The agent arm: the real walker, currently against a null freshness cache.
+fn agent_walk(root: &Path) -> Result<Rep, BulkloadRefusal> {
+    let options = WalkOptions {
+        hash_policy: HashPolicy::Never,
+        ..WalkOptions::new(root.to_path_buf())
+    };
+    let started = Instant::now();
+    // TODO(M3): swap NullCache for the persistent SqliteCache so the second
+    // rep measures a warm resume instead of a second cold walk.
+    let mut cache = NullCache;
+    let outcome = walk::walk(&options, &mut cache)?;
+    let elapsed = started.elapsed();
+
+    Ok(Rep {
+        elapsed,
+        files: outcome.stats.seats_seen,
+        bytes: outcome.stats.bytes_seen,
+        bytes_reread_on_resume: outcome.stats.bytes_reread_on_resume,
+        files_statted_twice: outcome.stats.files_statted_twice,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// measurement
+// ---------------------------------------------------------------------------
+
+fn measure<F>(name: &'static str, reps: usize, mut arm: F) -> Result<ArmSummary, BulkloadRefusal>
+where
+    F: FnMut() -> Result<Rep, BulkloadRefusal>,
+{
+    let mut results = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        results.push(arm()?);
+    }
+    let last = results.last().copied().ok_or(BulkloadRefusal::BudgetExceeded)?;
+
+    let mut millis: Vec<f64> = results
+        .iter()
+        .map(|rep| rep.elapsed.as_secs_f64() * 1000.0)
+        .collect();
+    millis.sort_by(f64::total_cmp);
+
+    let median_ms = median(&millis).ok_or(BulkloadRefusal::BudgetExceeded)?;
+    let lo = millis.first().copied().unwrap_or(median_ms);
+    let hi = millis.last().copied().unwrap_or(median_ms);
+
+    Ok(ArmSummary {
+        name,
+        reps,
+        median_ms,
+        spread_ms: hi - lo,
+        files: last.files,
+        bytes: last.bytes,
+        bytes_reread_on_resume: last.bytes_reread_on_resume,
+        files_statted_twice: last.files_statted_twice,
+    })
+}
+
+/// Median of a pre-sorted slice.
+fn median(sorted: &[f64]) -> Option<f64> {
+    let len = sorted.len();
+    if len == 0 {
+        return None;
+    }
+    let mid = len / 2;
+    if len % 2 == 1 {
+        sorted.get(mid).copied()
+    } else {
+        let lo = sorted.get(mid - 1).copied()?;
+        let hi = sorted.get(mid).copied()?;
+        Some(lo.midpoint(hi))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// output
+// ---------------------------------------------------------------------------
+
+fn print_table(summaries: &[ArmSummary]) {
+    println!(
+        "{:<10} {:>5} {:>12} {:>12} {:>12} {:>16} {:>24} {:>21}",
+        "arm",
+        "reps",
+        "median_ms",
+        "spread_ms",
+        "files",
+        "bytes",
+        "bytes_reread_on_resume",
+        "files_statted_twice",
+    );
+    println!("{}", "-".repeat(120));
+    for summary in summaries {
+        println!(
+            "{:<10} {:>5} {:>12.2} {:>12.2} {:>12} {:>16} {:>24} {:>21}",
+            summary.name,
+            summary.reps,
+            summary.median_ms,
+            summary.spread_ms,
+            summary.files,
+            summary.bytes,
+            summary.bytes_reread_on_resume,
+            summary.files_statted_twice,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use super::{median, Cli};
+    use clap::CommandFactory as _;
+
+    #[test]
+    fn cli_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn median_handles_odd_even_and_empty() {
+        assert_eq!(median(&[]), None);
+        assert_eq!(median(&[1.0]), Some(1.0));
+        assert_eq!(median(&[1.0, 3.0]), Some(2.0));
+        assert_eq!(median(&[1.0, 3.0, 100.0]), Some(3.0));
+        assert_eq!(median(&[1.0, 3.0, 5.0, 7.0]), Some(4.0));
+    }
+}

--- a/crates/tcfs-bulkload-bench/src/main.rs
+++ b/crates/tcfs-bulkload-bench/src/main.rs
@@ -127,6 +127,11 @@ fn run(cli: &Cli) -> Result<(), BulkloadRefusal> {
 
 /// The `rclone check`-style arm: a plain recursive stat walk with no cache and
 /// no parallelism. This is the bar the agent has to beat.
+///
+/// The `Result` is not currently reachable in the error direction -- this arm
+/// swallows per-entry I/O errors the way `rclone check` does -- but the
+/// signature has to match [`agent_walk`] so both can be handed to [`measure`].
+#[allow(clippy::unnecessary_wraps)]
 fn baseline_walk(root: &Path) -> Result<Rep, BulkloadRefusal> {
     let started = Instant::now();
     let mut files = 0_u64;

--- a/crates/tcfs-bulkload-bench/src/main.rs
+++ b/crates/tcfs-bulkload-bench/src/main.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 use clap::{Parser, ValueEnum};
 use tcfs_bulkload_agent::freshness::NullCache;
 use tcfs_bulkload_agent::transfer;
+use tcfs_bulkload_agent::transfer_store::ChunkTiming;
 use tcfs_bulkload_agent::walk::{walk, HashPolicy, WalkOptions};
 use tcfs_bulkload_proto::{FileKind, RowSchema};
 
@@ -200,6 +201,7 @@ fn run(cli: &Cli) -> io::Result<()> {
                 if rows(&source)? != expected {
                     return Err(io::Error::other("immutable corpus changed before arm"));
                 }
+                let timing_before = ChunkTiming::snapshot();
                 let started = Instant::now();
                 let (transferred, read) = match arm {
                     Arm::Native => {
@@ -227,6 +229,7 @@ fn run(cli: &Cli) -> io::Result<()> {
                     }
                 };
                 let elapsed = started.elapsed();
+                let timing = ChunkTiming::snapshot().since(timing_before);
                 if rows(&source)? != expected || !same_payload(&expected, &rows(&destination)?) {
                     return Err(io::Error::other(
                         "source mutation or destination content/mode mismatch",
@@ -238,6 +241,10 @@ fn run(cli: &Cli) -> io::Result<()> {
                     metric(transferred),
                     metric(read)
                 );
+                if arm == Arm::Native {
+                    println!("chunk_timing rep={rep} phase={phase} scope=process-worker-sums put_calls={} put_ns={} file_syncs={} file_sync_ns={} dir_syncs={} dir_sync_ns={}",
+                        timing.put_calls, timing.put_ns, timing.file_syncs, timing.file_sync_ns, timing.dir_syncs, timing.dir_sync_ns);
+                }
             }
         }
     }

--- a/crates/tcfs-bulkload-bench/src/main.rs
+++ b/crates/tcfs-bulkload-bench/src/main.rs
@@ -1,301 +1,291 @@
-//! `tcfs-bulkload-bench` -- the M0 real-corpus A/B harness.
-//!
-//! This is deliberately **not** a criterion benchmark. The thing being
-//! measured is a one-shot walk of a real corpus of millions of files on real
-//! storage; criterion's model -- warm up, then run the same tiny operation
-//! thousands of times against a hot page cache -- measures the opposite of
-//! what R25 cares about. So: N reps, median and spread, and the headline
-//! metrics printed as first-class columns.
-//!
-//! # Status (M0)
-//!
-//! The harness is a skeleton. It compiles, it runs, and its shape is the shape
-//! the real numbers will land in. It is not yet meaningful:
-//!
-//! * The `agent` arm runs the real walker but against a
-//!   [`NullCache`](tcfs_bulkload_agent::freshness::NullCache), so there is no
-//!   resume to measure yet.
-//! * `bytes_reread_on_resume` and `files_statted_twice` are wired through from
-//!   the walker for the agent arm and stubbed at `0` for the baseline arm --
-//!   see the TODOs below.
-//!
-//! # Usage
-//!
-//! ```text
-//! tcfs-bulkload-bench --corpus-root /path/to/corpus --reps 3
-//! ```
+//! Real local native/rclone copy and resume comparison on an immutable corpus.
+//! Verification is outside timing and warms the OS cache. Initial means fresh
+//! private application state, not cold storage. Outputs are retained, never deleted.
 
+use std::fs;
+use std::io;
+use std::os::unix::fs::DirBuilderExt as _;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::process::{Command, ExitCode, Stdio};
+use std::time::Instant;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use tcfs_bulkload_agent::freshness::NullCache;
-use tcfs_bulkload_agent::walk::{self, HashPolicy, WalkOptions};
-use tcfs_bulkload_proto::BulkloadRefusal;
+use tcfs_bulkload_agent::transfer;
+use tcfs_bulkload_agent::walk::{walk, HashPolicy, WalkOptions};
+use tcfs_bulkload_proto::{FileKind, RowSchema};
 
-/// The M0 real-corpus A/B harness.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum Arm {
+    #[value(alias = "agent")]
+    Native,
+    #[value(alias = "baseline")]
+    Rclone,
+}
+
+/// Real local copy/resume benchmark. No remote endpoints or live corpus allowed.
 #[derive(Debug, Parser)]
-#[command(name = "tcfs-bulkload-bench", version, about, long_about = None)]
+#[command(version)]
 struct Cli {
-    /// Corpus root to walk. Must be an absolute path to an existing directory.
-    #[arg(long, value_name = "PATH")]
+    /// Absolute sealed corpus directory; source identity is checked between runs.
+    #[arg(long)]
     corpus_root: PathBuf,
-
-    /// Repetitions per arm. The reported figure is the median.
-    #[arg(long, default_value_t = 3, value_name = "N")]
+    /// Absolute NEW directory under an existing parent. Retained after completion.
+    #[arg(long)]
+    work_root: PathBuf,
+    /// Absolute rclone executable. Required when running the rclone arm.
+    #[arg(long)]
+    rclone: Option<PathBuf>,
+    /// Repetitions, 1 through 5; arm order alternates each repetition.
+    #[arg(long, default_value_t = 3)]
     reps: usize,
-
-    /// Run only the named arm ("baseline" or "agent"). Default: both.
-    #[arg(long, value_name = "ARM")]
-    only: Option<String>,
+    /// Old agent/baseline spellings remain aliases, now performing real transfers.
+    #[arg(long)]
+    only: Option<Arm>,
 }
 
-/// One arm's result for one repetition.
-#[derive(Debug, Clone, Copy)]
-struct Rep {
-    elapsed: Duration,
-    files: u64,
-    bytes: u64,
-    bytes_reread_on_resume: u64,
-    files_statted_twice: u64,
-}
-
-/// One arm's aggregate across reps.
-#[derive(Debug)]
-struct ArmSummary {
-    name: &'static str,
-    reps: usize,
-    median_ms: f64,
-    spread_ms: f64,
-    files: u64,
-    bytes: u64,
-    bytes_reread_on_resume: u64,
-    files_statted_twice: u64,
-}
-
-fn main() -> std::process::ExitCode {
-    let cli = Cli::parse();
-    match run(&cli) {
-        Ok(()) => std::process::ExitCode::SUCCESS,
-        Err(refusal) => {
-            eprintln!("tcfs-bulkload-bench: refused: {refusal}");
-            std::process::ExitCode::FAILURE
+fn main() -> ExitCode {
+    match run(&Cli::parse()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("benchmark refused: {error}; private outputs retained");
+            ExitCode::FAILURE
         }
     }
 }
 
-fn run(cli: &Cli) -> Result<(), BulkloadRefusal> {
-    if !cli.corpus_root.is_absolute() {
-        return Err(BulkloadRefusal::PathNotAbsolute);
+fn rows(root: &Path) -> io::Result<Vec<RowSchema>> {
+    let result = walk(
+        &WalkOptions {
+            hash_policy: HashPolicy::Always,
+            cross_device: true,
+            ..WalkOptions::new(root.to_owned())
+        },
+        &mut NullCache,
+    )
+    .map_err(io::Error::other)?;
+    if !result.refusals.is_empty() {
+        return Err(io::Error::other("corpus verification refused entries"));
     }
-    if !cli.corpus_root.is_dir() {
-        return Err(BulkloadRefusal::SnapshotCustodyUnavailable);
+    let mut rows = result.rows;
+    if rows.iter().any(|row| {
+        !matches!(
+            row.kind,
+            FileKind::Regular | FileKind::Directory | FileKind::Symlink
+        )
+    }) {
+        return Err(io::Error::other("unsupported corpus entry"));
     }
-    if cli.reps == 0 {
-        return Err(BulkloadRefusal::FieldDomainViolation);
-    }
+    rows.sort_by(|a, b| a.rel_path.cmp(&b.rel_path));
+    Ok(rows)
+}
 
-    let wanted = cli.only.as_deref();
-    let mut summaries = Vec::new();
+fn same_payload(a: &[RowSchema], b: &[RowSchema]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b).all(|(a, b)| {
+            a.rel_path == b.rel_path
+                && a.kind == b.kind
+                && a.link_target == b.link_target
+                && (a.kind != FileKind::Regular || (a.size == b.size && a.blake3 == b.blake3))
+                && (a.kind == FileKind::Symlink || a.mode & 0o777 == b.mode & 0o777)
+        })
+}
 
-    if matches!(wanted, None | Some("baseline")) {
-        summaries.push(measure("baseline", cli.reps, || {
-            baseline_walk(&cli.corpus_root)
-        })?);
-    }
-    if matches!(wanted, None | Some("agent")) {
-        summaries.push(measure("agent", cli.reps, || agent_walk(&cli.corpus_root))?);
-    }
-    if summaries.is_empty() {
-        return Err(BulkloadRefusal::FieldDomainViolation);
-    }
+fn private_dir(path: &Path) -> io::Result<()> {
+    fs::DirBuilder::new().mode(0o700).create(path)
+}
 
-    println!("corpus_root: {}", cli.corpus_root.display());
-    println!("reps:        {}\n", cli.reps);
-    print_table(&summaries);
-    println!(
-        "\nNOTE (M0): this harness is a skeleton. The agent arm runs against a null\n\
-         freshness cache, so no resume is exercised yet and the two headline columns\n\
-         are not yet meaningful. See the M2 resume lane."
+fn prepare(cli: &Cli) -> io::Result<(PathBuf, PathBuf)> {
+    if !(1..=5).contains(&cli.reps)
+        || !cli.corpus_root.is_absolute()
+        || !cli.work_root.is_absolute()
+    {
+        return Err(io::Error::other(
+            "absolute paths and 1..=5 repetitions required",
+        ));
+    }
+    let source = fs::canonicalize(&cli.corpus_root)?;
+    let parent = fs::canonicalize(
+        cli.work_root
+            .parent()
+            .ok_or_else(|| io::Error::other("missing work parent"))?,
+    )?;
+    let work = parent.join(
+        cli.work_root
+            .file_name()
+            .ok_or_else(|| io::Error::other("missing work name"))?,
     );
+    if source.starts_with(&work) || work.starts_with(&source) || !source.is_dir() {
+        return Err(io::Error::other(
+            "corpus and work roots must be disjoint directories",
+        ));
+    }
+    if cli.only != Some(Arm::Native)
+        && !cli
+            .rclone
+            .as_ref()
+            .is_some_and(|p| p.is_absolute() && p.is_file())
+    {
+        return Err(io::Error::other(
+            "explicit absolute rclone executable required",
+        ));
+    }
+    private_dir(&work)?;
+    Ok((source, work))
+}
+
+const fn arm_order(rep: usize) -> [Arm; 2] {
+    if rep.is_multiple_of(2) {
+        [Arm::Native, Arm::Rclone]
+    } else {
+        [Arm::Rclone, Arm::Native]
+    }
+}
+
+fn rclone_copy(binary: &Path, source: &Path, destination: &Path) -> io::Result<()> {
+    let mut command = Command::new(binary);
+    // Do not let operator config/environment select remote backends or exclusions.
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("RCLONE_") {
+            command.env_remove(key);
+        }
+    }
+    let status = command
+        .args(["copy"])
+        .arg(source)
+        .arg(destination)
+        .args([
+            "--config",
+            "/dev/null",
+            "--create-empty-src-dirs",
+            "--links",
+            "--metadata",
+            "--transfers",
+            "4",
+            "--checkers",
+            "4",
+            "--stats",
+            "0",
+            "--log-level",
+            "ERROR",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!("rclone failed: {status}")));
+    }
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// arms
-// ---------------------------------------------------------------------------
+fn metric(value: Option<u64>) -> String {
+    value.map_or_else(|| "unknown".to_owned(), |value| value.to_string())
+}
 
-/// The `rclone check`-style arm: a plain recursive stat walk with no cache and
-/// no parallelism. This is the bar the agent has to beat.
-///
-/// The `Result` is not currently reachable in the error direction -- this arm
-/// swallows per-entry I/O errors the way `rclone check` does -- but the
-/// signature has to match [`agent_walk`] so both can be handed to [`measure`].
-#[allow(clippy::unnecessary_wraps)]
-fn baseline_walk(root: &Path) -> Result<Rep, BulkloadRefusal> {
-    let started = Instant::now();
-    let mut files = 0_u64;
-    let mut bytes = 0_u64;
-    let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
-
-    while let Some(dir) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let Ok(meta) = entry.metadata() else {
-                continue;
-            };
-            if meta.is_dir() {
-                stack.push(entry.path());
-            } else if meta.is_file() {
-                files += 1;
-                bytes = bytes.saturating_add(meta.len());
+fn run(cli: &Cli) -> io::Result<()> {
+    let (source, work) = prepare(cli)?;
+    let expected = rows(&source)?;
+    println!("scope=local-ordinary-file-copy verification=full-blake3-outside-timing cache=not-flushed outputs=retained");
+    println!("rep arm phase elapsed_ms transferred_content_bytes source_bytes_read acceptance");
+    for rep in 0..cli.reps {
+        for arm in arm_order(rep)
+            .into_iter()
+            .filter(|arm| cli.only.is_none_or(|only| only == *arm))
+        {
+            let root = work.join(format!("{rep}-{arm:?}"));
+            private_dir(&root)?;
+            let destination = root.join("destination");
+            private_dir(&destination)?;
+            for phase in ["initial", "resume"] {
+                if rows(&source)? != expected {
+                    return Err(io::Error::other("immutable corpus changed before arm"));
+                }
+                let started = Instant::now();
+                let (transferred, read) = match arm {
+                    Arm::Native => {
+                        let stats = transfer::copy(
+                            &source,
+                            &destination,
+                            &root.join("source-state"),
+                            &root.join("destination-state"),
+                        )
+                        .map_err(io::Error::other)?;
+                        if !stats.refusals.is_empty() {
+                            return Err(io::Error::other("native transfer refused entries"));
+                        }
+                        (Some(stats.bytes_received), Some(stats.source_bytes_read))
+                    }
+                    Arm::Rclone => {
+                        rclone_copy(
+                            cli.rclone
+                                .as_deref()
+                                .ok_or_else(|| io::Error::other("rclone missing"))?,
+                            &source,
+                            &destination,
+                        )?;
+                        (None, None)
+                    }
+                };
+                let elapsed = started.elapsed();
+                if rows(&source)? != expected || !same_payload(&expected, &rows(&destination)?) {
+                    return Err(io::Error::other(
+                        "source mutation or destination content/mode mismatch",
+                    ));
+                }
+                println!(
+                    "{rep} {arm:?} {phase} {:.3} {} {} verified",
+                    elapsed.as_secs_f64() * 1000.0,
+                    metric(transferred),
+                    metric(read)
+                );
             }
         }
     }
-
-    Ok(Rep {
-        elapsed: started.elapsed(),
-        files,
-        bytes,
-        // TODO(M2): a resume-aware baseline re-reads everything by
-        // construction; wire this to the real re-read accounting once the
-        // resume path exists so the two arms are comparable.
-        bytes_reread_on_resume: 0,
-        // TODO(M2): count the baseline's second stat per seat (read_dir
-        // metadata plus the transfer-time stat) once the transfer half lands.
-        files_statted_twice: 0,
-    })
-}
-
-/// The agent arm: the real walker, currently against a null freshness cache.
-fn agent_walk(root: &Path) -> Result<Rep, BulkloadRefusal> {
-    let options = WalkOptions {
-        hash_policy: HashPolicy::Never,
-        ..WalkOptions::new(root.to_path_buf())
-    };
-    let started = Instant::now();
-    // TODO(M3): swap NullCache for the persistent SqliteCache so the second
-    // rep measures a warm resume instead of a second cold walk.
-    let mut cache = NullCache;
-    let outcome = walk::walk(&options, &mut cache)?;
-    let elapsed = started.elapsed();
-
-    Ok(Rep {
-        elapsed,
-        files: outcome.stats.seats_seen,
-        bytes: outcome.stats.bytes_seen,
-        bytes_reread_on_resume: outcome.stats.bytes_reread_on_resume,
-        files_statted_twice: outcome.stats.files_statted_twice,
-    })
-}
-
-// ---------------------------------------------------------------------------
-// measurement
-// ---------------------------------------------------------------------------
-
-fn measure<F>(name: &'static str, reps: usize, mut arm: F) -> Result<ArmSummary, BulkloadRefusal>
-where
-    F: FnMut() -> Result<Rep, BulkloadRefusal>,
-{
-    let mut results = Vec::with_capacity(reps);
-    for _ in 0..reps {
-        results.push(arm()?);
-    }
-    let last = results
-        .last()
-        .copied()
-        .ok_or(BulkloadRefusal::BudgetExceeded)?;
-
-    let mut millis: Vec<f64> = results
-        .iter()
-        .map(|rep| rep.elapsed.as_secs_f64() * 1000.0)
-        .collect();
-    millis.sort_by(f64::total_cmp);
-
-    let median_ms = median(&millis).ok_or(BulkloadRefusal::BudgetExceeded)?;
-    let lo = millis.first().copied().unwrap_or(median_ms);
-    let hi = millis.last().copied().unwrap_or(median_ms);
-
-    Ok(ArmSummary {
-        name,
-        reps,
-        median_ms,
-        spread_ms: hi - lo,
-        files: last.files,
-        bytes: last.bytes,
-        bytes_reread_on_resume: last.bytes_reread_on_resume,
-        files_statted_twice: last.files_statted_twice,
-    })
-}
-
-/// Median of a pre-sorted slice.
-fn median(sorted: &[f64]) -> Option<f64> {
-    let len = sorted.len();
-    if len == 0 {
-        return None;
-    }
-    let mid = len / 2;
-    if len % 2 == 1 {
-        sorted.get(mid).copied()
-    } else {
-        let lo = sorted.get(mid - 1).copied()?;
-        let hi = sorted.get(mid).copied()?;
-        Some(lo.midpoint(hi))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// output
-// ---------------------------------------------------------------------------
-
-fn print_table(summaries: &[ArmSummary]) {
-    println!(
-        "{:<10} {:>5} {:>12} {:>12} {:>12} {:>16} {:>24} {:>21}",
-        "arm",
-        "reps",
-        "median_ms",
-        "spread_ms",
-        "files",
-        "bytes",
-        "bytes_reread_on_resume",
-        "files_statted_twice",
-    );
-    println!("{}", "-".repeat(120));
-    for summary in summaries {
-        println!(
-            "{:<10} {:>5} {:>12.2} {:>12.2} {:>12} {:>16} {:>24} {:>21}",
-            summary.name,
-            summary.reps,
-            summary.median_ms,
-            summary.spread_ms,
-            summary.files,
-            summary.bytes,
-            summary.bytes_reread_on_resume,
-            summary.files_statted_twice,
-        );
-    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::panic)]
-
-    use super::{median, Cli};
+    use super::*;
     use clap::CommandFactory as _;
 
     #[test]
-    fn cli_definition_is_valid() {
+    fn cli_and_order() {
         Cli::command().debug_assert();
+        assert_eq!(arm_order(0), [Arm::Native, Arm::Rclone]);
+        assert_eq!(arm_order(1), [Arm::Rclone, Arm::Native]);
+        assert_eq!(metric(None), "unknown");
+        assert_eq!(metric(Some(0)), "0");
     }
 
     #[test]
-    fn median_handles_odd_even_and_empty() {
-        assert_eq!(median(&[]), None);
-        assert_eq!(median(&[1.0]), Some(1.0));
-        assert_eq!(median(&[1.0, 3.0]), Some(2.0));
-        assert_eq!(median(&[1.0, 3.0, 100.0]), Some(3.0));
-        assert_eq!(median(&[1.0, 3.0, 5.0, 7.0]), Some(4.0));
+    fn native_copy_resume_and_acceptance() -> io::Result<()> {
+        let fixture = tempfile::tempdir()?;
+        let source = fixture.path().join("source");
+        private_dir(&source)?;
+        fs::write(source.join("raw"), b"raw\0bytes\r\n")?;
+        std::os::unix::fs::symlink("raw", source.join("link"))?;
+        private_dir(&source.join("empty"))?;
+        let cli = Cli {
+            corpus_root: source.clone(),
+            work_root: fixture.path().join("work"),
+            rclone: None,
+            reps: 1,
+            only: Some(Arm::Native),
+        };
+        run(&cli)?;
+        // A repeated invocation cannot accidentally reuse another run's state.
+        assert!(prepare(&cli).is_err());
+        let destination = cli.work_root.join("0-Native/destination");
+        let expected = rows(&source)?;
+        assert!(same_payload(&expected, &rows(&destination)?));
+        fs::write(destination.join("raw"), b"bad\0bytes\r\n")?;
+        assert!(!same_payload(&expected, &rows(&destination)?));
+        let overlapping = Cli {
+            work_root: source.join("nested"),
+            ..cli
+        };
+        assert!(prepare(&overlapping).is_err());
+        Ok(())
     }
 }

--- a/crates/tcfs-bulkload-bench/src/main.rs
+++ b/crates/tcfs-bulkload-bench/src/main.rs
@@ -203,7 +203,10 @@ where
     for _ in 0..reps {
         results.push(arm()?);
     }
-    let last = results.last().copied().ok_or(BulkloadRefusal::BudgetExceeded)?;
+    let last = results
+        .last()
+        .copied()
+        .ok_or(BulkloadRefusal::BudgetExceeded)?;
 
     let mut millis: Vec<f64> = results
         .iter()

--- a/crates/tcfs-bulkload-proto/Cargo.toml
+++ b/crates/tcfs-bulkload-proto/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tcfs-bulkload-proto"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "tcfs bulkload wire protocol: postcard frame codec, row schema, refusal taxonomy"
+
+[dependencies]
+serde = { workspace = true }
+postcard = { workspace = true }
+
+[lints.clippy]
+# R33 deny-panics wall. Refusals are Results, never panics.
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+unwrap_used = "deny"
+expect_used = "deny"
+indexing_slicing = "deny"
+panic = "deny"

--- a/crates/tcfs-bulkload-proto/src/frame.rs
+++ b/crates/tcfs-bulkload-proto/src/frame.rs
@@ -1,0 +1,172 @@
+//! The postcard frame codec skeleton.
+//!
+//! Wire format is deliberately boring: a 4-byte big-endian body length
+//! followed by a postcard-serialised [`Frame`]. Length-prefixing keeps a
+//! corrupt or truncated stream from being silently re-synchronised mid-record
+//! -- the Python engine's "turning one refused object into a desynchronised
+//! batch" hazard, refused here as [`BulkloadRefusal::FrameCodec`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::refusal::BulkloadRefusal;
+use crate::row::RowSchema;
+use crate::Result;
+
+/// Wire protocol version. Bump on any incompatible [`Frame`] change.
+pub const PROTO_VERSION: u16 = 1;
+
+/// Bytes of frame header carrying the body length.
+pub const LENGTH_PREFIX_BYTES: usize = 4;
+
+/// Largest body this codec will encode or accept, in bytes.
+///
+/// A frame carries one row or one small control record; anything larger is a
+/// desynchronised stream, not a big row.
+pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+
+/// The payload a frame carries.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FrameKind {
+    /// Opens a stream and names the corpus root as raw OS bytes.
+    Hello { corpus_root: Vec<u8> },
+    /// One scanned filesystem seat.
+    Row(RowSchema),
+    /// The agent declined a seat, naming the refusal code.
+    Refusal { code: String, rel_path: Vec<u8> },
+    /// Closes a stream. `rows` is the count the sender believes it emitted.
+    Done { rows: u64 },
+}
+
+/// One framed protocol message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Frame {
+    /// Protocol version the sender encoded with.
+    pub version: u16,
+    /// The payload.
+    pub kind: FrameKind,
+}
+
+impl Frame {
+    /// Build a frame at the current [`PROTO_VERSION`].
+    #[must_use]
+    pub const fn new(kind: FrameKind) -> Self {
+        Self {
+            version: PROTO_VERSION,
+            kind,
+        }
+    }
+
+    /// Encode to a length-prefixed postcard frame.
+    ///
+    /// # Errors
+    ///
+    /// Refuses with [`BulkloadRefusal::FrameCodec`] if postcard declines the
+    /// value, and [`BulkloadRefusal::BudgetExceeded`] if the body would exceed
+    /// [`MAX_FRAME_BYTES`].
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        let body = postcard::to_stdvec(self)?;
+        if body.len() > MAX_FRAME_BYTES {
+            return Err(BulkloadRefusal::BudgetExceeded);
+        }
+        let len = u32::try_from(body.len()).map_err(|_| BulkloadRefusal::BudgetExceeded)?;
+        let mut out = Vec::with_capacity(LENGTH_PREFIX_BYTES + body.len());
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(&body);
+        Ok(out)
+    }
+
+    /// Decode one frame from the front of `buf`.
+    ///
+    /// Returns the frame and the number of bytes consumed, so a caller can
+    /// drive a stream without re-scanning for a delimiter.
+    ///
+    /// # Errors
+    ///
+    /// Refuses with [`BulkloadRefusal::FrameCodec`] on a truncated header, a
+    /// truncated body, a postcard decode failure, or a version this build does
+    /// not speak; [`BulkloadRefusal::BudgetExceeded`] if the declared body
+    /// length exceeds [`MAX_FRAME_BYTES`].
+    pub fn decode(buf: &[u8]) -> Result<(Self, usize)> {
+        let header: [u8; LENGTH_PREFIX_BYTES] = buf
+            .get(..LENGTH_PREFIX_BYTES)
+            .ok_or(BulkloadRefusal::FrameCodec)?
+            .try_into()
+            .map_err(|_| BulkloadRefusal::FrameCodec)?;
+        let body_len = usize::try_from(u32::from_be_bytes(header))
+            .map_err(|_| BulkloadRefusal::BudgetExceeded)?;
+        if body_len > MAX_FRAME_BYTES {
+            return Err(BulkloadRefusal::BudgetExceeded);
+        }
+        let end = LENGTH_PREFIX_BYTES
+            .checked_add(body_len)
+            .ok_or(BulkloadRefusal::BudgetExceeded)?;
+        let body = buf
+            .get(LENGTH_PREFIX_BYTES..end)
+            .ok_or(BulkloadRefusal::FrameCodec)?;
+        let frame: Self = postcard::from_bytes(body)?;
+        if frame.version != PROTO_VERSION {
+            return Err(BulkloadRefusal::FrameCodec);
+        }
+        Ok((frame, end))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use super::{Frame, FrameKind, BulkloadRefusal, MAX_FRAME_BYTES};
+
+    fn sample() -> Frame {
+        Frame::new(FrameKind::Hello {
+            corpus_root: b"/srv/corpus".to_vec(),
+        })
+    }
+
+    #[test]
+    fn round_trips() {
+        let frame = sample();
+        let bytes = frame.encode().unwrap();
+        let (decoded, consumed) = Frame::decode(&bytes).unwrap();
+        assert_eq!(decoded, frame);
+        assert_eq!(consumed, bytes.len());
+    }
+
+    #[test]
+    fn decodes_back_to_back_frames() {
+        let mut stream = sample().encode().unwrap();
+        let second = Frame::new(FrameKind::Done { rows: 7 });
+        stream.extend_from_slice(&second.encode().unwrap());
+
+        let (first, consumed) = Frame::decode(&stream).unwrap();
+        assert_eq!(first, sample());
+        let (tail, _) = Frame::decode(stream.get(consumed..).unwrap()).unwrap();
+        assert_eq!(tail, second);
+    }
+
+    #[test]
+    fn refuses_truncated_header_and_body() {
+        let bytes = sample().encode().unwrap();
+        assert_eq!(
+            Frame::decode(&[0_u8, 0]).unwrap_err(),
+            BulkloadRefusal::FrameCodec
+        );
+        let truncated = bytes.get(..bytes.len() - 1).unwrap();
+        assert_eq!(
+            Frame::decode(truncated).unwrap_err(),
+            BulkloadRefusal::FrameCodec
+        );
+    }
+
+    #[test]
+    fn refuses_oversized_declared_length() {
+        let len = u32::try_from(MAX_FRAME_BYTES + 1).unwrap();
+        let mut bytes = len.to_be_bytes().to_vec();
+        bytes.push(0);
+        assert_eq!(
+            Frame::decode(&bytes).unwrap_err(),
+            BulkloadRefusal::BudgetExceeded
+        );
+    }
+}

--- a/crates/tcfs-bulkload-proto/src/frame.rs
+++ b/crates/tcfs-bulkload-proto/src/frame.rs
@@ -13,7 +13,7 @@ use crate::row::RowSchema;
 use crate::Result;
 
 /// Wire protocol version. Bump on any incompatible [`Frame`] change.
-pub const PROTO_VERSION: u16 = 2;
+pub const PROTO_VERSION: u16 = 3;
 
 /// Bytes of frame header carrying the body length.
 pub const LENGTH_PREFIX_BYTES: usize = 4;
@@ -55,6 +55,14 @@ pub enum FrameKind {
     TransferStart { authority: Vec<u8> },
     /// Final source accounting; refusals cannot be mistaken for completion.
     TransferDone { rows: u64, source_bytes_read: u64 },
+    /// Bounded row offers, allowing several requested files to be captured concurrently.
+    TransferBatch { rows: Vec<RowSchema> },
+    /// One request bit for each offered row, before any source content is read.
+    WantFiles { needed: Vec<bool> },
+    /// Names the requested batch row whose manifest follows.
+    FileContent { index: u32 },
+    /// All requested batch rows have produced content or a refusal.
+    BatchDone,
 }
 
 /// A content-defined chunk in a source file, in file order.
@@ -206,7 +214,7 @@ mod tests {
         });
         assert_eq!(Frame::decode(&chunk.encode().unwrap()).unwrap().0, chunk);
         let mut old = sample();
-        old.version = 1;
+        old.version = super::PROTO_VERSION - 1;
         assert_eq!(
             Frame::decode(&old.encode().unwrap()).unwrap_err(),
             BulkloadRefusal::FrameCodec

--- a/crates/tcfs-bulkload-proto/src/frame.rs
+++ b/crates/tcfs-bulkload-proto/src/frame.rs
@@ -1,4 +1,4 @@
-//! The postcard frame codec skeleton.
+//! Bounded postcard frames for native bulkload request/reply streams.
 //!
 //! Wire format is deliberately boring: a 4-byte big-endian body length
 //! followed by a postcard-serialised [`Frame`]. Length-prefixing keeps a
@@ -13,15 +13,15 @@ use crate::row::RowSchema;
 use crate::Result;
 
 /// Wire protocol version. Bump on any incompatible [`Frame`] change.
-pub const PROTO_VERSION: u16 = 1;
+pub const PROTO_VERSION: u16 = 2;
 
 /// Bytes of frame header carrying the body length.
 pub const LENGTH_PREFIX_BYTES: usize = 4;
 
 /// Largest body this codec will encode or accept, in bytes.
 ///
-/// A frame carries one row or one small control record; anything larger is a
-/// desynchronised stream, not a big row.
+/// Frames carry rows, bounded content chunks, or a file's chunk manifest.
+/// Oversized manifests refuse rather than allocating an unbounded wire body.
 pub const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
 
 /// The payload a frame carries.
@@ -36,6 +36,34 @@ pub enum FrameKind {
     Refusal { code: String, rel_path: Vec<u8> },
     /// Closes a stream. `rows` is the count the sender believes it emitted.
     Done { rows: u64 },
+    /// Requests a source root and private source-side resume store over stdio.
+    TransferOpen { root: Vec<u8>, state: Vec<u8> },
+    /// Receiver has a verified output for this exact source identity.
+    WantFile { needed: bool },
+    /// A completed source capture, expressed in content-addressed chunks.
+    Manifest {
+        digest: [u8; 32],
+        chunks: Vec<ChunkSpec>,
+    },
+    /// Receiver requests only chunks missing from its verified local store.
+    WantChunks { digests: Vec<[u8; 32]> },
+    /// One requested, digest-verified content chunk.
+    Chunk { digest: [u8; 32], data: Vec<u8> },
+    /// Receiver finished processing the current file; permits the next row.
+    Applied { success: bool },
+    /// Source authority includes canonical path and root device/inode.
+    TransferStart { authority: Vec<u8> },
+    /// Final source accounting; refusals cannot be mistaken for completion.
+    TransferDone { rows: u64, source_bytes_read: u64 },
+}
+
+/// A content-defined chunk in a source file, in file order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChunkSpec {
+    /// BLAKE3 of the chunk bytes.
+    pub digest: [u8; 32],
+    /// Exact plaintext byte length.
+    pub size: u64,
 }
 
 /// One framed protocol message.
@@ -116,7 +144,7 @@ impl Frame {
 mod tests {
     #![allow(clippy::unwrap_used, clippy::panic)]
 
-    use super::{Frame, FrameKind, BulkloadRefusal, MAX_FRAME_BYTES};
+    use super::{BulkloadRefusal, Frame, FrameKind, MAX_FRAME_BYTES};
 
     fn sample() -> Frame {
         Frame::new(FrameKind::Hello {
@@ -167,6 +195,21 @@ mod tests {
         assert_eq!(
             Frame::decode(&bytes).unwrap_err(),
             BulkloadRefusal::BudgetExceeded
+        );
+    }
+
+    #[test]
+    fn content_protocol_round_trips_and_refuses_the_previous_version() {
+        let chunk = Frame::new(FrameKind::Chunk {
+            digest: [7; 32],
+            data: vec![0, 255, 3],
+        });
+        assert_eq!(Frame::decode(&chunk.encode().unwrap()).unwrap().0, chunk);
+        let mut old = sample();
+        old.version = 1;
+        assert_eq!(
+            Frame::decode(&old.encode().unwrap()).unwrap_err(),
+            BulkloadRefusal::FrameCodec
         );
     }
 }

--- a/crates/tcfs-bulkload-proto/src/lib.rs
+++ b/crates/tcfs-bulkload-proto/src/lib.rs
@@ -1,0 +1,24 @@
+//! Shared wire types for the tcfs bulkload rebuild (plan workstream G, R32-R35).
+//!
+//! This crate is the contract between the thin darwin-side agent
+//! (`tcfs-bulkload-agent`) and whatever consumes its stream. It holds three
+//! things and deliberately nothing else:
+//!
+//! * [`frame`] -- the postcard frame codec skeleton.
+//! * [`row`] -- the scanned-row schema the agent emits.
+//! * [`refusal`] -- the [`BulkloadRefusal`] taxonomy.
+//!
+//! Everything here is `no_std`-friendly in spirit and panic-free in practice:
+//! the crate carries the R33 deny-panics wall, so every fallible path returns
+//! a `Result` carrying a [`BulkloadRefusal`].
+
+pub mod frame;
+pub mod refusal;
+pub mod row;
+
+pub use frame::{Frame, FrameKind, PROTO_VERSION};
+pub use refusal::BulkloadRefusal;
+pub use row::{FileKind, RowSchema};
+
+/// Convenience alias: every fallible bulkload operation refuses with a code.
+pub type Result<T> = core::result::Result<T, BulkloadRefusal>;

--- a/crates/tcfs-bulkload-proto/src/refusal.rs
+++ b/crates/tcfs-bulkload-proto/src/refusal.rs
@@ -12,12 +12,12 @@
 //! | variant family        | representative Python prose                       |
 //! |-----------------------|---------------------------------------------------|
 //! | `SnapshotCustody*`    | "live snapshot custody is unavailable"             |
-//! | `Digest*`             | "AgentCaptureV4 catalog digest mismatch"           |
+//! | `Digest*`             | "`AgentCaptureV4` catalog digest mismatch"           |
 //! | `Git*`                | "Git authority changed during live snapshot"       |
-//! | `Sqlite*`             | "SQLite quick_check failed"                        |
+//! | `Sqlite*`             | "`SQLite` `quick_check` failed"                        |
 //! | `Path*`               | "control and format characters are forbidden ..."  |
 //! | `Rollback*`           | "rollback end-state differs from its exact ..."    |
-//! | `Budget*`             | "SQLite row capture budget exceeded"               |
+//! | `Budget*`             | "`SQLite` row capture budget exceeded"               |
 //!
 //! Every variant is a *refusal*: the operation declined to proceed and made no
 //! partial mutation. Refusals are values, never panics (R33).
@@ -190,7 +190,7 @@ mod tests {
     use super::BulkloadRefusal;
 
     /// Codes are the wire identity of a refusal: they must be unique and
-    /// SCREAMING_SNAKE_CASE.
+    /// `SCREAMING_SNAKE_CASE`.
     #[test]
     fn codes_are_unique_and_well_formed() {
         let all = [

--- a/crates/tcfs-bulkload-proto/src/refusal.rs
+++ b/crates/tcfs-bulkload-proto/src/refusal.rs
@@ -1,0 +1,255 @@
+//! The bulkload refusal taxonomy.
+//!
+//! # Provenance
+//!
+//! The Python engine at `bulkload-refactor/.agents/skills/bulkload/scripts/
+//! bulkload_lib/{scanner,executor,model}.py` does not carry machine-readable
+//! refusal *codes*: it raises `BulkloadError("<prose>")` with several hundred
+//! distinct human-readable messages. The names below are a faithful port of
+//! the refusal *families* those messages fall into, grouped so that each
+//! variant covers one class of prose refusal:
+//!
+//! | variant family        | representative Python prose                       |
+//! |-----------------------|---------------------------------------------------|
+//! | `SnapshotCustody*`    | "live snapshot custody is unavailable"             |
+//! | `Digest*`             | "AgentCaptureV4 catalog digest mismatch"           |
+//! | `Git*`                | "Git authority changed during live snapshot"       |
+//! | `Sqlite*`             | "SQLite quick_check failed"                        |
+//! | `Path*`               | "control and format characters are forbidden ..."  |
+//! | `Rollback*`           | "rollback end-state differs from its exact ..."    |
+//! | `Budget*`             | "SQLite row capture budget exceeded"               |
+//!
+//! Every variant is a *refusal*: the operation declined to proceed and made no
+//! partial mutation. Refusals are values, never panics (R33).
+
+use core::fmt;
+
+/// A bulkload refusal.
+///
+/// Ported from the Python engine's `BulkloadError` prose families -- see the
+/// module docs for the mapping. Variants are non-exhaustive on purpose: the
+/// M2/M3 lanes will grow this set as more of the engine is rebuilt.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BulkloadRefusal {
+    // ---- custody / snapshot integrity ------------------------------------
+    /// The live snapshot custody root could not be established or opened.
+    SnapshotCustodyUnavailable,
+    /// A payload resolved outside the custody root it claims to live under.
+    SnapshotCustodyEscape,
+    /// Declared snapshot roots overlap, alias, or are not unique.
+    SnapshotRootsOverlap,
+    /// The source tree changed after the immutable snapshot was taken.
+    SourceChangedAfterSnapshot,
+    /// A capture claimed ownership of a published snapshot it cannot prove.
+    SnapshotOwnershipUnproven,
+
+    // ---- digest / sealing -------------------------------------------------
+    /// A content digest did not match the digest the plan was sealed against.
+    DigestMismatch,
+    /// A sealed object required by this stage is missing.
+    SealedObjectMissing,
+    /// A sealed object changed between sealing and apply.
+    SealedObjectChanged,
+    /// A receipt is not bound to the plan or push it claims.
+    ReceiptBindingInvalid,
+
+    // ---- schema / contract ------------------------------------------------
+    /// The input is not the record type this stage accepts.
+    SchemaMismatch,
+    /// A required field is absent from an otherwise well-formed record.
+    RequiredFieldMissing,
+    /// A declared enum-like field carries a value outside its domain.
+    FieldDomainViolation,
+    /// Readiness or completeness disagrees with the recorded blockers.
+    ContractSelfInconsistent,
+
+    // ---- path handling ----------------------------------------------------
+    /// A path that must be absolute is not.
+    PathNotAbsolute,
+    /// A path carries control or format characters, or an interior NUL.
+    PathNotPortable,
+    /// The path map is empty, detached from source authority, or unmapped.
+    PathMapDetached,
+    /// A path left the tree it was resolved against (traversal or symlink).
+    PathEscapesRoot,
+
+    // ---- git custody ------------------------------------------------------
+    /// Git is not available on this host.
+    GitUnavailable,
+    /// A git authority path resolves outside the live snapshot root.
+    GitAuthorityOutsideRoot,
+    /// Git bytes or refs changed while the live snapshot was being taken.
+    GitAuthorityChanged,
+    /// A git inventory (index, refs, worktrees) is malformed.
+    GitInventoryMalformed,
+    /// The git destination already exists or is non-empty.
+    GitDestinationOccupied,
+
+    // ---- sqlite -----------------------------------------------------------
+    /// `PRAGMA quick_check` or the foreign-key check failed.
+    SqliteIntegrityCheckFailed,
+    /// The database yielded a value type or magnitude the schema cannot carry.
+    SqliteUnsupportedValue,
+    /// Shared rows diverged between planning and apply.
+    SqliteStateChanged,
+
+    // ---- rollback / journal ------------------------------------------------
+    /// The rollback snapshot required to undo this journal is missing.
+    RollbackSnapshotMissing,
+    /// Rollback did not reach the exact recorded before-state.
+    RollbackEndStateDiverged,
+    /// A journal already rolled back cannot be applied again.
+    JournalAlreadyRolledBack,
+    /// An existing journal belongs to a different transaction.
+    JournalOwnershipConflict,
+
+    // ---- budgets / transport ------------------------------------------------
+    /// A capture, row, or spill budget was exceeded.
+    BudgetExceeded,
+    /// The transport authority differs from the captured authority.
+    TransportAuthorityMismatch,
+    /// The frame could not be encoded or decoded.
+    FrameCodec,
+    /// An underlying I/O operation refused; carries the OS errno when known.
+    Io(Option<i32>),
+}
+
+impl BulkloadRefusal {
+    /// The stable machine-readable code for this refusal.
+    ///
+    /// These strings are the wire/log identity of a refusal and must not change
+    /// once a milestone ships.
+    #[must_use]
+    pub const fn code(&self) -> &'static str {
+        match *self {
+            Self::SnapshotCustodyUnavailable => "SNAPSHOT_CUSTODY_UNAVAILABLE",
+            Self::SnapshotCustodyEscape => "SNAPSHOT_CUSTODY_ESCAPE",
+            Self::SnapshotRootsOverlap => "SNAPSHOT_ROOTS_OVERLAP",
+            Self::SourceChangedAfterSnapshot => "SOURCE_CHANGED_AFTER_SNAPSHOT",
+            Self::SnapshotOwnershipUnproven => "SNAPSHOT_OWNERSHIP_UNPROVEN",
+            Self::DigestMismatch => "DIGEST_MISMATCH",
+            Self::SealedObjectMissing => "SEALED_OBJECT_MISSING",
+            Self::SealedObjectChanged => "SEALED_OBJECT_CHANGED",
+            Self::ReceiptBindingInvalid => "RECEIPT_BINDING_INVALID",
+            Self::SchemaMismatch => "SCHEMA_MISMATCH",
+            Self::RequiredFieldMissing => "REQUIRED_FIELD_MISSING",
+            Self::FieldDomainViolation => "FIELD_DOMAIN_VIOLATION",
+            Self::ContractSelfInconsistent => "CONTRACT_SELF_INCONSISTENT",
+            Self::PathNotAbsolute => "PATH_NOT_ABSOLUTE",
+            Self::PathNotPortable => "PATH_NOT_PORTABLE",
+            Self::PathMapDetached => "PATH_MAP_DETACHED",
+            Self::PathEscapesRoot => "PATH_ESCAPES_ROOT",
+            Self::GitUnavailable => "GIT_UNAVAILABLE",
+            Self::GitAuthorityOutsideRoot => "GIT_AUTHORITY_OUTSIDE_ROOT",
+            Self::GitAuthorityChanged => "GIT_AUTHORITY_CHANGED",
+            Self::GitInventoryMalformed => "GIT_INVENTORY_MALFORMED",
+            Self::GitDestinationOccupied => "GIT_DESTINATION_OCCUPIED",
+            Self::SqliteIntegrityCheckFailed => "SQLITE_INTEGRITY_CHECK_FAILED",
+            Self::SqliteUnsupportedValue => "SQLITE_UNSUPPORTED_VALUE",
+            Self::SqliteStateChanged => "SQLITE_STATE_CHANGED",
+            Self::RollbackSnapshotMissing => "ROLLBACK_SNAPSHOT_MISSING",
+            Self::RollbackEndStateDiverged => "ROLLBACK_END_STATE_DIVERGED",
+            Self::JournalAlreadyRolledBack => "JOURNAL_ALREADY_ROLLED_BACK",
+            Self::JournalOwnershipConflict => "JOURNAL_OWNERSHIP_CONFLICT",
+            Self::BudgetExceeded => "BUDGET_EXCEEDED",
+            Self::TransportAuthorityMismatch => "TRANSPORT_AUTHORITY_MISMATCH",
+            Self::FrameCodec => "FRAME_CODEC",
+            Self::Io(_) => "IO",
+        }
+    }
+}
+
+impl fmt::Display for BulkloadRefusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Io(Some(errno)) => write!(f, "IO (errno {errno})"),
+            _ => f.write_str(self.code()),
+        }
+    }
+}
+
+impl std::error::Error for BulkloadRefusal {}
+
+impl From<std::io::Error> for BulkloadRefusal {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err.raw_os_error())
+    }
+}
+
+impl From<postcard::Error> for BulkloadRefusal {
+    fn from(_: postcard::Error) -> Self {
+        Self::FrameCodec
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use super::BulkloadRefusal;
+
+    /// Codes are the wire identity of a refusal: they must be unique and
+    /// SCREAMING_SNAKE_CASE.
+    #[test]
+    fn codes_are_unique_and_well_formed() {
+        let all = [
+            BulkloadRefusal::SnapshotCustodyUnavailable,
+            BulkloadRefusal::SnapshotCustodyEscape,
+            BulkloadRefusal::SnapshotRootsOverlap,
+            BulkloadRefusal::SourceChangedAfterSnapshot,
+            BulkloadRefusal::SnapshotOwnershipUnproven,
+            BulkloadRefusal::DigestMismatch,
+            BulkloadRefusal::SealedObjectMissing,
+            BulkloadRefusal::SealedObjectChanged,
+            BulkloadRefusal::ReceiptBindingInvalid,
+            BulkloadRefusal::SchemaMismatch,
+            BulkloadRefusal::RequiredFieldMissing,
+            BulkloadRefusal::FieldDomainViolation,
+            BulkloadRefusal::ContractSelfInconsistent,
+            BulkloadRefusal::PathNotAbsolute,
+            BulkloadRefusal::PathNotPortable,
+            BulkloadRefusal::PathMapDetached,
+            BulkloadRefusal::PathEscapesRoot,
+            BulkloadRefusal::GitUnavailable,
+            BulkloadRefusal::GitAuthorityOutsideRoot,
+            BulkloadRefusal::GitAuthorityChanged,
+            BulkloadRefusal::GitInventoryMalformed,
+            BulkloadRefusal::GitDestinationOccupied,
+            BulkloadRefusal::SqliteIntegrityCheckFailed,
+            BulkloadRefusal::SqliteUnsupportedValue,
+            BulkloadRefusal::SqliteStateChanged,
+            BulkloadRefusal::RollbackSnapshotMissing,
+            BulkloadRefusal::RollbackEndStateDiverged,
+            BulkloadRefusal::JournalAlreadyRolledBack,
+            BulkloadRefusal::JournalOwnershipConflict,
+            BulkloadRefusal::BudgetExceeded,
+            BulkloadRefusal::TransportAuthorityMismatch,
+            BulkloadRefusal::FrameCodec,
+            BulkloadRefusal::Io(None),
+        ];
+
+        let mut codes: Vec<&'static str> = all.iter().map(BulkloadRefusal::code).collect();
+        let total = codes.len();
+        assert!(total >= 15, "taxonomy should carry at least 15 refusals");
+        codes.sort_unstable();
+        codes.dedup();
+        assert_eq!(codes.len(), total, "refusal codes must be unique");
+
+        for code in codes {
+            assert!(
+                code.chars()
+                    .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'),
+                "code {code} is not SCREAMING_SNAKE_CASE"
+            );
+        }
+    }
+
+    #[test]
+    fn io_refusal_carries_errno() {
+        let refusal = BulkloadRefusal::from(std::io::Error::from_raw_os_error(2));
+        assert_eq!(refusal, BulkloadRefusal::Io(Some(2)));
+        assert_eq!(refusal.code(), "IO");
+        assert_eq!(refusal.to_string(), "IO (errno 2)");
+    }
+}

--- a/crates/tcfs-bulkload-proto/src/refusal.rs
+++ b/crates/tcfs-bulkload-proto/src/refusal.rs
@@ -19,8 +19,9 @@
 //! | `Rollback*`           | "rollback end-state differs from its exact ..."    |
 //! | `Budget*`             | "`SQLite` row capture budget exceeded"               |
 //!
-//! Every variant is a *refusal*: the operation declined to proceed and made no
-//! partial mutation. Refusals are values, never panics (R33).
+//! Every variant is a *refusal*: the operation did not complete. Earlier durable
+//! progress or prepared state can remain; inspect its receipts before retrying.
+//! Refusals are values, never panics (R33).
 
 use core::fmt;
 
@@ -85,6 +86,8 @@ pub enum BulkloadRefusal {
     GitInventoryMalformed,
     /// The git destination already exists or is non-empty.
     GitDestinationOccupied,
+    /// Captured and destination Git ignore policies differ.
+    GitIgnorePolicyConflict,
 
     // ---- sqlite -----------------------------------------------------------
     /// `PRAGMA quick_check` or the foreign-key check failed.
@@ -145,6 +148,7 @@ impl BulkloadRefusal {
             Self::GitAuthorityChanged => "GIT_AUTHORITY_CHANGED",
             Self::GitInventoryMalformed => "GIT_INVENTORY_MALFORMED",
             Self::GitDestinationOccupied => "GIT_DESTINATION_OCCUPIED",
+            Self::GitIgnorePolicyConflict => "GIT_IGNORE_POLICY_CONFLICT",
             Self::SqliteIntegrityCheckFailed => "SQLITE_INTEGRITY_CHECK_FAILED",
             Self::SqliteUnsupportedValue => "SQLITE_UNSUPPORTED_VALUE",
             Self::SqliteStateChanged => "SQLITE_STATE_CHANGED",
@@ -216,6 +220,7 @@ mod tests {
             BulkloadRefusal::GitAuthorityChanged,
             BulkloadRefusal::GitInventoryMalformed,
             BulkloadRefusal::GitDestinationOccupied,
+            BulkloadRefusal::GitIgnorePolicyConflict,
             BulkloadRefusal::SqliteIntegrityCheckFailed,
             BulkloadRefusal::SqliteUnsupportedValue,
             BulkloadRefusal::SqliteStateChanged,

--- a/crates/tcfs-bulkload-proto/src/row.rs
+++ b/crates/tcfs-bulkload-proto/src/row.rs
@@ -1,0 +1,64 @@
+//! The scanned-row schema.
+//!
+//! One [`RowSchema`] is one filesystem seat observed by the agent's walker.
+//! The identity fields `(dev, ino, size, mtime_ns, ctime_ns)` are exactly the
+//! `StatIdentity` tuple the agent's `FreshnessCache` keys on, so a row is
+//! self-sufficient for a resume decision without a second `stat`.
+
+use serde::{Deserialize, Serialize};
+
+/// The kind of seat a row describes.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FileKind {
+    /// A regular file.
+    Regular,
+    /// A directory.
+    Directory,
+    /// A symbolic link; the row's `link_target` carries the raw target bytes.
+    Symlink,
+    /// Anything else (fifo, socket, device). Bulkload refuses to copy these.
+    Other,
+}
+
+/// One scanned filesystem row.
+///
+/// Paths travel as raw bytes, not `String`: darwin hands out non-UTF-8 names
+/// and the Python engine's `PATH_NOT_PORTABLE` refusal is a policy decision
+/// made *after* the bytes are captured, not a decoding accident.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RowSchema {
+    /// Path relative to the corpus root, as raw OS bytes.
+    pub rel_path: Vec<u8>,
+    /// What kind of seat this is.
+    pub kind: FileKind,
+    /// Containing device id.
+    pub dev: u64,
+    /// Inode number.
+    pub ino: u64,
+    /// Apparent size in bytes.
+    pub size: u64,
+    /// Modification time, nanoseconds since the unix epoch.
+    pub mtime_ns: i128,
+    /// Inode change time, nanoseconds since the unix epoch.
+    pub ctime_ns: i128,
+    /// Unix mode bits.
+    pub mode: u32,
+    /// Number of hard links to this inode.
+    pub nlink: u64,
+    /// Symlink target as raw OS bytes, when `kind` is [`FileKind::Symlink`].
+    pub link_target: Option<Vec<u8>>,
+    /// blake3 of the file contents, when the walker was asked to hash.
+    pub blake3: Option<[u8; 32]>,
+}
+
+impl RowSchema {
+    /// The `StatIdentity` tuple this row asserts.
+    ///
+    /// A resume that finds the same tuple may skip the seat; anything else is
+    /// re-read. This is the input to the R25 `bytes_reread_on_resume` metric.
+    #[must_use]
+    pub const fn stat_identity(&self) -> (u64, u64, u64, i128, i128) {
+        (self.dev, self.ino, self.size, self.mtime_ns, self.ctime_ns)
+    }
+}

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -557,6 +557,14 @@ struct StorageCanaryScopeDenyReport {
 
 #[derive(Subcommand, Debug)]
 enum DeviceAction {
+    /// Merge a signed local registry without enrollment or remote writes
+    Import {
+        /// Signed registry carried from another device
+        source: PathBuf,
+        /// Write a signed union to a new candidate file; never replaces the active registry
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
     /// Enroll this device in the sync fleet
     Enroll {
         /// Device name (default: hostname)
@@ -948,6 +956,25 @@ async fn main() -> Result<()> {
             .await
         }
         Commands::Device { action } => match action {
+            DeviceAction::Import { source, out } => {
+                let key_path = config.crypto.master_key_file.as_ref().context(
+                    "device import requires the configured master_key_file; no key is generated",
+                )?;
+                let master = read_master_key(key_path)?;
+                let registry_path = config
+                    .sync
+                    .device_identity
+                    .clone()
+                    .unwrap_or_else(tcfs_secrets::device::default_registry_path);
+                let added = import_device_registry(
+                    &registry_path,
+                    &source,
+                    master.as_bytes(),
+                    out.as_deref(),
+                )?;
+                println!("Device registry import: added={added} candidate_written={} active_registry_unchanged=true remote_writes=0", out.is_some());
+                Ok(())
+            }
             DeviceAction::Enroll {
                 name,
                 repair_placeholder,
@@ -6309,6 +6336,108 @@ fn repair_placeholder_device_key(
     Ok(key_path)
 }
 
+/// Import only disjoint or identical device entries. Existing local identity,
+/// revocation and progress fields are never replaced by a carried snapshot.
+fn import_device_registry(
+    destination: &Path,
+    source: &Path,
+    master: &[u8; 32],
+    output: Option<&Path>,
+) -> Result<usize> {
+    use tcfs_secrets::device::{DeviceRegistry, RegistryTrust};
+
+    let before = std::fs::read(destination).context("reading local device registry")?;
+    let incoming_bytes = std::fs::read(source).context("reading carried device registry")?;
+    let decode = |bytes: &[u8]| -> Result<DeviceRegistry> {
+        let raw: serde_json::Value = serde_json::from_slice(bytes)?;
+        let registry: DeviceRegistry = serde_json::from_value(raw.clone())?;
+        let normalized = serde_json::to_value(&registry)?;
+        // Serde accepts future fields by default. An import must not silently
+        // discard them when it writes an older schema back to disk.
+        for (key, value) in raw.as_object().context("registry must be an object")? {
+            if key != "devices" {
+                anyhow::ensure!(
+                    normalized.get(key) == Some(value),
+                    "unsupported registry field"
+                );
+            }
+        }
+        for (raw_device, device) in raw["devices"]
+            .as_array()
+            .context("devices must be an array")?
+            .iter()
+            .zip(&registry.devices)
+        {
+            let normalized = serde_json::to_value(device)?;
+            for (key, value) in raw_device.as_object().context("device must be an object")? {
+                anyhow::ensure!(
+                    normalized.get(key) == Some(value),
+                    "unsupported device field"
+                );
+            }
+        }
+        Ok(registry)
+    };
+    let mut local = decode(&before)?;
+    let incoming = decode(&incoming_bytes)?;
+    for registry in [&local, &incoming] {
+        anyhow::ensure!(
+            registry.verify_signature(master)? == RegistryTrust::Signed,
+            "device import refuses unsigned registries"
+        );
+    }
+
+    // Check every identity axis before the existing merge primitive can choose
+    // one of them. Ambiguous names/keys and differing shared entries require
+    // explicit reconciliation, never a last-writer-wins device replacement.
+    let mut identities = std::collections::BTreeMap::new();
+    for (side, registry) in [(0, &local), (1, &incoming)] {
+        let mut seen = std::collections::BTreeSet::new();
+        for device in &registry.devices {
+            anyhow::ensure!(
+                !device.device_id.is_empty() && !device.name.is_empty(),
+                "device import requires nonempty device IDs and names"
+            );
+            let value = serde_json::to_value(device)?;
+            for (axis, identity) in [
+                ("id", &device.device_id),
+                ("name", &device.name),
+                ("public_key", &device.public_key),
+            ] {
+                anyhow::ensure!(
+                    seen.insert((axis, identity)),
+                    "device import has a duplicate {axis}"
+                );
+                if let Some((prior_side, prior)) = identities.get(&(axis, identity)) {
+                    anyhow::ensure!(
+                        *prior_side != side && prior == &value,
+                        "device import has a conflicting or duplicate {axis}"
+                    );
+                } else {
+                    identities.insert((axis, identity), (side, value.clone()));
+                }
+            }
+        }
+    }
+    let added = merge_device_registry(&mut local, &incoming)?;
+    if let Some(output) = output {
+        local.sign(master)?;
+        let bytes = serde_json::to_vec_pretty(&local)?;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut candidate = options.open(output).context("candidate path must be new")?;
+        candidate.write_all(&bytes)?;
+        candidate.sync_all()?;
+        sync_parent_directory(atomic_write_parent(output))?;
+    }
+    Ok(added)
+}
+
 fn merge_device_registry(
     local: &mut tcfs_secrets::device::DeviceRegistry,
     incoming: &tcfs_secrets::device::DeviceRegistry,
@@ -11615,6 +11744,117 @@ nats_token = ["TIN2860-malformed-left", "malformed-middle", "malformed-right"]
         assert!(tcfs_secrets::device::is_real_age_public_key(
             &merged.public_key
         ));
+    }
+
+    #[test]
+    fn import_device_registry_preserves_identity_and_is_idempotent() {
+        use tcfs_secrets::device::{DeviceRegistry, RegistryTrust};
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("devices.json");
+        let source = dir.path().join("incoming.json");
+        let master = [42; 32];
+        let mut local = DeviceRegistry::default();
+        local.enroll_local("sting", None);
+        local.save_signed(&destination, &master).unwrap();
+        let identity = serde_json::to_value(&local.devices[0]).unwrap();
+        let before = std::fs::read(&destination).unwrap();
+        let mut incoming = local.clone();
+        incoming.enroll_local("neo", None);
+        incoming.save_signed(&source, &master).unwrap();
+        let source_before = std::fs::read(&source).unwrap();
+
+        let output = dir.path().join("union.json");
+        assert_eq!(
+            import_device_registry(&destination, &source, &master, None).unwrap(),
+            1
+        );
+        assert_eq!(std::fs::read(&destination).unwrap(), before);
+        assert_eq!(
+            import_device_registry(&destination, &source, &master, Some(&output)).unwrap(),
+            1
+        );
+        let (merged, trust) = DeviceRegistry::load_verified(&output, &master).unwrap();
+        assert_eq!(trust, RegistryTrust::Signed);
+        assert_eq!(merged.devices.len(), 2);
+        assert_eq!(
+            serde_json::to_value(merged.find("sting").unwrap()).unwrap(),
+            identity
+        );
+        let once = std::fs::read(&output).unwrap();
+        assert_eq!(
+            import_device_registry(&output, &source, &master, None).unwrap(),
+            0
+        );
+        assert!(import_device_registry(&destination, &source, &master, Some(&output)).is_err());
+        assert!(
+            import_device_registry(&destination, &source, &master, Some(&destination)).is_err()
+        );
+        assert_eq!(std::fs::read(&output).unwrap(), once);
+        assert_eq!(std::fs::read(&destination).unwrap(), before);
+        assert_eq!(std::fs::read(&source).unwrap(), source_before);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&output).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn import_device_registry_refuses_untrusted_or_conflicting_input_without_writes() {
+        use tcfs_secrets::device::DeviceRegistry;
+        let dir = tempfile::tempdir().unwrap();
+        let destination = dir.path().join("devices.json");
+        let source = dir.path().join("incoming.json");
+        let output = dir.path().join("union.json");
+        let master = [42; 32];
+        let mut local = DeviceRegistry::default();
+        local.enroll_local("sting", None);
+        local.save_signed(&destination, &master).unwrap();
+        let before = std::fs::read(&destination).unwrap();
+        let mut incoming = DeviceRegistry::default();
+        incoming.enroll_local("neo", None);
+        incoming.save(&source).unwrap();
+        assert!(import_device_registry(&destination, &source, &master, Some(&output)).is_err());
+
+        incoming.save_signed(&source, &master).unwrap();
+        let mut future = serde_json::to_value(&incoming).unwrap();
+        future["devices"][0]["future_identity_field"] = serde_json::json!("preserve me");
+        std::fs::write(&source, serde_json::to_vec(&future).unwrap()).unwrap();
+        assert!(import_device_registry(&destination, &source, &master, Some(&output)).is_err());
+        incoming.save_signed(&source, &[43; 32]).unwrap();
+        assert!(import_device_registry(&destination, &source, &master, Some(&output)).is_err());
+        incoming.save_signed(&source, &master).unwrap();
+        incoming.devices[0].description = Some("tampered".into());
+        incoming.save(&source).unwrap();
+        assert!(import_device_registry(&destination, &source, &master, Some(&output)).is_err());
+
+        for axis in ["id", "name", "key", "progress", "duplicate"] {
+            incoming = local.clone();
+            if axis == "progress" {
+                incoming.devices[0].last_nats_seq += 1;
+            } else if axis == "duplicate" {
+                incoming.devices.push(incoming.devices[0].clone());
+            } else {
+                incoming = DeviceRegistry::default();
+                incoming.enroll_local("neo", None);
+                match axis {
+                    "id" => incoming.devices[0].device_id = local.devices[0].device_id.clone(),
+                    "name" => incoming.devices[0].name = local.devices[0].name.clone(),
+                    "key" => incoming.devices[0].public_key = local.devices[0].public_key.clone(),
+                    _ => unreachable!(),
+                }
+            }
+            incoming.save_signed(&source, &master).unwrap();
+            assert!(
+                import_device_registry(&destination, &source, &master, Some(&output)).is_err(),
+                "{axis}"
+            );
+            assert_eq!(std::fs::read(&destination).unwrap(), before);
+            assert!(!output.exists());
+        }
     }
 
     // ── TIN-1417 B4: unsigned-remote LAUNDERING bypass is BLOCKED ──────────────


### PR DESCRIPTION
Native Rust bulkload now supports resumable ordinary-file copy and SSH pull, offline SQLite composition, and Git-native archival union plus standalone and linked dirty-worktree restoration. This advances the R25/R32–R35 rebuild; the PR remains draft because full estate migration acceptance is not complete.

Implemented:
- BLAKE3/FastCDC chunk stores, source-store identity, durable successful capture/output records, and no-overwrite destination publication.
- Explicit reviewed estate plans support linear batch ingestion, bounded two-job captures, metadata-key reuse, common-repository serialized apply, and durable per-item outcomes. Import-only custody is distinguished from restored workspace availability; interrupted pending publications remain preserved without blocking resume.
- Protocol v3: batches of 32 row offers, four capture workers and a bounded completion channel. Warm completed files are not read speculatively. Each file permits at most 131072 chunks; frames are limited to 8 MiB.
- Literal symlinks and file modes, interrupted-directory resume, source-change refusals, SQLite-header refusal in ordinary-file transfer, and private executable selection for SSH without interpolating source paths.
- SQLite online backup and offline typed composition retain conflicting/unknown/recovery rows with provenance. Codex state composition maps paths only when retained rollouts exist; it never installs a candidate over a live database.
- Optional external state candidate import uses bounded zero-wait write transactions, exact schema guards, live-row conflict preservation, and a durable write-ahead identity journal preventing deleted rows from resurrecting on retry. After explicit operator authorization, the guarded live-state import completed with 1739 inserted rows, 10248 path compare-and-swap corrections and zero conflicts. The live database retained 52 migrations; schema digest, foreign-key checks and quick_check passed.
- Native provider hydration adds absent raw rollouts from retained gzip/zstd files with bounded workers and actual-output budgets. Each publication receipt is flushed independently; original compressed carriers remain untouched.
- Git export preserves refs, stash history, staged and dirty/untracked/ignored file trees. Import writes neutral carry refs; standalone and linked restore require an absent destination and preserve staged/unstaged distinctions, raw file permission bits and empty directories. Existing working trees and native refs are not overwritten.

Validation:
- Signed commits 6d186b3, e7975dc, 72765d1 and d4699b8 are GitHub-verified; subsequent delivery includes 840d634 and d56e47b.
- 47 registered tests pass across tcfs-bulkload-agent, tcfs-bulkload-proto and tcfs-bulkload-bench with --locked. Clippy --all-targets passes; optimized Linux release build passes on Sting. Independent source review found no P0/P1 in the ordinary-file pipeline.
- A 70-file, three-batch test proves concurrent chunk deduplication, continuation after a SQLite refusal, and zero transfer bytes on resume.
- Actual retained 23-session corpus, Linux local debug build 6d186b3: 1731238166 source bytes, 1337244921 transferred bytes, 23 completed, zero refusals, cold 273.56 seconds. Warm: 23 reused, zero source reads and transfer bytes. All 23 output SHA256 checks match independently retained hashes.
- Actual same 23-session corpus, Linux local optimized v3 e7975dc: cold 76.71 seconds, peak RSS 10288 KiB, identical source/transfer byte totals, zero refusals. Warm: 23 reused, zero source reads and transferred bytes. All 23 retained SHA256 checks pass. Profile and pipeline both changed, so this is not an isolated parallelism or rclone comparison.
- Darwin release d4699b8 is cross-built on Sting and runs natively on Neo. Actual Neo-to-Sting transfer of eGreg captures passes: four bundles, approximately 3.77 MB over the wire in 8.91 seconds; warm repeat reuses all four with zero source reads and transferred bytes. The earlier two-bundle run also matched independent SHA256 hashes exactly. No local Neo build was used.
- Real eGreg restoration on Sting passes for lane-console, lane-docs, lane-graph and a separate neo-active-20260913 main snapshot. All captured HEADs are 3617081; independently normalized index and staged/unstaged diffs match. Forward/reverse worktree administration pointers verify, new roots are 0700, and the original active Sting main HEAD 4775fa6 is unchanged.

- Interrupted native transport test completes one file, injects a broken pipe, then resumes the remaining two from persisted captures with zero source reads; all output bytes match.
- Five bidirectional Git exchanges converge after initial knowledge exchange, preserving both peers' native HEADs, stash history and legacy carry refs without recursively wrapping provenance.
- Meaningful network corpus (Sting-to-Neo, not the migration direction): all 23 retained session files transferred 1337244921 bytes in 135.69 seconds with zero original source reads using cached manifests. Warm repeat reused all 23 with zero reads/wire bytes in 0.14 seconds. All independent SHA256 checks passed. This is not a rclone comparison.

- Actual native missing-index repair completed for eleven reviewed same-HEAD repositories across two batches. All eleven retained their HEAD, now have an index equal to HEAD and clean status, and left no owned index lock. Original administration/absence receipts were retained; no working-tree payload was rewritten. This reconstructs the measured clean source baseline, not unknown historical staging.

- Actual native linked restoration completed for 12 previously absent workspaces at their intended paths: prompts-enqueue (1), ci-templates (6), site.scaffold (5). All full HEADs match retained captures; staged/unstaged diffs and status are clean, reverse Git administration pointers verify, and there were zero refusals. Existing occupied checkouts were not switched or overwritten.

- Two further gftb-site workspaces restored successfully from the optimized remaining-estate batch. Both HEADs and semantic staged-index hashes independently match Neo, with correct reverse pointers; both Lab items in that same batch retained explicit ignore-policy refusal receipts. Three additional workspaces (account-controller and two great-falls-tool-bus-infra lanes) also completed; full HEADs, semantic indexes and reverse pointers independently match Neo. Three more completed from the next batch (tummycrypt M1, bazel-registry tinyvectors, tinyland.dev ci-bazelisk-first); each HEAD/index matches its retained source capture and reverse pointers verify. The tummycrypt snapshot is intentionally the captured a685396 state, not a claim that later Neo work was already carried. Two other tinyland.dev targets refused existing stale/prunable Git registrations while their payload directories remain absent; old administration was not pruned or overwritten. Total completed absent workspace restorations: 20; held/partial items are not counted.
- Six existing payload-only workspaces were attached in place to their actual common repositories using native create-only Git metadata publication. Their existing bytes were not rewritten; common HEADs, inherited origins, captured staged trees and reverse pointers verify. One source untracked item remains visible as expected. Two site.scaffold payloads first received missing files via a separately reported additive rsync carry; that preparation is not native-mover evidence.
- Two additional create-only index repairs recovered exact dated retained indexes for bulkload and DarwinNicUtil at matching destination HEADs; both verify index==HEAD with no payload rewrite. These are dated snapshots, not a claim of later lost staging recovery.
- Git capture now batches all refs in one NUL-framed update-ref transaction and streams a raw workspace tree through one fast-import process, without filters or per-file Git processes. Descriptor/path freshness guards and a final metadata census replace the second content pass. Registered regressions verify unusual filenames, binary/CRLF bytes, symlinks, source mutation refusal and actual successful regular-byte counts. The old running capture is not modified, and no new throughput claim is made yet.
- Shared estate capture retains one verified common-history base plus per-workspace prerequisite bundles. Base bytes are fsynced before dependency/completion records; receivers verify and import the base before deltas. Tests cover independent dirty workspaces, unchanged completion encoding, warm reuse, and missing-base refusal. The reviewed 138-workspace source capture is running; its completion is not yet claimed. The first six delivered workspace applications refused differing source/destination common ignore policy before creating their destinations; ref custody is not counted as restored workspace parity. Ignore-policy conflicts now have their own explicit refusal code, with a regression proving the destination policy, index and HEAD remain unchanged.

- Standalone attachment now retains source local configuration as immutable capture data and activates only explicitly mapped local origin/tracking and safe declarative values. Executable helpers/hooks/includes/aliases are retained but not activated. This source adapter has registered test coverage, not yet live standalone acceptance.
- Ref imports use one sorted atomic NUL-framed create/verify transaction with --no-deref; a dangling carry symref cannot create a native branch. Estate locks explicitly unlock before close, with a regression covering inherited open-file descriptions.
- Replaced the misleading census-only benchmark with real native copy/resume and optional external rclone arms, fresh private per-arm state, alternating order and full BLAKE3 acceptance outside timing. Registered native-arm tests pass; no real rclone performance result is claimed.

Boundaries: enumeration still walks and retains O(N) rows. Completed-content memoization is not a no-rewalk guarantee. Transfer is bounded parallel capture with an ordered framed transport, not an unlimited parallel runner. Oversized manifests, unsupported Git index/submodule state and conflicting ordinary destinations refuse explicitly. No rclone performance-win, full estate coverage, or migration-complete claim is made.

Ownership: crates/tcfs-bulkload-agent, crates/tcfs-bulkload-proto, crates/tcfs-bulkload-bench. Coordinate before stacking changes.

Linear: none — implementation follows the ratified bulkload product issue tinyland-inc/bulkload#34 and this existing PR; it does not close the Sting migration acceptance issues.
